### PR TITLE
refactor: able to run on daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ scripts/*
 !scripts/run-clawdbot-stress.sh
 !scripts/monitor-clawd-resources.sh
 !scripts/validate-theme.js
+!scripts/start-detached.js
 
 # oh-my-cursor state
 .omc/

--- a/README.md
+++ b/README.md
@@ -97,9 +97,16 @@ cd clawd-on-desk
 # Install dependencies
 npm install
 
-# Start Clawd (auto-registers Claude Code hooks on launch)
+# Start Clawd in foreground (auto-registers Claude Code hooks on launch)
 npm start
+
+# Start Clawd in background and release the terminal
+npm run start:daemon
 ```
+
+If you do not want a terminal window involved at all, build the macOS app with
+`npm run build:mac` and launch the generated `.app` normally. The tray menu
+also exposes `Open at Login`, which writes the OS login item / autostart entry.
 
 **Claude Code** and **Codex CLI** work out of the box. Other agents (Copilot, Kiro, etc.) need one-time setup. Also covers remote SSH, WSL, and platform-specific notes (macOS / Linux): **[docs/setup-guide.md](docs/setup-guide.md)**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,9 +97,16 @@ cd clawd-on-desk
 # 安装依赖
 npm install
 
-# 启动 Clawd（启动时会自动注册 Claude Code hooks；如需预先手动注册，可单独执行 `node hooks/install.js`）
+# 前台启动 Clawd（启动时会自动注册 Claude Code hooks；如需预先手动注册，可单独执行 `node hooks/install.js`）
 npm start
+
+# 后台启动 Clawd，并立即释放当前终端
+npm run start:daemon
 ```
+
+如果你不想让终端参与运行流程，可以使用 `npm run build:mac` 构建 macOS
+应用，然后直接启动生成的 `.app`。托盘菜单里的 `Open at Login`
+会写入系统登录项 / 自启动配置。
 
 **Claude Code** 和 **Codex CLI** 开箱即用。其他 Agent（Copilot、Kiro 等）需一次性配置。也涵盖远程 SSH、WSL 及平台说明（macOS / Linux）：**[docs/setup-guide.zh-CN.md](docs/setup-guide.zh-CN.md)**
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/main.js",
   "scripts": {
     "start": "node launch.js",
+    "start:daemon": "node scripts/start-detached.js",
     "build": "electron-builder --win",
     "build:mac": "electron-builder --mac",
     "build:linux": "electron-builder --linux",

--- a/scripts/start-detached.js
+++ b/scripts/start-detached.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+// Detached launcher for development use.
+//
+// Unlike `npm start`, this spawns Electron in the background so the shell can
+// exit immediately while Clawd keeps running as a normal GUI app.
+
+const { spawn } = require("child_process");
+const path = require("path");
+const electron = require("electron");
+
+const repoRoot = path.join(__dirname, "..");
+const env = { ...process.env };
+delete env.ELECTRON_RUN_AS_NODE;
+
+if (process.platform === "linux") {
+  env.ELECTRON_DISABLE_SANDBOX = "1";
+  env.CHROME_DEVEL_SANDBOX = "";
+}
+
+const args = process.platform === "linux"
+  ? [".", "--no-sandbox", "--disable-setuid-sandbox"]
+  : ["."];
+
+const child = spawn(electron, args, {
+  cwd: repoRoot,
+  env,
+  detached: true,
+  stdio: "ignore",
+});
+
+child.unref();
+
+process.stdout.write(`Clawd started in background (pid ${child.pid})\n`);


### PR DESCRIPTION
## Summary

  This PR adds a detached development launcher so Clawd can keep running without holding the current terminal open.

## Changes

  - add npm run start:daemon for background startup in development mode
  - add scripts/start-detached.js to launch Electron as a detached GUI process
  - update README.md and README.zh-CN.md to document foreground vs background startup
  - document the recommended packaged .app flow for users who do not want to launch from a terminal

## Notes

  - this is intended for local development from a cloned repo
  - npm start remains the foreground/dev-friendly option
  - packaged app usage and Open at Login remain the better long-term path for end users

+) I don't speak Chinese. So I used AI translation. 
     If anything is mistranslated, please let me know.