### PR TITLE
fix(settings): grey out agent sub-switches when master is off

### DIFF
--- a/src/settings-tab-agents.js
+++ b/src/settings-tab-agents.js
@@ -33,11 +33,18 @@
   }
 
   function buildAgentRows(agent) {
+    // Sub-switches depend on the master: when the agent is turned off, the
+    // sub-flags have no effect (server-side gate drops the events upstream),
+    // so we render them as visually disabled to match reality. Committed
+    // values are preserved — flipping the master back on restores sub-switch
+    // state verbatim without re-asking the user to opt back in.
+    const masterOn = readers.readAgentFlagValue(agent.id, "enabled");
     const rows = [
       buildAgentSwitchRow({
         agent,
         flag: "enabled",
         extraClass: null,
+        disabled: false,
         buildText: (text) => {
           const label = document.createElement("span");
           label.className = "row-label";
@@ -68,6 +75,7 @@
         agent,
         flag: "permissionsEnabled",
         extraClass: "row-sub",
+        disabled: !masterOn,
         buildText: (text) => {
           const label = document.createElement("span");
           label.className = "row-label";
@@ -83,7 +91,7 @@
     return rows;
   }
 
-  function buildAgentSwitchRow({ agent, flag, extraClass, buildText }) {
+  function buildAgentSwitchRow({ agent, flag, extraClass, disabled = false, buildText }) {
     const row = document.createElement("div");
     row.className = extraClass ? `row ${extraClass}` : "row";
 
@@ -97,7 +105,11 @@
     const sw = document.createElement("div");
     sw.className = "switch";
     sw.setAttribute("role", "switch");
-    sw.setAttribute("tabindex", "0");
+    sw.setAttribute("tabindex", disabled ? "-1" : "0");
+    if (disabled) {
+      sw.classList.add("disabled");
+      sw.setAttribute("aria-disabled", "true");
+    }
     const stateId = readers.agentSwitchStateId(agent.id, flag);
     const override = state.transientUiState.agentSwitches.get(stateId);
     const committedVisual = readers.readAgentFlagValue(agent.id, flag);
@@ -108,7 +120,17 @@
       element: sw,
       agentId: agent.id,
       flag,
+      disabled,
     });
+    // Disabled sub-switches intentionally skip the click handler so the flip
+    // animation never fires while the master is off. Committed value stays
+    // untouched — buildAgentRows reads it at the next re-render and the flip
+    // restores naturally when the master turns back on.
+    if (disabled) {
+      ctrl.appendChild(sw);
+      row.appendChild(ctrl);
+      return row;
+    }
     helpers.attachAnimatedSwitch(sw, {
       getCommittedVisual: () => readers.readAgentFlagValue(agent.id, flag),
       getTransientState: () => state.transientUiState.agentSwitches.get(stateId) || null,
@@ -134,8 +156,25 @@
     const keys = changes ? Object.keys(changes) : [];
     if (!(keys.length === 1 && keys[0] === "agents")) return false;
     if (state.mountedControls.agentSwitches.size === 0) return false;
-    for (const [id, meta] of state.mountedControls.agentSwitches) {
+    // A master flip changes which sub-switches should render disabled; that's
+    // a structural change (attach/detach click handler + tabindex + aria),
+    // so fall back to a full re-render instead of trying to patch it in place.
+    // Also clear lingering transient state before doing so — otherwise the
+    // in-flight `pending:true` from the master click itself leaks into the
+    // re-render, locks `.pending` onto the new master switch, and
+    // attachAnimatedSwitch silently bails on every subsequent click.
+    for (const [, meta] of state.mountedControls.agentSwitches) {
       if (!meta || !document.body.contains(meta.element)) return false;
+      if (meta.flag === "enabled") continue;
+      const masterOn = readers.readAgentFlagValue(meta.agentId, "enabled");
+      if (meta.disabled === masterOn) {
+        for (const id of state.mountedControls.agentSwitches.keys()) {
+          state.transientUiState.agentSwitches.delete(id);
+        }
+        return false;
+      }
+    }
+    for (const [id, meta] of state.mountedControls.agentSwitches) {
       state.transientUiState.agentSwitches.delete(id);
       helpers.setSwitchVisual(meta.element, readers.readAgentFlagValue(meta.agentId, meta.flag), { pending: false });
     }


### PR DESCRIPTION
## Problem

Open **Settings → Agents** with Claude Code's master switch on and "Show pop-up bubbles" on. Flip Claude Code's master off. The sub-switch keeps rendering "on".

That's the UI lying. The server already drops every hook event for this agent at the `isAgentEnabled` gate in `src/server.js` — the sub-flag has no practical effect while the master is off, no matter what it reads. A user seeing "on" might reasonably expect bubbles to still appear.

## What this changes

Render-layer only. The sub-switch greys out (existing `.switch.disabled` CSS — 45% opacity + `not-allowed`), stops responding to clicks + keyboard, drops out of tab order. Committed value is untouched: flipping the master back on restores the sub-switch to exactly what the user last set it to.

Nothing moves at the data layer. `setAgentFlag` still writes flags independently, `isAgentPermissionsEnabled` still reads them independently, and the existing regression guard in `test/agent-gate.test.js` — *"toggling master flag preserves permissionsEnabled (no silent wipe)"* — stays green. This PR is a strict superset of that invariant, not a rewrite: same stored values, honest visuals.

## Why not a commit-layer cascade

Considered two alternatives:

- **Cascade sub-flag values to `false` on master flip.** Breaks the regression guard above. Worse, it punishes temporary master toggles — a user who had permissions deliberately off, briefly kills the agent to stop a runaway session, and re-enables now has to re-disable permissions by hand.
- **Leave the visual inconsistency.** Current state. Confuses users; doesn't scale as more sub-switches land (e.g. #155's "Wait-for-input alerts" adds a second sub-switch per agent, making the lie louder).

The render-layer fix gets visual honesty without either cost.

## Implementation notes

- `buildAgentRows` reads `masterOn` once and passes `disabled: !masterOn` to the sub-row builder.
- `buildAgentSwitchRow` accepts `disabled`, wires up class / aria / tabindex, and **skips `attachAnimatedSwitch` entirely** when disabled — clicks have nowhere to land (cleaner than a runtime guard inside the shared switch helper, and mirrors the same-file pattern in `buildGeneralSwitchRow` → `settings-ui-core.js:328`).
- `patchInPlace` compares each sub-switch's render-time `disabled` against the fresh `masterOn` — mismatch triggers a full re-render. Before returning `false`, it clears `state.transientUiState.agentSwitches` so the in-flight `pending:true` from the master click itself doesn't leak into the new render and lock `.pending` onto the new master switch (attachAnimatedSwitch silently bails on `.pending` — caught this one on first manual test).

## Testing

- `npm test`: 987/995 — same 8 macOS-only Windows install probing / calico SVG baseline / updater harness failures pre-existing on main. No new breaks.
- Manual on macOS with Claude Code, CodeBuddy, and Kimi CLI visible:
  - Master on → sub-switch interactive, value editable ✅
  - Master on → off: sub-switch greys out, clicks ignored ✅
  - Master off → on: sub-switch restores to prior committed value ✅
  - No stuck `.pending` state after rapid master flipping ✅
  - sub-switch tab-key navigation skips the disabled row ✅
- Not adding unit tests — the existing settings tabs have no renderer-level test harness (command-layer and helper-layer only, see `test/settings-*.test.js`), and this is a pure-DOM concern. Happy to add manual walkthrough screenshots if useful.

## Related

Stacks cleanly on top of main at `8ca7cc8`. Independent of #155 — both sub-switches ("Show pop-up bubbles" today, "Wait-for-input alerts" if that PR lands) benefit automatically because the render-layer fix lives in the shared `buildAgentSwitchRow` path.