### PR TITLE
fix: respect disabled agents during hook sync

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -154,6 +154,11 @@ function _deferredStartMonitorForAgent(id) {
 function _deferredStopMonitorForAgent(id) {
   return stopMonitorForAgent(id);
 }
+function _deferredSyncIntegrationForAgent(id) {
+  return _server && typeof _server.syncIntegrationForAgent === "function"
+    ? _server.syncIntegrationForAgent(id)
+    : false;
+}
 function _deferredClearSessionsByAgent(id) {
   return _state && typeof _state.clearSessionsByAgent === "function"
     ? _state.clearSessionsByAgent(id)
@@ -199,6 +204,7 @@ const _settingsController = createSettingsController({
     setOpenAtLogin: _writeSystemOpenAtLogin,
     startMonitorForAgent: _deferredStartMonitorForAgent,
     stopMonitorForAgent: _deferredStopMonitorForAgent,
+    syncIntegrationForAgent: _deferredSyncIntegrationForAgent,
     clearSessionsByAgent: _deferredClearSessionsByAgent,
     dismissPermissionsByAgent: _deferredDismissPermissionsByAgent,
     resizePet: _deferredResizePet,

--- a/src/main.js
+++ b/src/main.js
@@ -159,6 +159,11 @@ function _deferredSyncIntegrationForAgent(id) {
     ? _server.syncIntegrationForAgent(id)
     : false;
 }
+function _deferredStopIntegrationForAgent(id) {
+  return _server && typeof _server.stopIntegrationForAgent === "function"
+    ? _server.stopIntegrationForAgent(id)
+    : false;
+}
 function _deferredClearSessionsByAgent(id) {
   return _state && typeof _state.clearSessionsByAgent === "function"
     ? _state.clearSessionsByAgent(id)
@@ -205,6 +210,7 @@ const _settingsController = createSettingsController({
     startMonitorForAgent: _deferredStartMonitorForAgent,
     stopMonitorForAgent: _deferredStopMonitorForAgent,
     syncIntegrationForAgent: _deferredSyncIntegrationForAgent,
+    stopIntegrationForAgent: _deferredStopIntegrationForAgent,
     clearSessionsByAgent: _deferredClearSessionsByAgent,
     dismissPermissionsByAgent: _deferredDismissPermissionsByAgent,
     resizePet: _deferredResizePet,

--- a/src/server.js
+++ b/src/server.js
@@ -368,6 +368,11 @@ function shouldManageClaudeHooks() {
   return ctx.manageClaudeHooksAutomatically !== false;
 }
 
+function isAgentEnabled(agentId) {
+  if (typeof ctx.isAgentEnabled !== "function") return true;
+  return ctx.isAgentEnabled(agentId) !== false;
+}
+
 function getClaudeSettingsDir() {
   return typeof ctx.claudeSettingsDir === "string"
     ? ctx.claudeSettingsDir
@@ -497,6 +502,39 @@ function syncOpencodePlugin() {
     }
   } catch (err) {
     console.warn("Clawd: failed to sync opencode plugin:", err.message);
+  }
+}
+
+const AGENT_INTEGRATION_SYNCERS = Object.freeze({
+  "gemini-cli": syncGeminiHooks,
+  "cursor-agent": syncCursorHooks,
+  codebuddy: syncCodeBuddyHooks,
+  "kiro-cli": syncKiroHooks,
+  "kimi-cli": syncKimiHooks,
+  codex: syncCodexHooks,
+  opencode: syncOpencodePlugin,
+});
+
+function syncIntegrationForAgent(agentId) {
+  if (agentId === "claude-code") {
+    if (!shouldManageClaudeHooks()) return false;
+    syncClawdHooks();
+    startClaudeSettingsWatcher();
+    return true;
+  }
+  const sync = AGENT_INTEGRATION_SYNCERS[agentId];
+  if (typeof sync !== "function") return false;
+  sync();
+  return true;
+}
+
+function syncEnabledStartupIntegrations() {
+  if (shouldManageClaudeHooks() && isAgentEnabled("claude-code")) {
+    syncClawdHooks();
+    startClaudeSettingsWatcher();
+  }
+  for (const [agentId, sync] of Object.entries(AGENT_INTEGRATION_SYNCERS)) {
+    if (isAgentEnabled(agentId)) sync();
   }
 }
 
@@ -1070,17 +1108,7 @@ function startHttpServer() {
     // and they operate on independent files for independent agents, so
     // none of them need to block the HTTP server from accepting traffic.
     setImmediateFn(() => {
-      if (shouldManageClaudeHooks()) {
-        syncClawdHooks();
-        startClaudeSettingsWatcher();
-      }
-      syncGeminiHooks();
-      syncCursorHooks();
-      syncCodeBuddyHooks();
-      syncKiroHooks();
-      syncKimiHooks();
-      syncCodexHooks();
-      syncOpencodePlugin();
+      syncEnabledStartupIntegrations();
     });
   });
 
@@ -1104,6 +1132,7 @@ return {
   syncKimiHooks,
   syncCodexHooks,
   syncOpencodePlugin,
+  syncIntegrationForAgent,
   startClaudeSettingsWatcher,
   stopClaudeSettingsWatcher,
   cleanup,

--- a/src/server.js
+++ b/src/server.js
@@ -528,6 +528,11 @@ function syncIntegrationForAgent(agentId) {
   return true;
 }
 
+function stopIntegrationForAgent(agentId) {
+  if (agentId !== "claude-code") return false;
+  return stopClaudeSettingsWatcher();
+}
+
 function syncEnabledStartupIntegrations() {
   if (shouldManageClaudeHooks() && isAgentEnabled("claude-code")) {
     syncClawdHooks();
@@ -575,6 +580,7 @@ function startClaudeSettingsWatcher() {
       if (settingsWatchDebounceTimer) return;
       settingsWatchDebounceTimer = setTimeoutFn(() => {
         settingsWatchDebounceTimer = null;
+        if (!shouldManageClaudeHooks() || !isAgentEnabled("claude-code")) return;
         // Rate-limit: don't re-sync within 5s to avoid write wars with CC-Switch
         if (nowFn() - settingsWatchLastSyncTime < settingsWatchRateLimitMs) return;
         try {
@@ -1133,6 +1139,7 @@ return {
   syncCodexHooks,
   syncOpencodePlugin,
   syncIntegrationForAgent,
+  stopIntegrationForAgent,
   startClaudeSettingsWatcher,
   stopClaudeSettingsWatcher,
   cleanup,

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -848,6 +848,7 @@ function setAgentFlag(payload, deps) {
         if (typeof deps.clearSessionsByAgent === "function") deps.clearSessionsByAgent(agentId);
         if (typeof deps.dismissPermissionsByAgent === "function") deps.dismissPermissionsByAgent(agentId);
       } else {
+        if (typeof deps.syncIntegrationForAgent === "function") deps.syncIntegrationForAgent(agentId);
         if (typeof deps.startMonitorForAgent === "function") deps.startMonitorForAgent(agentId);
       }
     } else if (flag === "permissionsEnabled") {

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -49,6 +49,7 @@
 // keep validate side-effect-free.
 
 const { CURRENT_VERSION, AGENT_FLAGS, normalizeThemeOverrides } = require("./prefs");
+const { isAgentEnabled } = require("./agent-gate");
 const { isValidDisplaySnapshot } = require("./work-area");
 const {
   MAX_AUTO_CLOSE_SECONDS,
@@ -355,6 +356,9 @@ const updateRegistry = {
       }
       try {
         if (value) {
+          if (!isAgentEnabled(deps.snapshot, "claude-code")) {
+            return { status: "ok" };
+          }
           deps.syncClaudeHooksNow();
           deps.startClaudeSettingsWatcher();
         } else {
@@ -844,6 +848,9 @@ function setAgentFlag(payload, deps) {
   try {
     if (flag === "enabled") {
       if (!value) {
+        if (agentId === "claude-code" && typeof deps.stopIntegrationForAgent === "function") {
+          deps.stopIntegrationForAgent(agentId);
+        }
         if (typeof deps.stopMonitorForAgent === "function") deps.stopMonitorForAgent(agentId);
         if (typeof deps.clearSessionsByAgent === "function") deps.clearSessionsByAgent(agentId);
         if (typeof deps.dismissPermissionsByAgent === "function") deps.dismissPermissionsByAgent(agentId);

--- a/test/agent-gate.test.js
+++ b/test/agent-gate.test.js
@@ -177,6 +177,7 @@ describe("setAgentFlag command", () => {
       stopMonitorForAgent: [],
       clearSessionsByAgent: [],
       dismissPermissionsByAgent: [],
+      syncIntegrationForAgent: [],
     };
     return {
       calls,
@@ -186,6 +187,7 @@ describe("setAgentFlag command", () => {
         stopMonitorForAgent: (id) => calls.stopMonitorForAgent.push(id),
         clearSessionsByAgent: (id) => calls.clearSessionsByAgent.push(id),
         dismissPermissionsByAgent: (id) => calls.dismissPermissionsByAgent.push(id),
+        syncIntegrationForAgent: (id) => calls.syncIntegrationForAgent.push(id),
         ...overrides,
       },
     };
@@ -243,7 +245,7 @@ describe("setAgentFlag command", () => {
     assert.strictEqual(r.commit.agents["claude-code"].enabled, true);
   });
 
-  it("enabling a previously-disabled agent starts the monitor", () => {
+  it("enabling a previously-disabled agent syncs its integration and starts the monitor", () => {
     const seeded = prefs.getDefaults();
     seeded.agents.codex = { enabled: false, permissionsEnabled: true };
     const { deps, calls } = makeDeps({ snapshot: seeded });
@@ -252,6 +254,7 @@ describe("setAgentFlag command", () => {
       deps
     );
     assert.strictEqual(r.status, "ok");
+    assert.deepStrictEqual(calls.syncIntegrationForAgent, ["codex"]);
     assert.deepStrictEqual(calls.startMonitorForAgent, ["codex"]);
     assert.strictEqual(calls.stopMonitorForAgent.length, 0);
     assert.strictEqual(r.commit.agents.codex.enabled, true);

--- a/test/agent-gate.test.js
+++ b/test/agent-gate.test.js
@@ -178,6 +178,7 @@ describe("setAgentFlag command", () => {
       clearSessionsByAgent: [],
       dismissPermissionsByAgent: [],
       syncIntegrationForAgent: [],
+      stopIntegrationForAgent: [],
     };
     return {
       calls,
@@ -188,6 +189,7 @@ describe("setAgentFlag command", () => {
         clearSessionsByAgent: (id) => calls.clearSessionsByAgent.push(id),
         dismissPermissionsByAgent: (id) => calls.dismissPermissionsByAgent.push(id),
         syncIntegrationForAgent: (id) => calls.syncIntegrationForAgent.push(id),
+        stopIntegrationForAgent: (id) => calls.stopIntegrationForAgent.push(id),
         ...overrides,
       },
     };
@@ -237,6 +239,7 @@ describe("setAgentFlag command", () => {
       deps
     );
     assert.strictEqual(r.status, "ok");
+    assert.strictEqual(calls.stopIntegrationForAgent.length, 0);
     assert.deepStrictEqual(calls.stopMonitorForAgent, ["codex"]);
     assert.deepStrictEqual(calls.clearSessionsByAgent, ["codex"]);
     assert.deepStrictEqual(calls.dismissPermissionsByAgent, ["codex"]);
@@ -258,6 +261,22 @@ describe("setAgentFlag command", () => {
     assert.deepStrictEqual(calls.startMonitorForAgent, ["codex"]);
     assert.strictEqual(calls.stopMonitorForAgent.length, 0);
     assert.strictEqual(r.commit.agents.codex.enabled, true);
+  });
+
+  it("disabling Claude Code stops its integration watcher before commit", () => {
+    const seeded = prefs.getDefaults();
+    seeded.agents["claude-code"] = { enabled: true, permissionsEnabled: true };
+    const { deps, calls } = makeDeps({ snapshot: seeded });
+    const r = commandRegistry.setAgentFlag(
+      { agentId: "claude-code", flag: "enabled", value: false },
+      deps
+    );
+    assert.strictEqual(r.status, "ok");
+    assert.deepStrictEqual(calls.stopIntegrationForAgent, ["claude-code"]);
+    assert.deepStrictEqual(calls.stopMonitorForAgent, ["claude-code"]);
+    assert.deepStrictEqual(calls.clearSessionsByAgent, ["claude-code"]);
+    assert.deepStrictEqual(calls.dismissPermissionsByAgent, ["claude-code"]);
+    assert.strictEqual(r.commit.agents["claude-code"].enabled, false);
   });
 
   it("toggling master flag preserves permissionsEnabled (no silent wipe)", () => {

--- a/test/server-hook-management.test.js
+++ b/test/server-hook-management.test.js
@@ -257,6 +257,21 @@ describe("server Claude hook management", () => {
     assert.deepStrictEqual(syncCalls, []);
   });
 
+  it("watcher does not re-sync missing Claude hooks while Claude Code is disabled", () => {
+    let claudeEnabled = true;
+    const { api, syncCalls, timers, getWatcher, setSettingsRaw } = makeServer({
+      isAgentEnabled: (agentId) => agentId !== "claude-code" || claudeEnabled,
+    });
+
+    api.startClaudeSettingsWatcher();
+    claudeEnabled = false;
+    setSettingsRaw('{"hooks":{}}');
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.deepStrictEqual(syncCalls, []);
+  });
+
   it("disconnect-style restart does not reinstall Claude hooks when management stays disabled", () => {
     const first = makeServer({ manageClaudeHooksAutomatically: false });
     first.api.startHttpServer();

--- a/test/server-hook-management.test.js
+++ b/test/server-hook-management.test.js
@@ -112,6 +112,7 @@ function makeServer(overrides = {}) {
     syncCursorHooksImpl: () => syncCalls.push("cursor"),
     syncCodeBuddyHooksImpl: () => syncCalls.push("codebuddy"),
     syncKiroHooksImpl: () => syncCalls.push("kiro"),
+    syncKimiHooksImpl: () => syncCalls.push("kimi"),
     syncCodexHooksImpl: () => syncCalls.push("codex"),
     syncOpencodePluginImpl: () => syncCalls.push("opencode"),
     ...overrides,
@@ -135,7 +136,7 @@ describe("server Claude hook management", () => {
 
     api.startHttpServer();
 
-    assert.deepStrictEqual(syncCalls, ["claude", "gemini", "cursor", "codebuddy", "kiro", "codex", "opencode"]);
+    assert.deepStrictEqual(syncCalls, ["claude", "gemini", "cursor", "codebuddy", "kiro", "kimi", "codex", "opencode"]);
     assert.ok(getWatcher(), "watcher should start when management is enabled");
   });
 
@@ -146,7 +147,30 @@ describe("server Claude hook management", () => {
 
     api.startHttpServer();
 
-    assert.deepStrictEqual(syncCalls, ["gemini", "cursor", "codebuddy", "kiro", "codex", "opencode"]);
+    assert.deepStrictEqual(syncCalls, ["gemini", "cursor", "codebuddy", "kiro", "kimi", "codex", "opencode"]);
+    assert.strictEqual(getWatcher(), null);
+  });
+
+  it("startup skips automatic hook/plugin sync for disabled agents", () => {
+    const disabled = new Set(["gemini-cli", "cursor-agent", "kiro-cli", "opencode"]);
+    const { api, syncCalls, getWatcher } = makeServer({
+      isAgentEnabled: (agentId) => !disabled.has(agentId),
+    });
+
+    api.startHttpServer();
+
+    assert.deepStrictEqual(syncCalls, ["claude", "codebuddy", "kimi", "codex"]);
+    assert.ok(getWatcher(), "Claude watcher should still start when Claude is enabled");
+  });
+
+  it("startup skips Claude hook sync and watcher when Claude Code is disabled", () => {
+    const { api, syncCalls, getWatcher } = makeServer({
+      isAgentEnabled: (agentId) => agentId !== "claude-code",
+    });
+
+    api.startHttpServer();
+
+    assert.deepStrictEqual(syncCalls, ["gemini", "cursor", "codebuddy", "kiro", "kimi", "codex", "opencode"]);
     assert.strictEqual(getWatcher(), null);
   });
 
@@ -241,8 +265,8 @@ describe("server Claude hook management", () => {
     const second = makeServer({ manageClaudeHooksAutomatically: false });
     second.api.startHttpServer();
 
-    assert.deepStrictEqual(first.syncCalls, ["gemini", "cursor", "codebuddy", "kiro", "codex", "opencode"]);
-    assert.deepStrictEqual(second.syncCalls, ["gemini", "cursor", "codebuddy", "kiro", "codex", "opencode"]);
+    assert.deepStrictEqual(first.syncCalls, ["gemini", "cursor", "codebuddy", "kiro", "kimi", "codex", "opencode"]);
+    assert.deepStrictEqual(second.syncCalls, ["gemini", "cursor", "codebuddy", "kiro", "kimi", "codex", "opencode"]);
   });
 });
 

--- a/test/settings-actions.test.js
+++ b/test/settings-actions.test.js
@@ -295,6 +295,25 @@ describe("object-form effects (autoStartWithClaude / manageClaudeHooksAutomatica
     assert.strictEqual(stopCalls, 0);
   });
 
+  it("manageClaudeHooksAutomatically effect skips side effects on true when Claude Code is disabled", () => {
+    let syncCalls = 0;
+    let startCalls = 0;
+    let stopCalls = 0;
+    const snapshot = prefs.getDefaults();
+    snapshot.agents["claude-code"].enabled = false;
+    const deps = {
+      snapshot,
+      syncClaudeHooksNow: () => syncCalls++,
+      startClaudeSettingsWatcher: () => startCalls++,
+      stopClaudeSettingsWatcher: () => stopCalls++,
+    };
+    const r = updateRegistry.manageClaudeHooksAutomatically.effect(true, deps);
+    assert.deepStrictEqual(r, { status: "ok" });
+    assert.strictEqual(syncCalls, 0);
+    assert.strictEqual(startCalls, 0);
+    assert.strictEqual(stopCalls, 0);
+  });
+
   it("manageClaudeHooksAutomatically effect stops watcher on false", () => {
     let syncCalls = 0;
     let startCalls = 0;


### PR DESCRIPTION
## Summary
- Gate startup hook/plugin sync by each agent's enabled setting.
- Keep Claude hook management behind both manageClaudeHooksAutomatically and claude-code enabled.
- Sync an agent's integration once when it is re-enabled from Settings, without uninstalling existing hooks on disable.
- Add regression coverage for disabled-agent startup sync and re-enable behavior.

## Test Plan
- node --test test/server-hook-management.test.js
- node --test test/agent-gate.test.js
- npm ci
- npm test *(currently fails in this Linux/Node 20 environment on existing platform-path tests in test/install.test.js and test/kiro-install.test.js; targeted regression tests pass)*