### PR TITLE
fix: align Settings size bubble with slider thumb

### DIFF
--- a/src/settings-renderer.js
+++ b/src/settings-renderer.js
@@ -16,10 +16,12 @@ const {
   SIZE_UI_MIN,
   SIZE_UI_MAX,
   SIZE_TICK_VALUES,
+  SIZE_SLIDER_THUMB_DIAMETER,
   uiSizeToPrefs,
   prefsSizeToUi,
   clampSizeUi,
   sizeUiToPct,
+  getSizeSliderAnchorPx,
   createSizeSliderController,
 } = globalThis.ClawdSettingsSizeSlider || {};
 
@@ -2565,16 +2567,42 @@ function buildSizeSliderRow() {
   row.querySelector(".row-desc").textContent = t("rowSizeDesc");
 
   const control = row.querySelector(".size-control");
+  const sliderWrap = row.querySelector(".size-slider-wrap");
   const slider = row.querySelector(".size-slider");
   const bubble = row.querySelector(".size-bubble");
   const ticksEl = row.querySelector(".size-ticks");
+  const tickMarks = [];
+
+  function readThumbDiameterPx() {
+    const raw = window.getComputedStyle(slider).getPropertyValue("--size-slider-thumb-diameter");
+    const parsed = parseFloat(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : SIZE_SLIDER_THUMB_DIAMETER;
+  }
+
+  function getSliderAnchorPx(ui) {
+    return getSizeSliderAnchorPx({
+      value: ui,
+      min: SIZE_UI_MIN,
+      max: SIZE_UI_MAX,
+      sliderWidth: slider.clientWidth,
+      thumbDiameter: readThumbDiameterPx(),
+    });
+  }
+
+  function repositionScaleGeometry(ui) {
+    const anchorPx = getSliderAnchorPx(ui);
+    bubble.style.left = `${anchorPx}px`;
+    for (const tick of tickMarks) {
+      tick.element.style.left = `${getSliderAnchorPx(tick.value)}px`;
+    }
+  }
 
   function applyLocalValue(ui) {
     const pct = sizeUiToPct(ui);
     slider.value = String(ui);
     slider.style.setProperty("--size-fill", `${pct}%`);
     bubble.textContent = `${ui}%`;
-    bubble.style.left = `${pct}%`;
+    repositionScaleGeometry(ui);
   }
 
   function setDragging(nextDragging, pending = transientUiState.size.pending) {
@@ -2591,7 +2619,6 @@ function buildSizeSliderRow() {
     const mark = document.createElement("span");
     mark.className = "size-tick";
     mark.dataset.value = String(v);
-    mark.style.left = `${sizeUiToPct(v)}%`;
     const dot = document.createElement("span");
     dot.className = "size-tick-dot";
     const label = document.createElement("span");
@@ -2600,6 +2627,7 @@ function buildSizeSliderRow() {
     mark.appendChild(dot);
     mark.appendChild(label);
     ticksEl.appendChild(mark);
+    tickMarks.push({ value: v, element: mark });
   }
 
   const controller = createSizeSliderController({
@@ -2624,9 +2652,29 @@ function buildSizeSliderRow() {
   mountedControls.size = {
     row,
     syncFromSnapshot: (options) => controller.syncFromSnapshot(options),
-    dispose: () => controller.dispose(),
+    dispose: () => {
+      if (resizeObserver) resizeObserver.disconnect();
+      window.removeEventListener("resize", handleGeometryRefresh);
+      return controller.dispose();
+    },
   };
   controller.syncFromSnapshot();
+
+  function handleGeometryRefresh() {
+    const currentUi =
+      transientUiState.size.draftUi === null ? readSizeUiFromSnapshot() : transientUiState.size.draftUi;
+    repositionScaleGeometry(currentUi);
+  }
+
+  let resizeObserver = null;
+  if (typeof ResizeObserver === "function") {
+    resizeObserver = new ResizeObserver(() => {
+      handleGeometryRefresh();
+    });
+    resizeObserver.observe(sliderWrap);
+  }
+  window.addEventListener("resize", handleGeometryRefresh);
+  handleGeometryRefresh();
 
   slider.addEventListener("pointerdown", () => { void controller.pointerDown(); });
   slider.addEventListener("pointerup", () => { void controller.pointerUp(); });

--- a/src/settings-size-slider.js
+++ b/src/settings-size-slider.js
@@ -5,6 +5,8 @@ const SIZE_PREFS_MAX = 30;
 const SIZE_UI_MIN = 1;
 const SIZE_UI_MAX = 100;
 const SIZE_TICK_VALUES = [25, 50, 75, 100];
+const SIZE_SLIDER_TRACK_HEIGHT = 6;
+const SIZE_SLIDER_THUMB_DIAMETER = 18;
 
 function uiSizeToPrefs(ui) {
   return Math.round((ui * SIZE_PREFS_MAX / SIZE_UI_MAX) * 10) / 10;
@@ -20,6 +22,28 @@ function clampSizeUi(n) {
 
 function sizeUiToPct(ui) {
   return ((ui - SIZE_UI_MIN) / (SIZE_UI_MAX - SIZE_UI_MIN)) * 100;
+}
+
+function clampSliderNormalized(value, min, max) {
+  if (!Number.isFinite(value)) return 0;
+  if (!Number.isFinite(min) || !Number.isFinite(max) || max <= min) return 0;
+  return Math.max(0, Math.min(1, (value - min) / (max - min)));
+}
+
+function getSizeSliderAnchorPx({
+  value,
+  min = SIZE_UI_MIN,
+  max = SIZE_UI_MAX,
+  sliderWidth,
+  thumbDiameter = SIZE_SLIDER_THUMB_DIAMETER,
+}) {
+  const width = Number.isFinite(sliderWidth) ? Math.max(0, sliderWidth) : 0;
+  const diameter = Number.isFinite(thumbDiameter) ? Math.max(0, thumbDiameter) : 0;
+  const radius = diameter / 2;
+  if (width <= 0) return radius;
+  if (width <= diameter) return width / 2;
+  const normalized = clampSliderNormalized(value, min, max);
+  return radius + (normalized * (width - diameter));
 }
 
 function formatSizeKey(ui) {
@@ -191,10 +215,13 @@ return {
   SIZE_UI_MIN,
   SIZE_UI_MAX,
   SIZE_TICK_VALUES,
+  SIZE_SLIDER_TRACK_HEIGHT,
+  SIZE_SLIDER_THUMB_DIAMETER,
   uiSizeToPrefs,
   prefsSizeToUi,
   clampSizeUi,
   sizeUiToPct,
+  getSizeSliderAnchorPx,
   createSizeSliderController,
 };
 }

--- a/src/settings.html
+++ b/src/settings.html
@@ -269,6 +269,8 @@ html, body {
 
 /* ── Size slider ── */
 .size-control {
+  --size-slider-track-height: 6px;
+  --size-slider-thumb-diameter: 18px;
   flex-direction: column;
   align-items: stretch;
   gap: 2px;
@@ -320,7 +322,7 @@ html, body {
   touch-action: pan-y;
 }
 .size-slider::-webkit-slider-runnable-track {
-  height: 6px;
+  height: var(--size-slider-track-height);
   border-radius: 999px;
   background: linear-gradient(
     90deg,
@@ -332,9 +334,9 @@ html, body {
 }
 .size-slider::-webkit-slider-thumb {
   -webkit-appearance: none;
-  width: 18px;
-  height: 18px;
-  margin-top: -6px;
+  width: var(--size-slider-thumb-diameter);
+  height: var(--size-slider-thumb-diameter);
+  margin-top: calc((var(--size-slider-track-height) - var(--size-slider-thumb-diameter)) / 2);
   border-radius: 50%;
   border: 2px solid var(--accent);
   background: #fff;

--- a/test/settings-size-slider.test.js
+++ b/test/settings-size-slider.test.js
@@ -5,6 +5,8 @@ const assert = require("node:assert");
 
 const {
   createSizeSliderController,
+  getSizeSliderAnchorPx,
+  SIZE_SLIDER_THUMB_DIAMETER,
 } = require("../src/settings-size-slider");
 
 describe("settings size slider controller", () => {
@@ -67,5 +69,66 @@ describe("settings size slider controller", () => {
       ["preview", "P:16.5"],
       ["end", "P:16.5"],
     ]);
+  });
+});
+
+describe("settings size slider geometry", () => {
+  it("anchors bubble/ticks to the actual thumb center instead of raw percent width", () => {
+    assert.strictEqual(
+      getSizeSliderAnchorPx({
+        value: 1,
+        min: 1,
+        max: 100,
+        sliderWidth: 200,
+        thumbDiameter: SIZE_SLIDER_THUMB_DIAMETER,
+      }),
+      SIZE_SLIDER_THUMB_DIAMETER / 2
+    );
+
+    assert.strictEqual(
+      getSizeSliderAnchorPx({
+        value: 100,
+        min: 1,
+        max: 100,
+        sliderWidth: 200,
+        thumbDiameter: SIZE_SLIDER_THUMB_DIAMETER,
+      }),
+      200 - (SIZE_SLIDER_THUMB_DIAMETER / 2)
+    );
+
+    assert.strictEqual(
+      getSizeSliderAnchorPx({
+        value: 50.5,
+        min: 1,
+        max: 100,
+        sliderWidth: 200,
+        thumbDiameter: SIZE_SLIDER_THUMB_DIAMETER,
+      }),
+      100
+    );
+  });
+
+  it("recomputes the same value against a new slider width", () => {
+    assert.strictEqual(
+      getSizeSliderAnchorPx({
+        value: 75,
+        min: 1,
+        max: 100,
+        sliderWidth: 240,
+        thumbDiameter: SIZE_SLIDER_THUMB_DIAMETER,
+      }),
+      174.93939393939394
+    );
+
+    assert.strictEqual(
+      getSizeSliderAnchorPx({
+        value: 75,
+        min: 1,
+        max: 100,
+        sliderWidth: 320,
+        thumbDiameter: SIZE_SLIDER_THUMB_DIAMETER,
+      }),
+      234.73737373737376
+    );
   });
 });


### PR DESCRIPTION
## Summary

Align the Settings `General > Size` bubble and tick marks to the actual slider thumb center instead of positioning them by raw percent width.

This follows up on the Windows Settings size-slider work from #133. The previous implementation still left a small but stable visual offset between the floating percentage bubble and the circular thumb because the bubble anchor used the full range width instead of the thumb's real travel geometry.

## What changed

- add a shared slider-geometry helper in `src/settings-size-slider.js`
- compute the bubble anchor with `thumbRadius + normalized * (sliderWidth - thumbDiameter)`
- switch tick positioning to the same anchor calculation so bubble, ticks, and thumb use one coordinate system
- keep `sizeUiToPct()` only for the filled track gradient, not for visual anchor truth
- re-align geometry on width changes via `ResizeObserver` with a window-resize fallback
- move thumb/track dimensions into shared CSS variables so JS and CSS stay in sync

## Validation

- `node --test test/settings-size-slider.test.js test/settings-renderer-browser-env.test.js`
- `node --check src/settings-size-slider.js`
- `node --check src/settings-renderer.js`
- `git diff --check`
- `npm test`

Result in the clean worktree used for this PR:
- `809` passing
- `0` failing
- `1` skipped

## Platform note

- Windows: manually targeted by this fix
- macOS/Linux: shared UI path updated, but not manually verified in this pass