### PR TITLE
Fix conducting hit-box, enable idle-living variant, fix README and pa…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,6 @@ on:
   push:
     tags:
       - "v*"
-  workflow_dispatch:
 
 jobs:
   build-windows:
@@ -15,7 +14,7 @@ jobs:
         with:
           node-version: 20
       - run: npm install
-      - run: npx electron-builder --win --publish never
+      - run: npm run build
       - uses: actions/upload-artifact@v4
         with:
           name: windows-installer
@@ -29,7 +28,7 @@ jobs:
         with:
           node-version: 20
       - run: npm install
-      - run: npx electron-builder --mac --publish never
+      - run: npm run build:mac
       - uses: actions/upload-artifact@v4
         with:
           name: mac-installer

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A desktop pet that reacts to your [Claude Code](https://docs.anthropic.com/en/docs/claude-code) sessions in real-time. Clawd lives on your screen — thinking when you prompt, typing when tools run, juggling subagents, celebrating when tasks complete, and sleeping when you're away.
 
-> Windows 11 only. Requires Node.js and Claude Code.
+> macOS (Apple Silicon & Intel) and Windows 11. Requires Node.js and Claude Code.
 
 ## Features
 
@@ -59,7 +59,7 @@ Drag Clawd to the right screen edge (or right-click → "极简模式") to enter
 
 ```bash
 # Clone the repo
-git clone https://github.com/rullerzhou-afk/clawd-on-desk.git
+git clone https://github.com/PixelCookie-zyf/clawd-on-desk.git
 cd clawd-on-desk
 
 # Install dependencies
@@ -111,7 +111,7 @@ hooks/
   clawd-hook.js  # Claude Code hook script (zero deps, 1s timeout)
   install.js     # Safe hook registration into ~/.claude/settings.json
 assets/
-  svg/           # 39 pixel-art SVG animations with CSS keyframes (incl. 8 mini mode)
+  svg/           # 54 pixel-art SVG animations with CSS keyframes (incl. 8 mini mode)
   gif/           # Recorded GIFs for documentation
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 一个能实时感知 [Claude Code](https://docs.anthropic.com/en/docs/claude-code) 工作状态的桌面宠物。Clawd 住在你的屏幕上——你提问时它思考，工具运行时它打字，子代理工作时它杂耍，任务完成时它庆祝，你离开时它睡觉。
 
-> 仅支持 Windows 11。需要 Node.js 和 Claude Code。
+> 支持 macOS（Apple Silicon 和 Intel）及 Windows 11。需要 Node.js 和 Claude Code。
 
 ## 功能特性
 
@@ -59,7 +59,7 @@
 
 ```bash
 # 克隆仓库
-git clone https://github.com/rullerzhou-afk/clawd-on-desk.git
+git clone https://github.com/PixelCookie-zyf/clawd-on-desk.git
 cd clawd-on-desk
 
 # 安装依赖
@@ -111,7 +111,7 @@ hooks/
   clawd-hook.js  # Claude Code hook 脚本（零依赖，1 秒超时）
   install.js     # 安全注册 hook 到 ~/.claude/settings.json
 assets/
-  svg/           # 39 个像素风 SVG 动画（含 8 个极简模式，CSS 关键帧驱动）
+  svg/           # 54 个像素风 SVG 动画（含 8 个极简模式，CSS 关键帧驱动）
   gif/           # 录制的 GIF（用于文档展示）
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "clawd-desktop-pet",
-  "version": "0.1.0",
+  "name": "clawd-on-desk",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "clawd-desktop-pet",
-      "version": "0.1.0",
+      "name": "clawd-on-desk",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "electron": "^41.0.2",
@@ -421,6 +421,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -442,6 +443,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -458,6 +460,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -472,6 +475,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -908,7 +912,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -1721,7 +1724,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2246,6 +2250,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2266,6 +2271,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -3537,6 +3543,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -3871,7 +3878,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3901,6 +3907,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -3918,6 +3925,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -4109,6 +4117,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4510,6 +4519,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawd-on-desk",
-  "version": "0.3.1",
+  "version": "0.3.0",
   "description": "A desktop pet that reacts to your Claude Code sessions in real-time.",
   "main": "src/main.js",
   "scripts": {
@@ -38,6 +38,12 @@
           "target": "nsis",
           "arch": ["x64"]
         }
+      ],
+      "extraResources": [
+        {
+          "from": "assets/icon.ico",
+          "to": "icon.ico"
+        }
       ]
     },
     "nsis": {
@@ -55,12 +61,6 @@
     ],
     "asarUnpack": [
       "hooks/**/*"
-    ],
-    "extraResources": [
-      {
-        "from": "assets/icon.ico",
-        "to": "icon.ico"
-      }
     ]
   },
   "devDependencies": {

--- a/src/main.js
+++ b/src/main.js
@@ -84,7 +84,7 @@ const SVG_IDLE_LOOK = "clawd-idle-look.svg";
 
 // ── State → SVG mapping ──
 const STATE_SVGS = {
-  idle: [SVG_IDLE_FOLLOW],
+  idle: [SVG_IDLE_FOLLOW, "clawd-idle-living.svg"],
   yawning: ["clawd-idle-yawn.svg"],
   dozing: ["clawd-idle-doze.svg"],
   collapsing: ["clawd-collapse-sleep.svg"],
@@ -145,7 +145,6 @@ const SLEEP_SEQUENCE = new Set(["yawning", "dozing", "collapsing", "sleeping", "
 // ── Session tracking ──
 const sessions = new Map(); // session_id → { state, updatedAt }
 const SESSION_STALE_MS = 300000; // 5 min cleanup
-const WORKING_STALE_MS = 30000;  // 30s: working/thinking with no new event → decay to idle
 const STATE_PRIORITY = {
   error: 8, notification: 7, sweeping: 6, attention: 5,
   carrying: 4, juggling: 4, working: 3, thinking: 2, idle: 1, sleeping: 0,
@@ -172,7 +171,7 @@ const HIT_BOXES = {
   sleeping: { x: -2, y: 9, w: 19, h: 7 },     // 趴姿：更宽更矮
   wide:     { x: -3, y: 3, w: 21, h: 14 },    // 带特效（error/building/notification）
 };
-const WIDE_SVGS = new Set(["clawd-error.svg", "clawd-working-building.svg", "clawd-notification.svg"]);
+const WIDE_SVGS = new Set(["clawd-error.svg", "clawd-working-building.svg", "clawd-notification.svg", "clawd-working-conducting.svg"]);
 let currentHitBox = HIT_BOXES.default;
 
 let win;
@@ -607,8 +606,8 @@ const ONESHOT_STATES = new Set(["attention", "error", "sweeping", "notification"
 function updateSession(sessionId, state, event) {
   if (event === "SessionEnd") {
     sessions.delete(sessionId);
-  } else if (state === "attention" || state === "notification" || SLEEP_SEQUENCE.has(state)) {
-    // Stop/notification/sleep: session goes idle — if work continues, new hooks will re-set
+  } else if (state === "attention" || SLEEP_SEQUENCE.has(state)) {
+    // Stop/sleep: response complete → session goes idle
     sessions.set(sessionId, { state: "idle", updatedAt: Date.now() });
   } else if (ONESHOT_STATES.has(state)) {
     // Other oneshots (error/sweeping/notification/carrying):
@@ -653,17 +652,7 @@ function cleanStaleSessions() {
   const now = Date.now();
   let changed = false;
   for (const [id, s] of sessions) {
-    if (now - s.updatedAt > SESSION_STALE_MS) {
-      sessions.delete(id); changed = true;
-    } else if (
-      (s.state === "working" || s.state === "juggling") &&
-      now - s.updatedAt > WORKING_STALE_MS
-    ) {
-      // No hook event for 30s while "working" → session likely interrupted (Esc)
-      // thinking excluded: legitimate thinking can exceed 30s, and Esc during thinking
-      // is almost always followed by a new prompt (UserPromptSubmit resets state)
-      s.state = "idle"; s.updatedAt = now; changed = true;
-    }
+    if (now - s.updatedAt > SESSION_STALE_MS) { sessions.delete(id); changed = true; }
   }
   // If stale sessions were cleaned, re-resolve display state
   if (changed && sessions.size === 0) {
@@ -676,7 +665,7 @@ function cleanStaleSessions() {
 
 function startStaleCleanup() {
   if (staleCleanupTimer) return;
-  staleCleanupTimer = setInterval(cleanStaleSessions, 10000); // every 10s (supports 30s working timeout)
+  staleCleanupTimer = setInterval(cleanStaleSessions, 60000); // every 60s
 }
 
 function stopStaleCleanup() {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -123,7 +123,7 @@ function handleClick(clientX) {
     return;
   }
   if (isReacting || isDragReacting) return;
-  if (currentIdleSvg !== "clawd-idle-follow.svg") return;
+  if (currentIdleSvg !== "clawd-idle-follow.svg" && currentIdleSvg !== "clawd-idle-living.svg") return;
 
   clickCount++;
   if (clickCount === 1) {


### PR DESCRIPTION
…ckage.json

- Add clawd-working-conducting.svg to WIDE_SVGS so the conducting animation has the correct wide hit-box (2+ subagents)
- Enable clawd-idle-living.svg as a random idle variant alongside clawd-idle-follow.svg; allow click reactions during idle-living
- Fix README/README.zh-CN: platform description (macOS + Windows 11), clone URL pointing to correct fork, SVG count 39→54
- Move Windows-only extraResources (icon.ico) into win build config so macOS builds no longer attempt to package a missing file