### PR TITLE
Codex permission reply: async xdotool flow + Linux-only actionable bubble

### DIFF
--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -26,6 +26,7 @@ class CodexLogMonitor {
     this._recentDayDirsCache = [];
     this._recentDayDirsCacheAt = 0;
     this._recentDayDirsDateKey = "";
+    this._startedAtMs = Date.now();
   }
 
   _resolveBaseDir() {
@@ -38,6 +39,7 @@ class CodexLogMonitor {
 
   start() {
     if (this._interval) return;
+    this._startedAtMs = Date.now();
     // Initial scan
     this._poll();
     this._interval = setInterval(
@@ -247,6 +249,14 @@ class CodexLogMonitor {
       obj = JSON.parse(line);
     } catch {
       return; // corrupted line, skip
+    }
+
+    // Skip historical timestamped events that predate monitor start.
+    // This prevents replay storms on app restart from driving stale state
+    // transitions (e.g., old permission -> old clear) in live UI.
+    if (obj && typeof obj.timestamp === "string") {
+      const ts = Date.parse(obj.timestamp);
+      if (Number.isFinite(ts) && ts < this._startedAtMs - 1500) return;
     }
 
     const type = obj.type;

--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -295,10 +295,11 @@ class CodexLogMonitor {
       tracked.hadToolUse = false;
       tracked.lastState = resolved;
       tracked.lastEventTime = Date.now();
+      const agentPid = this._resolveTrackedAgentPid(tracked);
       this._onStateChange(tracked.sessionId, resolved, key, {
         cwd: tracked.cwd,
-        sourcePid: null,
-        agentPid: null,
+        sourcePid: agentPid,
+        agentPid,
       });
       return;
     }
@@ -309,6 +310,17 @@ class CodexLogMonitor {
       if (tracked.approvalTimer) clearTimeout(tracked.approvalTimer);
       const cmd = this._extractShellCommand(payload);
       if (cmd) {
+        if (this._isExplicitApprovalRequest(payload)) {
+          const agentPid = this._resolveTrackedAgentPid(tracked);
+          tracked.lastEventTime = Date.now();
+          this._onStateChange(tracked.sessionId, "codex-permission", key, {
+            cwd: tracked.cwd,
+            sourcePid: agentPid,
+            agentPid,
+            permissionDetail: { command: cmd, rawPayload: payload },
+          });
+          return;
+        }
         tracked.approvalTimer = setTimeout(() => {
           tracked.approvalTimer = null;
           const agentPid = this._resolveTrackedAgentPid(tracked);
@@ -337,16 +349,32 @@ class CodexLogMonitor {
   }
 
   // Extract shell command from function_call payload
-  // payload.arguments is a JSON string: {"command":"...","workdir":"...","timeout_ms":...}
+  // payload.arguments is typically:
+  //   shell_command: {"command":"...","workdir":"..."}
+  //   exec_command:  {"cmd":"...","workdir":"..."}
   _extractShellCommand(payload) {
     if (!payload || typeof payload !== "object") return "";
-    if (payload.name !== "shell_command") return "";
+    if (payload.name !== "shell_command" && payload.name !== "exec_command") return "";
     try {
       const args = typeof payload.arguments === "string"
         ? JSON.parse(payload.arguments) : payload.arguments;
       if (args && args.command) return String(args.command);
+      if (args && args.cmd) return String(args.cmd);
     } catch {}
     return "";
+  }
+
+  _isExplicitApprovalRequest(payload) {
+    if (!payload || typeof payload !== "object") return false;
+    if (payload.name !== "shell_command" && payload.name !== "exec_command") return false;
+    try {
+      const args = typeof payload.arguments === "string"
+        ? JSON.parse(payload.arguments) : payload.arguments;
+      if (!args || typeof args !== "object") return false;
+      if (args.sandbox_permissions === "require_escalated") return true;
+      if (typeof args.justification === "string" && args.justification.trim()) return true;
+    } catch {}
+    return false;
   }
 
   // Extract UUID from rollout filename

--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -81,6 +81,12 @@ class CodexLogMonitor {
 
   _getSessionDirs() {
     const dirs = [];
+    const seen = new Set();
+    const addDir = (dir) => {
+      if (!dir || seen.has(dir)) return;
+      seen.add(dir);
+      dirs.push(dir);
+    };
     const now = new Date();
     for (let daysAgo = 0; daysAgo <= 2; daysAgo++) {
       const d = new Date(now);
@@ -88,9 +94,61 @@ class CodexLogMonitor {
       const yyyy = d.getFullYear();
       const mm = String(d.getMonth() + 1).padStart(2, "0");
       const dd = String(d.getDate()).padStart(2, "0");
-      dirs.push(path.join(this._baseDir, String(yyyy), mm, dd));
+      addDir(path.join(this._baseDir, String(yyyy), mm, dd));
     }
+
+    // Fallback: include most recent existing session day dirs.
+    // This handles clock/timezone drift between Codex session paths and local date.
+    const recent = this._getRecentExistingDayDirs(7);
+    for (const dir of recent) addDir(dir);
+
     return dirs;
+  }
+
+  _getRecentExistingDayDirs(limit = 7) {
+    const out = [];
+    let years;
+    try {
+      years = fs.readdirSync(this._baseDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory() && /^\d{4}$/.test(d.name))
+        .map((d) => d.name)
+        .sort((a, b) => b.localeCompare(a));
+    } catch {
+      return out;
+    }
+
+    for (const y of years) {
+      const yPath = path.join(this._baseDir, y);
+      let months;
+      try {
+        months = fs.readdirSync(yPath, { withFileTypes: true })
+          .filter((d) => d.isDirectory() && /^\d{2}$/.test(d.name))
+          .map((d) => d.name)
+          .sort((a, b) => b.localeCompare(a));
+      } catch {
+        continue;
+      }
+
+      for (const m of months) {
+        const mPath = path.join(yPath, m);
+        let days;
+        try {
+          days = fs.readdirSync(mPath, { withFileTypes: true })
+            .filter((d) => d.isDirectory() && /^\d{2}$/.test(d.name))
+            .map((d) => d.name)
+            .sort((a, b) => b.localeCompare(a));
+        } catch {
+          continue;
+        }
+
+        for (const d of days) {
+          out.push(path.join(mPath, d));
+          if (out.length >= limit) return out;
+        }
+      }
+    }
+
+    return out;
   }
 
   _pollFile(filePath, fileName) {

--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -9,6 +9,7 @@ const os = require("os");
 const APPROVAL_HEURISTIC_MS = 2000;
 const MAX_TRACKED_FILES = 50;
 const MAX_PARTIAL_BYTES = 65536;
+const RECENT_DAY_DIR_CACHE_MS = 60 * 60 * 1000; // 1 hour
 
 class CodexLogMonitor {
   /**
@@ -22,6 +23,9 @@ class CodexLogMonitor {
     // Map<filePath, { offset, sessionId, cwd, lastEventTime, lastState, partial }>
     this._tracked = new Map();
     this._baseDir = this._resolveBaseDir();
+    this._recentDayDirsCache = [];
+    this._recentDayDirsCacheAt = 0;
+    this._recentDayDirsDateKey = "";
   }
 
   _resolveBaseDir() {
@@ -99,10 +103,31 @@ class CodexLogMonitor {
 
     // Fallback: include most recent existing session day dirs.
     // This handles clock/timezone drift between Codex session paths and local date.
-    const recent = this._getRecentExistingDayDirs(7);
+    const recent = this._getCachedRecentExistingDayDirs(7);
     for (const dir of recent) addDir(dir);
 
     return dirs;
+  }
+
+  _getCachedRecentExistingDayDirs(limit = 7) {
+    const now = Date.now();
+    const dateKey = this._getLocalDateKey();
+    const cacheStale = now - this._recentDayDirsCacheAt > RECENT_DAY_DIR_CACHE_MS;
+    const dayChanged = dateKey !== this._recentDayDirsDateKey;
+    if (!this._recentDayDirsCache.length || cacheStale || dayChanged) {
+      this._recentDayDirsCache = this._getRecentExistingDayDirs(limit);
+      this._recentDayDirsCacheAt = now;
+      this._recentDayDirsDateKey = dateKey;
+    }
+    return this._recentDayDirsCache.slice(0, limit);
+  }
+
+  _getLocalDateKey() {
+    const now = new Date();
+    const yyyy = now.getFullYear();
+    const mm = String(now.getMonth() + 1).padStart(2, "0");
+    const dd = String(now.getDate()).padStart(2, "0");
+    return `${yyyy}-${mm}-${dd}`;
   }
 
   _getRecentExistingDayDirs(limit = 7) {

--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -198,11 +198,13 @@ class CodexLogMonitor {
       tracked = {
         offset: 0,
         sessionId: "codex:" + sessionId,
+        filePath,
         cwd: "",
         lastEventTime: Date.now(),
         lastState: null,
         partial: "",
         hadToolUse: false,
+        agentPid: null,
       };
       this._tracked.set(filePath, tracked);
     }
@@ -309,11 +311,12 @@ class CodexLogMonitor {
       if (cmd) {
         tracked.approvalTimer = setTimeout(() => {
           tracked.approvalTimer = null;
+          const agentPid = this._resolveTrackedAgentPid(tracked);
           tracked.lastEventTime = Date.now();
           this._onStateChange(tracked.sessionId, "codex-permission", key, {
             cwd: tracked.cwd,
-            sourcePid: null,
-            agentPid: null,
+            sourcePid: agentPid,
+            agentPid,
             permissionDetail: { command: cmd, rawPayload: payload },
           });
         }, APPROVAL_HEURISTIC_MS);
@@ -325,10 +328,11 @@ class CodexLogMonitor {
     tracked.lastState = state;
     tracked.lastEventTime = Date.now();
 
+    const agentPid = this._resolveTrackedAgentPid(tracked);
     this._onStateChange(tracked.sessionId, state, key, {
       cwd: tracked.cwd,
-      sourcePid: null, // JSONL doesn't contain terminal PID
-      agentPid: null, // can't reliably match from log file
+      sourcePid: agentPid,
+      agentPid,
     });
   }
 
@@ -354,6 +358,63 @@ class CodexLogMonitor {
     // UUID: last 5 parts (8-4-4-4-12 hex)
     if (parts.length < 10) return null;
     return parts.slice(-5).join("-");
+  }
+
+  _resolveTrackedAgentPid(tracked) {
+    if (tracked.agentPid && this._isProcessAlive(tracked.agentPid)) {
+      return tracked.agentPid;
+    }
+    const pid = this._findCodexWriterPid(tracked.filePath);
+    tracked.agentPid = pid || null;
+    return tracked.agentPid;
+  }
+
+  _isProcessAlive(pid) {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (err) {
+      return err && err.code === "EPERM";
+    }
+  }
+
+  // Linux-only best-effort lookup: find codex process that currently has the
+  // rollout file open in /proc/<pid>/fd/*.
+  _findCodexWriterPid(filePath) {
+    if (process.platform !== "linux" || !filePath) return null;
+    let procEntries;
+    try {
+      procEntries = fs.readdirSync("/proc", { withFileTypes: true });
+    } catch {
+      return null;
+    }
+    for (const ent of procEntries) {
+      if (!ent.isDirectory() || !/^\d+$/.test(ent.name)) continue;
+      const pid = Number(ent.name);
+      if (!Number.isFinite(pid) || pid <= 1) continue;
+
+      // Fast prefilter: skip non-codex processes before scanning fd directory.
+      try {
+        const cmd = fs.readFileSync(`/proc/${pid}/cmdline`, "utf8");
+        if (!cmd.includes("codex")) continue;
+      } catch {
+        continue;
+      }
+
+      let fds;
+      try {
+        fds = fs.readdirSync(`/proc/${pid}/fd`);
+      } catch {
+        continue;
+      }
+      for (const fd of fds) {
+        try {
+          const target = fs.readlinkSync(`/proc/${pid}/fd/${fd}`);
+          if (target === filePath) return pid;
+        } catch {}
+      }
+    }
+    return null;
   }
 
   // Remove files not updated for 5 minutes

--- a/agents/codex.js
+++ b/agents/codex.js
@@ -13,7 +13,11 @@ module.exports = {
     "session_meta": "idle",
     "event_msg:task_started": "thinking",
     "event_msg:user_message": "thinking",
-    "event_msg:agent_message": null, // text output only — working is reserved for function_call
+    // Newer Codex builds emit work progress primarily as event_msg records.
+    "event_msg:agent_message": "working",
+    "event_msg:exec_command_end": "working",
+    "event_msg:patch_apply_end": "working",
+    "event_msg:custom_tool_call_output": "working",
     "response_item:function_call": "working",
     "response_item:custom_tool_call": "working",
     "response_item:web_search_call": "working",

--- a/launch.js
+++ b/launch.js
@@ -9,13 +9,20 @@
 // This launcher strips that variable before spawning the real Electron binary.
 
 const { spawn } = require("child_process");
-const path = require("path");
 const electron = require("electron");
 
 const env = { ...process.env };
 delete env.ELECTRON_RUN_AS_NODE;
+if (process.platform === "linux") {
+  // Some environments still trip Chromium sandbox initialization even with
+  // argv flags; force-disable via env too for local dev reliability.
+  env.ELECTRON_DISABLE_SANDBOX = "1";
+  env.CHROME_DEVEL_SANDBOX = "";
+}
 
-const args = process.platform === "linux" ? [".", "--no-sandbox"] : ["."];
+const args = process.platform === "linux"
+  ? [".", "--no-sandbox", "--disable-setuid-sandbox"]
+  : ["."];
 const child = spawn(electron, args, {
   stdio: "inherit",
   env,

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -273,6 +273,8 @@ const btnDeny = document.getElementById("btnDeny");
 const suggestionsContainer = document.getElementById("suggestions");
 const headerTitle = document.querySelector(".header-title");
 let elicitationMode = false;
+let codexNotifyMode = false;
+let codexCanReply = false;
 
 function formatDetail(name, input) {
   if (!input || typeof input !== "object") return "";
@@ -331,6 +333,8 @@ function revealCard() {
 }
 
 function show(data) {
+  codexNotifyMode = false;
+  codexCanReply = false;
   elicitationMode = data.isElicitation || false;
 
   // opencode branch — Phase 2. Three differences from CC:
@@ -424,25 +428,31 @@ function show(data) {
 
   // Codex notify mode — informational bubble with Dismiss button only
   if (data.toolName === "CodexExec") {
+    codexNotifyMode = true;
+    codexCanReply = data.platform === "linux";
     headerTitle.textContent = data.lang === "zh" ? "Codex \u6743\u9650\u8BF7\u6C42" : "Codex Permission";
     toolPill.textContent = "CODEX";
     toolPill.setAttribute("data-tool", "CodexExec");
     toolPill.style.display = "";
     commandBlock.textContent = (data.toolInput && data.toolInput.command) || "(unknown)";
-    btnAllow.textContent = data.lang === "zh" ? "\u6279\u51C6" : "Allow";
+    btnAllow.textContent = codexCanReply
+      ? (data.lang === "zh" ? "\u6279\u51C6" : "Allow")
+      : (data.lang === "zh" ? "\u77E5\u9053\u4E86" : "Got it");
     btnAllow.disabled = false;
-    btnDeny.style.display = "";
+    btnDeny.style.display = codexCanReply ? "" : "none";
     btnDeny.textContent = data.lang === "zh" ? "\u62D2\u7EDD" : "Deny";
-    btnDeny.disabled = false;
+    btnDeny.disabled = !codexCanReply;
     suggestionsContainer.innerHTML = "";
-    const btn = document.createElement("button");
-    btn.className = "btn-suggestion";
-    btn.textContent = data.lang === "zh" ? "\u524D\u5F80\u7EC8\u7AEF" : "Go to Terminal";
-    btn.addEventListener("click", () => {
-      disableAll();
-      window.bubbleAPI.decide("deny-and-focus");
-    });
-    suggestionsContainer.appendChild(btn);
+    if (codexCanReply) {
+      const btn = document.createElement("button");
+      btn.className = "btn-suggestion";
+      btn.textContent = data.lang === "zh" ? "\u524D\u5F80\u7EC8\u7AEF" : "Go to Terminal";
+      btn.addEventListener("click", () => {
+        disableAll();
+        window.bubbleAPI.decide("deny-and-focus");
+      });
+      suggestionsContainer.appendChild(btn);
+    }
     revealCard();
     return;
   }
@@ -511,6 +521,10 @@ function hide() {
 btnAllow.addEventListener("click", () => {
   btnAllow.textContent = "...";
   disableAll();
+  if (codexNotifyMode && !codexCanReply) {
+    window.bubbleAPI.decide("dismiss");
+    return;
+  }
   // Elicitation: "deny" tells Claude Code to fall back to terminal
   window.bubbleAPI.decide(elicitationMode ? "deny" : "allow");
 });

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -429,10 +429,20 @@ function show(data) {
     toolPill.setAttribute("data-tool", "CodexExec");
     toolPill.style.display = "";
     commandBlock.textContent = (data.toolInput && data.toolInput.command) || "(unknown)";
-    btnAllow.textContent = data.lang === "zh" ? "\u77E5\u9053\u4E86" : "Got it";
+    btnAllow.textContent = data.lang === "zh" ? "\u6279\u51C6" : "Allow";
     btnAllow.disabled = false;
-    btnDeny.style.display = "none";
+    btnDeny.style.display = "";
+    btnDeny.textContent = data.lang === "zh" ? "\u62D2\u7EDD" : "Deny";
+    btnDeny.disabled = false;
     suggestionsContainer.innerHTML = "";
+    const btn = document.createElement("button");
+    btn.className = "btn-suggestion";
+    btn.textContent = data.lang === "zh" ? "\u524D\u5F80\u7EC8\u7AEF" : "Go to Terminal";
+    btn.addEventListener("click", () => {
+      disableAll();
+      window.bubbleAPI.decide("deny-and-focus");
+    });
+    suggestionsContainer.appendChild(btn);
     revealCard();
     return;
   }

--- a/src/main.js
+++ b/src/main.js
@@ -1092,7 +1092,7 @@ if (!gotTheLock) {
           permLog(`codex-permission detected: sid=${sid} event=${event} pid=${extra.agentPid || "?"} cmd=${(extra.permissionDetail?.command || "").slice(0, 120)}`);
           updateSession(
             sid,
-            "notification",
+            "working",
             event,
             extra.sourcePid || null,
             extra.cwd,

--- a/src/main.js
+++ b/src/main.js
@@ -1089,10 +1089,21 @@ if (!gotTheLock) {
       const codexAgent = require("../agents/codex");
       _codexMonitor = new CodexLogMonitor(codexAgent, (sid, state, event, extra) => {
         if (state === "codex-permission") {
-          updateSession(sid, "notification", event, null, extra.cwd, null, null, null, "codex");
+          updateSession(
+            sid,
+            "notification",
+            event,
+            extra.sourcePid || null,
+            extra.cwd,
+            null,
+            null,
+            extra.agentPid || null,
+            "codex"
+          );
           showCodexNotifyBubble({
             sessionId: sid,
             command: extra.permissionDetail?.command || "",
+            codexPid: extra.agentPid || null,
           });
           return;
         }

--- a/src/main.js
+++ b/src/main.js
@@ -1089,6 +1089,7 @@ if (!gotTheLock) {
       const codexAgent = require("../agents/codex");
       _codexMonitor = new CodexLogMonitor(codexAgent, (sid, state, event, extra) => {
         if (state === "codex-permission") {
+          permLog(`codex-permission detected: sid=${sid} event=${event} pid=${extra.agentPid || "?"} cmd=${(extra.permissionDetail?.command || "").slice(0, 120)}`);
           updateSession(
             sid,
             "notification",
@@ -1107,8 +1108,12 @@ if (!gotTheLock) {
           });
           return;
         }
-        // Non-permission event — clear any lingering Codex notify bubbles
-        clearCodexNotifyBubbles(sid);
+        // Only clear Codex notify bubbles when a turn has resolved or errored.
+        // Do not clear on normal progress states (e.g. "working"), otherwise
+        // permission popups can disappear immediately after being shown.
+        if (state === "idle" || state === "attention" || state === "error") {
+          clearCodexNotifyBubbles(sid);
+        }
         updateSession(sid, state, event, null, extra.cwd, null, null, null, "codex");
       });
       _codexMonitor.start();

--- a/src/main.js
+++ b/src/main.js
@@ -1092,7 +1092,7 @@ if (!gotTheLock) {
           permLog(`codex-permission detected: sid=${sid} event=${event} pid=${extra.agentPid || "?"} cmd=${(extra.permissionDetail?.command || "").slice(0, 120)}`);
           updateSession(
             sid,
-            "working",
+            "notification",
             event,
             extra.sourcePid || null,
             extra.cwd,
@@ -1108,12 +1108,8 @@ if (!gotTheLock) {
           });
           return;
         }
-        // Only clear Codex notify bubbles when a turn has resolved or errored.
-        // Do not clear on normal progress states (e.g. "working"), otherwise
-        // permission popups can disappear immediately after being shown.
-        if (state === "idle" || state === "attention" || state === "error") {
-          clearCodexNotifyBubbles(sid);
-        }
+        // Non-permission event — clear any lingering Codex notify bubbles
+        clearCodexNotifyBubbles(sid);
         updateSession(sid, state, event, null, extra.cwd, null, null, null, "codex");
       });
       _codexMonitor.start();

--- a/src/permission.js
+++ b/src/permission.js
@@ -4,6 +4,7 @@
 const { BrowserWindow, globalShortcut } = require("electron");
 const path = require("path");
 const http = require("http");
+const fs = require("fs");
 const {
   CLAWD_SERVER_HEADER,
   CLAWD_SERVER_ID,
@@ -394,6 +395,15 @@ function handleDecide(event, behavior) {
   permLog(`IPC permission-decide: behavior=${behavior} matched=${!!perm}`);
   if (!perm) return;
   if (perm.isCodexNotify) {
+    if (behavior === "allow" || behavior === "deny") {
+      const replied = replyCodexPermission(perm, behavior);
+      if (!replied) {
+        // Best-effort fallback when direct stdin write is unavailable.
+        ctx.focusTerminalForSession(perm.sessionId);
+      }
+    } else if (behavior === "deny-and-focus") {
+      ctx.focusTerminalForSession(perm.sessionId);
+    }
     dismissCodexNotify(perm);
     return;
   }
@@ -447,7 +457,7 @@ function handleDecide(event, behavior) {
 
 const CODEX_NOTIFY_EXPIRE_MS = 30000;
 
-function showCodexNotifyBubble({ sessionId, command }) {
+function showCodexNotifyBubble({ sessionId, command, codexPid }) {
   if (ctx.doNotDisturb || ctx.hideBubbles) {
     permLog(`codex notify suppressed: session=${sessionId} dnd=${ctx.doNotDisturb} hideBubbles=${ctx.hideBubbles}`);
     return;
@@ -460,6 +470,7 @@ function showCodexNotifyBubble({ sessionId, command }) {
     toolInput: { command: command || "(unknown)" },
     resolvedSuggestion: null, createdAt: Date.now(),
     isElicitation: false, isCodexNotify: true,
+    codexPid: Number.isFinite(codexPid) && codexPid > 1 ? Math.floor(codexPid) : null,
     autoExpireTimer: null,
   };
   pendingPermissions.push(permEntry);
@@ -467,6 +478,21 @@ function showCodexNotifyBubble({ sessionId, command }) {
   permEntry.autoExpireTimer = setTimeout(() => {
     dismissCodexNotify(permEntry);
   }, CODEX_NOTIFY_EXPIRE_MS);
+}
+
+function replyCodexPermission(permEntry, behavior) {
+  if (process.platform !== "linux") return false;
+  const pid = Number(permEntry.codexPid);
+  if (!Number.isFinite(pid) || pid <= 1) return false;
+  const input = behavior === "allow" ? "y\n" : "n\n";
+  try {
+    fs.writeFileSync(`/proc/${pid}/fd/0`, input, "utf8");
+    permLog(`codex reply: pid=${pid} behavior=${behavior}`);
+    return true;
+  } catch (err) {
+    permLog(`codex reply failed: pid=${pid} behavior=${behavior} err=${err.message}`);
+    return false;
+  }
 }
 
 function dismissCodexNotify(permEntry) {

--- a/src/permission.js
+++ b/src/permission.js
@@ -4,8 +4,7 @@
 const { BrowserWindow, globalShortcut } = require("electron");
 const path = require("path");
 const http = require("http");
-const fs = require("fs");
-const { execFileSync } = require("child_process");
+const { execFile } = require("child_process");
 const {
   CLAWD_SERVER_HEADER,
   CLAWD_SERVER_ID,
@@ -188,6 +187,7 @@ function showPermissionBubble(permEntry) {
       toolName: permEntry.toolName,
       toolInput: permEntry.toolInput,
       suggestions: permEntry.suggestions || [],
+      platform: process.platform,
       lang: ctx.lang,
       isElicitation: permEntry.isElicitation || false,
       isOpencode: permEntry.isOpencode || false,
@@ -397,13 +397,11 @@ function handleDecide(event, behavior) {
   if (!perm) return;
   if (perm.isCodexNotify) {
     if (behavior === "allow" || behavior === "deny") {
-      const replied = replyCodexPermission(perm, behavior);
-      if (!replied) {
-        // Best-effort fallback when direct stdin write is unavailable.
-        ctx.focusTerminalForSession(perm.sessionId);
-      }
+      replyCodexPermission(perm, behavior);
     } else if (behavior === "deny-and-focus") {
       ctx.focusTerminalForSession(perm.sessionId);
+    } else if (behavior === "dismiss") {
+      // No-op; just close bubble below.
     }
     dismissCodexNotify(perm);
     return;
@@ -484,67 +482,49 @@ function showCodexNotifyBubble({ sessionId, command, codexPid }) {
 }
 
 function replyCodexPermission(permEntry, behavior) {
-  if (process.platform !== "linux") return false;
+  if (process.platform !== "linux") return;
   const pid = Number(permEntry.codexPid);
-  if (!Number.isFinite(pid) || pid <= 1) return false;
-  const input = behavior === "allow" ? "y\n" : "n\n";
-  const key = behavior === "allow" ? "y" : "n";
-  let stdinTarget = "";
-  let stdinLooksLikeTty = false;
-  try {
-    stdinTarget = fs.readlinkSync(`/proc/${pid}/fd/0`);
-    stdinLooksLikeTty = /^\/dev\/(pts|tty)\//.test(stdinTarget) || stdinTarget === "/dev/tty";
-  } catch {}
-  // Preferred path: inject keypress into the Codex window via xdotool.
-  // This works for interactive TTY prompts where writing to fd/0 may not.
-  try {
-    const out = execFileSync("xdotool", ["search", "--pid", String(pid)], {
-      encoding: "utf8",
-      timeout: 700,
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    const wins = String(out).trim().split(/\s+/).filter(Boolean);
-    if (wins.length) {
-      const winId = wins[wins.length - 1];
-      execFileSync("xdotool", ["key", "--window", winId, "--clearmodifiers", key, "Return"], {
-        timeout: 700,
-        stdio: ["ignore", "ignore", "ignore"],
-      });
-      permLog(`codex reply via xdotool: pid=${pid} window=${winId} behavior=${behavior}`);
-      return true;
-    }
-  } catch (err) {
-    permLog(`codex xdotool path failed: pid=${pid} behavior=${behavior} err=${err.message}`);
-  }
-
-  // Fallback: Codex often runs inside a terminal multiplexer and has no own GUI
-  // window. Focus the terminal session window, then send global key events.
-  try {
+  if (!Number.isFinite(pid) || pid <= 1) {
     ctx.focusTerminalForSession(permEntry.sessionId);
-    execFileSync("xdotool", ["key", "--clearmodifiers", key, "Return"], {
-      timeout: 900,
-      stdio: ["ignore", "ignore", "ignore"],
-    });
-    permLog(`codex reply via focused window: session=${permEntry.sessionId} behavior=${behavior}`);
-    return true;
-  } catch (err) {
-    permLog(`codex focused-window key failed: session=${permEntry.sessionId} behavior=${behavior} err=${err.message}`);
+    return;
   }
-
-  if (stdinLooksLikeTty) {
-    permLog(`codex fd0 fallback skipped for tty stdin: pid=${pid} target=${stdinTarget || "unknown"}`);
-    return false;
-  }
-
-  // Fallback: write to stdin fd directly. This can work for non-interactive pipes.
-  try {
-    fs.writeFileSync(`/proc/${pid}/fd/0`, input, "utf8");
-    permLog(`codex reply via fd0: pid=${pid} behavior=${behavior}`);
-    return true;
-  } catch (err) {
-    permLog(`codex reply failed: pid=${pid} behavior=${behavior} err=${err.message}`);
-    return false;
-  }
+  const key = behavior === "allow" ? "y" : "n";
+  execFile(
+    "xdotool",
+    ["search", "--pid", String(pid)],
+    { encoding: "utf8", timeout: 700 },
+    (searchErr, stdout) => {
+      if (searchErr) {
+        if (searchErr.code !== "ENOENT") {
+          permLog(`codex xdotool search failed: pid=${pid} behavior=${behavior} err=${searchErr.message}`);
+        }
+        ctx.focusTerminalForSession(permEntry.sessionId);
+        return;
+      }
+      const wins = String(stdout || "").trim().split(/\s+/).filter(Boolean);
+      if (!wins.length) {
+        permLog(`codex xdotool search found no window: pid=${pid} behavior=${behavior}`);
+        ctx.focusTerminalForSession(permEntry.sessionId);
+        return;
+      }
+      const winId = wins[wins.length - 1];
+      execFile(
+        "xdotool",
+        ["key", "--window", winId, "--clearmodifiers", key, "Return"],
+        { timeout: 700 },
+        (keyErr) => {
+          if (keyErr) {
+            if (keyErr.code !== "ENOENT") {
+              permLog(`codex xdotool key failed: pid=${pid} window=${winId} behavior=${behavior} err=${keyErr.message}`);
+            }
+            ctx.focusTerminalForSession(permEntry.sessionId);
+            return;
+          }
+          permLog(`codex reply via xdotool: pid=${pid} window=${winId} behavior=${behavior}`);
+        }
+      );
+    }
+  );
 }
 
 function dismissCodexNotify(permEntry) {

--- a/src/permission.js
+++ b/src/permission.js
@@ -5,6 +5,7 @@ const { BrowserWindow, globalShortcut } = require("electron");
 const path = require("path");
 const http = require("http");
 const fs = require("fs");
+const { execFileSync } = require("child_process");
 const {
   CLAWD_SERVER_HEADER,
   CLAWD_SERVER_ID,
@@ -487,9 +488,58 @@ function replyCodexPermission(permEntry, behavior) {
   const pid = Number(permEntry.codexPid);
   if (!Number.isFinite(pid) || pid <= 1) return false;
   const input = behavior === "allow" ? "y\n" : "n\n";
+  const key = behavior === "allow" ? "y" : "n";
+  let stdinTarget = "";
+  let stdinLooksLikeTty = false;
+  try {
+    stdinTarget = fs.readlinkSync(`/proc/${pid}/fd/0`);
+    stdinLooksLikeTty = /^\/dev\/(pts|tty)\//.test(stdinTarget) || stdinTarget === "/dev/tty";
+  } catch {}
+  // Preferred path: inject keypress into the Codex window via xdotool.
+  // This works for interactive TTY prompts where writing to fd/0 may not.
+  try {
+    const out = execFileSync("xdotool", ["search", "--pid", String(pid)], {
+      encoding: "utf8",
+      timeout: 700,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const wins = String(out).trim().split(/\s+/).filter(Boolean);
+    if (wins.length) {
+      const winId = wins[wins.length - 1];
+      execFileSync("xdotool", ["key", "--window", winId, "--clearmodifiers", key, "Return"], {
+        timeout: 700,
+        stdio: ["ignore", "ignore", "ignore"],
+      });
+      permLog(`codex reply via xdotool: pid=${pid} window=${winId} behavior=${behavior}`);
+      return true;
+    }
+  } catch (err) {
+    permLog(`codex xdotool path failed: pid=${pid} behavior=${behavior} err=${err.message}`);
+  }
+
+  // Fallback: Codex often runs inside a terminal multiplexer and has no own GUI
+  // window. Focus the terminal session window, then send global key events.
+  try {
+    ctx.focusTerminalForSession(permEntry.sessionId);
+    execFileSync("xdotool", ["key", "--clearmodifiers", key, "Return"], {
+      timeout: 900,
+      stdio: ["ignore", "ignore", "ignore"],
+    });
+    permLog(`codex reply via focused window: session=${permEntry.sessionId} behavior=${behavior}`);
+    return true;
+  } catch (err) {
+    permLog(`codex focused-window key failed: session=${permEntry.sessionId} behavior=${behavior} err=${err.message}`);
+  }
+
+  if (stdinLooksLikeTty) {
+    permLog(`codex fd0 fallback skipped for tty stdin: pid=${pid} target=${stdinTarget || "unknown"}`);
+    return false;
+  }
+
+  // Fallback: write to stdin fd directly. This can work for non-interactive pipes.
   try {
     fs.writeFileSync(`/proc/${pid}/fd/0`, input, "utf8");
-    permLog(`codex reply: pid=${pid} behavior=${behavior}`);
+    permLog(`codex reply via fd0: pid=${pid} behavior=${behavior}`);
     return true;
   } catch (err) {
     permLog(`codex reply failed: pid=${pid} behavior=${behavior} err=${err.message}`);

--- a/src/permission.js
+++ b/src/permission.js
@@ -458,6 +458,7 @@ function handleDecide(event, behavior) {
 const CODEX_NOTIFY_EXPIRE_MS = 30000;
 
 function showCodexNotifyBubble({ sessionId, command, codexPid }) {
+  permLog(`codex notify request: session=${sessionId} pid=${codexPid || "?"} cmd=${(command || "").slice(0, 120)}`);
   if (ctx.doNotDisturb || ctx.hideBubbles) {
     permLog(`codex notify suppressed: session=${sessionId} dnd=${ctx.doNotDisturb} hideBubbles=${ctx.hideBubbles}`);
     return;
@@ -474,6 +475,7 @@ function showCodexNotifyBubble({ sessionId, command, codexPid }) {
     autoExpireTimer: null,
   };
   pendingPermissions.push(permEntry);
+  permLog(`codex notify shown: session=${sessionId} pending=${pendingPermissions.length}`);
   showPermissionBubble(permEntry);
   permEntry.autoExpireTimer = setTimeout(() => {
     dismissCodexNotify(permEntry);
@@ -515,6 +517,9 @@ function clearCodexNotifyBubbles(sessionId) {
   const toRemove = pendingPermissions.filter(
     p => p.isCodexNotify && p.sessionId === sessionId
   );
+  if (toRemove.length) {
+    permLog(`codex notify clear: session=${sessionId} count=${toRemove.length}`);
+  }
   for (const perm of toRemove) dismissCodexNotify(perm);
 }
 

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -110,6 +110,25 @@ describe("CodexLogMonitor", () => {
     monitor.start();
   });
 
+  it("should map agent_message event to working", (_, done) => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+      '{"type":"event_msg","payload":{"type":"agent_message"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const states = [];
+    monitor = new CodexLogMonitor(config, (sid, state) => {
+      states.push(state);
+      if (states.length === 2) {
+        assert.strictEqual(states[1], "working");
+        done();
+      }
+    });
+    monitor.start();
+  });
+
   it("should map task_complete to idle when no tools were used", (_, done) => {
     const testFile = path.join(dateDir, TEST_FILENAME);
     fs.writeFileSync(testFile, [
@@ -275,6 +294,21 @@ describe("CodexLogMonitor", () => {
         assert.deepStrictEqual(states, ["idle", "thinking"]);
         done();
       }
+    });
+    monitor.start();
+  });
+
+  it("should process recent existing day dirs even if not today/yesterday", (_, done) => {
+    const oldDateDir = path.join(tmpDir, "2024", "01", "02");
+    fs.mkdirSync(oldDateDir, { recursive: true });
+    const testFile = path.join(oldDateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, '{"type":"session_meta","payload":{"cwd":"/tmp"}}\n');
+
+    const config = makeConfig(tmpDir);
+    monitor = new CodexLogMonitor(config, (sid, state) => {
+      assert.strictEqual(sid, EXPECTED_SID);
+      assert.strictEqual(state, "idle");
+      done();
     });
     monitor.start();
   });

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -336,6 +336,43 @@ describe("CodexLogMonitor", () => {
     monitor.start();
   });
 
+  it("should emit codex-permission for exec_command function calls", (_, done) => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/projects/foo"}}',
+      '{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\\"cmd\\":\\"git status\\"}"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    monitor = new CodexLogMonitor(config, (sid, state, event, extra) => {
+      if (state === "codex-permission") {
+        assert.strictEqual(extra.permissionDetail.command, "git status");
+        done();
+      }
+    });
+    monitor.start();
+  });
+
+  it("should emit codex-permission immediately for explicit escalated requests", (_, done) => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/projects/foo"}}',
+      '{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\\"cmd\\":\\"git push\\",\\"sandbox_permissions\\":\\"require_escalated\\",\\"justification\\":\\"needs network\\"}"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const startedAt = Date.now();
+    monitor = new CodexLogMonitor(config, (sid, state, event, extra) => {
+      if (state === "codex-permission") {
+        const elapsed = Date.now() - startedAt;
+        assert.ok(elapsed < 1500, `expected immediate permission signal, got ${elapsed}ms`);
+        assert.strictEqual(extra.permissionDetail.command, "git push");
+        done();
+      }
+    });
+    monitor.start();
+  });
+
   it("should NOT emit codex-permission if exec_command_end arrives within 2s", (_, done) => {
     const testFile = path.join(dateDir, TEST_FILENAME);
     // function_call immediately followed by exec_command_end — auto-approved
@@ -394,6 +431,10 @@ describe("CodexLogMonitor", () => {
     assert.strictEqual(
       monitor._extractShellCommand({ name: "shell_command", arguments: { command: "git status" } }),
       "git status"
+    );
+    assert.strictEqual(
+      monitor._extractShellCommand({ name: "exec_command", arguments: '{"cmd":"ls -la"}' }),
+      "ls -la"
     );
     // Non-shell function
     assert.strictEqual(

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -143,6 +143,10 @@ describe("Agent Registry", () => {
     const codex = registry.getAgent("codex");
     assert.strictEqual(codex.logEventMap["session_meta"], "idle");
     assert.strictEqual(codex.logEventMap["event_msg:task_started"], "thinking");
+    assert.strictEqual(codex.logEventMap["event_msg:agent_message"], "working");
+    assert.strictEqual(codex.logEventMap["event_msg:exec_command_end"], "working");
+    assert.strictEqual(codex.logEventMap["event_msg:patch_apply_end"], "working");
+    assert.strictEqual(codex.logEventMap["event_msg:custom_tool_call_output"], "working");
     assert.strictEqual(codex.logEventMap["event_msg:task_complete"], "codex-turn-end");
     assert.strictEqual(codex.logEventMap["event_msg:turn_aborted"], "idle");
   });


### PR DESCRIPTION
  This PR contains only the permission-reply track (separate from detection-side changes
  already being merged to main).

  ## What changed

  1. Async permission reply execution

  - Replaced blocking execFileSync with async execFile for Codex reply actions.
  - Prevents Electron UI stalls when xdotool hangs or is slow.

  2. Removed /proc/<pid>/fd/0 write path

  - Dropped cross-process stdin write fallback entirely.
  - Avoids PID-recycling / TOCTOU risk.
  - Fallback behavior is now safe: focus terminal only.

  3. Platform-gated Codex bubble actions

  - Linux: shows Allow, Deny, Go to Terminal.
  - macOS/Windows: Codex bubble is dismiss-only (Got it).
  - process.platform is passed to bubble renderer through permission-show IPC payload.

  4. Graceful missing-xdotool handling

  - Handles ENOENT in async callback.
  - Silently falls back to focusTerminalForSession(...) (no crash, no blocking).

  5. Main-flow alignment

  - Keeps permission state as notification.
  - Keeps Codex notify cleanup on any non-permission event (as requested).

  ## Files

  - src/permission.js
  - src/bubble.html
  - src/main.js

  ## Validation

  - node --check src/main.js
  - node --check src/permission.js
  - node --test test/codex-log-monitor.test.js

  ## Notes

  - This PR intentionally does not include detection-side/caching/event-map changes.
  - Behavior on Linux when auto-reply fails remains safe: user is focused to terminal to answer
    directly.