### PR TITLE
Fix Codex desktop sessions never being cleaned up

### DIFF
--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -593,7 +593,12 @@ class CodexLogMonitor {
         // them silently instead of synthesizing a fake "sleeping" event.
         if (tracked.approvalTimer) clearTimeout(tracked.approvalTimer);
         if (tracked.hasEmittedState) {
-          this._emitStateChange(tracked, "sleeping", "stale-cleanup", {
+          // Use SessionEnd so state.js actually deletes the session entry.
+          // Codex desktop runs as a long-lived process — every conversation
+          // shares the same agentPid/sourcePid, so the timeout-based cleanup
+          // in cleanStaleSessions can never observe the source dying and
+          // would otherwise leave idle zombie sessions piling up forever.
+          this._emitStateChange(tracked, "sleeping", "SessionEnd", {
             sourcePid: tracked.agentPid,
             agentPid: tracked.agentPid,
           });

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -400,6 +400,39 @@ describe("CodexLogMonitor", () => {
     assert.strictEqual(monitor._tracked.size, 0);
   });
 
+  it("emits SessionEnd on stale cleanup so state.js deletes the session", (_, done) => {
+    // Codex desktop is a long-lived process: every conversation reuses the
+    // same agentPid/sourcePid, so cleanStaleSessions in state.js can never
+    // observe the source dying. The log monitor's stale cleanup is the only
+    // signal that triggers actual deletion — and it must be SessionEnd, not
+    // a regular state event, because only SessionEnd takes the delete path.
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+      '{"type":"event_msg","payload":{"type":"task_started"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const events = [];
+    monitor = new CodexLogMonitor(config, (sid, state, event, extra) => {
+      events.push({ sid, state, event, extra });
+      if (events.length === 2) {
+        for (const tracked of monitor._tracked.values()) {
+          tracked.lastEventTime = Date.now() - 301000;
+        }
+        monitor._cleanStaleFiles();
+
+        const last = events[events.length - 1];
+        assert.strictEqual(last.event, "SessionEnd");
+        assert.strictEqual(last.state, "sleeping");
+        assert.strictEqual(last.sid, EXPECTED_SID);
+        assert.strictEqual(monitor._tracked.size, 0);
+        done();
+      }
+    });
+    monitor.start();
+  });
+
   it("should handle corrupted JSON lines gracefully", (_, done) => {
     const testFile = path.join(dateDir, TEST_FILENAME);
     fs.writeFileSync(testFile, [


### PR DESCRIPTION
## Summary

Codex 桌面端会话在桌宠的 session 列表里永远不会被清理掉，导致每开一次新对话就累积一个 idle 僵尸条目。本 PR 改一行让 `codex-log-monitor` 的 stale cleanup 走和 `gemini-log-monitor` 一致的 `SessionEnd` 路径，让 `state.js` 真正删除会话。

## 问题分析

对照 `agents/gemini-log-monitor.js:281`（正确实现）：

```js
this._onStateChange(tracked.sessionId, "sleeping", "SessionEnd", { ... });
```

而 `agents/codex-log-monitor.js`（修复前）：

```js
this._emitStateChange(tracked, "sleeping", "stale-cleanup", { ... });
```

差别在事件名。`src/state.js:954` 里只有 `event === "SessionEnd"` 才会真正 `sessions.delete(sessionId)`；其他事件（包括 `\"stale-cleanup\"`）走 fallback 分支（`state.js:979-980`），把会话 reset 成 \`idle\` 并刷新 \`updatedAt\`，**不删除**。

接下来 `cleanStaleSessions()` 本来还有一道兜底，但对 Codex 桌面端这道兜底也失效：

- `agents/codex.js:41` 显式声明 `sessionEnd: false`（"no SessionEnd event, rely on task_complete + timeout"）
- Codex 桌面端是个**长期常驻进程**，新建会话不会启新进程
- 所有会话挂在同一个 \`agentPid\` / \`sourcePid\` 上，进程一直活着
- 清理逻辑（`state.js:1114, 1124, 1145`）只在源进程死掉时才删，进程不死 → 永远走到 \`s.state !== \"idle\"\` 那个分支只把状态设成 \`idle\`，下次循环已经是 idle 就什么也不做

结果就是：每个 Codex 会话开了之后留下一个 idle 僵尸，直到关掉桌宠才清干净。Codex CLI 没这个问题（CLI 退出 → 进程死 → 兜底清理生效），所以 bug 只在桌面端表现明显。

## 改前 vs 改后

| 场景 | 改前 | 改后 |
|---|---|---|
| 开 Codex 桌面端对话 | 列表里出现一条会话 | 一样 |
| 对话进行中状态切换 | 正常更新 | 一样 |
| 关掉对话/不再发消息 | 5 分钟后状态被改成 \`idle\`，然后**永远留着** | 5 分钟后会话被**删除**，列表里消失 |
| 同一 agent 开过 N 次对话 | 累积 N 个 idle 僵尸条目 | 只剩当前活跃的 |
| 关掉 Codex 桌面端 app | 所有历史会话还挂着，需要重启桌宠才清理 | 5 分钟内自动清干净 |
| 桌宠的整体状态优先级 | 被僵尸 idle 会话拽住，不容易进入 sleeping | 没活会话时能正确进入 sleeping |

### 副作用：长回合间隔下的 UI 抖动

Codex 桌面端有时回合间隔超过 5 分钟（代码注释里写 "3-5 min write cadence"）。如果某一回合间隔超过 5 分钟：

- 改前：会话被设成 idle 但条目还在，下一回合直接复用
- 改后：会话从列表消失，下一回合 Codex 写文件时 log monitor 用同一个 UUID 重新建一条

视觉上偶尔会看到「会话短暂消失又出现」。功能上没问题（同一 \`sessionId\`、状态正常重建），并且这正是 Gemini log monitor 已经在用的语义。

## Test plan

- [x] 新增回归测试：`test/codex-log-monitor.test.js` 里加 \`emits SessionEnd on stale cleanup so state.js deletes the session\`，断言 stale cleanup 时 emit 出去的事件名必须是 \`SessionEnd\`
- [x] \`node --test test/codex-log-monitor.test.js\` 全部 33 个测试通过
- [x] 全部 codex 相关测试套件（83 个测试）通过：codex-log-monitor / codex-hook / codex-install / codex-debug-hook / codex-debug-install / codex-notify-subgate / permission-codex-response / server-codex-permission
- [ ] 手动验证：在 Codex 桌面端开几个对话，关掉它们，5 分钟后看 session 列表是否清空

🤖 Generated with [Claude Code](https://claude.com/claude-code)