### PR TITLE
fix(permission): hideBubbles should drop HTTP connection, not just hide the UI

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -19,8 +19,15 @@ const {
 // travel through /permission, but they're UX flows — not approvals the
 // sub-gate is named for. Silencing them would break plan-mode and leave
 // CC hanging on an elicitation.
+//
+// hideBubbles is also honored here: dropping the HTTP connection lets
+// CC/codebuddy fall back to their terminal chat prompt. The previous
+// behavior merely skipped showPermissionBubble, leaving the request
+// parked in pendingPermissions — CC would then hang for 600s before
+// timing out with nothing in the terminal.
 function shouldBypassCCBubble(ctx, toolName, agentId) {
   if (toolName === "ExitPlanMode" || toolName === "AskUserQuestion") return false;
+  if (ctx.hideBubbles) return true;
   if (typeof ctx.isAgentPermissionsEnabled !== "function") return false;
   return !ctx.isAgentPermissionsEnabled(agentId);
 }
@@ -533,7 +540,8 @@ function startHttpServer() {
           }
 
           if (shouldBypassCCBubble(ctx, toolName, permAgentId)) {
-            ctx.permLog(`${permAgentId} bubbles disabled → destroy connection, chat fallback (tool=${toolName})`);
+            const reason = ctx.hideBubbles ? "hideBubbles" : `${permAgentId} bubbles disabled`;
+            ctx.permLog(`${reason} → destroy connection, chat fallback (tool=${toolName})`);
             res.destroy();
             return;
           }
@@ -553,7 +561,7 @@ function startHttpServer() {
             permEntry.abortHandler = abortHandler;
             res.on("close", abortHandler);
             ctx.pendingPermissions.push(permEntry);
-            if (!ctx.hideBubbles) ctx.showPermissionBubble(permEntry);
+            ctx.showPermissionBubble(permEntry);
             return;
           }
 
@@ -575,12 +583,8 @@ function startHttpServer() {
           // mutating session state — so working/thinking is preserved for resolve.
           ctx.updateSession(sessionId, "notification", "PermissionRequest", { agentId: permAgentId });
 
-          if (ctx.hideBubbles) {
-            ctx.permLog(`bubble hidden: tool=${toolName} session=${sessionId} — terminal only`);
-          } else {
-            ctx.permLog(`showing bubble: tool=${toolName} session=${sessionId} suggestions=${suggestions.length} stack=${ctx.pendingPermissions.length}`);
-            ctx.showPermissionBubble(permEntry);
-          }
+          ctx.permLog(`showing bubble: tool=${toolName} session=${sessionId} suggestions=${suggestions.length} stack=${ctx.pendingPermissions.length}`);
+          ctx.showPermissionBubble(permEntry);
         } catch (err) {
           ctx.permLog(`/permission handler error: ${err && err.message}`);
           // Response may already be sent (opencode branch 200-ACKs before

--- a/test/server-permission-subgate.test.js
+++ b/test/server-permission-subgate.test.js
@@ -5,9 +5,10 @@ const assert = require("node:assert");
 
 const { shouldBypassCCBubble, shouldBypassOpencodeBubble } = require("../src/server").__test;
 
-function makeCtx({ enabled = true } = {}) {
+function makeCtx({ enabled = true, hideBubbles = false } = {}) {
   return {
     isAgentPermissionsEnabled: () => enabled,
+    hideBubbles,
   };
 }
 
@@ -34,6 +35,22 @@ describe("shouldBypassCCBubble", () => {
 
   it("missing isAgentPermissionsEnabled → fail-open (don't suppress)", () => {
     assert.strictEqual(shouldBypassCCBubble({}, "Bash", "claude-code"), false);
+  });
+
+  it("bypasses when hideBubbles is on, even if the per-agent gate is on", () => {
+    const ctx = makeCtx({ enabled: true, hideBubbles: true });
+    assert.strictEqual(shouldBypassCCBubble(ctx, "Bash", "claude-code"), true);
+    assert.strictEqual(shouldBypassCCBubble(ctx, "Edit", "codebuddy"), true);
+  });
+
+  it("hideBubbles does NOT bypass ExitPlanMode or AskUserQuestion — those would hang CC", () => {
+    const ctx = makeCtx({ enabled: true, hideBubbles: true });
+    assert.strictEqual(shouldBypassCCBubble(ctx, "ExitPlanMode", "claude-code"), false);
+    assert.strictEqual(shouldBypassCCBubble(ctx, "AskUserQuestion", "claude-code"), false);
+  });
+
+  it("hideBubbles works without isAgentPermissionsEnabled helper present", () => {
+    assert.strictEqual(shouldBypassCCBubble({ hideBubbles: true }, "Bash", "claude-code"), true);
   });
 });
 


### PR DESCRIPTION
## Summary

- \`hideBubbles=true\` currently hides the permission bubble UI but leaves the HTTP \`/permission\` request parked in \`pendingPermissions\`, so Claude Code / CodeBuddy hang for 600s with no terminal prompt either.
- Teach \`shouldBypassCCBubble\` to honor \`hideBubbles\`, mirroring the DND and per-agent-disabled paths: destroy the connection so CC/codebuddy fall back to their built-in terminal prompt.
- \`ExitPlanMode\` and \`AskUserQuestion\` remain exempt from bypass (those genuinely need the bubble — destroying would hang CC).

## Why

A user toggled \"Hide Bubbles\" expecting to route permission requests to the terminal, and every subsequent permission request silently froze. Previous behavior of \`hideBubbles\` was effectively broken for CC/codebuddy — the only working way to hide bubbles was per-agent \`permissionsEnabled=false\`. This unifies the two paths.

Note: opencode and Codex notify bubbles already honor \`hideBubbles\` correctly via their own branches (opencode 200-ACKs and silent-drops at server.js:422; Codex notify suppresses at permission.js:57), so no change needed there.

## Test plan

- [x] \`node --test test/server-permission-subgate.test.js\` — added 3 new cases covering hideBubbles bypass + exception preservation (12/12 pass)
- [x] \`node --test test/codex-notify-subgate.test.js test/prefs.test.js test/settings-actions.test.js\` — no regressions (103/103 pass)
- [ ] Manual: toggle Settings → Notifications → \"Hide permission bubbles\" ON, run a Claude Code request that needs permission → verify terminal prompt appears (no hang, no bubble)
- [ ] Manual: with hideBubbles ON, invoke an \`AskUserQuestion\` elicitation → verify bubble still appears (exception preserved)
- [ ] Manual: with hideBubbles ON, request \`ExitPlanMode\` approval → verify Plan Review bubble still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)