### PR TITLE
fix(settings): detect macOS reliably for Cmd shortcut display

### DIFF
--- a/src/settings-renderer.js
+++ b/src/settings-renderer.js
@@ -585,7 +585,12 @@ const formatAcceleratorLabel = SHORTCUT_API.formatAcceleratorLabel
   || ((value) => value || "— unassigned —");
 const formatAcceleratorPartial = SHORTCUT_API.formatAcceleratorPartial
   || (() => "");
-const IS_MAC = /\bMac\b/i.test(navigator.platform || "");
+// navigator.platform returns "MacIntel" on macOS (both Intel and Apple
+// Silicon — the latter retains "MacIntel" for web compatibility). The old
+// /\bMac\b/ pattern failed because the trailing \b needs a non-word char
+// after "c", but "I" is a word character. Follow the MDN-recommended check:
+// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform
+const IS_MAC = (navigator.platform || "").startsWith("Mac");
 
 let snapshot = null;
 let activeTab = "general";


### PR DESCRIPTION
## Summary

- `IS_MAC` in `src/settings-renderer.js` was `/\bMac\b/i.test(navigator.platform || "")`, which never matches on macOS because `navigator.platform` returns `"MacIntel"` — the `\b` word boundary after `c` fails since `I` is also a word character.
- As a result, `IS_MAC` was always `false` on Mac, and the Shortcuts tab rendered bindings as `Ctrl+Shift+Y` / `Ctrl+Shift+N` instead of `⌘⇧Y` / `⌘⇧N`. The keys themselves worked (Electron's `CommandOrControl` already maps to Cmd on Mac); only the displayed label was wrong.
- Replaced with the [MDN-recommended check](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/platform): `(navigator.platform || \"\").startsWith(\"Mac\")`. MDN explicitly lists this as a valid use of `navigator.platform` for keyboard-shortcut modifier display, and the value stays `\"MacIntel\"` on Apple Silicon too (retained for web compatibility).

## Why it matters

Only cosmetic, but confusing: a Mac user reading the settings panel would try to press Ctrl+Shift+Y and nothing would fire, because the actual registered accelerator is Cmd+Shift+Y.

## Test plan

- [x] \`npm test\` — no regressions (same 8 pre-existing failures on \`main\`, all in unrelated files: \`install.test.js\`, \`state.test.js\`, \`theme-loader.test.js\`, \`updater.test.js\`)
- [x] Manual: Settings → Shortcuts now shows \`⌘⇧⌥C\`, \`⌘⇧Y\`, \`⌘⇧N\` on macOS (verified on Apple Silicon, \`navigator.platform === \"MacIntel\"\`)
- [x] Other usages of \`IS_MAC\` (accelerator recording / live partial formatting) also benefit — \`⌘\` captured instead of \`Ctrl\` when user records a new shortcut

## Scope

1 file, +6 / -1 (5 of the additions are a comment explaining the pitfall so the next contributor doesn't repeat it). No behavior changes outside macOS shortcut rendering.