### PR TITLE
Restore release-like drag edge behavior

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,7 +6,7 @@ const { applyStationaryCollectionBehavior } = require("./mac-window");
 const hitGeometry = require("./hit-geometry");
 const animationCycle = require("./animation-cycle");
 const { findNearestWorkArea, computeLooseClamp, SYNTHETIC_WORK_AREA } = require("./work-area");
-const { getThemeMarginBox, computeStableVisibleContentMargins } = require("./visible-margins");
+const { computeRectMargins } = require("./visible-margins");
 const {
   createDragSnapshot,
   computeAnchoredDragBounds,
@@ -268,7 +268,6 @@ function getObjRect(bounds) {
 let win;
 let hitWin;  // input window — small opaque rect over hitbox, receives all pointer events
 let viewportOffsetY = 0;
-const themeMarginEnvelopeCache = new Map();
 let tray = null;
 let contextMenuOwner = null;
 // Mirror of _settingsController.get("size") — initialized from disk, kept in
@@ -740,22 +739,7 @@ function getHitRectScreen(bounds) {
 
 function getVisibleContentMargins(bounds) {
   if (!bounds || !activeTheme) return { top: 0, bottom: 0 };
-  const box = getThemeMarginBox(activeTheme);
-  if (!box) return { top: 0, bottom: 0 };
-
-  const cacheKey = [
-    activeTheme._id || "",
-    activeTheme._variantId || "",
-    bounds.width,
-    bounds.height,
-    JSON.stringify(box),
-  ].join("|");
-  const cached = themeMarginEnvelopeCache.get(cacheKey);
-  if (cached) return cached;
-
-  const margins = computeStableVisibleContentMargins(activeTheme, bounds, { box });
-  themeMarginEnvelopeCache.set(cacheKey, margins);
-  return margins;
+  return computeRectMargins(bounds, getHitRectScreen(bounds));
 }
 
 // ── Main tick — delegated to src/tick.js ──
@@ -2449,7 +2433,7 @@ function looseClampPetToDisplays(x, y, w, h) {
   return computeLooseClamp(screen.getAllDisplays(), getPrimaryWorkAreaSafe(), x, y, w, h, {
     marginX: Math.round(w * 0.25),
     marginTop: Math.max(Math.round(h * 0.25), margins.top),
-    marginBottom: Math.round(h * 0.25),
+    marginBottom: margins.bottom,
   });
 }
 

--- a/src/visible-margins.js
+++ b/src/visible-margins.js
@@ -7,6 +7,14 @@ function getThemeMarginBox(theme) {
   return theme.layout.marginBox || theme.layout.contentBox || null;
 }
 
+function computeRectMargins(bounds, rect) {
+  if (!bounds || !rect) return { top: 0, bottom: 0 };
+  return {
+    top: Math.max(0, Math.round(rect.top - bounds.y)),
+    bottom: Math.max(0, Math.round(bounds.y + bounds.height - rect.bottom)),
+  };
+}
+
 function collectThemeEnvelopeFiles(theme) {
   if (!theme) return [];
   if (Array.isArray(theme._marginEnvelopeFiles)) return theme._marginEnvelopeFiles;
@@ -56,8 +64,9 @@ function computeStableVisibleContentMargins(theme, bounds, options = {}) {
   for (const file of files) {
     const content = hitGeometry.getContentRectScreen(theme, bounds, null, file, { box });
     if (!content) continue;
-    top = Math.min(top, Math.max(0, Math.round(content.top - bounds.y)));
-    bottom = Math.min(bottom, Math.max(0, Math.round(bounds.y + bounds.height - content.bottom)));
+    const margins = computeRectMargins(bounds, content);
+    top = Math.min(top, margins.top);
+    bottom = Math.min(bottom, margins.bottom);
   }
 
   return {
@@ -67,6 +76,7 @@ function computeStableVisibleContentMargins(theme, bounds, options = {}) {
 }
 
 module.exports = {
+  computeRectMargins,
   getThemeMarginBox,
   collectThemeEnvelopeFiles,
   computeStableVisibleContentMargins,

--- a/test/visible-margins.test.js
+++ b/test/visible-margins.test.js
@@ -5,6 +5,7 @@ const path = require("path");
 const themeLoader = require("../src/theme-loader");
 const hitGeometry = require("../src/hit-geometry");
 const {
+  computeRectMargins,
   getThemeMarginBox,
   collectThemeEnvelopeFiles,
   computeStableVisibleContentMargins,
@@ -66,5 +67,15 @@ describe("visible margin envelopes", () => {
     });
     assert.ok(stable.top < Math.round(idleRect.top - bounds.y));
     assert.ok(stable.bottom <= Math.round(bounds.y + bounds.height - idleRect.bottom));
+  });
+
+  it("can derive margins from the current displayed drag-state hit rect", () => {
+    const clawd = themeLoader.loadTheme("clawd");
+    const dragRect = hitGeometry.getHitRectScreen(clawd, bounds, null, "clawd-react-drag.svg", clawd.hitBoxes.default);
+
+    assert.deepStrictEqual(computeRectMargins(bounds, dragRect), {
+      top: 169,
+      bottom: 14,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- follow-up to merged PR #124 for the separately confirmed drag-boundary mismatch tracked in #126
- this PR is about the active-drag top/bottom edge behavior on Windows `main`, not the cursor-drift bug from #109
- the key point is phase: while the mouse button is still held down and the pet is actively being dragged, current `main` does not match the known-good release behavior at the top and bottom edges

## Scope
- #124 is merged and handled the cursor-drift fix for #109
- #126 tracks the separate active-drag edge-behavior mismatch
- this PR now carries only the remaining follow-up delta on top of current `main`
- Refs #126

## Implementation
- tune the remaining drag-boundary math so the active-drag top edge no longer stops earlier than release
- tighten the drag-time bottom allowance so active drag no longer goes lower than release
- keep the already-landed virtual-bounds / viewport-offset architecture from current `main`
- add focused regression coverage for the derived current-state margin calculation

## Validation
- `node --check src/main.js`
- `node --check src/visible-margins.js`
- `node --test test/drag-position.test.js test/work-area.test.js test/hit-geometry.test.js test/visible-margins.test.js test/elicitation.test.js test/tick.test.js`
- `npm test` -> only remaining failure is the pre-existing `test/shared-process.test.js` PID-chain assertion

## Manual Verification
- installed release, current `main`, and the refreshed fix branch were compared side by side on Windows
- the mismatch is visible during active drag, before mouse-up:
  - current `main` reaches a lower false ceiling than release at the top
  - current `main` allows a lower bottom drag than release
- the refreshed follow-up branch restores active-drag top/bottom behavior to match release in local testing
