### PR TITLE
fix: restore window position when disconnected display is reconnected

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -193,6 +193,12 @@ function flushRuntimeStateToPrefs() {
   });
 }
 
+// ── Display-disconnect position backup ──
+// When a display is removed the window gets clamped to a surviving monitor.
+// We stash the pre-clamp position so that when the same display comes back
+// (display-added) we can restore the pet to where it was.
+let _preDisconnectBounds = null;   // { x, y, width, height } or null
+
 let _codexMonitor = null;          // Codex CLI JSONL log polling instance
 let _geminiMonitor = null;         // Gemini CLI session JSON polling instance
 
@@ -1778,12 +1784,36 @@ function createWindow() {
     const size = getCurrentPixelSize();
     const { x, y } = win.getBounds();
     const clamped = clampToScreen(x, y, size.width, size.height);
+    // Only stash when the pet actually had to move — avoids overwriting
+    // a good backup when a second, unrelated display is removed afterwards.
+    if (clamped.x !== x || clamped.y !== y) {
+      _preDisconnectBounds = { x, y, width: size.width, height: size.height };
+    }
     win.setBounds({ ...clamped, width: size.width, height: size.height });
     syncHitWin();
     repositionUpdateBubble();
   });
   screen.on("display-added", () => {
     reapplyMacVisibility();
+    // If we saved a pre-disconnect position, check whether the newly added
+    // display covers that location. If so, restore the pet there.
+    if (_preDisconnectBounds && win && !win.isDestroyed() && !_mini.getMiniMode()) {
+      const b = _preDisconnectBounds;
+      const cx = b.x + b.width / 2;
+      const cy = b.y + b.height / 2;
+      const displays = screen.getAllDisplays();
+      const hit = displays.some((d) => {
+        const wa = d.workArea;
+        return cx >= wa.x && cx < wa.x + wa.width &&
+               cy >= wa.y && cy < wa.y + wa.height;
+      });
+      if (hit) {
+        win.setBounds(b);
+        syncHitWin();
+        flushRuntimeStateToPrefs();
+        _preDisconnectBounds = null;
+      }
+    }
     repositionUpdateBubble();
   });
 }


### PR DESCRIPTION
## Problem

When an external monitor is disconnected, the pet window is clamped to a surviving display (expected). However, when the monitor is reconnected, the pet stays on the primary display instead of returning to its original position.

This is especially noticeable with multi-monitor setups (e.g., primary + 2 external monitors) — disconnecting both and reconnecting may place the pet on the wrong monitor.

## Root cause

- `display-removed` handler saves position *after* clamping, so if two displays are removed sequentially, the second event overwrites the backup with the already-clamped (primary) position.
- `display-added` handler had no position restoration logic at all.

## Fix

- **`display-removed`**: stash the pre-clamp bounds only when `clampToScreen()` actually moves the window. This naturally prevents overwriting a valid backup when a second, unrelated display is removed.
- **`display-added`**: check whether the stashed position's center point falls within any currently available display's work area. If so, restore the pet there and persist the position.

## Testing

Tested manually on macOS with primary + 2 external monitors:
1. Place pet on external monitor 2
2. Disconnect both external monitors → pet moves to primary ✓
3. Reconnect both monitors → pet returns to original position on monitor 2 ✓