### PR TITLE
fix: handle long MCP tool names in permission bubble

### DIFF
--- a/src/bubble.html
+++ b/src/bubble.html
@@ -103,8 +103,11 @@ body { padding: 6px; }
 /* ── Header ── */
 .header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
   margin-bottom: 0;
 }
 .header-title {
@@ -112,12 +115,15 @@ body { padding: 6px; }
   font-weight: 600;
   color: var(--header-color);
   letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 /* ── Tool pill ── */
 .tool-pill {
   display: inline-flex;
   align-items: center;
+  max-width: 100%;
+  min-width: 0;
   padding: 3px 8px;
   border-radius: 6px;
   font-size: 11px;
@@ -126,6 +132,26 @@ body { padding: 6px; }
   color: #fff;
   letter-spacing: 0.05em;
   background: #52525b;
+  overflow: hidden;
+  cursor: default;
+}
+.tool-pill-text {
+  display: inline-block;
+  min-width: 0;
+  max-width: 100%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  will-change: transform;
+}
+.tool-pill.is-marquee:hover > .tool-pill-text {
+  text-overflow: clip;
+  overflow: visible;
+  animation: pill-marquee 1.5s ease-in-out 1 forwards;
+}
+@keyframes pill-marquee {
+  from { transform: translateX(0); }
+  to   { transform: translateX(var(--marquee-shift, 0)); }
 }
 .tool-pill[data-tool="Bash"]  { background: #d97757; }
 .tool-pill[data-tool="Edit"]  { background: #5b8dd9; }
@@ -442,7 +468,7 @@ body { padding: 6px; }
 <div class="card" id="card">
   <div class="header">
     <span class="header-title">Permission Request</span>
-    <span class="tool-pill" id="toolPill"></span>
+    <span class="tool-pill" id="toolPill"><span class="tool-pill-text" id="toolPillText"></span></span>
   </div>
 
   <div class="session-tag" id="sessionTag"></div>
@@ -462,6 +488,19 @@ body { padding: 6px; }
 <script>
 const card = document.getElementById("card");
 const toolPill = document.getElementById("toolPill");
+const toolPillText = document.getElementById("toolPillText");
+function stopMarquee() {
+  toolPill.classList.remove("is-marquee");
+  toolPill.style.removeProperty("--marquee-shift");
+}
+function startMarqueeIfOverflowing() {
+  const overflow = toolPillText.scrollWidth - toolPillText.clientWidth;
+  if (overflow <= 0) return;
+  toolPill.style.setProperty("--marquee-shift", `-${overflow}px`);
+  toolPill.classList.add("is-marquee");
+}
+toolPill.addEventListener("mouseenter", startMarqueeIfOverflowing);
+toolPill.addEventListener("mouseleave", stopMarquee);
 const commandBlock = document.getElementById("commandBlock");
 const elicitationForm = document.getElementById("elicitationForm");
 const elicitationProgress = document.getElementById("elicitationProgress");
@@ -743,6 +782,7 @@ function resetBubbleContent() {
   elicitationProgress.textContent = "";
   elicitationProgress.classList.remove("visible");
   toolPill.style.display = "";
+  stopMarquee();
   btnAllow.style.display = "";
   btnAllow.disabled = false;
   btnDeny.style.display = "";
@@ -1063,7 +1103,7 @@ function show(data) {
 
     const rawName = data.toolName || "unknown";
     const displayName = rawName.charAt(0).toUpperCase() + rawName.slice(1);
-    toolPill.textContent = displayName;
+    toolPillText.textContent = displayName;
     toolPill.setAttribute("data-tool", displayName);
     toolPill.style.display = "";
 
@@ -1130,7 +1170,7 @@ function show(data) {
   // Codex notify mode — informational bubble with Dismiss button only
   if (data.toolName === "CodexExec") {
     headerTitle.textContent = bubbleText(data.lang, "codexPermission");
-    toolPill.textContent = "CODEX";
+    toolPillText.textContent = "CODEX";
     toolPill.setAttribute("data-tool", "CodexExec");
     toolPill.style.display = "";
     commandBlock.textContent = (data.toolInput && data.toolInput.command) || "(unknown)";
@@ -1145,7 +1185,7 @@ function show(data) {
   // Kimi notify mode — informational bubble with Dismiss button only
   if (data.toolName === "KimiPermission") {
     headerTitle.textContent = bubbleText(data.lang, "kimiPermission");
-    toolPill.textContent = "KIMI";
+    toolPillText.textContent = "KIMI";
     toolPill.setAttribute("data-tool", "KimiPermission");
     toolPill.style.display = "";
     commandBlock.textContent = (data.toolInput && data.toolInput.command) || bubbleText(data.lang, "checkKimiTerminal");
@@ -1167,7 +1207,7 @@ function show(data) {
   btnDeny.style.display = isPlanReview ? "none" : "";
 
   // Tool pill
-  toolPill.textContent = data.toolName || "Unknown";
+  toolPillText.textContent = data.toolName || "Unknown";
   toolPill.setAttribute("data-tool", data.toolName || "");
 
   // Command block (textContent only — never innerHTML)


### PR DESCRIPTION
Long MCP tool names like `MCP__CLAUDE_IN_CHROME__TABS_CONTEXT_MCP`
overflow the permission bubble header in every locale, pushing the
title into an awkward wrap (especially obvious with CJK characters
that break per-glyph).

**Changes**
- Stack header title and tool pill vertically.
- Ellipsize the pill when it exceeds the card width.
- On hover, marquee-scroll the pill once to reveal the full label;
  return to start on pointer leave.

**Before**
<img width="340" height="264" alt="스크린샷 2026-04-28 22 58 53" src="https://github.com/user-attachments/assets/1d03ee4b-423a-4178-b136-ac4b392a780e" />
<img width="340" height="228" alt="스크린샷 2026-04-28 22 58 36" src="https://github.com/user-attachments/assets/c2ffed0d-9b68-42c0-ad4b-9fd882c82d45" />
<img width="340" height="266" alt="스크린샷 2026-04-28 13 57 09" src="https://github.com/user-attachments/assets/dc2243bb-3e29-49e2-b31c-3bbb1e1f7385" />

---

**After**

https://github.com/user-attachments/assets/083d0682-2568-405b-ac07-b917a7fa1e29

<img width="340" height="238" alt="스크린샷 2026-04-28 23 25 08" src="https://github.com/user-attachments/assets/7d84882a-f9c9-4cb0-afc2-db9ce88e06fb" />
<img width="340" height="238" alt="스크린샷 2026-04-28 23 25 20" src="https://github.com/user-attachments/assets/1c590748-0fa4-439b-b600-a65ce3ba8849" />
