### PR TITLE
fix: arrow key navigation between options and Other textarea in elicitation bubble

### DIFF
--- a/src/bubble.html
+++ b/src/bubble.html
@@ -932,29 +932,25 @@ function createElicitationQuestionCard(question, questionIndex) {
     updateElicitationSubmitState();
   });
   // Enter activates the primary action when it is enabled; Shift+Enter inserts a newline.
-  // ArrowUp when cursor is at position 0 escapes back to the last preset radio option,
-  // matching CLI arrow-key navigation behaviour where Up always moves to the previous item.
+  // ArrowUp from the start of Other returns focus to the last preset option.
   otherTextarea.addEventListener("keydown", (e) => {
     if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
       e.preventDefault();
       if (!btnAllow.disabled) btnAllow.click();
       return;
     }
-    if ((e.key === "ArrowUp" || e.key === "ArrowDown") && !e.shiftKey && !e.isComposing) {
-      // Only escape when the textarea is empty OR cursor is at the very start (ArrowUp)
-      // or very end (ArrowDown). This avoids hijacking multi-line navigation inside a
-      // filled textarea.
+    if (e.key === "ArrowUp" && !e.shiftKey && !e.isComposing) {
       const atStart = otherTextarea.selectionStart === 0 && otherTextarea.selectionEnd === 0;
-      const atEnd = otherTextarea.selectionStart === otherTextarea.value.length
-        && otherTextarea.selectionEnd === otherTextarea.value.length;
       const isEmpty = otherTextarea.value.length === 0;
-      const shouldEscape = isEmpty || (e.key === "ArrowUp" && atStart) || (e.key === "ArrowDown" && atEnd);
+      const shouldEscape = isEmpty || atStart;
       if (shouldEscape) {
         e.preventDefault();
-        // Focus the last preset radio (ArrowUp) or first preset radio (ArrowDown).
-        const radios = optionList.querySelectorAll(`input[name="elicitation-${questionIndex}"]:not([data-other])`);
-        const target = e.key === "ArrowUp" ? radios[radios.length - 1] : radios[0];
-        if (target) { target.focus(); target.click(); }
+        const presetInputs = optionList.querySelectorAll(`input[name="elicitation-${questionIndex}"]:not([data-other])`);
+        const target = presetInputs[presetInputs.length - 1];
+        if (target) {
+          target.focus();
+          if (!question.multiSelect) target.click();
+        }
       }
     }
   });
@@ -974,8 +970,7 @@ function createElicitationQuestionCard(question, questionIndex) {
     setElicitationSelection(question, questionIndex, ELICITATION_OTHER_KEY, otherInput.checked);
     updateOtherTextarea();
   });
-  // ArrowDown on the "Other" radio (when textarea is visible) moves focus into the textarea,
-  // completing the loop: radio list ↔ ArrowUp/Down ↔ Other textarea.
+  // ArrowDown on Other moves focus into the textarea when it is visible.
   otherInput.addEventListener("keydown", (e) => {
     if (e.key === "ArrowDown" && !e.shiftKey && !e.isComposing) {
       const ta = optionList.querySelector("[data-other-textarea]");

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -932,10 +932,30 @@ function createElicitationQuestionCard(question, questionIndex) {
     updateElicitationSubmitState();
   });
   // Enter activates the primary action when it is enabled; Shift+Enter inserts a newline.
+  // ArrowUp when cursor is at position 0 escapes back to the last preset radio option,
+  // matching CLI arrow-key navigation behaviour where Up always moves to the previous item.
   otherTextarea.addEventListener("keydown", (e) => {
     if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
       e.preventDefault();
       if (!btnAllow.disabled) btnAllow.click();
+      return;
+    }
+    if ((e.key === "ArrowUp" || e.key === "ArrowDown") && !e.shiftKey && !e.isComposing) {
+      // Only escape when the textarea is empty OR cursor is at the very start (ArrowUp)
+      // or very end (ArrowDown). This avoids hijacking multi-line navigation inside a
+      // filled textarea.
+      const atStart = otherTextarea.selectionStart === 0 && otherTextarea.selectionEnd === 0;
+      const atEnd = otherTextarea.selectionStart === otherTextarea.value.length
+        && otherTextarea.selectionEnd === otherTextarea.value.length;
+      const isEmpty = otherTextarea.value.length === 0;
+      const shouldEscape = isEmpty || (e.key === "ArrowUp" && atStart) || (e.key === "ArrowDown" && atEnd);
+      if (shouldEscape) {
+        e.preventDefault();
+        // Focus the last preset radio (ArrowUp) or first preset radio (ArrowDown).
+        const radios = optionList.querySelectorAll(`input[name="elicitation-${questionIndex}"]:not([data-other])`);
+        const target = e.key === "ArrowUp" ? radios[radios.length - 1] : radios[0];
+        if (target) { target.focus(); target.click(); }
+      }
     }
   });
   optionList.appendChild(otherTextarea);
@@ -953,6 +973,17 @@ function createElicitationQuestionCard(question, questionIndex) {
   otherInput.addEventListener("change", () => {
     setElicitationSelection(question, questionIndex, ELICITATION_OTHER_KEY, otherInput.checked);
     updateOtherTextarea();
+  });
+  // ArrowDown on the "Other" radio (when textarea is visible) moves focus into the textarea,
+  // completing the loop: radio list ↔ ArrowUp/Down ↔ Other textarea.
+  otherInput.addEventListener("keydown", (e) => {
+    if (e.key === "ArrowDown" && !e.shiftKey && !e.isComposing) {
+      const ta = optionList.querySelector("[data-other-textarea]");
+      if (ta && ta.classList.contains("visible")) {
+        e.preventDefault();
+        ta.focus();
+      }
+    }
   });
   if (!question.multiSelect) {
     optionList.querySelectorAll("input[type=radio]").forEach(r => {

--- a/test/bubble-elicitation-other.test.js
+++ b/test/bubble-elicitation-other.test.js
@@ -33,4 +33,16 @@ describe("AskUserQuestion bubble Other option", () => {
     assert.match(bubbleHtml, /if \(!otherText\) return "";/);
     assert.match(bubbleHtml, /for \(const el of elicitationForm\.querySelectorAll\("input, textarea, button"\)\) el\.disabled = true;/);
   });
+
+  it("keeps Other arrow navigation narrow and avoids checkbox toggles", () => {
+    assert.match(bubbleHtml, /if \(e\.key === "ArrowUp" && !e\.shiftKey && !e\.isComposing\) \{/);
+    assert.match(bubbleHtml, /const shouldEscape = isEmpty \|\| atStart;/);
+    assert.match(bubbleHtml, /if \(!question\.multiSelect\) target\.click\(\);/);
+    assert.match(
+      bubbleHtml,
+      /otherInput\.addEventListener\("keydown", \(e\) => \{[\s\S]*?e\.key === "ArrowDown"[\s\S]*?ta\.focus\(\);/
+    );
+    assert.doesNotMatch(bubbleHtml, /if \(target\) \{ target\.focus\(\); target\.click\(\); \}/);
+    assert.doesNotMatch(bubbleHtml, /const atEnd = otherTextarea\.selectionStart === otherTextarea\.value\.length/);
+  });
 });


### PR DESCRIPTION
Fixes #203

## Problem

When `AskUserQuestion` shows and the user navigates to **Other**, the textarea gets DOM focus. Arrow keys are then captured by the browser for text cursor movement — there's no way to navigate back to preset options with the keyboard, unlike the CLI where ↑/↓ always move between options.

## Fix

Two changes in `src/bubble.html`:

**1. `otherTextarea` keydown handler**
- ↑ when cursor is at position 0 (or textarea is empty) → `focus() + click()` the last preset radio
- ↓ when cursor is at the end (or textarea is empty) → focus the first preset radio
- Multi-line text editing unaffected when cursor is not at boundary

**2. `otherInput` keydown handler (new)**
- ↓ when the textarea is visible → move focus into the textarea
- Completes the bidirectional loop: `radio list ↔ ArrowUp/Down ↔ Other textarea`

## Test

1. Trigger any `AskUserQuestion` with multiple options
2. Press ↓ to reach **Other** — textarea appears, focus enters it
3. Press ↑ — focus returns to last preset radio and it becomes selected ✅
4. Press ↓ from the Other radio — focus moves into the textarea ✅

<img width="1070" height="1140" alt="clawd" src="https://github.com/user-attachments/assets/836d67be-be00-4655-8898-f991d8e6e67c" />
