### PR TITLE
fix: include yml metadata files in release artifacts for auto-updater

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: windows-installer
-          path: dist/*.exe
+          path: |
+            dist/*.exe
+            dist/latest.yml
 
   build-mac:
     runs-on: macos-latest
@@ -33,7 +35,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: mac-installer
-          path: dist/*.dmg
+          path: |
+            dist/*.dmg
+            dist/latest-mac.yml
 
   release:
     needs: [build-windows, build-mac]


### PR DESCRIPTION
The CI workflow was only uploading binary files (.exe/.dmg) but missing the latest.yml/latest-mac.yml metadata files that electron-updater requires to download and verify updates. This caused 404 errors during update checks even when newer releases existed.