### PR TITLE
feat: auto-start Electron app when Claude Code session begins

### DIFF
--- a/hooks/auto-start.js
+++ b/hooks/auto-start.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Clawd Desktop Pet — Auto-Start Script
+// Registered as a SessionStart hook BEFORE clawd-hook.js.
+// Checks if the Electron app is running; if not, launches it detached.
+// Zero dependencies, must exit in <500ms.
+
+const http = require("http");
+const { spawn } = require("child_process");
+const path = require("path");
+
+const TIMEOUT_MS = 300;
+const PORT = 23333;
+
+// Check if app is already running
+const req = http.get(
+  { hostname: "127.0.0.1", port: PORT, path: "/state", timeout: TIMEOUT_MS },
+  () => {
+    // Any response (200, 404, etc.) means server is alive
+    process.exit(0);
+  }
+);
+
+req.on("error", () => {
+  launchApp();
+  process.exit(0);
+});
+
+req.on("timeout", () => {
+  req.destroy();
+  launchApp();
+  process.exit(0);
+});
+
+function launchApp() {
+  const isPackaged = __dirname.includes("app.asar");
+  const isWin = process.platform === "win32";
+
+  try {
+    if (isPackaged) {
+      if (isWin) {
+        // __dirname: <install>/resources/app.asar.unpacked/hooks
+        // exe:       <install>/Clawd on Desk.exe
+        const installDir = path.resolve(__dirname, "..", "..", "..");
+        const exe = path.join(installDir, "Clawd on Desk.exe");
+        spawn(exe, [], { detached: true, stdio: "ignore" }).unref();
+      } else {
+        // __dirname: <name>.app/Contents/Resources/app.asar.unpacked/hooks
+        // .app bundle: 4 levels up
+        const appBundle = path.resolve(__dirname, "..", "..", "..", "..");
+        spawn("open", ["-a", appBundle], {
+          detached: true,
+          stdio: "ignore",
+        }).unref();
+      }
+    } else {
+      // Source / development mode
+      const projectDir = path.resolve(__dirname, "..");
+      const npm = isWin ? "npm.cmd" : "npm";
+      spawn(npm, ["start"], {
+        cwd: projectDir,
+        detached: true,
+        stdio: "ignore",
+      }).unref();
+    }
+  } catch (err) {
+    process.stderr.write(`clawd auto-start: ${err.message}\n`);
+  }
+}

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -26,6 +26,8 @@ const HOOK_EVENTS = [
 ];
 
 const MARKER = "clawd-hook.js";
+const AUTO_START_MARKER = "auto-start.js";
+const LEGACY_AUTO_START_MARKER = "auto-start.sh";
 const HTTP_MARKER = "23333/permission";
 
 // HTTP hooks: PermissionRequest uses bidirectional HTTP hook for permission decisions.
@@ -47,6 +49,7 @@ const HTTP_HOOKS = {
  * Safe to call multiple times — skips already-registered hooks.
  * @param {object} [options]
  * @param {boolean} [options.silent] - suppress console output (for auto-registration)
+ * @param {boolean} [options.autoStart] - register auto-start hook for SessionStart
  * @returns {{ added: number, skipped: number }}
  */
 function registerHooks(options = {}) {
@@ -110,6 +113,49 @@ function registerHooks(options = {}) {
     added++;
   }
 
+  // Register auto-start hook for SessionStart (launches app if not running)
+  if (options.autoStart) {
+    let autoStartScript = path.resolve(__dirname, "auto-start.js").replace(/\\/g, "/");
+    autoStartScript = autoStartScript.replace("app.asar/", "app.asar.unpacked/");
+
+    if (!Array.isArray(settings.hooks.SessionStart)) {
+      settings.hooks.SessionStart = [];
+      changed = true;
+    }
+
+    const autoStartExists = settings.hooks.SessionStart.some((entry) => {
+      if (!entry || typeof entry !== "object") return false;
+      if (typeof entry.command === "string" && entry.command.includes(AUTO_START_MARKER)) return true;
+      if (Array.isArray(entry.hooks)) {
+        return entry.hooks.some((h) => h && typeof h.command === "string" && h.command.includes(AUTO_START_MARKER));
+      }
+      return false;
+    });
+
+    if (!autoStartExists) {
+      // Insert at index 0 — must run BEFORE clawd-hook.js so the app is starting
+      settings.hooks.SessionStart.unshift({
+        matcher: "",
+        hooks: [{ type: "command", command: `node "${autoStartScript}"` }],
+      });
+      added++;
+    } else {
+      skipped++;
+    }
+
+    // Remove all legacy auto-start.sh entries if present
+    const beforeLen = settings.hooks.SessionStart.length;
+    settings.hooks.SessionStart = settings.hooks.SessionStart.filter((entry) => {
+      if (!entry || typeof entry !== "object") return true;
+      if (typeof entry.command === "string" && entry.command.includes(LEGACY_AUTO_START_MARKER)) return false;
+      if (Array.isArray(entry.hooks)) {
+        if (entry.hooks.some((h) => h && typeof h.command === "string" && h.command.includes(LEGACY_AUTO_START_MARKER))) return false;
+      }
+      return true;
+    });
+    if (settings.hooks.SessionStart.length < beforeLen) changed = true;
+  }
+
   // Register HTTP hooks (permission decision collection)
   for (const [event, { matcher, hook }] of Object.entries(HTTP_HOOKS)) {
     if (!Array.isArray(settings.hooks[event])) {
@@ -160,8 +206,71 @@ function registerHooks(options = {}) {
   return { added, skipped };
 }
 
+/**
+ * Remove the auto-start hook from SessionStart in ~/.claude/settings.json.
+ * Also removes legacy auto-start.sh entries.
+ * @returns {boolean} true if a hook was removed
+ */
+function unregisterAutoStart() {
+  const settingsPath = path.join(os.homedir(), ".claude", "settings.json");
+  let settings;
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+  } catch {
+    return false;
+  }
+
+  const arr = settings.hooks && settings.hooks.SessionStart;
+  if (!Array.isArray(arr)) return false;
+
+  const before = arr.length;
+  settings.hooks.SessionStart = arr.filter((entry) => {
+    if (!entry || typeof entry !== "object") return true;
+    // Remove auto-start.js entries
+    if (typeof entry.command === "string" && entry.command.includes(AUTO_START_MARKER)) return false;
+    if (Array.isArray(entry.hooks)) {
+      if (entry.hooks.some((h) => h && typeof h.command === "string" && h.command.includes(AUTO_START_MARKER))) return false;
+    }
+    // Remove legacy auto-start.sh entries
+    if (typeof entry.command === "string" && entry.command.includes(LEGACY_AUTO_START_MARKER)) return false;
+    if (Array.isArray(entry.hooks)) {
+      if (entry.hooks.some((h) => h && typeof h.command === "string" && h.command.includes(LEGACY_AUTO_START_MARKER))) return false;
+    }
+    return true;
+  });
+
+  if (settings.hooks.SessionStart.length < before) {
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), "utf-8");
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Check if the auto-start hook is currently registered in settings.json.
+ * @returns {boolean}
+ */
+function isAutoStartRegistered() {
+  const settingsPath = path.join(os.homedir(), ".claude", "settings.json");
+  try {
+    const settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    const arr = settings.hooks && settings.hooks.SessionStart;
+    if (!Array.isArray(arr)) return false;
+    return arr.some((entry) => {
+      if (!entry || typeof entry !== "object") return false;
+      if (typeof entry.command === "string" && entry.command.includes(AUTO_START_MARKER)) return true;
+      if (Array.isArray(entry.hooks)) {
+        return entry.hooks.some((h) => h && typeof h.command === "string" && h.command.includes(AUTO_START_MARKER));
+      }
+      return false;
+    });
+  } catch {
+    return false;
+  }
+}
+
 // Export for use by main.js
-module.exports = { registerHooks };
+module.exports = { registerHooks, unregisterAutoStart, isAutoStartRegistered };
 
 // CLI: run directly with `node hooks/install.js`
 if (require.main === module) {

--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,7 @@ const i18n = {
     sleep: "Sleep (Do Not Disturb)",
     wake: "Wake Clawd",
     startOnLogin: "Start on Login",
+    startWithClaude: "Start with Claude Code",
     showInMenuBar: "Show in Menu Bar",
     showInDock: "Show in Dock",
     language: "Language",
@@ -64,6 +65,7 @@ const i18n = {
     sleep: "休眠（免打扰）",
     wake: "唤醒 Clawd",
     startOnLogin: "开机自启",
+    startWithClaude: "随 Claude Code 启动",
     showInMenuBar: "在菜单栏显示",
     showInDock: "在 Dock 显示",
     language: "语言",
@@ -124,6 +126,7 @@ function savePrefs() {
     x, y, size: currentSize,
     miniMode, preMiniX, preMiniY, lang,
     showTray, showDock,
+    autoStartWithClaude,
   };
   try { fs.writeFileSync(PREFS_PATH, JSON.stringify(data)); } catch {}
 }
@@ -235,6 +238,7 @@ let doNotDisturb = false;
 let isQuitting = false;
 let showTray = true;
 let showDock = true;
+let autoStartWithClaude = false;
 
 function sendToRenderer(channel, ...args) {
   if (win && !win.isDestroyed()) win.webContents.send(channel, ...args);
@@ -1418,6 +1422,25 @@ function buildTrayMenu() {
         app.setLoginItemSettings({ openAtLogin: menuItem.checked });
       },
     },
+    {
+      label: t("startWithClaude"),
+      type: "checkbox",
+      checked: autoStartWithClaude,
+      click: (menuItem) => {
+        autoStartWithClaude = menuItem.checked;
+        try {
+          const { registerHooks, unregisterAutoStart } = require("../hooks/install.js");
+          if (autoStartWithClaude) {
+            registerHooks({ silent: true, autoStart: true });
+          } else {
+            unregisterAutoStart();
+          }
+        } catch (err) {
+          console.warn("Clawd: failed to toggle auto-start hook:", err.message);
+        }
+        savePrefs();
+      },
+    },
   ];
   // macOS: Dock and Menu Bar visibility toggles
   if (isMac) {
@@ -1697,6 +1720,7 @@ function createWindow() {
     if (typeof prefs.showTray === "boolean") showTray = prefs.showTray;
     if (typeof prefs.showDock === "boolean") showDock = prefs.showDock;
   }
+  if (prefs && typeof prefs.autoStartWithClaude === "boolean") autoStartWithClaude = prefs.autoStartWithClaude;
   // macOS: apply dock visibility (default hidden)
   if (isMac && app.dock) {
     if (showDock) app.dock.show(); else app.dock.hide();
@@ -2276,7 +2300,7 @@ if (!gotTheLock) {
     // Auto-register Claude Code hooks on every launch (dedup-safe)
     try {
       const { registerHooks } = require("../hooks/install.js");
-      const { added } = registerHooks({ silent: true });
+      const { added } = registerHooks({ silent: true, autoStart: autoStartWithClaude });
       if (added > 0) console.log(`Clawd: auto-registered ${added} Claude Code hooks`);
     } catch (err) {
       console.warn("Clawd: failed to auto-register hooks:", err.message);


### PR DESCRIPTION

![20260324223512_rec_](https://github.com/user-attachments/assets/bde1103b-9890-46e7-ab84-b85153f031bc)


## Summary

- Add a **"Start with Claude Code"** tray menu option that automatically launches the desktop pet when a Claude Code session starts
- Cross-platform support: source mode (`npm start`), packaged macOS (`.app`), and packaged Windows (`.exe`)
- Opt-in via tray menu checkbox, persisted across app restarts
- Includes legacy migration for manual `auto-start.sh` hook entries

## Changes

| File | Description |
|------|-------------|
| `hooks/auto-start.js` | New SessionStart hook script: health-checks `127.0.0.1:23333`, spawns app detached if unreachable |
| `hooks/install.js` | `autoStart` option for `registerHooks()`, `unregisterAutoStart()`, `isAutoStartRegistered()` |
| `src/main.js` | i18n (en/zh), tray menu checkbox, pref persistence, app-ready registration |

## How it works

1. User enables "Start with Claude Code" in tray menu
2. `registerHooks({ autoStart: true })` inserts `auto-start.js` at `SessionStart[0]` (before `clawd-hook.js`)
3. Next time Claude Code starts → `auto-start.js` runs → detects app not running → spawns it
4. Subsequent hook events (thinking, working, etc.) arrive after ~2-3s and drive the pet animations

## Test plan

- [x] `auto-start.js` exits in ~59ms when app is already running
- [x] `auto-start.js` spawns app successfully when not running (app ready in ~3s)
- [x] `registerHooks({ autoStart: true })` → hook appears at SessionStart[0]
- [x] `unregisterAutoStart()` → hook removed from settings.json
- [x] `isAutoStartRegistered()` → correct boolean
- [x] Tray menu toggle → settings.json updated, pref persisted
- [x] End-to-end: quit app → start `claude` → app auto-launches

🤖 Generated with [Claude Code](https://claude.com/claude-code)