### PR TITLE
fix: keep context menu owner renderer persistent

### DIFF
--- a/src/menu.js
+++ b/src/menu.js
@@ -193,6 +193,12 @@ module.exports = function initMenu(ctx) {
       hasShadow: false,
     });
 
+    // Chromium reclaims empty (about:blank) hidden renderers, which defeats
+    // the "persistent helper window" design — every right-click ends up
+    // re-spawning a renderer process. Load a minimal data: URL so the
+    // renderer has a real document and stays alive across menu invocations.
+    ctx.contextMenuOwner.loadURL("data:text/html,%3C!doctype%20html%3E");
+
     // macOS: ensure owner can appear on fullscreen Spaces
     ctx.reapplyMacVisibility();
 


### PR DESCRIPTION
## Summary

The helper `BrowserWindow` created by `ensureContextMenuOwner()` (`src/menu.js`) was intended to persist across right-clicks — the commit that introduced it (1ba70d8) explicitly calls it a *persistent hidden helper window* and documents the workaround reasons (avoid DPI size jump when toggling the pet window focusable, ensure the menu dismisses on any outside click, prevent app quit).

However, because the owner window loads no content, Chromium reclaims the empty renderer whenever it sits hidden. I observed this locally on macOS: the owner's renderer PID changed on every right-click, meaning each menu invocation re-spawns a renderer process.

This fix loads a minimal `data:` URL so the renderer holds a real document and actually survives between invocations, restoring the original design.

## Observed impact (macOS, local test)

Measured with `ps` across the main / GPU / renderer processes while the pet sat idle with the default Clawd theme:

- **Before fix:** total CPU ≈ 17–31% (varied; higher values coincided with right-click cycles that re-spawned the owner renderer)
- **After fix:** total CPU ≈ 7% at idle
- Owner renderer PID now stays stable across repeated right-clicks

The remaining idle load comes from the pet window's CSS breathe/blink animations on a transparent always-on-top surface, which is by design. The churn on right-click is what this fix removes.

Not measured on Windows / Linux — the change is platform-agnostic and only adds a `loadURL` call before the existing `reapplyMacVisibility()`, so regression risk is low, but second eyes welcome.

## Test plan

- [x] Build and run (`npm start`) on macOS
- [x] Right-click the pet multiple times; confirm the owner renderer PID is stable in `ps`
- [x] Verify the context menu still opens, dismisses on outside click, and each menu item still fires (Language, Size, Mini Mode, Sleep, Quit)
- [ ] Windows / Linux smoke test (unable to test locally)