### PR TITLE
fix: skip mini-working when theme lacks typing animation

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -301,7 +301,8 @@ function applyState(state, svgOverride) {
     if (state === "notification") return applyState("mini-alert");
     if (state === "attention") return applyState("mini-happy");
     if (state === "working" || state === "thinking" || state === "juggling") {
-      return applyState("mini-working");
+      if (hasOwnVisualFiles("mini-working")) return applyState("mini-working");
+      return;
     }
     if ((AUTO_RETURN_MS[currentState] || currentState === "mini-working") && !autoReturnTimer) {
       return applyState(ctx.mouseOverPet ? "mini-peek" : "mini-idle");

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -314,6 +314,38 @@ describe("visual fallback resolution", () => {
   });
 });
 
+describe("mini mode working routing", () => {
+  let api, ctx;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+  });
+
+  afterEach(() => {
+    if (api) api.cleanup();
+    mock.timers.reset();
+  });
+
+  it("theme defines mini-working → working routes to mini-working", () => {
+    ctx = makeCtx({ miniMode: true });
+    api = require("../src/state")(ctx);
+    api.applyState("mini-idle");
+    api.applyState("working");
+    assert.strictEqual(api.getCurrentState(), "mini-working");
+  });
+
+  it("theme lacks mini-working → working stays on current mini state", () => {
+    const theme = cloneTheme(_defaultTheme);
+    delete theme.miniMode.states["mini-working"];
+    delete theme._stateBindings["mini-working"];
+    ctx = makeCtx({ miniMode: true, theme });
+    api = require("../src/state")(ctx);
+    api.applyState("mini-idle");
+    api.applyState("working");
+    assert.strictEqual(api.getCurrentState(), "mini-idle");
+  });
+});
+
 // ═════════════════════════════════════════════════════════════════════════════
 // Group 4: sleep sequence
 // ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- 补 PR #121 的多主题 fallback 漏洞
- mini 模式下 working/thinking/juggling 事件先检查主题有没有定义 mini-working，没定义就保持当前 mini 状态不动

## Context
PR #121 在 `applyState` 的 mini 分支里无条件把 working/thinking/juggling 映射到 `mini-working`。但 `theme-loader.js` 的 `MINI_REQUIRED_STATES` 并不强制主题定义 `mini-working` —— 支持 mini 的主题（如 calico）可以通过验证但没有这个状态的 files。

此时 `currentState` 被设为 `mini-working`，`resolveVisualBinding` 找不到 files 后兜底到全局 `idle` —— 结果就是屏幕边缘贴着一个非 mini 姿势的大坐姿，objectScale / spriteOffsets / hitbox 全错位。

## Fix
在 mini 分支里加 `hasOwnVisualFiles("mini-working")` 判断（这个 helper 是 #e6780df 的 visual fallback chain 已经引入的）：

- 主题有 mini-working → 走 sophie 的原逻辑，切到 mini-working（保留 PR #121 的行为）
- 主题没 mini-working → 静默 return，保持当前 mini 状态（mini-idle / mini-peek）

状态机和视觉都不进入 mini-working，语义一致。代价是主题工作时看不出"在忙"，但这是主题作者的显式选择（不画 mini-working 素材就不开启这个反馈）。

## Test plan
- [x] `npm test` 593/593 pass（新加 2 个测试：有 mini-working 路径 + 无 mini-working 路径）
- [x] 本地验 clawd 主题正常路径：mini 模式 + working → 新 typing 动画
- [x] 本地验 fallback 路径：临时删 clawd/theme.json 的 mini-working 映射 → mini 模式 + working → 桌宠保持 mini-idle 不动（不出大坐姿 bug）
- [x] 本地验恢复：`git checkout` 后 typing 动画又出来
- [x] 打断测试：working 中途收到 notification / attention 正常切换
- [x] 多会话测试：3 个会话并发 working 时 mini-working 保持不闪切