### PR TITLE
fix: spawn Electron directly in auto-start to avoid console window on Windows

### DIFF
--- a/hooks/auto-start.js
+++ b/hooks/auto-start.js
@@ -56,24 +56,19 @@ function launchApp() {
         }
       }
     } else {
-      // Source / development mode
+      // Source / development mode — spawn Electron directly to avoid
+      // a visible console window from the npm → launch.js chain.
       const projectDir = path.resolve(__dirname, "..");
-      if (isWin) {
-        // On Windows, .cmd files cannot be spawned directly with detached:true
-        // (EINVAL). Wrap with cmd.exe /c instead.
-        spawn("cmd.exe", ["/c", "npm.cmd", "start"], {
-          cwd: projectDir,
-          detached: true,
-          stdio: "ignore",
-          windowsHide: true,
-        }).unref();
-      } else {
-        spawn("npm", ["start"], {
-          cwd: projectDir,
-          detached: true,
-          stdio: "ignore",
-        }).unref();
-      }
+      const electron = require("electron");
+      const env = { ...process.env };
+      delete env.ELECTRON_RUN_AS_NODE;
+      spawn(electron, [projectDir], {
+        cwd: projectDir,
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+        env,
+      }).unref();
     }
   } catch (err) {
     process.stderr.write(`clawd auto-start: ${err.message}\n`);


### PR DESCRIPTION
## Problem

On Windows, the current fix in `hooks/auto-start.js` (`cmd.exe /c npm.cmd start` from PR #216) still produces a visible console window because the `npm start` → `launch.js` → `electron` chain leaves stdio attached to a console.

## Fix

Spawn Electron directly instead of going through npm/launch.js — the same pattern already used in `launch.js`:

- `require("electron")` locates the Electron binary
- Delete `ELECTRON_RUN_AS_NODE` from the inherited environment (same as launch.js)
- Pass `windowsHide: true` to suppress any console window

This bypasses the `npm start` → `launch.js` → `spawn(electron, { stdio: "inherit" })` chain entirely, so no console window appears.

## Test plan

- [ ] Windows (source/dev mode): auto-start launches Clawd without a visible console window
- [ ] macOS/Linux (source mode): launch behavior unchanged
- [ ] Packaged Windows (.exe): launch path unchanged
- [ ] Packaged macOS (.app): launch path unchanged
- [ ] Packaged Linux (AppImage/bin): launch path unchanged