### PR TITLE
fix: prevent rectangular shadow clipping on session HUD

### DIFF
--- a/src/session-hud.html
+++ b/src/session-hud.html
@@ -31,7 +31,7 @@
 }
 
 html, body {
-  width: 240px;
+  width: 100%;
   margin: 0;
   background: transparent;
   color: var(--text);
@@ -42,9 +42,11 @@ html, body {
 }
 
 html, body { height: 100%; overflow: hidden; }
+body { padding: 6px; }
 
 .hud {
-  width: 240px;
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   border: 1px solid var(--hud-border);

--- a/src/session-hud.js
+++ b/src/session-hud.js
@@ -12,6 +12,7 @@ const HUD_WIDTH = 240;
 const HUD_ROW_HEIGHT = 28;
 const HUD_MAX_EXPANDED_ROWS = 3;
 const HUD_HEIGHT = HUD_ROW_HEIGHT + HUD_BORDER_Y;
+const HUD_WINDOW_PADDING = 6;
 const HUD_PET_GAP = 4;
 const BUBBLE_GAP = 6;
 const EDGE_MARGIN = 8;
@@ -50,21 +51,35 @@ function computeHudHeight(rowCount) {
   return rowCount * HUD_ROW_HEIGHT + HUD_BORDER_Y;
 }
 
+function computeHudReservedOffset(cardHeight) {
+  const h = Number.isFinite(cardHeight) && cardHeight > 0 ? cardHeight : HUD_ROW_HEIGHT;
+  return HUD_PET_GAP + h + HUD_WINDOW_PADDING + BUBBLE_GAP;
+}
+
 function computeSessionHudBounds({ hitRect, workArea, width = HUD_WIDTH, height = HUD_HEIGHT }) {
   if (!hitRect || !workArea) return null;
   const hitTop = Math.round(hitRect.top);
   const hitBottom = Math.round(hitRect.bottom);
   const hitCx = Math.round((hitRect.left + hitRect.right) / 2);
 
+  const outerWidth = width + HUD_WINDOW_PADDING * 2;
+  const outerHeight = height + HUD_WINDOW_PADDING * 2;
   const minX = Math.round(workArea.x);
   const maxX = Math.round(workArea.x + workArea.width - width);
-  const x = clampToWorkArea(hitCx - Math.round(width / 2), minX, maxX);
+  const cardX = clampToWorkArea(hitCx - Math.round(width / 2), minX, maxX);
 
   const belowY = hitBottom + HUD_PET_GAP;
   const belowMax = workArea.y + workArea.height - EDGE_MARGIN;
   if (belowY + height <= belowMax) {
+    const contentBounds = { x: cardX, y: belowY, width, height };
     return {
-      bounds: { x, y: belowY, width, height },
+      bounds: {
+        x: contentBounds.x - HUD_WINDOW_PADDING,
+        y: contentBounds.y - HUD_WINDOW_PADDING,
+        width: outerWidth,
+        height: outerHeight,
+      },
+      contentBounds,
       flippedAbove: false,
     };
   }
@@ -72,13 +87,20 @@ function computeSessionHudBounds({ hitRect, workArea, width = HUD_WIDTH, height 
   const minY = Math.round(workArea.y + EDGE_MARGIN);
   const maxY = Math.round(workArea.y + workArea.height - EDGE_MARGIN - height);
   const aboveY = hitTop - height - HUD_PET_GAP;
+  const contentBounds = {
+    x: cardX,
+    y: clampToWorkArea(aboveY, minY, maxY),
+    width,
+    height,
+  };
   return {
     bounds: {
-      x,
-      y: clampToWorkArea(aboveY, minY, maxY),
-      width,
-      height,
+      x: contentBounds.x - HUD_WINDOW_PADDING,
+      y: contentBounds.y - HUD_WINDOW_PADDING,
+      width: outerWidth,
+      height: outerHeight,
     },
+    contentBounds,
     flippedAbove: true,
   };
 }
@@ -102,7 +124,7 @@ module.exports = function initSessionHud(ctx) {
   let latestSnapshot = null;
   let hudFlippedAbove = false;
   let lastReservedOffset = 0;
-  let lastHudHeight = HUD_ROW_HEIGHT;
+  let lastHudCardHeight = HUD_ROW_HEIGHT;
 
   function getCurrentSnapshot() {
     return typeof ctx.getSessionSnapshot === "function"
@@ -145,8 +167,8 @@ module.exports = function initSessionHud(ctx) {
     hudFlippedAbove = false;
     hudWindow = new BrowserWindow({
       parent: ctx.win,
-      width: HUD_WIDTH,
-      height: HUD_HEIGHT,
+      width: HUD_WIDTH + HUD_WINDOW_PADDING * 2,
+      height: HUD_HEIGHT + HUD_WINDOW_PADDING * 2,
       show: false,
       frame: false,
       transparent: true,
@@ -208,7 +230,7 @@ module.exports = function initSessionHud(ctx) {
       : { x: 0, y: 0, width: 1280, height: 800 };
     const layout = computeHudLayout(snapshot);
     const height = computeHudHeight(layout.rowCount);
-    lastHudHeight = height;
+    lastHudCardHeight = height;
     return computeSessionHudBounds({ hitRect, workArea, height });
   }
 
@@ -259,8 +281,7 @@ module.exports = function initSessionHud(ctx) {
   function readHudReservedOffset() {
     if (!hudWindow || hudWindow.isDestroyed() || !hudWindow.isVisible()) return 0;
     if (hudFlippedAbove) return 0;
-    const h = Number.isFinite(lastHudHeight) && lastHudHeight > 0 ? lastHudHeight : HUD_ROW_HEIGHT;
-    return HUD_PET_GAP + h + BUBBLE_GAP;
+    return computeHudReservedOffset(lastHudCardHeight);
   }
 
   function notifyReservedOffsetIfChanged() {
@@ -275,7 +296,7 @@ module.exports = function initSessionHud(ctx) {
     hudWindow = null;
     didFinishLoad = false;
     hudFlippedAbove = false;
-    lastHudHeight = HUD_ROW_HEIGHT;
+    lastHudCardHeight = HUD_ROW_HEIGHT;
     notifyReservedOffsetIfChanged();
   }
 
@@ -295,12 +316,14 @@ module.exports.__test = {
   computeSessionHudBounds,
   computeHudLayout,
   computeHudHeight,
+  computeHudReservedOffset,
   isHudSession,
   constants: {
     HUD_WIDTH,
     HUD_HEIGHT,
     HUD_ROW_HEIGHT,
     HUD_MAX_EXPANDED_ROWS,
+    HUD_WINDOW_PADDING,
     HUD_PET_GAP,
     BUBBLE_GAP,
     EDGE_MARGIN,

--- a/test/session-hud-style.test.js
+++ b/test/session-hud-style.test.js
@@ -1,0 +1,20 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sessionHudHtml = fs.readFileSync(path.join(__dirname, "..", "src", "session-hud.html"), "utf8");
+
+describe("session HUD visual shell", () => {
+  it("adds transparent body padding so rounded corners and shadows are not clipped", () => {
+    assert.match(sessionHudHtml, /body\s*\{[\s\S]*padding:\s*6px;[\s\S]*\}/);
+    assert.match(sessionHudHtml, /\.hud\s*\{[\s\S]*width:\s*100%;[\s\S]*height:\s*100%;[\s\S]*\}/);
+    assert.doesNotMatch(sessionHudHtml, /\.hud\s*\{[\s\S]*width:\s*240px;[\s\S]*\}/);
+  });
+
+  it("preserves the existing rounded card and shadow treatment", () => {
+    assert.match(sessionHudHtml, /\.hud\s*\{[\s\S]*border-radius:\s*8px;[\s\S]*\}/);
+    assert.match(sessionHudHtml, /\.hud\s*\{[\s\S]*box-shadow:\s*0 4px 14px var\(--shadow\);[\s\S]*\}/);
+    assert.match(sessionHudHtml, /\.hud\s*\{[\s\S]*background:\s*var\(--hud-bg\);[\s\S]*\}/);
+  });
+});

--- a/test/session-hud.test.js
+++ b/test/session-hud.test.js
@@ -20,36 +20,54 @@ function mkSession(id, overrides = {}) {
 }
 
 describe("session HUD geometry", () => {
-  it("positions below the pet hitbox and clamps horizontally", () => {
+  it("positions the visible HUD card below the pet hitbox with a fixed gap", () => {
     const result = computeSessionHudBounds({
       hitRect: { left: 10, top: 80, right: 90, bottom: 160 },
       workArea: { x: 0, y: 0, width: 800, height: 600 },
     });
 
-    assert.deepStrictEqual(result, {
-      bounds: {
-        x: 0,
-        y: 160 + constants.HUD_PET_GAP,
-        width: constants.HUD_WIDTH,
-        height: constants.HUD_HEIGHT,
-      },
-      flippedAbove: false,
+    assert.deepStrictEqual(result.contentBounds, {
+      x: 0,
+      y: 160 + constants.HUD_PET_GAP,
+      width: constants.HUD_WIDTH,
+      height: constants.HUD_HEIGHT,
     });
+    assert.deepStrictEqual(result.bounds, {
+      x: -constants.HUD_WINDOW_PADDING,
+      y: 160 + constants.HUD_PET_GAP - constants.HUD_WINDOW_PADDING,
+      width: constants.HUD_WIDTH + constants.HUD_WINDOW_PADDING * 2,
+      height: constants.HUD_HEIGHT + constants.HUD_WINDOW_PADDING * 2,
+    });
+    assert.strictEqual(result.flippedAbove, false);
   });
 
-  it("flips above the hitbox when there is no room below", () => {
+  it("keeps the visible HUD card above the pet hitbox with a fixed gap when flipped", () => {
     const result = computeSessionHudBounds({
       hitRect: { left: 320, top: 520, right: 400, bottom: 590 },
       workArea: { x: 0, y: 0, width: 800, height: 620 },
     });
 
     assert.strictEqual(result.flippedAbove, true);
-    assert.deepStrictEqual(result.bounds, {
+    assert.deepStrictEqual(result.contentBounds, {
       x: 240,
       y: 520 - constants.HUD_HEIGHT - constants.HUD_PET_GAP,
       width: constants.HUD_WIDTH,
       height: constants.HUD_HEIGHT,
     });
+    assert.deepStrictEqual(result.bounds, {
+      x: 240 - constants.HUD_WINDOW_PADDING,
+      y: 520 - constants.HUD_HEIGHT - constants.HUD_PET_GAP - constants.HUD_WINDOW_PADDING,
+      width: constants.HUD_WIDTH + constants.HUD_WINDOW_PADDING * 2,
+      height: constants.HUD_HEIGHT + constants.HUD_WINDOW_PADDING * 2,
+    });
+  });
+
+  it("keeps the reserved offset aligned to the visible card height plus the lower shadow pad", () => {
+    const expected = constants.HUD_PET_GAP
+      + constants.HUD_HEIGHT
+      + constants.HUD_WINDOW_PADDING
+      + constants.BUBBLE_GAP;
+    assert.strictEqual(sessionHud.__test.computeHudReservedOffset(constants.HUD_HEIGHT), expected);
   });
 });
 


### PR DESCRIPTION
## Summary
- prevent the Session HUD card shadow from being clipped by the transparent Electron window on Windows
- keep the visible HUD card pinned to the same pet gap while giving the rounded corners and box-shadow transparent breathing room
- add geometry and style tests for the new HUD window padding behavior

## Root cause
The HUD card was rendered flush against the edges of a transparent `BrowserWindow`.
On Windows, the transparent window bounds clip the card shadow at the rectangular window edge, so on light backgrounds the HUD could show a rectangular shadow artifact instead of a fully rounded shadow.

## What changed
- add transparent body padding in `session-hud.html` so the rounded card no longer touches the transparent window edge
- resize the HUD `BrowserWindow` to include that padding instead of treating the visible card size as the window size
- split visible card bounds from outer window bounds in `session-hud.js`
- preserve the existing visible card-to-pet gap for both below-pet and above-pet placements
- update the reserved-offset calculation so update bubbles still avoid the HUD correctly after the outer window grows
- add a new static HUD style test and extend the existing HUD geometry tests to cover the padded window shell

## Validation
- `node --test test\\session-hud.test.js`
- `node --test test\\session-hud-style.test.js`
- `npm test`
- `git diff --check`

## Manual QA
- Verified in a Windows development environment that Electron booted and accepted a live `/state` test session payload for HUD exercise.
- I also attempted a runtime screenshot pass, but the current local pet/HUD position did not produce a reliable on-screen HUD capture, so I am not attaching a visual proof screenshot or overstating this as a completed visual confirmation.
- macOS and Linux were not manually tested in this round.