### PR TITLE
[codex] Fix high-DPI drag cursor drift

### DIFF
--- a/src/drag-position.js
+++ b/src/drag-position.js
@@ -1,0 +1,41 @@
+"use strict";
+
+function copyPoint(point) {
+  return { x: point.x, y: point.y };
+}
+
+function copySize(size) {
+  return { width: size.width, height: size.height };
+}
+
+function createDragSnapshot(cursor, bounds, size) {
+  if (!cursor || !bounds || !size) return null;
+  return {
+    cursor: copyPoint(cursor),
+    bounds: { x: bounds.x, y: bounds.y },
+    size: copySize(size),
+  };
+}
+
+function computeAnchoredDragBounds(snapshot, cursor, clampPosition) {
+  if (!snapshot || !cursor) return null;
+  const { width, height } = snapshot.size;
+  const targetX = snapshot.bounds.x + (cursor.x - snapshot.cursor.x);
+  const targetY = snapshot.bounds.y + (cursor.y - snapshot.cursor.y);
+  const pos = clampPosition
+    ? clampPosition(targetX, targetY, width, height)
+    : { x: targetX, y: targetY };
+  return { x: pos.x, y: pos.y, width, height };
+}
+
+function computeFinalDragBounds(bounds, size, clampPosition) {
+  if (!bounds || !size || !clampPosition) return null;
+  const pos = clampPosition(bounds.x, bounds.y, size.width, size.height);
+  return { x: pos.x, y: pos.y, width: size.width, height: size.height };
+}
+
+module.exports = {
+  createDragSnapshot,
+  computeAnchoredDragBounds,
+  computeFinalDragBounds,
+};

--- a/src/hit-renderer.js
+++ b/src/hit-renderer.js
@@ -35,10 +35,7 @@ window.hitAPI.onStateSync((data) => {
 // --- Drag state ---
 let isDragging = false;
 let didDrag = false;
-let lastScreenX, lastScreenY;
 let mouseDownX, mouseDownY;
-let pendingDx = 0, pendingDy = 0;
-let dragRAF = null;
 const DRAG_THRESHOLD = 3;
 
 // --- Reaction state (tracked here to gate input) ---
@@ -59,12 +56,8 @@ area.addEventListener("pointerdown", (e) => {
     area.setPointerCapture(e.pointerId);
     isDragging = true;
     didDrag = false;
-    lastScreenX = e.screenX;
-    lastScreenY = e.screenY;
     mouseDownX = e.clientX;
     mouseDownY = e.clientY;
-    pendingDx = 0;
-    pendingDy = 0;
     window.hitAPI.dragLock(true);
     area.classList.add("dragging");
   }
@@ -72,11 +65,6 @@ area.addEventListener("pointerdown", (e) => {
 
 document.addEventListener("pointermove", (e) => {
   if (isDragging) {
-    pendingDx += e.screenX - lastScreenX;
-    pendingDy += e.screenY - lastScreenY;
-    lastScreenX = e.screenX;
-    lastScreenY = e.screenY;
-
     if (!didDrag) {
       const totalDx = e.clientX - mouseDownX;
       const totalDy = e.clientY - mouseDownY;
@@ -85,15 +73,7 @@ document.addEventListener("pointermove", (e) => {
         startDragReaction();
       }
     }
-
-    if (!dragRAF) {
-      dragRAF = setTimeout(() => {
-        window.hitAPI.moveWindowBy(pendingDx, pendingDy);
-        pendingDx = 0;
-        pendingDy = 0;
-        dragRAF = null;
-      }, 0);
-    }
+    window.hitAPI.dragMove();
   }
 });
 
@@ -102,11 +82,6 @@ function stopDrag() {
   isDragging = false;
   window.hitAPI.dragLock(false);
   area.classList.remove("dragging");
-  if (pendingDx !== 0 || pendingDy !== 0) {
-    if (dragRAF) { clearTimeout(dragRAF); dragRAF = null; }
-    window.hitAPI.moveWindowBy(pendingDx, pendingDy);
-    pendingDx = 0; pendingDy = 0;
-  }
   if (didDrag) {
     window.hitAPI.dragEnd();
   }

--- a/src/hit-renderer.js
+++ b/src/hit-renderer.js
@@ -36,6 +36,7 @@ window.hitAPI.onStateSync((data) => {
 let isDragging = false;
 let didDrag = false;
 let mouseDownX, mouseDownY;
+let dragMoveRAF = null;
 const DRAG_THRESHOLD = 3;
 
 // --- Reaction state (tracked here to gate input) ---
@@ -48,6 +49,21 @@ window.hitAPI.onCancelReaction(() => {
   isReacting = false;
   isDragReacting = false;
 });
+
+function queueDragMove() {
+  if (dragMoveRAF !== null) return;
+  dragMoveRAF = requestAnimationFrame(() => {
+    dragMoveRAF = null;
+    if (!isDragging) return;
+    window.hitAPI.dragMove();
+  });
+}
+
+function clearQueuedDragMove() {
+  if (dragMoveRAF === null) return;
+  cancelAnimationFrame(dragMoveRAF);
+  dragMoveRAF = null;
+}
 
 // --- Pointer handlers ---
 area.addEventListener("pointerdown", (e) => {
@@ -73,12 +89,13 @@ document.addEventListener("pointermove", (e) => {
         startDragReaction();
       }
     }
-    window.hitAPI.dragMove();
+    queueDragMove();
   }
 });
 
 function stopDrag() {
   if (!isDragging) return;
+  clearQueuedDragMove();
   isDragging = false;
   window.hitAPI.dragLock(false);
   area.classList.remove("dragging");

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,11 @@ const { applyStationaryCollectionBehavior } = require("./mac-window");
 const hitGeometry = require("./hit-geometry");
 const animationCycle = require("./animation-cycle");
 const { findNearestWorkArea, computeLooseClamp, SYNTHETIC_WORK_AREA } = require("./work-area");
+const {
+  createDragSnapshot,
+  computeAnchoredDragBounds,
+  computeFinalDragBounds,
+} = require("./drag-position");
 const { getLaunchSizingWorkArea, getProportionalPixelSize } = require("./size-utils");
 
 // ── Autoplay policy: allow sound playback without user gesture ──
@@ -457,10 +462,47 @@ function syncHitWin() {
 
 let mouseOverPet = false;
 let dragLocked = false;
+let dragSnapshot = null;
 let menuOpen = false;
 let idlePaused = false;
 let forceEyeResend = false;
 let themeReloadInProgress = false;
+
+// Keep drag math in Electron's main-process DIP coordinate space. Renderer
+// PointerEvent.screenX/Y can be scaled differently on high-DPI displays.
+function beginDragSnapshot() {
+  if (!win || win.isDestroyed()) {
+    dragSnapshot = null;
+    return;
+  }
+  dragSnapshot = createDragSnapshot(
+    screen.getCursorScreenPoint(),
+    win.getBounds(),
+    getCurrentPixelSize()
+  );
+}
+
+function clearDragSnapshot() {
+  dragSnapshot = null;
+}
+
+function moveWindowForDrag() {
+  if (_mini.getMiniMode() || _mini.getMiniTransitioning()) return;
+  if (!win || win.isDestroyed()) return;
+  if (!dragSnapshot) beginDragSnapshot();
+  if (!dragSnapshot) return;
+
+  const bounds = computeAnchoredDragBounds(
+    dragSnapshot,
+    screen.getCursorScreenPoint(),
+    looseClampToDisplays
+  );
+  if (!bounds) return;
+
+  win.setBounds(bounds);
+  syncHitWin();
+  if (bubbleFollowPet) repositionFloatingBubbles();
+}
 
 // ── Mini Mode — delegated to src/mini.js ──
 // Initialized after state module (needs applyState, resolveDisplayState, etc.)
@@ -1649,18 +1691,7 @@ function createWindow() {
 
   ipcMain.on("show-context-menu", showPetContextMenu);
 
-  ipcMain.on("move-window-by", (event, dx, dy) => {
-    if (_mini.getMiniMode() || _mini.getMiniTransitioning()) return;
-    const { x, y } = win.getBounds();
-    const size = getCurrentPixelSize();
-    // During drag: allow free movement across screens, only prevent
-    // the pet from going completely off-screen (keep 25% visible).
-    const newX = x + dx, newY = y + dy;
-    const looseClamped = looseClampToDisplays(newX, newY, size.width, size.height);
-    win.setBounds({ ...looseClamped, width: size.width, height: size.height });
-    syncHitWin();
-    if (bubbleFollowPet) repositionFloatingBubbles();
-  });
+  ipcMain.on("drag-move", () => moveWindowForDrag());
 
   ipcMain.on("pause-cursor-polling", () => { idlePaused = true; });
   ipcMain.on("resume-from-reaction", () => {
@@ -1671,7 +1702,12 @@ function createWindow() {
 
   ipcMain.on("drag-lock", (event, locked) => {
     dragLocked = !!locked;
-    if (locked) mouseOverPet = true;
+    if (locked) {
+      mouseOverPet = true;
+      beginDragSnapshot();
+    } else {
+      clearDragSnapshot();
+    }
   });
 
   // Reaction relay: hitWin → main → renderWin
@@ -1682,18 +1718,23 @@ function createWindow() {
   });
 
   ipcMain.on("drag-end", () => {
-    if (!_mini.getMiniMode() && !_mini.getMiniTransitioning()) {
-      checkMiniModeSnap();
-      // After drag, clamp to the nearest screen (loose clamp during drag allows cross-screen).
-      // In proportional mode, also recalculate size for the landing display.
-      if (win && !win.isDestroyed()) {
-        const size = getCurrentPixelSize();
-        const { x, y } = win.getBounds();
-        const clamped = clampToScreen(x, y, size.width, size.height);
-        win.setBounds({ ...clamped, width: size.width, height: size.height });
-        syncHitWin();
-        repositionUpdateBubble();
+    try {
+      if (!_mini.getMiniMode() && !_mini.getMiniTransitioning()) {
+        checkMiniModeSnap();
+        // After drag, clamp to the nearest screen (loose clamp during drag allows cross-screen).
+        // In proportional mode, also recalculate size for the landing display.
+        if (win && !win.isDestroyed()) {
+          const size = getCurrentPixelSize();
+          const { x, y } = win.getBounds();
+          const clamped = computeFinalDragBounds({ x, y }, size, clampToScreen);
+          if (clamped) win.setBounds(clamped);
+          syncHitWin();
+          repositionUpdateBubble();
+        }
       }
+    } finally {
+      dragLocked = false;
+      clearDragSnapshot();
     }
   });
 

--- a/src/main.js
+++ b/src/main.js
@@ -487,9 +487,9 @@ function clearDragSnapshot() {
 }
 
 function moveWindowForDrag() {
+  if (!dragLocked) return;
   if (_mini.getMiniMode() || _mini.getMiniTransitioning()) return;
   if (!win || win.isDestroyed()) return;
-  if (!dragSnapshot) beginDragSnapshot();
   if (!dragSnapshot) return;
 
   const bounds = computeAnchoredDragBounds(

--- a/src/preload-hit.js
+++ b/src/preload-hit.js
@@ -11,7 +11,7 @@ contextBridge.exposeInMainWorld("hitAPI", {
   onThemeConfig: (cb) => ipcRenderer.on("theme-config", (_, cfg) => cb(cfg)),
   // Sends → main
   dragLock: (locked) => ipcRenderer.send("drag-lock", locked),
-  moveWindowBy: (dx, dy) => ipcRenderer.send("move-window-by", dx, dy),
+  dragMove: () => ipcRenderer.send("drag-move"),
   dragEnd: () => ipcRenderer.send("drag-end"),
   showContextMenu: () => ipcRenderer.send("show-context-menu"),
   focusTerminal: () => ipcRenderer.send("focus-terminal"),

--- a/test/drag-position.test.js
+++ b/test/drag-position.test.js
@@ -1,0 +1,61 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+const {
+  createDragSnapshot,
+  computeAnchoredDragBounds,
+  computeFinalDragBounds,
+} = require("../src/drag-position");
+const { computeLooseClamp } = require("../src/work-area");
+
+const wa = (x, y, w, h) => ({ x, y, width: w, height: h });
+const display = (x, y, w, h) => ({ workArea: wa(x, y, w, h) });
+
+describe("anchored drag positioning", () => {
+  it("keeps the original cursor-to-window offset across repeated moves", () => {
+    const snapshot = createDragSnapshot(
+      { x: 100, y: 100 },
+      { x: 500, y: 500, width: 200, height: 200 },
+      { width: 200, height: 200 }
+    );
+
+    const cursorPath = [
+      { x: 150, y: 125 },
+      { x: 100, y: 100 },
+      { x: 60, y: 155 },
+      { x: 100, y: 100 },
+    ];
+
+    const positions = cursorPath.map((cursor) => computeAnchoredDragBounds(snapshot, cursor));
+
+    assert.deepStrictEqual(positions[0], { x: 550, y: 525, width: 200, height: 200 });
+    assert.deepStrictEqual(positions[1], { x: 500, y: 500, width: 200, height: 200 });
+    assert.deepStrictEqual(positions[2], { x: 460, y: 555, width: 200, height: 200 });
+    assert.deepStrictEqual(positions[3], { x: 500, y: 500, width: 200, height: 200 });
+  });
+
+  it("uses loose display-union clamping during drag so cross-screen movement is not pulled back", () => {
+    const displays = [display(0, 0, 1920, 1080), display(1920, 0, 1920, 1080)];
+    const snapshot = createDragSnapshot(
+      { x: 1900, y: 500 },
+      { x: 1800, y: 400, width: 200, height: 200 },
+      { width: 200, height: 200 }
+    );
+
+    const result = computeAnchoredDragBounds(snapshot, { x: 2200, y: 520 }, (x, y, w, h) =>
+      computeLooseClamp(displays, null, x, y, w, h)
+    );
+
+    assert.deepStrictEqual(result, { x: 2100, y: 420, width: 200, height: 200 });
+  });
+
+  it("applies the final clamp after drag ends", () => {
+    const result = computeFinalDragBounds(
+      { x: 3900, y: 100, width: 200, height: 200 },
+      { width: 200, height: 200 },
+      () => ({ x: 3640, y: 100 })
+    );
+
+    assert.deepStrictEqual(result, { x: 3640, y: 100, width: 200, height: 200 });
+  });
+});


### PR DESCRIPTION
## Summary
- move normal drag positioning to main-process Electron DIP cursor anchoring instead of renderer `screenX/screenY` deltas
- have the hit renderer send drag-move signals only, while main reads `screen.getCursorScreenPoint()` and applies movement from a drag-start snapshot
- preserve existing two-window architecture, loose cross-screen drag clamping, final drag-end clamp, and mini-mode snap behavior

Closes #109.

## Root Cause
The old drag path mixed renderer `PointerEvent.screenX/screenY` deltas with Electron `BrowserWindow` bounds. On high-DPI/scaled displays, browser screen-event coordinates can diverge from Electron's DIP coordinate space, so repeated movement accumulates cursor drift.

This PR keeps canonical drag math in main-process DIP coordinates by anchoring movement to `screen.getCursorScreenPoint()` and the window bounds captured at drag start.

## Repro Notes
I can reproduce the cursor drift by changing the active Windows display scale to a high value such as `200%` or `250%`.

Observed locally:
- Laptop display: easy to spot because it normally runs around `200%`
- External monitor: also reproduces if I raise it from its usual `125%` to `200%` or `250%`

So the trigger appears to be display scaling / DPI rather than a laptop-only panel-specific issue.

## Related History
Checked upstream first: no open issue matched this exact repeated-drag cursor drift behavior. Adjacent prior work includes #44, #47, and #77 for high-DPI hit-window offsets, mixed-DPI hitWin positioning, and cross-screen drag clamping.

Electron docs reference: `screen.getCursorScreenPoint()` returns DIP coordinates and Electron exposes physical-screen/DIP conversion APIs for high-DPI displays: https://github.com/electron/electron/blob/main/docs/api/screen.md

## Validation
- `node --check src\\main.js`
- `node --check src\\hit-renderer.js`
- `node --check src\\preload-hit.js`
- `node --test test/drag-position.test.js test/work-area.test.js` — 17 passed
- `npm test` — 565 passed, 1 failed, 1 skipped; remaining failure is the pre-existing `test/shared-process.test.js` PID-chain assertion (`pidChain.length >= 1`)

## Manual Verification
- Reproduced drift by setting Windows display scale to `200%` / `250%`
- Verified the anchored-drag fix locally on scaled displays after this patch
