### PR TITLE
fix: hitWin position offset on macOS mixed-DPI displays

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -511,6 +511,7 @@ function createWindow() {
       resizable: false,
       skipTaskbar: true,
       hasShadow: false,
+      enableLargerThanScreen: true,
       focusable: process.platform !== "linux",  // KEY EXPERIMENT: allow activation to avoid WS_EX_NOACTIVATE input routing bugs (Windows-only issue)
       webPreferences: {
         preload: path.join(__dirname, "preload-hit.js"),
@@ -521,6 +522,7 @@ function createWindow() {
     // hitWin has no visual content — clipping is irrelevant.
     hitWin.setShape([{ x: 0, y: 0, width: hw, height: hh }]);
     hitWin.setIgnoreMouseEvents(false);  // PERMANENT — never toggle
+    if (isMac) hitWin.setFocusable(false);
     hitWin.showInactive();
     // Linux WMs may reset skipTaskbar after showInactive — re-apply explicitly
     if (process.platform === "linux") hitWin.setSkipTaskbar(true);


### PR DESCRIPTION
## Problem

On macOS with **mixed-DPI displays** (e.g., a 1x primary monitor + a 2x Retina secondary monitor), the hitWin is positioned incorrectly on the secondary display. This causes a **click/drag offset of 55-106 pixels on the x-axis**, making the pet unresponsive or misaligned with its visual position.

## Root Cause

Electron's `setBounds()` applies incorrect coordinate transformation for `BrowserWindow` instances that lack `enableLargerThanScreen: true` when positioned on a secondary display with a different DPI scale factor than the primary display.

The **render window** (`win`) already has this property set to `true` and positions correctly. The **hitWin** was missing this property, causing Electron to silently clamp/adjust its coordinates through an incorrect scaling path.

### Diagnostic Evidence

| Window | setBounds({x: 5211}) | getBounds().x | Actual CGWindowInfo x |
|--------|----------------------|-----------------|----------------------|
| render (has enableLargerThanScreen) | 5211 | 5211 | **5160** (correct) |
| hitWin (missing property) | 5211 | 5211 | **5105** (106px off) |

`getBounds()` reports the requested value but macOS Core Graphics shows the actual window is offset.

## Fix

Two minimal changes to `src/main.js`:

1. **Add `enableLargerThanScreen: true`** to the hitWin `BrowserWindow` constructor options - ensures Electron uses the correct coordinate transformation path on mixed-DPI setups.

2. **Add `if (isMac) hitWin.setFocusable(false)`** after construction - prevents the hit window from stealing focus from other applications while maintaining correct input routing. (On macOS, the `focusable` constructor option alone is not sufficient after `showInactive()`.)

## Testing Environment

- macOS (Apple Silicon)
- Primary display: 3440x1440 @ 1x scale factor
- Secondary display: 3840x2560 (1920x1280 logical) @ 2x scale factor
- Pet positioned on the secondary (2x) display

Verified that after the fix, the hitWin CGWindowInfo coordinates match the expected position exactly.
