### PR TITLE
fix: resolve auto-update download failure caused by filename mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "win": {
       "icon": "assets/icon.ico",
       "signAndEditExecutable": false,
+      "artifactName": "Clawd-on-Desk-Setup-${version}.${ext}",
       "target": [
         {
           "target": "nsis",

--- a/src/updater.js
+++ b/src/updater.js
@@ -337,7 +337,8 @@ async function _checkForUpdatesInner(manual) {
       manualUpdateCheck = false;
       ctx.rebuildAllMenus();
     } else {
-      ctx.updateLog(`Update check result: ${JSON.stringify(result)}`);
+      const info = result.updateInfo || result.versionInfo || {};
+      ctx.updateLog(`Update check result: v${info.version}, files: ${info.files?.map(f => f.url).join(", ")}`);
     }
   }).catch((err) => {
     ctx.updateLog(`ERROR: checkForUpdates promise rejected: ${err.message}`);


### PR DESCRIPTION
- Add artifactName to win config to prevent filename mismatch between latest.yml (hyphens) and GitHub release downloads (dots)
- Trim verbose update check log to only show version and file names