### PR TITLE
fix: make Claude hooks management async

### DIFF
--- a/hooks/install.js
+++ b/hooks/install.js
@@ -6,8 +6,9 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const childProcess = require("child_process");
 const { buildPermissionUrl, DEFAULT_SERVER_PORT, PERMISSION_PATH, readRuntimePort, resolveNodeBin } = require("./server-config");
-const { writeJsonAtomic, asarUnpackedPath } = require("./json-utils");
+const { writeJsonAtomic, writeJsonAtomicAsync, asarUnpackedPath } = require("./json-utils");
 
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".claude");
 const DEFAULT_CONFIG_PATH = path.join(DEFAULT_PARENT_DIR, "settings.json");
@@ -50,6 +51,8 @@ const UNKNOWN_CLAUDE_VERSION = Object.freeze({
   source: null,
   status: "unknown",
 });
+let cachedClaudeVersionInfo = null;
+let cachedClaudeVersionPromise = null;
 
 /**
  * Compare two semver strings: return true if a < b.
@@ -247,6 +250,77 @@ function getClaudeVersion(options = {}) {
     if (fallback && !fallbackInfo) fallbackInfo = fallback;
   }
   return fallbackInfo || { ...UNKNOWN_CLAUDE_VERSION };
+}
+
+async function getClaudeVersionAsync(options = {}) {
+  if (options.resetCache) {
+    cachedClaudeVersionInfo = null;
+    cachedClaudeVersionPromise = null;
+  }
+  if (cachedClaudeVersionInfo) return cachedClaudeVersionInfo;
+  if (cachedClaudeVersionPromise) return cachedClaudeVersionPromise;
+
+  const compute = async () => {
+    const platform = options.platform || process.platform;
+    const homeDir = options.homeDir || os.homedir();
+    const execFile = options.execFile || ((command, args, execOptions) => new Promise((resolve, reject) => {
+      childProcess.execFile(command, args, execOptions, (err, stdout, stderr) => {
+        if (err) reject(err);
+        else resolve({ stdout, stderr });
+      });
+    }));
+    const candidates = Array.isArray(options.candidates)
+      ? [...options.candidates]
+      : [];
+
+    if (!candidates.length) {
+      if (platform === "darwin") {
+        candidates.push(
+          path.join(homeDir, ".local", "bin", "claude"),
+          path.join(homeDir, ".claude", "local", "claude"),
+          "/opt/homebrew/bin/claude",
+          "/usr/local/bin/claude"
+        );
+      }
+      candidates.push(...getClaudePathCandidates(options));
+      candidates.push("claude");
+    }
+
+    const seen = new Set();
+    let fallbackInfo = null;
+    for (const candidate of candidates) {
+      const key = platform === "win32" ? candidate.toLowerCase() : candidate;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      try {
+        const out = await execFile(candidate, ["--version"], {
+          encoding: "utf8",
+          timeout: 5000,
+          windowsHide: true,
+        });
+        const stdout = typeof out === "string" ? out : out && typeof out.stdout === "string" ? out.stdout : "";
+        const version = parseClaudeVersion(stdout);
+        if (!version) continue;
+        const result = {
+          version,
+          source: candidate === "claude" ? "PATH:claude" : candidate,
+          status: "known",
+        };
+        cachedClaudeVersionInfo = result;
+        return result;
+      } catch {}
+
+      const fallback = readClaudeVersionFallback(candidate, options);
+      if (fallback && !fallbackInfo) fallbackInfo = fallback;
+    }
+    if (fallbackInfo) cachedClaudeVersionInfo = fallbackInfo;
+    return fallbackInfo || { ...UNKNOWN_CLAUDE_VERSION };
+  };
+
+  cachedClaudeVersionPromise = compute().finally(() => {
+    cachedClaudeVersionPromise = null;
+  });
+  return cachedClaudeVersionPromise;
 }
 
 const MARKER = "clawd-hook.js";
@@ -798,6 +872,205 @@ function registerHooks(options = {}) {
   };
 }
 
+async function registerHooksAsync(options = {}) {
+  const settingsPath = options.settingsPath || path.join(os.homedir(), ".claude", "settings.json");
+  const hookPort = getHookServerPort(options.port);
+  const hookScript = asarUnpackedPath(path.resolve(__dirname, "clawd-hook.js").replace(/\\/g, "/"));
+  const platform = options.platform || process.platform;
+
+  let settings = {};
+  try {
+    settings = JSON.parse(await fs.promises.readFile(settingsPath, "utf-8"));
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      throw new Error(`Failed to read settings.json: ${err.message}`);
+    }
+  }
+
+  if (!settings.hooks) settings.hooks = {};
+
+  const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
+  const nodeBin = resolved
+    || extractNodeBinFromSettings(settings, MARKER)
+    || "node";
+
+  let added = 0;
+  let skipped = 0;
+  let versionSkipped = 0;
+  let updated = 0;
+  let removed = 0;
+  let changed = false;
+
+  const versionInfo = options.claudeVersionInfo || await getClaudeVersionAsync(options);
+  const { supported: supportedVersionedHooks, unsupported: unsupportedVersionedHooks } =
+    getSupportedVersionedHooks(versionInfo);
+  const supportedVersionedEvents = new Set(supportedVersionedHooks.map((hook) => hook.event));
+  versionSkipped = unsupportedVersionedHooks.length;
+
+  const reconcileResult = reconcileVersionedHooks(settings, supportedVersionedEvents, versionInfo);
+  removed += reconcileResult.removed;
+  changed = changed || reconcileResult.changed;
+
+  for (const event of DEPRECATED_CORE_HOOKS) {
+    if (!Array.isArray(settings.hooks[event])) continue;
+    const result = removeMatchingCommandHooks(
+      settings.hooks[event],
+      (command) => command.includes(MARKER)
+    );
+    if (!result.changed) continue;
+    removed += result.removed;
+    changed = true;
+    if (result.entries.length > 0) settings.hooks[event] = result.entries;
+    else delete settings.hooks[event];
+  }
+
+  const hookEvents = [...CORE_HOOKS];
+  for (const { event } of supportedVersionedHooks) {
+    hookEvents.push(event);
+  }
+
+  for (const event of hookEvents) {
+    if (!Array.isArray(settings.hooks[event])) {
+      const existing = settings.hooks[event];
+      settings.hooks[event] = existing && typeof existing === "object" ? [existing] : [];
+      changed = true;
+    }
+
+    const desiredHook = buildCommandHookSpec(nodeBin, hookScript, event, {
+      platform,
+      remote: options.remote,
+    });
+    const commandSync = syncCommandHook(settings.hooks[event], MARKER, desiredHook);
+    if (commandSync.found) {
+      if (commandSync.changed) {
+        updated++;
+        changed = true;
+      } else {
+        skipped++;
+      }
+      continue;
+    }
+
+    settings.hooks[event].push({
+      matcher: "",
+      hooks: [desiredHook],
+    });
+    added++;
+  }
+
+  if (options.autoStart) {
+    const autoStartScript = asarUnpackedPath(path.resolve(__dirname, "auto-start.js").replace(/\\/g, "/"));
+
+    if (!Array.isArray(settings.hooks.SessionStart)) {
+      settings.hooks.SessionStart = [];
+      changed = true;
+    }
+
+    const autoStartHook = buildCommandHookSpec(nodeBin, autoStartScript, "", { platform });
+    const autoStartSync = syncCommandHook(settings.hooks.SessionStart, AUTO_START_MARKER, autoStartHook);
+    if (!autoStartSync.found) {
+      settings.hooks.SessionStart.unshift({
+        matcher: "",
+        hooks: [autoStartHook],
+      });
+      added++;
+    } else if (autoStartSync.changed) {
+      updated++;
+      changed = true;
+    } else {
+      skipped++;
+    }
+
+    const beforeLen = settings.hooks.SessionStart.length;
+    settings.hooks.SessionStart = settings.hooks.SessionStart.filter((entry) => {
+      if (!entry || typeof entry !== "object") return true;
+      if (typeof entry.command === "string" && entry.command.includes(LEGACY_AUTO_START_MARKER)) return false;
+      if (Array.isArray(entry.hooks)) {
+        if (entry.hooks.some((h) => h && typeof h.command === "string" && h.command.includes(LEGACY_AUTO_START_MARKER))) return false;
+      }
+      return true;
+    });
+    if (settings.hooks.SessionStart.length < beforeLen) changed = true;
+  }
+
+  for (const event of Object.keys(HTTP_HOOKS)) {
+    if (!Array.isArray(settings.hooks[event])) continue;
+    const result = removeMatchingCommandHooks(
+      settings.hooks[event],
+      (command) => command.includes(MARKER)
+    );
+    if (result.changed) {
+      settings.hooks[event] = result.entries;
+      removed += result.removed;
+      changed = true;
+    }
+  }
+
+  for (const [event, { matcher, hook }] of Object.entries(HTTP_HOOKS)) {
+    if (!Array.isArray(settings.hooks[event])) {
+      settings.hooks[event] = [];
+      changed = true;
+    }
+
+    const desiredHook = { ...hook, url: buildPermissionUrl(hookPort) };
+    const httpSync = syncHttpHook(settings.hooks[event], desiredHook.url);
+    if (httpSync.found) {
+      if (httpSync.changed) {
+        updated++;
+        changed = true;
+      } else {
+        skipped++;
+      }
+      continue;
+    }
+
+    settings.hooks[event].push({
+      matcher,
+      hooks: [desiredHook],
+    });
+    added++;
+  }
+
+  if (added > 0 || changed) {
+    await writeJsonAtomicAsync(settingsPath, settings);
+  }
+
+  if (!options.silent) {
+    const versionLabel = versionInfo.status === "known" ? versionInfo.version : "unknown";
+    const versionSource = versionInfo.source || "unavailable";
+    console.log(`Clawd hooks installed to ${settingsPath}`);
+    console.log(`  Claude Code version: ${versionLabel}`);
+    console.log(`  Detection source: ${versionSource}`);
+    if (versionInfo.status === "unknown") {
+      console.log("  Versioned hooks: disabled (Claude Code version could not be detected)");
+    }
+    console.log(`  Added: ${added} hooks`);
+    if (updated > 0) console.log(`  Updated: ${updated} stale hook paths`);
+    if (removed > 0) console.log(`  Removed: ${removed} incompatible versioned hooks`);
+    if (skipped > 0) console.log(`  Skipped: ${skipped} (already registered)`);
+    if (versionSkipped > 0) {
+      const reason = versionInfo.status === "known"
+        ? `version too old for ${unsupportedVersionedHooks.map((hook) => hook.event).join(", ")}`
+        : "version unknown, versioned hooks disabled";
+      console.log(`  Skipped: ${versionSkipped} (${reason})`);
+    }
+    console.log(`\nHook events: ${hookEvents.join(", ")}`);
+    if (Object.keys(HTTP_HOOKS).length > 0) {
+      console.log(`HTTP hooks: ${Object.keys(HTTP_HOOKS).join(", ")}`);
+    }
+  }
+
+  return {
+    added,
+    skipped,
+    updated,
+    removed,
+    version: versionInfo.version,
+    versionStatus: versionInfo.status,
+    versionSource: versionInfo.source,
+  };
+}
+
 function unregisterHooks(options = {}) {
   const settingsPath = options.settingsPath || path.join(os.homedir(), ".claude", "settings.json");
   let settings = {};
@@ -838,6 +1111,51 @@ function unregisterHooks(options = {}) {
 
   if (changed) {
     writeJsonAtomic(settingsPath, settings);
+  }
+
+  return { removed, changed };
+}
+
+async function unregisterHooksAsync(options = {}) {
+  const settingsPath = options.settingsPath || path.join(os.homedir(), ".claude", "settings.json");
+  let settings = {};
+  try {
+    settings = JSON.parse(await fs.promises.readFile(settingsPath, "utf-8"));
+  } catch (err) {
+    if (err.code === "ENOENT") return { removed: 0, changed: false };
+    throw new Error(`Failed to read settings.json: ${err.message}`);
+  }
+
+  if (!settings.hooks || typeof settings.hooks !== "object") {
+    return { removed: 0, changed: false };
+  }
+
+  let removed = 0;
+  let changed = false;
+  for (const [event, entries] of Object.entries(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+
+    const commandResult = removeMatchingCommandHooks(
+      entries,
+      (command) => command.includes(MARKER)
+        || command.includes(AUTO_START_MARKER)
+        || command.includes(LEGACY_AUTO_START_MARKER)
+    );
+    const httpResult = removeMatchingHttpHooks(
+      commandResult.entries,
+      (hook) => isClawdPermissionHook(hook)
+    );
+
+    if (!commandResult.changed && !httpResult.changed) continue;
+
+    removed += commandResult.removed + httpResult.removed;
+    changed = true;
+    if (httpResult.entries.length > 0) settings.hooks[event] = httpResult.entries;
+    else delete settings.hooks[event];
+  }
+
+  if (changed) {
+    await writeJsonAtomicAsync(settingsPath, settings);
   }
 
   return { removed, changed };
@@ -911,7 +1229,9 @@ module.exports = {
   DEFAULT_PARENT_DIR,
   DEFAULT_CONFIG_PATH,
   registerHooks,
+  registerHooksAsync,
   unregisterHooks,
+  unregisterHooksAsync,
   unregisterAutoStart,
   isAutoStartRegistered,
   __test: {
@@ -922,6 +1242,7 @@ module.exports = {
     getClaudeVersionFromPackageJson,
     readClaudeVersionFallback,
     getClaudeVersion,
+    getClaudeVersionAsync,
     isClawdPermissionHook,
     isClawdPermissionUrl,
     removeMatchingHttpHooks,

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -129,6 +129,41 @@ function getClaudePathCandidates(options = {}) {
   return candidates;
 }
 
+async function getClaudePathCandidatesAsync(options = {}) {
+  const platform = options.platform || process.platform;
+  const pathEnv = options.pathEnv !== undefined ? options.pathEnv : process.env.PATH;
+  const access = options.access || fs.promises.access.bind(fs.promises);
+
+  if (typeof pathEnv !== "string" || !pathEnv) return [];
+
+  const suffixes = platform === "win32"
+    ? getWindowsClaudePathSuffixes(options.pathExt !== undefined ? options.pathExt : process.env.PATHEXT)
+    : [""];
+  const delimiter = platform === "win32" ? ";" : ":";
+  const candidates = [];
+  const seen = new Set();
+
+  for (const rawDir of pathEnv.split(delimiter)) {
+    if (typeof rawDir !== "string") continue;
+    const dir = rawDir.trim().replace(/^"(.*)"$/, "$1");
+    if (!dir) continue;
+
+    for (const suffix of suffixes) {
+      const candidate = path.join(dir, `claude${suffix}`);
+      const key = platform === "win32" ? candidate.toLowerCase() : candidate;
+      if (seen.has(key)) continue;
+      seen.add(key);
+
+      try {
+        await access(candidate);
+        candidates.push(candidate);
+      } catch {}
+    }
+  }
+
+  return candidates;
+}
+
 function getClaudePackageJsonCandidates(candidatePath, options = {}) {
   const platform = options.platform || process.platform;
   const existsSync = options.existsSync || fs.existsSync;
@@ -176,6 +211,53 @@ function getClaudePackageJsonCandidates(candidatePath, options = {}) {
   return candidates;
 }
 
+async function getClaudePackageJsonCandidatesAsync(candidatePath, options = {}) {
+  const platform = options.platform || process.platform;
+  const access = options.access || fs.promises.access.bind(fs.promises);
+  const readFile = options.readFile || fs.promises.readFile.bind(fs.promises);
+  const realpath = options.realpath || fs.promises.realpath.bind(fs.promises);
+  const stat = options.stat || fs.promises.stat.bind(fs.promises);
+
+  if (!path.isAbsolute(candidatePath)) return [];
+
+  const candidates = [];
+  const seen = new Set();
+  const addCandidate = async (packageJsonPath) => {
+    if (typeof packageJsonPath !== "string" || !packageJsonPath) return;
+    const key = platform === "win32" ? packageJsonPath.toLowerCase() : packageJsonPath;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    try {
+      await access(packageJsonPath);
+      candidates.push(packageJsonPath);
+    } catch {}
+  };
+
+  const candidateDir = path.dirname(candidatePath);
+  await addCandidate(path.join(candidateDir, ...CLAUDE_PACKAGE_JSON_SEGMENTS));
+
+  try {
+    const resolvedPath = await realpath(candidatePath);
+    await addCandidate(path.join(path.dirname(resolvedPath), "package.json"));
+  } catch {}
+
+  try {
+    const statResult = await stat(candidatePath);
+    const isRegularFile = typeof statResult.isFile === "function" ? statResult.isFile() : true;
+    if (isRegularFile && typeof statResult.size === "number" && statResult.size <= MAX_CLAUDE_SHIM_BYTES) {
+      const shimSource = await readFile(candidatePath, "utf8");
+      const shimMatch = String(shimSource).match(CLAUDE_SHIM_CLI_PATTERN);
+      if (shimMatch) {
+        const cliPath = path.resolve(candidateDir, shimMatch[0].replace(/[\\/]/g, path.sep));
+        await addCandidate(path.join(path.dirname(cliPath), "package.json"));
+      }
+    }
+  } catch {}
+
+  return candidates;
+}
+
 function getClaudeVersionFromPackageJson(packageJsonPath, options = {}) {
   const readFileSync = options.readFileSync || fs.readFileSync;
 
@@ -193,9 +275,34 @@ function getClaudeVersionFromPackageJson(packageJsonPath, options = {}) {
   }
 }
 
+async function getClaudeVersionFromPackageJsonAsync(packageJsonPath, options = {}) {
+  const readFile = options.readFile || fs.promises.readFile.bind(fs.promises);
+
+  try {
+    const packageJson = JSON.parse(String(await readFile(packageJsonPath, "utf8")));
+    const version = parseClaudeVersion(packageJson.version);
+    if (!version) return null;
+    return {
+      version,
+      source: packageJsonPath,
+      status: "known",
+    };
+  } catch {
+    return null;
+  }
+}
+
 function readClaudeVersionFallback(candidatePath, options = {}) {
   for (const packageJsonPath of getClaudePackageJsonCandidates(candidatePath, options)) {
     const versionInfo = getClaudeVersionFromPackageJson(packageJsonPath, options);
+    if (versionInfo) return versionInfo;
+  }
+  return null;
+}
+
+async function readClaudeVersionFallbackAsync(candidatePath, options = {}) {
+  for (const packageJsonPath of await getClaudePackageJsonCandidatesAsync(candidatePath, options)) {
+    const versionInfo = await getClaudeVersionFromPackageJsonAsync(packageJsonPath, options);
     if (versionInfo) return versionInfo;
   }
   return null;
@@ -282,7 +389,7 @@ async function getClaudeVersionAsync(options = {}) {
           "/usr/local/bin/claude"
         );
       }
-      candidates.push(...getClaudePathCandidates(options));
+      candidates.push(...await getClaudePathCandidatesAsync(options));
       candidates.push("claude");
     }
 
@@ -310,7 +417,7 @@ async function getClaudeVersionAsync(options = {}) {
         return result;
       } catch {}
 
-      const fallback = readClaudeVersionFallback(candidate, options);
+      const fallback = await readClaudeVersionFallbackAsync(candidate, options);
       if (fallback && !fallbackInfo) fallbackInfo = fallback;
     }
     if (fallbackInfo) cachedClaudeVersionInfo = fallbackInfo;
@@ -1238,9 +1345,13 @@ module.exports = {
     parseClaudeVersion,
     getWindowsClaudePathSuffixes,
     getClaudePathCandidates,
+    getClaudePathCandidatesAsync,
     getClaudePackageJsonCandidates,
+    getClaudePackageJsonCandidatesAsync,
     getClaudeVersionFromPackageJson,
+    getClaudeVersionFromPackageJsonAsync,
     readClaudeVersionFallback,
+    readClaudeVersionFallbackAsync,
     getClaudeVersion,
     getClaudeVersionAsync,
     isClawdPermissionHook,

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -7,7 +7,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const childProcess = require("child_process");
-const { buildPermissionUrl, DEFAULT_SERVER_PORT, PERMISSION_PATH, readRuntimePort, resolveNodeBin } = require("./server-config");
+const { buildPermissionUrl, DEFAULT_SERVER_PORT, PERMISSION_PATH, readRuntimePort, resolveNodeBin, resolveNodeBinAsync } = require("./server-config");
 const { writeJsonAtomic, writeJsonAtomicAsync, asarUnpackedPath } = require("./json-utils");
 
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".claude");
@@ -996,9 +996,11 @@ async function registerHooksAsync(options = {}) {
 
   if (!settings.hooks) settings.hooks = {};
 
-  const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
-  const nodeBin = resolved
-    || extractNodeBinFromSettings(settings, MARKER)
+  const configuredNodeBin = options.nodeBin !== undefined
+    ? options.nodeBin
+    : extractNodeBinFromSettings(settings, MARKER);
+  const nodeBin = configuredNodeBin
+    || await resolveNodeBinAsync(options)
     || "node";
 
   let added = 0;

--- a/hooks/json-utils.js
+++ b/hooks/json-utils.js
@@ -31,6 +31,20 @@ function writeJsonAtomic(filePath, data) {
   }
 }
 
+async function writeJsonAtomicAsync(filePath, data) {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const tmpPath = path.join(dir, `.${base}.${process.pid}.${Date.now()}.tmp`);
+  await fs.promises.mkdir(dir, { recursive: true });
+  try {
+    await fs.promises.writeFile(tmpPath, JSON.stringify(data, null, 2), "utf-8");
+    await fs.promises.rename(tmpPath, filePath);
+  } catch (err) {
+    try { await fs.promises.unlink(tmpPath); } catch {}
+    throw err;
+  }
+}
+
 /**
  * Rewrite a path so it points at the asar.unpacked mirror instead of asar.
  * In packaged builds, __dirname resolves to the virtual app.asar/ tree, but
@@ -130,6 +144,7 @@ function findHookCommands(settings, marker, options) {
 
 module.exports = {
   writeJsonAtomic,
+  writeJsonAtomicAsync,
   asarUnpackedPath,
   extractExistingNodeBin,
   findHookCommands,

--- a/hooks/server-config.js
+++ b/hooks/server-config.js
@@ -409,6 +409,62 @@ function resolveNodeBin(options = {}) {
   return null;
 }
 
+async function resolveNodeBinAsync(options = {}) {
+  const platform = options.platform || process.platform;
+
+  if (platform === "win32") return "node";
+
+  const isElectron = options.isElectron !== undefined
+    ? options.isElectron
+    : !!process.versions.electron;
+
+  if (!isElectron) {
+    return options.execPath || process.execPath;
+  }
+
+  const homeDir = options.homeDir || os.homedir();
+  const access = options.access || fs.promises.access.bind(fs.promises);
+  const candidates = [
+    "/opt/homebrew/bin/node",
+    "/usr/local/bin/node",
+    path.join(homeDir, ".volta", "bin", "node"),
+    path.join(homeDir, ".local", "bin", "node"),
+    "/usr/bin/node",
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await access(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {}
+  }
+
+  const execFile = options.execFile || ((command, args, execOptions) => new Promise((resolve, reject) => {
+    require("child_process").execFile(command, args, execOptions, (err, stdout, stderr) => {
+      if (err) reject(err);
+      else resolve({ stdout, stderr });
+    });
+  }));
+  const shells = ["/bin/zsh", "/bin/bash"];
+  for (const shell of shells) {
+    try {
+      const out = await execFile(shell, ["-lic", "which node"], {
+        encoding: "utf8",
+        timeout: 5000,
+        windowsHide: true,
+      });
+      const raw = typeof out === "string" ? out : out && typeof out.stdout === "string" ? out.stdout : "";
+      const lines = raw.split("\n");
+      for (let i = lines.length - 1; i >= 0; i--) {
+        const line = lines[i].trim();
+        if (line.startsWith("/")) return line;
+      }
+    } catch {}
+  }
+
+  return null;
+}
+
 module.exports = {
   CLAWD_SERVER_HEADER,
   CLAWD_SERVER_ID,
@@ -428,6 +484,7 @@ module.exports = {
   readHostPrefix,
   readRuntimePort,
   resolveNodeBin,
+  resolveNodeBinAsync,
   splitPortCandidates,
   postStateToPort,
   writeRuntimeConfig,

--- a/src/main.js
+++ b/src/main.js
@@ -111,9 +111,9 @@ function _uninstallAutoStartHook() {
   const { unregisterAutoStart } = require("../hooks/install.js");
   unregisterAutoStart();
 }
-function _uninstallClaudeHooksNow() {
-  const { unregisterHooks } = require("../hooks/install.js");
-  unregisterHooks();
+async function _uninstallClaudeHooksNow() {
+  const { unregisterHooksAsync } = require("../hooks/install.js");
+  await unregisterHooksAsync();
 }
 
 // Cross-platform "open at login" writer used by both the openAtLogin effect
@@ -223,7 +223,10 @@ const _settingsController = createSettingsController({
   injectedDeps: {
     installAutoStart: _installAutoStartHook,
     uninstallAutoStart: _uninstallAutoStartHook,
-    syncClaudeHooksNow: () => _server.syncClawdHooks(),
+    syncClaudeHooksNow: () => {
+      const { registerHooksAsync } = require("../hooks/install.js");
+      return registerHooksAsync({ silent: true, autoStart: autoStartWithClaude, port: getHookServerPort() });
+    },
     uninstallClaudeHooksNow: _uninstallClaudeHooksNow,
     startClaudeSettingsWatcher: () => _server.startClaudeSettingsWatcher(),
     stopClaudeSettingsWatcher: () => _server.stopClaudeSettingsWatcher(),

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -370,23 +370,30 @@ const updateRegistry = {
           message: "manageClaudeHooksAutomatically effect requires syncClaudeHooksNow/startClaudeSettingsWatcher/stopClaudeSettingsWatcher deps",
         };
       }
-      try {
-        if (value) {
-          if (!isAgentEnabled(deps.snapshot, "claude-code")) {
-            return { status: "ok" };
-          }
-          deps.syncClaudeHooksNow();
-          deps.startClaudeSettingsWatcher();
-        } else {
+      if (!value) {
+        try {
           deps.stopClaudeSettingsWatcher();
+          return { status: "ok" };
+        } catch (err) {
+          return {
+            status: "error",
+            message: `manageClaudeHooksAutomatically: ${err && err.message}`,
+          };
         }
+      }
+      if (!isAgentEnabled(deps.snapshot, "claude-code")) {
         return { status: "ok" };
-      } catch (err) {
-        return {
+      }
+      return Promise.resolve()
+        .then(() => deps.syncClaudeHooksNow())
+        .then(() => {
+          deps.startClaudeSettingsWatcher();
+          return { status: "ok" };
+        })
+        .catch((err) => ({
           status: "error",
           message: `manageClaudeHooksAutomatically: ${err && err.message}`,
-        };
-      }
+        }));
     },
   },
 
@@ -1613,7 +1620,7 @@ function resetThemeOverrides(payload, deps) {
   return { status: "ok", commit: { themeOverrides: nextOverrides } };
 }
 
-function installHooks(_payload, deps) {
+async function installHooks(_payload, deps) {
   if (!deps || typeof deps.syncClaudeHooksNow !== "function") {
     return {
       status: "error",
@@ -1621,14 +1628,14 @@ function installHooks(_payload, deps) {
     };
   }
   try {
-    deps.syncClaudeHooksNow();
+    await deps.syncClaudeHooksNow();
     return { status: "ok" };
   } catch (err) {
     return { status: "error", message: `installHooks: ${err && err.message}` };
   }
 }
 
-function uninstallHooks(_payload, deps) {
+async function uninstallHooks(_payload, deps) {
   if (
     !deps
     || typeof deps.uninstallClaudeHooksNow !== "function"
@@ -1643,7 +1650,7 @@ function uninstallHooks(_payload, deps) {
   const shouldRestoreWatcher = !!(deps.snapshot && deps.snapshot.manageClaudeHooksAutomatically);
   try {
     deps.stopClaudeSettingsWatcher();
-    deps.uninstallClaudeHooksNow();
+    await deps.uninstallClaudeHooksNow();
     return { status: "ok", commit: { manageClaudeHooksAutomatically: false } };
   } catch (err) {
     if (shouldRestoreWatcher && typeof deps.startClaudeSettingsWatcher === "function") {

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -89,6 +89,7 @@ const AUTO_REPAIRABLE_AGENT_IDS = new Set([
   "kimi-cli",
   "opencode",
 ]);
+const CLAUDE_HOOKS_LOCK_KEY = "claude-hooks";
 
 // ── Validator helpers ──
 
@@ -332,6 +333,7 @@ const updateRegistry = {
   //   (permission denied, disk full, corrupt JSON) MUST prevent the prefs
   //   commit so the UI never shows "on" while the file is unchanged.
   autoStartWithClaude: {
+    lockKey: CLAUDE_HOOKS_LOCK_KEY,
     validate: requireBoolean("autoStartWithClaude"),
     effect(value, deps) {
       if (deps && deps.snapshot && deps.snapshot.manageClaudeHooksAutomatically === false) {
@@ -357,6 +359,7 @@ const updateRegistry = {
   },
 
   manageClaudeHooksAutomatically: {
+    lockKey: CLAUDE_HOOKS_LOCK_KEY,
     validate: requireBoolean("manageClaudeHooksAutomatically"),
     effect(value, deps) {
       if (
@@ -1829,6 +1832,9 @@ function resizePet(payload, deps) {
     return { status: "error", message: `resizePet: ${err && err.message}` };
   }
 }
+
+installHooks.lockKey = CLAUDE_HOOKS_LOCK_KEY;
+uninstallHooks.lockKey = CLAUDE_HOOKS_LOCK_KEY;
 
 const commandRegistry = {
   removeTheme,

--- a/src/settings-controller.js
+++ b/src/settings-controller.js
@@ -80,13 +80,15 @@ function createSettingsController({
 
   const store = createStore(initialSnapshot);
 
-  // Per-key async serialization. When an async action is in flight for a key,
-  // later writes on the same key queue after it instead of racing — otherwise
-  // a slow-resolving effect could commit after a fast-resolving one and flip
-  // the store back. Sync actions on an idle key skip the lock entirely so the
-  // common path stays synchronous (menu setters rely on that). The Map self-
-  // cleans: once a tracked promise settles, its entry is removed unless
-  // another call has already chained a newer one on top.
+  // Per-key/domain async serialization. When an async action is in flight for a
+  // key, later writes on the same key queue after it instead of racing —
+  // otherwise a slow-resolving effect could commit after a fast-resolving one
+  // and flip the store back. Some actions can opt into a shared lock domain
+  // when different settings/commands mutate the same external resource (for
+  // example ~/.claude/settings.json). Sync actions on an idle key skip the lock
+  // entirely so the common path stays synchronous (menu setters rely on that).
+  // The Map self-cleans: once a tracked promise settles, its entry is removed
+  // unless another call has already chained a newer one on top.
   const _asyncLocks = new Map();
   function _trackAsyncLock(lockKey, p) {
     _asyncLocks.set(lockKey, p);
@@ -136,6 +138,22 @@ function createSettingsController({
       return entry.effect;
     }
     return null;
+  }
+
+  function resolveUpdateLockKey(key) {
+    const entry = updates[key];
+    if (entry && typeof entry.lockKey === "string" && entry.lockKey) {
+      return `domain:${entry.lockKey}`;
+    }
+    return `update:${key}`;
+  }
+
+  function resolveCommandLockKey(name) {
+    const command = commands[name];
+    if (command && typeof command.lockKey === "string" && command.lockKey) {
+      return `domain:${command.lockKey}`;
+    }
+    return `cmd:${name}`;
   }
 
   // Run one fn (validator or effect) and normalize its return into a sync
@@ -216,13 +234,14 @@ function createSettingsController({
   // because returning sync `{ok}` while a pending commit is about to stomp
   // the same key would be a lie.
   function applyUpdate(key, value) {
-    const pending = _asyncLocks.get(key);
+    const lockKey = resolveUpdateLockKey(key);
+    const pending = _asyncLocks.get(lockKey);
     if (pending) {
       const next = pending.then(
         () => _doApplyUpdate(key, value),
         () => _doApplyUpdate(key, value)
       );
-      _trackAsyncLock(key, next);
+      _trackAsyncLock(lockKey, next);
       return next;
     }
     const actionResult = invokeAction(key, value);
@@ -230,7 +249,7 @@ function createSettingsController({
       return finishSingle(key, value, actionResult);
     }
     const next = actionResult.then((r) => finishSingle(key, value, r));
-    _trackAsyncLock(key, next);
+    _trackAsyncLock(lockKey, next);
     return next;
   }
 
@@ -360,10 +379,10 @@ function createSettingsController({
     ).then(finishBulk);
   }
 
-  // Serialize commands by name — same-name rapid toggles would otherwise
+  // Serialize commands by name/domain — same-name rapid toggles would otherwise
   // race and the later-resolving one would commit over the earlier.
   function applyCommand(name, payload) {
-    const lockKey = `cmd:${name}`;
+    const lockKey = resolveCommandLockKey(name);
     const prev = _asyncLocks.get(lockKey);
     const run = () => _doApplyCommand(name, payload);
     const next = prev ? prev.then(run, run) : run();

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -233,7 +233,7 @@
             showToast(t("toastSaveFailed") + msg, { error: true });
             return;
           }
-          setTransientState({ visualOn: nextVisual, pending: false, seq });
+          clearTransientState(seq);
           setSwitchVisual(sw, nextVisual, { pending: false });
         })
         .catch((err) => {

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -787,6 +787,16 @@
     if (state.activeTab === "shortcuts") requestRender({ content: true });
   }
 
+  function clearTransientStateForChanges(changes) {
+    if (!changes || typeof changes !== "object") return;
+    for (const key of Object.keys(changes)) {
+      state.transientUiState.generalSwitches.delete(key);
+    }
+    if (Object.prototype.hasOwnProperty.call(changes, "agents")) {
+      state.transientUiState.agentSwitches.clear();
+    }
+  }
+
   function applyChanges(payload) {
     if (payload && payload.snapshot) {
       state.snapshot = payload.snapshot;
@@ -796,6 +806,7 @@
     if (!state.snapshot) return;
 
     const changes = payload && payload.changes;
+    clearTransientStateForChanges(changes);
     const needsAnimOverridesRefresh = !!(changes && (
       "theme" in changes || "themeVariant" in changes || "themeOverrides" in changes
     ));

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -8,9 +8,13 @@ const {
   parseClaudeVersion,
   getWindowsClaudePathSuffixes,
   getClaudePathCandidates,
+  getClaudePathCandidatesAsync,
   getClaudePackageJsonCandidates,
+  getClaudePackageJsonCandidatesAsync,
   getClaudeVersionFromPackageJson,
+  getClaudeVersionFromPackageJsonAsync,
   readClaudeVersionFallback,
+  readClaudeVersionFallbackAsync,
   getClaudeVersionAsync,
 } = __test;
 
@@ -168,6 +172,32 @@ describe("Claude version detection helpers", () => {
     ]);
   });
 
+  it("finds existing Windows Claude shims asynchronously from PATH", async () => {
+    const npmDir = "C:\\Users\\Tester\\AppData\\Roaming\\npm";
+    const npmDirUpper = "C:\\USERS\\Tester\\AppData\\Roaming\\NPM";
+    const toolsDir = "C:\\Tools";
+    const existing = new Set([
+      path.join(npmDir, "claude.cmd").toLowerCase(),
+      path.join(toolsDir, "claude.ps1").toLowerCase(),
+    ]);
+
+    const candidates = await getClaudePathCandidatesAsync({
+      platform: "win32",
+      pathEnv: `"${npmDir}";${npmDirUpper};${toolsDir}`,
+      pathExt: ".CMD;.Ps1",
+      async access(candidatePath) {
+        if (!existing.has(candidatePath.toLowerCase())) {
+          throw new Error(`missing: ${candidatePath}`);
+        }
+      },
+    });
+
+    assert.deepStrictEqual(candidates, [
+      path.join(npmDir, "claude.cmd"),
+      path.join(toolsDir, "claude.ps1"),
+    ]);
+  });
+
   it("finds existing POSIX Claude binaries from PATH", () => {
     const localDir = "/usr/local/bin";
     const optDir = "/opt/claude/bin";
@@ -203,6 +233,40 @@ describe("Claude version detection helpers", () => {
         return { size: 512, isFile: () => true };
       },
       readFileSync(targetPath) {
+        assert.strictEqual(targetPath, candidatePath);
+        return '@ECHO off\n"%dp0%\\node.exe" "%dp0%\\node_modules\\@anthropic-ai\\claude-code\\cli.js" %*\n';
+      },
+    });
+
+    assert.deepStrictEqual(candidates, [
+      siblingPackageJson,
+      realpathPackageJson,
+    ]);
+  });
+
+  it("collects Claude package.json candidates asynchronously", async () => {
+    const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
+    const candidateDir = path.dirname(candidatePath);
+    const siblingPackageJson = path.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const realpathCli = "D:\\shim-store\\claude\\cli.js";
+    const realpathPackageJson = path.join(path.dirname(realpathCli), "package.json");
+    const existing = new Set([siblingPackageJson.toLowerCase(), realpathPackageJson.toLowerCase()]);
+
+    const candidates = await getClaudePackageJsonCandidatesAsync(candidatePath, {
+      platform: "win32",
+      async access(packageJsonPath) {
+        if (!existing.has(packageJsonPath.toLowerCase())) {
+          throw new Error(`missing: ${packageJsonPath}`);
+        }
+      },
+      async realpath(targetPath) {
+        assert.strictEqual(targetPath, candidatePath);
+        return realpathCli;
+      },
+      async stat() {
+        return { size: 512, isFile: () => true };
+      },
+      async readFile(targetPath) {
         assert.strictEqual(targetPath, candidatePath);
         return '@ECHO off\n"%dp0%\\node.exe" "%dp0%\\node_modules\\@anthropic-ai\\claude-code\\cli.js" %*\n';
       },
@@ -268,6 +332,33 @@ describe("Claude version detection helpers", () => {
     );
   });
 
+  it("reads Claude version from package.json asynchronously", async () => {
+    const packageJsonPath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\node_modules\\@anthropic-ai\\claude-code\\package.json";
+
+    assert.deepStrictEqual(
+      await getClaudeVersionFromPackageJsonAsync(packageJsonPath, {
+        async readFile(targetPath) {
+          assert.strictEqual(targetPath, packageJsonPath);
+          return JSON.stringify({ version: "2.1.109" });
+        },
+      }),
+      {
+        version: "2.1.109",
+        source: packageJsonPath,
+        status: "known",
+      }
+    );
+
+    assert.strictEqual(
+      await getClaudeVersionFromPackageJsonAsync(packageJsonPath, {
+        async readFile() {
+          return JSON.stringify({ version: "latest" });
+        },
+      }),
+      null
+    );
+  });
+
   it("returns the first valid fallback version info from candidate package.json files", () => {
     const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
     const candidateDir = path.dirname(candidatePath);
@@ -303,6 +394,126 @@ describe("Claude version detection helpers", () => {
     assert.deepStrictEqual(result, {
       version: "2.1.109",
       source: realpathPackageJson,
+      status: "known",
+    });
+  });
+
+  it("returns the first valid async fallback version info from candidate package.json files", async () => {
+    const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
+    const candidateDir = path.dirname(candidatePath);
+    const siblingPackageJson = path.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const realpathCli = "D:\\shim-store\\claude\\cli.js";
+    const realpathPackageJson = path.join(path.dirname(realpathCli), "package.json");
+    const existing = new Set([siblingPackageJson.toLowerCase(), realpathPackageJson.toLowerCase()]);
+
+    const result = await readClaudeVersionFallbackAsync(candidatePath, {
+      platform: "win32",
+      async access(packageJsonPath) {
+        if (!existing.has(packageJsonPath.toLowerCase())) {
+          throw new Error(`missing: ${packageJsonPath}`);
+        }
+      },
+      async realpath() {
+        return realpathCli;
+      },
+      async stat() {
+        return { size: 256, isFile: () => true };
+      },
+      async readFile(targetPath) {
+        if (targetPath === candidatePath) {
+          return '@ECHO off\n"%dp0%\\node.exe" "%dp0%\\node_modules\\@anthropic-ai\\claude-code\\cli.js" %*\n';
+        }
+        if (targetPath === siblingPackageJson) {
+          return JSON.stringify({ version: "latest" });
+        }
+        if (targetPath === realpathPackageJson) {
+          return JSON.stringify({ version: "2.1.109" });
+        }
+        throw new Error(`unexpected read: ${targetPath}`);
+      },
+    });
+
+    assert.deepStrictEqual(result, {
+      version: "2.1.109",
+      source: realpathPackageJson,
+      status: "known",
+    });
+  });
+
+  it("getClaudeVersionAsync uses async metadata fallback when exec probes fail", async () => {
+    const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
+    const packageJsonPath = path.join(path.dirname(candidatePath), "node_modules", "@anthropic-ai", "claude-code", "package.json");
+
+    const result = await getClaudeVersionAsync({
+      platform: "win32",
+      candidates: [candidatePath],
+      resetCache: true,
+      async execFile() {
+        throw new Error("spawn failed");
+      },
+      async access(targetPath) {
+        if (targetPath !== packageJsonPath) throw new Error(`missing: ${targetPath}`);
+      },
+      async realpath() {
+        throw new Error("no realpath");
+      },
+      async stat() {
+        return { size: 0, isFile: () => true };
+      },
+      async readFile(targetPath) {
+        if (targetPath === packageJsonPath) return JSON.stringify({ version: "2.1.109" });
+        return "";
+      },
+    });
+
+    assert.deepStrictEqual(result, {
+      version: "2.1.109",
+      source: packageJsonPath,
+      status: "known",
+    });
+  });
+
+  it("getClaudeVersionAsync does not call sync filesystem probes", async () => {
+    const npmDir = "C:\\Users\\Tester\\AppData\\Roaming\\npm";
+    const candidatePath = path.join(npmDir, "claude.cmd");
+    const packageJsonPath = path.join(npmDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+
+    const throwSync = () => {
+      throw new Error("sync filesystem probe should not run");
+    };
+
+    const result = await getClaudeVersionAsync({
+      platform: "win32",
+      pathEnv: npmDir,
+      pathExt: ".CMD",
+      resetCache: true,
+      existsSync: throwSync,
+      statSync: throwSync,
+      readFileSync: throwSync,
+      realpathSync: throwSync,
+      async execFile() {
+        throw new Error("spawn failed");
+      },
+      async access(targetPath) {
+        if (targetPath !== candidatePath && targetPath !== packageJsonPath) {
+          throw new Error(`missing: ${targetPath}`);
+        }
+      },
+      async realpath() {
+        throw new Error("no realpath");
+      },
+      async stat() {
+        return { size: 0, isFile: () => true };
+      },
+      async readFile(targetPath) {
+        if (targetPath === packageJsonPath) return JSON.stringify({ version: "2.1.109" });
+        return "";
+      },
+    });
+
+    assert.deepStrictEqual(result, {
+      version: "2.1.109",
+      source: packageJsonPath,
       status: "known",
     });
   });

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { registerHooks, unregisterHooks, __test } = require("../hooks/install");
+const { registerHooks, unregisterHooks, registerHooksAsync, unregisterHooksAsync, __test } = require("../hooks/install");
 const {
   parseClaudeVersion,
   getWindowsClaudePathSuffixes,
@@ -11,6 +11,7 @@ const {
   getClaudePackageJsonCandidates,
   getClaudeVersionFromPackageJson,
   readClaudeVersionFallback,
+  getClaudeVersionAsync,
 } = __test;
 
 const tempDirs = [];
@@ -80,6 +81,60 @@ describe("Claude version detection helpers", () => {
     assert.strictEqual(parseClaudeVersion("2.1.109 (Claude Code)"), "2.1.109");
     assert.strictEqual(parseClaudeVersion("Claude Code vnext"), null);
     assert.strictEqual(parseClaudeVersion(null), null);
+  });
+
+  it("reuses the in-flight async Claude version probe", async () => {
+    let execCalls = 0;
+    const execFile = async () => {
+      execCalls++;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return { stdout: "Claude Code 2.1.109\n" };
+    };
+
+    const [a, b] = await Promise.all([
+      getClaudeVersionAsync({
+        platform: "linux",
+        pathEnv: "",
+        candidates: ["/usr/bin/claude"],
+        execFile,
+        resetCache: true,
+      }),
+      getClaudeVersionAsync({
+        platform: "linux",
+        pathEnv: "",
+        candidates: ["/usr/bin/claude"],
+        execFile,
+      }),
+    ]);
+
+    assert.deepStrictEqual(a, b);
+    assert.strictEqual(execCalls, 1);
+  });
+
+  it("reuses a cached async Claude version result after success", async () => {
+    let execCalls = 0;
+    const execFile = async () => {
+      execCalls++;
+      return { stdout: "Claude Code 2.1.109\n" };
+    };
+
+    const first = await getClaudeVersionAsync({
+      platform: "linux",
+      pathEnv: "",
+      candidates: ["/usr/bin/claude"],
+      execFile,
+      resetCache: true,
+    });
+    const second = await getClaudeVersionAsync({
+      platform: "linux",
+      pathEnv: "",
+      candidates: ["/usr/bin/claude"],
+      execFile,
+    });
+
+    assert.strictEqual(first.version, "2.1.109");
+    assert.deepStrictEqual(second, first);
+    assert.strictEqual(execCalls, 1);
   });
 
   it("normalizes Windows PATHEXT suffixes with stable order", () => {
@@ -930,5 +985,43 @@ describe("Hook installer unregisterHooks", () => {
     const settings = readSettings(settingsPath);
 
     assert.deepStrictEqual(settings.hooks, {});
+  });
+});
+
+describe("async hook installer parity", () => {
+  it("registerHooksAsync writes the same hook set as registerHooks", async () => {
+    const syncSettingsPath = makeTempSettings({});
+    const asyncSettingsPath = makeTempSettings({});
+
+    const syncResult = registerHooks({
+      silent: true,
+      settingsPath: syncSettingsPath,
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+    });
+    const asyncResult = await registerHooksAsync({
+      silent: true,
+      settingsPath: asyncSettingsPath,
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+    });
+
+    assert.deepStrictEqual(readSettings(asyncSettingsPath), readSettings(syncSettingsPath));
+    assert.deepStrictEqual(asyncResult, syncResult);
+  });
+
+  it("unregisterHooksAsync removes the same entries as unregisterHooks", async () => {
+    const initial = {
+      hooks: {
+        Stop: [{ matcher: "", hooks: [{ type: "command", command: '"/usr/bin/node" "/tmp/clawd-hook.js"' }] }],
+        PermissionRequest: [{ matcher: "", hooks: [{ type: "http", url: "http://127.0.0.1:23333/permission" }] }],
+      },
+    };
+    const syncSettingsPath = makeTempSettings(initial);
+    const asyncSettingsPath = makeTempSettings(initial);
+
+    const syncResult = unregisterHooks({ settingsPath: syncSettingsPath });
+    const asyncResult = await unregisterHooksAsync({ settingsPath: asyncSettingsPath });
+
+    assert.deepStrictEqual(readSettings(asyncSettingsPath), readSettings(syncSettingsPath));
+    assert.deepStrictEqual(asyncResult, syncResult);
   });
 });

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1200,6 +1200,74 @@ describe("Hook installer unregisterHooks", () => {
 });
 
 describe("async hook installer parity", () => {
+  it("registerHooksAsync preserves an existing Node path before probing asynchronously", async () => {
+    const existingAbsPath = "/Users/tester/.nvm/versions/node/v20.11.0/bin/node";
+    const settingsPath = makeTempSettings({
+      hooks: {
+        Stop: [
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: `"${existingAbsPath}" "/app/hooks/clawd-hook.js" Stop` }],
+          },
+        ],
+      },
+    });
+
+    await registerHooksAsync({
+      silent: true,
+      settingsPath,
+      platform: "darwin",
+      isElectron: true,
+      homeDir: "/Users/tester",
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+      async access() {
+        throw new Error("async node probing should not run when settings already has a node path");
+      },
+      async execFile() {
+        throw new Error("async shell probing should not run when settings already has a node path");
+      },
+      accessSync() {
+        throw new Error("sync node probing should not run");
+      },
+      execFileSync() {
+        throw new Error("sync shell probing should not run");
+      },
+    });
+
+    const commands = getClawdCommands(readSettings(settingsPath), "Stop");
+    assert.ok(commands.some((command) => command.includes(existingAbsPath)), commands.join("\n"));
+  });
+
+  it("registerHooksAsync resolves Node with async probes without calling sync probes", async () => {
+    const settingsPath = makeTempSettings({});
+    const nodeBin = "/opt/homebrew/bin/node";
+
+    await registerHooksAsync({
+      silent: true,
+      settingsPath,
+      platform: "darwin",
+      isElectron: true,
+      homeDir: "/Users/tester",
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+      async access(candidate) {
+        if (candidate === nodeBin) return;
+        throw new Error("ENOENT");
+      },
+      async execFile() {
+        throw new Error("shell probing should not run after a well-known path succeeds");
+      },
+      accessSync() {
+        throw new Error("sync access should not run");
+      },
+      execFileSync() {
+        throw new Error("sync exec should not run");
+      },
+    });
+
+    const commands = getClawdCommands(readSettings(settingsPath), "Stop");
+    assert.ok(commands.some((command) => command.startsWith(`"${nodeBin}" "`)), commands.join("\n"));
+  });
+
   it("registerHooksAsync writes the same hook set as registerHooks", async () => {
     const syncSettingsPath = makeTempSettings({});
     const asyncSettingsPath = makeTempSettings({});

--- a/test/json-utils.test.js
+++ b/test/json-utils.test.js
@@ -1,6 +1,9 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
-const { extractExistingNodeBin, formatNodeHookCommand } = require("../hooks/json-utils");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { extractExistingNodeBin, formatNodeHookCommand, writeJsonAtomicAsync } = require("../hooks/json-utils");
 
 describe("extractExistingNodeBin", () => {
   it("extracts node path from flat command format", () => {
@@ -136,5 +139,21 @@ describe("formatNodeHookCommand", () => {
       }),
       'cmd /d /s /c ""C:\\Program Files\\nodejs\\node.exe" "D:/app/hooks/codex-debug-hook.js""'
     );
+  });
+});
+
+describe("writeJsonAtomicAsync", () => {
+  it("writes pretty JSON atomically and cleans up tmp files", async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-json-utils-"));
+    const filePath = path.join(tmpDir, "settings.json");
+    try {
+      await writeJsonAtomicAsync(filePath, { hooks: { Stop: [] } });
+      const parsed = JSON.parse(fs.readFileSync(filePath, "utf8"));
+      assert.deepStrictEqual(parsed, { hooks: { Stop: [] } });
+      const leftovers = fs.readdirSync(tmpDir).filter((name) => name.includes(".tmp"));
+      assert.deepStrictEqual(leftovers, []);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/test/server-config.test.js
+++ b/test/server-config.test.js
@@ -156,6 +156,57 @@ describe("server-config helpers", () => {
     assert.strictEqual(result, null);
   });
 
+  it("resolveNodeBinAsync finds node from well-known paths without sync probes", async () => {
+    const result = await serverConfig.resolveNodeBinAsync({
+      platform: "darwin",
+      isElectron: true,
+      homeDir: "/Users/tester",
+      async access(candidate) {
+        if (candidate === "/opt/homebrew/bin/node") return;
+        throw new Error("ENOENT");
+      },
+      async execFile() {
+        throw new Error("shell probing should not run after a well-known path succeeds");
+      },
+      accessSync() {
+        throw new Error("sync access should not run");
+      },
+      execFileSync() {
+        throw new Error("sync exec should not run");
+      },
+    });
+
+    assert.strictEqual(result, "/opt/homebrew/bin/node");
+  });
+
+  it("resolveNodeBinAsync falls back to async login shell output", async () => {
+    const result = await serverConfig.resolveNodeBinAsync({
+      platform: "darwin",
+      isElectron: true,
+      homeDir: "/Users/tester",
+      async access() {
+        throw new Error("ENOENT");
+      },
+      async execFile(shell, args) {
+        assert.deepStrictEqual(args, ["-lic", "which node"]);
+        if (shell === "/bin/zsh") {
+          return {
+            stdout: "[oh-my-zsh]\n/Users/tester/.nvm/versions/node/v22.0.0/bin/node\n",
+          };
+        }
+        throw new Error("not found");
+      },
+      accessSync() {
+        throw new Error("sync access should not run");
+      },
+      execFileSync() {
+        throw new Error("sync exec should not run");
+      },
+    });
+
+    assert.strictEqual(result, "/Users/tester/.nvm/versions/node/v22.0.0/bin/node");
+  });
+
   it("postStateToRunningServer probes fallback ports before posting", async () => {
     const probes = [];
     const posts = [];

--- a/test/settings-actions.test.js
+++ b/test/settings-actions.test.js
@@ -279,23 +279,33 @@ describe("object-form effects (autoStartWithClaude / manageClaudeHooksAutomatica
     assert.strictEqual(uninstallCalls, 0);
   });
 
-  it("manageClaudeHooksAutomatically effect syncs hooks and starts watcher on true", () => {
+  it("manageClaudeHooksAutomatically effect waits for async sync before starting watcher on true", async () => {
     let syncCalls = 0;
     let startCalls = 0;
     let stopCalls = 0;
+    const calls = [];
     const deps = {
-      syncClaudeHooksNow: () => syncCalls++,
-      startClaudeSettingsWatcher: () => startCalls++,
+      syncClaudeHooksNow: async () => {
+        syncCalls++;
+        calls.push("sync:start");
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        calls.push("sync:end");
+      },
+      startClaudeSettingsWatcher: () => {
+        startCalls++;
+        calls.push("watcher:start");
+      },
       stopClaudeSettingsWatcher: () => stopCalls++,
     };
-    const r = updateRegistry.manageClaudeHooksAutomatically.effect(true, deps);
+    const r = await updateRegistry.manageClaudeHooksAutomatically.effect(true, deps);
     assert.strictEqual(r.status, "ok");
     assert.strictEqual(syncCalls, 1);
     assert.strictEqual(startCalls, 1);
     assert.strictEqual(stopCalls, 0);
+    assert.deepStrictEqual(calls, ["sync:start", "sync:end", "watcher:start"]);
   });
 
-  it("manageClaudeHooksAutomatically effect skips side effects on true when Claude Code is disabled", () => {
+  it("manageClaudeHooksAutomatically effect skips side effects on true when Claude Code is disabled", async () => {
     let syncCalls = 0;
     let startCalls = 0;
     let stopCalls = 0;
@@ -307,14 +317,14 @@ describe("object-form effects (autoStartWithClaude / manageClaudeHooksAutomatica
       startClaudeSettingsWatcher: () => startCalls++,
       stopClaudeSettingsWatcher: () => stopCalls++,
     };
-    const r = updateRegistry.manageClaudeHooksAutomatically.effect(true, deps);
+    const r = await updateRegistry.manageClaudeHooksAutomatically.effect(true, deps);
     assert.deepStrictEqual(r, { status: "ok" });
     assert.strictEqual(syncCalls, 0);
     assert.strictEqual(startCalls, 0);
     assert.strictEqual(stopCalls, 0);
   });
 
-  it("manageClaudeHooksAutomatically effect stops watcher on false", () => {
+  it("manageClaudeHooksAutomatically effect stops watcher on false", async () => {
     let syncCalls = 0;
     let startCalls = 0;
     let stopCalls = 0;
@@ -323,7 +333,7 @@ describe("object-form effects (autoStartWithClaude / manageClaudeHooksAutomatica
       startClaudeSettingsWatcher: () => startCalls++,
       stopClaudeSettingsWatcher: () => stopCalls++,
     };
-    const r = updateRegistry.manageClaudeHooksAutomatically.effect(false, deps);
+    const r = await updateRegistry.manageClaudeHooksAutomatically.effect(false, deps);
     assert.strictEqual(r.status, "ok");
     assert.strictEqual(syncCalls, 0);
     assert.strictEqual(startCalls, 0);
@@ -334,6 +344,22 @@ describe("object-form effects (autoStartWithClaude / manageClaudeHooksAutomatica
     const r = updateRegistry.manageClaudeHooksAutomatically.effect(true, {});
     assert.strictEqual(r.status, "error");
     assert.match(r.message, /syncClaudeHooksNow/);
+  });
+
+  it("manageClaudeHooksAutomatically effect returns error and does not start watcher when async sync fails", async () => {
+    let startCalls = 0;
+    const deps = {
+      syncClaudeHooksNow: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        throw new Error("spawn failed");
+      },
+      startClaudeSettingsWatcher: () => { startCalls++; },
+      stopClaudeSettingsWatcher: () => {},
+    };
+    const r = await updateRegistry.manageClaudeHooksAutomatically.effect(true, deps);
+    assert.strictEqual(r.status, "error");
+    assert.match(r.message, /spawn failed/);
+    assert.strictEqual(startCalls, 0);
   });
 
   it("openAtLogin effect calls setOpenAtLogin with the value", () => {
@@ -440,7 +466,10 @@ describe("hook commands", () => {
     let syncCalls = 0;
     const r = await commandRegistry.installHooks(null, {
       snapshot: prefs.getDefaults(),
-      syncClaudeHooksNow: () => syncCalls++,
+      syncClaudeHooksNow: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        syncCalls++;
+      },
     });
     assert.strictEqual(r.status, "ok");
     assert.strictEqual(syncCalls, 1);
@@ -452,7 +481,10 @@ describe("hook commands", () => {
     const r = await commandRegistry.uninstallHooks(null, {
       snapshot: { ...prefs.getDefaults(), manageClaudeHooksAutomatically: true, autoStartWithClaude: true },
       stopClaudeSettingsWatcher: () => calls.push("stop"),
-      uninstallClaudeHooksNow: () => calls.push("uninstall"),
+      uninstallClaudeHooksNow: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1));
+        calls.push("uninstall");
+      },
       startClaudeSettingsWatcher: () => calls.push("start"),
     });
     assert.strictEqual(r.status, "ok");
@@ -466,8 +498,9 @@ describe("hook commands", () => {
     const r = await commandRegistry.uninstallHooks(null, {
       snapshot: { ...prefs.getDefaults(), manageClaudeHooksAutomatically: true },
       stopClaudeSettingsWatcher: () => calls.push("stop"),
-      uninstallClaudeHooksNow: () => {
+      uninstallClaudeHooksNow: async () => {
         calls.push("uninstall");
+        await new Promise((resolve) => setTimeout(resolve, 1));
         throw new Error("disk locked");
       },
       startClaudeSettingsWatcher: () => calls.push("start"),

--- a/test/settings-controller.test.js
+++ b/test/settings-controller.test.js
@@ -104,6 +104,28 @@ describe("applyUpdate sync invariant", () => {
     assert.deepStrictEqual(order, ["start:1:S", "end:1:S", "start:2:M", "end:2:M"]);
     assert.strictEqual(ctrl.get("size"), "M");
   });
+
+  it("manageClaudeHooksAutomatically uses the async effect path without changing controller semantics", async () => {
+    const ctrl = createSettingsController({
+      prefsPath: makeTempPath(),
+      loadResult: {
+        snapshot: { ...prefs.getDefaults(), manageClaudeHooksAutomatically: false },
+        locked: false,
+      },
+      injectedDeps: {
+        syncClaudeHooksNow: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 1));
+        },
+        startClaudeSettingsWatcher: () => {},
+        stopClaudeSettingsWatcher: () => {},
+      },
+    });
+    const ret = ctrl.applyUpdate("manageClaudeHooksAutomatically", true);
+    assert.strictEqual(typeof ret.then, "function");
+    const result = await ret;
+    assert.strictEqual(result.status, "ok");
+    assert.strictEqual(ctrl.get("manageClaudeHooksAutomatically"), true);
+  });
 });
 
 // Tiny helper — must be sync because controller's applyUpdate stays sync

--- a/test/settings-controller.test.js
+++ b/test/settings-controller.test.js
@@ -126,6 +126,47 @@ describe("applyUpdate sync invariant", () => {
     assert.strictEqual(result.status, "ok");
     assert.strictEqual(ctrl.get("manageClaudeHooksAutomatically"), true);
   });
+
+  it("serializes Claude hook update and command work on one shared lock", async () => {
+    const calls = [];
+    const ctrl = createSettingsController({
+      prefsPath: makeTempPath(),
+      loadResult: {
+        snapshot: { ...prefs.getDefaults(), manageClaudeHooksAutomatically: false },
+        locked: false,
+      },
+      injectedDeps: {
+        syncClaudeHooksNow: async () => {
+          calls.push("sync:start");
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          calls.push("sync:end");
+        },
+        startClaudeSettingsWatcher: () => calls.push("watcher:start"),
+        stopClaudeSettingsWatcher: () => calls.push("watcher:stop"),
+        uninstallClaudeHooksNow: async () => {
+          calls.push("uninstall:start");
+          await new Promise((resolve) => setTimeout(resolve, 1));
+          calls.push("uninstall:end");
+        },
+      },
+    });
+
+    const enable = ctrl.applyUpdate("manageClaudeHooksAutomatically", true);
+    const disconnect = ctrl.applyCommand("uninstallHooks");
+    const results = await Promise.all([enable, disconnect]);
+
+    assert.strictEqual(results[0].status, "ok");
+    assert.strictEqual(results[1].status, "ok");
+    assert.deepStrictEqual(calls, [
+      "sync:start",
+      "sync:end",
+      "watcher:start",
+      "watcher:stop",
+      "uninstall:start",
+      "uninstall:end",
+    ]);
+    assert.strictEqual(ctrl.get("manageClaudeHooksAutomatically"), false);
+  });
 });
 
 // Tiny helper — must be sync because controller's applyUpdate stays sync

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -290,6 +290,18 @@ describe("settings renderer browser environment", () => {
     assert.ok(i18nSource.includes("claudeHooksDisconnectConfirmKeep"));
   });
 
+  it("clears successful switch transient state so rerenders do not keep wait cursors", () => {
+    const coreSource = fs.readFileSync(SETTINGS_UI_CORE, "utf8");
+    assert.ok(
+      coreSource.includes("clearTransientState(seq);\n          setSwitchVisual(sw, nextVisual, { pending: false });"),
+      "successful switch actions must delete transient pending state before any later rerender"
+    );
+    assert.ok(
+      !coreSource.includes("setTransientState({ visualOn: nextVisual, pending: false, seq });"),
+      "leaving a non-pending transient row lets rerendered controls inherit stale pending state"
+    );
+  });
+
   it("uses a roomier grid layout for Settings confirmation buttons", () => {
     const html = fs.readFileSync(SETTINGS_HTML, "utf8");
     assert.ok(/\.settings-confirm-modal\s*\{[\s\S]*width:\s*min\(480px,\s*100%\);/.test(html));

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -293,13 +293,29 @@ describe("settings renderer browser environment", () => {
   it("clears successful switch transient state so rerenders do not keep wait cursors", () => {
     const coreSource = fs.readFileSync(SETTINGS_UI_CORE, "utf8");
     assert.ok(
-      coreSource.includes("clearTransientState(seq);\n          setSwitchVisual(sw, nextVisual, { pending: false });"),
+      /clearTransientState\(seq\);\s*setSwitchVisual\(sw,\s*nextVisual,\s*\{\s*pending:\s*false\s*\}\);/.test(coreSource),
       "successful switch actions must delete transient pending state before any later rerender"
     );
     assert.ok(
       !coreSource.includes("setTransientState({ visualOn: nextVisual, pending: false, seq });"),
       "leaving a non-pending transient row lets rerendered controls inherit stale pending state"
     );
+  });
+
+  it("clears settings-broadcast transient state before patching or rerendering", () => {
+    const coreSource = fs.readFileSync(SETTINGS_UI_CORE, "utf8");
+    assert.ok(coreSource.includes("function clearTransientStateForChanges(changes)"));
+    assert.ok(coreSource.includes("state.transientUiState.generalSwitches.delete(key);"));
+    assert.ok(coreSource.includes('Object.prototype.hasOwnProperty.call(changes, "agents")'));
+    assert.ok(coreSource.includes("state.transientUiState.agentSwitches.clear();"));
+    const clearIndex = coreSource.indexOf("clearTransientStateForChanges(changes);");
+    const patchIndex = coreSource.indexOf("activeTab.patchInPlace(changes)");
+    const renderIndex = coreSource.indexOf("requestRender({ sidebar: true, content: true });", patchIndex);
+    assert.notStrictEqual(clearIndex, -1);
+    assert.notStrictEqual(patchIndex, -1);
+    assert.notStrictEqual(renderIndex, -1);
+    assert.ok(clearIndex < patchIndex, "broadcast cleanup must happen before in-place patching");
+    assert.ok(clearIndex < renderIndex, "broadcast cleanup must happen before full rerender");
   });
 
   it("uses a roomier grid layout for Settings confirmation buttons", () => {


### PR DESCRIPTION
Fixes #181.

## Summary
- make the heavy Claude hooks management path truly async instead of running sync file I/O / sync process probing behind the Settings click path
- keep the existing Settings controller / pending / toast model, so the UI waits visibly while hook install or uninstall work is still running
- preserve the lightweight "turn off automatic management only" behavior: it stops the watcher and updates prefs, but does not uninstall hooks
- fix the follow-up pending-state issue where a Settings broadcast could rerender the switch with stale transient pending state, leaving the cursor/spinner behavior stuck after completion
- address review feedback by making the async Claude version probe and async Node binary probe avoid synchronous filesystem or child-process helpers

## Problem context
Issue #181 reports visible Settings freezes on Windows when interacting with `Settings > General > 自动管理 Claude hooks`, especially on:

- enabling automatic Claude hooks management
- choosing `关闭并移除当前 hooks`
- clicking the inline `断开` button

The root cause is that those UI actions wait on a main-process path that previously performed synchronous work: reading/writing `~/.claude/settings.json`, atomic JSON writes, Claude version detection, and Node binary detection for generated hook commands. That work can block the Electron main process, so wrapping it in `setImmediate()` would only move the freeze to a later tick rather than remove it.

Follow-up review also pointed out two async-path gaps: the new async Claude version probe still reused synchronous filesystem helpers for PATH/package metadata fallback, and `registerHooksAsync()` still called the synchronous Node binary resolver before falling back to existing hook settings. This PR now keeps the sync compatibility paths intact while giving the Settings async path async-only probe helpers.

## What changed
- async Claude hooks installer path
  - added async variants for Claude hook registration, unregistration, version detection, and atomic JSON writes
  - converted the heavy settings file reads/writes to `fs.promises`
  - converted Claude version probing to an async child-process path
  - kept the existing sync `registerHooks()` / `unregisterHooks()` APIs for CLI scripts, older tests, and other sync callers
- async Claude version filesystem probing
  - added async helper variants for Claude PATH candidate discovery, package.json candidate discovery, package.json version reads, and metadata fallback
  - replaced sync PATH probing in `getClaudeVersionAsync()` with `fs.promises.access()` based discovery
  - replaced sync fallback metadata probing with async `access`, `realpath`, `stat`, and `readFile`
  - exposed the async helpers through `__test` so regressions can assert the async path does not call sync filesystem injection points
- async Node binary probing
  - added `resolveNodeBinAsync()` for Electron macOS/Linux hook command generation
  - uses async `fs.promises.access()` for well-known Node locations and async `execFile()` for login-shell fallback
  - changed `registerHooksAsync()` to prefer `options.nodeBin`, then an existing Node path already present in settings, and only then async probing
  - left synchronous `resolveNodeBin()` and `registerHooks()` behavior unchanged for CLI and sync callers
- version detection caching
  - caches only successfully parsed Claude version results in process memory
  - reuses an in-flight Promise for concurrent async version probes
  - does not add disk persistence or new prefs/schema fields
- Settings action semantics
  - `manageClaudeHooksAutomatically=true` now awaits the async hook sync before starting the watcher and committing the setting
  - failed enable attempts return an error result, do not commit prefs, and allow the existing UI rollback/toast path to handle feedback
  - `manageClaudeHooksAutomatically=false` remains lightweight and only stops the watcher
  - `installHooks` now waits for async hook sync but still does not write prefs
  - `uninstallHooks` stops the watcher, awaits async uninstall, and commits `manageClaudeHooksAutomatically=false` only after successful uninstall
  - failed uninstall restores the watcher when automatic management was previously enabled and does not commit the false state
- Settings pending UI cleanup
  - successful switch updates clear their transient pending state before applying the final visual state
  - Settings broadcasts now clear matching transient switch state before patching/rerendering, so a completed off/on state cannot keep the wait cursor or block immediate re-enable

## Behavior after this PR
- enabling automatic Claude hooks management shows the existing pending switch state while async hook sync runs
- disabling automatic management without removal stays fast and does not uninstall user hooks
- `关闭并移除当前 hooks` and inline `断开` keep pending feedback until hooks are actually removed
- uninstall failure no longer makes the UI look like hooks were removed or management was turned off
- repeated clicks are still blocked while an operation is pending, but the pending state is cleared once the controller result or settings broadcast lands
- async Claude version detection preserves the existing candidate order and fallback behavior, but no longer calls sync filesystem probes on the Settings path
- async hook registration now reuses an existing hook Node path before probing, and required Node probing no longer calls sync fs or sync shell commands on the Settings path

## Scope control
- no Settings controller architecture rewrite
- no new persistent prefs fields or schema changes
- no background task list UI
- no `setImmediate()` wrapper around the old sync hook path as a substitute for real async work
- sync Claude hook APIs remain available for CLI scripts and existing sync callers

## Validation
- `npm ci` passed earlier in this clean PR worktree
- `node --test test/install.test.js test/server-config.test.js test/json-utils.test.js test/settings-actions.test.js test/settings-controller.test.js test/settings-renderer-browser-env.test.js` passed after the async Node-probe follow-up: 268 tests, 0 failures
- `git diff --check` passed after the async Node-probe follow-up
- `npm test` was rerun after the async Node-probe follow-up; the issue #181 target tests passed, but the full local suite is still blocked by `test/server-ringbuffer.test.js`: 1358 passed, 1 failed, 5 cancelled, 2 skipped
- `node --test test/server-ringbuffer.test.js` also fails when run alone: 5 passed, 5 cancelled, with `Promise resolution is still pending but the event loop has already resolved`. This test is outside the files changed by this PR.

## Platform note
- automated verification was run on Windows
- manual Electron-window verification is still recommended for the hover/pending visual behavior before merge because this path depends on real renderer interaction timing
