### PR TITLE
fix: allow resizing pet when pinned to screen edge in mini mode

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3557,7 +3557,7 @@ function clampToScreenVisual(x, y, w, h, options = {}) {
   const clampMargins = getRestClampMargins({
     height: h,
     visibleMargins: margins,
-    allowEdgePinning: allowEdgePinningCached,
+    allowEdgePinning: "allowEdgePinning" in options ? options.allowEdgePinning : allowEdgePinningCached,
     bottomInset,
   });
   return {
@@ -3584,6 +3584,7 @@ const _miniCtx = {
   SIZES,
   getCurrentPixelSize,
   getEffectiveCurrentPixelSize,
+  getPixelSizeFor,
   isProportionalMode,
   sendToRenderer,
   sendToHitWin,

--- a/src/menu.js
+++ b/src/menu.js
@@ -381,7 +381,7 @@ module.exports = function initMenu(ctx) {
     if (!ctx.miniHandleResize(sizeKey)) {
       if (ctx.win && !ctx.win.isDestroyed()) {
         const { x, y } = ctx.getPetWindowBounds();
-        const clamped = ctx.clampToScreenVisual(x, y, size.width, size.height);
+        const clamped = ctx.clampToScreenVisual(x, y, size.width, size.height, { allowEdgePinning: false });
         ctx.applyPetWindowBounds({ ...clamped, width: size.width, height: size.height });
       }
     }

--- a/src/menu.js
+++ b/src/menu.js
@@ -381,7 +381,7 @@ module.exports = function initMenu(ctx) {
     if (!ctx.miniHandleResize(sizeKey)) {
       if (ctx.win && !ctx.win.isDestroyed()) {
         const { x, y } = ctx.getPetWindowBounds();
-        const clamped = ctx.clampToScreenVisual(x, y, size.width, size.height, { allowEdgePinning: false });
+        const clamped = ctx.clampToScreenVisual(x, y, size.width, size.height);
         ctx.applyPetWindowBounds({ ...clamped, width: size.width, height: size.height });
       }
     }

--- a/src/mini.js
+++ b/src/mini.js
@@ -22,6 +22,7 @@ let miniPeeked = false;
 let preMiniX = 0, preMiniY = 0;
 let currentMiniX = 0;
 let miniSnap = null;  // { y, width, height } — canonical rect to prevent DPI drift
+let lastMiniWorkArea = null;  // workArea of the display the mini pet is on
 let miniTransitionTimer = null;
 let peekAnimTimer = null;
 let isAnimating = false;
@@ -260,6 +261,7 @@ function enterMiniMode(wa, viaMenu, edge) {
   if (edge) miniEdge = edge;
   const size = _getSize();
   currentMiniX = calcMiniX(wa, size);
+  lastMiniWorkArea = wa;
   miniSnap = { y: bounds.y, width: size.width, height: size.height };
 
   ctx.stopWakePoll();
@@ -422,6 +424,7 @@ function handleDisplayChange() {
   const bounds = ctx.win.getBounds();
   const snapY = miniSnap ? miniSnap.y : bounds.y;
   const wa = ctx.getNearestWorkArea(currentMiniX + size.width / 2, snapY + size.height / 2);
+  lastMiniWorkArea = wa;
   currentMiniX = calcMiniX(wa, size);
   // mini 的 y 必须在工作区内(real 坐标),加回两端 clamp
   const clampedY = Math.max(wa.y, Math.min(snapY, wa.y + wa.height - size.height));
@@ -432,13 +435,13 @@ function handleDisplayChange() {
 
 function handleResize(sizeKey) {
   if (!miniMode) return false;
+  const { y: curY } = ctx.win.getBounds();
+  const wa = lastMiniWorkArea || ctx.getNearestWorkArea(currentMiniX, curY);
   const size = (typeof ctx.getPixelSizeFor === "function")
-    ? ctx.getPixelSizeFor(sizeKey)
-    : (ctx.SIZES[sizeKey] || _getSize());
-  const { y } = ctx.win.getBounds();
-  const wa = ctx.getNearestWorkArea(currentMiniX + size.width / 2, y + size.height / 2);
+    ? ctx.getPixelSizeFor(sizeKey, wa)
+    : ctx.SIZES[sizeKey];
   currentMiniX = calcMiniX(wa, size);
-  const clampedY = Math.max(wa.y, Math.min(y, wa.y + wa.height - size.height));
+  const clampedY = Math.max(wa.y, Math.min(curY, wa.y + wa.height - size.height));
   miniSnap = { y: clampedY, width: size.width, height: size.height };
   ctx.win.setBounds({ x: currentMiniX, y: clampedY, width: size.width, height: size.height });
   syncSessionHudVisibility();
@@ -450,6 +453,7 @@ function restoreFromPrefs(prefs, size) {
   preMiniY = prefs.preMiniY || 0;
   miniEdge = prefs.miniEdge || "right";
   const wa = ctx.getNearestWorkArea(prefs.x + size.width / 2, prefs.y + size.height / 2);
+  lastMiniWorkArea = wa;
   currentMiniX = calcMiniX(wa, size);
   // 启动恢复 mini 时 y 必须在工作区内(保证 offset = 0,符合 mini 语义)
   const startY = Math.max(wa.y, Math.min(prefs.y, wa.y + wa.height - size.height));

--- a/src/mini.js
+++ b/src/mini.js
@@ -431,8 +431,10 @@ function handleDisplayChange() {
 }
 
 function handleResize(sizeKey) {
-  const size = ctx.SIZES[sizeKey] || _getSize();
   if (!miniMode) return false;
+  const size = (typeof ctx.getPixelSizeFor === "function")
+    ? ctx.getPixelSizeFor(sizeKey)
+    : (ctx.SIZES[sizeKey] || _getSize());
   const { y } = ctx.win.getBounds();
   const wa = ctx.getNearestWorkArea(currentMiniX + size.width / 2, y + size.height / 2);
   currentMiniX = calcMiniX(wa, size);


### PR DESCRIPTION
## Summary

- Fixed the pet not resizing when pinned to screen edge (mini mode)
- Fixed `mini.js handleResize` using `ctx.SIZES[sizeKey]` which only has S/M/L, failing for proportional size keys (e.g. `P:6.9`) and falling back to current size unchanged
- Added `getPixelSizeFor` to `_miniCtx` so mini mode can compute proportional pixel sizes
- `clampToScreenVisual` now accepts an `allowEdgePinning` option override, used by `resizeWindow` to keep the pet fully on-screen after resize

## Root Cause

Two bugs prevented resizing when the pet was edge-pinned (mini mode):

1. `handleResize` in `mini.js` used `ctx.SIZES[sizeKey]` to resolve the new size, but `SIZES` only contains fixed `S`/`M`/`L` entries. For proportional keys like `P:6.9`, the lookup failed and fell back to `_getSize()` which returned the **current** size — so the window bounds never changed.

2. `_miniCtx` did not expose `getPixelSizeFor`, so even if the fallback logic tried to use it, the function was unavailable.

## Test Plan

- [x] Drag pet to right edge → enters mini mode
- [x] Drag size slider in settings panel → pet resizes correctly
- [x] Click size tick marks → pet resizes correctly
- [x] Resize when NOT at edge → still works as before
- [x] Context menu S/M/L resize → still works

Fixes #212

🤖 Generated with [Claude Code](https://claude.ai/claude-code)