### PR TITLE
fix: keep hidden windows out of taskbar after explorer restart

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -43,6 +43,7 @@ const {
   getLaunchSizingWorkArea,
   getProportionalPixelSize,
 } = require("./size-utils");
+const { keepOutOfTaskbar } = require("./taskbar");
 
 // ── Autoplay policy: allow sound playback without user gesture ──
 // MUST be set before any BrowserWindow is created (before app.whenReady)
@@ -521,16 +522,16 @@ function togglePetVisibility() {
   if (_mini.getMiniTransitioning()) return;
   if (petHidden) {
     win.showInactive();
-    if (isLinux) win.setSkipTaskbar(true);
+    keepOutOfTaskbar(win);
     if (hitWin && !hitWin.isDestroyed()) {
       hitWin.showInactive();
-      if (isLinux) hitWin.setSkipTaskbar(true);
+      keepOutOfTaskbar(hitWin);
     }
     // Restore any permission bubbles that were hidden
     for (const perm of pendingPermissions) {
       if (perm.bubble && !perm.bubble.isDestroyed()) {
         perm.bubble.showInactive();
-        if (isLinux) perm.bubble.setSkipTaskbar(true);
+        keepOutOfTaskbar(perm.bubble);
       }
     }
     syncUpdateBubbleVisibility();
@@ -574,10 +575,10 @@ function bringPetToPrimaryDisplay() {
     togglePetVisibility();
   } else {
     win.showInactive();
-    if (isLinux) win.setSkipTaskbar(true);
+    keepOutOfTaskbar(win);
     if (hitWin && !hitWin.isDestroyed()) {
       hitWin.showInactive();
-      if (isLinux) hitWin.setSkipTaskbar(true);
+      keepOutOfTaskbar(hitWin);
     }
   }
 
@@ -1265,21 +1266,28 @@ function startTopmostWatchdog() {
   topmostWatchdog = setInterval(() => {
     if (win && !win.isDestroyed()) {
       win.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+      keepOutOfTaskbar(win);
     }
     // Keep hitWin topmost too
     if (hitWin && !hitWin.isDestroyed()) {
       hitWin.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+      keepOutOfTaskbar(hitWin);
     }
     for (const perm of pendingPermissions) {
-      if (perm.bubble && !perm.bubble.isDestroyed() && perm.bubble.isVisible()) perm.bubble.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+      if (perm.bubble && !perm.bubble.isDestroyed() && perm.bubble.isVisible()) {
+        perm.bubble.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+        keepOutOfTaskbar(perm.bubble);
+      }
     }
     const updateBubbleWin = _updateBubble.getBubbleWindow();
     if (updateBubbleWin && !updateBubbleWin.isDestroyed() && updateBubbleWin.isVisible()) {
       updateBubbleWin.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+      keepOutOfTaskbar(updateBubbleWin);
     }
     const sessionHudWin = getSessionHudWindow();
     if (sessionHudWin && !sessionHudWin.isDestroyed() && sessionHudWin.isVisible()) {
       sessionHudWin.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+      keepOutOfTaskbar(sessionHudWin);
     }
   }, TOPMOST_WATCHDOG_MS);
 }
@@ -3209,7 +3217,10 @@ function createWindow() {
     win.on("close", (event) => {
       if (!isQuitting) {
         event.preventDefault();
-        if (!win.isVisible()) win.showInactive();
+        if (!win.isVisible()) {
+          win.showInactive();
+          keepOutOfTaskbar(win);
+        }
       }
     });
     win.on("unresponsive", () => {
@@ -3226,8 +3237,7 @@ function createWindow() {
   win.loadFile(path.join(__dirname, "index.html"));
   applyPetWindowBounds(initialVirtualBounds);
   win.showInactive();
-  // Linux WMs may reset skipTaskbar after showInactive — re-apply explicitly
-  if (isLinux) win.setSkipTaskbar(true);
+  keepOutOfTaskbar(win);
   // macOS: apply after showInactive() — it resets NSWindowCollectionBehavior
   reapplyMacVisibility();
 
@@ -3281,8 +3291,7 @@ function createWindow() {
     hitWin.setIgnoreMouseEvents(false);  // PERMANENT — never toggle
     if (isMac) hitWin.setFocusable(false);
     hitWin.showInactive();
-    // Linux WMs may reset skipTaskbar after showInactive — re-apply explicitly
-    if (isLinux) hitWin.setSkipTaskbar(true);
+    keepOutOfTaskbar(hitWin);
     if (isWin) {
       hitWin.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
     }
@@ -3793,11 +3802,11 @@ if (!gotTheLock) {
   app.on("second-instance", (_event, commandLine) => {
     if (win) {
       win.showInactive();
-      if (isLinux) win.setSkipTaskbar(true);
+      keepOutOfTaskbar(win);
     }
     if (hitWin && !hitWin.isDestroyed()) {
       hitWin.showInactive();
-      if (isLinux) hitWin.setSkipTaskbar(true);
+      keepOutOfTaskbar(hitWin);
     }
     if (shouldOpenSettingsWindowFromArgv(commandLine)) {
       openSettingsWindowWhenReady();

--- a/src/permission.js
+++ b/src/permission.js
@@ -3,6 +3,7 @@
 
 const { BrowserWindow, globalShortcut } = require("electron");
 const { getDefaultShortcuts } = require("./shortcut-actions");
+const { keepOutOfTaskbar } = require("./taskbar");
 const path = require("path");
 const http = require("http");
 const {
@@ -505,8 +506,7 @@ function showPermissionBubble(permEntry) {
   repositionBubbles();
   bub.showInactive();
   repositionDependentBubbles();
-  // Linux WMs may reset skipTaskbar after showInactive — re-apply explicitly
-  if (isLinux) bub.setSkipTaskbar(true);
+  keepOutOfTaskbar(bub);
   // macOS: constructing/raising a topmost panel too early can still activate
   // Clawd on some setups. Defer topmost restoration until after showInactive.
   if (isMac) deferMacFloatingVisibility(ctx, bub);

--- a/src/session-hud.js
+++ b/src/session-hud.js
@@ -2,6 +2,7 @@
 
 const { BrowserWindow } = require("electron");
 const path = require("path");
+const { keepOutOfTaskbar } = require("./taskbar");
 
 const isLinux = process.platform === "linux";
 const isMac = process.platform === "darwin";
@@ -243,7 +244,7 @@ module.exports = function initSessionHud(ctx) {
     if (!win || win.isDestroyed() || !didFinishLoad) return;
     if (!win.isVisible()) {
       win.showInactive();
-      if (isLinux) win.setSkipTaskbar(true);
+      keepOutOfTaskbar(win);
       if (isMac) deferMacFloatingVisibility(ctx, win);
       else if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
     }

--- a/src/taskbar.js
+++ b/src/taskbar.js
@@ -1,0 +1,23 @@
+"use strict";
+
+function shouldKeepOutOfTaskbar(platform = process.platform) {
+  return platform === "win32" || platform === "linux";
+}
+
+// Some shells/window managers can lose the BrowserWindow creation-time
+// skipTaskbar flag after showInactive() or taskbar/shell restart. Reassert it
+// for floating Clawd windows whenever they are shown without activation, and
+// from Windows' shell-state watchdog while they remain visible.
+function keepOutOfTaskbar(w) {
+  if (!w || w.isDestroyed()) return;
+  if (shouldKeepOutOfTaskbar() && typeof w.setSkipTaskbar === "function") {
+    w.setSkipTaskbar(true);
+  }
+}
+
+module.exports = {
+  keepOutOfTaskbar,
+  __test: {
+    shouldKeepOutOfTaskbar,
+  },
+};

--- a/src/update-bubble.js
+++ b/src/update-bubble.js
@@ -1,5 +1,6 @@
 const { BrowserWindow } = require("electron");
 const path = require("path");
+const { keepOutOfTaskbar } = require("./taskbar");
 
 const isLinux = process.platform === "linux";
 const isMac = process.platform === "darwin";
@@ -221,7 +222,7 @@ module.exports = function initUpdateBubble(ctx) {
       return;
     }
     bubble.showInactive();
-    if (isLinux) bubble.setSkipTaskbar(true);
+    keepOutOfTaskbar(bubble);
     if (isMac) deferMacFloatingVisibility(ctx, bubble);
     else if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
   }

--- a/test/taskbar.test.js
+++ b/test/taskbar.test.js
@@ -1,0 +1,30 @@
+const assert = require("assert");
+const { describe, it } = require("node:test");
+
+const { keepOutOfTaskbar, __test } = require("../src/taskbar");
+
+describe("taskbar helpers", () => {
+  it("reasserts skipTaskbar on Windows and Linux", () => {
+    assert.strictEqual(__test.shouldKeepOutOfTaskbar("win32"), true);
+    assert.strictEqual(__test.shouldKeepOutOfTaskbar("linux"), true);
+    assert.strictEqual(__test.shouldKeepOutOfTaskbar("darwin"), false);
+  });
+
+  it("safely ignores missing or destroyed windows", () => {
+    assert.doesNotThrow(() => keepOutOfTaskbar(null));
+    assert.doesNotThrow(() => keepOutOfTaskbar({ isDestroyed: () => true }));
+    assert.doesNotThrow(() => keepOutOfTaskbar({ isDestroyed: () => false }));
+  });
+
+  it("calls setSkipTaskbar on supported runtime platforms", () => {
+    let called = false;
+    keepOutOfTaskbar({
+      isDestroyed: () => false,
+      setSkipTaskbar(value) {
+        called = value;
+      },
+    });
+
+    assert.strictEqual(called, __test.shouldKeepOutOfTaskbar(process.platform));
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a Windows taskbar leak where Clawd's floating pet/helper windows can remain visible after `explorer.exe` is restarted while Clawd is running.

Fixes #184

## Problem

On Windows, Clawd creates pet/helper `BrowserWindow`s with `skipTaskbar: true`.

After restarting Explorer, Windows can show extra taskbar entries:

- `Clawd` — mascot/pet preview
- `Clawd on Desk` — empty preview

Restarting Clawd hides them again.

## Reproduction

1. Start Clawd.
2. Confirm no pet/helper entries are visible in the Windows taskbar.
3. Restart Explorer:

   ```cmd
   taskkill /f /im explorer.exe
   start explorer.exe
   ```

4. Observe extra `Clawd` / `Clawd on Desk` taskbar entries.

## Root cause

The affected windows are created with `skipTaskbar: true`, but Windows shell/taskbar state can be recreated after Explorer restarts.

Creation-time `skipTaskbar` is therefore not always sufficient. Floating windows need to reassert taskbar-hidden state after relevant show/restore paths and after shell/taskbar recovery.

This is similar to the existing Linux workaround, where `setSkipTaskbar(true)` is re-applied after `showInactive()` because some Linux window managers reset the flag.

## Implementation

- Adds `src/taskbar.js` with shared helper logic to safely reassert `setSkipTaskbar(true)` for floating taskbar-hidden windows.
- Applies the helper on Windows and Linux where relevant.
- Centralizes the existing Linux `showInactive()` reassertion behavior instead of leaving it as repeated Linux-only call sites.
- Covers floating windows such as:
  - main pet window
  - hit/input helper window
  - second-instance restore path
  - permission bubble
  - update bubble
  - session HUD
- Adds watchdog reassertion for Windows shell/taskbar recovery after Explorer restarts, using the existing Windows topmost watchdog.
- Leaves Settings unchanged with `skipTaskbar: false`, so Settings can still appear in the taskbar.

## Behavior after this fix

After `explorer.exe` restarts, Windows may briefly show an Electron/Clawd taskbar entry while the shell is recovering.

The fix prevents the taskbar entry from lingering: within a few seconds, the watchdog/reassertion logic removes the floating pet/helper windows from the taskbar again.

## Verification

Automated:

- [x] `node --test test/taskbar.test.js`
- [x] `npm test`
  - Result: `1201 tests, 199 suites, 1199 pass, 2 skipped, 0 fail`

Manual Windows:

- [x] Start Clawd: no pet/helper taskbar entries.
- [x] Restart `explorer.exe` using the repro commands.
- [x] Confirm any transient Electron/Clawd taskbar entry disappears after the watchdog/reassertion logic runs.
- [x] Confirm no persistent `Clawd` / `Clawd on Desk` pet/helper taskbar entries remain.
- [x] Open Settings and verify Settings still appears in the taskbar and works normally.

## Test limitations

The Explorer restart/taskbar behavior is OS shell integration behavior. It is not reliably covered by unit tests without flaky or disruptive Windows UI automation.

The added unit tests cover the shared helper contract, including supported platform policy, safe no-op behavior, and `setSkipTaskbar(true)` reassertion behavior. The Windows watchdog integration is covered by manual verification.

A brief taskbar flash after Explorer restarts may still occur because Windows recreates shell/taskbar state before Clawd can reassert floating-window taskbar policy.