### PR TITLE
feat: add OpenClaw bridge for real-time agent state sync

### DIFF
--- a/bridges/openclaw/README.md
+++ b/bridges/openclaw/README.md
@@ -1,0 +1,45 @@
+# OpenClaw Bridge
+
+Connects [OpenClaw](https://github.com/openclaw/openclaw) agent sessions to Clawd on Desk. The bridge watches session JSONL files for state changes and pushes them to the pet in real-time.
+
+## Setup
+
+```bash
+# Same machine (agent + pet on one device)
+node bridges/openclaw/bridge.js
+
+# Remote (agent on server, pet on laptop via Tailscale/LAN)
+PET_HOST=<pet-machine-ip> PET_TOKEN=<secret> node bridges/openclaw/bridge.js
+```
+
+## State Mapping
+
+| Agent Event | Pet State | Animation |
+|---|---|---|
+| User sends message | `thinking` | Thought bubbles |
+| Tool call (search, exec, etc.) | `working` | Typing on keyboard |
+| Tool result returns | `working` | Still typing |
+| Text reply complete | `attention` | Happy nod ✨ |
+| Memory compaction | `sweeping` | Sweeping animation |
+| No activity (2 min) | `idle` | Eye tracking cursor |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PET_HOST` | `127.0.0.1` | Pet server hostname/IP |
+| `PET_TOKEN` | _(none)_ | Bearer token for remote auth |
+| `SESSIONS_DIR` | `~/.openclaw/agents/main/sessions` | Session JSONL directory |
+
+## Architecture
+
+```
+OpenClaw Agent          Bridge              Desktop Pet
+┌────────────┐    ┌──────────────┐    ┌──────────────┐
+│ Session     │    │ Watch JSONL  │    │ Electron app │
+│ JSONL files │───→│ Map states   │───→│ HTTP :23333  │
+│             │    │ POST /state  │    │ SVG + CSS    │
+└────────────┘    └──────────────┘    └──────────────┘
+```
+
+The bridge polls the most recently modified `.jsonl` file in the sessions directory every 500ms, reads new lines, and maps entry types to pet animation states.

--- a/bridges/openclaw/bridge.js
+++ b/bridges/openclaw/bridge.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+/**
+ * OpenClaw Bridge for Clawd on Desk
+ * 
+ * Monitors OpenClaw agent session files and pushes state changes
+ * to the desktop pet via HTTP.
+ * 
+ * Usage:
+ *   node bridge.js
+ *   PET_HOST=192.168.1.x PET_TOKEN=secret node bridge.js
+ * 
+ * Environment variables:
+ *   PET_HOST    - Pet server host (default: 127.0.0.1)
+ *   PET_TOKEN   - Bearer token for auth (optional)
+ *   SESSIONS_DIR - Override sessions directory path
+ * 
+ * State mapping:
+ *   user message      → thinking
+ *   assistant+toolCall → working
+ *   toolResult        → working
+ *   assistant+text    → attention
+ *   compaction        → sweeping
+ *   no activity 2min  → idle
+ */
+
+const fs = require("fs");
+const path = require("path");
+const http = require("http");
+const os = require("os");
+
+// ── Config ──
+const SESSIONS_DIR =
+  process.env.SESSIONS_DIR ||
+  path.join(os.homedir(), ".openclaw/agents/main/sessions");
+const PET_HOST = process.env.PET_HOST || "127.0.0.1";
+const PET_TOKEN = process.env.PET_TOKEN || "";
+const PET_URL = `http://${PET_HOST}:23333/state`;
+const POLL_INTERVAL = 500;
+const IDLE_TIMEOUT = 120000;
+const SESSION_ID = "openclaw-main";
+
+// ── State ──
+let currentFile = null;
+let lastSize = 0;
+let idleTimer = null;
+let lastState = null;
+let lastPostTime = 0;
+const MIN_STATE_GAP = 300;
+
+function log(msg) {
+  const ts = new Date().toLocaleTimeString("en-GB", { hour12: false });
+  console.log(`[${ts}] ${msg}`);
+}
+
+function postState(state) {
+  const now = Date.now();
+  if (state === lastState && now - lastPostTime < 2000) return;
+  if (now - lastPostTime < MIN_STATE_GAP && state !== "attention") return;
+
+  lastState = state;
+  lastPostTime = now;
+
+  const data = JSON.stringify({ state, session_id: SESSION_ID });
+  const url = new URL(PET_URL);
+
+  const headers = {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(data),
+  };
+  if (PET_TOKEN) headers["Authorization"] = `Bearer ${PET_TOKEN}`;
+
+  const req = http.request(
+    {
+      hostname: url.hostname,
+      port: url.port,
+      path: url.pathname,
+      method: "POST",
+      headers,
+    },
+    (res) => res.resume()
+  );
+  req.on("error", () => {});
+  req.write(data);
+  req.end();
+
+  if (idleTimer) clearTimeout(idleTimer);
+  if (state !== "idle") {
+    idleTimer = setTimeout(() => postState("idle"), IDLE_TIMEOUT);
+  }
+
+  log(`→ ${state}`);
+}
+
+function findActiveSession() {
+  try {
+    const files = fs
+      .readdirSync(SESSIONS_DIR)
+      .filter((f) => f.endsWith(".jsonl"))
+      .map((f) => ({
+        path: path.join(SESSIONS_DIR, f),
+        mtime: fs.statSync(path.join(SESSIONS_DIR, f)).mtimeMs,
+      }))
+      .sort((a, b) => b.mtime - a.mtime);
+    return files.length > 0 ? files[0].path : null;
+  } catch {
+    return null;
+  }
+}
+
+function processNewLines() {
+  if (!currentFile || !fs.existsSync(currentFile)) return;
+
+  let stat;
+  try {
+    stat = fs.statSync(currentFile);
+  } catch {
+    return;
+  }
+  if (stat.size <= lastSize) return;
+
+  const fd = fs.openSync(currentFile, "r");
+  const buf = Buffer.alloc(stat.size - lastSize);
+  fs.readSync(fd, buf, 0, buf.length, lastSize);
+  fs.closeSync(fd);
+  lastSize = stat.size;
+
+  for (const line of buf.toString("utf8").split("\n").filter(Boolean)) {
+    try {
+      mapToState(JSON.parse(line));
+    } catch {}
+  }
+}
+
+function mapToState(entry) {
+  if (entry.type === "message") {
+    const role = entry.message?.role;
+    const content = entry.message?.content;
+
+    if (role === "user") {
+      postState("thinking");
+    } else if (role === "assistant") {
+      if (Array.isArray(content)) {
+        if (content.some((c) => c.type === "toolCall" || c.type === "tool_use")) {
+          postState("working");
+        } else if (content.some((c) => c.type === "text" && c.text?.trim())) {
+          postState("attention");
+        }
+      } else if (typeof content === "string" && content.trim()) {
+        postState("attention");
+      }
+    } else if (role === "toolResult") {
+      postState("working");
+    }
+  } else if (entry.type === "compaction") {
+    postState("sweeping");
+  }
+}
+
+function start() {
+  console.log("🦀 Clawd OpenClaw Bridge");
+  console.log(`   Sessions: ${SESSIONS_DIR}`);
+  console.log(`   Pet:      ${PET_URL}`);
+  console.log("");
+
+  currentFile = findActiveSession();
+  if (currentFile) {
+    lastSize = fs.statSync(currentFile).size;
+    console.log(`   Active:   ${path.basename(currentFile)}`);
+  } else {
+    console.log("   No active session found, waiting...");
+  }
+
+  console.log("");
+
+  fs.watch(SESSIONS_DIR, { persistent: true }, (_, filename) => {
+    if (!filename?.endsWith(".jsonl")) return;
+    const fp = path.join(SESSIONS_DIR, filename);
+    if (!fs.existsSync(fp)) return;
+    if (fp !== currentFile) {
+      if (currentFile && fs.statSync(fp).mtimeMs <= fs.statSync(currentFile).mtimeMs) return;
+      log(`session: ${filename}`);
+      currentFile = fp;
+      lastSize = fs.statSync(fp).size;
+    }
+  });
+
+  setInterval(() => {
+    const active = findActiveSession();
+    if (active && active !== currentFile) {
+      log(`session: ${path.basename(active)}`);
+      currentFile = active;
+      lastSize = fs.statSync(active).size;
+    }
+    processNewLines();
+  }, POLL_INTERVAL);
+
+  postState("idle");
+}
+
+start();


### PR DESCRIPTION
## What this PR does

Adds an [OpenClaw](https://github.com/openclaw/openclaw) bridge that monitors agent session files and pushes state changes to the desktop pet in real-time.

### Why a bridge?

The existing Claude Code integration uses hooks (installed into `~/.claude/hooks/`). OpenClaw stores session data as JSONL files, so we need a different approach — a lightweight watcher that tails the active session file and maps events to pet states.

### Structure

```
bridges/
└── openclaw/
    ├── bridge.js    # The bridge script
    └── README.md    # Setup & usage docs
```

Placed in `bridges/` to keep it organized alongside the existing `hooks/` approach, and to allow future bridges for other agent runtimes.

### State Mapping

| Agent Event | Pet State |
|---|---|
| User message | `thinking` |
| Tool call | `working` |
| Text reply | `attention` |
| Compaction | `sweeping` |
| 2 min idle | `idle` |

### Features

- Watches JSONL session files for new entries (500ms poll)
- Auto-detects active session (most recently modified file)
- Supports remote connections with bearer token auth (pairs with PR #5)
- Zero dependencies (Node.js stdlib only)
- Configurable via env vars (`PET_HOST`, `PET_TOKEN`, `SESSIONS_DIR`)

### Testing

Tested with OpenClaw on macOS — the pet reacts to agent activity within ~500ms. Works both locally and over Tailscale to a remote display machine.

This pairs well with #5 (macOS support + remote access). Together they enable a setup where the agent runs headless and the pet lives on a separate display.