### PR TITLE
fix: complete elicitation keyboard UX — window focus, no scroll, auto-select first option

### DIFF
--- a/src/bubble.html
+++ b/src/bubble.html
@@ -669,15 +669,25 @@ function measureNaturalBubbleHeight() {
 }
 
 function applyElicitationViewport() {
-  if (!elicitationMode || !elicitationForm.classList.contains("visible")) return;
-  const cardRect = card.getBoundingClientRect();
-  const formRect = elicitationForm.getBoundingClientRect();
-  const fixedCardHeight = Math.max(0, cardRect.height - formRect.height);
-  const availableFormHeight = Math.floor(window.innerHeight - BUBBLE_BODY_PADDING_Y - fixedCardHeight);
-  const maxFormHeight = Math.max(MIN_ELICITATION_FORM_HEIGHT, availableFormHeight);
-
-  elicitationForm.style.maxHeight = `${maxFormHeight}px`;
-  card.classList.add("elicitation-scrollable");
+  // Intentionally a no-op.
+  //
+  // Previously this function clamped the elicitation form's maxHeight and added
+  // the `elicitation-scrollable` class (overflow-y: auto). The scroll container
+  // caused arrow keys to scroll the div instead of navigating between radio
+  // options — even with preventDefault()/stopPropagation() on keydown — because
+  // Chromium's scroll-on-arrow default action fires before JS handlers in the
+  // bubble phase, not after.
+  //
+  // The correct approach: let the form grow to its natural height and drive
+  // window size through reportHeight() → IPC bubble-height → setBounds().
+  // permission.js clampBubbleHeight() already caps the window at workArea.height
+  // so content-heavy bubbles will never exceed the screen.
+  //
+  // Safety: "User answered in terminal" cannot be triggered by elicitation
+  // bubbles. That denial path is wired to PostToolUse/Stop hook events matched
+  // by toolUseId (server.js:694) — elicitation uses a completely separate
+  // code path (server.js:1008, isElicitation: true) and is explicitly excluded
+  // from the shortcut-navigation and resolve logic (permission.js:321, 630).
 }
 
 function scheduleBubbleHeightReport() {
@@ -1000,6 +1010,23 @@ function renderElicitationStep() {
 
   updateElicitationSubmitState();
   scheduleBubbleHeightReport();
+
+  // Auto-focus the first preset radio on render so arrow keys work immediately
+  // without requiring a click first. Uses rAF so the DOM is painted before we
+  // query it. If a radio is already checked (navigating back to a previously
+  // answered question), keep that selection instead of resetting it.
+  requestAnimationFrame(() => {
+    const question = elicitationQuestions[activeQuestionIndex];
+    if (!question) return;
+    const alreadyChecked = elicitationForm.querySelector(
+      `input[name="elicitation-${activeQuestionIndex}"]:checked`
+    );
+    if (alreadyChecked) { alreadyChecked.focus(); return; }
+    const first = elicitationForm.querySelector(
+      `input[name="elicitation-${activeQuestionIndex}"]:not([data-other])`
+    );
+    if (first) { first.focus(); first.click(); }
+  });
 }
 
 function renderElicitationForm(data) {

--- a/src/permission.js
+++ b/src/permission.js
@@ -499,8 +499,12 @@ function showPermissionBubble(permEntry) {
   bub.webContents.once("did-finish-load", () => {
     permEntry.bubbleReady = true;
     syncPermissionBubbleContent(permEntry);
-    // Don't call bub.focus() — it steals focus from terminal and can trigger
-    // false "User answered in terminal" denials in Claude Code, wasting tokens.
+    // Elicitation bubbles need keyboard focus so arrow keys and Enter work.
+    // Regular permission bubbles must NOT steal focus from the terminal —
+    // doing so triggers false "User answered in terminal" denials in Claude Code.
+    if (permEntry.isElicitation) {
+      bub.focus();
+    }
   });
 
   repositionBubbles();


### PR DESCRIPTION
Fixes #205

## Three coordinated fixes

### 1. `permission.js` — call `bub.focus()` for elicitation bubbles

`showInactive()` never grants keyboard focus, so arrow keys and Enter were silently dropped. Gated on `isElicitation` so regular permission bubbles are completely unaffected.

### 2. `bubble.html` — `applyElicitationViewport()` → no-op

The `overflow-y: auto` scroll container caused Chromium to consume ArrowUp/Down for scrolling before any JS handler could fire. `preventDefault()` / `stopPropagation()` cannot intercept this — Chromium's scroll-on-arrow fires at the default-action phase, not the JS event phase.

Fix: remove the `maxHeight` clamp and `elicitation-scrollable` class. Window height is driven by `reportHeight() → IPC bubble-height → setBounds()`. `permission.js` `clampBubbleHeight()` already caps the window at `workArea.height` as the overflow safety net, so content can never exceed the screen.

### 3. `bubble.html` — auto-focus first radio on `renderElicitationStep()`

Without an explicitly focused radio, the first ArrowDown after the bubble appears moves browser focus into the radio group but doesn't select anything — requiring an extra keypress. `rAF focus() + click()` on the first preset radio on render fixes this. Navigating back to a previously answered question keeps the existing selection.

---

## Safety analysis — "User answered in terminal" regression

The original `bub.focus()` warning was about **regular permission prompts**: stealing terminal focus can cause CC to detect a terminal interaction and fire a false deny via the PostToolUse/Stop hook path (`server.js:694`).

**Elicitation is immune** because:
- It uses a completely separate code path (`server.js:1008`, `isElicitation: true`)
- It is explicitly excluded from shortcut-nav and resolve logic (`permission.js:321, 630`)
- `AskUserQuestion` has no terminal-answer fallback by design; the only exit paths are bubble submit or "Go to Terminal" (explicit deny)

---

## Result

| Before | After |
|--------|-------|
| Arrow keys do nothing | Arrow keys navigate options immediately |
| First option not selected | First option auto-selected on open |
| Scrollbar appears with many options | Window grows to fit content, no scrollbar |
| Must click with mouse | Fully keyboard-navigable |