### PR TITLE
Let Clawd follow Antigravity's real work state

### DIFF
--- a/agents/antigravity-log-monitor.js
+++ b/agents/antigravity-log-monitor.js
@@ -1,0 +1,150 @@
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+class AntigravityLogMonitor {
+  constructor(agentConfig, onStateChange) {
+    this._config = agentConfig;
+    this._onStateChange = onStateChange;
+    this._interval = null;
+    this._baseDir = this._resolveBaseDir();
+    this._trackedFile = null;
+    this._lineCount = 0;
+    this._lastState = null;
+    this._lastSessionId = "antigravity:main";
+    this._idleTimer = null;
+    this._lastAgentPid = null;
+    this._lastWorkAt = 0;
+  }
+
+  _resolveBaseDir() {
+    const dir = this._config.logConfig.logsDir;
+    if (dir.startsWith("~")) return path.join(os.homedir(), dir.slice(1));
+    return dir;
+  }
+
+  start() {
+    if (this._interval) return;
+    this._poll();
+    this._interval = setInterval(() => this._poll(), this._config.logConfig.pollIntervalMs || 1500);
+  }
+
+  stop() {
+    if (this._interval) {
+      clearInterval(this._interval);
+      this._interval = null;
+    }
+    if (this._idleTimer) {
+      clearTimeout(this._idleTimer);
+      this._idleTimer = null;
+    }
+    this._trackedFile = null;
+    this._lineCount = 0;
+    this._lastState = null;
+  }
+
+  _poll() {
+    const latest = this._findLatestLogFile();
+    if (!latest) return;
+    const switched = latest !== this._trackedFile;
+    this._trackedFile = latest;
+
+    let text;
+    try {
+      text = fs.readFileSync(latest, "utf8");
+    } catch {
+      return;
+    }
+
+    const lines = text.split(/\r?\n/).filter(Boolean);
+    const startIndex = switched
+      ? Math.max(0, lines.length - (this._config.logConfig.tailLinesOnStart || 200))
+      : Math.min(this._lineCount, lines.length);
+    const freshLines = lines.slice(startIndex);
+    this._lineCount = lines.length;
+
+    for (const line of freshLines) this._processLine(line);
+  }
+
+  _findLatestLogFile() {
+    let dirs;
+    try {
+      dirs = fs.readdirSync(this._baseDir, { withFileTypes: true });
+    } catch {
+      return null;
+    }
+
+    let best = null;
+    let bestMtime = -1;
+    for (const entry of dirs) {
+      if (!entry.isDirectory()) continue;
+      const candidate = path.join(this._baseDir, entry.name, this._config.logConfig.fileName);
+      try {
+        const stat = fs.statSync(candidate);
+        if (stat.mtimeMs > bestMtime) {
+          best = candidate;
+          bestMtime = stat.mtimeMs;
+        }
+      } catch {}
+    }
+    return best;
+  }
+
+  _processLine(line) {
+    const plannerMatch = line.match(/planner_generator\.go:283\] Requesting planner/);
+    if (plannerMatch) {
+      const now = Date.now();
+      if (now - this._lastWorkAt > 2500) {
+        this._emit(this._lastSessionId, "thinking", "BeforeAgent");
+      }
+      return;
+    }
+
+    const overlayMatch = line.match(/updateActuationOverlay\((\{.*\})\)/);
+    if (overlayMatch) {
+      let payload;
+      try {
+        payload = JSON.parse(overlayMatch[1]);
+      } catch {
+        return;
+      }
+      if (payload.cascadeId) this._lastSessionId = `antigravity:${payload.cascadeId}`;
+      if (payload.passthroughEnabled === false) return;
+      if (payload.capturingScreenshot === true && !payload.displayString) {
+        this._lastWorkAt = Date.now();
+        this._emit(this._lastSessionId, "working", "BeforeTool", "Taking screenshot...");
+        return;
+      }
+      this._lastWorkAt = Date.now();
+      this._emit(this._lastSessionId, "working", "BeforeTool", payload.displayString || null);
+      return;
+    }
+
+    if (/error executing cascade step:/i.test(line)) {
+      this._emit(this._lastSessionId, "error", "PostToolUseFailure");
+    }
+  }
+
+  _emit(sessionId, state, event, displayString = null) {
+    this._lastState = state;
+    const extra = {
+      cwd: "",
+      sourcePid: null,
+      agentPid: this._lastAgentPid,
+      display_svg: null,
+    };
+    if (displayString) extra.displayString = displayString;
+    this._onStateChange(sessionId, state, event, extra);
+    this._scheduleIdle(sessionId, extra);
+  }
+
+  _scheduleIdle(sessionId, extra) {
+    if (this._idleTimer) clearTimeout(this._idleTimer);
+    this._idleTimer = setTimeout(() => {
+      this._lastState = "idle";
+      this._onStateChange(sessionId, "idle", "SessionIdle", extra);
+    }, this._config.logConfig.idleAfterMs || 6000);
+  }
+}
+
+module.exports = AntigravityLogMonitor;

--- a/agents/antigravity.js
+++ b/agents/antigravity.js
@@ -1,0 +1,33 @@
+// Antigravity editor agent configuration
+// Uses Antigravity language-server logs under ~/Library/Application Support/Antigravity/logs
+
+module.exports = {
+  id: "antigravity",
+  name: "Antigravity",
+  processNames: {
+    win: ["Antigravity.exe"],
+    mac: ["Antigravity"],
+    linux: ["antigravity", "Antigravity"],
+  },
+  eventSource: "log-poll",
+  logEventMap: {
+    plannerRequest: "thinking",
+    overlayAction: "working",
+    cascadeFailure: "error",
+    sessionIdle: "idle",
+  },
+  capabilities: {
+    httpHook: false,
+    permissionApproval: false,
+    sessionEnd: false,
+    subagent: false,
+  },
+  logConfig: {
+    logsDir: "~/Library/Application Support/Antigravity/logs",
+    fileName: "ls-main.log",
+    pollIntervalMs: 1500,
+    idleAfterMs: 6000,
+    tailLinesOnStart: 200,
+  },
+  pidField: "antigravity_pid",
+};

--- a/agents/registry.js
+++ b/agents/registry.js
@@ -9,8 +9,9 @@ const cursorAgent = require("./cursor-agent");
 const codebuddy = require("./codebuddy");
 const kiroCli = require("./kiro-cli");
 const opencode = require("./opencode");
+const antigravity = require("./antigravity");
 
-const AGENTS = [claudeCode, codex, copilotCli, geminiCli, cursorAgent, codebuddy, kiroCli, opencode];
+const AGENTS = [claudeCode, codex, copilotCli, geminiCli, cursorAgent, codebuddy, kiroCli, opencode, antigravity];
 const AGENT_MAP = new Map(AGENTS.map((a) => [a.id, a]));
 
 module.exports = {

--- a/src/main.js
+++ b/src/main.js
@@ -177,16 +177,19 @@ function flushRuntimeStateToPrefs() {
 
 let _codexMonitor = null;          // Codex CLI JSONL log polling instance
 let _geminiMonitor = null;         // Gemini CLI session JSON polling instance
+let _antigravityMonitor = null;    // Antigravity log polling instance
 
 // Hook-based agents have no module-level monitor — they're gated at the
 // HTTP route layer. Only log-poll agents hit these branches.
 function startMonitorForAgent(agentId) {
   if (agentId === "codex" && _codexMonitor) _codexMonitor.start();
   else if (agentId === "gemini-cli" && _geminiMonitor) _geminiMonitor.start();
+  else if (agentId === "antigravity" && _antigravityMonitor) _antigravityMonitor.start();
 }
 function stopMonitorForAgent(agentId) {
   if (agentId === "codex" && _codexMonitor) _codexMonitor.stop();
   else if (agentId === "gemini-cli" && _geminiMonitor) _geminiMonitor.stop();
+  else if (agentId === "antigravity" && _antigravityMonitor) _antigravityMonitor.stop();
 }
 
 // ── Theme loader ──
@@ -1542,6 +1545,19 @@ if (!gotTheLock) {
       console.warn("Clawd: Gemini log monitor not started:", err.message);
     }
 
+    try {
+      const AntigravityLogMonitor = require("../agents/antigravity-log-monitor");
+      const antigravityAgent = require("../agents/antigravity");
+      _antigravityMonitor = new AntigravityLogMonitor(antigravityAgent, (sid, state, event, extra) => {
+        updateSession(sid, state, event, extra.sourcePid || null, extra.cwd || "", null, null, extra.agentPid || null, "antigravity");
+      });
+      if (_isAgentEnabled(_settingsController.getSnapshot(), "antigravity")) {
+        _antigravityMonitor.start();
+      }
+    } catch (err) {
+      console.warn("Clawd: Antigravity log monitor not started:", err.message);
+    }
+
     // Auto-install VS Code/Cursor terminal-focus extension
     try { installTerminalFocusExtension(); } catch (err) {
       console.warn("Clawd: failed to auto-install terminal-focus extension:", err.message);
@@ -1564,6 +1580,7 @@ if (!gotTheLock) {
     _mini.cleanup();
     if (_codexMonitor) _codexMonitor.stop();
     if (_geminiMonitor) _geminiMonitor.stop();
+    if (_antigravityMonitor) _antigravityMonitor.stop();
     stopTopmostWatchdog();
     if (hwndRecoveryTimer) { clearTimeout(hwndRecoveryTimer); hwndRecoveryTimer = null; }
     _focus.cleanup();

--- a/src/state.js
+++ b/src/state.js
@@ -527,7 +527,7 @@ function detectRunningAgentProcesses(callback) {
       (err, stdout) => done(!err && /\d+/.test(stdout))
     );
   } else {
-    exec("pgrep -f 'claude-code|codex|copilot|codebuddy' || pgrep -x 'gemini' || pgrep -x 'kiro' || pgrep -x 'opencode'", { timeout: 3000 },
+    exec("pgrep -f 'claude-code|codex|copilot|codebuddy' || pgrep -x 'gemini' || pgrep -x 'kiro' || pgrep -x 'opencode' || pgrep -x 'Antigravity'", { timeout: 3000 },
       (err) => done(!err)
     );
   }

--- a/test/antigravity-log-monitor.test.js
+++ b/test/antigravity-log-monitor.test.js
@@ -1,0 +1,125 @@
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const AntigravityLogMonitor = require("../agents/antigravity-log-monitor");
+const antigravityConfig = require("../agents/antigravity");
+
+function makeTempLogDir() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "antigravity-test-"));
+  const logDir = path.join(tmpDir, "20260413T213055");
+  fs.mkdirSync(logDir, { recursive: true });
+  return { tmpDir, logFile: path.join(logDir, "ls-main.log") };
+}
+
+function makeConfig(tmpDir, idleAfterMs = 120) {
+  return {
+    ...antigravityConfig,
+    logConfig: {
+      ...antigravityConfig.logConfig,
+      logsDir: tmpDir,
+      pollIntervalMs: 30,
+      idleAfterMs,
+      tailLinesOnStart: 50,
+    },
+  };
+}
+
+describe("AntigravityLogMonitor", () => {
+  let tmpDir, logFile, monitor;
+
+  beforeEach(() => {
+    const dirs = makeTempLogDir();
+    tmpDir = dirs.tmpDir;
+    logFile = dirs.logFile;
+  });
+
+  afterEach(() => {
+    if (monitor) monitor.stop();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("sees planner requests as thinking", (_, done) => {
+    fs.writeFileSync(logFile, "I0413 22:00:32.692358 53208 planner_generator.go:283] Requesting planner with 38 chat messages\n");
+    monitor = new AntigravityLogMonitor(makeConfig(tmpDir), (sid, state, event) => {
+      assert.strictEqual(sid, "antigravity:main");
+      assert.strictEqual(state, "thinking");
+      assert.strictEqual(event, "BeforeAgent");
+      done();
+    });
+    monitor.start();
+  });
+
+  it("sees overlay actions as working and uses cascade id", (_, done) => {
+    fs.writeFileSync(logFile, 'I0413 21:52:31.254712 53208 operator.go:899] [overlay] Running JS: window.updateActuationOverlay({"cascadeId":"abc-123","displayString":"Getting DOM...","passthroughEnabled":true})\n');
+    monitor = new AntigravityLogMonitor(makeConfig(tmpDir), (sid, state, event, extra) => {
+      assert.strictEqual(sid, "antigravity:abc-123");
+      assert.strictEqual(state, "working");
+      assert.strictEqual(event, "BeforeTool");
+      assert.strictEqual(extra.displayString, "Getting DOM...");
+      done();
+    });
+    monitor.start();
+  });
+
+  it("ignores passthrough false overlay duplicates", async () => {
+    fs.writeFileSync(logFile, 'I0413 21:52:31.254712 53208 operator.go:899] [overlay] Running JS: window.updateActuationOverlay({"cascadeId":"abc-123","displayString":"Getting DOM...","passthroughEnabled":false})\n');
+    const seen = [];
+    monitor = new AntigravityLogMonitor(makeConfig(tmpDir), (...args) => seen.push(args));
+    monitor.start();
+    await new Promise((r) => setTimeout(r, 120));
+    assert.deepStrictEqual(seen, []);
+  });
+
+  it("sees cascade execution failures as error", (_, done) => {
+    fs.writeFileSync(logFile, 'E0413 22:02:19.797888 53208 log.go:398] error executing cascade step: boom\n');
+    monitor = new AntigravityLogMonitor(makeConfig(tmpDir), (sid, state, event) => {
+      assert.strictEqual(sid, "antigravity:main");
+      assert.strictEqual(state, "error");
+      assert.strictEqual(event, "PostToolUseFailure");
+      done();
+    });
+    monitor.start();
+  });
+
+
+  it("does not let planner chatter override active work", async () => {
+    fs.writeFileSync(logFile, [
+      'I0413 21:52:31.254712 53208 operator.go:899] [overlay] Running JS: window.updateActuationOverlay({"cascadeId":"busy-case","displayString":"Getting DOM...","passthroughEnabled":true})',
+      'I0413 21:52:31.454712 53208 planner_generator.go:283] Requesting planner with 38 chat messages',
+    ].join("\n") + "\n");
+    const seen = [];
+    monitor = new AntigravityLogMonitor(makeConfig(tmpDir, 500), (sid, state, event) => {
+      seen.push([sid, state, event]);
+    });
+    monitor.start();
+    await new Promise((r) => setTimeout(r, 150));
+    assert.deepStrictEqual(seen, [["antigravity:busy-case", "working", "BeforeTool"]]);
+  });
+
+  it("treats screenshot capture as work too", (_, done) => {
+    fs.writeFileSync(logFile, 'I0413 23:11:16.082014 53208 operator.go:899] [overlay] Running JS: window.updateActuationOverlay({"capturingScreenshot":true})\n');
+    monitor = new AntigravityLogMonitor(makeConfig(tmpDir), (sid, state, event, extra) => {
+      assert.strictEqual(sid, "antigravity:main");
+      assert.strictEqual(state, "working");
+      assert.strictEqual(event, "BeforeTool");
+      assert.strictEqual(extra.displayString, "Taking screenshot...");
+      done();
+    });
+    monitor.start();
+  });
+  it("falls back to idle after the activity goes quiet", async () => {
+    fs.writeFileSync(logFile, 'I0413 21:52:31.254712 53208 operator.go:899] [overlay] Running JS: window.updateActuationOverlay({"cascadeId":"idle-case","displayString":"Clicking...","passthroughEnabled":true})\n');
+    const seen = [];
+    monitor = new AntigravityLogMonitor(makeConfig(tmpDir, 80), (sid, state, event) => {
+      seen.push([sid, state, event]);
+    });
+    monitor.start();
+    await new Promise((r) => setTimeout(r, 180));
+    assert.deepStrictEqual(seen, [
+      ["antigravity:idle-case", "working", "BeforeTool"],
+      ["antigravity:idle-case", "idle", "SessionIdle"],
+    ]);
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -3,9 +3,9 @@ const assert = require("node:assert");
 const registry = require("../agents/registry");
 
 describe("Agent Registry", () => {
-  it("should return all seven agents", () => {
+  it("should return all supported agents", () => {
     const agents = registry.getAllAgents();
-    assert.strictEqual(agents.length, 8);
+    assert.strictEqual(agents.length, 9);
     const ids = agents.map((a) => a.id);
     assert.ok(ids.includes("claude-code"));
     assert.ok(ids.includes("codex"));
@@ -15,6 +15,7 @@ describe("Agent Registry", () => {
     assert.ok(ids.includes("codebuddy"));
     assert.ok(ids.includes("kiro-cli"));
     assert.ok(ids.includes("opencode"));
+    assert.ok(ids.includes("antigravity"));
   });
 
   it("should look up agents by ID", () => {
@@ -25,6 +26,7 @@ describe("Agent Registry", () => {
     assert.strictEqual(registry.getAgent("cursor-agent").name, "Cursor Agent");
     assert.strictEqual(registry.getAgent("codebuddy").name, "CodeBuddy");
     assert.strictEqual(registry.getAgent("kiro-cli").name, "Kiro CLI");
+    assert.strictEqual(registry.getAgent("antigravity").name, "Antigravity");
     assert.strictEqual(registry.getAgent("nonexistent"), undefined);
   });
 
@@ -45,6 +47,9 @@ describe("Agent Registry", () => {
 
     const cursor = registry.getAgent("cursor-agent");
     assert.deepStrictEqual(cursor.processNames.win, ["Cursor.exe"]);
+
+    const antigravity = registry.getAgent("antigravity");
+    assert.deepStrictEqual(antigravity.processNames.win, ["Antigravity.exe"]);
   });
 
   it("should include explicit Linux process names", () => {
@@ -62,6 +67,9 @@ describe("Agent Registry", () => {
 
     const cursor = registry.getAgent("cursor-agent");
     assert.deepStrictEqual(cursor.processNames.linux, ["cursor", "Cursor"]);
+
+    const antigravity = registry.getAgent("antigravity");
+    assert.deepStrictEqual(antigravity.processNames.linux, ["antigravity", "Antigravity"]);
   });
 
   it("should aggregate all process names", () => {
@@ -76,6 +84,7 @@ describe("Agent Registry", () => {
     assert.ok(agentIds.includes("gemini-cli"));
     assert.ok(agentIds.includes("cursor-agent"));
     assert.ok(agentIds.includes("kiro-cli"));
+    assert.ok(agentIds.includes("antigravity"));
   });
 
   it("should have correct capabilities", () => {
@@ -114,6 +123,12 @@ describe("Agent Registry", () => {
     assert.strictEqual(kiro.capabilities.permissionApproval, false);
     assert.strictEqual(kiro.capabilities.sessionEnd, false);
     assert.strictEqual(kiro.capabilities.subagent, false);
+
+    const antigravity = registry.getAgent("antigravity");
+    assert.strictEqual(antigravity.capabilities.httpHook, false);
+    assert.strictEqual(antigravity.capabilities.permissionApproval, false);
+    assert.strictEqual(antigravity.capabilities.sessionEnd, false);
+    assert.strictEqual(antigravity.capabilities.subagent, false);
   });
 
   it("should have eventMap for hook-based agents", () => {


### PR DESCRIPTION
## Summary
- add an Antigravity log-poll agent and monitor that reads `ls-main.log` under Antigravity's app data directory
- treat live `updateActuationOverlay` actions as working, keep screenshot capture in working too, and avoid planner chatter overriding active work
- wire the new agent into registry, process detection, startup monitor wiring, and regression tests

## Testing
- `node --test test/antigravity-log-monitor.test.js test/registry.test.js test/agents.test.js test/state.test.js`
- `npm test` *(454 passed, 1 existing failure remains in `test/updater.test.js`)*
