### PR TITLE
fix(hooks): skip WorktreeCreate to unblock `claude -w`

### DIFF
--- a/hooks/install.js
+++ b/hooks/install.js
@@ -23,8 +23,13 @@ const CORE_HOOKS = [
   "Notification",
   // PermissionRequest: handled by HTTP_HOOKS (blocking), not command hook
   "Elicitation",
-  "WorktreeCreate",
 ];
+
+// Events we used to register but shouldn't anymore. WorktreeCreate is a
+// work-performing hook (must print the new worktree path to stdout) — our
+// notification-only handler broke `claude -w` with "no successful output".
+// Reported by @IsuminI in issue #127.
+const DEPRECATED_CORE_HOOKS = ["WorktreeCreate"];
 
 // Hooks that require a minimum Claude Code version
 const VERSIONED_HOOKS = [
@@ -575,6 +580,21 @@ function registerHooks(options = {}) {
   const reconcileResult = reconcileVersionedHooks(settings, supportedVersionedEvents, versionInfo);
   removed += reconcileResult.removed;
   changed = changed || reconcileResult.changed;
+
+  // Remove deprecated hooks we used to register. Match by MARKER so user-authored
+  // hooks for the same event are preserved untouched. See issue #127.
+  for (const event of DEPRECATED_CORE_HOOKS) {
+    if (!Array.isArray(settings.hooks[event])) continue;
+    const result = removeMatchingCommandHooks(
+      settings.hooks[event],
+      (command) => command.includes(MARKER)
+    );
+    if (!result.changed) continue;
+    removed += result.removed;
+    changed = true;
+    if (result.entries.length > 0) settings.hooks[event] = result.entries;
+    else delete settings.hooks[event];
+  }
 
   // Build the full hook list: core + version-compatible hooks
   const hookEvents = [...CORE_HOOKS];

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -546,6 +546,78 @@ describe("Hook installer version compatibility", () => {
   });
 });
 
+describe("Hook installer deprecated hook cleanup", () => {
+  it("does not register WorktreeCreate on fresh install (issue #127)", () => {
+    const settingsPath = makeTempSettings({});
+    registerHooks({
+      silent: true,
+      settingsPath,
+      claudeVersionInfo: { version: "2.1.112", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(settings.hooks, "WorktreeCreate"),
+      "WorktreeCreate should not be registered"
+    );
+  });
+
+  it("removes stale Clawd WorktreeCreate hook while preserving user-authored entries", () => {
+    const settingsPath = makeTempSettings({
+      hooks: {
+        WorktreeCreate: [
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: 'node "/tmp/clawd-hook.js" WorktreeCreate' }],
+          },
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: 'node "/tmp/user-worktree.js" WorktreeCreate' }],
+          },
+        ],
+      },
+    });
+
+    const result = registerHooks({
+      silent: true,
+      settingsPath,
+      claudeVersionInfo: { version: "2.1.112", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    assert.ok(Array.isArray(settings.hooks.WorktreeCreate), "user entry should be preserved");
+    assert.strictEqual(settings.hooks.WorktreeCreate.length, 1);
+    assert.strictEqual(
+      settings.hooks.WorktreeCreate[0].hooks[0].command,
+      'node "/tmp/user-worktree.js" WorktreeCreate'
+    );
+    assert.strictEqual(getClawdCommands(settings, "WorktreeCreate").length, 0);
+    assert.ok(result.removed >= 1);
+  });
+
+  it("deletes WorktreeCreate key when the only entry was the Clawd hook", () => {
+    const settingsPath = makeTempSettings({
+      hooks: {
+        WorktreeCreate: [
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: 'node "/tmp/clawd-hook.js" WorktreeCreate' }],
+          },
+        ],
+      },
+    });
+
+    registerHooks({
+      silent: true,
+      settingsPath,
+      claudeVersionInfo: { version: "2.1.112", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    assert.ok(!Object.prototype.hasOwnProperty.call(settings.hooks, "WorktreeCreate"));
+  });
+});
+
 describe("Hook installer unregisterHooks", () => {
   it("removes Clawd command hooks, HTTP hook, and auto-start while preserving third-party hooks", () => {
     const settingsPath = makeTempSettings({


### PR DESCRIPTION
## Summary

- `WorktreeCreate` is a **work-performing** hook — Claude Code expects the hook to print the new worktree path to stdout and uses that output to locate the worktree. Our notification-only handler (`clawd-hook.js`) exited 0 with empty stdout, so Claude Code reported `no successful output` and `claude -w` failed immediately for every user with Clawd installed.
- Remove `WorktreeCreate` from `CORE_HOOKS` so fresh installs no longer register it.
- Add a `DEPRECATED_CORE_HOOKS` cleanup pass in `registerHooks`: scan `~/.claude/settings.json` and remove `WorktreeCreate` entries **only when the `command` points to `clawd-hook.js`**. User-authored hooks on the same event are preserved untouched.
- The `carrying` animation and its event mappings in `clawd-hook.js` / `agents/claude-code.js` / `settings-renderer.js` are kept so a follow-up can wire the animation to a `PreToolUse` matcher for `git worktree add`.

## Credits

Huge thanks to @IsuminI for the full diagnosis, reproduction steps, affected file list, and minimal fix recommendation in #127 — this PR implements exactly the plan he proposed.

## Test plan

- [x] All 722 existing unit tests pass (`npm test`)
- [x] 3 new unit tests in `test/install.test.js`:
  - fresh install does not register `WorktreeCreate`
  - stale Clawd `WorktreeCreate` hook is removed while user-authored entries on the same event are preserved
  - `WorktreeCreate` key is deleted when the only entry was the Clawd hook
- [x] Manual smoke test on Windows: re-ran installer to clean up an existing `~/.claude/settings.json`, then `claude -w test-worktree-fix-127` — worktree folder created, Claude Code session started normally (no `no successful output` error)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)
