### PR TITLE
fix(state): move notification-hook mute to presentation layer

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1015,7 +1015,6 @@ const _serverCtx = {
   get sessions() { return sessions; },
   isAgentEnabled: (agentId) => _isAgentEnabled({ agents: _settingsController.get("agents") }, agentId),
   isAgentPermissionsEnabled: (agentId) => _isAgentPermissionsEnabled({ agents: _settingsController.get("agents") }, agentId),
-  isAgentNotificationHookEnabled: (agentId) => _isAgentNotificationHookEnabled({ agents: _settingsController.get("agents") }, agentId),
   setState,
   updateSession,
   resolvePermissionEntry,

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -764,8 +764,11 @@ function resetAllShortcuts(_payload, deps) {
 // Payload `{ agentId, flag, value }` where flag ∈ AGENT_FLAGS.
 //
 // Flags:
-//   enabled             — master: event stream on/off
-//   permissionsEnabled  — sub: bubble UI on/off (events still flow)
+//   enabled                  — master: event stream on/off
+//   permissionsEnabled       — sub: bubble UI on/off (events still flow)
+//   notificationHookEnabled  — sub: wait-for-input bell + animation on/off
+//                              (presentation-layer mute; session bookkeeping
+//                              and Kimi hold-release cleanup still run)
 //
 // Main + sub share one command so rapid toggles serialize under the same
 // controller lockKey — two separate commands would lost-update the

--- a/src/state.js
+++ b/src/state.js
@@ -674,19 +674,6 @@ function updateSession(sessionId, state, event, opts = {}) {
     return;
   }
 
-  // Per-agent Notification-hook gate: silences self-issued "I'm idle /
-  // waiting for input" pings (Claude Code fires these ~60s after Stop; other
-  // agents have similar bells). Sits at the state layer — not the HTTP
-  // boundary — so it applies uniformly across event sources (hook POST,
-  // log poll, plugin push). Permission bubbles are safe: PermissionRequest
-  // is handled by the branch above and never reaches here.
-  if (
-    event === "Notification"
-    && permAgentId
-    && typeof ctx.isAgentNotificationHookEnabled === "function"
-    && !ctx.isAgentNotificationHookEnabled(permAgentId)
-  ) return;
-
   const existing = sessions.get(sessionId);
   const srcPid = sourcePid || (existing && existing.sourcePid) || null;
   const srcCwd = cwd || (existing && existing.cwd) || "";
@@ -855,6 +842,22 @@ function updateSession(sessionId, state, event, opts = {}) {
     // keep the pet on notification and block all other one-shot visuals.
     // (One-shot branch normally bypasses resolveDisplayState()).
     if (hasPermissionAnimationLock() && state !== "notification") {
+      return;
+    }
+    // Per-agent Notification-hook mute: presentation-layer only. By this
+    // point session bookkeeping, recentEvents, and Kimi hold-release cleanup
+    // have already run — matching the Animation Map "events still fire"
+    // contract. We only skip the bell + animation for agents whose
+    // wait-for-input alerts toggle is off.
+    if (
+      event === "Notification"
+      && state === "notification"
+      && srcAgentId
+      && typeof ctx.isAgentNotificationHookEnabled === "function"
+      && !ctx.isAgentNotificationHookEnabled(srcAgentId)
+    ) {
+      const displayState = resolveDisplayState();
+      setState(displayState, getSvgOverride(displayState));
       return;
     }
     setState(state);

--- a/test/agent-gate.test.js
+++ b/test/agent-gate.test.js
@@ -342,8 +342,9 @@ describe("setAgentFlag command", () => {
   });
 
   it("accepts notificationHookEnabled as a pure data flip — no side effects", () => {
-    // The idle-alert gate runs at the server route layer (shouldDropNotificationHook),
-    // so toggling the flag has no monitor / session / bubble side effects.
+    // The idle-alert mute is a presentation-layer check inside state.js
+    // updateSession (gated right before setState("notification")), so
+    // toggling the flag has no monitor / session / bubble side effects.
     const { deps, calls } = makeDeps();
     const r = commandRegistry.setAgentFlag(
       { agentId: "claude-code", flag: "notificationHookEnabled", value: false },

--- a/test/state-notification-hook-gate.test.js
+++ b/test/state-notification-hook-gate.test.js
@@ -57,18 +57,24 @@ describe("updateSession: Notification hook gate", () => {
     mock.timers.reset();
   });
 
-  it("drops Notification events when the per-agent flag is off", () => {
+  it("mutes Notification bell + animation when the per-agent flag is off", () => {
+    // Presentation-layer mute: session bookkeeping still runs (so the agent
+    // stays visible in the Sessions menu, stale timers keep refreshing, and
+    // Kimi hold-release cleanup still fires) — only the notification visual
+    // and confirm sound are skipped. Mirrors the Animation Map "events still
+    // fire" contract.
     mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
     ctx = makeCtx({ notificationHookEnabled: false });
     api = require("../src/state")(ctx);
 
     api.updateSession("cc-1", "notification", "Notification", { agentId: "claude-code" });
 
-    // No session entry created, no state broadcast, no bell sound.
-    assert.strictEqual(api.sessions.has("cc-1"), false, "session must not be registered for a dropped event");
+    assert.strictEqual(api.sessions.has("cc-1"), true, "session must still be registered (bookkeeping runs)");
+    assert.strictEqual(api.sessions.get("cc-1").state, "idle", "session state resolves to idle after Notification");
     const stateChanges = ctx._rendererEvents.filter(([ch]) => ch === "state-change");
-    assert.strictEqual(stateChanges.length, 0, "no state-change broadcast");
-    assert.deepStrictEqual(ctx._soundsPlayed, [], "no sound triggered");
+    assert.ok(stateChanges.length >= 1, "pet must still get a state-change (to idle, not notification)");
+    assert.notStrictEqual(stateChanges[0][1], "notification", "must not enter notification state");
+    assert.deepStrictEqual(ctx._soundsPlayed, [], "confirm sound must not play");
   });
 
   it("lets Notification events through when the per-agent flag is on", () => {
@@ -157,11 +163,39 @@ describe("updateSession: Notification hook gate", () => {
     ctx._rendererEvents.length = 0;
     ctx._soundsPlayed.length = 0;
 
-    // Now send Notification without agentId — gate must still fire for CC.
+    // Now send Notification without agentId — gate must still mute for CC.
     api.updateSession("cc-1", "notification", "Notification", {});
 
     const stateChanges = ctx._rendererEvents.filter(([ch]) => ch === "state-change");
-    assert.strictEqual(stateChanges.length, 0, "gate must resolve agentId from session and drop");
-    assert.deepStrictEqual(ctx._soundsPlayed, []);
+    // Pet still gets a broadcast (fall-through to resolveDisplayState), but
+    // never enters notification state and never plays the bell.
+    assert.ok(stateChanges.every(([, s]) => s !== "notification"), "must not enter notification state");
+    assert.deepStrictEqual(ctx._soundsPlayed, [], "no bell when gate resolves agentId from session");
+  });
+
+  it("does not break Kimi hold-release when the flag is off", () => {
+    // Regression guard: Kimi's permission hold is cleared by a subsequent
+    // `Notification` event (KIMI_HOLD_CLEAR_EVENTS in state.js). An earlier
+    // version of this gate early-returned at the top of updateSession, which
+    // skipped the Kimi cleanup and left the pet pinned on notification until
+    // the 10-minute safety timeout. The presentation-layer gate must run
+    // *after* the Kimi cleanup block so hold-release keeps working.
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx({ notificationHookEnabled: false });
+    api = require("../src/state")(ctx);
+
+    // Open a Kimi permission hold — pet pins on notification.
+    api.updateSession("kimi-a", "notification", "PermissionRequest", { agentId: "kimi-cli" });
+    assert.strictEqual(api.resolveDisplayState(), "notification", "hold pins display");
+
+    // Kimi emits Notification with the toggle off. The bell must be muted
+    // *and* the hold must release so the pet returns to idle.
+    api.updateSession("kimi-a", "notification", "Notification", { agentId: "kimi-cli" });
+
+    assert.strictEqual(
+      api.resolveDisplayState(),
+      "idle",
+      "Kimi hold must release even when the Notification bell is muted"
+    );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #155. Post-merge review caught that the `state.js` gate early-returned at `updateSession` entry — before the Kimi hold-release cleanup block that treats `Notification` as a permission-poll stop signal. With Kimi's toggle off, approving a permission in the Kimi terminal would have left the pet pinned on notification until the 10-minute safety timeout.

This moves the mute inside the `ONESHOT_STATES` branch so all upstream work (`pushRecentEvent`, session state transition, Kimi cleanup) runs first. Only the `setState("notification")` + confirm-sound step is replaced with `setState(resolveDisplayState())` when the agent's wait-for-input alerts toggle is off. Matches the existing Animation Map "events still fire" contract documented in `settings-i18n.js`.

## Changes

- `src/state.js` — gate moved from `updateSession` entry to inside `ONESHOT_STATES` branch, post-bookkeeping
- `src/main.js` — remove dead `_serverCtx.isAgentNotificationHookEnabled` (never read by `server.js` — `state.js` is the only consumer)
- `src/settings-actions.js` — docstring now covers the third `AGENT_FLAGS` entry
- `test/state-notification-hook-gate.test.js` — flip the "drops" test to assert bookkeeping + no-bell instead of whole-event drop; add a Kimi hold-release regression test
- `test/agent-gate.test.js` — fix a stale "server route layer" comment

## Note to @Rladmsrl

Thanks for the thorough PR — the design analysis was great and the test scaffolding saved us a lot of time. Two things worth flagging for the record:

1. **Kimi hold-release coupling**: Kimi uses `Notification` as a secondary signal to release its permission-poll hold (see `KIMI_HOLD_CLEAR_EVENTS` in `state.js`). Dropping the event at `updateSession` entry skipped that cleanup. You don't use Kimi so this wouldn't have bitten you in practice, and your own `notificationHookEnabled` toggle should stay on for CC — that path was working correctly. No action needed from you.

2. **Parity rationale, minor**: in the current codebase only hook-backed emitters actually produce `Notification` (Gemini log-poll and opencode plugin do not). State-layer placement is still the right call — it's just forward-compat for when those paths grow `Notification` support, not a current-day behavioral fix.

## Test plan

- [x] `npm test` on this branch: 1007/1011 pass (2 fails are pre-existing calico SVG baseline, 2 skips unchanged from main)
- [x] 8/8 tests in `state-notification-hook-gate.test.js` pass, including the new Kimi hold-release regression guard
- [x] Manual on Windows: toggle off CC's Wait-for-input alerts → idle 60s → pet stays in current state, no bell
- [x] Manual on Windows: toggle on → idle 60s → pet plays notification animation + confirm sound
- [x] Manual on Windows: trigger permission bubble with toggle off → bell + animation fire regardless (PermissionRequest path unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
