### PR TITLE
fix(settings): fallback preview sound when confirm is missing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1912,7 +1912,7 @@ ipcMain.handle("settings:end-size-preview", (_event, value) => {
   return settingsSizePreviewSession.end(value || null);
 });
 ipcMain.handle("settings:get-preview-sound-url", () => {
-  try { return themeLoader.getSoundUrl("confirm") || null; }
+  try { return themeLoader.getPreviewSoundUrl(); }
   catch { return null; }
 });
 ipcMain.handle("settings:command", async (_event, payload) => {

--- a/src/theme-loader.js
+++ b/src/theme-loader.js
@@ -1416,6 +1416,10 @@ function getSoundUrl(soundName) {
   return null;
 }
 
+function getPreviewSoundUrl() {
+  return getSoundUrl("confirm") || getSoundUrl("complete") || null;
+}
+
 // basename() strips any path segments in theme.json so a malicious
 // `preview: "../../foo"` can't escape the theme dir.
 function _buildPreviewUrl(raw, themeDir, isBuiltin) {
@@ -1541,6 +1545,7 @@ module.exports = {
   getHitRendererConfig,
   ensureUserThemesDir,
   getSoundUrl,
+  getPreviewSoundUrl,
   // Schema constants + helpers — shared with scripts/validate-theme.js to
   // keep validator and runtime loader from drifting on the same invariants.
   REQUIRED_STATES,

--- a/test/theme-loader.test.js
+++ b/test/theme-loader.test.js
@@ -171,6 +171,76 @@ describe("theme-loader getThemeMetadata", () => {
   });
 });
 
+describe("theme-loader preview sound selection", () => {
+  let fixture;
+  before(() => {
+    fixture = makeFixture([
+      { id: "clawd", builtin: true, json: validThemeJson({ name: "Clawd" }) },
+      {
+        id: "preview-theme",
+        builtin: false,
+        json: validThemeJson({
+          name: "Preview Theme",
+          sounds: {
+            confirm: "preview-confirm.mp3",
+          },
+        }),
+      },
+      {
+        id: "fallback-theme",
+        builtin: false,
+        json: validThemeJson({
+          name: "Fallback Theme",
+          sounds: {
+            confirm: null,
+          },
+        }),
+      },
+      {
+        id: "silent-theme",
+        builtin: false,
+        json: validThemeJson({
+          name: "Silent Theme",
+          sounds: {
+            confirm: null,
+            complete: null,
+          },
+        }),
+      },
+    ]);
+
+    fs.writeFileSync(path.join(fixture.tmp, "assets", "sounds", "complete.mp3"), "complete", "utf8");
+
+    for (const themeId of ["preview-theme", "fallback-theme", "silent-theme"]) {
+      fs.mkdirSync(path.join(fixture.tmp, "userData", "themes", themeId, "assets"), { recursive: true });
+    }
+
+    const previewSoundsDir = path.join(fixture.tmp, "userData", "themes", "preview-theme", "sounds");
+    fs.mkdirSync(previewSoundsDir, { recursive: true });
+    fs.writeFileSync(path.join(previewSoundsDir, "preview-confirm.mp3"), "confirm", "utf8");
+  });
+  after(() => fixture && fixture.cleanup());
+
+  it("prefers confirm for settings preview when available", () => {
+    themeLoader.loadTheme("preview-theme", { strict: true });
+    const previewUrl = themeLoader.getPreviewSoundUrl();
+    assert.ok(previewUrl, "preview URL expected");
+    assert.ok(previewUrl.includes("preview-confirm.mp3"));
+  });
+
+  it("falls back to complete when confirm is unavailable", () => {
+    themeLoader.loadTheme("fallback-theme", { strict: true });
+    const previewUrl = themeLoader.getPreviewSoundUrl();
+    assert.ok(previewUrl, "preview URL expected");
+    assert.ok(previewUrl.includes("complete.mp3"));
+  });
+
+  it("returns null when neither confirm nor complete is available", () => {
+    themeLoader.loadTheme("silent-theme", { strict: true });
+    assert.strictEqual(themeLoader.getPreviewSoundUrl(), null);
+  });
+});
+
 describe("theme-loader discovery", () => {
   let fixture;
   before(() => {


### PR DESCRIPTION
## Summary

Follow-up to #151.

Make the Settings sound preview fall back to `complete` when the active theme does not provide `confirm`, so the volume slider preview still works for themes with partial sound overrides.

## Changes

- Add `themeLoader.getPreviewSoundUrl()` with `confirm` → `complete` → `null` fallback
- Switch `settings:get-preview-sound-url` IPC handler to use the new helper
- Add `theme-loader.test.js` cases covering:
  - prefers `confirm` when available
  - falls back to `complete` when `confirm` is missing
  - returns `null` when neither sound exists

## Testing

- `npm test` — all new cases pass; same pre-existing `test/hit-geometry.test.js` failures remain unchanged
