### PR TITLE
Add Windows ARM64 installer support

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "start": "node launch.js",
     "build": "electron-builder --win",
+    "build:win:x64": "electron-builder --win nsis:x64",
+    "build:win:arm64": "electron-builder --win nsis:arm64",
+    "build:win:all": "electron-builder --win nsis:x64 nsis:arm64",
     "build:mac": "electron-builder --mac",
     "build:linux": "electron-builder --linux",
     "build:all": "electron-builder --win --mac --linux",
@@ -49,12 +52,13 @@
     "win": {
       "icon": "assets/icon.ico",
       "signAndEditExecutable": false,
-      "artifactName": "Clawd-on-Desk-Setup-${version}.${ext}",
+      "artifactName": "Clawd-on-Desk-Setup-${version}-${arch}.${ext}",
       "target": [
         {
           "target": "nsis",
           "arch": [
-            "x64"
+            "x64",
+            "arm64"
           ]
         }
       ]
@@ -81,6 +85,7 @@
     "nsis": {
       "oneClick": false,
       "allowToChangeInstallationDirectory": true,
+      "buildUniversalInstaller": false,
       "installerIcon": "assets/icon.ico",
       "uninstallerIcon": "assets/icon.ico",
       "installerHeaderIcon": "assets/icon.ico"

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -37,6 +37,45 @@ describe("package build config", () => {
     );
   });
 
+  describe("Windows architecture targets", () => {
+    function getWindowsNsisTarget() {
+      const targets = pkg.build.win && pkg.build.win.target;
+      return Array.isArray(targets) ? targets.find((target) => target && target.target === "nsis") : null;
+    }
+
+    it("builds native Windows installers for x64 and arm64", () => {
+      const target = getWindowsNsisTarget();
+      assert.ok(target, "build.win.target should include an nsis target");
+      assert.deepStrictEqual(
+        target.arch,
+        ["x64", "arm64"],
+        "Windows NSIS builds should publish both x64 and ARM64 installers"
+      );
+    });
+
+    it("uses architecture-specific Windows installer names", () => {
+      assert.match(
+        pkg.build.win && pkg.build.win.artifactName,
+        /\$\{arch\}/,
+        "Windows artifactName must include ${arch} so x64 and ARM64 installers cannot collide"
+      );
+    });
+
+    it("exposes explicit Windows architecture build scripts", () => {
+      assert.strictEqual(pkg.scripts["build:win:x64"], "electron-builder --win nsis:x64");
+      assert.strictEqual(pkg.scripts["build:win:arm64"], "electron-builder --win nsis:arm64");
+      assert.strictEqual(pkg.scripts["build:win:all"], "electron-builder --win nsis:x64 nsis:arm64");
+    });
+
+    it("does not emit a redundant universal Windows installer", () => {
+      assert.strictEqual(
+        pkg.build.nsis && pkg.build.nsis.buildUniversalInstaller,
+        false,
+        "Windows releases should publish explicit x64/ARM64 installers, not an extra universal NSIS installer"
+      );
+    });
+  });
+
   // getWindowsShellIconPath has a three-step fallback:
   //   1. resourcesPath/icon.ico            ← extraResources copy
   //   2. resourcesPath/app.asar.unpacked/assets/icon.ico

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -47,15 +47,21 @@ describe("package build config", () => {
       const target = getWindowsNsisTarget();
       assert.ok(target, "build.win.target should include an nsis target");
       assert.deepStrictEqual(
-        target.arch,
-        ["x64", "arm64"],
+        target.arch.slice().sort(),
+        ["x64", "arm64"].slice().sort(),
         "Windows NSIS builds should publish both x64 and ARM64 installers"
       );
     });
 
     it("uses architecture-specific Windows installer names", () => {
+      const artifactName = pkg.build.win && pkg.build.win.artifactName;
+      assert.strictEqual(
+        typeof artifactName,
+        "string",
+        "build.win.artifactName should be a string"
+      );
       assert.match(
-        pkg.build.win && pkg.build.win.artifactName,
+        artifactName,
         /\$\{arch\}/,
         "Windows artifactName must include ${arch} so x64 and ARM64 installers cannot collide"
       );


### PR DESCRIPTION
Closes #178

## Summary

- add native Windows ARM64 packaging alongside x64
- add explicit Windows build scripts for x64, ARM64, and both architectures
- include `${arch}` in Windows installer artifact names to prevent collisions
- disable redundant universal NSIS output so releases publish explicit architecture installers
- add package config tests for Windows architecture support

## Verification

- `node --test test/package-build-config.test.js`  
  Passes: 11/11
- `git diff --check`
- `npm run build:win:arm64`
  - produced `dist/Clawd-on-Desk-Setup-0.6.1-arm64.exe`
  - produced no `*x64*` artifact
  - unpacked app PE machine: `0xAA64`
- `npm run build:win:x64`
  - produced `dist/Clawd-on-Desk-Setup-0.6.1-x64.exe`
  - produced no `*arm64*` artifact
  - unpacked app PE machine: `0x8664`
- `npm run build:win:all`
  - produced separate `x64` and `arm64` installers
  - produced no redundant `Clawd-on-Desk-Setup-0.6.1.exe` universal installer
