### PR TITLE
style: selective-merge cosmetic polish for Settings size bubble

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -271,6 +271,9 @@ html, body {
 .size-control {
   --size-slider-track-height: 6px;
   --size-slider-thumb-diameter: 18px;
+  --size-bubble-tail-size: 4px;
+  --size-bubble-tail-inner-size: 3px;
+  --size-bubble-tail-gap: 1px;
   flex-direction: column;
   align-items: stretch;
   gap: 2px;
@@ -279,11 +282,11 @@ html, body {
 }
 .size-slider-wrap {
   position: relative;
-  padding-top: 28px; /* room for floating bubble */
+  padding-top: 29px; /* room for compact floating bubble + tail */
 }
 .size-bubble {
   position: absolute;
-  top: 0;
+  top: 6px;
   left: 0;
   transform: translateX(-50%);
   font-size: 11px;
@@ -291,24 +294,34 @@ html, body {
   color: var(--accent);
   background: var(--panel-bg);
   border: 1px solid var(--accent);
-  border-radius: 10px;
-  padding: 1px 7px;
+  border-radius: 9px;
+  padding: 0 7px;
   pointer-events: none;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
-  line-height: 1.3;
+  line-height: 1.2;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
   transition: transform 0.14s ease, box-shadow 0.18s ease;
 }
+.size-bubble::before,
 .size-bubble::after {
   content: "";
   position: absolute;
-  top: 100%;
   left: 50%;
   transform: translateX(-50%);
-  border: 4px solid transparent;
-  border-top-color: var(--accent);
-  margin-top: -1px;
+  pointer-events: none;
+}
+.size-bubble::before {
+  top: calc(100% + var(--size-bubble-tail-gap));
+  border-left: var(--size-bubble-tail-size) solid transparent;
+  border-right: var(--size-bubble-tail-size) solid transparent;
+  border-top: var(--size-bubble-tail-size) solid var(--accent);
+}
+.size-bubble::after {
+  top: calc(100% + var(--size-bubble-tail-gap));
+  border-left: var(--size-bubble-tail-inner-size) solid transparent;
+  border-right: var(--size-bubble-tail-inner-size) solid transparent;
+  border-top: var(--size-bubble-tail-inner-size) solid var(--panel-bg);
 }
 .size-slider {
   width: 100%;

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -31,4 +31,17 @@ describe("settings renderer browser environment", () => {
     assert.ok(!/transition:\s*left\b/.test(match[1]));
     assert.ok(/transition:\s*transform 0\.14s ease,\s*box-shadow 0\.18s ease;/.test(match[1]));
   });
+
+  it("renders the size bubble tail as a separated double-layer callout instead of overlapping the pill", () => {
+    const html = fs.readFileSync(SETTINGS_HTML, "utf8");
+    assert.ok(/--size-bubble-tail-size:\s*4px;/.test(html));
+    assert.ok(/--size-bubble-tail-inner-size:\s*3px;/.test(html));
+    assert.ok(/--size-bubble-tail-gap:\s*1px;/.test(html));
+    assert.ok(/padding-top:\s*29px;/.test(html));
+    assert.ok(/\.size-bubble\s*\{[\s\S]*top:\s*6px;[\s\S]*border-radius:\s*9px;[\s\S]*padding:\s*0 7px;[\s\S]*line-height:\s*1\.2;[\s\S]*\}/.test(html));
+    assert.ok(/\.size-bubble::before,\s*\.size-bubble::after\s*\{/.test(html));
+    assert.ok(/\.size-bubble::before\s*\{[\s\S]*top:\s*calc\(100%\s*\+\s*var\(--size-bubble-tail-gap\)\);[\s\S]*border-top:\s*var\(--size-bubble-tail-size\)\s+solid\s+var\(--accent\);[\s\S]*\}/.test(html));
+    assert.ok(/\.size-bubble::after\s*\{[\s\S]*top:\s*calc\(100%\s*\+\s*var\(--size-bubble-tail-gap\)\);[\s\S]*border-top:\s*var\(--size-bubble-tail-inner-size\)\s+solid\s+var\(--panel-bg\);[\s\S]*\}/.test(html));
+    assert.ok(!/\.size-bubble::after\s*\{[\s\S]*margin-top:\s*-1px;/.test(html));
+  });
 });


### PR DESCRIPTION
## Summary

This is a selective-merge, cosmetic-only PR for the Settings > General > Size bubble.

It only polishes the bubble visuals and does not change slider behavior, preview/commit logic, or thumb alignment logic.

## What changed

- moved the bubble body down slightly so it sits closer to the slider
- kept the compact outlined tail style instead of the heavier solid triangle
- refined the bubble tail spacing and pill proportions for a cleaner callout look
- added a browser-environment regression test to lock the visual CSS tokens

## Scope

Files changed:
- `src/settings.html`
- `test/settings-renderer-browser-env.test.js`

This PR is intended to be safe for selective merge or cherry-pick because it is purely cosmetic.

## Verification

- `node --test test/settings-renderer-browser-env.test.js`
- `npm test`

Result:
- `834 passing`
- `0 failing`
- `1 skipped`

## Platform note

- Windows: manually checked for the Settings panel bubble appearance
- macOS/Linux: shared CSS path only, not manually QA'd in this environment
