### PR TITLE
feat: macOS support + remote access with token auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "src/main.js",
   "scripts": {
     "start": "electron .",
-    "build": "electron-builder --win",
+    "build": "electron-builder",
+    "build:win": "electron-builder --win",
+    "build:mac": "electron-builder --mac",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": ["clawd", "desktop-pet", "electron", "claude-code"],

--- a/src/main.js
+++ b/src/main.js
@@ -736,8 +736,24 @@ function disableDoNotDisturb() {
 let httpServer = null;
 
 function startHttpServer() {
+  // CLAWD_BIND: set to "0.0.0.0" for remote access (Tailscale, LAN). Default: localhost.
+  const bindHost = process.env.CLAWD_BIND || "127.0.0.1";
+  // CLAWD_TOKEN: optional bearer token auth for remote connections.
+  const authToken = process.env.CLAWD_TOKEN || "";
+
   httpServer = http.createServer((req, res) => {
     if (req.method === "POST" && req.url === "/state") {
+      // Token auth: skip for localhost, enforce for remote when token is set
+      if (authToken) {
+        const remote = req.socket.remoteAddress;
+        const isLocal = remote === "127.0.0.1" || remote === "::1" || remote === "::ffff:127.0.0.1";
+        if (!isLocal && (req.headers.authorization || "") !== `Bearer ${authToken}`) {
+          res.writeHead(403);
+          res.end("forbidden");
+          return;
+        }
+      }
+
       let body = "";
       let bodySize = 0;
       let destroyed = false;
@@ -784,8 +800,8 @@ function startHttpServer() {
     }
   });
 
-  httpServer.listen(23333, "127.0.0.1", () => {
-    console.log("Clawd state server listening on 127.0.0.1:23333");
+  httpServer.listen(23333, bindHost, () => {
+    console.log(`Clawd state server listening on ${bindHost}:23333`);
   });
 
   httpServer.on("error", (err) => {


### PR DESCRIPTION
## What this PR does

Adds macOS compatibility and remote access support for running the desktop pet on a separate display machine.

### Changes

1. **`CLAWD_BIND` env var** — Controls HTTP server bind address
   - Default: `127.0.0.1` (unchanged, localhost only)
   - Set to `0.0.0.0` for remote access (e.g. via Tailscale, LAN)

2. **`CLAWD_TOKEN` env var** — Optional bearer token authentication
   - When set, non-localhost requests must include `Authorization: Bearer <token>`
   - Localhost requests are always allowed (backward compatible)

3. **macOS build target** — Added `npm run build:mac` alongside existing `build:win`

### Use Case

Running the pet on a display machine (MacBook) while the agent session runs on a headless server (Mac Mini), connected via Tailscale:

```
Headless Server          Display Machine (macOS)
┌──────────────┐         ┌──────────────────┐
│ Claude Code  │  HTTP   │  Electron pet    │
│ / Agent      ├────────→│  0.0.0.0:23333   │
│              │Tailscale│  + token auth     │
└──────────────┘         └──────────────────┘
```

### Backward Compatible

- No changes to default behavior (still binds to localhost)
- No new dependencies
- Existing Windows setup works unchanged

### Testing

- Tested on macOS Sequoia (M4) with Electron 41.0.2
- Verified token auth blocks unauthorized requests
- Verified localhost requests bypass auth when token is set

Love this project! 🦀 We've been running it daily on macOS and wanted to contribute the remote access feature back.