### PR TITLE
Fix Windows open-at-login for unpackaged Electron runs

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -13,6 +13,16 @@ const os = require("os");
 const AUTOSTART_DIR = path.join(os.homedir(), ".config", "autostart");
 const AUTOSTART_FILE = path.join(AUTOSTART_DIR, "clawd-on-desk.desktop");
 
+function getLoginItemSettings({ isLinux, isPackaged, openAtLogin, execPath, appPath }) {
+  if (isLinux) return null;
+  if (isPackaged) return { openAtLogin };
+  return {
+    openAtLogin,
+    path: execPath,
+    args: [appPath],
+  };
+}
+
 function linuxGetOpenAtLogin() {
   try { return fs.existsSync(AUTOSTART_FILE); } catch { return false; }
 }
@@ -342,7 +352,13 @@ module.exports = function initMenu(ctx) {
           if (isLinux) {
             linuxSetOpenAtLogin(menuItem.checked);
           } else {
-            app.setLoginItemSettings({ openAtLogin: menuItem.checked });
+            app.setLoginItemSettings(getLoginItemSettings({
+              isLinux,
+              isPackaged: app.isPackaged,
+              openAtLogin: menuItem.checked,
+              execPath: process.execPath,
+              appPath: app.getAppPath(),
+            }));
           }
           buildTrayMenu();
           buildContextMenu();
@@ -722,4 +738,8 @@ module.exports = function initMenu(ctx) {
     resizeWindow,
     requestAppQuit,
   };
+};
+
+module.exports.__test = {
+  getLoginItemSettings,
 };

--- a/src/menu.js
+++ b/src/menu.js
@@ -347,7 +347,10 @@ module.exports = function initMenu(ctx) {
       {
         label: t("startOnLogin"),
         type: "checkbox",
-        checked: isLinux ? linuxGetOpenAtLogin() : app.getLoginItemSettings().openAtLogin,
+        checked: isLinux ? linuxGetOpenAtLogin()
+          : app.getLoginItemSettings(
+              app.isPackaged ? {} : { path: process.execPath, args: [app.getAppPath()] }
+            ).openAtLogin,
         click: (menuItem) => {
           if (isLinux) {
             linuxSetOpenAtLogin(menuItem.checked);

--- a/test/menu-autostart.test.js
+++ b/test/menu-autostart.test.js
@@ -1,0 +1,34 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+const { __test } = require("../src/menu");
+
+describe("login item settings", () => {
+  it("includes the app path when enabling login items for an unpackaged Windows app", () => {
+    const settings = __test.getLoginItemSettings({
+      isLinux: false,
+      isPackaged: false,
+      openAtLogin: true,
+      execPath: "D:\\clawd-on-desk\\node_modules\\electron\\dist\\electron.exe",
+      appPath: "D:\\clawd-on-desk",
+    });
+
+    assert.deepStrictEqual(settings, {
+      openAtLogin: true,
+      path: "D:\\clawd-on-desk\\node_modules\\electron\\dist\\electron.exe",
+      args: ["D:\\clawd-on-desk"],
+    });
+  });
+
+  it("uses the default packaged login item settings", () => {
+    const settings = __test.getLoginItemSettings({
+      isLinux: false,
+      isPackaged: true,
+      openAtLogin: true,
+      execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+      appPath: "C:\\Program Files\\Clawd on Desk\\resources\\app.asar",
+    });
+
+    assert.deepStrictEqual(settings, { openAtLogin: true });
+  });
+});

--- a/test/menu-autostart.test.js
+++ b/test/menu-autostart.test.js
@@ -31,4 +31,30 @@ describe("login item settings", () => {
 
     assert.deepStrictEqual(settings, { openAtLogin: true });
   });
+
+  it("includes the app path when disabling login items for an unpackaged app", () => {
+    const settings = __test.getLoginItemSettings({
+      isLinux: false,
+      isPackaged: false,
+      openAtLogin: false,
+      execPath: "D:\\clawd-on-desk\\node_modules\\electron\\dist\\electron.exe",
+      appPath: "D:\\clawd-on-desk",
+    });
+
+    assert.deepStrictEqual(settings, {
+      openAtLogin: false,
+      path: "D:\\clawd-on-desk\\node_modules\\electron\\dist\\electron.exe",
+      args: ["D:\\clawd-on-desk"],
+    });
+  });
+
+  it("returns null for Linux (uses .desktop file instead)", () => {
+    const settings = __test.getLoginItemSettings({
+      isLinux: true,
+      isPackaged: false,
+      openAtLogin: true,
+    });
+
+    assert.strictEqual(settings, null);
+  });
 });


### PR DESCRIPTION
Fix Windows open-at-login for unpackaged Electron runs

## Summary
- fix `openAtLogin` registration for unpackaged Windows runs by passing the app path to Electron
- add a regression test covering the unpackaged login item settings

## Reproduction
I hit this while following the `README.zh-CN.md` quick-start flow:

```bash
git clone https://github.com/rullerzhou-afk/clawd-on-desk.git
cd clawd-on-desk
npm install
node hooks/install.js
npm start
```

After launching the app from source and enabling the app's open-at-login option, Windows login startup tried to run the bare Electron binary and showed:

```text
To run a local app, execute the following on the command line:

D:\clawd-on-desk\node_modules\electron\dist\electron.exe path-to-app
```

## Root Cause
In the unpackaged/source-run case, `app.setLoginItemSettings({ openAtLogin: true })` only registers `electron.exe`. Electron also needs the app path argument when the app is started from source.

## Notes on the setup docs
The English quick start says `npm start` auto-registers Claude Code hooks on launch, which matches the current code path in `src/server.js`.

So for local startup, `node hooks/install.js` is not strictly required before `npm start`; it is an optional manual pre-registration step. The Chinese guide currently makes it look mandatory, but this PR does not change docs yet.

## Testing
- `node --test test/menu-autostart.test.js`
- `node --test test/install.test.js`
