### PR TITLE
feat: subscription usage display (statusLine proxy + context menu + badge)

### DIFF
--- a/hooks/statusline-install.js
+++ b/hooks/statusline-install.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Clawd Desktop Pet — StatusLine Proxy Installer
+// Registers Clawd's statusLine proxy into ~/.claude/settings.json
+// Preserves the user's original statusLine command by chaining
+
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const { writeJsonAtomic, asarUnpackedPath } = require("./json-utils");
+const { resolveNodeBin } = require("./server-config");
+
+const PROXY_MARKER = "statusline-proxy.js";
+
+/**
+ * Register Clawd's statusLine proxy in Claude Code settings.
+ * @param {object} [options]
+ * @param {boolean} [options.silent]
+ * @param {string} [options.settingsPath] - override for tests
+ * @returns {{ added: boolean, updated: boolean }}
+ */
+function registerStatusLine(options = {}) {
+  const settingsPath = options.settingsPath || path.join(os.homedir(), ".claude", "settings.json");
+  const proxyScript = asarUnpackedPath(path.resolve(__dirname, "statusline-proxy.js").replace(/\\/g, "/"));
+
+  let settings = {};
+  try {
+    settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+  } catch (err) {
+    if (err.code !== "ENOENT") return { added: false, updated: false };
+    // No settings file — nothing to do (hooks installer creates it)
+  }
+
+  const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
+  const nodeBin = resolved || "node";
+
+  const existing = settings.statusLine;
+  let added = false;
+  let updated = false;
+
+  // Already registered — check if path needs updating
+  if (existing && existing.type === "command" && typeof existing.command === "string" && existing.command.includes(PROXY_MARKER)) {
+    // Extract original command from existing proxy invocation (everything after proxy script path)
+    const originalCmd = extractOriginalFromProxy(existing.command);
+    const desired = buildProxyCommand(nodeBin, proxyScript, originalCmd);
+    if (existing.command !== desired) {
+      existing.command = desired;
+      updated = true;
+      writeJsonAtomic(settingsPath, settings);
+    }
+    if (!options.silent && (added || updated)) {
+      console.log(`Clawd: statusLine proxy ${updated ? "updated" : "unchanged"}`);
+    }
+    return { added, updated };
+  }
+
+  // Not registered — preserve original and wrap with proxy
+  let originalCmd = null;
+  if (existing && existing.type === "command" && typeof existing.command === "string") {
+    originalCmd = existing.command;
+  }
+
+  settings.statusLine = {
+    type: "command",
+    command: buildProxyCommand(nodeBin, proxyScript, originalCmd),
+    padding: (existing && typeof existing.padding === "number") ? existing.padding : 0,
+  };
+  added = true;
+
+  writeJsonAtomic(settingsPath, settings);
+
+  if (!options.silent) {
+    console.log(`Clawd: statusLine proxy registered${originalCmd ? " (chaining original)" : ""}`);
+  }
+  return { added, updated };
+}
+
+function buildProxyCommand(nodeBin, proxyScript, originalCmd) {
+  const base = `"${nodeBin}" "${proxyScript}"`;
+  if (!originalCmd) return base;
+  return `${base} ${originalCmd}`;
+}
+
+/**
+ * Extract the original statusLine command from an existing proxy command string.
+ * Format: "node" "path/to/statusline-proxy.js" original-command-here
+ */
+function extractOriginalFromProxy(command) {
+  const idx = command.indexOf(PROXY_MARKER);
+  if (idx === -1) return null;
+  // Find the closing quote after the proxy script path
+  const afterMarker = command.indexOf('"', idx);
+  if (afterMarker === -1) return null;
+  const rest = command.substring(afterMarker + 1).trim();
+  return rest || null;
+}
+
+module.exports = { registerStatusLine };
+
+if (require.main === module) {
+  registerStatusLine();
+}

--- a/hooks/statusline-proxy.js
+++ b/hooks/statusline-proxy.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Clawd Desktop Pet — Claude Code StatusLine Proxy
+// Forwards usage data (rate_limits, cost, context_window) to Clawd server,
+// then chains to the user's original statusLine command if configured.
+//
+// Usage in ~/.claude/settings.json:
+//   "statusLine": {
+//     "type": "command",
+//     "command": "\"node\" \"path/to/statusline-proxy.js\" [original-command]"
+//   }
+
+const http = require("http");
+const { spawn } = require("child_process");
+const { readRuntimePort, DEFAULT_SERVER_PORT } = require("./server-config");
+
+// Read all stdin
+let input = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk) => { input += chunk; });
+process.stdin.on("end", () => {
+  // Forward usage data to Clawd (fire-and-forget)
+  forwardUsage(input);
+
+  // Chain to original statusLine command if specified
+  const originalCmd = process.argv[2];
+  if (originalCmd) {
+    chainOriginal(originalCmd, process.argv.slice(3), input);
+  }
+});
+
+function forwardUsage(raw) {
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    return; // invalid JSON, skip
+  }
+
+  // Only forward if there's usage-relevant data
+  const payload = {};
+  if (data.rate_limits) payload.rate_limits = data.rate_limits;
+  if (data.cost) payload.cost = data.cost;
+  if (data.model) payload.model = data.model;
+  if (data.context_window) payload.context_window = data.context_window;
+
+  if (Object.keys(payload).length === 0) return;
+
+  const body = JSON.stringify(payload);
+  const port = readRuntimePort() || DEFAULT_SERVER_PORT;
+
+  const req = http.request(
+    {
+      hostname: "127.0.0.1",
+      port,
+      path: "/usage",
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(body),
+      },
+      timeout: 200,
+    },
+    (res) => { res.resume(); } // drain response
+  );
+
+  req.on("error", () => {}); // silently ignore connection failures
+  req.on("timeout", () => { req.destroy(); });
+  req.end(body);
+}
+
+function chainOriginal(cmd, args, stdinData) {
+  // The original command could be a quoted path or a shell command.
+  // Spawn it and pipe the same stdin data.
+  const isWin = process.platform === "win32";
+  const child = spawn(cmd, args, {
+    stdio: ["pipe", "inherit", "inherit"],
+    shell: isWin, // use shell on Windows for proper command resolution
+    windowsHide: true,
+  });
+
+  child.stdin.write(stdinData);
+  child.stdin.end();
+
+  child.on("exit", (code) => {
+    process.exitCode = code || 0;
+  });
+
+  child.on("error", () => {
+    // Original command failed — output nothing, let Claude Code show blank statusLine
+  });
+}

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
 <body>
   <div id="pet-container">
     <object id="clawd" type="image/svg+xml"></object>
+    <div id="usage-badge"></div>
   </div>
   <script src="renderer.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -106,6 +106,7 @@ let bubbleFollowPet = false;
 let hideBubbles = false;
 let showSessionId = false;
 let soundMuted = false;
+let usageData = null;
 let petHidden = false;
 const DEFAULT_TOGGLE_SHORTCUT = "CommandOrControl+Shift+Alt+C";
 
@@ -356,6 +357,11 @@ const _serverCtx = {
   showPermissionBubble,
   replyOpencodePermission,
   permLog,
+  sendToRenderer,
+  buildContextMenu: () => buildContextMenu(),
+  buildTrayMenu: () => buildTrayMenu(),
+  get usageData() { return usageData; },
+  set usageData(v) { usageData = v; },
 };
 const _server = require("./server")(_serverCtx);
 const { startHttpServer, getHookServerPort } = _server;
@@ -488,6 +494,7 @@ const _menuCtx = {
   discoverThemes: () => themeLoader.discoverThemes(),
   getActiveThemeId: () => activeTheme ? activeTheme._id : "clawd",
   ensureUserThemesDir: () => themeLoader.ensureUserThemesDir(),
+  get usageData() { return usageData; },
 };
 const _menu = require("./menu")(_menuCtx);
 const { t, buildContextMenu, buildTrayMenu, rebuildAllMenus, createTray,

--- a/src/menu.js
+++ b/src/menu.js
@@ -101,6 +101,13 @@ const i18n = {
     sessionMinAgo: "{n}m ago",
     sessionHrAgo: "{n}h ago",
     soundEffects: "Sound Effects",
+    usage: "Usage",
+    usage5h: "5h Window",
+    usage7d: "Weekly",
+    usageContext: "Context",
+    usageCost: "Session Cost",
+    usageModel: "Model",
+    usageResets: "resets in {time}",
     showPet: "Show Clawd",
     hidePet: "Hide Clawd",
     theme: "Theme",
@@ -155,6 +162,13 @@ const i18n = {
     sessionMinAgo: "{n}分钟前",
     sessionHrAgo: "{n}小时前",
     soundEffects: "音效",
+    usage: "使用量",
+    usage5h: "5 小时窗口",
+    usage7d: "每周",
+    usageContext: "上下文",
+    usageCost: "本次花费",
+    usageModel: "模型",
+    usageResets: "{time}后重置",
     showPet: "显示 Clawd",
     hidePet: "隐藏 Clawd",
     theme: "主题",
@@ -198,6 +212,81 @@ module.exports = function initMenu(ctx) {
     });
 
     return items;
+  }
+
+  // ── Usage submenu builder ──
+  function formatTimeRemaining(resetAt) {
+    if (!resetAt) return null;
+    const now = Date.now();
+    // resets_at can be a Unix timestamp in seconds or an ISO date string
+    let resetMs = typeof resetAt === "number" && resetAt < 1e12
+      ? resetAt * 1000
+      : new Date(resetAt).getTime();
+    if (Number.isNaN(resetMs)) return null;
+    const diff = resetMs - now;
+    if (diff <= 0) return "0m";
+    const days = Math.floor(diff / 86400000);
+    const hours = Math.floor((diff % 86400000) / 3600000);
+    const mins = Math.floor((diff % 3600000) / 60000);
+    if (days > 0) return `${days}d${hours}h`;
+    if (hours > 0) return `${hours}h${mins}m`;
+    return `${mins}m`;
+  }
+
+  function usageBar(pct) {
+    const filled = Math.round((pct / 100) * 10);
+    const empty = 10 - filled;
+    return "█".repeat(filled) + "░".repeat(empty);
+  }
+
+  function buildUsageSubmenu() {
+    const u = ctx.usageData;
+    if (!u) return [{ label: t("usageNoData"), enabled: false }];
+    // Stale check: ignore data older than 10 minutes
+    if (u.updatedAt && Date.now() - u.updatedAt > 600000) {
+      return [{ label: t("usageNoData"), enabled: false }];
+    }
+    const items = [];
+    if (u.model && u.model.display_name) {
+      items.push({ label: `${t("usageModel")}: ${u.model.display_name}`, enabled: false });
+    }
+    if (u.cost && typeof u.cost.total_cost_usd === "number") {
+      items.push({ label: `${t("usageCost")}: $${u.cost.total_cost_usd.toFixed(3)}`, enabled: false });
+    }
+    if (u.rate_limits) {
+      if (u.rate_limits.five_hour) {
+        const pct = Math.round(u.rate_limits.five_hour.used_percentage || 0);
+        const bar = usageBar(pct);
+        let label = `${t("usage5h")}  ${bar}  ${pct}%`;
+        const remaining = formatTimeRemaining(u.rate_limits.five_hour.resets_at);
+        if (remaining) label += `  (${t("usageResets").replace("{time}", remaining)})`;
+        items.push({ label, enabled: false });
+      }
+      if (u.rate_limits.seven_day) {
+        const pct = Math.round(u.rate_limits.seven_day.used_percentage || 0);
+        const bar = usageBar(pct);
+        let label = `${t("usage7d")}  ${bar}  ${pct}%`;
+        const remaining = formatTimeRemaining(u.rate_limits.seven_day.resets_at);
+        if (remaining) label += `  (${t("usageResets").replace("{time}", remaining)})`;
+        items.push({ label, enabled: false });
+      }
+    }
+    if (u.context_window && typeof u.context_window.used_percentage === "number") {
+      const pct = Math.round(u.context_window.used_percentage);
+      const bar = usageBar(pct);
+      items.push({ label: `${t("usageContext")}  ${bar}  ${pct}%`, enabled: false });
+    }
+    return items;
+  }
+
+  function buildUsageMenuItems() {
+    const u = ctx.usageData;
+    if (!u || !u.rate_limits) return [];
+    if (u.updatedAt && Date.now() - u.updatedAt > 600000) return [];
+    return [
+      { label: t("usage"), submenu: buildUsageSubmenu() },
+      { type: "separator" },
+    ];
   }
 
   // ── System tray ──
@@ -311,6 +400,7 @@ module.exports = function initMenu(ctx) {
         },
       },
       { type: "separator" },
+      ...buildUsageMenuItems(),
       {
         label: t("theme"),
         submenu: buildThemeSubmenu(),
@@ -503,6 +593,7 @@ module.exports = function initMenu(ctx) {
         submenu: ctx.buildSessionSubmenu(),
       },
       { type: "separator" },
+      ...buildUsageMenuItems(),
       {
         label: t("theme"),
         submenu: buildThemeSubmenu(),

--- a/src/preload.js
+++ b/src/preload.js
@@ -21,6 +21,8 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onPlayClickReaction: (cb) => ipcRenderer.on("play-click-reaction", (_, svg, duration) => cb(svg, duration)),
   // Sound playback (from main)
   onPlaySound: (cb) => ipcRenderer.on("play-sound", (_, name) => cb(name)),
+  // Usage badge
+  onUsageUpdate: (cb) => ipcRenderer.on("usage-update", (_, data) => cb(data)),
   // Render window → main (cursor polling control during reactions)
   pauseCursorPolling: () => ipcRenderer.send("pause-cursor-polling"),
   resumeFromReaction: () => ipcRenderer.send("resume-from-reaction"),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -284,8 +284,51 @@ function swapToFile(file, state, useObjectChannel) {
   }
 }
 
+// --- Usage badge (below pet during working/thinking states) ---
+const usageBadge = document.getElementById("usage-badge");
+let usageBadgeData = null;
+const USAGE_BADGE_STATES = new Set(["working", "thinking", "juggling"]);
+
+function pickBarColor(pct) {
+  if (pct >= 80) return "#ff5252";
+  if (pct >= 50) return "#ffab40";
+  return "#69f0ae";
+}
+
+function fmtRemaining(resetAt) {
+  if (!resetAt) return null;
+  const resetMs = typeof resetAt === "number" && resetAt < 1e12 ? resetAt * 1000 : new Date(resetAt).getTime();
+  if (Number.isNaN(resetMs)) return null;
+  const diff = resetMs - Date.now();
+  if (diff <= 0) return "0m";
+  const h = Math.floor(diff / 3600000);
+  const m = Math.floor((diff % 3600000) / 60000);
+  return h > 0 ? `${h}h${m}m` : `${m}m`;
+}
+
+function renderUsageBadge(state) {
+  if (!usageBadge) return;
+  const fh = usageBadgeData && usageBadgeData.rate_limits && usageBadgeData.rate_limits.five_hour;
+  if (!fh || typeof fh.used_percentage !== "number" || !USAGE_BADGE_STATES.has(state)) {
+    usageBadge.classList.remove("visible");
+    return;
+  }
+  const pct = Math.round(fh.used_percentage);
+  const color = pickBarColor(pct);
+  const remaining = fmtRemaining(fh.resets_at);
+  const text = remaining ? `${pct}%/${remaining}` : `${pct}%`;
+  usageBadge.textContent = text;
+  usageBadge.style.color = color;
+  usageBadge.classList.add("visible");
+}
+
+window.electronAPI.onUsageUpdate((data) => {
+  usageBadgeData = data;
+});
+
 // --- State change → switch animation (preload + instant swap) ---
 window.electronAPI.onStateChange((state, svg) => {
+  renderUsageBadge(state);
   // Main process state change → cancel any active click reaction
   cancelReaction();
 

--- a/src/server.js
+++ b/src/server.js
@@ -100,6 +100,18 @@ function syncOpencodePlugin() {
   }
 }
 
+function syncStatusLineProxy() {
+  try {
+    const { registerStatusLine } = require("../hooks/statusline-install.js");
+    const { added, updated } = registerStatusLine({ silent: true });
+    if (added || updated) {
+      console.log(`Clawd: synced statusLine proxy (added=${added}, updated=${updated})`);
+    }
+  } catch (err) {
+    console.warn("Clawd: failed to sync statusLine proxy:", err.message);
+  }
+}
+
 function sendStateHealthResponse(res) {
   const body = JSON.stringify({ ok: true, app: CLAWD_SERVER_ID, port: getHookServerPort() });
   res.writeHead(200, {
@@ -438,6 +450,37 @@ function startHttpServer() {
           }
         }
       });
+    } else if (req.method === "POST" && req.url === "/usage") {
+      let body = "";
+      let bodySize = 0;
+      let tooLarge = false;
+      req.on("data", (chunk) => {
+        if (tooLarge) return;
+        bodySize += chunk.length;
+        if (bodySize > 4096) { tooLarge = true; return; }
+        body += chunk;
+      });
+      req.on("end", () => {
+        if (tooLarge) {
+          res.writeHead(413);
+          res.end("usage payload too large");
+          return;
+        }
+        let data;
+        try {
+          data = JSON.parse(body);
+        } catch {
+          res.writeHead(400);
+          res.end("bad json");
+          return;
+        }
+        ctx.usageData = { ...data, updatedAt: Date.now() };
+        ctx.sendToRenderer("usage-update", ctx.usageData);
+        ctx.buildContextMenu();
+        ctx.buildTrayMenu();
+        res.writeHead(200, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
+        res.end("ok");
+      });
     } else {
       res.writeHead(404);
       res.end();
@@ -476,6 +519,7 @@ function startHttpServer() {
       syncCodeBuddyHooks();
       syncKiroHooks();
       syncOpencodePlugin();
+      syncStatusLineProxy();
       watchSettingsForHookLoss();
     });
   });
@@ -489,6 +533,6 @@ function cleanup() {
   if (httpServer) httpServer.close();
 }
 
-return { startHttpServer, getHookServerPort, syncClawdHooks, syncGeminiHooks, syncCursorHooks, syncCodeBuddyHooks, syncKiroHooks, syncOpencodePlugin, cleanup };
+return { startHttpServer, getHookServerPort, syncClawdHooks, syncGeminiHooks, syncCursorHooks, syncCodeBuddyHooks, syncKiroHooks, syncOpencodePlugin, syncStatusLineProxy, cleanup };
 
 };

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,3 +41,27 @@ html, body {
 #pet-container.mini-left {
   transform: scaleX(-1);
 }
+
+/* ── Usage badge (below pet) ── */
+#usage-badge {
+  position: absolute;
+  bottom: 2%;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  pointer-events: none;
+  font-family: "SF Mono", "Cascadia Code", "Consolas", monospace;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  white-space: nowrap;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.9), 0 0 6px currentColor;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+#usage-badge.visible {
+  opacity: 1;
+}
+.mini-left #usage-badge {
+  transform: translateX(-50%) scaleX(-1);
+}


### PR DESCRIPTION
## Summary

- Add real-time subscription usage display by intercepting Claude Code's statusLine hook data
- Show compact `26%/2h47m` badge below the pet during working/thinking states
- Add Usage submenu in right-click menu and system tray with 5h/7d rate limits, context window, model, and session cost
- New `POST /usage` endpoint + statusLine proxy script (zero dependencies, chains to user's original statusLine command)

## Data flow

```
Claude Code statusLine → statusline-proxy.js → POST /usage → main.js shared state → IPC to renderer + menu rebuild
```