### PR TITLE
fix(settings): grey out notificationHookEnabled sub-switch when master is off

### DIFF
--- a/src/settings-tab-agents.js
+++ b/src/settings-tab-agents.js
@@ -93,6 +93,7 @@
         agent,
         flag: "notificationHookEnabled",
         extraClass: "row-sub",
+        disabled: !masterOn,
         buildText: (text) => {
           const label = document.createElement("span");
           label.className = "row-label";


### PR DESCRIPTION
## Context

#156 landed the render-layer grey-out for agent sub-switches. It branched from `8ca7cc8`, before #155 introduced the `notificationHookEnabled` sub-switch in `src/settings-tab-agents.js:91-99` — so the new row never got wired up with `disabled: !masterOn`.

## What's wrong on current `main`

Open **Settings → Agents** with Claude Code on + "Wait-for-input alerts" on. Flip Claude Code's master switch off.

- **Show pop-up bubbles** — greys out ✓ (fixed by #156)
- **Wait-for-input alerts** — still renders "on", still clickable, still tab-reachable ✗

Exactly the UI lie #156 was written to kill, just on a sibling row the author couldn't see yet.

## Fix

One line: pass `disabled: !masterOn` to the `notificationHookEnabled` row builder so both sub-switches take the same render-layer grey-out path that `buildAgentSwitchRow` already handles.

```diff
     if (caps.notificationHook) {
       rows.push(buildAgentSwitchRow({
         agent,
         flag: "notificationHookEnabled",
         extraClass: "row-sub",
+        disabled: !masterOn,
         buildText: (text) => {
```

No data-layer change. No new code path — `buildAgentSwitchRow(disabled)` already does the class / aria / tabindex / skip-`attachAnimatedSwitch` wiring from #156, and `patchInPlace` already falls back to a full re-render on `meta.disabled !== !masterOn` for any sub-switch.

## Testing

- `npm test`: 1007/1011 — same 4 pre-existing Windows-only baseline failures (`hit-geometry.test.js` calico SVG layout checks). No new breaks.
- Manual on Windows with Claude Code (both sub-switches visible):
  - Master on → both sub-switches interactive ✓
  - Master on → off → both sub-switches grey out together ✓
  - Master off → on → both sub-switches restore to prior committed values ✓
  - Rapid master flipping → no stuck `.pending` on either sub-switch ✓

No unit tests added — same reasoning as #156 (no renderer-layer test harness for settings tabs; this is a pure-DOM concern).

## Why not ask #156's author to rebase

One-line gap, and #155 wasn't merged when they opened #156 — they couldn't have known. Handling it forward ourselves keeps their PR clean and avoids a re-review cycle over a single line.
