### PR TITLE
[codex] Fix high-DPI drag cursor drift

### DIFF
--- a/src/drag-position.js
+++ b/src/drag-position.js
@@ -1,0 +1,52 @@
+"use strict";
+
+function copyPoint(point) {
+  return { x: point.x, y: point.y };
+}
+
+function copySize(size) {
+  return { width: size.width, height: size.height };
+}
+
+function createDragSnapshot(cursor, bounds, size) {
+  if (!cursor || !bounds || !size) return null;
+  return {
+    cursor: copyPoint(cursor),
+    bounds: { x: bounds.x, y: bounds.y },
+    size: copySize(size),
+  };
+}
+
+function computeAnchoredDragBounds(snapshot, cursor, clampPosition) {
+  if (!snapshot || !cursor) return null;
+  const { width, height } = snapshot.size;
+  const targetX = snapshot.bounds.x + (cursor.x - snapshot.cursor.x);
+  const targetY = snapshot.bounds.y + (cursor.y - snapshot.cursor.y);
+  const pos = clampPosition
+    ? clampPosition(targetX, targetY, width, height)
+    : { x: targetX, y: targetY };
+  return { x: pos.x, y: pos.y, width, height };
+}
+
+function computeFinalDragBounds(bounds, size, clampPosition) {
+  if (!bounds || !size || !clampPosition) return null;
+  const pos = clampPosition(bounds.x, bounds.y, size.width, size.height);
+  return { x: pos.x, y: pos.y, width: size.width, height: size.height };
+}
+
+function materializeVirtualBounds(virtualBounds, workArea) {
+  if (!virtualBounds) return null;
+  const minY = workArea && Number.isFinite(workArea.y) ? workArea.y : -Infinity;
+  const y = Math.max(virtualBounds.y, minY);
+  return {
+    bounds: { ...virtualBounds, y },
+    viewportOffsetY: y - virtualBounds.y,
+  };
+}
+
+module.exports = {
+  createDragSnapshot,
+  computeAnchoredDragBounds,
+  computeFinalDragBounds,
+  materializeVirtualBounds,
+};

--- a/src/hit-geometry.js
+++ b/src/hit-geometry.js
@@ -131,8 +131,26 @@ function getHitRectScreen(theme, bounds, state, file, hitBox, options = {}) {
   };
 }
 
+function getContentRectScreen(theme, bounds, state, file) {
+  if (!theme || !bounds || !theme.layout || !theme.layout.contentBox) return null;
+  const artRect = getAssetRectScreen(theme, bounds, state, file);
+  if (!artRect) return null;
+
+  const box = theme.layout.contentBox;
+  const vb = theme.viewBox;
+  const scaleX = artRect.w / vb.width;
+  const scaleY = artRect.h / vb.height;
+  return {
+    left: artRect.x + (box.x - vb.x) * scaleX,
+    top: artRect.y + (box.y - vb.y) * scaleY,
+    right: artRect.x + (box.x - vb.x + box.width) * scaleX,
+    bottom: artRect.y + (box.y - vb.y + box.height) * scaleY,
+  };
+}
+
 module.exports = {
   getAssetRectScreen,
+  getContentRectScreen,
   getHitRectScreen,
   usesObjectChannel,
   usesNormalizedLayout,

--- a/src/hit-renderer.js
+++ b/src/hit-renderer.js
@@ -35,10 +35,8 @@ window.hitAPI.onStateSync((data) => {
 // --- Drag state ---
 let isDragging = false;
 let didDrag = false;
-let lastScreenX, lastScreenY;
 let mouseDownX, mouseDownY;
-let pendingDx = 0, pendingDy = 0;
-let dragRAF = null;
+let dragMoveRAF = null;
 const DRAG_THRESHOLD = 3;
 
 // --- Reaction state (tracked here to gate input) ---
@@ -59,12 +57,8 @@ area.addEventListener("pointerdown", (e) => {
     area.setPointerCapture(e.pointerId);
     isDragging = true;
     didDrag = false;
-    lastScreenX = e.screenX;
-    lastScreenY = e.screenY;
     mouseDownX = e.clientX;
     mouseDownY = e.clientY;
-    pendingDx = 0;
-    pendingDy = 0;
     window.hitAPI.dragLock(true);
     area.classList.add("dragging");
   }
@@ -72,11 +66,6 @@ area.addEventListener("pointerdown", (e) => {
 
 document.addEventListener("pointermove", (e) => {
   if (isDragging) {
-    pendingDx += e.screenX - lastScreenX;
-    pendingDy += e.screenY - lastScreenY;
-    lastScreenX = e.screenX;
-    lastScreenY = e.screenY;
-
     if (!didDrag) {
       const totalDx = e.clientX - mouseDownX;
       const totalDy = e.clientY - mouseDownY;
@@ -86,29 +75,30 @@ document.addEventListener("pointermove", (e) => {
       }
     }
 
-    if (!dragRAF) {
-      dragRAF = setTimeout(() => {
-        window.hitAPI.moveWindowBy(pendingDx, pendingDy);
-        pendingDx = 0;
-        pendingDy = 0;
-        dragRAF = null;
-      }, 0);
-    }
+    if (didDrag) scheduleDragMove();
   }
 });
+
+function scheduleDragMove() {
+  if (dragMoveRAF) return;
+  dragMoveRAF = setTimeout(() => {
+    dragMoveRAF = null;
+    window.hitAPI.dragMove();
+  }, 0);
+}
 
 function stopDrag() {
   if (!isDragging) return;
   isDragging = false;
-  window.hitAPI.dragLock(false);
   area.classList.remove("dragging");
-  if (pendingDx !== 0 || pendingDy !== 0) {
-    if (dragRAF) { clearTimeout(dragRAF); dragRAF = null; }
-    window.hitAPI.moveWindowBy(pendingDx, pendingDy);
-    pendingDx = 0; pendingDy = 0;
-  }
   if (didDrag) {
+    if (dragMoveRAF) { clearTimeout(dragMoveRAF); dragMoveRAF = null; }
+    window.hitAPI.dragMove();
     window.hitAPI.dragEnd();
+    window.hitAPI.dragLock(false);
+  } else {
+    if (dragMoveRAF) { clearTimeout(dragMoveRAF); dragMoveRAF = null; }
+    window.hitAPI.dragLock(false);
   }
   endDragReaction();
 }

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,12 @@ const { applyStationaryCollectionBehavior } = require("./mac-window");
 const hitGeometry = require("./hit-geometry");
 const animationCycle = require("./animation-cycle");
 const { findNearestWorkArea, computeLooseClamp, SYNTHETIC_WORK_AREA } = require("./work-area");
+const {
+  createDragSnapshot,
+  computeAnchoredDragBounds,
+  computeFinalDragBounds,
+  materializeVirtualBounds,
+} = require("./drag-position");
 const { getLaunchSizingWorkArea, getProportionalPixelSize } = require("./size-utils");
 
 // ── Autoplay policy: allow sound playback without user gesture ──
@@ -438,9 +444,35 @@ function resetSoundCooldown() {
 // Sync input window position to match render window's hitbox.
 // Called manually after every win position/size change + event-level safety net.
 let _lastHitW = 0, _lastHitH = 0;
+let viewportOffsetY = 0;
+
+function setViewportOffsetY(offsetY) {
+  const next = Number.isFinite(offsetY) ? Math.max(0, Math.round(offsetY)) : 0;
+  if (next === viewportOffsetY) return;
+  viewportOffsetY = next;
+  sendToRenderer("viewport-offset", viewportOffsetY);
+}
+
+function getVirtualWindowBounds() {
+  const bounds = win.getBounds();
+  return { ...bounds, y: bounds.y - viewportOffsetY };
+}
+
+function applyVirtualWindowBounds(virtualBounds) {
+  const wa = getNearestWorkArea(
+    virtualBounds.x + virtualBounds.width / 2,
+    virtualBounds.y + virtualBounds.height / 2
+  );
+  const materialized = materializeVirtualBounds(virtualBounds, wa);
+  if (!materialized) return null;
+  setViewportOffsetY(materialized.viewportOffsetY);
+  win.setBounds(materialized.bounds);
+  return materialized.bounds;
+}
+
 function syncHitWin() {
   if (!hitWin || hitWin.isDestroyed() || !win || win.isDestroyed()) return;
-  const bounds = win.getBounds();
+  const bounds = getVirtualWindowBounds();
   const hit = getHitRectScreen(bounds);
   const x = Math.round(hit.left);
   const y = Math.round(hit.top);
@@ -457,10 +489,47 @@ function syncHitWin() {
 
 let mouseOverPet = false;
 let dragLocked = false;
+let dragSnapshot = null;
 let menuOpen = false;
 let idlePaused = false;
 let forceEyeResend = false;
 let themeReloadInProgress = false;
+
+// Keep drag math in Electron's main-process DIP coordinate space. Renderer
+// PointerEvent.screenX/Y can be scaled differently on high-DPI displays.
+function beginDragSnapshot() {
+  if (!win || win.isDestroyed()) {
+    dragSnapshot = null;
+    return;
+  }
+  dragSnapshot = createDragSnapshot(
+    screen.getCursorScreenPoint(),
+    getVirtualWindowBounds(),
+    getCurrentPixelSize()
+  );
+}
+
+function clearDragSnapshot() {
+  dragSnapshot = null;
+}
+
+function moveWindowForDrag() {
+  if (_mini.getMiniMode() || _mini.getMiniTransitioning()) return;
+  if (!win || win.isDestroyed()) return;
+  if (!dragSnapshot) beginDragSnapshot();
+  if (!dragSnapshot) return;
+
+  const bounds = computeAnchoredDragBounds(
+    dragSnapshot,
+    screen.getCursorScreenPoint(),
+    looseClampPetToDisplays
+  );
+  if (!bounds) return;
+
+  applyVirtualWindowBounds(bounds);
+  syncHitWin();
+  if (bubbleFollowPet) repositionFloatingBubbles();
+}
 
 // ── Mini Mode — delegated to src/mini.js ──
 // Initialized after state module (needs applyState, resolveDisplayState, etc.)
@@ -1649,18 +1718,7 @@ function createWindow() {
 
   ipcMain.on("show-context-menu", showPetContextMenu);
 
-  ipcMain.on("move-window-by", (event, dx, dy) => {
-    if (_mini.getMiniMode() || _mini.getMiniTransitioning()) return;
-    const { x, y } = win.getBounds();
-    const size = getCurrentPixelSize();
-    // During drag: allow free movement across screens, only prevent
-    // the pet from going completely off-screen (keep 25% visible).
-    const newX = x + dx, newY = y + dy;
-    const looseClamped = looseClampToDisplays(newX, newY, size.width, size.height);
-    win.setBounds({ ...looseClamped, width: size.width, height: size.height });
-    syncHitWin();
-    if (bubbleFollowPet) repositionFloatingBubbles();
-  });
+  ipcMain.on("drag-move", () => moveWindowForDrag());
 
   ipcMain.on("pause-cursor-polling", () => { idlePaused = true; });
   ipcMain.on("resume-from-reaction", () => {
@@ -1671,7 +1729,12 @@ function createWindow() {
 
   ipcMain.on("drag-lock", (event, locked) => {
     dragLocked = !!locked;
-    if (locked) mouseOverPet = true;
+    if (locked) {
+      mouseOverPet = true;
+      beginDragSnapshot();
+    } else {
+      clearDragSnapshot();
+    }
   });
 
   // Reaction relay: hitWin → main → renderWin
@@ -1682,18 +1745,22 @@ function createWindow() {
   });
 
   ipcMain.on("drag-end", () => {
-    if (!_mini.getMiniMode() && !_mini.getMiniTransitioning()) {
-      checkMiniModeSnap();
-      // After drag, clamp to the nearest screen (loose clamp during drag allows cross-screen).
-      // In proportional mode, also recalculate size for the landing display.
-      if (win && !win.isDestroyed()) {
-        const size = getCurrentPixelSize();
-        const { x, y } = win.getBounds();
-        const clamped = clampToScreen(x, y, size.width, size.height);
-        win.setBounds({ ...clamped, width: size.width, height: size.height });
-        syncHitWin();
-        repositionUpdateBubble();
+    try {
+      if (!_mini.getMiniMode() && !_mini.getMiniTransitioning()) {
+        checkMiniModeSnap();
+        // After drag, clamp to the nearest screen (loose clamp during drag allows cross-screen).
+        // In proportional mode, also recalculate size for the landing display.
+        if (win && !win.isDestroyed()) {
+          const size = getCurrentPixelSize();
+          const clamped = computeFinalDragBounds(getVirtualWindowBounds(), size, clampToScreen);
+          if (clamped) applyVirtualWindowBounds(clamped);
+          syncHitWin();
+          repositionUpdateBubble();
+        }
       }
+    } finally {
+      dragLocked = false;
+      clearDragSnapshot();
     }
   });
 
@@ -1734,6 +1801,7 @@ function createWindow() {
   // Also handles crash recovery (render-process-gone → reload)
   win.webContents.on("did-finish-load", () => {
     sendToRenderer("theme-config", themeLoader.getRendererConfig());
+    sendToRenderer("viewport-offset", viewportOffsetY);
     if (themeReloadInProgress) return;
     syncRendererStateAfterLoad();
   });
@@ -1808,6 +1876,22 @@ function getNearestWorkArea(cx, cy) {
 // so the pet can freely cross between screens. Only prevents going fully off-screen.
 function looseClampToDisplays(x, y, w, h) {
   return computeLooseClamp(screen.getAllDisplays(), getPrimaryWorkAreaSafe(), x, y, w, h);
+}
+
+function getVisibleContentMargins(bounds) {
+  const content = getHitRectScreen(bounds);
+  return {
+    top: Math.max(0, Math.round(content.top - bounds.y)),
+    bottom: Math.max(0, Math.round(bounds.y + bounds.height - content.bottom)),
+  };
+}
+
+function looseClampPetToDisplays(x, y, w, h) {
+  const margins = getVisibleContentMargins({ x, y, width: w, height: h });
+  return computeLooseClamp(screen.getAllDisplays(), getPrimaryWorkAreaSafe(), x, y, w, h, {
+    marginTop: Math.max(Math.round(h * 0.25), margins.top),
+    marginBottom: Math.max(Math.round(h * 0.25), margins.bottom),
+  });
 }
 
 function clampToScreen(x, y, w, h) {

--- a/src/preload-hit.js
+++ b/src/preload-hit.js
@@ -11,7 +11,7 @@ contextBridge.exposeInMainWorld("hitAPI", {
   onThemeConfig: (cb) => ipcRenderer.on("theme-config", (_, cfg) => cb(cfg)),
   // Sends → main
   dragLock: (locked) => ipcRenderer.send("drag-lock", locked),
-  moveWindowBy: (dx, dy) => ipcRenderer.send("move-window-by", dx, dy),
+  dragMove: () => ipcRenderer.send("drag-move"),
   dragEnd: () => ipcRenderer.send("drag-end"),
   showContextMenu: () => ipcRenderer.send("show-context-menu"),
   focusTerminal: () => ipcRenderer.send("focus-terminal"),

--- a/src/preload.js
+++ b/src/preload.js
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onWakeFromDoze: (callback) => ipcRenderer.on("wake-from-doze", () => callback()),
   onDndChange: (callback) => ipcRenderer.on("dnd-change", (_, enabled) => callback(enabled)),
   onMiniModeChange: (cb) => ipcRenderer.on("mini-mode-change", (_, enabled, edge) => cb(enabled, edge)),
+  onViewportOffset: (cb) => ipcRenderer.on("viewport-offset", (_, offsetY) => cb(offsetY)),
   // Reaction control (from main, relayed from hit window)
   onStartDragReaction: (cb) => ipcRenderer.on("start-drag-reaction", () => cb()),
   onEndDragReaction: (cb) => ipcRenderer.on("end-drag-reaction", () => cb()),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -68,13 +68,13 @@ function applyObjectScaleStyle(el, file) {
     el.style.height = "auto";
     el.style.left = `calc(${_objectScaleCSS.imgLeft} + ${ox}px)`;
     el.style.top = "auto";
-    el.style.bottom = `calc(${_objectScaleCSS.imgBottom || "5%"} + ${oy}px)`;
+    el.style.bottom = `calc(${_objectScaleCSS.imgBottom || "5%"} + ${oy + _viewportOffsetY}px)`;
   } else {
     el.style.width = _objectScaleCSS.width;
     el.style.height = _objectScaleCSS.height;
     el.style.left = `calc(${_objectScaleCSS.left} + ${ox}px)`;
     el.style.top = "auto";
-    el.style.bottom = `calc(${_objectScaleCSS.objBottom} + ${oy}px)`;
+    el.style.bottom = `calc(${_objectScaleCSS.objBottom} + ${oy + _viewportOffsetY}px)`;
   }
 }
 
@@ -106,14 +106,22 @@ function applyNormalizedLayoutStyle(el, file) {
     el.style.height = "auto";
     el.style.left = `calc(${leftRatio * 100}% + ${ox}px)`;
     el.style.top = "auto";
-    el.style.bottom = `calc(${bottomRatio * 100}% + ${oy}px)`;
+    el.style.bottom = `calc(${bottomRatio * 100}% + ${oy + _viewportOffsetY}px)`;
   } else {
     el.style.width = `${widthRatio * 100}%`;
     el.style.height = `${heightRatio * 100}%`;
     el.style.left = `calc(${leftRatio * 100}% + ${ox}px)`;
     el.style.top = "auto";
-    el.style.bottom = `calc(${bottomRatio * 100}% + ${oy}px)`;
+    el.style.bottom = `calc(${bottomRatio * 100}% + ${oy + _viewportOffsetY}px)`;
   }
+}
+
+function setViewportOffset(offsetY) {
+  const next = Number.isFinite(offsetY) ? Math.max(0, Math.round(offsetY)) : 0;
+  if (next === _viewportOffsetY) return;
+  _viewportOffsetY = next;
+  applyObjectScaleStyle(clawdEl, currentDisplayedSvg);
+  applyObjectScaleStyle(pendingNext, pendingNext && getObjectSvgName(pendingNext));
 }
 
 let _assetsPath;
@@ -134,6 +142,7 @@ let _fileOffsets = {};
 let _transitions = {};  // per-file fade config: { "file.apng": { in: 400, out: 400 } }
 let _miniFlipAssets = false; // theme's mini assets drawn in reverse direction
 let _inMiniMode = false;
+let _viewportOffsetY = 0;
 
 function applyMiniFlip(el) {
   if (!el || el.tagName !== "IMG") return;
@@ -751,6 +760,10 @@ window.electronAPI.onEyeMove((dx, dy) => {
     return;
   }
   applyEyeMove(effectiveDx, dy);
+});
+
+window.electronAPI.onViewportOffset((offsetY) => {
+  setViewportOffset(offsetY);
 });
 
 // --- Sound playback (IPC from main, receives file:// URL from theme) ---

--- a/src/work-area.js
+++ b/src/work-area.js
@@ -27,7 +27,7 @@ function findNearestWorkArea(displays, primaryWa, cx, cy) {
   return nearest;
 }
 
-function computeLooseClamp(displays, primaryWa, x, y, w, h) {
+function computeLooseClamp(displays, primaryWa, x, y, w, h, options = {}) {
   let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
   if (Array.isArray(displays)) {
     for (const d of displays) {
@@ -48,10 +48,12 @@ function computeLooseClamp(displays, primaryWa, x, y, w, h) {
     maxX = wa.x + wa.width;
     maxY = wa.y + wa.height;
   }
-  const margin = Math.round(w * 0.25);
+  const marginX = options.marginX != null ? options.marginX : Math.round(w * 0.25);
+  const marginTop = options.marginTop != null ? options.marginTop : Math.round(h * 0.25);
+  const marginBottom = options.marginBottom != null ? options.marginBottom : Math.round(h * 0.25);
   return {
-    x: Math.max(minX - margin, Math.min(x, maxX - w + margin)),
-    y: Math.max(minY - margin, Math.min(y, maxY - h + margin)),
+    x: Math.max(minX - marginX, Math.min(x, maxX - w + marginX)),
+    y: Math.max(minY - marginTop, Math.min(y, maxY - h + marginBottom)),
   };
 }
 

--- a/test/drag-position.test.js
+++ b/test/drag-position.test.js
@@ -1,0 +1,74 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+const {
+  createDragSnapshot,
+  computeAnchoredDragBounds,
+  computeFinalDragBounds,
+  materializeVirtualBounds,
+} = require("../src/drag-position");
+const { computeLooseClamp } = require("../src/work-area");
+
+const wa = (x, y, w, h) => ({ x, y, width: w, height: h });
+const display = (x, y, w, h) => ({ workArea: wa(x, y, w, h) });
+
+describe("anchored drag positioning", () => {
+  it("keeps the original cursor-to-window offset across repeated moves", () => {
+    const snapshot = createDragSnapshot(
+      { x: 100, y: 100 },
+      { x: 500, y: 500, width: 200, height: 200 },
+      { width: 200, height: 200 }
+    );
+
+    const cursorPath = [
+      { x: 150, y: 125 },
+      { x: 100, y: 100 },
+      { x: 60, y: 155 },
+      { x: 100, y: 100 },
+    ];
+
+    const positions = cursorPath.map((cursor) => computeAnchoredDragBounds(snapshot, cursor));
+
+    assert.deepStrictEqual(positions[0], { x: 550, y: 525, width: 200, height: 200 });
+    assert.deepStrictEqual(positions[1], { x: 500, y: 500, width: 200, height: 200 });
+    assert.deepStrictEqual(positions[2], { x: 460, y: 555, width: 200, height: 200 });
+    assert.deepStrictEqual(positions[3], { x: 500, y: 500, width: 200, height: 200 });
+  });
+
+  it("uses loose display-union clamping during drag so cross-screen movement is not pulled back", () => {
+    const displays = [display(0, 0, 1920, 1080), display(1920, 0, 1920, 1080)];
+    const snapshot = createDragSnapshot(
+      { x: 1900, y: 500 },
+      { x: 1800, y: 400, width: 200, height: 200 },
+      { width: 200, height: 200 }
+    );
+
+    const result = computeAnchoredDragBounds(snapshot, { x: 2200, y: 520 }, (x, y, w, h) =>
+      computeLooseClamp(displays, null, x, y, w, h)
+    );
+
+    assert.deepStrictEqual(result, { x: 2100, y: 420, width: 200, height: 200 });
+  });
+
+  it("applies the final clamp after drag ends", () => {
+    const result = computeFinalDragBounds(
+      { x: 3900, y: 100, width: 200, height: 200 },
+      { width: 200, height: 200 },
+      () => ({ x: 3640, y: 100 })
+    );
+
+    assert.deepStrictEqual(result, { x: 3640, y: 100, width: 200, height: 200 });
+  });
+
+  it("materializes above-screen virtual bounds as a window-top render offset", () => {
+    const result = materializeVirtualBounds(
+      { x: 500, y: -74, width: 200, height: 200 },
+      wa(0, 0, 1920, 1080)
+    );
+
+    assert.deepStrictEqual(result, {
+      bounds: { x: 500, y: 0, width: 200, height: 200 },
+      viewportOffsetY: 74,
+    });
+  });
+});

--- a/test/hit-geometry.test.js
+++ b/test/hit-geometry.test.js
@@ -99,4 +99,10 @@ describe("hit geometry", () => {
     approx(rect.w, 261);
     approx(rect.h, 261);
   });
+
+  it("reports visible content padding for clawd drag svg", () => {
+    const content = hitGeometry.getContentRectScreen(clawd, bounds, null, "clawd-react-drag.svg");
+    approx(content.top, 74);
+    approx(content.bottom, 190);
+  });
 });

--- a/test/work-area.test.js
+++ b/test/work-area.test.js
@@ -79,6 +79,14 @@ describe("computeLooseClamp", () => {
     assert.strictEqual(result.x, -50);
   });
 
+  it("accepts an explicit top margin for windows with invisible padding", () => {
+    const displays = [display(0, 0, 1920, 1080)];
+    const result = computeLooseClamp(displays, null, 100, -120, 200, 200, {
+      marginTop: 110,
+    });
+    assert.strictEqual(result.y, -110);
+  });
+
   // ── issue #93 regression cases ──
 
   it("falls back to primary when displays is empty", () => {


### PR DESCRIPTION
## Summary
- move normal drag positioning to main-process Electron DIP cursor anchoring instead of renderer `screenX/screenY` deltas
- send drag-move signals from the hit renderer and compute movement from `screen.getCursorScreenPoint()` against a drag-start snapshot in main
- preserve hit-window synchronization, loose cross-screen drag clamping, final drag-end clamp, and mini-mode snap behavior
- handle the related laptop top-edge ceiling by keeping virtual drag bounds and applying a renderer viewport offset when Windows clamps the transparent BrowserWindow at the work-area top

Closes #109.

## Root Cause
The pre-fix drag path mixed renderer `PointerEvent.screenX/screenY` deltas with Electron `BrowserWindow` bounds. On high-DPI/scaled displays, browser screen-event coordinates can diverge from Electron's DIP coordinate space, so repeated movement can accumulate cursor drift.

After anchoring movement in the main process, the same coordinate path exposed a related top-edge issue on the laptop display: Windows/Electron can clamp the actual transparent BrowserWindow at `y = 0`, while Clawd's visible sprite sits below the transparent window top. This looked like an invisible ceiling below the real screen edge.

This patch keeps drag math canonical in main-process DIP coordinates, treats the pet position as virtual when necessary, materializes the real Electron window within the work area, and shifts the rendered pet upward inside that window while keeping the hit window aligned to the virtual bounds.

## Related History
Checked upstream first: no open issue matched this exact repeated-drag cursor drift behavior. Adjacent prior work includes #44, #47, and #77 for high-DPI hit-window offsets, mixed-DPI hitWin positioning, and cross-screen drag clamping.

Electron docs reference: `screen.getCursorScreenPoint()` returns DIP coordinates and Electron exposes physical-screen/DIP conversion APIs for high-DPI displays: https://github.com/electron/electron/blob/main/docs/api/screen.md

## Validation
- `node --check src\\main.js`
- `node --check src\\renderer.js`
- `node --check src\\preload.js`
- `node --test test/drag-position.test.js test/work-area.test.js test/hit-geometry.test.js` — 26 passed
- `npm test` — 568 passed, 1 failed, 1 skipped; remaining failure is the pre-existing `test/shared-process.test.js` PID-chain assertion (`pidChain.length >= 1`)

## Manual Verification
- Reporter verified the cursor-anchor drift fix locally on the high-DPI laptop display.
- Reporter captured monitor-specific evidence: external monitor has no issue, laptop monitor reproduces the issue.
- The laptop top-edge ceiling appeared during the drag fix and is handled by the virtual-bounds viewport-offset path; this still needs final manual confirmation on the laptop display before marking ready.
