### PR TITLE
[codex] Fix Windows Settings taskbar shell icon

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,8 @@ const { applyStationaryCollectionBehavior } = require("./mac-window");
 const {
   applyWindowsAppUserModelId,
   getSettingsWindowIconPath,
+  getSettingsWindowTaskbarDetails: getSettingsWindowTaskbarDetailsHelper,
+  SETTINGS_WINDOW_TITLE,
 } = require("./settings-window-icon");
 const hitGeometry = require("./hit-geometry");
 const animationCycle = require("./animation-cycle");
@@ -2315,6 +2317,18 @@ function getSettingsWindowIcon() {
   });
 }
 
+function getSettingsWindowTaskbarDetails() {
+  return getSettingsWindowTaskbarDetailsHelper({
+    platform: process.platform,
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    appDir: path.join(__dirname, ".."),
+    execPath: process.execPath,
+    appPath: app.getAppPath(),
+    existsSync: fs.existsSync,
+  });
+}
+
 function openSettingsWindow() {
   if (settingsWindow && !settingsWindow.isDestroyed()) {
     if (settingsWindow.isMinimized()) settingsWindow.restore();
@@ -2336,7 +2350,7 @@ function openSettingsWindow() {
     maximizable: true,
     skipTaskbar: false,
     alwaysOnTop: false,
-    title: "Clawd Settings",
+    title: SETTINGS_WINDOW_TITLE,
     // Match settings.html's dark-mode palette to avoid a white flash before
     // CSS media query kicks in. Hex values must stay in sync with the
     // `--bg` CSS variable in settings.html for each theme.
@@ -2349,6 +2363,12 @@ function openSettingsWindow() {
   };
   if (iconPath) opts.icon = iconPath;
   settingsWindow = new BrowserWindow(opts);
+  if (isWin && typeof settingsWindow.setAppDetails === "function") {
+    const taskbarDetails = getSettingsWindowTaskbarDetails();
+    if (taskbarDetails && taskbarDetails.appIconPath) {
+      settingsWindow.setAppDetails(taskbarDetails);
+    }
+  }
   settingsWindow.setMenuBarVisibility(false);
   settingsWindow.loadFile(path.join(__dirname, "settings.html"));
   settingsWindow.once("ready-to-show", () => {

--- a/src/settings-window-icon.js
+++ b/src/settings-window-icon.js
@@ -3,6 +3,12 @@
 const path = require("path");
 
 const WINDOWS_APP_USER_MODEL_ID = "com.clawd.on-desk";
+const SETTINGS_WINDOW_TITLE = "Clawd Settings";
+
+function quoteWindowsCommandArg(value) {
+  const text = String(value || "");
+  return `"${text.replace(/"/g, '\\"')}"`;
+}
 
 function getSettingsWindowIconPath({
   platform,
@@ -33,6 +39,66 @@ function getSettingsWindowIconPath({
   return candidates.find((candidate) => candidate && hasFile(candidate));
 }
 
+function getWindowsShellIconPath({
+  isPackaged,
+  resourcesPath,
+  appDir,
+  existsSync,
+}) {
+  const hasFile = typeof existsSync === "function" ? existsSync : () => true;
+  const candidates = isPackaged
+    ? [
+        path.join(resourcesPath || "", "icon.ico"),
+        path.join(resourcesPath || "", "app.asar.unpacked", "assets", "icon.ico"),
+        path.join(resourcesPath || "", "app.asar", "assets", "icon.ico"),
+      ]
+    : [
+        path.join(appDir || "", "assets", "icon.ico"),
+      ];
+
+  return candidates.find((candidate) => candidate && hasFile(candidate));
+}
+
+function getSettingsWindowTaskbarDetails({
+  platform,
+  isPackaged,
+  resourcesPath,
+  appDir,
+  execPath,
+  appPath,
+  existsSync,
+}) {
+  if (platform !== "win32") return null;
+
+  const appIconPath = getWindowsShellIconPath({
+    isPackaged,
+    resourcesPath,
+    appDir,
+    existsSync,
+  }) || getSettingsWindowIconPath({
+    platform,
+    isPackaged,
+    resourcesPath,
+    appDir,
+    existsSync,
+  });
+
+  const relaunchParts = [execPath];
+  if (!isPackaged && appPath) relaunchParts.push(appPath);
+  const relaunchCommand = relaunchParts
+    .filter(Boolean)
+    .map(quoteWindowsCommandArg)
+    .join(" ");
+
+  return {
+    appId: WINDOWS_APP_USER_MODEL_ID,
+    appIconPath,
+    appIconIndex: 0,
+    relaunchCommand,
+    relaunchDisplayName: SETTINGS_WINDOW_TITLE,
+  };
+}
+
 function applyWindowsAppUserModelId(app, platform = process.platform) {
   if (platform !== "win32") return;
   if (!app || typeof app.setAppUserModelId !== "function") return;
@@ -41,6 +107,9 @@ function applyWindowsAppUserModelId(app, platform = process.platform) {
 
 module.exports = {
   WINDOWS_APP_USER_MODEL_ID,
+  SETTINGS_WINDOW_TITLE,
   getSettingsWindowIconPath,
+  getWindowsShellIconPath,
+  getSettingsWindowTaskbarDetails,
   applyWindowsAppUserModelId,
 };

--- a/test/settings-window-icon.test.js
+++ b/test/settings-window-icon.test.js
@@ -6,7 +6,10 @@ const path = require("path");
 
 const {
   WINDOWS_APP_USER_MODEL_ID,
+  SETTINGS_WINDOW_TITLE,
   getSettingsWindowIconPath,
+  getWindowsShellIconPath,
+  getSettingsWindowTaskbarDetails,
   applyWindowsAppUserModelId,
 } = require("../src/settings-window-icon");
 
@@ -68,5 +71,57 @@ describe("windows app user model id", () => {
       setAppUserModelId() { called = true; },
     }, "darwin");
     assert.strictEqual(called, false);
+  });
+});
+
+describe("windows shell icon path", () => {
+  it("prefers icon.ico for unpackaged Windows shell surfaces", () => {
+    const appDir = "D:\\clawd-on-desk";
+    const expected = path.join(appDir, "assets", "icon.ico");
+    const actual = getWindowsShellIconPath({
+      isPackaged: false,
+      appDir,
+      existsSync: (candidate) => candidate === expected,
+    });
+    assert.strictEqual(actual, expected);
+  });
+
+  it("prefers the extra resource icon for packaged Windows shell surfaces", () => {
+    const resourcesPath = "C:\\Program Files\\Clawd on Desk\\resources";
+    const expected = path.join(resourcesPath, "icon.ico");
+    const actual = getWindowsShellIconPath({
+      isPackaged: true,
+      resourcesPath,
+      existsSync: (candidate) => candidate === expected,
+    });
+    assert.strictEqual(actual, expected);
+  });
+});
+
+describe("settings window taskbar details", () => {
+  it("builds Windows taskbar metadata for unpackaged runs", () => {
+    const appDir = "D:\\clawd-on-desk";
+    const execPath = "D:\\clawd-on-desk\\node_modules\\electron\\dist\\electron.exe";
+    const appPath = "D:\\clawd-on-desk";
+    const iconPath = path.join(appDir, "assets", "icon.ico");
+    const actual = getSettingsWindowTaskbarDetails({
+      platform: "win32",
+      isPackaged: false,
+      appDir,
+      execPath,
+      appPath,
+      existsSync: (candidate) => candidate === iconPath,
+    });
+    assert.deepStrictEqual(actual, {
+      appId: WINDOWS_APP_USER_MODEL_ID,
+      appIconPath: iconPath,
+      appIconIndex: 0,
+      relaunchCommand: `"${execPath}" "${appPath}"`,
+      relaunchDisplayName: SETTINGS_WINDOW_TITLE,
+    });
+  });
+
+  it("returns null on non-Windows platforms", () => {
+    assert.strictEqual(getSettingsWindowTaskbarDetails({ platform: "darwin" }), null);
   });
 });


### PR DESCRIPTION
## Summary

Fix the Windows Settings window taskbar button still showing the default Electron shell identity in source runs.

## Root cause

The Settings window already had a custom `BrowserWindow` icon and an application-wide `AppUserModelID`, but the Windows taskbar right-click menu and shell surfaces still fell back to the underlying `electron.exe` identity in unpackaged runs.

## What changed

- add a Windows-specific helper that builds taskbar-shell metadata for the Settings window
- set `BrowserWindow.setAppDetails(...)` for the Settings window on Windows
- use the project `.ico` asset for shell-facing surfaces while keeping the existing window icon selection logic
- add regression tests for the shell icon path and unpackaged relaunch metadata

## Validation

- `node --check src/main.js`
- `node --test test/settings-window-icon.test.js`
- `npm test`

## Platform notes

- Windows: manually reproduced and verified against the taskbar right-click menu case shown by the reporter
- macOS: not manually tested for this change
- Linux: not manually tested for this change
