### PR TITLE
Fix Codex auto-review idle regression

### DIFF
--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -377,9 +377,15 @@ class CodexLogMonitor {
       tracked.sessionTitle = extractedTitle;
     }
 
-    // Approval heuristic: exec_command_end or function_call_output means command finished —
-    // clear pending approval timer (these events are not in logEventMap)
-    if (key === "event_msg:exec_command_end" || key === "response_item:function_call_output") {
+    // Approval heuristic: exec_command_end / function_call_output means command finished.
+    // guardian_assessment is Codex Desktop auto-review approving or checking the shell
+    // call before it runs; once present, the shell is not waiting on the user-facing
+    // approval prompt this heuristic is trying to infer.
+    if (
+      key === "event_msg:exec_command_end"
+      || key === "response_item:function_call_output"
+      || this._isGuardianApprovalActivity(payload)
+    ) {
       if (tracked.approvalTimer) {
         clearTimeout(tracked.approvalTimer);
         tracked.approvalTimer = null;
@@ -508,6 +514,12 @@ class CodexLogMonitor {
       if (typeof args.justification === "string" && args.justification.trim()) return true;
     } catch {}
     return false;
+  }
+
+  _isGuardianApprovalActivity(payload) {
+    if (!payload || typeof payload !== "object") return false;
+    if (payload.type !== "guardian_assessment") return false;
+    return payload.status === "in_progress" || payload.status === "approved";
   }
 
   // Extract UUID from rollout filename

--- a/agents/codex.js
+++ b/agents/codex.js
@@ -15,8 +15,9 @@ module.exports = {
     PostToolUse: "working",
     Stop: "codex-turn-end",
   },
-  // JSONL record type:subtype → pet state mapping
-  // ⚠️ Also duplicated in hooks/codex-remote-monitor.js (zero-dep requirement) — keep in sync
+  // JSONL record type:subtype → pet state mapping. The remote monitor keeps
+  // a zero-dep subset of this table; update both paths when adding shared
+  // Codex JSONL events.
   logEventMap: {
     "session_meta": "idle",
     "event_msg:task_started": "thinking",

--- a/agents/codex.js
+++ b/agents/codex.js
@@ -22,6 +22,7 @@ module.exports = {
     "event_msg:task_started": "thinking",
     "event_msg:user_message": "thinking",
     "event_msg:agent_message": null, // text output only — working is reserved for function_call
+    "event_msg:guardian_assessment": "working", // Codex Desktop auto-review/approval is active work, not terminal idle
     "event_msg:exec_command_end": "working",
     "event_msg:patch_apply_end": "working",
     "event_msg:custom_tool_call_output": "working",

--- a/hooks/codex-remote-monitor.js
+++ b/hooks/codex-remote-monitor.js
@@ -24,8 +24,10 @@ const { postStateToRunningServer, readHostPrefix } = require("./server-config");
 const SESSION_DIR = path.join(os.homedir(), ".codex", "sessions");
 const POLL_INTERVAL_MS = 1500;
 
-// JSONL record type[:subtype] → pet state
-// ⚠️ Duplicated from agents/codex.js logEventMap (zero-dep requirement) — keep in sync
+// JSONL record type[:subtype] → pet state. This standalone remote monitor keeps
+// a zero-dep subset of agents/codex.js because it posts final states directly
+// and does not carry the full local monitor's turn-end/approval heuristics.
+// Keep shared Codex JSONL event additions in sync where they affect both paths.
 const LOG_EVENT_MAP = {
   "session_meta": "idle",
   "event_msg:task_started": "thinking",

--- a/hooks/codex-remote-monitor.js
+++ b/hooks/codex-remote-monitor.js
@@ -31,6 +31,7 @@ const LOG_EVENT_MAP = {
   "event_msg:task_started": "thinking",
   "event_msg:user_message": "thinking",
   "event_msg:agent_message": "working",
+  "event_msg:guardian_assessment": "working",
   "response_item:function_call": "working",
   "response_item:custom_tool_call": "working",
   "response_item:web_search_call": "working",

--- a/src/main.js
+++ b/src/main.js
@@ -308,6 +308,7 @@ const CODEX_LOG_EVENTS_COVERED_BY_OFFICIAL_HOOKS = new Set([
   "session_meta",
   "event_msg:task_started",
   "event_msg:user_message",
+  "event_msg:guardian_assessment",
   "response_item:function_call",
   "response_item:custom_tool_call",
   "event_msg:exec_command_end",

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -469,6 +469,50 @@ describe("CodexLogMonitor", () => {
     }, 3000);
   });
 
+  it("should NOT emit codex-permission if guardian assessment starts before command end", (_, done) => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+      '{"type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\\"command\\":\\"npm run build\\"}"}}',
+      '{"type":"event_msg","payload":{"type":"guardian_assessment","status":"in_progress"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const states = [];
+    monitor = new CodexLogMonitor(config, (sid, state) => {
+      states.push(state);
+    });
+    monitor.start();
+
+    setTimeout(() => {
+      assert.ok(!states.includes("codex-permission"), "should not emit permission while auto-review is active");
+      assert.ok(states.includes("working"));
+      done();
+    }, 3000);
+  });
+
+  it("should return to working when guardian approves after an explicit permission signal", (_, done) => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+      '{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\\"cmd\\":\\"npm run build\\",\\"sandbox_permissions\\":\\"require_escalated\\",\\"justification\\":\\"needs local build\\"}"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const states = [];
+    monitor = new CodexLogMonitor(config, (sid, state) => {
+      states.push(state);
+      if (state === "codex-permission") {
+        fs.appendFileSync(testFile, '{"type":"event_msg","payload":{"type":"guardian_assessment","status":"approved"}}\n');
+      }
+      if (state === "working" && states.includes("codex-permission")) {
+        assert.deepStrictEqual(states, ["idle", "codex-permission", "working"]);
+        done();
+      }
+    });
+    monitor.start();
+  });
+
   it("should NOT emit codex-permission for non-shell function calls", (_, done) => {
     const testFile = path.join(dateDir, TEST_FILENAME);
     // web_search_call — not a shell command, no approval needed

--- a/test/main-codex-log-suppress.test.js
+++ b/test/main-codex-log-suppress.test.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+describe("main Codex official hook JSONL suppression", () => {
+  it("suppresses guardian_assessment for hook-active Codex sessions", () => {
+    const source = fs.readFileSync(path.join(__dirname, "..", "src", "main.js"), "utf8");
+    const match = source.match(/CODEX_LOG_EVENTS_COVERED_BY_OFFICIAL_HOOKS = new Set\(\[([\s\S]*?)\]\);/);
+    assert.ok(match, "main.js should define the Codex official hook suppression set");
+    assert.ok(
+      match[1].includes('"event_msg:guardian_assessment"'),
+      "guardian_assessment should not re-drive hook-active Codex sessions from JSONL"
+    );
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -156,6 +156,7 @@ describe("Agent Registry", () => {
     const codex = registry.getAgent("codex");
     assert.strictEqual(codex.logEventMap["session_meta"], "idle");
     assert.strictEqual(codex.logEventMap["event_msg:task_started"], "thinking");
+    assert.strictEqual(codex.logEventMap["event_msg:guardian_assessment"], "working");
     assert.strictEqual(codex.logEventMap["event_msg:exec_command_end"], "working");
     assert.strictEqual(codex.logEventMap["event_msg:patch_apply_end"], "working");
     assert.strictEqual(codex.logEventMap["event_msg:custom_tool_call_output"], "working");


### PR DESCRIPTION
## Summary

- Treat Codex Desktop `guardian_assessment` JSONL events as active Codex work.
- Cancel the inferred permission timer when auto-review starts or approves a shell call.
- Restore `working` after an explicit permission signal once guardian approval arrives.
- Keep the standalone remote Codex monitor mapping in sync.

Closes #188

## Testing

- `node --test test/codex-log-monitor.test.js`
- `node --test test/registry.test.js`
- `node --check agents/codex-log-monitor.js`
- `node --check hooks/codex-remote-monitor.js`
- `git diff --check`
- `npm test` *(1210 pass, 1 existing environment/process-walk failure in `test/shared-process.test.js`: `pidChain.length >= 1`)*
