### PR TITLE
fix: restore previous app focus after permission hotkey on macOS

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -12,6 +12,24 @@ const {
 const isMac = process.platform === "darwin";
 const isLinux = process.platform === "linux";
 const isWin = process.platform === "win32";
+const { execFile } = require("child_process");
+
+function captureFrontApp(cb) {
+  if (!isMac) { cb(null); return; }
+  execFile("osascript", ["-e",
+    'tell application "System Events" to get name of first application process whose frontmost is true'
+  ], { timeout: 500 }, (err, stdout) => {
+    cb(err ? null : stdout.trim());
+  });
+}
+
+function restoreFrontApp(appName) {
+  if (!isMac || !appName) return;
+  execFile("osascript", ["-e",
+    `tell application "${appName.replace(/"/g, '\\"')}" to activate`
+  ], { timeout: 1000 }, () => {});
+}
+
 const WIN_TOPMOST_LEVEL = "pop-up-menu";
 const LINUX_WINDOW_TYPE = "toolbar";
 
@@ -52,19 +70,21 @@ function syncPermissionShortcuts() {
   }
 }
 
-function hotkeyAllow() {
+function hotkeyResolve(behavior, message) {
   const targets = getActionablePermissions();
   if (!targets.length) return;
   const perm = targets[targets.length - 1]; // newest
-  resolvePermissionEntry(perm, "allow");
+  captureFrontApp((appName) => {
+    resolvePermissionEntry(perm, behavior, message);
+    setTimeout(() => {
+      if (appName) restoreFrontApp(appName);
+      else ctx.focusTerminalForSession(perm.sessionId);
+    }, 300);
+  });
 }
 
-function hotkeyDeny() {
-  const targets = getActionablePermissions();
-  if (!targets.length) return;
-  const perm = targets[targets.length - 1]; // newest
-  resolvePermissionEntry(perm, "deny", "Denied via hotkey");
-}
+function hotkeyAllow() { hotkeyResolve("allow"); }
+function hotkeyDeny()  { hotkeyResolve("deny", "Denied via hotkey"); }
 
 // Fallback height before renderer reports actual measurement
 function estimateBubbleHeight(sugCount) {

--- a/src/permission.js
+++ b/src/permission.js
@@ -26,7 +26,7 @@ function captureFrontApp(cb) {
 function restoreFrontApp(appName) {
   if (!isMac || !appName) return;
   execFile("osascript", ["-e",
-    `tell application "${appName.replace(/"/g, '\\"')}" to activate`
+    `tell application "${appName.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}" to activate`
   ], { timeout: 1000 }, () => {});
 }
 
@@ -76,10 +76,13 @@ function hotkeyResolve(behavior, message) {
   const perm = targets[targets.length - 1]; // newest
   captureFrontApp((appName) => {
     resolvePermissionEntry(perm, behavior, message);
-    setTimeout(() => {
-      if (appName) restoreFrontApp(appName);
-      else ctx.focusTerminalForSession(perm.sessionId);
-    }, 300);
+    if (appName) {
+      setTimeout(() => restoreFrontApp(appName), 300);
+    } else if (isMac) {
+      // macOS only: osascript failed — fall back to terminal focus
+      setTimeout(() => ctx.focusTerminalForSession(perm.sessionId), 300);
+    }
+    // non-macOS: no focus change (matches pre-PR behavior)
   });
 }
 


### PR DESCRIPTION
When the user pressed Ctrl+Shift+Y / Ctrl+Shift+N to approve or deny a permission request, focus was not returned to the app the user was in before the bubble appeared. macOS would arbitrarily activate another window (often clawd's own hitWin).

Fix: capture the frontmost application via osascript at the moment the hotkey is pressed (not at bubble creation time), then restore it 300ms after resolving (allowing the bubble destroy animation to complete). Falls back to focusing the Claude Code terminal if capture fails (non-macOS or osascript timeout).