### PR TITLE
fix: tune mini-typing animation for more energetic feel

### DIFF
--- a/assets/svg/clawd-mini-typing.svg
+++ b/assets/svg/clawd-mini-typing.svg
@@ -15,12 +15,12 @@
       }
 
       .arm-l-type {
-        transform-origin: 2px 10px;
-        animation: type-l 0.4s infinite ease-in-out;
+        transform-origin: 3px 10px;
+        animation: type-l 0.15s infinite ease-in-out;
       }
       .arm-r-type {
-        transform-origin: 13px 10px;
-        animation: type-r 0.35s infinite ease-in-out;
+        transform-origin: 12px 10px;
+        animation: type-r 0.12s infinite ease-in-out;
       }
 
       /* Floating data packets */
@@ -42,26 +42,28 @@
       }
 
       @keyframes read-code {
-        0%, 24%  { transform: translate(-2px, 0); }
-        25%, 54% { transform: translate(-1px, 0); }
-        55%, 84% { transform: translate(0px, 0); }
+        0%, 14%   { transform: translate(-2px, 0); }
+        15%, 29%  { transform: translate(-1.5px, 0); }
+        30%, 44%  { transform: translate(-1px, 0); }
+        45%, 59%  { transform: translate(-0.5px, 0); }
+        60%, 84%  { transform: translate(0px, 0); }
         85%, 100% { transform: translate(-2px, 0); }
       }
 
       @keyframes type-l {
-        0%   { transform: rotate(70deg); }
-        25%  { transform: rotate(110deg); }
-        50%  { transform: rotate(80deg); }
-        75%  { transform: rotate(100deg); }
-        100% { transform: rotate(70deg); }
+        0%   { transform: rotate(-10deg); }
+        25%  { transform: rotate(15deg); }
+        50%  { transform: rotate(-5deg); }
+        75%  { transform: rotate(10deg); }
+        100% { transform: rotate(-10deg); }
       }
 
       @keyframes type-r {
-        0%   { transform: rotate(-80deg); }
-        25%  { transform: rotate(-100deg); }
-        50%  { transform: rotate(-70deg); }
-        75%  { transform: rotate(-110deg); }
-        100% { transform: rotate(-80deg); }
+        0%   { transform: rotate(10deg); }
+        25%  { transform: rotate(-15deg); }
+        50%  { transform: rotate(5deg); }
+        75%  { transform: rotate(-10deg); }
+        100% { transform: rotate(10deg); }
       }
 
       .logo-glow {
@@ -109,12 +111,12 @@
 
         <!-- Left Arm — typing -->
         <g class="arm-l-type">
-          <rect x="0" y="9" width="2" height="2" fill="#DE886D"/>
+          <rect x="0" y="9" width="3" height="2" fill="#DE886D"/>
         </g>
 
         <!-- Right Arm — typing -->
         <g class="arm-r-type">
-          <rect x="13" y="9" width="2" height="2" fill="#DE886D"/>
+          <rect x="12" y="9" width="3" height="2" fill="#DE886D"/>
         </g>
 
         <!-- Eyes: JS translate wrapper + CSS blink -->


### PR DESCRIPTION
## Summary
- Follow-up polish to sophie's mini-typing (#121). Original felt too tame compared to the regular clawd-working-typing.
- Faster arm speed, denser eye scan, horizontal arm motion (instead of vertical swing), and tighter shoulder fit.

## Changes

### Arm speed
| | before | after |
|--|--|--|
| Left arm | 0.4s | **0.15s** |
| Right arm | 0.35s | **0.12s** |

Matches the frantic pace of the regular clawd-working-typing SVG.

### Eye scan
- 4 frames → 6 frames
- Densely steps `-2 → -1.5 → -1 → -0.5 → 0 → -2` (all on the left half), matching the mini pose's `rotate(-12°)` lean toward the screen. Staying on screen-side instead of drifting to the right (which would read as "looking at the sky").

### Arm motion redesign
- **Before**: vertical swing (`rotate(70° to 110°)` / `rotate(-70° to -110°)`) — arms swung down toward the keyboard, but short 2×2 sprites read as tiny nubs at the shoulders.
- **After**: horizontal oscillation (`±15°`) — arms extend outward along the body sides, with small up-down tap motion. The mini pose is already leaning over the laptop, so horizontal reach reads as "typing in front of me" rather than "jabbing down at a distant keyboard".

### Arm sizing + shoulder fit
- Sprite: `2×2 square` → `3×2 horizontal rectangle`
- Extends 2px outward from body (not too long — stays visually balanced with the torso)
- Rotation origin moved 1px **inside** the torso (`2,10` → `3,10` and `13,10` → `12,10`) so rotation doesn't expose gaps between shoulder and body

## Visual iteration

Three rounds with 鹿鹿:
1. Tried vertical swing + longer arms → arms poked toward the head (right arm uses negative rotation in the original, which swings upward). Rolled back.
2. Fixed right-arm rotation symmetry (both arms rotating down) + longer arms → arms extended downward, still not the sideways reach 鹿鹿 wanted.
3. Redesigned to horizontal oscillation → correct direction, but arms were too long and shoulder gap was visible. Final tune: shorter arms (w=3), origin anchored inside torso.

## Test plan
- [x] Local `npm start` → mini mode → trigger working via curl
- [x] Arms extend horizontally along body sides (no vertical swing)
- [x] No rotation gap between shoulder and torso
- [x] Typing feels frantic (matches regular typing SVG energy)
- [x] Eye scan reads as "scanning code" not "staring"
- [x] No regressions to the mini-working state machine routing (fix from #122 still works)