### PR TITLE
fix: dismiss stale elicitation bubbles when user answers in terminal

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -920,6 +920,17 @@ function startHttpServer() {
                 allowSingletonFallback: event === "Stop",
               });
               if (perm) ctx.resolvePermissionEntry(perm, "deny", "User answered in terminal");
+              // Stale elicitation sweep: AskUserQuestion is a blocking tool
+              // call, so any forward progress in the same session means the
+              // user already answered in the terminal.  The exact-match above
+              // may miss the elicitation entry when the /state PostToolUse
+              // carries a different tool_input fingerprint from the original
+              // /permission request, or when tool_use_id is absent.
+              for (const stale of [...ctx.pendingPermissions]) {
+                if (stale !== perm && stale.isElicitation && stale.res && stale.sessionId === sid) {
+                  ctx.resolvePermissionEntry(stale, "deny", "User answered in terminal");
+                }
+              }
             }
             recordRequestHookEvent.acceptedUnlessDnd(shouldDropForDnd());
             if (svg) {

--- a/test/server-permission-state-cleanup.test.js
+++ b/test/server-permission-state-cleanup.test.js
@@ -331,6 +331,66 @@ describe("/state permission cleanup", () => {
     assert.deepStrictEqual(resolved, []);
   });
 
+  it("sweeps stale elicitation bubble when any PostToolUse fires for the same session", async () => {
+    const pendingPermissions = [
+      {
+        id: "elicit",
+        sessionId: "sid",
+        toolName: "AskUserQuestion",
+        toolUseId: "toolu_elicit",
+        toolInputFingerprint: buildToolInputFingerprint({ questions: [{ question: "Pick one" }] }),
+        isElicitation: true,
+        res: {},
+      },
+    ];
+    const { handler, resolved } = startServer({ pendingPermissions });
+
+    const res = await callHandler(handler, makeReq("POST", "/state", JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "PostToolUse",
+      tool_name: "Bash",
+      tool_use_id: "toolu_bash_after",
+      tool_input_fingerprint: buildToolInputFingerprint({ command: "echo hi" }),
+    })));
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(resolved.map((e) => e.perm.id), ["elicit"]);
+    assert.deepStrictEqual(resolved.map((e) => e.message), ["User answered in terminal"]);
+  });
+
+  it("does not sweep non-elicitation bubbles from other sessions", async () => {
+    const pendingPermissions = [
+      {
+        id: "elicit",
+        sessionId: "other-sid",
+        toolName: "AskUserQuestion",
+        toolUseId: "toolu_elicit",
+        isElicitation: true,
+        res: {},
+      },
+      {
+        id: "bash-perm",
+        sessionId: "sid",
+        toolUseId: "toolu_bash_perm",
+        toolName: "Bash",
+        res: {},
+      },
+    ];
+    const { handler, resolved } = startServer({ pendingPermissions });
+
+    const res = await callHandler(handler, makeReq("POST", "/state", JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "PostToolUse",
+      tool_name: "Read",
+      tool_use_id: "toolu_read",
+    })));
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(resolved, []);
+  });
+
   it("clears a terminal-answered pending Bash request when the pending entry lacks tool_use_id", async () => {
     const command = "printenv COMPUTERNAME";
     const pendingPermissions = [


### PR DESCRIPTION
## Summary

- AskUserQuestion (elicitation) bubbles persist on screen after the user already answered in the CLI terminal
- Root cause: the `/state` PostToolUse cleanup can't match the elicitation entry because the `tool_input_fingerprint` differs (PostToolUse includes the user's answer, but the original `/permission` request only had the question)
- Added a sweep after the exact-match cleanup that resolves any remaining `isElicitation` entries for the same session when forward progress is observed — safe because AskUserQuestion is a blocking tool call

## Test plan

- [x] Added test: stale elicitation bubble is swept when any PostToolUse fires for the same session
- [x] Added test: non-elicitation bubbles and other sessions are not affected
- [x] All 16 tests in `server-permission-state-cleanup.test.js` pass
- [x] Full test suite shows no regressions (same 5 pre-existing failures)

## Files changed

- `src/server.js` — 11-line elicitation sweep after exact-match cleanup (line 923)
- `test/server-permission-state-cleanup.test.js` — 2 new test cases (60 lines)