### PR TITLE
fix(hooks): narrow PermissionRequest matcher to Bash (#46193 mitigation)

### DIFF
--- a/hooks/install.js
+++ b/hooks/install.js
@@ -468,7 +468,7 @@ function removeMatchingHttpHooks(entries, predicate) {
   return { entries: nextEntries, removed, changed };
 }
 
-function syncHttpHook(entries, expectedUrl) {
+function syncHttpHook(entries, expectedUrl, expectedMatcher) {
   let found = false;
   let changed = false;
   if (!Array.isArray(entries)) return { found, changed };
@@ -482,13 +482,31 @@ function syncHttpHook(entries, expectedUrl) {
       }
     }
     if (!Array.isArray(entry.hooks)) continue;
+    let entryHasClawd = false;
+    let entryAllClawd = entry.hooks.length > 0;
     for (const hook of entry.hooks) {
-      if (!isClawdPermissionHook(hook)) continue;
-      found = true;
-      if (hook.url !== expectedUrl) {
-        hook.url = expectedUrl;
-        changed = true;
+      if (isClawdPermissionHook(hook)) {
+        entryHasClawd = true;
+        found = true;
+        if (hook.url !== expectedUrl) {
+          hook.url = expectedUrl;
+          changed = true;
+        }
+      } else {
+        entryAllClawd = false;
       }
+    }
+    // Upgrade matcher on Clawd-owned entries that have a stale (e.g. legacy "")
+    // matcher. We only touch entries whose hooks are exclusively Clawd's, so we
+    // never modify user-authored entries that happen to bundle a Clawd hook.
+    if (
+      entryHasClawd
+      && entryAllClawd
+      && typeof expectedMatcher === "string"
+      && entry.matcher !== expectedMatcher
+    ) {
+      entry.matcher = expectedMatcher;
+      changed = true;
     }
   }
   return { found, changed };
@@ -501,9 +519,12 @@ function getHookServerPort(explicitPort) {
 // HTTP hooks: PermissionRequest uses bidirectional HTTP hook for permission decisions.
 // Claude Code fires PermissionRequest for tools needing approval (primarily Bash).
 // Edit/Write permissions are handled by Claude Code's own permission mode — not our hook.
+// We narrow the matcher to "Bash" so when Clawd's HTTP server is offline (ECONNREFUSED),
+// only Bash calls are affected — Edit/Write/mcp__* fall through to CC's native permission
+// flow instead of being silent-denied (upstream anthropics/claude-code#46193).
 const HTTP_HOOKS = {
   PermissionRequest: {
-    matcher: "",
+    matcher: "Bash",
     hook: {
       type: "http",
       url: "http://127.0.0.1:23333/permission",
@@ -736,7 +757,7 @@ function registerHooks(options = {}) {
     }
 
     const desiredHook = { ...hook, url: buildPermissionUrl(hookPort) };
-    const httpSync = syncHttpHook(settings.hooks[event], desiredHook.url);
+    const httpSync = syncHttpHook(settings.hooks[event], desiredHook.url, matcher);
     if (httpSync.found) {
       if (httpSync.changed) {
         updated++;

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -806,6 +806,110 @@ describe("Hook installer deprecated hook cleanup", () => {
   });
 });
 
+describe("Hook installer PermissionRequest matcher", () => {
+  function getPermissionEntries(settings) {
+    return (settings.hooks?.PermissionRequest ?? []).filter((entry) => {
+      if (!entry || typeof entry !== "object") return false;
+      if (!Array.isArray(entry.hooks)) return false;
+      return entry.hooks.some(
+        (h) => h && h.type === "http" && typeof h.url === "string" && h.url.includes("/permission")
+      );
+    });
+  }
+
+  it("registers PermissionRequest with matcher 'Bash' on fresh install", () => {
+    const settingsPath = makeTempSettings({});
+    registerHooks({
+      silent: true,
+      settingsPath,
+      claudeVersionInfo: { version: "2.1.112", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    const entries = getPermissionEntries(settings);
+    assert.strictEqual(entries.length, 1);
+    assert.strictEqual(entries[0].matcher, "Bash");
+  });
+
+  it("upgrades legacy Clawd PermissionRequest matcher '' -> 'Bash'", () => {
+    const settingsPath = makeTempSettings({
+      hooks: {
+        PermissionRequest: [
+          {
+            matcher: "",
+            hooks: [{ type: "http", url: "http://127.0.0.1:23333/permission", timeout: 600 }],
+          },
+        ],
+      },
+    });
+
+    const result = registerHooks({
+      silent: true,
+      settingsPath,
+      claudeVersionInfo: { version: "2.1.112", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    const entries = getPermissionEntries(settings);
+    assert.strictEqual(entries.length, 1);
+    assert.strictEqual(entries[0].matcher, "Bash");
+    assert.ok(result.updated >= 1);
+  });
+
+  it("is idempotent — second install does not churn matcher or duplicate entries", () => {
+    const settingsPath = makeTempSettings({});
+    registerHooks({
+      silent: true,
+      settingsPath,
+      claudeVersionInfo: { version: "2.1.112", source: "test", status: "known" },
+    });
+    const second = registerHooks({
+      silent: true,
+      settingsPath,
+      claudeVersionInfo: { version: "2.1.112", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    const entries = getPermissionEntries(settings);
+    assert.strictEqual(entries.length, 1);
+    assert.strictEqual(entries[0].matcher, "Bash");
+    assert.strictEqual(second.added, 0);
+    assert.strictEqual(second.updated, 0);
+  });
+
+  it("does not modify user-authored PermissionRequest entries (no Clawd marker)", () => {
+    const settingsPath = makeTempSettings({
+      hooks: {
+        PermissionRequest: [
+          {
+            matcher: "",
+            hooks: [{ type: "http", url: "http://localhost:9999/permission", timeout: 100 }],
+          },
+        ],
+      },
+    });
+
+    registerHooks({
+      silent: true,
+      settingsPath,
+      claudeVersionInfo: { version: "2.1.112", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    const userEntry = settings.hooks.PermissionRequest.find(
+      (e) => e.hooks?.[0]?.url === "http://localhost:9999/permission"
+    );
+    assert.ok(userEntry, "user entry should be preserved");
+    assert.strictEqual(userEntry.matcher, "", "user matcher must NOT be touched");
+
+    const clawdEntry = settings.hooks.PermissionRequest.find(
+      (e) => e.hooks?.[0]?.url?.startsWith("http://127.0.0.1:") && e !== userEntry
+    );
+    assert.ok(clawdEntry, "Clawd entry should be added");
+    assert.strictEqual(clawdEntry.matcher, "Bash");
+  });
+});
+
 describe("Hook installer unregisterHooks", () => {
   it("removes Clawd command hooks, HTTP hook, and auto-start while preserving third-party hooks", () => {
     const settingsPath = makeTempSettings({


### PR DESCRIPTION
## Summary
- Narrow the PermissionRequest HTTP hook matcher from `""` (match-everything) to `"Bash"` to reduce the blast radius of upstream [anthropics/claude-code#46193](https://github.com/anthropics/claude-code/issues/46193) (still open) — when Clawd's HTTP server is offline, CC currently silent-denies any tool call covered by the hook instead of falling through to the native permission flow.
- Edit / Write / mcp__* are already handled by CC's own permission mode (per the existing comment at `hooks/install.js:503`), so they should never have been routed through Clawd's hook in the first place.
- `syncHttpHook` learns an `expectedMatcher` parameter and idempotently rewrites *Clawd-owned* entries that have a stale matcher (e.g. legacy `""`). Only entries whose hooks array is exclusively Clawd-owned get touched — user-authored entries that happen to bundle a Clawd hook are left alone.

## Why this and not the full fix
The complete fix is to convert the PermissionRequest registration from an HTTP hook to a `command` wrapper hook (like `hooks/codex-hook.js`), so the wrapper can stdout `{}` (no-decision) when Clawd is offline and let CC fall through to its native prompt. That's a larger change behind its own ADR; this PR is the immediate-mitigation step that ships independently.

## Test plan
- [x] `npm test` — 4 new tests pass (fresh install writes `matcher:"Bash"`, legacy `""` upgrades to `"Bash"`, install is idempotent, user-authored entries are not touched). Pre-existing test failures are unrelated to this change (Claude version detection on Windows shims, Kiro Windows paths, updater visual flow — same set fails on baseline `main`).
- [x] Restart-free upgrade path: existing installs pick up the new matcher on next Clawd boot via `registerHooks` → `syncHttpHook` reconcile.
- [ ] Manual smoke on a live Claude Code session: `Bash ls` still routes through Clawd bubble; `Edit somefile` no longer routes through Clawd (falls through to CC native).

Refs: anthropics/claude-code#46193

🤖 Generated with [Claude Code](https://claude.com/claude-code)