### PR TITLE
fix: strip ELECTRON_RUN_AS_NODE so app launches from Claude Code

### DIFF
--- a/launch.js
+++ b/launch.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+// Cross-platform launcher that ensures Electron runs in GUI mode.
+//
+// Claude Code (and other Electron-based tools) set ELECTRON_RUN_AS_NODE=1,
+// which forces Electron to behave as a plain Node.js process — the browser
+// layer never initializes, so `require("electron").app` is undefined.
+//
+// This launcher strips that variable before spawning the real Electron binary.
+
+const { spawn } = require("child_process");
+const path = require("path");
+const electron = require("electron");
+
+const env = { ...process.env };
+delete env.ELECTRON_RUN_AS_NODE;
+
+const child = spawn(electron, ["."], {
+  stdio: "inherit",
+  env,
+  cwd: __dirname,
+});
+
+child.on("close", (code) => process.exit(code ?? 0));

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A desktop pet that reacts to your Claude Code sessions in real-time.",
   "main": "src/main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "node launch.js",
     "build": "electron-builder --win",
     "build:mac": "electron-builder --mac",
     "build:all": "electron-builder --win --mac",


### PR DESCRIPTION
## Summary

- **Problem**: When launching `clawd-on-desk` from within a Claude Code session (terminal or hook), the app crashes immediately with `TypeError: Cannot read properties of undefined (reading 'getPath')`. This is because Claude Code exports `ELECTRON_RUN_AS_NODE=1`, which forces Electron to run as a plain Node.js process — the browser layer never initializes and `require("electron").app` is `undefined`.

- **Fix**: Add `launch.js`, a lightweight Node.js launcher that strips `ELECTRON_RUN_AS_NODE` from the environment before spawning the Electron binary. Update the `start` script in `package.json` to use it (`node launch.js` instead of `electron .`).

- This also means the app works on **Windows 10** (tested on 22H2 build 19045) — the previous "Windows 11 only" limitation was caused by this env var, not an actual OS incompatibility.

## Changes

| File | Change |
|------|--------|
| `launch.js` | New cross-platform launcher that cleans env before spawning Electron |
| `package.json` | `"start"` script → `"node launch.js"` |

## Test plan

- [x] Verified `ELECTRON_RUN_AS_NODE=1` is set in Claude Code's shell environment
- [x] Confirmed `npm start` crashes without the fix (`app` is `undefined`)
- [x] Confirmed `npm start` works with the fix (state server on `127.0.0.1:23333`, pet visible on desktop)
- [x] Tested on Windows 10 22H2 (build 19045)
- [x] No impact on `electron-builder` packaging (only affects dev `npm start`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)