### PR TITLE
feat: add Cursor IDE native hook support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## 项目概述
 
-Clawd 桌宠 — 一个 Electron 桌面宠物，通过 hook 系统和日志轮询实时感知 AI coding agent 的工作状态并播放对应的像素风 SVG 动画。支持 **Claude Code**（command + HTTP hook）、**Codex CLI**（JSONL 日志轮询）、**Copilot CLI**（command hook）三个 agent 同时运行。支持 Windows、macOS 和 Linux。
+Clawd 桌宠 — 一个 Electron 桌面宠物，通过 hook 系统和日志轮询实时感知 AI coding agent 的工作状态并播放对应的像素风 SVG 动画。支持 **Claude Code**（command + HTTP hook）、**Cursor**（native command hook）、**Codex CLI**（JSONL 日志轮询）、**Copilot CLI**（command hook）四个 agent 同时运行。支持 Windows、macOS 和 Linux。
 
 ## 常用命令
 
@@ -48,6 +48,11 @@ Claude Code 状态同步（command hook，非阻塞）：
     → IPC state-change 事件
     → src/renderer.js（<object> SVG 预加载 + 淡入切换 + 眼球追踪）
 
+Cursor 状态同步（native command hook，非阻塞）：
+  Cursor Agent 触发事件
+    → hooks/cursor-hook.js（stdin JSON 读 hook_event_name + conversation_id → HTTP POST）
+    → 同上状态机
+
 Copilot CLI 状态同步（command hook，非阻塞）：
   Copilot 触发事件
     → hooks/copilot-hook.js（camelCase 事件名 → agents/copilot-cli.js 映射 → HTTP POST）
@@ -85,6 +90,7 @@ Codex CLI 状态同步（JSONL 日志轮询，~1.5s 延迟）：
 
 每个 agent 定义为一个配置模块，导出事件映射、进程名、能力声明：
 - `agents/claude-code.js` — Claude Code 事件映射 + 能力（hooks、permission、terminal focus）
+- `agents/cursor.js` — Cursor native hook 事件映射（camelCase，从 stdin JSON 的 hook_event_name 获取事件名）
 - `agents/codex.js` — Codex CLI JSONL 事件映射 + 轮询配置
 - `agents/copilot-cli.js` — Copilot CLI camelCase 事件映射
 - `agents/registry.js` — agent 注册表：按 ID 或进程名查找 agent 配置
@@ -111,8 +117,10 @@ Codex CLI 状态同步（JSONL 日志轮询，~1.5s 延迟）：
 | `src/bubble.html` | 权限气泡 UI：工具名 pill + 命令预览 + Allow/Deny 按钮 + suggestion 按钮，支持 light/dark 主题 |
 | `src/preload-bubble.js` | bubble 窗口的 contextBridge（permission-show、permission-decide、bubble-height） |
 | `hooks/clawd-hook.js` | Claude Code command hook：事件名 → 状态映射 → HTTP POST，零依赖 |
+| `hooks/cursor-hook.js` | Cursor native hook：stdin JSON 读 hook_event_name + conversation_id → HTTP POST，零依赖 |
 | `hooks/copilot-hook.js` | Copilot CLI command hook：camelCase 事件名，与 clawd-hook.js 相同架构 |
-| `hooks/install.js` | 安全注册 hooks 到 settings.json（command + HTTP），逐事件追加不覆盖，导出 `registerHooks()` 供 main.js 启动时自动注册 |
+| `hooks/install.js` | 安全注册 Claude Code hooks 到 ~/.claude/settings.json（command + HTTP），逐事件追加不覆盖 |
+| `hooks/cursor-install.js` | 安全注册 Cursor hooks 到 ~/.cursor/hooks.json（native format），逐事件追加不覆盖 |
 | `hooks/auto-start.js` | SessionStart hook：检测 Electron 是否在运行，未运行则 detached 启动，<500ms 退出 |
 | `hooks/server-config.js` | 共享工具：端口常量、运行时配置读写、HTTP helper、服务发现 |
 | `hooks/codex-remote-monitor.js` | 远程 Codex 监控：独立守护进程，通过 SSH 隧道轮询 JSONL 日志并 POST 状态变更 |
@@ -269,8 +277,9 @@ Codex CLI 状态同步（JSONL 日志轮询，~1.5s 延迟）：
 - hook 脚本依赖 Node.js 可用
 - Windows 终端聚焦依赖 `koffi`（FFI 调用 `user32.dll AllowSetForegroundWindow`），koffi 加载失败时降级为纯 ALT trick；macOS 用 `osascript`
 - Codex CLI：JSONL 轮询有 ~1.5s 延迟；无终端聚焦（日志不含终端 PID）；Windows 下 hooks 被 Codex 硬编码禁用
+- Cursor：无权限气泡（Cursor 的 PermissionRequest 不支持第三方 HTTP hook）；无进程存活检测（Cursor 作为 IDE 始终运行，session 清理依赖 sessionEnd hook 和超时机制）；background agent（`is_background_agent: true`）映射为 headless 模式
 - Copilot CLI：需手动创建 `~/.copilot/hooks/hooks.json`；无权限气泡（仅支持 deny）
-- 进程存活检测：main.js 定期检查 agent 进程是否存活，清理孤儿会话；但依赖进程名匹配，非标准进程名可能漏检
+- 进程存活检测：main.js 定期检查 agent 进程是否存活，清理孤儿会话；但依赖进程名匹配，非标准进程名可能漏检；Cursor 不参与进程检测（IDE 始终运行）
 
 ## ⚠️ 不要再修 Language 子菜单截断 bug
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 
 A desktop pet that reacts to your AI coding agent sessions in real-time. Clawd lives on your screen — thinking when you prompt, typing when tools run, juggling subagents, reviewing permissions, celebrating when tasks complete, and sleeping when you're away.
 
-> Supports Windows 11, macOS, and Ubuntu/Linux. Requires Node.js. Works with **Claude Code**, **Codex CLI**, and **Copilot CLI**.
+> Supports Windows 11, macOS, and Ubuntu/Linux. Requires Node.js. Works with **Claude Code**, **Cursor**, **Codex CLI**, and **Copilot CLI**.
 
 ## Features
 
 ### Multi-Agent Support
 - **Claude Code** — full integration via command hooks + HTTP permission hooks
+- **Cursor** — native hooks via `~/.cursor/hooks.json` (registered automatically when Clawd starts, or run `npm run install:cursor-hooks`)
 - **Codex CLI** — automatic JSONL log polling (`~/.codex/sessions/`), no configuration needed
 - **Copilot CLI** — command hooks via `~/.copilot/hooks/hooks.json`
 - **Gemini CLI** — command hooks via `~/.gemini/settings.json` (registered automatically when Clawd starts, or run `npm run install:gemini-hooks`)
@@ -38,7 +39,7 @@ A desktop pet that reacts to your AI coding agent sessions in real-time. Clawd l
 - **Multi-session tracking** — sessions across all agents resolve to the highest-priority state
 - **Subagent awareness** — juggling for 1 subagent, conducting for 2+
 - **Terminal focus** — right-click Clawd → Sessions menu to jump to a specific session's terminal window; notification/attention states auto-focus the relevant terminal
-- **Process liveness detection** — detects crashed/exited agent processes (Claude Code, Codex, Copilot) and cleans up orphan sessions
+- **Process liveness detection** — detects crashed/exited agent processes (Claude Code, Codex, Copilot, Gemini) and cleans up orphan sessions; Cursor sessions are cleaned up via sessionEnd hooks and timeout
 - **Startup recovery** — if Clawd restarts while any agent is running, it stays awake instead of falling asleep
 
 ### System
@@ -53,7 +54,7 @@ A desktop pet that reacts to your AI coding agent sessions in real-time. Clawd l
 
 ## State Mapping
 
-Events from all agents (Claude Code hooks, Codex JSONL, Copilot hooks) map to the same animation states:
+Events from all agents (Claude Code hooks, Cursor hooks, Codex JSONL, Copilot hooks) map to the same animation states:
 
 | Agent Event | Clawd State | Animation | |
 |---|---|---|---|
@@ -105,6 +106,8 @@ npm start
 ### Agent Setup
 
 **Claude Code** — works out of the box. Hooks are auto-registered on launch. Versioned hooks (`PreCompact`, `PostCompact`, `StopFailure`) are registered only when Clawd can positively detect a compatible Claude Code version; if detection fails (common for packaged macOS launches), Clawd falls back to core hooks and removes stale incompatible versioned hooks automatically.
+
+**Cursor** — works out of the box. Native Cursor hooks are auto-registered to `~/.cursor/hooks.json` when Clawd starts. Supports Agent mode sessions (Cmd+K / Agent Chat) including subagent tracking. Permission bubbles are not available (Cursor does not expose PermissionRequest to third-party hooks). Background agent sessions are tracked as headless.
 
 **Codex CLI** — works out of the box. Clawd polls `~/.codex/sessions/` for JSONL logs automatically.
 
@@ -164,6 +167,8 @@ Remote hooks run in `CLAWD_REMOTE` mode which skips PID collection (remote PIDs 
 | **Codex CLI: no terminal focus** | Codex sessions use JSONL log polling which doesn't carry terminal PID info. Clicking Clawd won't jump to the Codex terminal. Claude Code and Copilot CLI work fine. |
 | **Codex CLI: Windows hooks disabled** | Codex hardcodes hooks off on Windows, so we poll log files instead. This means ~1.5s latency vs near-instant for hook-based agents. |
 | **Copilot CLI: manual hook setup** | Copilot hooks require manually creating `~/.copilot/hooks/hooks.json`. Claude Code and Codex work out of the box. |
+| **Cursor: no permission bubble** | Cursor does not expose `PermissionRequest` to third-party hooks. Permission bubbles only work with Claude Code. |
+| **Cursor: no process liveness detection** | Cursor is always running as an IDE, so process detection can't determine if an AI session is active. Orphan sessions are cleaned up by `sessionEnd` hooks and timeout. |
 | **Copilot CLI: no permission bubble** | Copilot's `preToolUse` hook only supports deny, not the full allow/deny flow. Permission bubbles only work with Claude Code. |
 | **macOS/Linux auto-update** | No Apple code signing on macOS, no auto-update on Linux — download updates manually from GitHub Releases. |
 | **No test framework for Electron** | Unit tests cover agents and log polling, but the Electron main process (state machine, windows, tray) has no automated tests. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,12 +8,13 @@
 
 一个能实时感知 AI 编程助手工作状态的桌面宠物。Clawd 住在你的屏幕上——你提问时它思考，工具运行时它打字，子代理工作时它杂耍，审批权限时它弹卡片，任务完成时它庆祝，你离开时它睡觉。
 
-> 支持 Windows 11、macOS 和 Ubuntu/Linux。需要 Node.js。支持 **Claude Code**、**Codex CLI**、**Copilot CLI** 与 **Gemini CLI**。
+> 支持 Windows 11、macOS 和 Ubuntu/Linux。需要 Node.js。支持 **Claude Code**、**Cursor**、**Codex CLI**、**Copilot CLI** 与 **Gemini CLI**。
 
 ## 功能特性
 
 ### 多 Agent 支持
 - **Claude Code** — 通过 command hook + HTTP 权限 hook 完整集成
+- **Cursor** — 通过 `~/.cursor/hooks.json` native hook 集成（Clawd 启动时自动注册，或执行 `npm run install:cursor-hooks`）
 - **Codex CLI** — 自动轮询 JSONL 日志（`~/.codex/sessions/`），无需配置
 - **Copilot CLI** — 通过 `~/.copilot/hooks/hooks.json` 配置 command hook
 - **Gemini CLI** — 通过 `~/.gemini/settings.json` 配置 command hook（Clawd 启动时自动注册，或执行 `npm run install:gemini-hooks`）
@@ -157,6 +158,8 @@ Host my-server
 | **Codex CLI：无法跳转终端** | Codex 通过 JSONL 日志轮询，日志中不含终端 PID，点击桌宠无法跳转到 Codex 终端。Claude Code 和 Copilot CLI 正常。 |
 | **Codex CLI：Windows hooks 禁用** | Codex 在 Windows 上硬编码禁用了 hooks，因此走日志轮询，延迟约 1.5 秒（hook 方式几乎无延迟）。 |
 | **Copilot CLI：需手动配置 hooks** | Copilot 需要手动创建 `~/.copilot/hooks/hooks.json`。Claude Code 和 Codex 开箱即用。 |
+| **Cursor：无权限气泡** | Cursor 不对第三方 hook 暴露 `PermissionRequest`。权限气泡仅支持 Claude Code。 |
+| **Cursor：无进程存活检测** | Cursor 作为 IDE 始终运行，无法通过进程检测判断 AI 会话是否活跃。孤儿会话通过 `sessionEnd` hook 和超时机制清理。 |
 | **Copilot CLI：无权限气泡** | Copilot 的 `preToolUse` 只支持拒绝，无法做完整的允许/拒绝审批流。权限气泡仅支持 Claude Code。 |
 | **macOS/Linux 自动更新** | macOS 无 Apple 代码签名，Linux 不支持自动更新，均需从 GitHub Releases 手动下载。 |
 | **Electron 主进程无自动化测试** | 单元测试覆盖了 agent 配置和日志轮询，但状态机、窗口管理、托盘等 Electron 逻辑暂无自动化测试。 |

--- a/agents/cursor.js
+++ b/agents/cursor.js
@@ -1,0 +1,36 @@
+// Cursor agent configuration
+// Native hooks via ~/.cursor/hooks.json, stdin JSON with hook_event_name
+
+module.exports = {
+  id: "cursor",
+  name: "Cursor",
+  // Empty: Cursor is always running while the IDE is open, so process detection
+  // would permanently suppress sleep. Sessions are tracked via hooks instead.
+  processNames: { win: [], mac: [], linux: [] },
+  nodeCommandPatterns: [],
+  eventSource: "hook",
+  // camelCase event names — matches Cursor native hook system
+  eventMap: {
+    sessionStart: "idle",
+    sessionEnd: "sleeping",
+    beforeSubmitPrompt: "thinking",
+    preToolUse: "working",
+    postToolUse: "working",
+    postToolUseFailure: "error",
+    subagentStart: "juggling",
+    subagentStop: "working",
+    preCompact: "sweeping",
+    stop: "attention",
+  },
+  capabilities: {
+    httpHook: false,
+    permissionApproval: false,
+    sessionEnd: true,
+    subagent: true,
+  },
+  hookConfig: {
+    configFormat: "cursor-hooks-json",
+  },
+  stdinFormat: "cursorHookJson",
+  pidField: "cursor_pid",
+};

--- a/agents/registry.js
+++ b/agents/registry.js
@@ -5,8 +5,9 @@ const claudeCode = require("./claude-code");
 const codex = require("./codex");
 const copilotCli = require("./copilot-cli");
 const geminiCli = require("./gemini-cli");
+const cursor = require("./cursor");
 
-const AGENTS = [claudeCode, codex, copilotCli, geminiCli];
+const AGENTS = [claudeCode, codex, copilotCli, geminiCli, cursor];
 const AGENT_MAP = new Map(AGENTS.map((a) => [a.id, a]));
 
 module.exports = {

--- a/hooks/cursor-hook.js
+++ b/hooks/cursor-hook.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Clawd Desktop Pet — Cursor Hook Script
+// Zero dependencies, fast cold start
+// Usage: node cursor-hook.js
+// Reads stdin JSON from Cursor with hook_event_name, conversation_id, etc.
+
+const { postStateToRunningServer } = require("./server-config");
+
+// Cursor camelCase event → { state, event (PascalCase for server compat) }
+const HOOK_MAP = {
+  sessionStart:        { state: "idle",         event: "SessionStart" },
+  sessionEnd:          { state: "sleeping",     event: "SessionEnd" },
+  beforeSubmitPrompt:  { state: "thinking",     event: "UserPromptSubmit" },
+  preToolUse:          { state: "working",      event: "PreToolUse" },
+  postToolUse:         { state: "working",      event: "PostToolUse" },
+  postToolUseFailure:  { state: "error",        event: "PostToolUseFailure" },
+  subagentStart:       { state: "juggling",     event: "SubagentStart" },
+  subagentStop:        { state: "working",      event: "SubagentStop" },
+  preCompact:          { state: "sweeping",     event: "PreCompact" },
+  stop:                { state: "attention",    event: "Stop" },
+};
+
+// Stdout response for gating hooks — always allow, never block
+function stdoutForEvent(hookName) {
+  if (hookName === "preToolUse" || hookName === "subagentStart") {
+    return JSON.stringify({ permission: "allow" });
+  }
+  if (hookName === "beforeSubmitPrompt") {
+    return JSON.stringify({ continue: true });
+  }
+  return "{}";
+}
+
+// Walk the process tree to find the terminal/editor PID.
+// Duplicated because hook scripts must be zero-dependency.
+const TERMINAL_NAMES_WIN = new Set([
+  "windowsterminal.exe", "cmd.exe", "powershell.exe", "pwsh.exe",
+  "code.exe", "alacritty.exe", "wezterm-gui.exe", "mintty.exe",
+  "conemu64.exe", "conemu.exe", "hyper.exe", "tabby.exe",
+  "antigravity.exe", "warp.exe", "iterm.exe", "ghostty.exe",
+  "cursor.exe",
+]);
+const TERMINAL_NAMES_MAC = new Set([
+  "terminal", "iterm2", "alacritty", "wezterm-gui", "kitty",
+  "hyper", "tabby", "warp", "ghostty",
+]);
+const TERMINAL_NAMES_LINUX = new Set([
+  "gnome-terminal", "kgx", "konsole", "xfce4-terminal", "tilix",
+  "alacritty", "wezterm", "wezterm-gui", "kitty", "ghostty",
+  "xterm", "lxterminal", "terminator", "tabby", "hyper", "warp",
+]);
+
+const SYSTEM_BOUNDARY_WIN = new Set(["explorer.exe", "services.exe", "winlogon.exe", "svchost.exe"]);
+const SYSTEM_BOUNDARY_MAC = new Set(["launchd", "init", "systemd"]);
+const SYSTEM_BOUNDARY_LINUX = new Set(["systemd", "init"]);
+
+let _stablePid = null;
+let _pidChain = [];
+
+function getStablePid() {
+  if (_stablePid) return _stablePid;
+  const { execSync } = require("child_process");
+  const isWin = process.platform === "win32";
+  const terminalNames = isWin ? TERMINAL_NAMES_WIN : (process.platform === "linux" ? TERMINAL_NAMES_LINUX : TERMINAL_NAMES_MAC);
+  const systemBoundary = isWin ? SYSTEM_BOUNDARY_WIN : (process.platform === "linux" ? SYSTEM_BOUNDARY_LINUX : SYSTEM_BOUNDARY_MAC);
+  let pid = process.ppid;
+  let lastGoodPid = pid;
+  let terminalPid = null;
+  _pidChain = [];
+  for (let i = 0; i < 8; i++) {
+    let name, parentPid;
+    try {
+      if (isWin) {
+        const out = execSync(
+          `wmic process where "ProcessId=${pid}" get Name,ParentProcessId /format:csv`,
+          { encoding: "utf8", timeout: 1500, windowsHide: true }
+        );
+        const lines = out.trim().split("\n").filter(l => l.includes(","));
+        if (!lines.length) break;
+        const parts = lines[lines.length - 1].split(",");
+        name = (parts[1] || "").trim().toLowerCase();
+        parentPid = parseInt(parts[2], 10);
+      } else {
+        const cp = require("child_process");
+        const ppidOut = cp.execSync(`ps -o ppid= -p ${pid}`, { encoding: "utf8", timeout: 1000 }).trim();
+        const commOut = cp.execSync(`ps -o comm= -p ${pid}`, { encoding: "utf8", timeout: 1000 }).trim();
+        name = require("path").basename(commOut).toLowerCase();
+        parentPid = parseInt(ppidOut, 10);
+      }
+    } catch { break; }
+    _pidChain.push(pid);
+    if (systemBoundary.has(name)) break;
+    if (terminalNames.has(name)) terminalPid = pid;
+    lastGoodPid = pid;
+    if (!parentPid || parentPid === pid || parentPid <= 1) break;
+    pid = parentPid;
+  }
+  _stablePid = terminalPid || lastGoodPid;
+  return _stablePid;
+}
+
+// Read stdin JSON, extract event, post state, write stdout
+const chunks = [];
+let _ran = false;
+let _stdinTimer = null;
+
+function finishOnce(payload) {
+  if (_ran) return;
+  _ran = true;
+  if (_stdinTimer) clearTimeout(_stdinTimer);
+
+  const hookName = (payload && payload.hook_event_name) || "";
+  let mapped = HOOK_MAP[hookName];
+
+  if (!mapped) {
+    process.stdout.write(stdoutForEvent(hookName) + "\n");
+    process.exit(0);
+    return;
+  }
+
+  // stop with status=error → error state
+  if (hookName === "stop" && payload.status === "error") {
+    mapped = { state: "error", event: "StopFailure" };
+  }
+
+  const { state, event } = mapped;
+
+  if (hookName === "sessionStart") getStablePid();
+
+  // conversation_id is the stable session ID across turns
+  const sessionId = (payload && (payload.conversation_id || payload.session_id)) || "default";
+  const cwd = (payload && Array.isArray(payload.workspace_roots) && payload.workspace_roots[0]) || "";
+  const isHeadless = !!(payload && payload.is_background_agent);
+
+  const body = { state, session_id: sessionId, event };
+  body.agent_id = "cursor";
+  body.editor = "cursor";
+  if (cwd) body.cwd = cwd;
+  if (isHeadless) body.headless = true;
+  body.source_pid = getStablePid();
+  if (_pidChain.length) body.pid_chain = _pidChain;
+
+  const outLine = stdoutForEvent(hookName);
+  const data = JSON.stringify(body);
+  postStateToRunningServer(data, { timeoutMs: 100 }, () => {
+    process.stdout.write(outLine + "\n");
+    process.exit(0);
+  });
+}
+
+process.stdin.on("data", (c) => chunks.push(c));
+process.stdin.on("end", () => {
+  let payload = {};
+  try {
+    const raw = Buffer.concat(chunks).toString();
+    if (raw.trim()) payload = JSON.parse(raw);
+  } catch {
+    payload = {};
+  }
+  finishOnce(payload);
+});
+
+_stdinTimer = setTimeout(() => finishOnce({}), 400);

--- a/hooks/cursor-install.js
+++ b/hooks/cursor-install.js
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Merge Clawd Cursor hooks into ~/.cursor/hooks.json (append-only, idempotent)
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const MARKER = "cursor-hook.js";
+
+const CURSOR_HOOK_EVENTS = [
+  "sessionStart",
+  "sessionEnd",
+  "beforeSubmitPrompt",
+  "preToolUse",
+  "postToolUse",
+  "postToolUseFailure",
+  "subagentStart",
+  "subagentStop",
+  "preCompact",
+  "stop",
+];
+
+function writeJsonAtomic(filePath, data) {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const tmpPath = path.join(dir, `.${base}.${process.pid}.${Date.now()}.tmp`);
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), "utf-8");
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch {}
+    throw err;
+  }
+}
+
+/**
+ * Register Clawd hooks into ~/.cursor/hooks.json
+ * @param {object} [options]
+ * @param {boolean} [options.silent]
+ * @param {string} [options.hooksPath]
+ * @returns {{ added: number, skipped: number, updated: number }}
+ */
+function registerCursorHooks(options = {}) {
+  const hooksPath = options.hooksPath || path.join(os.homedir(), ".cursor", "hooks.json");
+
+  // Skip if ~/.cursor/ doesn't exist (Cursor not installed)
+  const cursorDir = path.dirname(hooksPath);
+  if (!options.hooksPath && !fs.existsSync(cursorDir)) {
+    if (!options.silent) console.log("Clawd: ~/.cursor/ not found — skipping Cursor hook registration");
+    return { added: 0, skipped: 0, updated: 0 };
+  }
+
+  let hookScript = path.resolve(__dirname, "cursor-hook.js").replace(/\\/g, "/");
+  hookScript = hookScript.replace("app.asar/", "app.asar.unpacked/");
+  const desiredCommand = `node "${hookScript}"`;
+
+  let config = {};
+  try {
+    config = JSON.parse(fs.readFileSync(hooksPath, "utf-8"));
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      throw new Error(`Failed to read hooks.json: ${err.message}`);
+    }
+  }
+
+  if (!config.version) config.version = 1;
+  if (!config.hooks || typeof config.hooks !== "object") config.hooks = {};
+
+  let added = 0;
+  let skipped = 0;
+  let updated = 0;
+  let changed = false;
+
+  for (const event of CURSOR_HOOK_EVENTS) {
+    if (!Array.isArray(config.hooks[event])) {
+      config.hooks[event] = [];
+      changed = true;
+    }
+
+    const arr = config.hooks[event];
+    let found = false;
+    let stalePath = false;
+    for (const entry of arr) {
+      if (!entry || typeof entry !== "object") continue;
+      const cmd = entry.command || "";
+      if (!cmd.includes(MARKER)) continue;
+      found = true;
+      if (cmd !== desiredCommand) {
+        entry.command = desiredCommand;
+        stalePath = true;
+      }
+      break;
+    }
+
+    if (found) {
+      if (stalePath) {
+        updated++;
+        changed = true;
+      } else {
+        skipped++;
+      }
+      continue;
+    }
+
+    arr.push({ command: desiredCommand });
+    added++;
+    changed = true;
+  }
+
+  if (added > 0 || changed) {
+    writeJsonAtomic(hooksPath, config);
+  }
+
+  if (!options.silent) {
+    console.log(`Clawd Cursor hooks → ${hooksPath}`);
+    console.log(`  Added: ${added}, updated: ${updated}, skipped: ${skipped}`);
+  }
+
+  return { added, skipped, updated };
+}
+
+module.exports = { registerCursorHooks, CURSOR_HOOK_EVENTS };
+
+if (require.main === module) {
+  try {
+    registerCursorHooks({});
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:linux": "electron-builder --linux",
     "build:all": "electron-builder --win --mac --linux",
     "test": "node --test test/*.test.js",
-    "install:gemini-hooks": "node hooks/gemini-install.js"
+    "install:gemini-hooks": "node hooks/gemini-install.js",
+    "install:cursor-hooks": "node hooks/cursor-install.js"
   },
   "keywords": [
     "clawd",

--- a/src/server.js
+++ b/src/server.js
@@ -52,6 +52,18 @@ function syncGeminiHooks() {
   }
 }
 
+function syncCursorHooks() {
+  try {
+    const { registerCursorHooks } = require("../hooks/cursor-install.js");
+    const { added, updated } = registerCursorHooks({ silent: true });
+    if (added > 0 || updated > 0) {
+      console.log(`Clawd: synced Cursor hooks (added ${added}, updated ${updated})`);
+    }
+  } catch (err) {
+    console.warn("Clawd: failed to sync Cursor hooks:", err.message);
+  }
+}
+
 function sendStateHealthResponse(res) {
   const body = JSON.stringify({ ok: true, app: CLAWD_SERVER_ID, port: getHookServerPort() });
   res.writeHead(200, {
@@ -302,6 +314,7 @@ function startHttpServer() {
     console.log(`Clawd state server listening on 127.0.0.1:${activeServerPort}`);
     syncClawdHooks();
     syncGeminiHooks();
+    syncCursorHooks();
     watchSettingsForHookLoss();
   });
 

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -3,14 +3,15 @@ const assert = require("node:assert");
 const registry = require("../agents/registry");
 
 describe("Agent Registry", () => {
-  it("should return all four agents", () => {
+  it("should return all five agents", () => {
     const agents = registry.getAllAgents();
-    assert.strictEqual(agents.length, 4);
+    assert.strictEqual(agents.length, 5);
     const ids = agents.map((a) => a.id);
     assert.ok(ids.includes("claude-code"));
     assert.ok(ids.includes("codex"));
     assert.ok(ids.includes("copilot-cli"));
     assert.ok(ids.includes("gemini-cli"));
+    assert.ok(ids.includes("cursor"));
   });
 
   it("should look up agents by ID", () => {
@@ -18,6 +19,7 @@ describe("Agent Registry", () => {
     assert.strictEqual(registry.getAgent("codex").name, "Codex CLI");
     assert.strictEqual(registry.getAgent("copilot-cli").name, "Copilot CLI");
     assert.strictEqual(registry.getAgent("gemini-cli").name, "Gemini CLI");
+    assert.strictEqual(registry.getAgent("cursor").name, "Cursor");
     assert.strictEqual(registry.getAgent("nonexistent"), undefined);
   });
 
@@ -35,6 +37,9 @@ describe("Agent Registry", () => {
 
     const gemini = registry.getAgent("gemini-cli");
     assert.deepStrictEqual(gemini.processNames.win, ["gemini.exe"]);
+
+    const cursor = registry.getAgent("cursor");
+    assert.deepStrictEqual(cursor.processNames.win, []);
   });
 
   it("should include explicit Linux process names", () => {
@@ -49,6 +54,9 @@ describe("Agent Registry", () => {
 
     const gemini = registry.getAgent("gemini-cli");
     assert.deepStrictEqual(gemini.processNames.linux, ["gemini"]);
+
+    const cursor = registry.getAgent("cursor");
+    assert.deepStrictEqual(cursor.processNames.linux, []);
   });
 
   it("should aggregate all process names", () => {
@@ -87,6 +95,12 @@ describe("Agent Registry", () => {
     assert.strictEqual(gemini.capabilities.permissionApproval, false);
     assert.strictEqual(gemini.capabilities.sessionEnd, true);
     assert.strictEqual(gemini.capabilities.subagent, false);
+
+    const cursor = registry.getAgent("cursor");
+    assert.strictEqual(cursor.capabilities.httpHook, false);
+    assert.strictEqual(cursor.capabilities.permissionApproval, false);
+    assert.strictEqual(cursor.capabilities.sessionEnd, true);
+    assert.strictEqual(cursor.capabilities.subagent, true);
   });
 
   it("should have eventMap for hook-based agents", () => {
@@ -104,6 +118,12 @@ describe("Agent Registry", () => {
     assert.strictEqual(gemini.eventMap.SessionStart, "idle");
     assert.strictEqual(gemini.eventMap.BeforeTool, "working");
     assert.strictEqual(gemini.eventMap.AfterAgent, "attention");
+
+    const cursor = registry.getAgent("cursor");
+    assert.strictEqual(cursor.eventMap.sessionStart, "idle");
+    assert.strictEqual(cursor.eventMap.preToolUse, "working");
+    assert.strictEqual(cursor.eventMap.stop, "attention");
+    assert.strictEqual(cursor.eventMap.subagentStart, "juggling");
   });
 
   it("should have logEventMap for poll-based agents", () => {


### PR DESCRIPTION
## Summary

- Add **Cursor** as the fifth supported agent (alongside Claude Code, Codex CLI, Copilot CLI, Gemini CLI)
- Cursor hooks auto-register to `~/.cursor/hooks.json` on Clawd startup using Cursor's native hook format (`{ "version": 1, "hooks": { ... } }`)
- Tracks 10 Cursor events: `sessionStart`, `sessionEnd`, `beforeSubmitPrompt`, `preToolUse`, `postToolUse`, `postToolUseFailure`, `subagentStart`, `subagentStop`, `preCompact`, `stop`

### New files
| File | Purpose |
|------|---------|
| `agents/cursor.js` | Agent config — camelCase event map, subagent support, empty processNames (Cursor is always-on as an IDE) |
| `hooks/cursor-hook.js` | Zero-dep hook script — reads Cursor's stdin JSON (`hook_event_name`, `conversation_id`, `workspace_roots`, `is_background_agent`), maps to Clawd states, POSTs to local server |
| `hooks/cursor-install.js` | Idempotent installer for `~/.cursor/hooks.json`, skips if `~/.cursor/` doesn't exist |

### Design decisions
- **Empty `processNames`**: Cursor is always running while the IDE is open, so process detection would permanently suppress the sleep sequence. Sessions are tracked entirely via hooks and cleaned up by `sessionEnd` + timeout.
- **`is_background_agent` → `headless`**: Background agent sessions in Cursor are treated as headless (excluded from display state priority, auto-denied for permissions).
- **`stop` with `status: "error"` → error state**: Maps to `StopFailure` equivalent, while normal `stop` maps to `attention` (happy animation).
- **Stdout JSON for gating hooks**: Always outputs `{ "permission": "allow" }` for `preToolUse`/`subagentStart` and `{ "continue": true }` for `beforeSubmitPrompt` to never block Cursor's actions.

### Modified files
- `agents/registry.js` — added Cursor to agents array (4 → 5)
- `src/server.js` — added `syncCursorHooks()` called on server startup
- `package.json` — added `install:cursor-hooks` npm script
- `test/registry.test.js` — updated agent count assertions, added Cursor capability/event tests
- `CLAUDE.md`, `README.md`, `README.zh-CN.md` — documented Cursor support

## Test plan

- [x] All 41 existing unit tests pass (`npm test`)
- [x] `node hooks/cursor-install.js` registers 10 hooks to `~/.cursor/hooks.json`
- [x] Manual HTTP POST tests (thinking → working → attention → sleeping) all return `ok`
- [x] Clawd startup log shows "synced Cursor hooks (added 10, updated 0)"
- [x] Idempotent re-registration shows "skipped: 10"
- [x] Live test: Cursor Agent session triggers hooks and Clawd reacts in real-time

Made with [Cursor](https://cursor.com)