### PR TITLE
Reduce idle CPU/GPU activity on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ scripts/*
 !scripts/remote-deploy.sh
 !scripts/run-clawdbot-stress.sh
 !scripts/monitor-clawd-resources.sh
+!scripts/monitor-clawd-power.ps1
 !scripts/validate-theme.js
 !scripts/create-theme.js
 

--- a/scripts/monitor-clawd-power.ps1
+++ b/scripts/monitor-clawd-power.ps1
@@ -183,7 +183,10 @@ function New-OutputRow {
       if ($null -ne $proc.CPU) {
         $cpuValue = [double]$proc.CPU
       }
-      $cpuDelta += $cpuValue - [double]$Previous.CpuByPid[$pidValue]
+      $processCpuDelta = $cpuValue - [double]$Previous.CpuByPid[$pidValue]
+      if ($processCpuDelta -gt 0) {
+        $cpuDelta += $processCpuDelta
+      }
     }
   }
 
@@ -211,7 +214,7 @@ function New-OutputRow {
       $pidValue = [int]$_.Id
       $pidCpuDelta = 0.0
       if ($Previous.CpuByPid.ContainsKey($pidValue)) {
-        $pidCpuDelta = $cpuValue - [double]$Previous.CpuByPid[$pidValue]
+        $pidCpuDelta = [math]::Max(0.0, $cpuValue - [double]$Previous.CpuByPid[$pidValue])
       }
       $pidCpuOneCore = 100.0 * $pidCpuDelta / $elapsed
       "pid=$($_.Id) deltaCpuSeconds=$([math]::Round($pidCpuDelta, 4)) cpuOneCorePercent=$([math]::Round($pidCpuOneCore, 2)) cpuSeconds=$([math]::Round($cpuValue, 2)) wsMB=$([math]::Round($_.WorkingSet64 / 1MB, 1)) privateMB=$([math]::Round($_.PrivateMemorySize64 / 1MB, 1)) name=$($_.ProcessName)"

--- a/scripts/monitor-clawd-power.ps1
+++ b/scripts/monitor-clawd-power.ps1
@@ -1,0 +1,290 @@
+param(
+  [int]$DurationSeconds = 600,
+  [double]$IntervalSeconds = 2,
+  [string]$Pattern = 'Clawd on Desk|clawd-on-desk|src[\\/]+main\.js',
+  [int[]]$RootPid,
+  [string]$OutputPath,
+  [switch]$Once,
+  [switch]$Quiet
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($IntervalSeconds -le 0) {
+  throw "IntervalSeconds must be greater than zero."
+}
+
+if ($DurationSeconds -le 0 -and -not $Once) {
+  throw "DurationSeconds must be greater than zero."
+}
+
+if (-not $OutputPath) {
+  $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+  $OutputPath = Join-Path "logs" "clawd-power-$timestamp.csv"
+}
+
+$outputDir = Split-Path -Parent $OutputPath
+if ($outputDir) {
+  New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+}
+
+function Get-AllProcessRows {
+  return @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)
+}
+
+function Get-CandidateProcessRows {
+  $rows = Get-AllProcessRows |
+    Where-Object {
+      $_.Name -eq "Clawd on Desk.exe" -or
+      (
+        ($_.Name -eq "electron.exe" -or $_.Name -eq "node.exe") -and
+        $_.CommandLine -and
+        $_.CommandLine -match $Pattern
+      )
+    }
+
+  return @($rows)
+}
+
+function Get-DescendantPids {
+  param([int[]]$RootPids)
+
+  if (-not $RootPids -or $RootPids.Count -eq 0) {
+    return @()
+  }
+
+  $rows = Get-AllProcessRows
+  $childrenByParent = @{}
+  foreach ($row in $rows) {
+    $parent = [int]$row.ParentProcessId
+    if (-not $childrenByParent.ContainsKey($parent)) {
+      $childrenByParent[$parent] = New-Object System.Collections.Generic.List[int]
+    }
+    $childrenByParent[$parent].Add([int]$row.ProcessId)
+  }
+
+  $seen = @{}
+  $queue = New-Object System.Collections.Generic.Queue[int]
+  foreach ($root in $RootPids) {
+    $queue.Enqueue([int]$root)
+  }
+
+  while ($queue.Count -gt 0) {
+    $current = $queue.Dequeue()
+    if ($seen.ContainsKey($current)) {
+      continue
+    }
+    $seen[$current] = $true
+    if ($childrenByParent.ContainsKey($current)) {
+      foreach ($child in $childrenByParent[$current]) {
+        $queue.Enqueue($child)
+      }
+    }
+  }
+
+  return @($seen.Keys | ForEach-Object { [int]$_ })
+}
+
+function Get-TargetPids {
+  if ($RootPid -and $RootPid.Count -gt 0) {
+    return @(Get-DescendantPids -RootPids $RootPid)
+  }
+
+  $rows = Get-CandidateProcessRows | Where-Object {
+    $_.Name -eq "Clawd on Desk.exe" -or
+    ($_.CommandLine -and $_.CommandLine -match $Pattern)
+  }
+
+  return @($rows | ForEach-Object { [int]$_.ProcessId } | Sort-Object -Unique)
+}
+
+function Get-BatterySnapshot {
+  $battery = Get-CimInstance Win32_Battery -ErrorAction SilentlyContinue | Select-Object -First 1
+  $status = Get-CimInstance -Namespace root\wmi -ClassName BatteryStatus -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+
+  $powerOnline = $null
+  $discharging = $null
+  $rate = $null
+  $remainingCapacity = $null
+  $estimatedPercent = $null
+
+  if ($status) {
+    if ($status.PSObject.Properties["PowerOnline"]) {
+      $powerOnline = [bool]$status.PowerOnline
+    }
+    if ($status.PSObject.Properties["Discharging"]) {
+      $discharging = [bool]$status.Discharging
+    }
+    if ($status.PSObject.Properties["RemainingCapacity"]) {
+      $remainingCapacity = $status.RemainingCapacity
+    }
+    if ($status.PSObject.Properties["Rate"]) {
+      $rate = $status.Rate
+    }
+  }
+
+  if ($battery) {
+    if ($battery.PSObject.Properties["EstimatedChargeRemaining"]) {
+      $estimatedPercent = $battery.EstimatedChargeRemaining
+    }
+  }
+
+  return [pscustomobject]@{
+    PowerOnline = $powerOnline
+    Discharging = $discharging
+    RateMilliwatts = $rate
+    RemainingCapacity = $remainingCapacity
+    EstimatedChargePercent = $estimatedPercent
+  }
+}
+
+function Get-SampleSnapshot {
+  $targetPids = @(Get-TargetPids)
+  $processes = @()
+  if ($targetPids.Count -gt 0) {
+    $processes = @(Get-Process -Id $targetPids -ErrorAction SilentlyContinue)
+  }
+
+  $cpuByPid = @{}
+  foreach ($proc in $processes) {
+    $cpuValue = 0.0
+    if ($null -ne $proc.CPU) {
+      $cpuValue = [double]$proc.CPU
+    }
+    $cpuByPid[[int]$proc.Id] = $cpuValue
+  }
+
+  return [pscustomobject]@{
+    At = Get-Date
+    Pids = $targetPids
+    Processes = $processes
+    CpuByPid = $cpuByPid
+  }
+}
+
+function New-OutputRow {
+  param(
+    [object]$Previous,
+    [object]$Current
+  )
+
+  $elapsed = ($Current.At - $Previous.At).TotalSeconds
+  if ($elapsed -le 0) {
+    $elapsed = $IntervalSeconds
+  }
+
+  $cpuDelta = 0.0
+  foreach ($proc in $Current.Processes) {
+    $pidValue = [int]$proc.Id
+    if ($Previous.CpuByPid.ContainsKey($pidValue)) {
+      $cpuValue = 0.0
+      if ($null -ne $proc.CPU) {
+        $cpuValue = [double]$proc.CPU
+      }
+      $cpuDelta += $cpuValue - [double]$Previous.CpuByPid[$pidValue]
+    }
+  }
+
+  $cpuOneCore = 100.0 * $cpuDelta / $elapsed
+  $cpuSystem = $cpuOneCore / [Environment]::ProcessorCount
+  $battery = Get-BatterySnapshot
+
+  $workingSetMeasure = $Current.Processes | Measure-Object WorkingSet64 -Sum
+  $privateMeasure = $Current.Processes | Measure-Object PrivateMemorySize64 -Sum
+  $workingSetBytes = 0
+  $privateBytes = 0
+  if ($workingSetMeasure -and $workingSetMeasure.PSObject.Properties["Sum"] -and $null -ne $workingSetMeasure.Sum) {
+    $workingSetBytes = $workingSetMeasure.Sum
+  }
+  if ($privateMeasure -and $privateMeasure.PSObject.Properties["Sum"] -and $null -ne $privateMeasure.Sum) {
+    $privateBytes = $privateMeasure.Sum
+  }
+  $details = ($Current.Processes |
+    Sort-Object Id |
+    ForEach-Object {
+      $cpuValue = 0.0
+      if ($null -ne $_.CPU) {
+        $cpuValue = [double]$_.CPU
+      }
+      $pidValue = [int]$_.Id
+      $pidCpuDelta = 0.0
+      if ($Previous.CpuByPid.ContainsKey($pidValue)) {
+        $pidCpuDelta = $cpuValue - [double]$Previous.CpuByPid[$pidValue]
+      }
+      $pidCpuOneCore = 100.0 * $pidCpuDelta / $elapsed
+      "pid=$($_.Id) deltaCpuSeconds=$([math]::Round($pidCpuDelta, 4)) cpuOneCorePercent=$([math]::Round($pidCpuOneCore, 2)) cpuSeconds=$([math]::Round($cpuValue, 2)) wsMB=$([math]::Round($_.WorkingSet64 / 1MB, 1)) privateMB=$([math]::Round($_.PrivateMemorySize64 / 1MB, 1)) name=$($_.ProcessName)"
+    }) -join " ; "
+
+  return [pscustomobject]@{
+    timestamp = $Current.At.ToString("yyyy-MM-dd HH:mm:ss")
+    epoch = [int64](($Current.At.ToUniversalTime() - [datetime]"1970-01-01T00:00:00Z").TotalSeconds)
+    elapsed_seconds = [math]::Round($elapsed, 3)
+    power_online = $battery.PowerOnline
+    discharging = $battery.Discharging
+    battery_rate_mw = $battery.RateMilliwatts
+    battery_remaining_capacity = $battery.RemainingCapacity
+    battery_estimated_percent = $battery.EstimatedChargePercent
+    pid_count = $Current.Processes.Count
+    pids = ($Current.Pids -join "|")
+    cpu_seconds_delta = [math]::Round($cpuDelta, 4)
+    cpu_percent_one_core = [math]::Round($cpuOneCore, 2)
+    cpu_percent_system = [math]::Round($cpuSystem, 2)
+    working_set_mb = [math]::Round($workingSetBytes / 1MB, 1)
+    private_mb = [math]::Round($privateBytes / 1MB, 1)
+    logical_processors = [Environment]::ProcessorCount
+    details = $details
+  }
+}
+
+if (-not $Quiet) {
+  Write-Host "Monitoring Clawd power/resource proxy metrics."
+  Write-Host "Output: $OutputPath"
+  Write-Host "Pattern: $Pattern"
+  if ($RootPid) {
+    Write-Host "Root PID(s): $($RootPid -join ', ')"
+  }
+}
+
+$started = Get-Date
+$previous = Get-SampleSnapshot
+$wroteHeader = $false
+
+while ($true) {
+  Start-Sleep -Milliseconds ([int]($IntervalSeconds * 1000))
+  $current = Get-SampleSnapshot
+  $row = New-OutputRow -Previous $previous -Current $current
+
+  if ($wroteHeader) {
+    $row | Export-Csv -Path $OutputPath -NoTypeInformation -Append
+  } else {
+    $row | Export-Csv -Path $OutputPath -NoTypeInformation
+    $wroteHeader = $true
+  }
+
+  if (-not $Quiet) {
+    Write-Host ("[{0}] pids={1} cpu={2}% system/{3}% one-core mem={4}MB powerOnline={5} rateMw={6}" -f
+      $row.timestamp,
+      $row.pid_count,
+      $row.cpu_percent_system,
+      $row.cpu_percent_one_core,
+      $row.working_set_mb,
+      $row.power_online,
+      $row.battery_rate_mw)
+  }
+
+  $previous = $current
+
+  if ($Once) {
+    break
+  }
+
+  if (((Get-Date) - $started).TotalSeconds -ge $DurationSeconds) {
+    break
+  }
+}
+
+if (-not $Quiet) {
+  Write-Host "Monitoring stopped. CSV saved at: $OutputPath"
+}

--- a/src/main.js
+++ b/src/main.js
@@ -714,6 +714,8 @@ let dragSnapshot = null;
 let menuOpen = false;
 let idlePaused = false;
 let forceEyeResend = false;
+let forceEyeResendBoostUntil = 0;
+let requestFastTick = () => {};
 let themeReloadInProgress = false;
 let repositionSessionHud = () => {};
 let syncSessionHudVisibility = () => {};
@@ -721,6 +723,14 @@ let broadcastSessionHudSnapshot = () => {};
 let sendSessionHudI18n = () => {};
 let getSessionHudReservedOffset = () => 0;
 let getSessionHudWindow = () => null;
+
+function setForceEyeResend(value) {
+  forceEyeResend = !!value;
+  if (forceEyeResend) {
+    forceEyeResendBoostUntil = Math.max(forceEyeResendBoostUntil, Date.now() + 2000);
+    requestFastTick(100);
+  }
+}
 
 // Keep drag math in Electron's main-process DIP coordinate space. Renderer
 // PointerEvent.screenX/Y can be scaled differently on high-DPI displays.
@@ -891,7 +901,7 @@ const _stateCtx = {
   get idlePaused() { return idlePaused; },
   set idlePaused(v) { idlePaused = v; },
   get forceEyeResend() { return forceEyeResend; },
-  set forceEyeResend(v) { forceEyeResend = v; },
+  set forceEyeResend(v) { setForceEyeResend(v); },
   get mouseStillSince() { return _tick ? _tick._mouseStillSince : Date.now(); },
   get pendingPermissions() { return pendingPermissions; },
   sendToRenderer,
@@ -1020,7 +1030,8 @@ const _tickCtx = {
   get mouseOverPet() { return mouseOverPet; },
   set mouseOverPet(v) { mouseOverPet = v; },
   get forceEyeResend() { return forceEyeResend; },
-  set forceEyeResend(v) { forceEyeResend = v; },
+  set forceEyeResend(v) { setForceEyeResend(v); },
+  get forceEyeResendBoostUntil() { return forceEyeResendBoostUntil; },
   get startupRecoveryActive() { return _state.getStartupRecoveryActive(); },
   sendToRenderer,
   sendToHitWin,
@@ -1032,6 +1043,7 @@ const _tickCtx = {
   getHitRectScreen,
 };
 const _tick = require("./tick")(_tickCtx);
+requestFastTick = (maxDelay) => _tick.scheduleSoon(maxDelay);
 const { startMainTick, resetIdleTimer } = _tick;
 
 // ── Terminal focus — delegated to src/focus.js ──
@@ -1145,7 +1157,7 @@ function scheduleHwndRecovery() {
     if (!win || win.isDestroyed()) return;
     // Just restore z-order — input routing is handled by hitWin now
     reassertWinTopmost();
-    forceEyeResend = true;
+    setForceEyeResend(true);
   }, 1000);
 }
 
@@ -1155,7 +1167,7 @@ function guardAlwaysOnTop(w) {
     if (!isOnTop && w && !w.isDestroyed()) {
       w.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
       if (w === win && !dragLocked && !_mini.getIsAnimating() && !_mini.getMiniTransitioning()) {
-        forceEyeResend = true;
+        setForceEyeResend(true);
         const bounds = getPetWindowBounds();
         applyPetWindowPosition(bounds.x + 1, bounds.y);
         applyPetWindowPosition(bounds.x, bounds.y);

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -592,6 +592,17 @@ function _calcLayerOffset(dx, dy, maxOffset) {
   return [(dx / dist) * clamp, (dy / dist) * clamp];
 }
 
+function _getLayerTarget(layer, rawDx, rawDy) {
+  const scale = layer.maxOffset / (_themeMaxOffset || 20);
+  return [rawDx * scale, rawDy * scale];
+}
+
+function _layerNeedsAnimation(layer, rawDx, rawDy) {
+  const [tx, ty] = _getLayerTarget(layer, rawDx, rawDy);
+  return Math.abs(layer.x - tx) >= LAYER_SETTLE_EPSILON
+    || Math.abs(layer.y - ty) >= LAYER_SETTLE_EPSILON;
+}
+
 /**
  * Initialize layered tracking for a loaded SVG document.
  * Creates <g> wrappers for each element listed in trackingLayers config.
@@ -633,8 +644,11 @@ function _initLayeredTracking(svgDoc) {
     };
   }
 
-  // The loop starts on the next eye-move event. Starting immediately at (0,0)
-  // keeps Chromium repainting an already-settled SVG.
+  _layerTargetDx = lastEyeDx;
+  _layerTargetDy = lastEyeDy;
+  if (Object.values(_trackingLayers).some(layer => _layerNeedsAnimation(layer, _layerTargetDx, _layerTargetDy))) {
+    _startLayerAnimLoop();
+  }
 }
 
 /**
@@ -653,9 +667,7 @@ function _startLayerAnimLoop() {
     for (const layer of Object.values(_trackingLayers)) {
       // Scale the pre-calculated offset (from tick.js, already in [-maxOffset, maxOffset])
       // to this layer's range. No second normalization — tick.js already did it.
-      const scale = layer.maxOffset / (_themeMaxOffset || 20);
-      const tx = rawDx * scale;
-      const ty = rawDy * scale;
+      const [tx, ty] = _getLayerTarget(layer, rawDx, rawDy);
 
       // Lerp towards target
       layer.x += (tx - layer.x) * layer.ease;

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -160,6 +160,7 @@ let _layerTargetDx = 0;           // raw dx from tick.js (scaled to _themeMaxOff
 let _layerTargetDy = 0;           // raw dy from tick.js
 let _layerAnimFrame = null;        // requestAnimationFrame handle
 let _layeredTrackingObj = null;    // the <object> element currently tracked (guard against re-init)
+const LAYER_SETTLE_EPSILON = 0.02;
 
 initWithConfig(tc);
 
@@ -632,8 +633,8 @@ function _initLayeredTracking(svgDoc) {
     };
   }
 
-  // Start the easing animation loop
-  _startLayerAnimLoop();
+  // The loop starts on the next eye-move event. Starting immediately at (0,0)
+  // keeps Chromium repainting an already-settled SVG.
 }
 
 /**
@@ -647,6 +648,7 @@ function _startLayerAnimLoop() {
 
     const rawDx = _layerTargetDx;
     const rawDy = _layerTargetDy;
+    let allSettled = true;
 
     for (const layer of Object.values(_trackingLayers)) {
       // Scale the pre-calculated offset (from tick.js, already in [-maxOffset, maxOffset])
@@ -659,11 +661,16 @@ function _startLayerAnimLoop() {
       layer.x += (tx - layer.x) * layer.ease;
       layer.y += (ty - layer.y) * layer.ease;
 
+      if (Math.abs(layer.x - tx) < LAYER_SETTLE_EPSILON) layer.x = tx;
+      if (Math.abs(layer.y - ty) < LAYER_SETTLE_EPSILON) layer.y = ty;
+
       // Snap to zero when very close (avoid sub-pixel jitter)
       if (Math.abs(layer.x) < 0.01 && Math.abs(layer.y) < 0.01 && tx === 0 && ty === 0) {
         layer.x = 0;
         layer.y = 0;
       }
+
+      if (layer.x !== tx || layer.y !== ty) allSettled = false;
 
       // Quantize to quarter-pixel grid for smooth rendering
       const qx = Math.round(layer.x * 4) / 4;
@@ -673,6 +680,11 @@ function _startLayerAnimLoop() {
       for (const w of layer.wrappers) {
         w.setAttribute("transform", `translate(${qx},${qy})`);
       }
+    }
+
+    if (allSettled) {
+      _layerAnimFrame = null;
+      return;
     }
 
     _layerAnimFrame = requestAnimationFrame(tick);
@@ -775,6 +787,7 @@ window.electronAPI.onEyeMove((dx, dy) => {
     // Layered tracking: store targets, RAF loop handles easing
     _layerTargetDx = effectiveDx;
     _layerTargetDy = dy;
+    _startLayerAnimLoop();
     return;
   }
 

--- a/src/tick.js
+++ b/src/tick.js
@@ -97,7 +97,7 @@ function runMainTick() {
   mainTickTimer = null;
   nextMainTickAt = 0;
   const delay = runMainTickOnce();
-  if (mainTickActive) scheduleNextTick(delay);
+  if (mainTickActive && !mainTickTimer) scheduleNextTick(delay);
 }
 
 function runMainTickOnce() {

--- a/src/tick.js
+++ b/src/tick.js
@@ -16,6 +16,15 @@ let yawnDelayTimer = null;     // tracked setTimeout for yawn/idle-look transiti
 let idleWasActive = false;
 let lastEyeDx = 0, lastEyeDy = 0;
 let mainTickTimer = null;
+let mainTickActive = false;
+let nextMainTickAt = 0;
+
+const FAST_TICK_MS = 50;
+const BOOST_TICK_MS = 100;
+const IDLE_TICK_MS = 250;
+const REACTION_TICK_MS = 500;
+const BACKGROUND_TICK_MS = 750;
+const RECENT_MOUSE_MS = 2000;
 
 // ── Theme-driven state (refreshed on hot theme switch) ──
 let theme = null;
@@ -39,17 +48,65 @@ refreshTheme();
 // ── Unified main tick (cursor polling for eye tracking + sleep + mini peek) ──
 // Input routing is handled by hitWin — no setIgnoreMouseEvents toggling here.
 function startMainTick() {
-  if (mainTickTimer) return;
+  if (mainTickActive) return;
   // Render window: permanently click-through (set once, never toggle)
   ctx.win.setIgnoreMouseEvents(true);
   ctx.mouseOverPet = false;
 
-  mainTickTimer = setInterval(() => {
-    if (!ctx.win || ctx.win.isDestroyed()) return;
+  mainTickActive = true;
+  scheduleNextTick(0);
+}
+
+function getBaseTickDelay(idleNow, miniIdleNow) {
+  if (ctx.miniMode || miniIdleNow || ctx.dragLocked) return FAST_TICK_MS;
+  if (idleNow) {
+    if (Date.now() - mouseStillSince <= RECENT_MOUSE_MS) return BOOST_TICK_MS;
+    return IDLE_TICK_MS;
+  }
+  if (ctx.idlePaused) return REACTION_TICK_MS;
+  return BACKGROUND_TICK_MS;
+}
+
+function applyBoost(delay) {
+  const boostUntil = Number(ctx.forceEyeResendBoostUntil) || 0;
+  if (boostUntil > Date.now()) return Math.min(delay, BOOST_TICK_MS);
+  return delay;
+}
+
+function getNextTickDelay(idleNow, miniIdleNow) {
+  return applyBoost(getBaseTickDelay(idleNow, miniIdleNow));
+}
+
+function scheduleNextTick(delay) {
+  if (!mainTickActive) return;
+  if (mainTickTimer) clearTimeout(mainTickTimer);
+  const safeDelay = Math.max(0, Number.isFinite(delay) ? delay : BACKGROUND_TICK_MS);
+  nextMainTickAt = Date.now() + safeDelay;
+  mainTickTimer = setTimeout(runMainTick, safeDelay);
+}
+
+function scheduleSoon(maxDelay = BOOST_TICK_MS) {
+  if (!mainTickActive) return;
+  const safeDelay = Math.max(0, Number.isFinite(maxDelay) ? maxDelay : BOOST_TICK_MS);
+  if (!mainTickTimer || nextMainTickAt - Date.now() > safeDelay) {
+    scheduleNextTick(safeDelay);
+  }
+}
+
+function runMainTick() {
+  mainTickTimer = null;
+  nextMainTickAt = 0;
+  const delay = runMainTickOnce();
+  if (mainTickActive) scheduleNextTick(delay);
+}
+
+function runMainTickOnce() {
+    if (!ctx.win || ctx.win.isDestroyed()) return BACKGROUND_TICK_MS;
 
     // ── Idle state edge detection (must run every tick for timer cleanup) ──
     const idleNow = ctx.currentState === "idle" && !ctx.idlePaused;
     const miniIdleNow = ctx.currentState === "mini-idle" && !ctx.idlePaused && !ctx.miniTransitioning;
+    const nextDelay = () => getNextTickDelay(idleNow, miniIdleNow);
 
     if (idleNow && !idleWasActive) {
       isMouseIdle = false;
@@ -73,15 +130,22 @@ function startMainTick() {
     // Skip expensive native IPC calls (getCursorScreenPoint, getBounds) when
     // cursor tracking is not needed — saves ~20 calls/sec to the OS layer.
     const needsCursorPoll = idleNow || miniIdleNow || ctx.miniMode;
-    if (!needsCursorPoll) return;
+    if (!needsCursorPoll) return nextDelay();
 
     const cursor = screen.getCursorScreenPoint();
+    const moved = lastCursorX !== null && (cursor.x !== lastCursorX || cursor.y !== lastCursorY);
+    lastCursorX = cursor.x;
+    lastCursorY = cursor.y;
 
     // ── Cursor-over-pet tracking (for mini peek + eye tracking, NOT for input routing) ──
-    const bounds = typeof ctx.getPetWindowBounds === "function"
-      ? ctx.getPetWindowBounds()
-      : ctx.win.getBounds();
-    if (!ctx.dragLocked) {
+    const needsBounds = ctx.miniMode || moved || ctx.forceEyeResend || miniIdleNow;
+    let bounds = null;
+    if (needsBounds) {
+      bounds = typeof ctx.getPetWindowBounds === "function"
+        ? ctx.getPetWindowBounds()
+        : ctx.win.getBounds();
+    }
+    if (bounds && !ctx.dragLocked) {
       const hit = ctx.getHitRectScreen(bounds);
       const over = cursor.x >= hit.left && cursor.x <= hit.right
                 && cursor.y >= hit.top  && cursor.y <= hit.bottom;
@@ -110,13 +174,9 @@ function startMainTick() {
       }
     }
 
-    if (!idleNow && !miniIdleNow) return;
+    if (!idleNow && !miniIdleNow) return nextDelay();
 
     // ── Below: idle or mini-idle logic ──
-    const moved = lastCursorX !== null && (cursor.x !== lastCursorX || cursor.y !== lastCursorY);
-    lastCursorX = cursor.x;
-    lastCursorY = cursor.y;
-
     // Normal idle: mouse idle detection + sleep sequence
     if (idleNow) {
       if (moved) {
@@ -151,7 +211,7 @@ function startMainTick() {
             if (ctx.currentState === "idle") ctx.setState("yawning");
           }, isMouseIdle ? 50 : 250);
         }
-        return;
+        return nextDelay();
       }
 
       // 20s no mouse movement → random idle animation (play once, then return to idle-follow)
@@ -175,21 +235,27 @@ function startMainTick() {
             setTimeout(() => { ctx.forceEyeResend = true; }, 200);
           }
         }, 250 + pick.duration);
-        return;
+        return nextDelay();
       }
     }
 
     const trackEyesNow = (idleNow && ctx.currentSvg === SVG_IDLE_FOLLOW && !isMouseIdle) || miniIdleNow;
-    if (!trackEyesNow) return;
+    if (!trackEyesNow) return nextDelay();
     if (ctx.eyePauseUntil) {
-      if (Date.now() < ctx.eyePauseUntil) return;
+      if (Date.now() < ctx.eyePauseUntil) return nextDelay();
       ctx.eyePauseUntil = null;
     }
-    if (!moved && !ctx.forceEyeResend) return;
+    if (!moved && !ctx.forceEyeResend) return nextDelay();
 
     // ── Eye position calculation (shared by idle and mini-idle) ──
     const skipDedup = ctx.forceEyeResend;
     ctx.forceEyeResend = false;
+
+    if (!bounds) {
+      bounds = typeof ctx.getPetWindowBounds === "function"
+        ? ctx.getPetWindowBounds()
+        : ctx.win.getBounds();
+    }
 
     const obj = ctx.getObjRect(bounds);
     const eyeScreenX = obj.x + obj.w * theme.eyeTracking.eyeRatioX;
@@ -217,7 +283,8 @@ function startMainTick() {
       lastEyeDy = eyeDy;
       ctx.sendToRenderer("eye-move", eyeDx, eyeDy);
     }
-  }, 50); // ~20fps — hit-test needs faster response than 67ms eye tracking
+
+    return nextDelay();
 }
 
 function resetIdleTimer() {
@@ -225,7 +292,9 @@ function resetIdleTimer() {
 }
 
 function cleanup() {
-  if (mainTickTimer) { clearInterval(mainTickTimer); mainTickTimer = null; }
+  mainTickActive = false;
+  if (mainTickTimer) { clearTimeout(mainTickTimer); mainTickTimer = null; }
+  nextMainTickAt = 0;
   if (idleLookReturnTimer) { clearTimeout(idleLookReturnTimer); idleLookReturnTimer = null; }
   if (yawnDelayTimer) { clearTimeout(yawnDelayTimer); yawnDelayTimer = null; }
   lastCursorX = null;
@@ -243,6 +312,6 @@ Object.defineProperty(startMainTick, '_mouseStillSince', {
   get() { return mouseStillSince; },
 });
 
-return { startMainTick, resetIdleTimer, cleanup, refreshTheme, get _mouseStillSince() { return mouseStillSince; } };
+return { startMainTick, resetIdleTimer, cleanup, refreshTheme, scheduleSoon, get _mouseStillSince() { return mouseStillSince; } };
 
 };

--- a/test/tick.test.js
+++ b/test/tick.test.js
@@ -299,4 +299,37 @@ describe("tick adaptive polling", () => {
     assert.equal(eyeMoves.length, 1);
     assert.equal(ctx.forceEyeResend, false);
   });
+
+  it("preserves ticks scheduled while the current tick is running", () => {
+    const theme = cloneTheme(_defaultTheme);
+    theme.timings.mouseIdleTimeout = 60000;
+    theme.timings.mouseSleepTimeout = 120000;
+    theme.idleAnimations = [];
+    let eyeMoveCount = 0;
+
+    ctx = makeCtx(theme, statesSeen);
+    ctx.sendToRenderer = (channel) => {
+      if (channel === "eye-move") {
+        eyeMoveCount++;
+        tickApi.scheduleSoon(100);
+      }
+    };
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+
+    mock.timers.tick(2200);
+    ctx.forceEyeResend = true;
+
+    for (let elapsed = 0; eyeMoveCount === 0 && elapsed < 1000; elapsed++) {
+      mock.timers.tick(1);
+    }
+    assert.equal(eyeMoveCount, 1);
+    const callsAfterEyeMove = cursorCalls;
+
+    mock.timers.tick(99);
+    assert.equal(cursorCalls, callsAfterEyeMove);
+
+    mock.timers.tick(1);
+    assert.equal(cursorCalls, callsAfterEyeMove + 1);
+  });
 });

--- a/test/tick.test.js
+++ b/test/tick.test.js
@@ -62,6 +62,7 @@ function makeCtx(theme, statesSeen) {
     mouseOverPet: false,
     miniPeeked: false,
     forceEyeResend: false,
+    forceEyeResendBoostUntil: 0,
     startupRecoveryActive: false,
     sendToRenderer() {},
     sendToHitWin() {},
@@ -188,5 +189,114 @@ describe("tick mini hover", () => {
     assert.equal(peekOutCalls, 1);
     assert.equal(ctx.miniPeeked, false);
     assert.deepStrictEqual(statesSeen, ["mini-idle"]);
+  });
+});
+
+describe("tick adaptive polling", () => {
+  let cursor;
+  let cursorCalls;
+  let loader;
+  let tickApi;
+  let ctx;
+  let statesSeen;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    cursor = { x: 40, y: 40 };
+    cursorCalls = 0;
+    loader = loadTickWithScreen(() => {
+      cursorCalls++;
+      return { ...cursor };
+    });
+    statesSeen = [];
+  });
+
+  afterEach(() => {
+    if (tickApi) tickApi.cleanup();
+    if (loader) loader.restore();
+    mock.timers.reset();
+    tickApi = null;
+    ctx = null;
+  });
+
+  it("backs off idle cursor polling below the old fixed 20Hz rate", () => {
+    const theme = cloneTheme(_defaultTheme);
+
+    ctx = makeCtx(theme, statesSeen);
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+
+    mock.timers.tick(3000);
+
+    assert.ok(cursorCalls > 0);
+    assert.ok(cursorCalls < 45, `expected fewer than 45 polls, got ${cursorCalls}`);
+  });
+
+  it("cleanup clears the pending adaptive tick", () => {
+    const theme = cloneTheme(_defaultTheme);
+
+    ctx = makeCtx(theme, statesSeen);
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+    tickApi.cleanup();
+
+    mock.timers.tick(1000);
+
+    assert.equal(cursorCalls, 0);
+  });
+
+  it("still enters direct sleep near mouseSleepTimeout under adaptive scheduling", () => {
+    const theme = cloneTheme(_defaultTheme);
+    theme.sleepSequence = { mode: "direct" };
+    theme.timings.mouseIdleTimeout = 5000;
+    theme.timings.mouseSleepTimeout = 500;
+
+    ctx = makeCtx(theme, statesSeen);
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+
+    for (const step of [100, 100, 100, 100, 100, 100, 100]) mock.timers.tick(step);
+    assert.deepStrictEqual(statesSeen, ["sleeping"]);
+  });
+
+  it("uses the ctx setter path to pull a pending tick forward for force eye resend boost", () => {
+    const theme = cloneTheme(_defaultTheme);
+    const eyeMoves = [];
+    let forceEyeResend = false;
+    let forceEyeResendBoostUntil = 0;
+
+    ctx = makeCtx(theme, statesSeen);
+    Object.defineProperty(ctx, "forceEyeResend", {
+      get() { return forceEyeResend; },
+      set(value) {
+        forceEyeResend = !!value;
+        if (forceEyeResend) {
+          forceEyeResendBoostUntil = Math.max(forceEyeResendBoostUntil, Date.now() + 2000);
+          if (tickApi) tickApi.scheduleSoon(100);
+        }
+      },
+      configurable: true,
+    });
+    Object.defineProperty(ctx, "forceEyeResendBoostUntil", {
+      get() { return forceEyeResendBoostUntil; },
+      configurable: true,
+    });
+    ctx.sendToRenderer = (channel, ...args) => {
+      if (channel === "eye-move") eyeMoves.push(args);
+    };
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+
+    mock.timers.tick(2200);
+    eyeMoves.length = 0;
+
+    ctx.forceEyeResend = true;
+
+    mock.timers.tick(99);
+    assert.equal(eyeMoves.length, 0);
+
+    mock.timers.tick(1);
+    assert.equal(eyeMoves.length, 1);
+    assert.equal(ctx.forceEyeResend, false);
   });
 });


### PR DESCRIPTION
## Summary

- throttle normal idle cursor/native polling while keeping mini/drag-sensitive paths fast
- stop layered renderer tracking RAF once transforms settle, and restart it only on new eye movement
- add a unified `forceEyeResend` boost path so all resend writers pull the adaptive tick forward
- add tick coverage for idle backoff, cleanup, sleep timing, and force-eye-resend boost behavior
- add a Windows PowerShell sampler for repeatable Clawd CPU/battery proxy measurements

## Context

Refs #166.

The battery A/B run did not prove Clawd alone caused the full battery drop, but it did show sustained Clawd process activity while idle: about 59% one-core average and 85.58% one-core peak over a 12-minute Windows battery sample.

## Validation

- `node --check src\tick.js`
- `node --check src\main.js`
- `node --check src\renderer.js`
- PowerShell parser check for `scripts\monitor-clawd-power.ps1`
- `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\monitor-clawd-power.ps1 -Once -IntervalSeconds 1 -OutputPath .tmp_clawd_power_verify.csv`
- `node --test test/tick.test.js`
- `node --test test/mini.test.js test/theme-loader.test.js test/animation-cycle.test.js`
- `npm test` mostly passed: 1061 pass, 1 fail, 2 skipped. The remaining failure is `test/shared-process.test.js` (`walks from startPid and populates pidChain`), reproduced when run alone and unrelated to these files.
