### PR TITLE
feat: add unread notification bell to session HUD

### DIFF
--- a/src/session-hud-renderer.js
+++ b/src/session-hud-renderer.js
@@ -61,7 +61,9 @@ function updateUnread(sessions) {
   for (const session of sessions) {
     const prev = prevBadges.get(session.id);
     const curr = session.badge;
-    if (prev !== undefined && prev !== "done" && curr === "done") {
+    if (curr !== "done") {
+      unreadSessions.delete(session.id);
+    } else if (prev !== undefined && prev !== "done") {
       unreadSessions.add(session.id);
     }
     prevBadges.set(session.id, curr);
@@ -104,7 +106,7 @@ function createRowForSession(session, now) {
   const right = document.createElement("span");
   right.className = "right";
 
-  if (unreadSessions.has(session.id)) {
+  if (session.badge === "done" && unreadSessions.has(session.id)) {
     const bell = document.createElement("span");
     bell.className = "unread-bell";
     bell.innerHTML = BELL_SVG;
@@ -120,6 +122,7 @@ function createRowForSession(session, now) {
 
   row.addEventListener("click", () => {
     unreadSessions.delete(session.id);
+    render();
     window.sessionHudAPI.focusSession(session.id);
   });
 

--- a/src/session-hud-renderer.js
+++ b/src/session-hud-renderer.js
@@ -5,6 +5,9 @@ const HUD_MAX_EXPANDED_ROWS = 3;
 let snapshot = { sessions: [], orderedIds: [], hudTotalNonIdle: 0, hudLastTitle: null };
 let i18nPayload = { lang: "en", translations: {} };
 
+const unreadSessions = new Set();
+const prevBadges = new Map();
+
 const hudEl = document.getElementById("hud");
 
 function isHudSession(session) {
@@ -48,6 +51,26 @@ function orderedHudSessions(currentSnapshot) {
   return ordered.concat(missing).filter(isHudSession);
 }
 
+const BELL_SVG = `<svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 22c1.1 0 2-.9 2-2h-4c0 1.1.9 2 2 2zm6-6v-5c0-3.07-1.64-5.64-4.5-6.32V4c0-.83-.67-1.5-1.5-1.5s-1.5.67-1.5 1.5v.68C7.63 5.36 6 7.92 6 11v5l-2 2v1h16v-1l-2-2z"/></svg>`;
+
+function updateUnread(sessions) {
+  const currentIds = new Set(sessions.map((s) => s.id));
+  for (const id of unreadSessions) {
+    if (!currentIds.has(id)) unreadSessions.delete(id);
+  }
+  for (const session of sessions) {
+    const prev = prevBadges.get(session.id);
+    const curr = session.badge;
+    if (prev !== undefined && prev !== "done" && curr === "done") {
+      unreadSessions.add(session.id);
+    }
+    prevBadges.set(session.id, curr);
+  }
+  for (const id of prevBadges.keys()) {
+    if (!currentIds.has(id)) prevBadges.delete(id);
+  }
+}
+
 function splitHudLayout(sessions) {
   const expanded = sessions.slice(0, HUD_MAX_EXPANDED_ROWS);
   const folded = sessions.slice(HUD_MAX_EXPANDED_ROWS);
@@ -80,12 +103,23 @@ function createRowForSession(session, now) {
 
   const right = document.createElement("span");
   right.className = "right";
-  right.textContent = formatElapsed(now - (Number(session.updatedAt) || now));
+
+  if (unreadSessions.has(session.id)) {
+    const bell = document.createElement("span");
+    bell.className = "unread-bell";
+    bell.innerHTML = BELL_SVG;
+    right.appendChild(bell);
+  }
+
+  const elapsed = document.createElement("span");
+  elapsed.textContent = formatElapsed(now - (Number(session.updatedAt) || now));
+  right.appendChild(elapsed);
 
   row.appendChild(left);
   row.appendChild(right);
 
   row.addEventListener("click", () => {
+    unreadSessions.delete(session.id);
     window.sessionHudAPI.focusSession(session.id);
   });
 
@@ -119,6 +153,7 @@ function createFoldedRow(count) {
 
 function render() {
   const sessions = orderedHudSessions(snapshot);
+  updateUnread(sessions);
   hudEl.replaceChildren();
   if (!sessions.length) return;
 

--- a/src/session-hud.html
+++ b/src/session-hud.html
@@ -133,6 +133,9 @@ body { padding: 2px 3px 8px; }
 
 .right {
   flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 5px;
   font-weight: 400;
   line-height: 1;
   color: var(--text-muted);
@@ -141,6 +144,28 @@ body { padding: 2px 3px 8px; }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.unread-bell {
+  flex: 0 0 auto;
+  color: #f59e0b;
+  display: flex;
+  align-items: center;
+}
+
+@keyframes bell-ring {
+  0%   { transform: rotate(0deg); }
+  10%  { transform: rotate(12deg); }
+  20%  { transform: rotate(-10deg); }
+  30%  { transform: rotate(8deg); }
+  40%  { transform: rotate(-6deg); }
+  50%  { transform: rotate(0deg); }
+  100% { transform: rotate(0deg); }
+}
+
+.unread-bell svg {
+  animation: bell-ring 1.8s ease-in-out infinite;
+  transform-origin: 50% 2px;
 }
 </style>
 </head>

--- a/src/session-hud.html
+++ b/src/session-hud.html
@@ -167,6 +167,12 @@ body { padding: 2px 3px 8px; }
   animation: bell-ring 1.8s ease-in-out infinite;
   transform-origin: 50% 2px;
 }
+
+@media (prefers-reduced-motion: reduce) {
+  .unread-bell svg {
+    animation: none;
+  }
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
When an agent completes (badge transitions to "done"), a ringing amber bell icon appears on the right side of its HUD row. Clicking the row dismisses the bell and focuses the session. If the agent runs again and completes, the bell reappears.

Make it useful to understand which agents you did check and which not.

https://github.com/user-attachments/assets/3ff71125-8910-4b5b-bcfb-7411917613b3

