### PR TITLE
feat: add WSL2 terminal focus support

### DIFF
--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -167,7 +167,10 @@ function buildStateBody(event, payload, resolve) {
   } else {
     const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
     body.source_pid = stablePid;
-    if (detectedEditor) body.editor = detectedEditor;
+    const termProgram = process.env.TERM_PROGRAM;
+    const editorFromEnv = termProgram === "vscode" ? "code" : termProgram === "cursor" ? "cursor" : null;
+    const resolvedEditor = detectedEditor || editorFromEnv;
+    if (resolvedEditor) body.editor = resolvedEditor;
     if (agentPid) {
       body.agent_pid = agentPid;
       body.claude_pid = agentPid; // backward compat with older Clawd versions

--- a/src/focus.js
+++ b/src/focus.js
@@ -57,7 +57,32 @@ public class WinFocus {
 "@
 `;
 
-function makeFocusCmd(sourcePid, cwdCandidates) {
+function makeEditorFallbackBlock(editor, psNames) {
+  if (editor !== "code" && editor !== "cursor") return "";
+  // Process name for VS Code is "Code", for Cursor is "Cursor".
+  // This fallback activates when the PID walk + WT scan found nothing,
+  // which happens when Claude Code runs in WSL2 (Linux PIDs are invisible
+  // to the Windows process tree).
+  const procName = editor === "cursor" ? "Cursor" : "Code";
+  const titleFallback = psNames ? `
+    foreach ($name in @(${psNames})) {
+        $hwnd = [WinFocus]::FindByPidTitle([uint32]$ep.Id, $name)
+        if ($hwnd -ne [IntPtr]::Zero) { [WinFocus]::Focus($hwnd); $focused = $true; break }
+    }` : "";
+  return `
+if (-not $focused) {
+    $editorProcs = Get-Process -Name '${procName}' -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne 0 }
+    foreach ($ep in $editorProcs) {${titleFallback}
+        if ($focused) { break }
+    }
+    if (-not $focused) {
+        $ep = $editorProcs | Select-Object -First 1
+        if ($ep) { [WinFocus]::Focus($ep.MainWindowHandle); $focused = $true }
+    }
+}`;
+}
+
+function makeFocusCmd(sourcePid, cwdCandidates, editor) {
   // Walk up the process tree (same proven logic as before).
   // When we find the process with MainWindowHandle, try title-matching first
   // to support multi-window editors (Cursor/VS Code). Fall back to MainWindowHandle.
@@ -113,6 +138,7 @@ if (-not $focused) {${wtTitleMatch}
         if ($wt -and $wt.MainWindowHandle -ne 0) { [WinFocus]::Focus($wt.MainWindowHandle) }
     }
 }
+${makeEditorFallbackBlock(editor, psNames)}
 `;
 }
 
@@ -252,14 +278,14 @@ function focusTerminalWindow(sourcePid, cwd, editor, pidChain) {
   }
 
   // Legacy focus for reliable window activation (ALT key trick + SetForegroundWindow)
-  focusTerminalWindowLegacy(sourcePid, cwd);
+  focusTerminalWindowLegacy(sourcePid, cwd, null, pidChain, editor);
 
   // VS Code / Cursor: request precise terminal tab switch via extension's HTTP server.
   // Delayed so legacy PowerShell focus completes first (it's fire-and-forget via stdin).
   scheduleTerminalTabFocus(editor, pidChain);
 }
 
-function focusTerminalWindowLegacy(sourcePid, cwd, onDone, pidChain) {
+function focusTerminalWindowLegacy(sourcePid, cwd, onDone, pidChain, editor) {
   if (isMac) {
     const pidCandidates = [sourcePid];
     if (Array.isArray(pidChain)) {
@@ -331,7 +357,7 @@ function focusTerminalWindowLegacy(sourcePid, cwd, onDone, pidChain) {
   }
 
   // Windows: send command to persistent PowerShell process (near-instant)
-  const cmd = makeFocusCmd(sourcePid, cwdCandidates);
+  const cmd = makeFocusCmd(sourcePid, cwdCandidates, editor);
   if (psProc && psProc.stdin.writable) {
     psProc.stdin.write(cmd + "\n");
   } else {

--- a/src/focus.js
+++ b/src/focus.js
@@ -9,6 +9,31 @@ const isMac = process.platform === "darwin";
 const isWin = process.platform === "win32";
 const isLinux = process.platform === "linux";
 
+function makeEditorFallbackBlock(editor, psNames) {
+  if (editor !== "code" && editor !== "cursor") return "";
+  // Process name for VS Code is "Code", for Cursor is "Cursor".
+  // This fallback activates when the PID walk + WT scan found nothing,
+  // which happens when Claude Code runs in WSL2 (Linux PIDs are invisible
+  // to the Windows process tree).
+  const procName = editor === "cursor" ? "Cursor" : "Code";
+  const titleFallback = psNames ? `
+    foreach ($name in @(${psNames})) {
+        $hwnd = [WinFocus]::FindByPidTitle([uint32]$ep.Id, $name)
+        if ($hwnd -ne [IntPtr]::Zero) { [WinFocus]::Focus($hwnd); $focused = $true; break }
+    }` : "";
+  return `
+if (-not $focused) {
+    $editorProcs = Get-Process -Name '${procName}' -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne 0 }
+    foreach ($ep in $editorProcs) {${titleFallback}
+        if ($focused) { break }
+    }
+    if (-not $focused) {
+        $ep = $editorProcs | Select-Object -First 1
+        if ($ep) { [WinFocus]::Focus($ep.MainWindowHandle); $focused = $true }
+    }
+}`;
+}
+
 module.exports = function initFocus(ctx) {
 
 const PS_FOCUS_ADDTYPE = `
@@ -56,31 +81,6 @@ public class WinFocus {
 }
 "@
 `;
-
-function makeEditorFallbackBlock(editor, psNames) {
-  if (editor !== "code" && editor !== "cursor") return "";
-  // Process name for VS Code is "Code", for Cursor is "Cursor".
-  // This fallback activates when the PID walk + WT scan found nothing,
-  // which happens when Claude Code runs in WSL2 (Linux PIDs are invisible
-  // to the Windows process tree).
-  const procName = editor === "cursor" ? "Cursor" : "Code";
-  const titleFallback = psNames ? `
-    foreach ($name in @(${psNames})) {
-        $hwnd = [WinFocus]::FindByPidTitle([uint32]$ep.Id, $name)
-        if ($hwnd -ne [IntPtr]::Zero) { [WinFocus]::Focus($hwnd); $focused = $true; break }
-    }` : "";
-  return `
-if (-not $focused) {
-    $editorProcs = Get-Process -Name '${procName}' -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowHandle -ne 0 }
-    foreach ($ep in $editorProcs) {${titleFallback}
-        if ($focused) { break }
-    }
-    if (-not $focused) {
-        $ep = $editorProcs | Select-Object -First 1
-        if ($ep) { [WinFocus]::Focus($ep.MainWindowHandle); $focused = $true }
-    }
-}`;
-}
 
 function makeFocusCmd(sourcePid, cwdCandidates, editor) {
   // Walk up the process tree (same proven logic as before).
@@ -383,3 +383,5 @@ function cleanup() {
 return { initFocusHelper, killFocusHelper, focusTerminalWindow, clearMacFocusCooldownTimer, cleanup };
 
 };
+
+module.exports.__test = { makeEditorFallbackBlock };

--- a/test/focus-wsl2.test.js
+++ b/test/focus-wsl2.test.js
@@ -1,0 +1,101 @@
+"use strict";
+
+// Unit tests for WSL2 focus support:
+// - makeEditorFallbackBlock (src/focus.js): PowerShell block targeting editor
+//   by process name when Linux PID walk finds nothing.
+// - TERM_PROGRAM fallback (hooks/clawd-hook.js): editor detection via env var
+//   injected by VS Code / Cursor into WSL terminals.
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert");
+
+const { makeEditorFallbackBlock } = require("../src/focus.js").__test;
+const { buildStateBody } = require("../hooks/clawd-hook.js");
+
+// ── makeEditorFallbackBlock ──────────────────────────────────────────────────
+
+describe("makeEditorFallbackBlock", () => {
+  it("returns empty string for unknown editor", () => {
+    assert.strictEqual(makeEditorFallbackBlock("terminal", ""), "");
+    assert.strictEqual(makeEditorFallbackBlock(null, ""), "");
+    assert.strictEqual(makeEditorFallbackBlock(undefined, ""), "");
+  });
+
+  it("targets Code process for editor=code", () => {
+    const block = makeEditorFallbackBlock("code", "");
+    assert.ok(block.includes("Get-Process -Name 'Code'"));
+    assert.ok(!block.includes("Cursor"));
+  });
+
+  it("targets Cursor process for editor=cursor", () => {
+    const block = makeEditorFallbackBlock("cursor", "");
+    assert.ok(block.includes("Get-Process -Name 'Cursor'"));
+    assert.ok(!block.includes("'Code'"));
+  });
+
+  it("includes title match block when psNames provided", () => {
+    const psNames = `([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('Y2xhd2Q=')))`;
+    const block = makeEditorFallbackBlock("code", psNames);
+    assert.ok(block.includes("FindByPidTitle"));
+    assert.ok(block.includes(psNames));
+  });
+
+  it("omits title match when psNames empty", () => {
+    const block = makeEditorFallbackBlock("code", "");
+    assert.ok(!block.includes("FindByPidTitle"));
+  });
+
+  it("always includes fallback to first window", () => {
+    const block = makeEditorFallbackBlock("code", "");
+    assert.ok(block.includes("Select-Object -First 1"));
+    assert.ok(block.includes("[WinFocus]::Focus"));
+  });
+});
+
+// ── TERM_PROGRAM editor fallback in buildStateBody ───────────────────────────
+
+const nullResolve = () => ({ stablePid: null, agentPid: null, detectedEditor: null, pidChain: [] });
+
+describe("buildStateBody TERM_PROGRAM fallback", () => {
+  let origTermProgram;
+
+  beforeEach(() => {
+    origTermProgram = process.env.TERM_PROGRAM;
+  });
+
+  afterEach(() => {
+    if (origTermProgram === undefined) delete process.env.TERM_PROGRAM;
+    else process.env.TERM_PROGRAM = origTermProgram;
+  });
+
+  it("sets editor=code when TERM_PROGRAM=vscode and no detectedEditor", () => {
+    process.env.TERM_PROGRAM = "vscode";
+    const body = buildStateBody("PreToolUse", { session_id: "s" }, nullResolve);
+    assert.strictEqual(body.editor, "code");
+  });
+
+  it("sets editor=cursor when TERM_PROGRAM=cursor and no detectedEditor", () => {
+    process.env.TERM_PROGRAM = "cursor";
+    const body = buildStateBody("PreToolUse", { session_id: "s" }, nullResolve);
+    assert.strictEqual(body.editor, "cursor");
+  });
+
+  it("omits editor when TERM_PROGRAM unset and no detectedEditor", () => {
+    delete process.env.TERM_PROGRAM;
+    const body = buildStateBody("PreToolUse", { session_id: "s" }, nullResolve);
+    assert.ok(!("editor" in body));
+  });
+
+  it("detectedEditor takes precedence over TERM_PROGRAM", () => {
+    process.env.TERM_PROGRAM = "vscode";
+    const resolveWithEditor = () => ({ stablePid: 1, agentPid: null, detectedEditor: "cursor", pidChain: [] });
+    const body = buildStateBody("PreToolUse", { session_id: "s" }, resolveWithEditor);
+    assert.strictEqual(body.editor, "cursor");
+  });
+
+  it("omits editor for unknown TERM_PROGRAM value", () => {
+    process.env.TERM_PROGRAM = "iterm2";
+    const body = buildStateBody("PreToolUse", { session_id: "s" }, nullResolve);
+    assert.ok(!("editor" in body));
+  });
+});


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                              
                                                                               
  When Claude Code runs inside WSL2, hook payloads carry Linux PIDs. The Windows-side Electron process tree walk uses `Get-Process -Id <pid>` which only sees Windows PIDs — Linux PIDs are invisible, so the walk always fails and VS    
  Code never gets focused.
                                                                                                                                                                                                                                          
  ## Solution                                                                  
                                               
  - Added `makeEditorFallbackBlock` in `src/focus.js`: when the PID walk and Windows Terminal scan both find nothing, falls back to locating VS Code or Cursor directly by process name (`Code` / `Cursor`). Tries title-matching by cwd  
  folder name first for multi-window accuracy, then takes the first visible window.
  - Threaded `editor` param through `makeFocusCmd` and `focusTerminalWindowLegacy` so the fallback knows which editor to target.                                                                                                          
  - Added `TERM_PROGRAM` → `editor` fallback in `hooks/clawd-hook.js`: VS Code injects `TERM_PROGRAM=vscode` into WSL terminals, so when process tree detection yields no editor this provides the signal needed to trigger the PowerShell
   fallback.                                                                                                                                                                                                                              
                                                                                                                                                                                                                                          
  ## Setup requirement                                                                                                                                                                                                                    
                                                                               
  WSL2 must use mirrored networking so hook HTTP calls reach the Windows-side Clawd server (as per https://github.com/rullerzhou-afk/clawd-on-desk/issues/96#issuecomment-4230348542)

  ```ini
  # %USERPROFILE%\.wslconfig
  [wsl2]
  networkingMode=mirrored                                                                                                                                                                                                                 
   ```

  Tested on                                                                                                                                                                                                                               
```                                                     
  Windows + WSL2 (Ubuntu) + VS Code Remote-WSL 
```


https://github.com/user-attachments/assets/475789d1-1bbd-4a9c-8ef0-c6c2ef077dc0

