### PR TITLE
feat: add Qoder IDE agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 A desktop pet that reacts to your AI coding agent sessions in real-time. Clawd lives on your screen — thinking when you prompt, typing when tools run, juggling subagents, reviewing permissions, celebrating when tasks complete, and sleeping when you're away.
 
-> Supports Windows 11, macOS, and Ubuntu/Linux. Requires Node.js. Works with **Claude Code**, **Codex CLI**, **Copilot CLI**, **Gemini CLI**, and **Cursor Agent**.
+> Supports Windows 11, macOS, and Ubuntu/Linux. Requires Node.js. Works with **Claude Code**, **Codex CLI**, **Copilot CLI**, **Gemini CLI**, **Cursor Agent**, and **Qoder IDE**.
 
 ## Features
 
@@ -18,6 +18,7 @@ A desktop pet that reacts to your AI coding agent sessions in real-time. Clawd l
 - **Copilot CLI** — command hooks via `~/.copilot/hooks/hooks.json`
 - **Gemini CLI** — command hooks via `~/.gemini/settings.json` (registered automatically when Clawd starts, or run `npm run install:gemini-hooks`)
 - **Cursor Agent** — [Cursor IDE hooks](https://cursor.com/docs/agent/hooks) in `~/.cursor/hooks.json` (registered automatically when Clawd starts, or run `npm run install:cursor-hooks`)
+- **Qoder IDE** — command hooks via `~/.qoder/settings.json` (registered automatically when Clawd starts)
 - **Multi-agent coexistence** — run all agents simultaneously; Clawd tracks each session independently
 
 ### Animations & Interaction
@@ -56,7 +57,7 @@ A desktop pet that reacts to your AI coding agent sessions in real-time. Clawd l
 
 ## State Mapping
 
-Events from all agents (Claude Code hooks, Codex JSONL, Copilot hooks) map to the same animation states:
+Events from all agents (Claude Code hooks, Codex JSONL, Copilot hooks, Gemini CLI, Cursor Agent, Qoder IDE) map to the same animation states:
 
 | Agent Event | Clawd State | Animation | |
 |---|---|---|---|
@@ -168,6 +169,7 @@ Remote hooks run in `CLAWD_REMOTE` mode which skips PID collection (remote PIDs 
 | **Codex CLI: Windows hooks disabled** | Codex hardcodes hooks off on Windows, so we poll log files instead. This means ~1.5s latency vs near-instant for hook-based agents. |
 | **Copilot CLI: manual hook setup** | Copilot hooks require manually creating `~/.copilot/hooks/hooks.json`. Claude Code and Codex work out of the box. |
 | **Copilot CLI: no permission bubble** | Copilot's `preToolUse` hook only supports deny, not the full allow/deny flow. Permission bubbles only work with Claude Code. |
+| **Qoder IDE: no session events** | Qoder doesn't emit SessionStart/SessionEnd hooks, so Clawd can't detect when sessions begin or end. |
 | **macOS/Linux auto-update** | No Apple code signing on macOS, no auto-update on Linux — download updates manually from GitHub Releases. |
 | **No test framework for Electron** | Unit tests cover agents and log polling, but the Electron main process (state machine, windows, tray) has no automated tests. |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 一个能实时感知 AI 编程助手工作状态的桌面宠物。Clawd 住在你的屏幕上——你提问时它思考，工具运行时它打字，子代理工作时它杂耍，审批权限时它弹卡片，任务完成时它庆祝，你离开时它睡觉。
 
-> 支持 Windows 11、macOS 和 Ubuntu/Linux。需要 Node.js。支持 **Claude Code**、**Codex CLI**、**Copilot CLI**、**Gemini CLI** 与 **Cursor Agent**。
+> 支持 Windows 11、macOS 和 Ubuntu/Linux。需要 Node.js。支持 **Claude Code**、**Codex CLI**、**Copilot CLI**、**Gemini CLI**、**Cursor Agent** 与 **Qoder IDE**。
 
 ## 功能特性
 
@@ -18,6 +18,7 @@
 - **Copilot CLI** — 通过 `~/.copilot/hooks/hooks.json` 配置 command hook
 - **Gemini CLI** — 通过 `~/.gemini/settings.json` 配置 command hook（Clawd 启动时自动注册，或执行 `npm run install:gemini-hooks`）
 - **Cursor Agent** — [Cursor IDE hooks](https://cursor.com/docs/agent/hooks)，配置在 `~/.cursor/hooks.json`（Clawd 启动时自动注册，或执行 `npm run install:cursor-hooks`）
+- **Qoder IDE** — 通过 `~/.qoder/settings.json` 配置 command hook（Clawd 启动时自动注册）
 - **多 Agent 共存** — 多个 Agent 可同时运行，Clawd 独立追踪每个会话
 
 ### 动画与交互

--- a/agents/qoder.js
+++ b/agents/qoder.js
@@ -1,0 +1,30 @@
+// Qoder IDE agent configuration
+// Hooks via ~/.qoder/settings.json, stdin JSON + stdout JSON
+// Based on https://docs.qoder.com/zh/extensions/hooks
+
+module.exports = {
+  id: "qoder",
+  name: "Qoder IDE",
+  processNames: { win: ["qoder.exe"], mac: ["qoder"], linux: ["qoder"] },
+  nodeCommandPatterns: [],
+  eventSource: "hook",
+  // PascalCase event names — matches Qoder hook system
+  eventMap: {
+    UserPromptSubmit: "thinking",
+    PreToolUse: "working",
+    PostToolUse: "working",
+    PostToolUseFailure: "error",
+    Stop: "attention",
+  },
+  capabilities: {
+    httpHook: false,
+    permissionApproval: false, // PreToolUse exit 2 blocks, but no HTTP decision
+    sessionEnd: false,
+    subagent: false,
+  },
+  hookConfig: {
+    configFormat: "qoder-settings-json",
+  },
+  stdinFormat: "qoderHookJson",
+  pidField: "qoder_pid",
+};

--- a/agents/registry.js
+++ b/agents/registry.js
@@ -6,8 +6,9 @@ const codex = require("./codex");
 const copilotCli = require("./copilot-cli");
 const geminiCli = require("./gemini-cli");
 const cursorAgent = require("./cursor-agent");
+const qoder = require("./qoder");
 
-const AGENTS = [claudeCode, codex, copilotCli, geminiCli, cursorAgent];
+const AGENTS = [claudeCode, codex, copilotCli, geminiCli, cursorAgent, qoder];
 const AGENT_MAP = new Map(AGENTS.map((a) => [a.id, a]));
 
 module.exports = {

--- a/hooks/qoder-hook.js
+++ b/hooks/qoder-hook.js
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+// Clawd — Qoder IDE hook (stdin JSON with hook_event_name; stdout JSON for gating hooks)
+// Registered in ~/.qoder/settings.json by hooks/qoder-install.js
+
+const { postStateToRunningServer, readHostPrefix } = require("./server-config");
+
+// Qoder hook event → { state, event } for the Clawd state machine
+const HOOK_MAP = {
+  UserPromptSubmit: { state: "thinking", event: "UserPromptSubmit" },
+  PreToolUse:       { state: "working",  event: "PreToolUse" },
+  PostToolUse:      { state: "working",  event: "PostToolUse" },
+  PostToolUseFailure: { state: "error",  event: "PostToolUseFailure" },
+  Stop:             { state: "attention", event: "Stop" },
+};
+
+// Walk the process tree to find the terminal app PID.
+// Duplicated because hook scripts must be zero-dependency.
+const TERMINAL_NAMES_WIN = new Set([
+  "windowsterminal.exe", "cmd.exe", "powershell.exe", "pwsh.exe",
+  "code.exe", "alacritty.exe", "wezterm-gui.exe", "mintty.exe",
+  "conemu64.exe", "conemu.exe", "hyper.exe", "tabby.exe",
+  "antigravity.exe", "warp.exe", "iterm.exe", "ghostty.exe",
+]);
+const TERMINAL_NAMES_MAC = new Set([
+  "terminal", "iterm2", "alacritty", "wezterm-gui", "kitty",
+  "hyper", "tabby", "warp", "ghostty",
+]);
+const TERMINAL_NAMES_LINUX = new Set([
+  "gnome-terminal", "kgx", "konsole", "xfce4-terminal", "tilix",
+  "alacritty", "wezterm", "wezterm-gui", "kitty", "ghostty",
+  "xterm", "lxterminal", "terminator", "tabby", "hyper", "warp",
+]);
+
+const SYSTEM_BOUNDARY_WIN = new Set(["explorer.exe", "services.exe", "winlogon.exe", "svchost.exe"]);
+const SYSTEM_BOUNDARY_MAC = new Set(["launchd", "init", "systemd"]);
+const SYSTEM_BOUNDARY_LINUX = new Set(["systemd", "init"]);
+
+const EDITOR_MAP_WIN = { "code.exe": "code", "cursor.exe": "cursor", "qoder.exe": "qoder" };
+const EDITOR_MAP_MAC = { "code": "code", "cursor": "cursor", "qoder": "qoder" };
+const EDITOR_MAP_LINUX = { "code": "code", "cursor": "cursor", "code-insiders": "code", "qoder": "qoder" };
+
+const QODER_NAMES_WIN = new Set(["qoder.exe"]);
+const QODER_NAMES_MAC = new Set(["qoder"]);
+const QODER_NAMES_LINUX = new Set(["qoder"]);
+
+let _stablePid = null;
+let _detectedEditor = null;
+let _qoderPid = null;
+let _pidChain = [];
+
+function getStablePid() {
+  if (_stablePid) return _stablePid;
+  const { execSync } = require("child_process");
+  const isWin = process.platform === "win32";
+  const terminalNames = isWin ? TERMINAL_NAMES_WIN : (process.platform === "linux" ? TERMINAL_NAMES_LINUX : TERMINAL_NAMES_MAC);
+  const systemBoundary = isWin ? SYSTEM_BOUNDARY_WIN : (process.platform === "linux" ? SYSTEM_BOUNDARY_LINUX : SYSTEM_BOUNDARY_MAC);
+  const editorMap = isWin ? EDITOR_MAP_WIN : (process.platform === "linux" ? EDITOR_MAP_LINUX : EDITOR_MAP_MAC);
+  const qoderNames = isWin ? QODER_NAMES_WIN : (process.platform === "linux" ? QODER_NAMES_LINUX : QODER_NAMES_MAC);
+  let pid = process.ppid;
+  let lastGoodPid = pid;
+  let terminalPid = null;
+  _pidChain = [];
+  _detectedEditor = null;
+  _qoderPid = null;
+  for (let i = 0; i < 8; i++) {
+    let name, parentPid;
+    try {
+      if (isWin) {
+        const out = execSync(
+          `wmic process where "ProcessId=${pid}" get Name,ParentProcessId /format:csv`,
+          { encoding: "utf8", timeout: 1500, windowsHide: true }
+        );
+        const lines = out.trim().split("\n").filter(l => l.includes(","));
+        if (!lines.length) break;
+        const parts = lines[lines.length - 1].split(",");
+        name = (parts[1] || "").trim().toLowerCase();
+        parentPid = parseInt(parts[2], 10);
+      } else {
+        const cp = require("child_process");
+        const ppidOut = cp.execSync(`ps -o ppid= -p ${pid}`, { encoding: "utf8", timeout: 1000 }).trim();
+        const commOut = cp.execSync(`ps -o comm= -p ${pid}`, { encoding: "utf8", timeout: 1000 }).trim();
+        name = require("path").basename(commOut).toLowerCase();
+        if (!_detectedEditor) {
+          const fullLower = commOut.toLowerCase();
+          if (fullLower.includes("visual studio code")) _detectedEditor = "code";
+          else if (fullLower.includes("cursor.app")) _detectedEditor = "cursor";
+        }
+        parentPid = parseInt(ppidOut, 10);
+      }
+    } catch { break; }
+    _pidChain.push(pid);
+    if (!_detectedEditor && editorMap[name]) _detectedEditor = editorMap[name];
+    if (!_qoderPid && qoderNames.has(name)) _qoderPid = pid;
+    if (systemBoundary.has(name)) break;
+    if (terminalNames.has(name)) terminalPid = pid;
+    lastGoodPid = pid;
+    if (!parentPid || parentPid === pid || parentPid <= 1) break;
+    pid = parentPid;
+  }
+  _stablePid = terminalPid || lastGoodPid;
+  return _stablePid;
+}
+
+// Qoder gating hooks need stdout JSON response
+// exit 0 with empty JSON = allow, exit 2 = block
+function stdoutForEvent(hookName) {
+  // For PreToolUse, return empty JSON to allow execution
+  // The hook script exits 0 to indicate success/allow
+  return "{}";
+}
+
+// Read stdin JSON, extract event, post state, write stdout
+const chunks = [];
+let _ran = false;
+let _stdinTimer = null;
+
+function finishOnce(payload) {
+  if (_ran) return;
+  _ran = true;
+  if (_stdinTimer) clearTimeout(_stdinTimer);
+
+  const hookName = (payload && payload.hook_event_name) || "";
+  const mapped = HOOK_MAP[hookName];
+
+  if (!mapped) {
+    process.stdout.write(stdoutForEvent(hookName) + "\n");
+    process.exit(0);
+    return;
+  }
+
+  const { state, event } = mapped;
+
+  // Pre-resolve PID on first event if not remote
+  if (!process.env.CLAWD_REMOTE) getStablePid();
+
+  const sessionId = (payload && payload.session_id) || "default";
+  const cwd = (payload && payload.cwd) || "";
+
+  const body = { state, session_id: sessionId, event };
+  body.agent_id = "qoder";
+  if (cwd) body.cwd = cwd;
+  if (process.env.CLAWD_REMOTE) {
+    body.host = readHostPrefix();
+  } else {
+    body.source_pid = getStablePid();
+    if (_detectedEditor) body.editor = _detectedEditor;
+    if (_qoderPid) {
+      body.agent_pid = _qoderPid;
+      body.qoder_pid = _qoderPid;
+    }
+    if (_pidChain.length) body.pid_chain = _pidChain;
+  }
+
+  const outLine = stdoutForEvent(hookName);
+  const data = JSON.stringify(body);
+  postStateToRunningServer(data, { timeoutMs: 100 }, () => {
+    process.stdout.write(outLine + "\n");
+    process.exit(0);
+  });
+}
+
+// Fallback: if stdin doesn't arrive in 400ms, send minimal response
+_stdinTimer = setTimeout(() => finishOnce(null), 400);
+
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => chunks.push(chunk));
+process.stdin.on("end", () => {
+  let payload = null;
+  try {
+    payload = JSON.parse(chunks.join(""));
+  } catch {}
+  finishOnce(payload);
+});

--- a/hooks/qoder-install.js
+++ b/hooks/qoder-install.js
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// Merge Clawd Qoder hooks into ~/.qoder/settings.json (append-only, idempotent)
+// Based on https://docs.qoder.com/zh/extensions/hooks
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { resolveNodeBin } = require("./server-config");
+const MARKER = "qoder-hook.js";
+
+/** Extract the existing absolute node path from hook commands containing marker. */
+function extractExistingNodeBin(settings, marker) {
+  if (!settings || !settings.hooks) return null;
+  for (const entries of Object.values(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== "object") continue;
+      // Qoder uses nested format: entry.hooks[].command
+      if (Array.isArray(entry.hooks)) {
+        for (const hook of entry.hooks) {
+          if (!hook || typeof hook !== "object" || typeof hook.command !== "string") continue;
+          if (!hook.command.includes(marker)) continue;
+          const qi = hook.command.indexOf('"');
+          if (qi === -1) continue;
+          const qe = hook.command.indexOf('"', qi + 1);
+          if (qe === -1) continue;
+          const first = hook.command.substring(qi + 1, qe);
+          if (!first.includes(marker) && first.startsWith("/")) return first;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+// Qoder hook events to register
+// Based on docs: UserPromptSubmit, PreToolUse, PostToolUse, PostToolUseFailure, Stop
+const QODER_HOOK_EVENTS = [
+  "UserPromptSubmit",
+  "PreToolUse",
+  "PostToolUse",
+  "PostToolUseFailure",
+  "Stop",
+];
+
+function writeJsonAtomic(filePath, data) {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const tmpPath = path.join(dir, `.${base}.${process.pid}.${Date.now()}.tmp`);
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2), "utf-8");
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch {}
+    throw err;
+  }
+}
+
+/**
+ * Register Clawd hooks into ~/.qoder/settings.json
+ * Qoder hook format:
+ * {
+ *   "hooks": {
+ *     "EventName": [
+ *       {
+ *         "matcher": "...",
+ *         "hooks": [
+ *           { "type": "command", "command": "..." }
+ *         ]
+ *       }
+ *     ]
+ *   }
+ * }
+ * @param {object} [options]
+ * @param {boolean} [options.silent]
+ * @param {string} [options.settingsPath]
+ * @returns {{ added: number, skipped: number, updated: number }}
+ */
+function registerQoderHooks(options = {}) {
+  const settingsPath = options.settingsPath || path.join(os.homedir(), ".qoder", "settings.json");
+
+  // Skip if ~/.qoder/ doesn't exist (Qoder not installed)
+  const qoderDir = path.dirname(settingsPath);
+  if (!options.settingsPath && !fs.existsSync(qoderDir)) {
+    if (!options.silent) console.log("Clawd: ~/.qoder/ not found — skipping Qoder hook registration");
+    return { added: 0, skipped: 0, updated: 0 };
+  }
+
+  let hookScript = path.resolve(__dirname, "qoder-hook.js").replace(/\\/g, "/");
+  hookScript = hookScript.replace("app.asar/", "app.asar.unpacked/");
+
+  let settings = {};
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      throw new Error(`Failed to read settings.json: ${err.message}`);
+    }
+  }
+
+  // Resolve node path; if detection fails, preserve existing absolute path
+  const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
+  const nodeBin = resolved
+    || extractExistingNodeBin(settings, MARKER)
+    || "node";
+  const desiredCommand = `"${nodeBin}" "${hookScript}"`;
+
+  if (!settings.hooks || typeof settings.hooks !== "object") settings.hooks = {};
+
+  let added = 0;
+  let skipped = 0;
+  let updated = 0;
+  let changed = false;
+
+  for (const event of QODER_HOOK_EVENTS) {
+    if (!Array.isArray(settings.hooks[event])) {
+      settings.hooks[event] = [];
+      changed = true;
+    }
+
+    const arr = settings.hooks[event];
+    let found = false;
+    let stalePath = false;
+
+    // Search for existing Clawd hook entry
+    for (const entry of arr) {
+      if (!entry || typeof entry !== "object") continue;
+
+      // Check nested hooks array format (Qoder uses matcher + hooks structure)
+      if (Array.isArray(entry.hooks)) {
+        for (const hook of entry.hooks) {
+          if (!hook || typeof hook !== "object" || typeof hook.command !== "string") continue;
+          if (!hook.command.includes(MARKER)) continue;
+          found = true;
+          if (hook.command !== desiredCommand) {
+            hook.command = desiredCommand;
+            stalePath = true;
+          }
+          break;
+        }
+      }
+      if (found) break;
+    }
+
+    if (found) {
+      if (stalePath) {
+        updated++;
+        changed = true;
+      } else {
+        skipped++;
+      }
+      continue;
+    }
+
+    // Add new hook entry using Qoder's nested format
+    arr.push({
+      matcher: "",
+      hooks: [
+        {
+          type: "command",
+          command: desiredCommand,
+        },
+      ],
+    });
+    added++;
+    changed = true;
+  }
+
+  if (added > 0 || changed) {
+    writeJsonAtomic(settingsPath, settings);
+  }
+
+  if (!options.silent) {
+    console.log(`Clawd Qoder hooks → ${settingsPath}`);
+    console.log(`  Added: ${added}, updated: ${updated}, skipped: ${skipped}`);
+  }
+
+  return { added, skipped, updated };
+}
+
+/**
+ * Unregister Clawd hooks from ~/.qoder/settings.json
+ * @param {object} [options]
+ * @param {boolean} [options.silent]
+ * @param {string} [options.settingsPath]
+ * @returns {{ removed: number }}
+ */
+function unregisterQoderHooks(options = {}) {
+  const settingsPath = options.settingsPath || path.join(os.homedir(), ".qoder", "settings.json");
+
+  let settings = {};
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+  } catch (err) {
+    if (err.code === "ENOENT") {
+      return { removed: 0 };
+    }
+    throw new Error(`Failed to read settings.json: ${err.message}`);
+  }
+
+  if (!settings.hooks || typeof settings.hooks !== "object") {
+    return { removed: 0 };
+  }
+
+  let removed = 0;
+  let changed = false;
+
+  for (const event of Object.keys(settings.hooks)) {
+    if (!Array.isArray(settings.hooks[event])) continue;
+
+    const originalLen = settings.hooks[event].length;
+    settings.hooks[event] = settings.hooks[event].filter((entry) => {
+      if (!entry || typeof entry !== "object") return true;
+
+      // Check nested hooks array
+      if (Array.isArray(entry.hooks)) {
+        const hasClawdHook = entry.hooks.some(
+          (hook) => hook && typeof hook.command === "string" && hook.command.includes(MARKER)
+        );
+        if (hasClawdHook) return false;
+      }
+      return true;
+    });
+
+    const removedCount = originalLen - settings.hooks[event].length;
+    if (removedCount > 0) {
+      removed += removedCount;
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    writeJsonAtomic(settingsPath, settings);
+  }
+
+  if (!options.silent && removed > 0) {
+    console.log(`Clawd: Removed ${removed} Qoder hooks from ${settingsPath}`);
+  }
+
+  return { removed };
+}
+
+module.exports = { registerQoderHooks, unregisterQoderHooks };
+
+// CLI execution
+if (require.main === module) {
+  registerQoderHooks({ silent: false });
+}

--- a/src/server.js
+++ b/src/server.js
@@ -64,6 +64,18 @@ function syncCursorHooks() {
   }
 }
 
+function syncQoderHooks() {
+  try {
+    const { registerQoderHooks } = require("../hooks/qoder-install.js");
+    const { added, updated } = registerQoderHooks({ silent: true });
+    if (added > 0 || updated > 0) {
+      console.log(`Clawd: synced Qoder hooks (added ${added}, updated ${updated})`);
+    }
+  } catch (err) {
+    console.warn("Clawd: failed to sync Qoder hooks:", err.message);
+  }
+}
+
 function sendStateHealthResponse(res) {
   const body = JSON.stringify({ ok: true, app: CLAWD_SERVER_ID, port: getHookServerPort() });
   res.writeHead(200, {
@@ -323,6 +335,7 @@ function startHttpServer() {
     syncClawdHooks();
     syncGeminiHooks();
     syncCursorHooks();
+    syncQoderHooks();
     watchSettingsForHookLoss();
   });
 
@@ -335,6 +348,6 @@ function cleanup() {
   if (httpServer) httpServer.close();
 }
 
-return { startHttpServer, getHookServerPort, syncClawdHooks, syncGeminiHooks, syncCursorHooks, cleanup };
+return { startHttpServer, getHookServerPort, syncClawdHooks, syncGeminiHooks, syncCursorHooks, syncQoderHooks, cleanup };
 
 };

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -3,15 +3,16 @@ const assert = require("node:assert");
 const registry = require("../agents/registry");
 
 describe("Agent Registry", () => {
-  it("should return all five agents", () => {
+  it("should return all six agents", () => {
     const agents = registry.getAllAgents();
-    assert.strictEqual(agents.length, 5);
+    assert.strictEqual(agents.length, 6);
     const ids = agents.map((a) => a.id);
     assert.ok(ids.includes("claude-code"));
     assert.ok(ids.includes("codex"));
     assert.ok(ids.includes("copilot-cli"));
     assert.ok(ids.includes("gemini-cli"));
     assert.ok(ids.includes("cursor-agent"));
+    assert.ok(ids.includes("qoder"));
   });
 
   it("should look up agents by ID", () => {
@@ -20,6 +21,7 @@ describe("Agent Registry", () => {
     assert.strictEqual(registry.getAgent("copilot-cli").name, "Copilot CLI");
     assert.strictEqual(registry.getAgent("gemini-cli").name, "Gemini CLI");
     assert.strictEqual(registry.getAgent("cursor-agent").name, "Cursor Agent");
+    assert.strictEqual(registry.getAgent("qoder").name, "Qoder IDE");
     assert.strictEqual(registry.getAgent("nonexistent"), undefined);
   });
 
@@ -40,6 +42,9 @@ describe("Agent Registry", () => {
 
     const cursor = registry.getAgent("cursor-agent");
     assert.deepStrictEqual(cursor.processNames.win, ["Cursor.exe"]);
+
+    const qoder = registry.getAgent("qoder");
+    assert.deepStrictEqual(qoder.processNames.win, ["qoder.exe"]);
   });
 
   it("should include explicit Linux process names", () => {
@@ -57,11 +62,14 @@ describe("Agent Registry", () => {
 
     const cursor = registry.getAgent("cursor-agent");
     assert.deepStrictEqual(cursor.processNames.linux, ["cursor", "Cursor"]);
+
+    const qoder = registry.getAgent("qoder");
+    assert.deepStrictEqual(qoder.processNames.linux, ["qoder"]);
   });
 
   it("should aggregate all process names", () => {
     const all = registry.getAllProcessNames();
-    assert.ok(all.length >= 5);
+    assert.ok(all.length >= 6);
     const names = all.map((p) => p.name);
     // Should contain at least one entry per agent (platform-dependent)
     const agentIds = [...new Set(all.map((p) => p.agentId))];
@@ -70,6 +78,7 @@ describe("Agent Registry", () => {
     assert.ok(agentIds.includes("copilot-cli"));
     assert.ok(agentIds.includes("gemini-cli"));
     assert.ok(agentIds.includes("cursor-agent"));
+    assert.ok(agentIds.includes("qoder"));
   });
 
   it("should have correct capabilities", () => {
@@ -102,6 +111,12 @@ describe("Agent Registry", () => {
     assert.strictEqual(cursor.capabilities.permissionApproval, false);
     assert.strictEqual(cursor.capabilities.sessionEnd, true);
     assert.strictEqual(cursor.capabilities.subagent, true);
+
+    const qoder = registry.getAgent("qoder");
+    assert.strictEqual(qoder.capabilities.httpHook, false);
+    assert.strictEqual(qoder.capabilities.permissionApproval, false);
+    assert.strictEqual(qoder.capabilities.sessionEnd, false);
+    assert.strictEqual(qoder.capabilities.subagent, false);
   });
 
   it("should have eventMap for hook-based agents", () => {
@@ -125,6 +140,11 @@ describe("Agent Registry", () => {
     assert.strictEqual(cursor.eventMap.preToolUse, "working");
     assert.strictEqual(cursor.eventMap.afterAgentThought, "thinking");
     assert.strictEqual(cursor.eventMap.stop, "attention");
+
+    const qoder = registry.getAgent("qoder");
+    assert.strictEqual(qoder.eventMap.UserPromptSubmit, "thinking");
+    assert.strictEqual(qoder.eventMap.PreToolUse, "working");
+    assert.strictEqual(qoder.eventMap.Stop, "attention");
   });
 
   it("should have logEventMap for poll-based agents", () => {


### PR DESCRIPTION
## Summary

Add Qoder IDE as a new supported agent for Clawd on Desk.

## Changes

- **agents/qoder.js** - Agent configuration with event mapping (UserPromptSubmit, PreToolUse, PostToolUse, PostToolUseFailure, Stop)
- **hooks/qoder-hook.js** - Hook script that processes stdin JSON and posts state to Clawd server
- **hooks/qoder-install.js** - Installation script to register hooks in `~/.qoder/settings.json`
- **agents/registry.js** - Added Qoder to agent registry (now 6 agents total)
- **src/server.js** - Added `syncQoderHooks()` to auto-register hooks on startup
- **README.md / README.zh-CN.md** - Updated documentation
- **test/registry.test.js** - Updated tests for 6 agents

## Implementation Details

Based on [Qoder Hooks documentation](https://docs.qoder.com/zh/extensions/hooks):
- Hooks are registered in `~/.qoder/settings.json` using nested format (matcher + hooks array)
- stdin JSON contains `hook_event_name`, `session_id`, `cwd`, etc.
- stdout JSON response with exit 0 = allow, exit 2 = block

## Limitations

- Qoder doesn't emit SessionStart/SessionEnd events, so Clawd can't detect session lifecycle

## Testing

All 55 tests pass.