### PR TITLE
fix: stabilize Settings collapsible interactions

### DIFF
--- a/src/settings-tab-agents.js
+++ b/src/settings-tab-agents.js
@@ -84,11 +84,6 @@
   }
 
   function buildAgentDetailRows(agent) {
-    // Sub-switches depend on the master: when the agent is turned off, the
-    // sub-flags have no effect (server-side gate drops the events upstream),
-    // so we render them as visually disabled to match reality. Committed
-    // values are preserved — flipping the master back on restores sub-switch
-    // state verbatim without re-asking the user to opt back in.
     const masterOn = readers.readAgentFlagValue(agent.id, "enabled");
     const rows = [];
     const caps = agent.capabilities || {};
@@ -131,6 +126,14 @@
     return rows;
   }
 
+  function syncAgentSwitchDisabledState(meta, disabled) {
+    meta.disabled = !!disabled;
+    const sw = meta.element;
+    sw.classList.toggle("disabled", !!disabled);
+    sw.setAttribute("aria-disabled", disabled ? "true" : "false");
+    sw.setAttribute("tabindex", disabled ? "-1" : "0");
+  }
+
   function buildAgentSwitchRow({ agent, flag, extraClass, disabled = false, buildText }) {
     const row = document.createElement("div");
     row.className = extraClass ? `row ${extraClass}` : "row";
@@ -152,31 +155,21 @@
     sw.addEventListener("keydown", (ev) => {
       ev.stopPropagation();
     });
-    if (disabled) {
-      sw.classList.add("disabled");
-      sw.setAttribute("aria-disabled", "true");
-    }
     const stateId = readers.agentSwitchStateId(agent.id, flag);
     const override = state.transientUiState.agentSwitches.get(stateId);
     const committedVisual = readers.readAgentFlagValue(agent.id, flag);
     helpers.setSwitchVisual(sw, override ? override.visualOn : committedVisual, {
       pending: override ? override.pending : false,
     });
-    state.mountedControls.agentSwitches.set(stateId, {
+    const meta = {
       element: sw,
       agentId: agent.id,
       flag,
       disabled,
-    });
-    // Disabled sub-switches intentionally skip the click handler so the flip
-    // animation never fires while the master is off. Committed value stays
-    // untouched — buildAgentRows reads it at the next re-render and the flip
-    // restores naturally when the master turns back on.
-    if (disabled) {
-      ctrl.appendChild(sw);
-      row.appendChild(ctrl);
-      return row;
-    }
+      syncDisabledState: (nextDisabled) => syncAgentSwitchDisabledState(meta, nextDisabled),
+    };
+    state.mountedControls.agentSwitches.set(stateId, meta);
+    syncAgentSwitchDisabledState(meta, disabled);
     helpers.attachAnimatedSwitch(sw, {
       getCommittedVisual: () => readers.readAgentFlagValue(agent.id, flag),
       getTransientState: () => state.transientUiState.agentSwitches.get(stateId) || null,
@@ -202,26 +195,14 @@
     const keys = changes ? Object.keys(changes) : [];
     if (!(keys.length === 1 && keys[0] === "agents")) return false;
     if (state.mountedControls.agentSwitches.size === 0) return false;
-    // A master flip changes which sub-switches should render disabled; that's
-    // a structural change (attach/detach click handler + tabindex + aria),
-    // so fall back to a full re-render instead of trying to patch it in place.
-    // Also clear lingering transient state before doing so — otherwise the
-    // in-flight `pending:true` from the master click itself leaks into the
-    // re-render, locks `.pending` onto the new master switch, and
-    // attachAnimatedSwitch silently bails on every subsequent click.
     for (const [, meta] of state.mountedControls.agentSwitches) {
       if (!meta || !document.body.contains(meta.element)) return false;
-      if (meta.flag === "enabled") continue;
-      const masterOn = readers.readAgentFlagValue(meta.agentId, "enabled");
-      if (meta.disabled === masterOn) {
-        for (const id of state.mountedControls.agentSwitches.keys()) {
-          state.transientUiState.agentSwitches.delete(id);
-        }
-        return false;
-      }
     }
     for (const [id, meta] of state.mountedControls.agentSwitches) {
       state.transientUiState.agentSwitches.delete(id);
+      if (meta.flag !== "enabled") {
+        meta.syncDisabledState(!readers.readAgentFlagValue(meta.agentId, "enabled"));
+      }
       helpers.setSwitchVisual(meta.element, readers.readAgentFlagValue(meta.agentId, meta.flag), { pending: false });
     }
     return true;

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -15,6 +15,11 @@
     "notificationBubbleAutoCloseSeconds",
     "updateBubbleAutoCloseSeconds",
   ]);
+  const BUBBLE_POLICY_KEYS = new Set([
+    "permissionBubblesEnabled",
+    "notificationBubbleAutoCloseSeconds",
+    "updateBubbleAutoCloseSeconds",
+  ]);
 
   let state = null;
   let readers = null;
@@ -189,47 +194,64 @@
   }
 
   function buildBubblePolicyRow() {
+    const summaryControl = buildBubblePolicySummary();
+    state.mountedControls.bubblePolicySummary = summaryControl;
     return helpers.buildCollapsibleGroup({
       id: "general:bubble-policy",
       title: t("rowBubblePolicy"),
       desc: t("rowBubblePolicyDesc"),
-      summary: buildBubblePolicySummary(),
+      summary: summaryControl.element,
       defaultCollapsed: true,
       children: [buildBubblePolicyList()],
       className: "bubble-policy-collapsible",
     });
   }
 
+  function readBubblePolicySnapshot() {
+    const aggregateHidden = !!(state.snapshot && state.snapshot.hideBubbles === true);
+    return {
+      permissionOn: !aggregateHidden && !!(state.snapshot && state.snapshot.permissionBubblesEnabled !== false),
+      notificationSeconds: aggregateHidden ? 0 : Number(state.snapshot && state.snapshot.notificationBubbleAutoCloseSeconds) || 0,
+      updateSeconds: aggregateHidden ? 0 : Number(state.snapshot && state.snapshot.updateBubbleAutoCloseSeconds) || 0,
+    };
+  }
+
   function buildBubblePolicySummary() {
     const wrap = document.createElement("div");
-    const aggregateHidden = !!(state.snapshot && state.snapshot.hideBubbles === true);
-    const permissionOn = !aggregateHidden && !!(state.snapshot && state.snapshot.permissionBubblesEnabled !== false);
-    const notificationSeconds = aggregateHidden ? 0 : Number(state.snapshot && state.snapshot.notificationBubbleAutoCloseSeconds) || 0;
-    const updateSeconds = aggregateHidden ? 0 : Number(state.snapshot && state.snapshot.updateBubbleAutoCloseSeconds) || 0;
-    const items = [
+
+    function syncFromSnapshot() {
+      wrap.innerHTML = "";
+      const snapshot = readBubblePolicySnapshot();
+      const items = [
       {
         text: t("bubblePolicySummaryPermission").replace(
           "{state}",
-          permissionOn ? t("bubblePolicySummaryOn") : t("bubblePolicySummaryOff")
+          snapshot.permissionOn ? t("bubblePolicySummaryOn") : t("bubblePolicySummaryOff")
         ),
-        accent: permissionOn,
+        accent: snapshot.permissionOn,
       },
       {
-        text: t("bubblePolicySummaryNotification").replace("{seconds}", String(notificationSeconds)),
-        accent: notificationSeconds > 0,
+        text: t("bubblePolicySummaryNotification").replace("{seconds}", String(snapshot.notificationSeconds)),
+        accent: snapshot.notificationSeconds > 0,
       },
       {
-        text: t("bubblePolicySummaryUpdate").replace("{seconds}", String(updateSeconds)),
-        accent: updateSeconds > 0,
+        text: t("bubblePolicySummaryUpdate").replace("{seconds}", String(snapshot.updateSeconds)),
+        accent: snapshot.updateSeconds > 0,
       },
-    ];
-    for (const item of items) {
-      const chip = document.createElement("span");
-      chip.className = "collapsible-summary-chip" + (item.accent ? " accent" : "");
-      chip.textContent = item.text;
-      wrap.appendChild(chip);
+      ];
+      for (const item of items) {
+        const chip = document.createElement("span");
+        chip.className = "collapsible-summary-chip" + (item.accent ? " accent" : "");
+        chip.textContent = item.text;
+        wrap.appendChild(chip);
+      }
     }
-    return wrap;
+
+    syncFromSnapshot();
+    return {
+      element: wrap,
+      syncFromSnapshot,
+    };
   }
 
   function buildBubblePolicyList() {
@@ -258,6 +280,7 @@
   }
 
   function buildBubbleCategoryControl({ category, labelKey, descKey, warningKey = null, secondsKey = null }) {
+    const stateKey = secondsKey || "permissionBubblesEnabled";
     const item = document.createElement("div");
     item.className = "bubble-policy-item";
     item.innerHTML =
@@ -279,6 +302,7 @@
 
     const sw = item.querySelector(".switch");
     const controls = item.querySelector(".bubble-policy-controls");
+    let secondsInput = null;
 
     function currentEnabled() {
       if (state.snapshot && state.snapshot.hideBubbles === true) return false;
@@ -287,12 +311,19 @@
       return Number.isFinite(seconds) && seconds > 0;
     }
 
+    function currentSeconds() {
+      if (!secondsKey) return 0;
+      return Number(state.snapshot && state.snapshot[secondsKey]) || 0;
+    }
+
     function setVisual(enabled, pending = false) {
       helpers.setSwitchVisual(sw, enabled, { pending });
-      if (secondsKey) {
-        const input = controls.querySelector("input");
-        if (input) input.disabled = !enabled || pending;
-      }
+      if (secondsInput) secondsInput.disabled = !enabled || pending;
+    }
+
+    function syncFromSnapshot() {
+      setVisual(currentEnabled(), false);
+      if (secondsInput) secondsInput.value = String(currentSeconds());
     }
 
     function runToggle() {
@@ -349,6 +380,7 @@
       controls.insertBefore(prefix, sw);
       controls.insertBefore(input, sw);
       controls.insertBefore(suffix, sw);
+      secondsInput = input;
       input.disabled = !currentEnabled();
       input.addEventListener("input", () => {
         const next = input.value.replace(/\D+/g, "").slice(0, 4);
@@ -365,6 +397,11 @@
         commitSecondsValue(input, secondsKey, next, category);
       });
     }
+
+    state.mountedControls.bubblePolicyControls.set(stateKey, {
+      row: item,
+      syncFromSnapshot,
+    });
 
     return item;
   }
@@ -406,12 +443,12 @@
 
       const cancelBtn = document.createElement("button");
       cancelBtn.type = "button";
-      cancelBtn.className = "soft-btn";
+      cancelBtn.className = "soft-btn accent";
       cancelBtn.textContent = cancelLabel;
 
       const confirmBtn = document.createElement("button");
       confirmBtn.type = "button";
-      confirmBtn.className = "soft-btn accent settings-confirm-danger";
+      confirmBtn.className = "soft-btn";
       confirmBtn.textContent = confirmLabel;
 
       function close(confirmed) {
@@ -433,8 +470,8 @@
       confirmBtn.addEventListener("click", () => close(true));
       document.addEventListener("keydown", onKeyDown, true);
 
-      actions.appendChild(cancelBtn);
       actions.appendChild(confirmBtn);
+      actions.appendChild(cancelBtn);
       modal.appendChild(icon);
       modal.appendChild(titleNode);
       modal.appendChild(detailNode);
@@ -717,6 +754,11 @@
     }
     for (const key of keys) {
       if (key === "size" || key === "soundVolume") continue;
+      if (BUBBLE_POLICY_KEYS.has(key)) {
+        const meta = state.mountedControls.bubblePolicyControls.get(key);
+        if (!meta || !document.body.contains(meta.row)) return false;
+        continue;
+      }
       const meta = state.mountedControls.generalSwitches.get(key);
       if (!meta || !document.body.contains(meta.element)) return false;
     }
@@ -726,12 +768,21 @@
         state.mountedControls.soundVolume.syncValueFromSnapshot();
         continue;
       }
+      if (BUBBLE_POLICY_KEYS.has(key)) {
+        state.mountedControls.bubblePolicyControls.get(key).syncFromSnapshot();
+        continue;
+      }
       const meta = state.mountedControls.generalSwitches.get(key);
       state.transientUiState.generalSwitches.delete(key);
       helpers.setSwitchVisual(meta.element, readers.readGeneralSwitchVisual(key, meta.invert), { pending: false });
       if (key === "soundMuted") {
         state.mountedControls.soundVolume.syncDisabled();
       }
+    }
+    if (keys.some((key) => BUBBLE_POLICY_KEYS.has(key))) {
+      const summaryControl = state.mountedControls.bubblePolicySummary;
+      if (!summaryControl || !document.body.contains(summaryControl.element)) return false;
+      summaryControl.syncFromSnapshot();
     }
     return true;
   }

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -53,7 +53,9 @@
     },
     mountedControls: {
       generalSwitches: new Map(),
+      bubblePolicyControls: new Map(),
       agentSwitches: new Map(),
+      bubblePolicySummary: null,
       size: null,
       soundVolume: null,
     },
@@ -203,6 +205,7 @@
     invoke,
   }) {
     const run = () => {
+      if (sw.classList.contains("disabled") || sw.getAttribute("aria-disabled") === "true") return;
       if (sw.classList.contains("pending")) return;
       const currentVisual = getCommittedVisual();
       const nextVisual = !currentVisual;
@@ -356,6 +359,23 @@
       }
     }
 
+    function preserveScrollAnchor(invoke) {
+      const scroller = document.getElementById("content");
+      if (!scroller || !document.body.contains(header)) {
+        invoke();
+        return;
+      }
+      const beforeTop = header.getBoundingClientRect().top;
+      const beforeScrollTop = scroller.scrollTop;
+      invoke();
+      requestAnimationFrame(() => {
+        if (!document.body.contains(header)) return;
+        const afterTop = header.getBoundingClientRect().top;
+        const delta = afterTop - beforeTop;
+        if (delta !== 0) scroller.scrollTop = beforeScrollTop + delta;
+      });
+    }
+
     function applyCollapsedState({ animate = false } = {}) {
       header.setAttribute("aria-expanded", collapsed ? "false" : "true");
       header.setAttribute("aria-label", collapsed ? t("collapsibleExpand") : t("collapsibleCollapse"));
@@ -392,7 +412,7 @@
       const nextState = readCollapsedGroupState();
       nextState[id] = collapsed;
       writeCollapsedGroupState(nextState);
-      applyCollapsedState({ animate: true });
+      preserveScrollAnchor(() => applyCollapsedState({ animate: true }));
     }
 
     header.addEventListener("click", toggleCollapsed);
@@ -547,7 +567,9 @@
       state.mountedControls.soundVolume.dispose();
     }
     state.mountedControls.generalSwitches.clear();
+    state.mountedControls.bubblePolicyControls.clear();
     state.mountedControls.agentSwitches.clear();
+    state.mountedControls.bubblePolicySummary = null;
     state.mountedControls.size = null;
     state.mountedControls.soundVolume = null;
   }

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -111,6 +111,8 @@ describe("settings renderer browser environment", () => {
     const html = fs.readFileSync(SETTINGS_HTML, "utf8");
     assert.ok(generalSource.includes("buildBubblePolicyRow()"));
     assert.ok(generalSource.includes("setBubbleCategoryEnabled"));
+    assert.ok(generalSource.includes("state.mountedControls.bubblePolicyControls"));
+    assert.ok(generalSource.includes("state.mountedControls.bubblePolicySummary"));
     assert.ok(generalSource.includes("confirmDisableUpdateBubbles"));
     assert.ok(generalSource.includes("category === \"update\" && next === 0"));
     assert.ok(generalSource.includes("notificationBubbleAutoCloseSeconds"));
@@ -146,6 +148,10 @@ describe("settings renderer browser environment", () => {
     assert.ok(!mainSource.includes('ipcMain.handle("settings:confirm-disable-update-bubbles"'));
     assert.ok(i18nSource.includes("Hide update bubbles"));
     assert.ok(i18nSource.includes("隐藏更新气泡"));
+    assert.ok(generalSource.includes('confirmBtn.className = "soft-btn";'));
+    assert.ok(generalSource.includes('cancelBtn.className = "soft-btn accent";'));
+    assert.ok(generalSource.indexOf("actions.appendChild(confirmBtn);") < generalSource.indexOf("actions.appendChild(cancelBtn);"));
+    assert.ok(generalSource.includes("cancelBtn.focus();"));
   });
 
   it("provides a persisted collapsible Settings group helper with smart default collapse", () => {
@@ -169,6 +175,7 @@ describe("settings renderer browser environment", () => {
     const coreSource = fs.readFileSync(SETTINGS_UI_CORE, "utf8");
     const html = fs.readFileSync(SETTINGS_HTML, "utf8");
     assert.ok(coreSource.includes("function measureCollapsibleBodyHeight("));
+    assert.ok(coreSource.includes("function preserveScrollAnchor("));
     assert.ok(coreSource.includes('body.style.setProperty("--collapsible-body-height"'));
     assert.ok(coreSource.includes("requestAnimationFrame(() => {"));
     assert.ok(coreSource.includes("collapsing"));
@@ -191,7 +198,8 @@ describe("settings renderer browser environment", () => {
     assert.ok(generalSource.includes('id: "general:bubble-policy"'));
     assert.ok(generalSource.includes("defaultCollapsed: true"));
     assert.ok(generalSource.includes('title: t("rowBubblePolicy")'));
-    assert.ok(generalSource.includes("summary: buildBubblePolicySummary()"));
+    assert.ok(generalSource.includes("const summaryControl = buildBubblePolicySummary();"));
+    assert.ok(generalSource.includes("summary: summaryControl.element"));
     assert.ok(generalSource.includes("children: [buildBubblePolicyList()]"));
     assert.ok(generalSource.includes('key: "bubbleFollowPet"'));
     assert.ok(!generalSource.includes('key: "showSessionId"'));
@@ -212,6 +220,8 @@ describe("settings renderer browser environment", () => {
     assert.ok(agentsSource.includes("children: detailRows"));
     assert.ok(agentsSource.includes("ev.stopPropagation();"));
     assert.ok(agentsSource.includes("agent-subgroup"));
+    assert.ok(agentsSource.includes("function syncAgentSwitchDisabledState("));
+    assert.ok(!agentsSource.includes("full re-render"));
   });
 
   it("uses a dedicated Settings agent ordering helper before rendering Agent management groups", () => {


### PR DESCRIPTION
## Summary
This PR fixes three UX regressions in the new Settings collapsible menus without changing prefs schema, IPC contracts, bubble policy semantics, or agent runtime behavior.

1. General > Bubbles no longer scroll-jumps when bubble policy switches change.
2. The "hide update bubbles" confirmation now defaults to the safer action.
3. Agent Management no longer flickers expanded subgroups when the master switch changes.

## Root cause
- The bubble policy controls were not wired into `patchInPlace()`, so toggling them forced a full content re-render and the Settings content scroller jumped.
- The update-bubble confirmation modal visually emphasized the destructive action instead of the safe action.
- Agent sub-switches depended on a forced full re-render after a master toggle, which destroyed and recreated the expanded subgroup and caused visible flicker.

## What changed
- Added dedicated mounted-control tracking for bubble policy controls and bubble policy summary state.
- Updated `General` in-place patching so `permissionBubblesEnabled`, `notificationBubbleAutoCloseSeconds`, and `updateBubbleAutoCloseSeconds` now sync in place instead of re-rendering the full content area.
- Added scroll-anchor preservation to the generic collapsible helper so expand/collapse animations do not nudge the Settings scroller.
- Swapped the update-bubble confirmation button emphasis/order:
  - left: `Hide update bubbles`
  - right: `Keep showing them`
  - the safe action is now accent-highlighted and receives initial focus.
- Kept agent sub-switches permanently bound and moved disabled-state updates to in-place patching so master toggles no longer force a subtree rebuild.

## Scope / non-goals
- No prefs migration changes.
- No Settings preload / IPC changes.
- No bubble policy default changes.
- No agent ordering or collapsible default-state changes.

## Validation
Ran on Windows:
- `node --check src\\settings-ui-core.js`
- `node --check src\\settings-tab-general.js`
- `node --check src\\settings-tab-agents.js`
- `node --test test\\settings-renderer-browser-env.test.js`
- `npm test`
- `git diff --check`

## Platform note
- Automated validation was run on Windows.
- macOS and Linux were not manually tested in this round.
