### PR TITLE
fix(deploy): include json-utils.js and shared-process.js in remote deploy

### DIFF
--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -43,6 +43,8 @@ REMOTE_HOOKS_DIR='~/.claude/hooks'
 # Files to deploy
 FILES=(
   "$HOOKS_DIR/server-config.js"
+  "$HOOKS_DIR/json-utils.js"
+  "$HOOKS_DIR/shared-process.js"
   "$HOOKS_DIR/clawd-hook.js"
   "$HOOKS_DIR/install.js"
   "$HOOKS_DIR/codex-remote-monitor.js"

--- a/test/remote-deploy.test.js
+++ b/test/remote-deploy.test.js
@@ -1,0 +1,42 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const path = require("path");
+
+const SCRIPT_PATH = path.join(__dirname, "..", "scripts", "remote-deploy.sh");
+const HOOKS_DIR = path.join(__dirname, "..", "hooks");
+
+function parseDeployedFiles() {
+  const script = fs.readFileSync(SCRIPT_PATH, "utf8");
+  const block = script.match(/FILES=\(\s*\n([\s\S]*?)\n\s*\)/);
+  if (!block) throw new Error("FILES=() block not found in remote-deploy.sh");
+  const entries = [...block[1].matchAll(/"\$HOOKS_DIR\/([^"]+)"/g)];
+  return entries.map((m) => m[1]);
+}
+
+function findRelativeRequires(filePath) {
+  const content = fs.readFileSync(filePath, "utf8");
+  const matches = [...content.matchAll(/require\(["']\.\/([^"')]+)["']\)/g)];
+  return matches.map((m) => (m[1].endsWith(".js") ? m[1] : `${m[1]}.js`));
+}
+
+describe("scripts/remote-deploy.sh FILES manifest", () => {
+  it("ships every relative require target of every listed file", () => {
+    const deployed = parseDeployedFiles();
+    assert.ok(deployed.length > 0, "FILES array parsed as empty");
+    const deployedSet = new Set(deployed);
+
+    for (const name of deployed) {
+      const absPath = path.join(HOOKS_DIR, name);
+      assert.ok(fs.existsSync(absPath), `listed file missing: hooks/${name}`);
+
+      const deps = findRelativeRequires(absPath);
+      for (const dep of deps) {
+        assert.ok(
+          deployedSet.has(dep),
+          `hooks/${name} requires './${dep.replace(/\.js$/, "")}' but ${dep} is not in scripts/remote-deploy.sh FILES — add it or the remote deploy will ship a broken subset`
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`scripts/remote-deploy.sh` scp's a hard-coded list of files to the remote, then runs `install.js --remote` to register Claude Code hooks. After two recent refactors that list no longer matches the actual `require()` graph, causing two cascading failures:

1. **Install: `install.js` crashes during hook registration.**
   ```
   Error: Cannot find module './json-utils'
   Require stack: /home/<user>/.claude/hooks/install.js
   ```
   The script catches this with `|| { echo "WARNING..." }` and continues printing "Done!", so users see a successful-looking deploy.

2. **Runtime: installed hooks crash on every Claude Code event.**
   ```
   Error: Cannot find module './shared-process'
   Require stack: /home/<user>/.claude/hooks/clawd-hook.js
   Stop hook error: Failed with non-blocking status code
   ```

## Root cause

Two refactors added new relative imports without updating `remote-deploy.sh`:

- **7132d1d** (*refactor: dedupe writeJsonAtomic and simplify opencode-plugin*) — extracted `json-utils.js` and made `install.js` require it.
- **9e6a6a1** (*refactor: extract shared-process.js from hook scripts*) — extracted `shared-process.js` and made `clawd-hook.js` require it.

Neither commit updates the `FILES` array, so the deploy ships a subset of `hooks/`. Local testing doesn't catch this because the scripts always run from a full `hooks/` directory where every dep exists. The bug only appears when `hooks/` is copied as a partial set to another machine.

## Fix

1. Add `json-utils.js` and `shared-process.js` to the `FILES` array.
2. Add `test/remote-deploy.test.js` — parses `scripts/remote-deploy.sh` for the `FILES` array, walks `require("./...")` patterns in each listed file, and asserts every target is present in `FILES`. This catches the same class of drift automatically, so future refactors that add a new relative require to a deployed file will break `npm test` with a clear message rather than silently breaking remote deploys.

Verified the test fails with a clear actionable error message when either missing file is reverted from the array:

> `hooks/clawd-hook.js requires './shared-process' but shared-process.js is not in scripts/remote-deploy.sh FILES — add it or the remote deploy will ship a broken subset`

## Verification

1. Cleared the remote to a fresh state (removed `~/.claude/hooks/` and all Clawd entries from `~/.claude/settings.json`)
2. Ran `bash scripts/remote-deploy.sh <ssh-target>` — output showed `Added: 13 hooks`, confirming a clean fresh-install path
3. Fired an end-to-end test hook through the reverse SSH tunnel:
   ```bash
   ssh <host-alias> "CLAWD_REMOTE=1 echo '{\"session_id\":\"e2e-test\"}' \
     | /usr/bin/node ~/.claude/hooks/clawd-hook.js PreCompact"
   ```
4. Local Clawd played the sweeping animation, confirming the full remote hook → tunnel → local server pipeline works.
5. Cleaned up the orphan session the test hook left in Clawd's Sessions menu:
   ```bash
   ssh <host-alias> "CLAWD_REMOTE=1 echo '{\"session_id\":\"e2e-test\"}' \
     | /usr/bin/node ~/.claude/hooks/clawd-hook.js SessionEnd"
   ```