### PR TITLE
fix(macOS): use NSPanel for permission bubble to prevent focus theft

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -265,6 +265,7 @@ function showPermissionBubble(permEntry) {
     skipTaskbar: true,
     hasShadow: false,
     ...(isLinux ? { type: LINUX_WINDOW_TYPE } : {}),
+    ...(isMac ? { type: "panel" } : {}),
     focusable: false,
     webPreferences: {
       preload: path.join(__dirname, "preload-bubble.js"),


### PR DESCRIPTION
## Problem

On macOS, the permission bubble briefly activates the Clawd app when shown, stealing key-window status from the user's active app. Symptoms:

- Keystrokes dropped mid-stream when the bubble appears
- Menu bar swaps from the user's active app to Clawd
- Having to click back into the previous window after dismissing the bubble
- The "false 'User answered in terminal' denials" warned against in the in-code comment at `src/permission.js:305`

## Root cause

The bubble `BrowserWindow` uses the default macOS window class (regular `NSWindow`). Instantiating a regular `NSWindow` from a background Electron app triggers macOS app activation as a side effect of construction. `focusable: false` and `showInactive()` only affect window key-window status, not app-level activation.

## Fix

Add `type: "panel"` on macOS so the bubble is an `NSPanel` instead of a regular `NSWindow`. `NSPanel` is designed to float without activating its owner application at any phase of the window lifecycle.

This matches the pattern already used for Clawd's pet windows in `src/main.js:813` and `src/main.js:887`:

```js
...(isMac ? { type: "panel", roundedCorners: false } : {}),
```

The permission bubble was simply missed when the `type: "panel"` pattern was introduced in #55.

## Relationship to #75

PR #75 ("Fix lost focus") addressed the same symptom by adding `show: false` to defer initial window display. This reduced but did not eliminate the problem on macOS — the activation happens at `BrowserWindow` *construction* time, which always precedes `show()`. `NSPanel` prevents activation at every phase, so this is the root-cause fix.

## Reproduction (against upstream main)

1. Launch Clawd
2. From a terminal, run (note the 5-second delay):
   ```bash
   sleep 5 && curl -X POST http://127.0.0.1:23333/permission \
     -H "Content-Type: application/json" \
     -d '{"tool_name":"Bash","tool_input":{"command":"echo test"},"session_id":"focus-repro","permission_suggestions":[]}'
   ```
3. Within those 5 seconds, click into any text field in another app (Safari URL bar, TextEdit, Notes) and start holding a key (e.g. `a`) so you see a continuous input stream.
4. When the bubble appears: the stream stops, menu bar swaps to Clawd, you have to click back into the previous app to resume typing.
5. Click Deny on the bubble, then clean up the orphan session the repro leaves in Clawd's Sessions menu:
   ```bash
   curl -X POST http://127.0.0.1:23333/state \
     -H "Content-Type: application/json" \
     -d '{"state":"sleeping","session_id":"focus-repro","event":"SessionEnd","agent_id":"claude-code"}'
   ```

With this patch: the bubble appears without disrupting the active app.