### PR TITLE
fix(macOS): allow pet to be dragged to the top of the screen

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1969,6 +1969,7 @@ function createWindow() {
     resizable: false,
     skipTaskbar: true,
     hasShadow: false,
+    enableLargerThanScreen: true,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
       backgroundThrottling: false,


### PR DESCRIPTION
## Summary

On macOS, the pet cannot be dragged to the top ~25% of the screen. This is caused by macOS's `NSWindow.constrainFrameRect:toScreen:` method, which silently prevents windows from being positioned above the menu bar (y < ~25). When `setBounds({y: -100})` is called, macOS overrides it to `y: 29`.

This PR adds `enableLargerThanScreen: true` to the main `BrowserWindow` options. When this flag is set, Electron's custom `NSWindow` subclass overrides `constrainFrameRect:toScreen:` to return the frame rect unchanged — disabling the position constraint entirely.

This is the recommended Electron approach for windows that need to break out of macOS screen constraints, and is appropriate for a desktop pet that should be freely positionable anywhere on screen.

**Related issues:** https://github.com/electron/electron/issues/39445 and #16 

## Changes

- Added `enableLargerThanScreen: true` to the pet `BrowserWindow` constructor options in `src/main.js`

## Test plan

- [ ] Launch app on macOS
- [ ] Drag the pet upward toward the top of the screen
- [ ] Verify the pet can now reach the menu bar / notch area
- [ ] Verify dragging still works normally in all other directions
- [ ] Verify mini mode (edge snap) still functions correctly