### PR TITLE
Security: Electron sandbox explicitly disabled on Linux

### DIFF
--- a/launch.js
+++ b/launch.js
@@ -14,14 +14,13 @@ const electron = require("electron");
 
 const env = { ...process.env };
 delete env.ELECTRON_RUN_AS_NODE;
-if (process.platform === "linux") {
-  // Some Linux environments still trip Chromium sandbox initialization even
-  // with argv flags; force-disable via env too for reliability.
+const disableSandbox = process.platform === "linux" && process.env.CLAWD_DISABLE_SANDBOX === "1";
+if (disableSandbox) {
   env.ELECTRON_DISABLE_SANDBOX = "1";
   env.CHROME_DEVEL_SANDBOX = "";
 }
 
-const args = process.platform === "linux"
+const args = disableSandbox
   ? [".", "--no-sandbox", "--disable-setuid-sandbox"]
   : ["."];
 const child = spawn(electron, args, {


### PR DESCRIPTION
## Summary

Security: Electron sandbox explicitly disabled on Linux

## Problem

**Severity**: `High` | **File**: `launch.js:L15`

The launcher unconditionally sets `ELECTRON_DISABLE_SANDBOX=1` and starts Electron with `--no-sandbox --disable-setuid-sandbox` on Linux. This removes Chromium/Electron sandbox protections, so any renderer compromise has significantly higher impact (greater access to host resources/process).

## Solution

Avoid disabling the sandbox globally. Prefer running with sandbox enabled and fixing environment-specific issues via targeted packaging/runtime fixes. If a fallback is required, gate it behind an explicit opt-in flag (e.g., env var for troubleshooting) and default to sandbox ON in production.

## Changes

- `launch.js` (modified)