### PR TITLE
Fix Windows Settings window taskbar icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     },
     "files": [
       "src/**/*",
+      "assets/icons/**/*",
       "assets/icons/agents/**/*",
       "assets/svg/**/*",
       "assets/sounds/**/*",

--- a/src/main.js
+++ b/src/main.js
@@ -3,6 +3,10 @@ const path = require("path");
 const fs = require("fs");
 const { pathToFileURL } = require("url");
 const { applyStationaryCollectionBehavior } = require("./mac-window");
+const {
+  applyWindowsAppUserModelId,
+  getSettingsWindowIconPath,
+} = require("./settings-window-icon");
 const hitGeometry = require("./hit-geometry");
 const animationCycle = require("./animation-cycle");
 const { findNearestWorkArea, computeLooseClamp, SYNTHETIC_WORK_AREA } = require("./work-area");
@@ -28,6 +32,8 @@ const isMac = process.platform === "darwin";
 const isLinux = process.platform === "linux";
 const isWin = process.platform === "win32";
 const LINUX_WINDOW_TYPE = "toolbar";
+
+applyWindowsAppUserModelId(app, process.platform);
 
 
 // ── Windows: AllowSetForegroundWindow via FFI ──
@@ -2300,20 +2306,13 @@ function startShortcutRecording(actionId) {
 }
 
 function getSettingsWindowIcon() {
-  // Don't pass an icon on macOS — the system uses the .app bundle icon.
-  if (isMac) return undefined;
-  if (isWin) {
-    // Packaged build: extraResources puts icon.ico at process.resourcesPath.
-    // Dev: read it from assets/. The files[] glob in package.json doesn't
-    // include assets/icon.ico, so don't try to load it from __dirname/.. in
-    // a packaged build — that path doesn't exist inside app.asar.
-    return app.isPackaged
-      ? path.join(process.resourcesPath, "icon.ico")
-      : path.join(__dirname, "..", "assets", "icon.ico");
-  }
-  // Linux: build config points at assets/icons/, but those aren't shipped in
-  // files[]. Skip the icon — the .desktop file (deb/AppImage) provides one.
-  return undefined;
+  return getSettingsWindowIconPath({
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    appDir: path.join(__dirname, ".."),
+    existsSync: fs.existsSync,
+  });
 }
 
 function openSettingsWindow() {

--- a/src/settings-window-icon.js
+++ b/src/settings-window-icon.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const path = require("path");
+
+const WINDOWS_APP_USER_MODEL_ID = "com.clawd.on-desk";
+
+function getSettingsWindowIconPath({
+  platform,
+  isPackaged,
+  resourcesPath,
+  appDir,
+  existsSync,
+}) {
+  if (platform === "darwin") return undefined;
+  if (platform !== "win32") return undefined;
+
+  const hasFile = typeof existsSync === "function" ? existsSync : () => true;
+  const candidates = [];
+
+  if (isPackaged) {
+    candidates.push(
+      path.join(resourcesPath || "", "app.asar.unpacked", "assets", "icons", "256x256.png"),
+      path.join(resourcesPath || "", "app.asar", "assets", "icons", "256x256.png"),
+      path.join(resourcesPath || "", "icon.ico")
+    );
+  } else {
+    candidates.push(
+      path.join(appDir || "", "assets", "icons", "256x256.png"),
+      path.join(appDir || "", "assets", "icon.ico")
+    );
+  }
+
+  return candidates.find((candidate) => candidate && hasFile(candidate));
+}
+
+function applyWindowsAppUserModelId(app, platform = process.platform) {
+  if (platform !== "win32") return;
+  if (!app || typeof app.setAppUserModelId !== "function") return;
+  app.setAppUserModelId(WINDOWS_APP_USER_MODEL_ID);
+}
+
+module.exports = {
+  WINDOWS_APP_USER_MODEL_ID,
+  getSettingsWindowIconPath,
+  applyWindowsAppUserModelId,
+};

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -4,6 +4,13 @@ const { describe, it } = require("node:test");
 const pkg = require("../package.json");
 
 describe("package build config", () => {
+  it("ships project window icons in packaged builds", () => {
+    assert.ok(
+      pkg.build.files.includes("assets/icons/**/*"),
+      "build.files should include assets/icons/**/*"
+    );
+  });
+
   it("ships agent session icons in packaged builds", () => {
     assert.ok(
       pkg.build.files.includes("assets/icons/agents/**/*"),

--- a/test/settings-window-icon.test.js
+++ b/test/settings-window-icon.test.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+
+const {
+  WINDOWS_APP_USER_MODEL_ID,
+  getSettingsWindowIconPath,
+  applyWindowsAppUserModelId,
+} = require("../src/settings-window-icon");
+
+describe("settings window icon path", () => {
+  it("prefers the 256px project icon for unpackaged Windows runs", () => {
+    const appDir = "D:\\clawd-on-desk";
+    const expected = path.join(appDir, "assets", "icons", "256x256.png");
+    const actual = getSettingsWindowIconPath({
+      platform: "win32",
+      isPackaged: false,
+      appDir,
+      existsSync: (candidate) => candidate === expected,
+    });
+    assert.strictEqual(actual, expected);
+  });
+
+  it("falls back to icon.ico when the 256px icon is unavailable", () => {
+    const appDir = "D:\\clawd-on-desk";
+    const expected = path.join(appDir, "assets", "icon.ico");
+    const actual = getSettingsWindowIconPath({
+      platform: "win32",
+      isPackaged: false,
+      appDir,
+      existsSync: (candidate) => candidate === expected,
+    });
+    assert.strictEqual(actual, expected);
+  });
+
+  it("prefers unpacked packaged assets before falling back to icon.ico", () => {
+    const resourcesPath = "C:\\Program Files\\Clawd on Desk\\resources";
+    const expected = path.join(resourcesPath, "app.asar.unpacked", "assets", "icons", "256x256.png");
+    const actual = getSettingsWindowIconPath({
+      platform: "win32",
+      isPackaged: true,
+      resourcesPath,
+      existsSync: (candidate) => candidate === expected,
+    });
+    assert.strictEqual(actual, expected);
+  });
+
+  it("returns undefined on non-Windows platforms", () => {
+    assert.strictEqual(getSettingsWindowIconPath({ platform: "darwin" }), undefined);
+    assert.strictEqual(getSettingsWindowIconPath({ platform: "linux" }), undefined);
+  });
+});
+
+describe("windows app user model id", () => {
+  it("applies the project app id on Windows", () => {
+    let appId = null;
+    applyWindowsAppUserModelId({
+      setAppUserModelId(value) { appId = value; },
+    }, "win32");
+    assert.strictEqual(appId, WINDOWS_APP_USER_MODEL_ID);
+  });
+
+  it("does nothing on non-Windows platforms", () => {
+    let called = false;
+    applyWindowsAppUserModelId({
+      setAppUserModelId() { called = true; },
+    }, "darwin");
+    assert.strictEqual(called, false);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the Windows Settings window taskbar icon so it uses a project icon instead of inheriting the default Electron icon.

## Problem

After the new Settings panel was added, the Settings window title bar used the Clawd icon, but on Windows the taskbar thumbnail / grouped taskbar icon could still show the default Electron icon.

This was reproduced in source-mode on Windows with the Settings window open from the desktop pet.

## Root cause

The Settings window icon path logic was still centered around `assets/icon.ico`, and the app was not explicitly setting a Windows App User Model ID for the process.

That combination is enough for the window chrome to look correct while the taskbar grouping identity still falls back to Electron defaults in some Windows cases.

## What changed

- Added `src/settings-window-icon.js` to centralize Windows Settings-window icon selection and AppUserModelID setup.
- On Windows, the Settings window now prefers the project `assets/icons/256x256.png` icon, with `assets/icon.ico` as a fallback.
- Applied the project Windows App User Model ID at startup so the Settings window is grouped under the app identity instead of Electron's default identity.
- Updated packaging config so `assets/icons/**/*` is included in packaged builds.
- Added regression tests for the icon selection logic and packaging config.

## Files changed

- `package.json`
- `src/main.js`
- `src/settings-window-icon.js`
- `test/package-build-config.test.js`
- `test/settings-window-icon.test.js`

## Validation

Automated:
- `node --check src/main.js`
- `node --test test/settings-window-icon.test.js test/package-build-config.test.js`
- `npm test`

Latest full run:
- `781` passing
- `0` failing
- `1` skipped

Manual:
- Verified on Windows that the Settings window taskbar entry now uses the project icon rather than the default Electron icon.
- The reported Windows scenario was reproduced from the new Settings panel UI and rechecked after the fix.

## Platform status

- Windows: manually validated
- macOS: not manually tested for this change
- Linux: not manually tested for this change

## Notes

- This PR is intentionally narrow: it only changes the Settings window icon identity path on Windows and the packaging needed to ship the selected icon asset.
- I did not attach the local screenshot file to the PR body, but the Windows validation above was performed against that exact reported taskbar case.