### PR TITLE
fix: rebalance session HUD shadow shell

### DIFF
--- a/src/session-hud.html
+++ b/src/session-hud.html
@@ -31,7 +31,7 @@
 }
 
 html, body {
-  width: 240px;
+  width: 100%;
   margin: 0;
   background: transparent;
   color: var(--text);
@@ -42,15 +42,17 @@ html, body {
 }
 
 html, body { height: 100%; overflow: hidden; }
+body { padding: 2px 3px 8px; }
 
 .hud {
-  width: 240px;
+  width: 100%;
+  height: 100%;
   display: flex;
   flex-direction: column;
   border: 1px solid var(--hud-border);
   border-radius: 8px;
   background: var(--hud-bg);
-  box-shadow: 0 4px 14px var(--shadow);
+  box-shadow: 0 8px 18px -12px var(--shadow), 0 2px 4px rgba(0, 0, 0, 0.10);
   overflow: hidden;
 }
 

--- a/src/session-hud.js
+++ b/src/session-hud.js
@@ -12,6 +12,12 @@ const HUD_WIDTH = 240;
 const HUD_ROW_HEIGHT = 28;
 const HUD_MAX_EXPANDED_ROWS = 3;
 const HUD_HEIGHT = HUD_ROW_HEIGHT + HUD_BORDER_Y;
+const HUD_WINDOW_SHELL = Object.freeze({
+  top: 2,
+  right: 3,
+  bottom: 8,
+  left: 3,
+});
 const HUD_PET_GAP = 4;
 const BUBBLE_GAP = 6;
 const EDGE_MARGIN = 8;
@@ -50,12 +56,19 @@ function computeHudHeight(rowCount) {
   return rowCount * HUD_ROW_HEIGHT + HUD_BORDER_Y;
 }
 
+function computeHudReservedOffset(cardHeight) {
+  const h = Number.isFinite(cardHeight) && cardHeight > 0 ? cardHeight : HUD_ROW_HEIGHT;
+  return HUD_PET_GAP + h + HUD_WINDOW_SHELL.bottom + BUBBLE_GAP;
+}
+
 function computeSessionHudBounds({ hitRect, workArea, width = HUD_WIDTH, height = HUD_HEIGHT }) {
   if (!hitRect || !workArea) return null;
   const hitTop = Math.round(hitRect.top);
   const hitBottom = Math.round(hitRect.bottom);
   const hitCx = Math.round((hitRect.left + hitRect.right) / 2);
 
+  const outerWidth = width + HUD_WINDOW_SHELL.left + HUD_WINDOW_SHELL.right;
+  const outerHeight = height + HUD_WINDOW_SHELL.top + HUD_WINDOW_SHELL.bottom;
   const minX = Math.round(workArea.x);
   const maxX = Math.round(workArea.x + workArea.width - width);
   const x = clampToWorkArea(hitCx - Math.round(width / 2), minX, maxX);
@@ -63,8 +76,15 @@ function computeSessionHudBounds({ hitRect, workArea, width = HUD_WIDTH, height 
   const belowY = hitBottom + HUD_PET_GAP;
   const belowMax = workArea.y + workArea.height - EDGE_MARGIN;
   if (belowY + height <= belowMax) {
+    const contentBounds = { x, y: belowY, width, height };
     return {
-      bounds: { x, y: belowY, width, height },
+      bounds: {
+        x: contentBounds.x - HUD_WINDOW_SHELL.left,
+        y: contentBounds.y - HUD_WINDOW_SHELL.top,
+        width: outerWidth,
+        height: outerHeight,
+      },
+      contentBounds,
       flippedAbove: false,
     };
   }
@@ -72,13 +92,20 @@ function computeSessionHudBounds({ hitRect, workArea, width = HUD_WIDTH, height 
   const minY = Math.round(workArea.y + EDGE_MARGIN);
   const maxY = Math.round(workArea.y + workArea.height - EDGE_MARGIN - height);
   const aboveY = hitTop - height - HUD_PET_GAP;
+  const contentBounds = {
+    x,
+    y: clampToWorkArea(aboveY, minY, maxY),
+    width,
+    height,
+  };
   return {
     bounds: {
-      x,
-      y: clampToWorkArea(aboveY, minY, maxY),
-      width,
-      height,
+      x: contentBounds.x - HUD_WINDOW_SHELL.left,
+      y: contentBounds.y - HUD_WINDOW_SHELL.top,
+      width: outerWidth,
+      height: outerHeight,
     },
+    contentBounds,
     flippedAbove: true,
   };
 }
@@ -145,8 +172,8 @@ module.exports = function initSessionHud(ctx) {
     hudFlippedAbove = false;
     hudWindow = new BrowserWindow({
       parent: ctx.win,
-      width: HUD_WIDTH,
-      height: HUD_HEIGHT,
+      width: HUD_WIDTH + HUD_WINDOW_SHELL.left + HUD_WINDOW_SHELL.right,
+      height: HUD_HEIGHT + HUD_WINDOW_SHELL.top + HUD_WINDOW_SHELL.bottom,
       show: false,
       frame: false,
       transparent: true,
@@ -259,8 +286,7 @@ module.exports = function initSessionHud(ctx) {
   function readHudReservedOffset() {
     if (!hudWindow || hudWindow.isDestroyed() || !hudWindow.isVisible()) return 0;
     if (hudFlippedAbove) return 0;
-    const h = Number.isFinite(lastHudHeight) && lastHudHeight > 0 ? lastHudHeight : HUD_ROW_HEIGHT;
-    return HUD_PET_GAP + h + BUBBLE_GAP;
+    return computeHudReservedOffset(lastHudHeight);
   }
 
   function notifyReservedOffsetIfChanged() {
@@ -295,12 +321,14 @@ module.exports.__test = {
   computeSessionHudBounds,
   computeHudLayout,
   computeHudHeight,
+  computeHudReservedOffset,
   isHudSession,
   constants: {
     HUD_WIDTH,
     HUD_HEIGHT,
     HUD_ROW_HEIGHT,
     HUD_MAX_EXPANDED_ROWS,
+    HUD_WINDOW_SHELL,
     HUD_PET_GAP,
     BUBBLE_GAP,
     EDGE_MARGIN,

--- a/test/session-hud-style.test.js
+++ b/test/session-hud-style.test.js
@@ -1,0 +1,21 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const sessionHudHtml = fs.readFileSync(path.join(__dirname, "..", "src", "session-hud.html"), "utf8");
+
+describe("session HUD visual shell", () => {
+  it("adds asymmetric body padding so the shadow has more room below than above", () => {
+    assert.match(sessionHudHtml, /body\s*\{[\s\S]*padding:\s*2px 3px 8px;[\s\S]*\}/);
+    assert.match(sessionHudHtml, /\.hud\s*\{[\s\S]*width:\s*100%;[\s\S]*height:\s*100%;[\s\S]*\}/);
+    assert.doesNotMatch(sessionHudHtml, /\.hud\s*\{[\s\S]*width:\s*240px;[\s\S]*\}/);
+  });
+
+  it("keeps the rounded card while switching to a bottom-biased shadow", () => {
+    assert.match(sessionHudHtml, /\.hud\s*\{[\s\S]*border-radius:\s*8px;[\s\S]*\}/);
+    assert.match(sessionHudHtml, /\.hud\s*\{[\s\S]*box-shadow:\s*0 8px 18px -12px var\(--shadow\),\s*0 2px 4px rgba\(0,\s*0,\s*0,\s*0\.10\);[\s\S]*\}/);
+    assert.doesNotMatch(sessionHudHtml, /\.hud\s*\{[\s\S]*box-shadow:\s*0 4px 14px var\(--shadow\);[\s\S]*\}/);
+    assert.match(sessionHudHtml, /\.hud\s*\{[\s\S]*background:\s*var\(--hud-bg\);[\s\S]*\}/);
+  });
+});

--- a/test/session-hud.test.js
+++ b/test/session-hud.test.js
@@ -20,36 +20,60 @@ function mkSession(id, overrides = {}) {
 }
 
 describe("session HUD geometry", () => {
-  it("positions below the pet hitbox and clamps horizontally", () => {
+  it("positions the visible HUD card below the pet hitbox with a fixed gap", () => {
     const result = computeSessionHudBounds({
       hitRect: { left: 10, top: 80, right: 90, bottom: 160 },
       workArea: { x: 0, y: 0, width: 800, height: 600 },
     });
 
-    assert.deepStrictEqual(result, {
-      bounds: {
-        x: 0,
-        y: 160 + constants.HUD_PET_GAP,
-        width: constants.HUD_WIDTH,
-        height: constants.HUD_HEIGHT,
-      },
-      flippedAbove: false,
+    assert.deepStrictEqual(result.contentBounds, {
+      x: 0,
+      y: 160 + constants.HUD_PET_GAP,
+      width: constants.HUD_WIDTH,
+      height: constants.HUD_HEIGHT,
     });
+    assert.deepStrictEqual(result.bounds, {
+      x: -constants.HUD_WINDOW_SHELL.left,
+      y: 160 + constants.HUD_PET_GAP - constants.HUD_WINDOW_SHELL.top,
+      width: constants.HUD_WIDTH + constants.HUD_WINDOW_SHELL.left + constants.HUD_WINDOW_SHELL.right,
+      height: constants.HUD_HEIGHT + constants.HUD_WINDOW_SHELL.top + constants.HUD_WINDOW_SHELL.bottom,
+    });
+    assert.strictEqual(result.flippedAbove, false);
   });
 
-  it("flips above the hitbox when there is no room below", () => {
+  it("keeps the visible HUD card above the pet hitbox with a fixed gap when flipped", () => {
     const result = computeSessionHudBounds({
       hitRect: { left: 320, top: 520, right: 400, bottom: 590 },
       workArea: { x: 0, y: 0, width: 800, height: 620 },
     });
 
     assert.strictEqual(result.flippedAbove, true);
-    assert.deepStrictEqual(result.bounds, {
+    assert.deepStrictEqual(result.contentBounds, {
       x: 240,
       y: 520 - constants.HUD_HEIGHT - constants.HUD_PET_GAP,
       width: constants.HUD_WIDTH,
       height: constants.HUD_HEIGHT,
     });
+    assert.deepStrictEqual(result.bounds, {
+      x: 240 - constants.HUD_WINDOW_SHELL.left,
+      y: 520 - constants.HUD_HEIGHT - constants.HUD_PET_GAP - constants.HUD_WINDOW_SHELL.top,
+      width: constants.HUD_WIDTH + constants.HUD_WINDOW_SHELL.left + constants.HUD_WINDOW_SHELL.right,
+      height: constants.HUD_HEIGHT + constants.HUD_WINDOW_SHELL.top + constants.HUD_WINDOW_SHELL.bottom,
+    });
+  });
+
+  it("keeps the reserved offset aligned to the visible card height plus the bottom shell only", () => {
+    const expected = constants.HUD_PET_GAP
+      + constants.HUD_HEIGHT
+      + constants.HUD_WINDOW_SHELL.bottom
+      + constants.BUBBLE_GAP;
+    assert.strictEqual(sessionHud.__test.computeHudReservedOffset(constants.HUD_HEIGHT), expected);
+  });
+
+  it("uses a bottom-heavier outer shell than the top and side edges", () => {
+    assert.ok(constants.HUD_WINDOW_SHELL.bottom > constants.HUD_WINDOW_SHELL.top);
+    assert.ok(constants.HUD_WINDOW_SHELL.bottom > constants.HUD_WINDOW_SHELL.left);
+    assert.ok(constants.HUD_WINDOW_SHELL.bottom > constants.HUD_WINDOW_SHELL.right);
   });
 });
 


### PR DESCRIPTION
## Summary
This PR reworks the Session HUD shadow fix after the earlier transparent-padding approach produced a visible halo ring around the card on light backgrounds.

The new fix keeps the rounded HUD card intact, but changes the shell geometry and shadow treatment so the HUD reads like a bottom-cast floating card instead of a uniformly shadowed ring.

## Root cause
The previous fix solved the rectangular clipping problem by adding equal transparent padding around the entire HUD window.
That removed the hard clipping edge, but it also exposed the full blur on the top and side edges because the HUD card still used a symmetric `box-shadow`.
On white backgrounds, that made the HUD look like it had a circular halo instead of a natural downward shadow.

## What changed
- replaced the old implicit symmetric HUD padding with an explicit asymmetric `HUD_WINDOW_SHELL`
- kept the visible HUD card anchored to the same pet gap while computing a larger outer transparent window around it
- made the bottom shell larger than the top/side shell so only the downward shadow gets extra breathing room
- updated reserved-offset math so update bubbles only account for the bottom shell, not a symmetric outer pad
- changed the HUD CSS from the old `0 4px 14px` card shadow to a bottom-biased shadow stack
- added a dedicated `test/session-hud-style.test.js` regression test and expanded `test/session-hud.test.js` to cover content bounds, asymmetric shell geometry, and reserved-offset behavior

## Validation
Run on Windows:
- `node --check src\\session-hud.js`
- `node --test test\\session-hud.test.js`
- `node --test test\\session-hud-style.test.js`
- `npm test`
- `git diff --check`

## Manual QA note
- Automated validation was completed on Windows.
- I did not attach a visual proof screenshot for this round.
- macOS and Linux were not manually tested.
