### PR TITLE
fix: keep permission bubbles anchored to pet under load

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -108,10 +108,14 @@ function repositionBubbles() {
 
   let x, yBottom;
   if (ctx.bubbleFollowPet) {
-    // Use hitbox bottom for tight positioning against actual pet body
+    // Use hitbox edges for tight positioning against actual pet body
     const hit = ctx.getHitRectScreen(petBounds);
     const hitBottom = Math.round(hit.bottom);
+    const hitTop = Math.round(hit.top);
+    const hitLeft = Math.round(hit.left);
+    const hitRight = Math.round(hit.right);
     const hitCx = Math.round((hit.left + hit.right) / 2);
+    const hitCy = Math.round((hit.top + hit.bottom) / 2);
 
     // Calculate total bubble stack height
     let totalH = 0;
@@ -119,17 +123,30 @@ function repositionBubbles() {
       totalH += (perm.measuredHeight || estimateBubbleHeight((perm.suggestions || []).length)) + gap;
     }
 
-    // Degradation: if total bubble height exceeds half the workspace, fall back to
-    // default bottom-right stacking so bubbles don't crowd the pet or overflow
-    if (totalH > wa.height / 2) {
-      x = wa.x + wa.width - bw - margin;
-      yBottom = wa.y + wa.height - margin;
-      // Fall through to upward stacking loop below
-    } else if (wa.y + wa.height - hitBottom >= totalH) {
-      // Enough room below — place bubbles under the pet body
+    // Layout priority (followPet):
+    //   1. below pet (room available)         — stack hangs from pet body
+    //   2. side of pet (with horizontal room) — stack vertically anchored on
+    //                                            pet center, clamped to screen
+    //   3. final fallback: nearest screen corner — only when neither side
+    //                                              has enough horizontal room
+    //                                              for one bubble width.
+    // We deliberately do NOT degrade to the screen corner just because the
+    // stack is tall — that would yank bubbles far away from the pet, which
+    // is the opposite of what "follow pet" promises (especially on multi-
+    // monitor setups where the pet may be on the left of a side display).
+
+    if (wa.y + wa.height - hitBottom >= totalH) {
+      // Enough room below — place bubbles under the pet body.
+      // Iterate oldest→newest (i=0..N-1), placing each downward from
+      // hitBottom, so the newest bubble lands furthest from the pet
+      // (i.e. at the bottom of the visual stack). This keeps "newest at
+      // the growth end of the stack" consistent with the side/corner
+      // upward-stacking loop below — without this alignment, crossing
+      // a layout threshold would flip the visual order of all existing
+      // bubbles.
       x = Math.max(wa.x, Math.min(hitCx - Math.round(bw / 2), wa.x + wa.width - bw));
       let yTop = hitBottom;
-      for (let i = pendingPermissions.length - 1; i >= 0; i--) {
+      for (let i = 0; i < pendingPermissions.length; i++) {
         const perm = pendingPermissions[i];
         const bh = perm.measuredHeight || estimateBubbleHeight((perm.suggestions || []).length);
         if (perm.bubble && !perm.bubble.isDestroyed()) {
@@ -138,19 +155,35 @@ function repositionBubbles() {
         yTop += bh + gap;
       }
       return;
+    }
+
+    // Side placement: pick the side of the pet with more horizontal room.
+    const spaceRight = wa.x + wa.width - hitRight;
+    const spaceLeft = hitLeft - wa.x;
+    if (spaceRight >= bw && spaceRight >= spaceLeft) {
+      x = Math.min(hitRight, wa.x + wa.width - bw);
+    } else if (spaceLeft >= bw) {
+      x = Math.max(wa.x, hitLeft - bw);
     } else {
-      // Not enough room below — place to the side with more space
-      const hitRight = Math.round(hit.right);
-      const hitLeft = Math.round(hit.left);
-      const spaceRight = wa.x + wa.width - hitRight;
-      const spaceLeft = hitLeft - wa.x;
-      if (spaceRight >= bw || spaceRight >= spaceLeft) {
-        x = Math.min(hitRight, wa.x + wa.width - bw);
-      } else {
-        x = Math.max(wa.x, hitLeft - bw);
-      }
-      // Side fallback: stack from workspace bottom upward (not pet bottom, which would occlude pet)
+      // Neither side has bw of clearance — final fallback to the bottom-
+      // right corner of the pet's current work area. Rare in practice
+      // (pet would have to be near horizontal screen center on a
+      // very narrow display).
+      x = wa.x + wa.width - bw - margin;
       yBottom = wa.y + wa.height - margin;
+    }
+
+    if (yBottom === undefined) {
+      // Vertical anchor: center the stack on the pet vertically, then
+      // clamp to the work area so it never overflows the screen edges.
+      // The newest bubble ends up roughly aligned with the pet's lower
+      // body and the oldest with the upper body — visually the stack
+      // "hugs" the pet on its side.
+      yBottom = hitCy + Math.round(totalH / 2);
+      const maxBottom = wa.y + wa.height - margin;
+      const minBottom = wa.y + margin + totalH;
+      if (yBottom > maxBottom) yBottom = maxBottom;
+      if (yBottom < minBottom) yBottom = minBottom;
     }
   } else {
     // Default: bottom-right corner of nearest work area

--- a/test-bubble.sh
+++ b/test-bubble.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# 发送模拟权限请求测试气泡堆叠 / 复现 below-pet ↔ degraded 分支翻转 bug
+#
+# 用法:
+#   bash test-bubble.sh           # 发 2+6 个气泡, 回车后自动清理
+#   bash test-bubble.sh send      # 同上
+#   bash test-bubble.sh clean     # 只清理上次留下的 curl
+#
+# 复现要点:
+#   - 宠物窗口放屏幕中部, bubbleFollowPet 已开启
+#   - 第 1 波 2 个气泡走 below-pet 分支, 紧贴宠物下方
+#   - 第 2 波累计 8 个, totalH 跨过 wa.height/2 → flip 到 degraded 分支
+#     视觉上整堆气泡瞬移到屏幕右下角, 且新旧顺序整个翻转
+
+set -u
+
+PORT="${CLAWD_PORT:-23333}"
+URL="http://127.0.0.1:${PORT}/permission"
+PID_FILE="/tmp/clawd-test-bubble-pids.txt"
+
+send_one() {
+  local sid="$1" cmd="$2"
+  curl -s -X POST "$URL" \
+    -H "Content-Type: application/json" \
+    -d "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$cmd\"},\"session_id\":\"$sid\",\"permission_suggestions\":[]}" \
+    >/dev/null &
+  echo $! >> "$PID_FILE"
+}
+
+clean_all() {
+  if [ -f "$PID_FILE" ]; then
+    while read -r pid; do kill "$pid" 2>/dev/null; done < "$PID_FILE"
+    rm -f "$PID_FILE"
+  fi
+  # safety net: nuke any leftover curls hitting /permission
+  pkill -f "curl.*${PORT}/permission" 2>/dev/null || true
+  echo "cleaned"
+}
+
+case "${1:-send}" in
+  clean)
+    clean_all
+    exit 0
+    ;;
+  send)
+    rm -f "$PID_FILE"
+    echo "wave 1: 2 bubbles (should land below pet)"
+    send_one drift-test-1 "echo first bubble"
+    send_one drift-test-2 "ls -la /tmp"
+    sleep 1.5
+    echo "wave 2: 6 more bubbles (totalH should cross wa.height/2 → flip)"
+    send_one drift-test-3 "git status"
+    send_one drift-test-4 "npm run build && echo done"
+    send_one drift-test-5 "find . -name '*.js' -type f"
+    send_one drift-test-6 "grep -r TODO src/"
+    send_one drift-test-7 "cat /etc/hosts | head -20"
+    send_one drift-test-8 "ps aux | grep electron | head -5"
+    echo "all 8 sent. press Enter to clean up, or Ctrl-C then run 'bash test-bubble.sh clean'"
+    read -r _
+    clean_all
+    ;;
+  *)
+    echo "usage: bash test-bubble.sh [send|clean]" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## 背景

开启"气泡跟随宠物"（`bubbleFollowPet`）后，并行 agent 同时触发多个权限请求时，气泡堆栈会出现两个叠加的视觉异常。

## 复现

```bash
bash test-bubble.sh          # 发 2+6 个气泡，回车自动清理
bash test-bubble.sh clean    # 清理上次留下的 curl
```

也可以通过任意能并发触发 PreToolUse 的 agent 复现：让宠物处于第二屏左侧，触发 8+ 个权限请求。

## 问题

`src/permission.js` 的 `repositionBubbles()` 在 followPet 模式下有两个 bug 叠加：

### 1. degraded 分支硬把气泡甩到屏幕角落

当 `totalH > wa.height/2` 时，`permission.js` 旧逻辑会把锚点切到 `wa.x + wa.width - bw - margin`（当前显示器右下角）。多屏场景下宠物在第二屏左侧时，气泡会瞬移到第二屏右下角——离宠物可能十几英寸远，完全违反 followPet 的语义。

### 2. 跨分支切换时气泡顺序整个翻转

`below-pet` 分支用 `i = N-1 → 0` + `yTop` 向下递增（newest 紧贴宠物，向下生长），而 `degraded`/`side` 分支共用的默认 loop 用 `i = N-1 → 0` + `yBottom` 向上递减（newest 在 anchor 端，向上生长）。

同一份 `pendingPermissions` 数组被两套相反的放置规则解读，跨阈值切换分支的瞬间所有气泡的 y 坐标整个倒过来。auto-resolve 让 `totalH` 掉回阈值下方时，又会反向翻一次。

## 修复

**重排 followPet 的优先级**（删除 degraded 分支）：

1. **below-pet**：宠物下方有空间 → 贴宠物身体下方
2. **side**：宠物下方放不下 → 选左/右两边空间更大的一侧（默认偏右），垂直方向锚在宠物中线并 clamp 到工作区，气泡始终"贴"在宠物侧边
3. **corner fallback**：左右都塞不下一个气泡宽度（340px）才退到屏幕右下角——实际上只有宠物在很窄的屏幕正中央时才会触发

**统一所有分支的迭代方向**：把 `below-pet` 改成 `i = 0 → N-1` + `yTop` 向下递增（oldest 紧贴宠物，newest 在堆栈最远端）。所有分支现在都满足同一个不变量——**oldest 在 anchor 一端，newest 在 stack 的"生长端"**。跨分支切换只是 anchor 平移，顺序永远不翻转。

## 行为变化

- ✅ 开 followPet 时，气泡永远跟着宠物，不会再飞到屏幕角落
- ✅ 多屏场景下气泡始终留在宠物所在显示器、宠物附近
- ✅ 跨分支切换不再翻转气泡顺序
- ⚠️ 没开 followPet 的默认行为（屏幕右下角堆叠）完全不变

## Test plan

- [x] `npm test` 全绿（249/249）
- [x] `bash test-bubble.sh` 在多屏场景手动验证：宠物在第二屏左侧，8 个气泡全部贴在宠物右侧，无翻转无跨屏
- [x] 关掉 followPet 验证默认右下角堆叠行为不变
- [x] 单屏场景手动验证（宠物在屏幕中央 / 左侧 / 右侧 / 顶部 / 底部）