### PR TITLE
feat: add iTerm2 tab-level focus switching

### DIFF
--- a/src/focus.js
+++ b/src/focus.js
@@ -164,6 +164,53 @@ function scheduleTerminalTabFocus(editor, pidChain) {
   }, 800);
 }
 
+function scheduleITermTabFocus(sourcePid, pidChain) {
+  if (!isMac || !sourcePid || !Array.isArray(pidChain) || !pidChain.length) return;
+  execFile("ps", ["-o", "comm=", "-p", String(sourcePid)], { encoding: "utf8", timeout: 500 }, (err, stdout) => {
+    if (err) return;
+    const name = path.basename(stdout.trim()).toLowerCase();
+    if (name !== "iterm2") return;
+
+    // Find the shell PID's TTY to match against iTerm2 sessions.
+    // Walk pidChain from agent (index 0) upward — the first PID with a valid TTY
+    // is typically the shell or login process that owns the iTerm2 session.
+    const candidates = pidChain.filter(p => Number.isFinite(p) && p > 0 && p !== sourcePid);
+    if (!candidates.length) return;
+
+    const pidsArg = candidates.slice(0, 5).join(",");
+    execFile("ps", ["-o", "pid=,tty=", "-p", pidsArg], { encoding: "utf8", timeout: 500 }, (psErr, psOut) => {
+      if (psErr || !psOut) return;
+      let ttyName = null;
+      for (const line of psOut.trim().split("\n")) {
+        const parts = line.trim().split(/\s+/);
+        if (parts.length >= 2 && parts[1] !== "??" && parts[1] !== "?") {
+          ttyName = parts[1];
+          break;
+        }
+      }
+      if (!ttyName) return;
+
+      const script = `
+        tell application "iTerm2"
+          repeat with w in windows
+            repeat with t in tabs of w
+              repeat with s in sessions of t
+                if tty of s ends with "${ttyName}" then
+                  select t
+                  select w
+                  return "ok"
+                end if
+              end repeat
+            end repeat
+          end repeat
+        end tell`;
+      setTimeout(() => {
+        execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, () => {});
+      }, 400);
+    });
+  });
+}
+
 function clearMacFocusCooldownTimer() {
   if (macFocusCooldownTimer) {
     clearTimeout(macFocusCooldownTimer);
@@ -206,6 +253,7 @@ function executeMacFocusRequest(request) {
 
   focusTerminalWindowLegacy(request.sourcePid, request.cwd, finalize, request.pidChain);
   scheduleTerminalTabFocus(request.editor, request.pidChain);
+  scheduleITermTabFocus(request.sourcePid, request.pidChain);
 }
 
 function requestMacFocus(sourcePid, cwd, editor, pidChain) {

--- a/src/focus.js
+++ b/src/focus.js
@@ -123,7 +123,7 @@ const MAC_FOCUS_THROTTLE_MS = 1500;
 const MAC_FOCUS_TIMEOUT_MS = 1500;
 let macFocusInFlight = false;
 let macFocusLastRunAt = 0;
-let macFocusLastPid = null;
+let macFocusLastRequestKey = null;
 let macQueuedFocusRequest = null;
 let macFocusCooldownTimer = null;
 
@@ -241,10 +241,17 @@ function flushQueuedMacFocus() {
   executeMacFocusRequest(nextRequest);
 }
 
+function getMacFocusRequestKey(sourcePid, pidChain) {
+  const chain = Array.isArray(pidChain)
+    ? pidChain.filter(p => Number.isFinite(p) && p > 0).join(",")
+    : "";
+  return `${sourcePid || ""}|${chain}`;
+}
+
 function executeMacFocusRequest(request) {
   macFocusInFlight = true;
   macFocusLastRunAt = Date.now();
-  macFocusLastPid = request.sourcePid;
+  macFocusLastRequestKey = request.key;
 
   const finalize = () => {
     macFocusInFlight = false;
@@ -259,9 +266,10 @@ function executeMacFocusRequest(request) {
 function requestMacFocus(sourcePid, cwd, editor, pidChain) {
   const elapsed = Date.now() - macFocusLastRunAt;
   const inCooldown = elapsed < MAC_FOCUS_THROTTLE_MS;
-  if (inCooldown && macFocusLastPid === sourcePid) return;
+  const key = getMacFocusRequestKey(sourcePid, pidChain);
+  if (inCooldown && macFocusLastRequestKey === key) return;
 
-  const request = { sourcePid, cwd, editor, pidChain };
+  const request = { sourcePid, cwd, editor, pidChain, key };
   if (macFocusInFlight) {
     macQueuedFocusRequest = request;
     return;

--- a/test/focus-iterm-tab.test.js
+++ b/test/focus-iterm-tab.test.js
@@ -1,27 +1,37 @@
 // test/focus-iterm-tab.test.js — Tests for iTerm2 tab-level focus switching
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
-const path = require("path");
 
 // focus.js destructures { execFile, spawn } at require-time, so we must
-// patch child_process BEFORE requiring focus.js.
+// patch child_process and process.platform BEFORE requiring focus.js.
 
-function loadFocusWithMock(execFileMock) {
+function loadFocusWithMock(execFileMock, options = {}) {
   const cpKey = require.resolve("child_process");
   const focusKey = require.resolve("../src/focus");
+  const platform = options.platform || "darwin";
 
   // Save originals
   const origCp = require.cache[cpKey];
   const origFocus = require.cache[focusKey];
+  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
   // Build a patched child_process module
   const realCp = require("child_process");
   const patchedCp = { ...realCp, execFile: execFileMock, spawn: realCp.spawn };
   require.cache[cpKey] = { id: cpKey, filename: cpKey, loaded: true, exports: patchedCp };
+  Object.defineProperty(process, "platform", {
+    ...origPlatform,
+    value: platform,
+  });
 
   // Clear focus.js cache so it picks up patched child_process
   delete require.cache[focusKey];
-  const initFocus = require("../src/focus");
+  let initFocus;
+  try {
+    initFocus = require("../src/focus");
+  } finally {
+    Object.defineProperty(process, "platform", origPlatform);
+  }
 
   // Restore child_process cache immediately (focus.js already captured the reference)
   if (origCp) require.cache[cpKey] = origCp;
@@ -172,5 +182,56 @@ describe("iTerm2 tab focus (macOS)", () => {
 
       done();
     }, 2000);
+  });
+
+  it("should not drop same-iTerm2-PID focus requests with different pid chains", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args] });
+      if (cmd === "osascript") {
+        if (cb) cb(null, "", "");
+        return;
+      }
+      if (cmd === "ps") {
+        const a = args.join(" ");
+        if (a.includes("comm=")) {
+          if (cb) cb(null, "iTerm2\n", "");
+          return;
+        }
+        if (a.includes("tty=")) {
+          const pids = args[args.indexOf("-p") + 1] || "";
+          const tty = pids.includes("301") ? "ttys002" : "ttys001";
+          if (cb) cb(null, `  ${pids.split(",")[0]} ${tty}\n`, "");
+          return;
+        }
+      }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(11940, "/test/cwd-a", null, [201, 11940]);
+    setTimeout(() => {
+      focusTerminalWindow(11940, "/test/cwd-b", null, [301, 11940]);
+    }, 10);
+
+    setTimeout(() => {
+      cleanup();
+
+      const itermScripts = calls
+        .filter(c => c.cmd === "osascript")
+        .filter(c => c.args.some(a => typeof a === "string" && a.includes("iTerm2")));
+      assert.strictEqual(itermScripts.length, 2, "Should run tab switch for both pid chains");
+      assert.ok(
+        itermScripts.some(c => c.args.some(a => a.includes("ttys001"))),
+        "Should switch to first TTY"
+      );
+      assert.ok(
+        itermScripts.some(c => c.args.some(a => a.includes("ttys002"))),
+        "Should switch to second TTY"
+      );
+
+      done();
+    }, 2600);
   });
 });

--- a/test/focus-iterm-tab.test.js
+++ b/test/focus-iterm-tab.test.js
@@ -1,0 +1,176 @@
+// test/focus-iterm-tab.test.js — Tests for iTerm2 tab-level focus switching
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+
+// focus.js destructures { execFile, spawn } at require-time, so we must
+// patch child_process BEFORE requiring focus.js.
+
+function loadFocusWithMock(execFileMock) {
+  const cpKey = require.resolve("child_process");
+  const focusKey = require.resolve("../src/focus");
+
+  // Save originals
+  const origCp = require.cache[cpKey];
+  const origFocus = require.cache[focusKey];
+
+  // Build a patched child_process module
+  const realCp = require("child_process");
+  const patchedCp = { ...realCp, execFile: execFileMock, spawn: realCp.spawn };
+  require.cache[cpKey] = { id: cpKey, filename: cpKey, loaded: true, exports: patchedCp };
+
+  // Clear focus.js cache so it picks up patched child_process
+  delete require.cache[focusKey];
+  const initFocus = require("../src/focus");
+
+  // Restore child_process cache immediately (focus.js already captured the reference)
+  if (origCp) require.cache[cpKey] = origCp;
+  else delete require.cache[cpKey];
+
+  const cleanup = () => {
+    if (origFocus) require.cache[focusKey] = origFocus;
+    else delete require.cache[focusKey];
+  };
+
+  return { initFocus, cleanup };
+}
+
+describe("iTerm2 tab focus (macOS)", () => {
+
+  it("should call iTerm2 AppleScript when sourcePid belongs to iterm2 process", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args] });
+      if (cmd === "osascript") {
+        if (cb) cb(null, "", "");
+        return;
+      }
+      if (cmd === "ps") {
+        const a = args.join(" ");
+        if (a.includes("comm=")) {
+          if (cb) cb(null, "/Applications/iTerm.app/Contents/MacOS/iTerm2\n", "");
+          return;
+        }
+        if (a.includes("tty=")) {
+          if (cb) cb(null, "  16199 ttys003\n  16197 ttys003\n", "");
+          return;
+        }
+      }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(11940, "/test/cwd", null, [16199, 16197, 16196, 12235, 12225, 12174, 11940]);
+
+    setTimeout(() => {
+      cleanup();
+
+      const psCalls = calls.filter(c => c.cmd === "ps");
+      assert.ok(psCalls.length >= 2, `Expected >= 2 ps calls, got ${psCalls.length}`);
+
+      const commCall = psCalls.find(c => c.args.some(a => a.includes("comm=")));
+      assert.ok(commCall, "Should call ps -o comm= to detect terminal type");
+
+      const ttyCall = psCalls.find(c => c.args.some(a => a.includes("tty=")));
+      assert.ok(ttyCall, "Should call ps -o tty= to find shell TTY");
+
+      const osaCalls = calls.filter(c => c.cmd === "osascript");
+      const itermScript = osaCalls.find(c =>
+        c.args.some(a => typeof a === "string" && a.includes("iTerm2") && a.includes("tty of s"))
+      );
+      assert.ok(itermScript, "Should run iTerm2 AppleScript for tab switching");
+      assert.ok(
+        itermScript.args.some(a => a.includes("ttys003")),
+        "Should use the resolved TTY name"
+      );
+
+      done();
+    }, 2500);
+  });
+
+  it("should NOT call iTerm2 AppleScript for non-iTerm2 terminals", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args] });
+      if (cmd === "ps" && args.join(" ").includes("comm=")) {
+        if (cb) cb(null, "Terminal\n", "");
+        return;
+      }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(44444, "/test/cwd", null, [100, 200, 300, 44444]);
+
+    setTimeout(() => {
+      cleanup();
+
+      const osaCalls = calls.filter(c => c.cmd === "osascript");
+      const itermScript = osaCalls.find(c =>
+        c.args.some(a => typeof a === "string" && a.includes("iTerm2"))
+      );
+      assert.ok(!itermScript, "Should NOT run iTerm2 AppleScript for Terminal.app");
+
+      done();
+    }, 2000);
+  });
+
+  it("should skip iTerm2 tab focus when pidChain is empty", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args] });
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(11940, "/test/cwd", null, []);
+
+    setTimeout(() => {
+      cleanup();
+
+      const commCalls = calls.filter(c => c.cmd === "ps" && c.args.join(" ").includes("comm="));
+      assert.strictEqual(commCalls.length, 0, "Should not attempt iTerm detection with empty pidChain");
+
+      done();
+    }, 1000);
+  });
+
+  it("should skip iTerm2 tab focus when no valid TTY found", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args] });
+      if (cmd === "ps") {
+        const a = args.join(" ");
+        if (a.includes("comm=")) {
+          if (cb) cb(null, "iTerm2\n", "");
+          return;
+        }
+        if (a.includes("tty=")) {
+          // All PIDs have no TTY
+          if (cb) cb(null, "  100 ??\n  200 ??\n", "");
+          return;
+        }
+      }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(11940, "/test/cwd", null, [100, 200, 11940]);
+
+    setTimeout(() => {
+      cleanup();
+
+      const osaCalls = calls.filter(c => c.cmd === "osascript");
+      const itermScript = osaCalls.find(c =>
+        c.args.some(a => typeof a === "string" && a.includes("iTerm2"))
+      );
+      assert.ok(!itermScript, "Should NOT run iTerm2 AppleScript when no valid TTY");
+
+      done();
+    }, 2000);
+  });
+});


### PR DESCRIPTION
## Summary

- **Root cause**: Clicking Session HUD only brought iTerm2's window to front via System Events AppleScript (`set frontmost`), but could not switch to the specific tab — all sessions shared the same iTerm2 main process PID, so the operation was invisible when already in iTerm2.
- **Fix**: Add `scheduleITermTabFocus()` in `src/focus.js` that detects iTerm2 by checking `sourcePid`'s process name, resolves the shell TTY from `pidChain`, then runs iTerm2-native AppleScript to `select` the matching tab.
- Non-iTerm2 terminals are unaffected (auto-skipped). 4 new unit tests added.

## How it works

1. `ps -o comm=` on `sourcePid` → detect if terminal is iTerm2
2. `ps -o tty=` on `pidChain` candidates → find the shell's TTY (e.g. `ttys003`)
3. iTerm2 AppleScript iterates `windows > tabs > sessions`, matches by `tty of s ends with "<ttyName>"`, then `select` that tab + window
4. Fires 400ms after existing System Events window focus to avoid race conditions

## Test plan

- [x] Unit tests pass (`node --test test/focus-iterm-tab.test.js` — 4/4 pass)
- [x] Full test suite — no regressions (same 6 pre-existing failures)
- [x] Manual verification: clicking Session HUD row switches to correct iTerm2 tab
- [ ] Verify non-iTerm2 terminals (Terminal.app, Alacritty, etc.) still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)