### PR TITLE
fix(kimi): gate PermissionRequest setState by isAgentPermissionsEnabled

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -658,6 +658,17 @@ function updateSession(sessionId, state, event, opts = {}) {
   const permAgentId = agentId || (sessionForPerm && sessionForPerm.agentId) || null;
 
   if (event === "PermissionRequest") {
+    // Kimi-only gate: startKimiPermissionPoll suppresses the passive bubble
+    // when the user disabled Kimi permissions in Settings, but the setState
+    // ran first and flashed notification anyway — leaving a silent animation
+    // with no follow-up UI. setState already early-returns under DND so we
+    // don't need a second DND check here. CC / opencode keep the
+    // unconditional setState — their bubble flow gates DND upstream.
+    if (
+      permAgentId === "kimi-cli"
+      && typeof ctx.isAgentPermissionsEnabled === "function"
+      && !ctx.isAgentPermissionsEnabled("kimi-cli")
+    ) return;
     setState("notification");
     if (permAgentId === "kimi-cli") startKimiPermissionPoll(sessionId);
     return;

--- a/test/state-kimi-permission.test.js
+++ b/test/state-kimi-permission.test.js
@@ -192,10 +192,13 @@ describe("Kimi permission hold by session", () => {
   it("does not create a hold when Kimi permissions are disabled", () => {
     ctx.isAgentPermissionsEnabled = (id) => id !== "kimi-cli";
     api.updateSession("kimi-a", "notification", "PermissionRequest", { agentId: "kimi-cli" });
-    // isAgentPermissionsEnabled("kimi-cli") = false → bubble AND hold should
-    // both be skipped, matching the behavior of the DND guard.
+    // Pre-fix the setState("notification") ran unconditionally before the
+    // hold gate, so the pet flashed notification with no follow-up bubble
+    // when the user had disabled Kimi permissions in Settings. Asserting
+    // currentState (not just resolveDisplayState) catches that regression.
     assert.deepStrictEqual(ctx._kimiNotifyShown, []);
     assert.notStrictEqual(api.resolveDisplayState(), "notification");
+    assert.notStrictEqual(api.getCurrentState(), "notification");
   });
 
   it("disposeAllKimiPermissionState clears holds without triggering a state resolve", () => {


### PR DESCRIPTION
## Summary

Follow-up to #138. Codex review caught one real bug after merge: `updateSession()`'s `PermissionRequest` branch fires `setState("notification")` before checking whether the user has Kimi permission bubbles disabled in Settings, leaving a silent notification flash with no follow-up bubble.

## The bug

```js
if (event === "PermissionRequest") {
  setState("notification");                                    // ← unconditional
  if (permAgentId === "kimi-cli") startKimiPermissionPoll(sessionId);  // ← gated
  return;
}
```

`startKimiPermissionPoll()` early-returns when `isAgentPermissionsEnabled("kimi-cli")` is false, so no bubble or hold is created — but `setState` already ran. Net effect: pet animates notification once with nothing to dismiss.

DND is fine because `setState()` itself early-returns under DND (`state.js:249`). Only the permissions-disabled case needed a fix.

## The fix

Hoist the `isAgentPermissionsEnabled` check above `setState` for `permAgentId === "kimi-cli"` only. CC / opencode `PermissionRequest` paths are unchanged — their bubble flow gates DND upstream.

## Test plan

- [x] New assert in `test/state-kimi-permission.test.js` — `getCurrentState() !== "notification"` (the existing `resolveDisplayState()` assertion didn't catch the bug because resolveDisplayState reads from sessions map, not currentState)
- [x] Verified the new assert fails on pre-fix code, passes post-fix
- [x] Full suite: 954 pass / 2 fail (the 2 fails are pre-existing calico hit-geometry tests that also fail on `main`, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)