### PR TITLE
fix: complete Gemini hook-only integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ Copilot CLI 是唯一仍需手动配置 hooks 的受支持 agent；见 `docs/gui
 | `src/hit-renderer.js` + `src/hit-geometry.js` | 输入窗口命中、拖拽、连击反应 |
 | `agents/registry.js` | agent 注册表 |
 | `agents/codex-log-monitor.js` | Codex JSONL fallback 轮询 |
-| `agents/gemini-log-monitor.js` | Gemini session JSON 轮询 |
+| `agents/gemini-log-monitor.js` | legacy Gemini session JSON 轮询器；当前 Gemini hook-only 路径不启动 |
 | `hooks/clawd-hook.js` + `hooks/copilot-hook.js` | Claude Code / Copilot CLI 状态上报脚本 |
 | `hooks/install.js` | Claude hook 注册 / 卸载 |
 | `hooks/auto-start.js` | Claude `SessionStart` 自动拉起 Clawd 的 hook |

--- a/agents/gemini-cli.js
+++ b/agents/gemini-cli.js
@@ -20,6 +20,7 @@ module.exports = {
   capabilities: {
     httpHook: false,
     permissionApproval: false,
+    notificationHook: true,
     sessionEnd: true,
     subagent: false,
   },

--- a/agents/gemini-cli.js
+++ b/agents/gemini-cli.js
@@ -5,8 +5,8 @@ module.exports = {
   id: "gemini-cli",
   name: "Gemini CLI",
   processNames: { win: ["gemini.exe"], mac: ["gemini"], linux: ["gemini"] },
-  eventSource: "log-poll",
-  // PascalCase event names — matches Gemini CLI hook system (retained for future use)
+  eventSource: "hook",
+  // PascalCase event names — matches Gemini CLI hook system
   eventMap: {
     SessionStart: "idle",
     SessionEnd: "sleeping",
@@ -28,8 +28,4 @@ module.exports = {
   },
   stdinFormat: "geminiHookJson",
   pidField: "gemini_pid",
-  logConfig: {
-    sessionDir: "~/.gemini/tmp",
-    pollIntervalMs: 1500,
-  },
 };

--- a/agents/gemini-log-monitor.js
+++ b/agents/gemini-log-monitor.js
@@ -1,5 +1,6 @@
 // Gemini CLI session JSON monitor
 // Polls ~/.gemini/tmp/*/chats/session-*.json for state changes
+// Legacy only: Gemini CLI runtime integration is hook-only and does not start this monitor.
 
 const fs = require("fs");
 const path = require("path");

--- a/docs/guides/known-limitations.md
+++ b/docs/guides/known-limitations.md
@@ -8,10 +8,7 @@
 | **Codex CLI: partial hook coverage** | Official hooks cover live state and `PermissionRequest` observation/intercept mode, but not every runtime signal. Clawd keeps JSONL polling active for hook-disabled sessions and fallback-only events such as web search, compaction, and aborted turns, so those events can still have polling latency. |
 | **Copilot CLI: manual hook setup** | Copilot is the one supported agent that still requires manually creating `~/.copilot/hooks/hooks.json`. |
 | **Copilot CLI: no permission bubble** | Copilot's `preToolUse` hook only supports deny, not the full allow/deny flow. Permission bubbles currently work with Claude Code, CodeBuddy, and opencode. |
-| **Gemini CLI: no working state** | Gemini's session JSON only records completed messages, not in-progress tool execution. The pet jumps from thinking straight to happy/error — no typing animation during work. |
-| **Gemini CLI: no permission bubble** | Gemini handles tool approval inside the terminal. File polling can't intercept or display approval requests. |
-| **Gemini CLI: no terminal focus** | Session JSON doesn't carry terminal PID info, same limitation as Codex. |
-| **Gemini CLI: polling latency** | ~1.5s poll interval + 4s defer window for batching tool completion signals. Noticeably slower than hook-based agents. |
+| **Gemini CLI: no permission bubble** | Gemini handles tool approval inside the terminal. Clawd observes Gemini hook events, but does not show permission bubbles unless Gemini adds a compatible blocking approval contract later. |
 | **Cursor Agent: no permission bubble** | Cursor handles permissions via stdout JSON in the hook, not HTTP blocking — Clawd can't intercept the approval flow. |
 | **Cursor Agent: startup recovery** | No process detection on startup (matching the editor PID would false-trigger on any Cursor instance). Clawd stays idle until the first hook event fires. |
 | **Kiro CLI: no session tracking** | Kiro CLI stdin JSON has no session_id — all Kiro sessions are merged into a single tracked session. |

--- a/docs/guides/known-limitations.zh-CN.md
+++ b/docs/guides/known-limitations.zh-CN.md
@@ -8,10 +8,7 @@
 | **Codex CLI：hook 覆盖仍不完整** | Official hooks 已覆盖实时状态和 `PermissionRequest` 观察 / intercept 模式，但不是所有运行时信号都有 hook。Clawd 会保留 JSONL 轮询，用于 hook 被禁用的会话，以及 web search、context compaction、turn aborted 等 fallback-only 事件；这些事件仍可能有轮询延迟。 |
 | **Copilot CLI：需手动配置 hooks** | Copilot 是目前唯一仍需手动创建 `~/.copilot/hooks/hooks.json` 的受支持 Agent。 |
 | **Copilot CLI：无权限气泡** | Copilot 的 `preToolUse` 只支持拒绝，无法做完整的允许/拒绝审批流。权限气泡目前支持 Claude Code、CodeBuddy 和 opencode。 |
-| **Gemini CLI：无 working 状态** | Gemini 的 session JSON 只记录已完成消息，不包含进行中的工具执行。桌宠会从 thinking 直接跳到 happy/error，工作中没有打字动画。 |
-| **Gemini CLI：无权限气泡** | Gemini 在终端内处理工具审批。文件轮询无法拦截或展示审批请求。 |
-| **Gemini CLI：无法跳转终端** | Session JSON 不携带终端 PID，和 Codex 一样无法做终端聚焦。 |
-| **Gemini CLI：轮询延迟** | 约 1.5 秒轮询间隔，另加 4 秒延迟窗口用于批量处理工具完成信号，明显慢于 hook 驱动的 agent。 |
+| **Gemini CLI：无权限气泡** | Gemini 仍在终端内处理工具审批。Clawd 会观察 Gemini hook 事件，但除非 Gemini 未来提供兼容的阻塞式审批协议，否则不显示权限气泡。 |
 | **Cursor Agent：无权限气泡** | Cursor 在 hook 的 stdout JSON 里处理权限，而不是走 HTTP 阻塞式审批，Clawd 无法接管这条审批链路。 |
 | **Cursor Agent：启动恢复能力有限** | 启动时不做进程检测，否则任意 Cursor 编辑器进程都可能误判为活跃会话。Clawd 会保持 idle，直到收到第一条 hook 事件。 |
 | **Kiro CLI：无法区分会话** | Kiro CLI stdin JSON 不含 session_id，所有 Kiro 会话会被合并为单个追踪会话。 |

--- a/docs/plans/plan-clawd-doctor.md
+++ b/docs/plans/plan-clawd-doctor.md
@@ -424,7 +424,7 @@ Step 1 覆盖 ①②④。**③⑤ 是 Step 2 核心。**
 | 类型 | agent | 入口 |
 |---|---|---|
 | **HTTP 入口（进 ringbuffer）**| 9 个全部 | `src/server.js` `/state` `/permission` |
-| **文件 mtime（副路径）**| gemini-cli (~/.gemini/tmp)、codex rollout (~/.codex/sessions/) | 仅 detector 用 |
+| **文件 mtime（副路径）**| codex rollout (~/.codex/sessions/) | 仅 detector 用；Gemini 已改为 hook-only，不再用 ~/.gemini/tmp 兜底 |
 
 ### 5.3 ringbuffer 实现（v8：多点 record，每路径只 record 一次）
 
@@ -519,7 +519,7 @@ Overall: WARNING (2 issues)
 | codex | hook+log-poll | ok | ~/.codex/hooks.json registered; supplementary: codex_hooks=true |
 | cursor-agent | hook | not-connected | ~/.cursor/ exists but ~/.cursor/hooks.json missing |
 | copilot-cli | hook | manual-only | Project-level hooks.json; cannot be auto-detected |
-| gemini-cli | hook+log-poll | not-installed | ~/.gemini/ home directory missing |
+| gemini-cli | hook | not-installed | ~/.gemini/ home directory missing |
 | codebuddy | hook | ok | ~/.codebuddy/settings.json registered, scriptPath verified |
 | kiro-cli | hook | ok | 2 fully-valid in ~/.kiro/agents/: clawd.json, custom.json |
 | kimi-cli | hook | ok | ~/.kimi/config.toml registered, scriptPath verified |

--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -32,9 +32,10 @@ Codex CLI 状态同步（official hooks primary + JSONL fallback）：
     → agents/codex-log-monitor.js（fallback：hook 未覆盖事件、hook 禁用/不可用、历史兼容）
     → main.js wrapper 对 hook-active session 做事件级 suppression，避免重复状态/重复气泡
 
-Gemini CLI 状态同步（session JSON 轮询，~1.5s 延迟 + 4s 完成延迟窗口）：
-  Gemini 写入 ~/.gemini/tmp/<project>/chats/session-*.json
-    → agents/gemini-log-monitor.js（轮询 JSON，diff 消息数组检测工具调用/完成）
+Gemini CLI 状态同步（hook-only，stdin JSON + stdout JSON）：
+  Gemini CLI 触发 SessionStart / BeforeAgent / BeforeTool / AfterTool / AfterAgent / SessionEnd 等事件
+    → hooks/gemini-hook.js（hook_event_name 或 argv 事件名 → agents/gemini-cli.js 映射）
+    → HTTP POST 127.0.0.1:23333/state
     → 同上状态机（agent_id: gemini-cli）
 
 Kiro CLI 状态同步（per-agent hook，stdin JSON）：
@@ -100,14 +101,14 @@ opencode 权限气泡（event hook + 反向 bridge，非阻塞）：
 - `agents/codex.js` — Codex CLI official hook 事件映射 + JSONL fallback 轮询配置
 - `agents/copilot-cli.js` — Copilot CLI camelCase 事件映射
 - `agents/cursor-agent.js` — Cursor Agent（hooks.json）事件映射
-- `agents/gemini-cli.js` — Gemini CLI 事件映射 + JSON 轮询配置
+- `agents/gemini-cli.js` — Gemini CLI hook 事件映射
 - `agents/kimi-cli.js` — Kimi Code CLI（Kimi-CLI）hook 事件映射 + permission 分类策略
 - `agents/kiro-cli.js` — Kiro CLI 事件映射（camelCase），无 HTTP hook / 无权限 / 无 subagent
 - `agents/codebuddy.js` — CodeBuddy 事件映射（PascalCase，Claude Code 兼容），支持权限
 - `agents/opencode.js` — opencode 事件映射 + 能力（plugin、permission、terminal focus）
 - `agents/registry.js` — agent 注册表：按 ID 或进程名查找 agent 配置
 - `agents/codex-log-monitor.js` — Codex JSONL fallback 增量轮询器（文件监视 + 增量读取 + approval heuristic）
-- `agents/gemini-log-monitor.js` — Gemini session JSON 轮询器（消息数组 diff + 4s 完成延迟窗口）
+- `agents/gemini-log-monitor.js` — legacy Gemini session JSON 轮询器；当前 hook-only 路径不启动
 
 运行时的 agent 启停 / 权限气泡开关通过 `src/agent-gate.js` 读 `prefs.agents[id].enabled` / `.permissionsEnabled`（默认 true，snapshot 缺字段时也 true 以兼容旧版），供 `state.js` 和 `server.js` 判断是否处理该 agent 的事件。
 

--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -166,7 +166,7 @@ Mini 状态映射：
 - Windows 终端聚焦依赖 `koffi`；macOS 依赖 `osascript`
 - Codex CLI 以 official hooks 为主、JSONL 轮询为 fallback；WebSearch / compaction / abort 等 hook 未覆盖事件仍可能有轮询延迟
 - Copilot CLI 需要手动创建 `~/.copilot/hooks/hooks.json`
-- Gemini 无权限气泡；Cursor 权限走 stdout；Kiro 没有 global hooks；opencode 权限只能走 event hook + bridge
+- Gemini 无权限气泡，除非未来提供兼容的阻塞式审批协议；Cursor 权限走 stdout；Kiro 没有 global hooks；opencode 权限只能走 event hook + bridge
 - opencode 子会话会短暂出现在 Sessions 菜单里
 - 进程存活检测依赖进程名匹配，非标准进程名可能漏检
 

--- a/hooks/gemini-hook.js
+++ b/hooks/gemini-hook.js
@@ -26,12 +26,13 @@ const resolve = createPidResolver({
 // Gemini CLI gating hooks need stdout JSON response
 function stdoutForEvent(hookName) {
   if (hookName === "BeforeTool") return JSON.stringify({ decision: "allow" });
+  if (hookName === "AfterTool") return JSON.stringify({ decision: "allow" });
   if (hookName === "BeforeAgent") return JSON.stringify({});
   return "{}";
 }
 
 readStdinJson().then((payload) => {
-  const hookName = (payload && payload.hook_event_name) || "";
+  const hookName = (payload && payload.hook_event_name) || process.argv[2] || "";
   const mapped = HOOK_MAP[hookName];
 
   if (!mapped) {

--- a/hooks/gemini-hook.js
+++ b/hooks/gemini-hook.js
@@ -31,39 +31,94 @@ function stdoutForEvent(hookName) {
   return "{}";
 }
 
-readStdinJson().then((payload) => {
-  const hookName = (payload && payload.hook_event_name) || process.argv[2] || "";
-  const mapped = HOOK_MAP[hookName];
+function resolveHookName(payload, argvEvent) {
+  return (payload && payload.hook_event_name) || argvEvent || "";
+}
 
-  if (!mapped) {
-    process.stdout.write(stdoutForEvent(hookName) + "\n");
-    process.exit(0);
-    return;
-  }
+function shouldResolvePid(hookName, env = process.env) {
+  return hookName === "SessionStart" && !env.CLAWD_REMOTE;
+}
+
+function buildStateBody(hookName, payload, options = {}) {
+  const mapped = HOOK_MAP[hookName];
+  if (!mapped) return null;
 
   const { state, event } = mapped;
-  if (hookName === "SessionStart" && !process.env.CLAWD_REMOTE) resolve();
-
   const sessionId = (payload && payload.session_id) || "default";
   const cwd = (payload && payload.cwd) || "";
+  const body = {
+    state,
+    session_id: sessionId,
+    event,
+    agent_id: "gemini-cli",
+  };
 
-  const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
-
-  const body = { state, session_id: sessionId, event };
-  body.agent_id = "gemini-cli";
   if (cwd) body.cwd = cwd;
-  if (process.env.CLAWD_REMOTE) {
-    body.host = readHostPrefix();
-  } else {
-    body.source_pid = stablePid;
-    if (detectedEditor) body.editor = detectedEditor;
-    if (agentPid) body.agent_pid = agentPid;
-    if (pidChain.length) body.pid_chain = pidChain;
+
+  if (options.remote) {
+    body.host = options.host || readHostPrefix();
+    return body;
   }
 
+  const pidMeta = options.pidMeta;
+  if (!pidMeta || typeof pidMeta !== "object") return body;
+  if (Number.isFinite(pidMeta.stablePid) && pidMeta.stablePid > 0) body.source_pid = Math.floor(pidMeta.stablePid);
+  if (pidMeta.detectedEditor) body.editor = pidMeta.detectedEditor;
+  if (Number.isFinite(pidMeta.agentPid) && pidMeta.agentPid > 0) body.agent_pid = Math.floor(pidMeta.agentPid);
+  if (Array.isArray(pidMeta.pidChain) && pidMeta.pidChain.length) body.pid_chain = pidMeta.pidChain;
+  return body;
+}
+
+function sendHookEvent(payload, argvEvent, deps = {}) {
+  const env = deps.env || process.env;
+  const hookName = resolveHookName(payload, argvEvent);
   const outLine = stdoutForEvent(hookName);
-  postStateToRunningServer(JSON.stringify(body), { timeoutMs: 100 }, () => {
-    process.stdout.write(outLine + "\n");
+  const remote = !!env.CLAWD_REMOTE;
+  const body = buildStateBody(hookName, payload, {
+    remote,
+    host: remote && deps.readHostPrefix ? deps.readHostPrefix() : undefined,
+    pidMeta: shouldResolvePid(hookName, env)
+      ? (deps.resolvePid ? deps.resolvePid() : undefined)
+      : undefined,
+  });
+
+  if (!body) {
+    return Promise.resolve({ hookName, stdout: outLine, body: null, posted: false, port: null });
+  }
+
+  const postState = deps.postState || postStateToRunningServer;
+  return new Promise((resolvePost) => {
+    postState(JSON.stringify(body), { timeoutMs: 100 }, (posted, port) => {
+      resolvePost({ hookName, stdout: outLine, body, posted: !!posted, port: port || null });
+    });
+  });
+}
+
+async function main(argvEvent = process.argv[2], deps = {}) {
+  const payload = deps.payload !== undefined
+    ? deps.payload
+    : await (deps.readStdinJson || readStdinJson)();
+  const result = await sendHookEvent(payload, argvEvent, {
+    env: deps.env || process.env,
+    postState: deps.postState || postStateToRunningServer,
+    readHostPrefix: deps.readHostPrefix || readHostPrefix,
+    resolvePid: deps.resolvePid || resolve,
+  });
+  process.stdout.write(result.stdout + "\n");
+}
+
+if (require.main === module) {
+  main().then(() => {
     process.exit(0);
   });
-});
+}
+
+module.exports = {
+  __test: {
+    buildStateBody,
+    resolveHookName,
+    sendHookEvent,
+    shouldResolvePid,
+    stdoutForEvent,
+  },
+};

--- a/hooks/gemini-install.js
+++ b/hooks/gemini-install.js
@@ -33,7 +33,7 @@ function buildGeminiHookEntry(command) {
 }
 
 function buildGeminiHookCommand(nodeBin, hookScript, event, options = {}) {
-  return `${formatNodeHookCommand(nodeBin, hookScript, options)} ${event}`;
+  return formatNodeHookCommand(nodeBin, hookScript, { ...options, args: [event] });
 }
 
 function replaceEntry(target, source) {
@@ -128,6 +128,41 @@ function normalizeGeminiHookEntries(entries, desiredCommand) {
   return { matched: true, changed };
 }
 
+function normalizeGeminiDisabledHooks(settings) {
+  const hooksConfig = settings && typeof settings === "object" ? settings.hooksConfig : null;
+  if (!hooksConfig || typeof hooksConfig !== "object" || !Array.isArray(hooksConfig.disabled)) return false;
+
+  let changed = false;
+  let sawClawd = false;
+  const nextDisabled = [];
+
+  for (const entry of hooksConfig.disabled) {
+    if (entry === "clawd") {
+      if (sawClawd) {
+        changed = true;
+        continue;
+      }
+      sawClawd = true;
+      nextDisabled.push(entry);
+      continue;
+    }
+
+    if (isClawdHookCommand(entry)) {
+      if (!sawClawd) {
+        nextDisabled.push("clawd");
+        sawClawd = true;
+      }
+      changed = true;
+      continue;
+    }
+
+    nextDisabled.push(entry);
+  }
+
+  if (changed) hooksConfig.disabled = nextDisabled;
+  return changed;
+}
+
 /**
  * Register Clawd hooks into ~/.gemini/settings.json
  * @param {object} [options]
@@ -162,12 +197,13 @@ function registerGeminiHooks(options = {}) {
     || extractExistingNodeBin(settings, MARKER, { nested: true })
     || "node";
 
-  if (!settings.hooks || typeof settings.hooks !== "object") settings.hooks = {};
-
   let added = 0;
   let skipped = 0;
   let updated = 0;
   let changed = false;
+
+  if (!settings.hooks || typeof settings.hooks !== "object") settings.hooks = {};
+  if (normalizeGeminiDisabledHooks(settings)) changed = true;
 
   for (const event of GEMINI_HOOK_EVENTS) {
     const desiredCommand = buildGeminiHookCommand(nodeBin, hookScript, event);

--- a/hooks/gemini-install.js
+++ b/hooks/gemini-install.js
@@ -5,7 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const { resolveNodeBin } = require("./server-config");
-const { writeJsonAtomic, asarUnpackedPath, extractExistingNodeBin } = require("./json-utils");
+const { writeJsonAtomic, asarUnpackedPath, extractExistingNodeBin, formatNodeHookCommand } = require("./json-utils");
 const MARKER = "gemini-hook.js";
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".gemini");
 const DEFAULT_CONFIG_PATH = path.join(DEFAULT_PARENT_DIR, "settings.json");
@@ -20,6 +20,58 @@ const GEMINI_HOOK_EVENTS = [
   "Notification",
   "PreCompress",
 ];
+
+function isClawdHookCommand(command) {
+  return typeof command === "string" && command.includes(MARKER);
+}
+
+function buildGeminiHookEntry(command) {
+  return {
+    matcher: "*",
+    hooks: [{ name: "clawd", type: "command", command }],
+  };
+}
+
+function buildGeminiHookCommand(nodeBin, hookScript, event, options = {}) {
+  return `${formatNodeHookCommand(nodeBin, hookScript, options)} ${event}`;
+}
+
+function normalizeGeminiHookEntry(entry, desiredCommand) {
+  if (!entry || typeof entry !== "object") return { matched: false, changed: false };
+
+  if (isClawdHookCommand(entry.command)) {
+    const desired = buildGeminiHookEntry(desiredCommand);
+    const changed = JSON.stringify(entry) !== JSON.stringify(desired);
+    if (changed) {
+      for (const key of Object.keys(entry)) delete entry[key];
+      Object.assign(entry, desired);
+    }
+    return { matched: true, changed };
+  }
+
+  if (!Array.isArray(entry.hooks)) return { matched: false, changed: false };
+  const hook = entry.hooks.find((candidate) => candidate && isClawdHookCommand(candidate.command));
+  if (!hook) return { matched: false, changed: false };
+
+  let changed = false;
+  if (entry.matcher !== "*") {
+    entry.matcher = "*";
+    changed = true;
+  }
+  if (hook.name !== "clawd") {
+    hook.name = "clawd";
+    changed = true;
+  }
+  if (hook.type !== "command") {
+    hook.type = "command";
+    changed = true;
+  }
+  if (hook.command !== desiredCommand) {
+    hook.command = desiredCommand;
+    changed = true;
+  }
+  return { matched: true, changed };
+}
 
 /**
  * Register Clawd hooks into ~/.gemini/settings.json
@@ -52,9 +104,8 @@ function registerGeminiHooks(options = {}) {
   // Resolve node path; if detection fails, preserve existing absolute path
   const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
   const nodeBin = resolved
-    || extractExistingNodeBin(settings, MARKER)
+    || extractExistingNodeBin(settings, MARKER, { nested: true })
     || "node";
-  const desiredCommand = `"${nodeBin}" "${hookScript}"`;
 
   if (!settings.hooks || typeof settings.hooks !== "object") settings.hooks = {};
 
@@ -64,6 +115,7 @@ function registerGeminiHooks(options = {}) {
   let changed = false;
 
   for (const event of GEMINI_HOOK_EVENTS) {
+    const desiredCommand = buildGeminiHookCommand(nodeBin, hookScript, event);
     if (!Array.isArray(settings.hooks[event])) {
       settings.hooks[event] = [];
       changed = true;
@@ -71,30 +123,28 @@ function registerGeminiHooks(options = {}) {
 
     const arr = settings.hooks[event];
     let found = false;
-    let stalePath = false;
+    let entryChanged = false;
     for (const entry of arr) {
-      if (!entry || typeof entry !== "object") continue;
-      const cmd = entry.command || "";
-      if (!cmd.includes(MARKER)) continue;
+      const result = normalizeGeminiHookEntry(entry, desiredCommand);
+      if (!result.matched) continue;
       found = true;
-      if (cmd !== desiredCommand) {
-        entry.command = desiredCommand;
-        stalePath = true;
+      if (result.changed) {
+        entryChanged = true;
+        changed = true;
       }
       break;
     }
 
     if (found) {
-      if (stalePath) {
+      if (entryChanged) {
         updated++;
-        changed = true;
       } else {
         skipped++;
       }
       continue;
     }
 
-    arr.push({ type: "command", command: desiredCommand, name: "clawd" });
+    arr.push(buildGeminiHookEntry(desiredCommand));
     added++;
     changed = true;
   }
@@ -116,6 +166,7 @@ module.exports = {
   DEFAULT_CONFIG_PATH,
   registerGeminiHooks,
   GEMINI_HOOK_EVENTS,
+  __test: { buildGeminiHookCommand },
 };
 
 if (require.main === module) {

--- a/hooks/gemini-install.js
+++ b/hooks/gemini-install.js
@@ -36,38 +36,93 @@ function buildGeminiHookCommand(nodeBin, hookScript, event, options = {}) {
   return `${formatNodeHookCommand(nodeBin, hookScript, options)} ${event}`;
 }
 
-function normalizeGeminiHookEntry(entry, desiredCommand) {
-  if (!entry || typeof entry !== "object") return { matched: false, changed: false };
+function replaceEntry(target, source) {
+  for (const key of Object.keys(target)) delete target[key];
+  Object.assign(target, source);
+}
 
-  if (isClawdHookCommand(entry.command)) {
-    const desired = buildGeminiHookEntry(desiredCommand);
-    const changed = JSON.stringify(entry) !== JSON.stringify(desired);
-    if (changed) {
-      for (const key of Object.keys(entry)) delete entry[key];
-      Object.assign(entry, desired);
-    }
-    return { matched: true, changed };
-  }
+function isDesiredGeminiHookEntry(entry, desiredCommand) {
+  return !!(
+    entry
+    && typeof entry === "object"
+    && entry.matcher === "*"
+    && Array.isArray(entry.hooks)
+    && entry.hooks.length === 1
+    && entry.hooks[0]
+    && entry.hooks[0].name === "clawd"
+    && entry.hooks[0].type === "command"
+    && entry.hooks[0].command === desiredCommand
+  );
+}
 
-  if (!Array.isArray(entry.hooks)) return { matched: false, changed: false };
-  const hook = entry.hooks.find((candidate) => candidate && isClawdHookCommand(candidate.command));
-  if (!hook) return { matched: false, changed: false };
+function normalizeGeminiHookEntries(entries, desiredCommand) {
+  if (!Array.isArray(entries)) return { matched: false, changed: false };
 
+  let matched = false;
   let changed = false;
-  if (entry.matcher !== "*") {
-    entry.matcher = "*";
+  let dedicatedIndex = -1;
+
+  for (let index = 0; index < entries.length; index++) {
+    const entry = entries[index];
+    if (!entry || typeof entry !== "object") continue;
+
+    if (isClawdHookCommand(entry.command)) {
+      matched = true;
+      if (dedicatedIndex === -1) {
+        replaceEntry(entry, buildGeminiHookEntry(desiredCommand));
+        dedicatedIndex = index;
+        changed = true;
+      } else {
+        entries.splice(index, 1);
+        index--;
+        changed = true;
+      }
+      continue;
+    }
+
+    if (!Array.isArray(entry.hooks)) continue;
+    const otherHooks = [];
+    let clawdHookCount = 0;
+    for (const hook of entry.hooks) {
+      if (hook && isClawdHookCommand(hook.command)) {
+        clawdHookCount++;
+      } else {
+        otherHooks.push(hook);
+      }
+    }
+    if (clawdHookCount === 0) continue;
+
+    matched = true;
+    if (otherHooks.length > 0) {
+      entry.hooks = otherHooks;
+      changed = true;
+      continue;
+    }
+
+    if (dedicatedIndex === -1) {
+      if (!isDesiredGeminiHookEntry(entry, desiredCommand)) {
+        replaceEntry(entry, buildGeminiHookEntry(desiredCommand));
+        changed = true;
+      }
+      dedicatedIndex = index;
+      continue;
+    }
+
+    entries.splice(index, 1);
+    index--;
     changed = true;
   }
-  if (hook.name !== "clawd") {
-    hook.name = "clawd";
-    changed = true;
+
+  if (!matched) return { matched: false, changed: false };
+
+  if (dedicatedIndex === -1) {
+    entries.push(buildGeminiHookEntry(desiredCommand));
+    return { matched: true, changed: true };
   }
-  if (hook.type !== "command") {
-    hook.type = "command";
-    changed = true;
-  }
-  if (hook.command !== desiredCommand) {
-    hook.command = desiredCommand;
+
+  const dedicatedEntry = entries[dedicatedIndex];
+  if (!isDesiredGeminiHookEntry(dedicatedEntry, desiredCommand)) {
+    replaceEntry(dedicatedEntry, buildGeminiHookEntry(desiredCommand));
     changed = true;
   }
   return { matched: true, changed };
@@ -122,18 +177,10 @@ function registerGeminiHooks(options = {}) {
     }
 
     const arr = settings.hooks[event];
-    let found = false;
-    let entryChanged = false;
-    for (const entry of arr) {
-      const result = normalizeGeminiHookEntry(entry, desiredCommand);
-      if (!result.matched) continue;
-      found = true;
-      if (result.changed) {
-        entryChanged = true;
-        changed = true;
-      }
-      break;
-    }
+    const result = normalizeGeminiHookEntries(arr, desiredCommand);
+    const found = result.matched;
+    const entryChanged = result.changed;
+    if (entryChanged) changed = true;
 
     if (found) {
       if (entryChanged) {

--- a/src/doctor-detectors/agent-descriptors.js
+++ b/src/doctor-detectors/agent-descriptors.js
@@ -80,7 +80,7 @@ const AGENT_DESCRIPTORS = Object.freeze([
     configMode: "file",
     autoInstall: true,
     marker: "gemini-hook.js",
-    nested: false,
+    nested: true,
   }),
   Object.freeze({
     agentId: "codebuddy",

--- a/src/doctor-detectors/agent-integrations.js
+++ b/src/doctor-detectors/agent-integrations.js
@@ -180,13 +180,6 @@ function getGeminiHooksSupplementary(settings, descriptor) {
       detail: 'hooksConfig.disabled includes "clawd"',
     };
   }
-  if (disabled.some((entry) => typeof entry === "string" && entry.includes(descriptor.marker))) {
-    return {
-      key: "gemini_hooks",
-      value: "disabled-clawd",
-      detail: "hooksConfig.disabled includes a Clawd Gemini hook entry",
-    };
-  }
 
   return {
     key: "gemini_hooks",

--- a/src/doctor-detectors/agent-integrations.js
+++ b/src/doctor-detectors/agent-integrations.js
@@ -18,6 +18,7 @@ const INFO_ONLY_STATUSES = new Set([
   "not-installed",
 ]);
 const REPAIRABLE_AGENT_STATUSES = new Set(["not-connected", "broken-path"]);
+const GEMINI_HOOKS_DISABLED_DETAIL = "Gemini hooks are disabled in settings.json; Clawd preserves this user setting and will not receive hook events";
 
 function dirExists(fsImpl, dirPath) {
   try {
@@ -52,6 +53,14 @@ function withAgentBubbleNote(detail, prefs, agentId) {
 
 function withAgentFixAction(detail, descriptor) {
   if (!descriptor.autoInstall || !REPAIRABLE_AGENT_STATUSES.has(detail.status)) return detail;
+  if (
+    descriptor.agentId === "gemini-cli"
+    && detail.supplementary
+    && detail.supplementary.key === "gemini_hooks"
+    && detail.supplementary.value !== "enabled"
+  ) {
+    return detail;
+  }
   const fixAction = { type: "agent-integration", agentId: descriptor.agentId };
   if (
     descriptor.agentId === "codex"
@@ -145,6 +154,67 @@ function applyCodexSupplementary(detail, descriptor, options) {
   };
 }
 
+function getGeminiHooksSupplementary(settings, descriptor) {
+  const hooksConfig = settings && typeof settings === "object" ? settings.hooksConfig : null;
+  if (!hooksConfig || typeof hooksConfig !== "object") {
+    return {
+      key: "gemini_hooks",
+      value: "enabled",
+      detail: "hooksConfig allows Clawd Gemini hooks",
+    };
+  }
+
+  if (hooksConfig.enabled === false) {
+    return {
+      key: "gemini_hooks",
+      value: "disabled-global",
+      detail: "hooksConfig.enabled is false",
+    };
+  }
+
+  const disabled = Array.isArray(hooksConfig.disabled) ? hooksConfig.disabled : [];
+  if (disabled.includes("clawd")) {
+    return {
+      key: "gemini_hooks",
+      value: "disabled-clawd",
+      detail: 'hooksConfig.disabled includes "clawd"',
+    };
+  }
+  if (disabled.some((entry) => typeof entry === "string" && entry.includes(descriptor.marker))) {
+    return {
+      key: "gemini_hooks",
+      value: "disabled-clawd",
+      detail: "hooksConfig.disabled includes a Clawd Gemini hook entry",
+    };
+  }
+
+  return {
+    key: "gemini_hooks",
+    value: "enabled",
+    detail: "hooksConfig allows Clawd Gemini hooks",
+  };
+}
+
+function applyGeminiSupplementary(detail, descriptor, settings) {
+  if (descriptor.agentId !== "gemini-cli") return detail;
+  if (detail.status !== "ok") return detail;
+
+  const supplementary = getGeminiHooksSupplementary(settings, descriptor);
+  if (supplementary.value !== "enabled") {
+    return {
+      ...detail,
+      status: "not-connected",
+      level: "warning",
+      detail: GEMINI_HOOKS_DISABLED_DETAIL,
+      supplementary,
+    };
+  }
+  return {
+    ...detail,
+    supplementary,
+  };
+}
+
 function checkFileMode(descriptor, options) {
   if (!fileExists(options.fs, descriptor.configPath)) {
     return makeDetail(descriptor, descriptor.autoInstall ? "not-connected" : "manual-only", {
@@ -184,7 +254,8 @@ function checkFileMode(descriptor, options) {
     configFileExists: true,
     configPath: descriptor.configPath,
   };
-  return applyCodexSupplementary(detail, descriptor, options);
+  detail = applyCodexSupplementary(detail, descriptor, options);
+  return applyGeminiSupplementary(detail, descriptor, settings);
 }
 
 function checkTomlTextMode(descriptor, options) {

--- a/src/doctor-hook-activity.js
+++ b/src/doctor-hook-activity.js
@@ -119,24 +119,9 @@ function scanCodexMtimeActivity(options = {}) {
   return summarizeActivity("codex", files);
 }
 
-function scanGeminiMtimeActivity(options = {}) {
-  const pathApi = options.path || path;
-  const homeDir = options.homeDir || os.homedir();
-  const rootDir = pathApi.join(homeDir, ".gemini", "tmp");
-  const files = findRecentMatchingFiles({
-    ...options,
-    rootDir,
-    maxDepth: 4,
-    maxEntries: 1500,
-    predicate: (name) => name.startsWith("session-") && name.endsWith(".json"),
-  });
-  return summarizeActivity("gemini-cli", files);
-}
-
 function scanFileMtimeActivity(options = {}) {
   return [
     scanCodexMtimeActivity(options),
-    scanGeminiMtimeActivity(options),
   ].filter(Boolean);
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -349,7 +349,6 @@ const {
 } = require("./codex-monitor-callback");
 const _codexSubagentClassifier = new CodexSubagentClassifier();
 let _codexMonitor = null;          // Codex CLI JSONL log polling instance
-let _geminiMonitor = null;         // Gemini CLI session JSON polling instance
 const CODEX_OFFICIAL_LOG_SUPPRESS_TTL_MS = 10 * 60 * 1000;
 const CODEX_LOG_EVENTS_COVERED_BY_OFFICIAL_HOOKS = new Set([
   "session_meta",
@@ -400,11 +399,9 @@ function updateSessionFromServer(sessionId, state, event, opts = {}) {
 // HTTP route layer. Only log-poll agents hit these branches.
 function startMonitorForAgent(agentId) {
   if (agentId === "codex" && _codexMonitor) _codexMonitor.start();
-  else if (agentId === "gemini-cli" && _geminiMonitor) _geminiMonitor.start();
 }
 function stopMonitorForAgent(agentId) {
   if (agentId === "codex" && _codexMonitor) _codexMonitor.stop();
-  else if (agentId === "gemini-cli" && _geminiMonitor) _geminiMonitor.stop();
 }
 
 // ── Theme loader ──
@@ -4222,22 +4219,6 @@ if (!gotTheLock) {
       console.warn("Clawd: Codex log monitor not started:", err.message);
     }
 
-    try {
-      const GeminiLogMonitor = require("../agents/gemini-log-monitor");
-      const geminiAgent = require("../agents/gemini-cli");
-      _geminiMonitor = new GeminiLogMonitor(geminiAgent, (sid, state, event, extra) => {
-        updateSession(sid, state, event, {
-          cwd: extra.cwd,
-          agentId: "gemini-cli",
-        });
-      });
-      if (_isAgentEnabled(_settingsController.getSnapshot(), "gemini-cli")) {
-        _geminiMonitor.start();
-      }
-    } catch (err) {
-      console.warn("Clawd: Gemini log monitor not started:", err.message);
-    }
-
     // Auto-install VS Code/Cursor terminal-focus extension
     try { installTerminalFocusExtension(); } catch (err) {
       console.warn("Clawd: failed to auto-install terminal-focus extension:", err.message);
@@ -4260,7 +4241,6 @@ if (!gotTheLock) {
     _mini.cleanup();
     _sessionHud.cleanup();
     if (_codexMonitor) _codexMonitor.stop();
-    if (_geminiMonitor) _geminiMonitor.stop();
     stopTopmostWatchdog();
     if (hwndRecoveryTimer) { clearTimeout(hwndRecoveryTimer); hwndRecoveryTimer = null; }
     _focus.cleanup();

--- a/src/settings-agent-order.js
+++ b/src/settings-agent-order.js
@@ -4,6 +4,7 @@ function buildSettingsAgentOrderExports() {
   const COLLAPSIBLE_AGENT_PRIORITY = [
     "claude-code",
     "codex",
+    "gemini-cli",
     "kimi-cli",
     "opencode",
     "codebuddy",
@@ -11,7 +12,6 @@ function buildSettingsAgentOrderExports() {
 
   const NON_COLLAPSIBLE_AGENT_PRIORITY = [
     "cursor-agent",
-    "gemini-cli",
     "copilot-cli",
     "kiro-cli",
   ];

--- a/test/doctor-agent-descriptors.test.js
+++ b/test/doctor-agent-descriptors.test.js
@@ -67,4 +67,11 @@ describe("doctor agent descriptors", () => {
     assert.strictEqual(getAgentDescriptor("claude-code").agentId, "claude-code");
     assert.strictEqual(getAgentDescriptor("missing"), null);
   });
+
+  it("checks Gemini hooks with the official nested settings shape", () => {
+    const descriptor = getAgentDescriptor("gemini-cli");
+
+    assert.strictEqual(descriptor.eventSource, "hook");
+    assert.strictEqual(descriptor.nested, true);
+  });
 });

--- a/test/doctor-agent-integrations.test.js
+++ b/test/doctor-agent-integrations.test.js
@@ -208,7 +208,7 @@ describe("checkAgentIntegrations", () => {
     assert.strictEqual(detail.fixAction, undefined);
   });
 
-  it("treats legacy disabled Gemini hook entries as disabled-clawd", () => {
+  it("does not treat legacy disabled Gemini hook command strings as a stable disabled signal", () => {
     const descriptor = baseDescriptor({
       agentId: "gemini-cli",
       marker: "gemini-hook.js",
@@ -227,12 +227,12 @@ describe("checkAgentIntegrations", () => {
     });
 
     const detail = runOne(descriptor);
-    assert.strictEqual(detail.status, "not-connected");
-    assert.strictEqual(detail.level, "warning");
+    assert.strictEqual(detail.status, "ok");
+    assert.strictEqual(detail.level, null);
     assert.deepStrictEqual(detail.supplementary, {
       key: "gemini_hooks",
-      value: "disabled-clawd",
-      detail: "hooksConfig.disabled includes a Clawd Gemini hook entry",
+      value: "enabled",
+      detail: "hooksConfig allows Clawd Gemini hooks",
     });
     assert.strictEqual(detail.fixAction, undefined);
   });

--- a/test/doctor-agent-integrations.test.js
+++ b/test/doctor-agent-integrations.test.js
@@ -115,6 +115,128 @@ describe("checkAgentIntegrations", () => {
     assert.strictEqual(detail.status, "ok");
   });
 
+  it("validates Gemini nested hook commands", () => {
+    const descriptor = baseDescriptor({
+      agentId: "gemini-cli",
+      marker: "gemini-hook.js",
+      nested: true,
+    });
+    writeJson(descriptor.configPath, {
+      hooks: {
+        BeforeTool: [{
+          matcher: "*",
+          hooks: [{ name: "clawd", type: "command", command: '"/node" "/app/hooks/gemini-hook.js" BeforeTool' }],
+        }],
+      },
+    });
+
+    const detail = runOne(descriptor, {
+      validateCommand: (command) => {
+        assert.strictEqual(command, '"/node" "/app/hooks/gemini-hook.js" BeforeTool');
+        return {
+          ok: true,
+          nodeBin: "/node",
+          scriptPath: "/app/hooks/gemini-hook.js",
+        };
+      },
+    });
+
+    assert.strictEqual(detail.status, "ok");
+    assert.deepStrictEqual(detail.supplementary, {
+      key: "gemini_hooks",
+      value: "enabled",
+      detail: "hooksConfig allows Clawd Gemini hooks",
+    });
+  });
+
+  it("turns Gemini ok into warning when hooksConfig.enabled=false", () => {
+    const descriptor = baseDescriptor({
+      agentId: "gemini-cli",
+      marker: "gemini-hook.js",
+      nested: true,
+    });
+    writeJson(descriptor.configPath, {
+      hooks: {
+        BeforeTool: [{
+          matcher: "*",
+          hooks: [{ name: "clawd", type: "command", command: '"/node" "/app/hooks/gemini-hook.js" BeforeTool' }],
+        }],
+      },
+      hooksConfig: {
+        enabled: false,
+      },
+    });
+
+    const detail = runOne(descriptor);
+    assert.strictEqual(detail.status, "not-connected");
+    assert.strictEqual(detail.level, "warning");
+    assert.strictEqual(detail.detail, "Gemini hooks are disabled in settings.json; Clawd preserves this user setting and will not receive hook events");
+    assert.deepStrictEqual(detail.supplementary, {
+      key: "gemini_hooks",
+      value: "disabled-global",
+      detail: "hooksConfig.enabled is false",
+    });
+    assert.strictEqual(detail.fixAction, undefined);
+  });
+
+  it("turns Gemini ok into warning when hooksConfig.disabled includes clawd", () => {
+    const descriptor = baseDescriptor({
+      agentId: "gemini-cli",
+      marker: "gemini-hook.js",
+      nested: true,
+    });
+    writeJson(descriptor.configPath, {
+      hooks: {
+        BeforeTool: [{
+          matcher: "*",
+          hooks: [{ name: "clawd", type: "command", command: '"/node" "/app/hooks/gemini-hook.js" BeforeTool' }],
+        }],
+      },
+      hooksConfig: {
+        disabled: ["clawd"],
+      },
+    });
+
+    const detail = runOne(descriptor);
+    assert.strictEqual(detail.status, "not-connected");
+    assert.strictEqual(detail.level, "warning");
+    assert.deepStrictEqual(detail.supplementary, {
+      key: "gemini_hooks",
+      value: "disabled-clawd",
+      detail: 'hooksConfig.disabled includes "clawd"',
+    });
+    assert.strictEqual(detail.fixAction, undefined);
+  });
+
+  it("treats legacy disabled Gemini hook entries as disabled-clawd", () => {
+    const descriptor = baseDescriptor({
+      agentId: "gemini-cli",
+      marker: "gemini-hook.js",
+      nested: true,
+    });
+    writeJson(descriptor.configPath, {
+      hooks: {
+        BeforeTool: [{
+          matcher: "*",
+          hooks: [{ name: "clawd", type: "command", command: '"/node" "/app/hooks/gemini-hook.js" BeforeTool' }],
+        }],
+      },
+      hooksConfig: {
+        disabled: ['"/node" "/app/hooks/gemini-hook.js" BeforeTool'],
+      },
+    });
+
+    const detail = runOne(descriptor);
+    assert.strictEqual(detail.status, "not-connected");
+    assert.strictEqual(detail.level, "warning");
+    assert.deepStrictEqual(detail.supplementary, {
+      key: "gemini_hooks",
+      value: "disabled-clawd",
+      detail: "hooksConfig.disabled includes a Clawd Gemini hook entry",
+    });
+    assert.strictEqual(detail.fixAction, undefined);
+  });
+
   it("returns broken-path when all matching commands fail validation", () => {
     const descriptor = baseDescriptor();
     writeJson(descriptor.configPath, {
@@ -285,6 +407,39 @@ describe("checkAgentIntegrations", () => {
     });
     assert.strictEqual(result.status, "critical");
     assert.strictEqual(result.level, "critical");
+  });
+
+  it("keeps the integration summary in warning when Gemini hooks are disabled", () => {
+    const descriptor = baseDescriptor({
+      agentId: "gemini-cli",
+      marker: "gemini-hook.js",
+      nested: true,
+    });
+    writeJson(descriptor.configPath, {
+      hooks: {
+        BeforeTool: [{
+          matcher: "*",
+          hooks: [{ name: "clawd", type: "command", command: '"/node" "/app/hooks/gemini-hook.js" BeforeTool' }],
+        }],
+      },
+      hooksConfig: {
+        enabled: false,
+      },
+    });
+
+    const result = checkAgentIntegrations({
+      fs,
+      descriptors: [descriptor],
+      validateCommand: () => ({
+        ok: true,
+        nodeBin: "/node",
+        scriptPath: "/app/hooks/gemini-hook.js",
+      }),
+    });
+    assert.strictEqual(result.status, "warning");
+    assert.strictEqual(result.level, "warning");
+    assert.strictEqual(result.warningCount, 1);
+    assert.strictEqual(result.okCount, 0);
   });
 });
 

--- a/test/doctor-hook-activity.test.js
+++ b/test/doctor-hook-activity.test.js
@@ -38,14 +38,14 @@ describe("doctor hook activity connection test", () => {
     assert.match(result.detail, /dropped-by-dnd/);
   });
 
-  it("warns when fallback files changed but no HTTP event arrived", () => {
+  it("warns when Codex fallback files changed but no HTTP event arrived", () => {
     const result = evaluateConnectionTest({
-      fileActivity: [{ agentId: "gemini-cli", source: "file-mtime", count: 1 }],
+      fileActivity: [{ agentId: "codex", source: "file-mtime", count: 1 }],
     });
 
     assert.strictEqual(result.status, "http-blocked");
     assert.strictEqual(result.level, "warning");
-    assert.match(result.detail, /gemini-cli/);
+    assert.match(result.detail, /codex/);
   });
 
   it("warns when nothing changed during the window", () => {
@@ -55,7 +55,7 @@ describe("doctor hook activity connection test", () => {
     assert.strictEqual(result.level, "warning");
   });
 
-  it("scans Codex and Gemini fallback mtime activity without collecting file names in the summary", () => {
+  it("scans only Codex fallback mtime activity without collecting file names in the summary", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-doctor-activity-"));
     const since = Date.now() - 1000;
     const codexDir = path.join(tmp, ".codex", "sessions", "2026", "04", "28");
@@ -67,7 +67,7 @@ describe("doctor hook activity connection test", () => {
 
     const activity = scanFileMtimeActivity({ homeDir: tmp, since });
 
-    assert.deepStrictEqual(activity.map((entry) => entry.agentId).sort(), ["codex", "gemini-cli"]);
+    assert.deepStrictEqual(activity.map((entry) => entry.agentId).sort(), ["codex"]);
     assert.ok(activity.every((entry) => !Object.prototype.hasOwnProperty.call(entry, "path")));
     fs.rmSync(tmp, { recursive: true, force: true });
   });

--- a/test/doctor-report.test.js
+++ b/test/doctor-report.test.js
@@ -126,6 +126,20 @@ describe("formatDiagnosticReport", () => {
     assert.match(detail, /opencode entry:/);
   });
 
+  it("formats Gemini supplementary diagnostics into visible detail text", () => {
+    const detail = formatAgentDetail({
+      detail: "Gemini hooks are disabled in settings.json; Clawd preserves this user setting and will not receive hook events",
+      supplementary: {
+        key: "gemini_hooks",
+        value: "disabled-global",
+        detail: "hooksConfig.enabled is false",
+      },
+    });
+
+    assert.match(detail, /gemini_hooks=disabled-global/);
+    assert.match(detail, /hooksConfig\.enabled is false/);
+  });
+
   it("formats summary and agent integration details", () => {
     const report = formatDiagnosticReport({
       generatedAt: "2026-04-28T14:32:00.000Z",
@@ -173,7 +187,7 @@ describe("formatDiagnosticReport", () => {
           eventType: "PermissionRequest",
         }],
         fileActivity: [{
-          agentId: "gemini-cli",
+          agentId: "codex",
           source: "file-mtime",
           count: 1,
         }],
@@ -198,7 +212,7 @@ describe("formatDiagnosticReport", () => {
     assert.match(report, /## Connection Test/);
     assert.match(report, /HTTP works but events were dropped/);
     assert.match(report, /dropped-by-dnd/);
-    assert.match(report, /Fallback file activity also observed: gemini-cli \(1\)\./);
+    assert.match(report, /Fallback file activity also observed: codex \(1\)\./);
     assert.doesNotMatch(report, /\| gemini-cli \| file-mtime \| 1 \|/);
     assert.ok(!report.includes("Alice"));
     assert.ok(!report.includes("D:/animation"));

--- a/test/gemini-hook.test.js
+++ b/test/gemini-hook.test.js
@@ -2,6 +2,7 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const path = require("path");
 const { spawnSync } = require("child_process");
+const { __test } = require("../hooks/gemini-hook");
 
 function runGeminiHook(argvEvent, payload = {}) {
   const scriptPath = path.resolve(__dirname, "..", "hooks", "gemini-hook.js");
@@ -44,5 +45,103 @@ describe("Gemini hook script", () => {
 
     assert.strictEqual(result.status, 0);
     assert.deepStrictEqual(JSON.parse(result.stdout), {});
+  });
+
+  it("posts PID metadata on SessionStart", async () => {
+    const postedBodies = [];
+    let resolveCalls = 0;
+    const result = await __test.sendHookEvent({
+      session_id: "s1",
+      cwd: process.cwd(),
+    }, "SessionStart", {
+      env: {},
+      resolvePid: () => {
+        resolveCalls++;
+        return {
+          stablePid: 4242,
+          agentPid: 4343,
+          detectedEditor: "code",
+          pidChain: [4343, 4242],
+        };
+      },
+      postState: (body, _options, callback) => {
+        postedBodies.push(JSON.parse(body));
+        callback(true, 23333);
+      },
+    });
+
+    assert.strictEqual(resolveCalls, 1);
+    assert.strictEqual(result.posted, true);
+    assert.strictEqual(postedBodies.length, 1);
+    assert.strictEqual(postedBodies[0].agent_id, "gemini-cli");
+    assert.strictEqual(postedBodies[0].event, "SessionStart");
+    assert.strictEqual(postedBodies[0].cwd, process.cwd());
+    assert.strictEqual(postedBodies[0].source_pid, 4242);
+    assert.strictEqual(postedBodies[0].agent_pid, 4343);
+    assert.strictEqual(postedBodies[0].editor, "code");
+    assert.deepStrictEqual(postedBodies[0].pid_chain, [4343, 4242]);
+  });
+
+  it("does not post PID metadata on non-SessionStart events", async () => {
+    const postedBodies = [];
+    let resolveCalls = 0;
+    const result = await __test.sendHookEvent({
+      session_id: "s1",
+      cwd: process.cwd(),
+    }, "BeforeTool", {
+      env: {},
+      resolvePid: () => {
+        resolveCalls++;
+        return {
+          stablePid: 4242,
+          agentPid: 4343,
+          detectedEditor: "code",
+          pidChain: [4343, 4242],
+        };
+      },
+      postState: (body, _options, callback) => {
+        postedBodies.push(JSON.parse(body));
+        callback(true, 23333);
+      },
+    });
+
+    assert.strictEqual(resolveCalls, 0);
+    assert.deepStrictEqual(result.stdout, JSON.stringify({ decision: "allow" }));
+    assert.strictEqual(postedBodies.length, 1);
+    assert.strictEqual(postedBodies[0].agent_id, "gemini-cli");
+    assert.strictEqual(postedBodies[0].event, "PreToolUse");
+    assert.strictEqual(postedBodies[0].cwd, process.cwd());
+    assert.ok(!Object.prototype.hasOwnProperty.call(postedBodies[0], "source_pid"));
+    assert.ok(!Object.prototype.hasOwnProperty.call(postedBodies[0], "agent_pid"));
+    assert.ok(!Object.prototype.hasOwnProperty.call(postedBodies[0], "pid_chain"));
+    assert.ok(!Object.prototype.hasOwnProperty.call(postedBodies[0], "editor"));
+  });
+
+  it("posts host instead of local PID metadata in remote mode", async () => {
+    const postedBodies = [];
+    let resolveCalls = 0;
+    const result = await __test.sendHookEvent({
+      session_id: "s1",
+      cwd: process.cwd(),
+    }, "AfterAgent", {
+      env: { CLAWD_REMOTE: "1" },
+      readHostPrefix: () => "remote-host",
+      resolvePid: () => {
+        resolveCalls++;
+        return { stablePid: 4242, pidChain: [4242] };
+      },
+      postState: (body, _options, callback) => {
+        postedBodies.push(JSON.parse(body));
+        callback(true, 23333);
+      },
+    });
+
+    assert.strictEqual(resolveCalls, 0);
+    assert.deepStrictEqual(result.stdout, "{}");
+    assert.strictEqual(postedBodies.length, 1);
+    assert.strictEqual(postedBodies[0].agent_id, "gemini-cli");
+    assert.strictEqual(postedBodies[0].event, "Stop");
+    assert.strictEqual(postedBodies[0].host, "remote-host");
+    assert.ok(!Object.prototype.hasOwnProperty.call(postedBodies[0], "source_pid"));
   });
 });

--- a/test/gemini-hook.test.js
+++ b/test/gemini-hook.test.js
@@ -1,0 +1,48 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+function runGeminiHook(argvEvent, payload = {}) {
+  const scriptPath = path.resolve(__dirname, "..", "hooks", "gemini-hook.js");
+  return spawnSync(process.execPath, [scriptPath, argvEvent], {
+    input: JSON.stringify(payload),
+    encoding: "utf8",
+    windowsHide: true,
+  });
+}
+
+describe("Gemini hook script", () => {
+  it("writes only allow JSON for BeforeTool", () => {
+    const result = runGeminiHook("BeforeTool", { session_id: "s1" });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stderr, "");
+    assert.strictEqual(result.stdout.trim(), JSON.stringify({ decision: "allow" }));
+  });
+
+  it("uses argv event name when hook_event_name is absent", () => {
+    const result = runGeminiHook("AfterTool", { session_id: "s1", cwd: process.cwd() });
+
+    assert.strictEqual(result.status, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: "allow" });
+  });
+
+  it("writes empty JSON for passive lifecycle hooks", () => {
+    const result = runGeminiHook("AfterAgent", { session_id: "s1" });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stderr, "");
+    assert.strictEqual(result.stdout.trim(), "{}");
+  });
+
+  it("prefers payload hook_event_name over argv event name", () => {
+    const result = runGeminiHook("BeforeTool", {
+      hook_event_name: "AfterAgent",
+      session_id: "s1",
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), {});
+  });
+});

--- a/test/gemini-install.test.js
+++ b/test/gemini-install.test.js
@@ -52,7 +52,7 @@ describe("Gemini hook installer", () => {
       assert.strictEqual(hook.name, "clawd");
       assert.ok(hook.command.includes(MARKER));
       assert.ok(hook.command.includes("/usr/local/bin/node"));
-      assert.ok(hook.command.endsWith(`" ${event}`));
+      assert.ok(hook.command.endsWith(`"${event}"`));
     }
   });
 
@@ -87,7 +87,7 @@ describe("Gemini hook installer", () => {
     assert.strictEqual(settings.hooks.AfterTool.length, 1);
     assert.ok(settings.hooks.AfterTool[0].hooks[0].command.includes("/usr/local/bin/node"));
     assert.ok(!settings.hooks.AfterTool[0].hooks[0].command.includes("/old/path/"));
-    assert.ok(settings.hooks.AfterTool[0].hooks[0].command.endsWith('" AfterTool'));
+    assert.ok(settings.hooks.AfterTool[0].hooks[0].command.endsWith('"AfterTool"'));
   });
 
   it("migrates stale flat Clawd entries into nested Gemini hook shape", () => {
@@ -112,7 +112,7 @@ describe("Gemini hook installer", () => {
     assert.strictEqual(settings.hooks.BeforeTool[0].matcher, "*");
     assert.strictEqual(settings.hooks.BeforeTool[0].hooks[0].name, "clawd");
     assert.ok(settings.hooks.BeforeTool[0].hooks[0].command.includes(MARKER));
-    assert.ok(settings.hooks.BeforeTool[0].hooks[0].command.endsWith('" BeforeTool'));
+    assert.ok(settings.hooks.BeforeTool[0].hooks[0].command.endsWith('"BeforeTool"'));
   });
 
   it("preserves existing node path when detection fails", () => {
@@ -179,7 +179,7 @@ describe("Gemini hook installer", () => {
       }],
     });
     assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.includes(MARKER));
-    assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.endsWith('" BeforeTool'));
+    assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.endsWith('"BeforeTool"'));
   });
 
   it("removes Clawd from shared matcher entries when a dedicated Clawd entry already exists", () => {
@@ -223,7 +223,7 @@ describe("Gemini hook installer", () => {
       }],
     });
     assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.includes("/usr/local/bin/node"));
-    assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.endsWith('" BeforeTool'));
+    assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.endsWith('"BeforeTool"'));
   });
 
   it("does not force hooksConfig.enabled when the user disabled hooks", () => {
@@ -237,6 +237,20 @@ describe("Gemini hook installer", () => {
     assert.strictEqual(settings.hooksConfig.enabled, false);
   });
 
+  it("migrates legacy disabled Gemini hook command entries to clawd", () => {
+    const legacyDisabled = '"/old/node" "/old/path/gemini-hook.js" BeforeTool';
+    const settingsPath = makeTempSettingsFile({
+      hooksConfig: {
+        disabled: ["other-hook", legacyDisabled],
+      },
+    });
+
+    registerGeminiHooks({ silent: true, settingsPath, nodeBin: "/usr/local/bin/node" });
+
+    const settings = readJson(settingsPath);
+    assert.deepStrictEqual(settings.hooksConfig.disabled, ["other-hook", "clawd"]);
+  });
+
   it("builds Windows PowerShell commands with the Gemini event argv", () => {
     const command = __test.buildGeminiHookCommand(
       "node",
@@ -245,7 +259,18 @@ describe("Gemini hook installer", () => {
       { platform: "win32" }
     );
 
-    assert.strictEqual(command, '& "node" "D:/clawd/hooks/gemini-hook.js" BeforeTool');
+    assert.strictEqual(command, '& "node" "D:/clawd/hooks/gemini-hook.js" "BeforeTool"');
+  });
+
+  it("builds Windows cmd-wrapped commands with the Gemini event argv", () => {
+    const command = __test.buildGeminiHookCommand(
+      "node",
+      "D:/clawd/hooks/gemini-hook.js",
+      "BeforeTool",
+      { platform: "win32", windowsWrapper: "cmd" }
+    );
+
+    assert.strictEqual(command, 'cmd /d /s /c ""node" "D:/clawd/hooks/gemini-hook.js" "BeforeTool""');
   });
 
   it("skips when ~/.gemini/ does not exist", () => {

--- a/test/gemini-install.test.js
+++ b/test/gemini-install.test.js
@@ -144,6 +144,88 @@ describe("Gemini hook installer", () => {
     assert.ok(settings.hooks.SessionStart[1].hooks[0].command.includes(MARKER));
   });
 
+  it("splits Clawd out of shared matcher entries instead of widening third-party hooks", () => {
+    const settingsPath = makeTempSettingsFile({
+      hooks: {
+        BeforeTool: [{
+          matcher: "Edit",
+          hooks: [
+            { type: "command", command: "other-tool --flag", name: "other" },
+            { type: "command", command: '"/old/node" "/old/path/gemini-hook.js"', name: "clawd" },
+          ],
+        }],
+      },
+    });
+
+    const result = registerGeminiHooks({
+      silent: true,
+      settingsPath,
+      nodeBin: "/usr/local/bin/node",
+    });
+
+    assert.ok(result.updated >= 1);
+    const settings = readJson(settingsPath);
+    assert.strictEqual(settings.hooks.BeforeTool.length, 2);
+    assert.deepStrictEqual(settings.hooks.BeforeTool[0], {
+      matcher: "Edit",
+      hooks: [{ type: "command", command: "other-tool --flag", name: "other" }],
+    });
+    assert.deepStrictEqual(settings.hooks.BeforeTool[1], {
+      matcher: "*",
+      hooks: [{
+        type: "command",
+        command: settings.hooks.BeforeTool[1].hooks[0].command,
+        name: "clawd",
+      }],
+    });
+    assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.includes(MARKER));
+    assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.endsWith('" BeforeTool'));
+  });
+
+  it("removes Clawd from shared matcher entries when a dedicated Clawd entry already exists", () => {
+    const settingsPath = makeTempSettingsFile({
+      hooks: {
+        BeforeTool: [
+          {
+            matcher: "Edit",
+            hooks: [
+              { type: "command", command: "other-tool --flag", name: "other" },
+              { type: "command", command: '"/old/node" "/old/path/gemini-hook.js"', name: "clawd" },
+            ],
+          },
+          {
+            matcher: "*",
+            hooks: [{ type: "command", command: '"/stale/node" "/stale/path/gemini-hook.js"', name: "clawd" }],
+          },
+        ],
+      },
+    });
+
+    const result = registerGeminiHooks({
+      silent: true,
+      settingsPath,
+      nodeBin: "/usr/local/bin/node",
+    });
+
+    assert.ok(result.updated >= 1);
+    const settings = readJson(settingsPath);
+    assert.strictEqual(settings.hooks.BeforeTool.length, 2);
+    assert.deepStrictEqual(settings.hooks.BeforeTool[0], {
+      matcher: "Edit",
+      hooks: [{ type: "command", command: "other-tool --flag", name: "other" }],
+    });
+    assert.deepStrictEqual(settings.hooks.BeforeTool[1], {
+      matcher: "*",
+      hooks: [{
+        type: "command",
+        command: settings.hooks.BeforeTool[1].hooks[0].command,
+        name: "clawd",
+      }],
+    });
+    assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.includes("/usr/local/bin/node"));
+    assert.ok(settings.hooks.BeforeTool[1].hooks[0].command.endsWith('" BeforeTool'));
+  });
+
   it("does not force hooksConfig.enabled when the user disabled hooks", () => {
     const settingsPath = makeTempSettingsFile({
       hooksConfig: { enabled: false },

--- a/test/gemini-install.test.js
+++ b/test/gemini-install.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { registerGeminiHooks, GEMINI_HOOK_EVENTS } = require("../hooks/gemini-install");
+const { registerGeminiHooks, GEMINI_HOOK_EVENTS, __test } = require("../hooks/gemini-install");
 
 const MARKER = "gemini-hook.js";
 const tempDirs = [];
@@ -44,10 +44,15 @@ describe("Gemini hook installer", () => {
       assert.ok(Array.isArray(settings.hooks[event]), `missing hooks for ${event}`);
       assert.strictEqual(settings.hooks[event].length, 1);
       const entry = settings.hooks[event][0];
-      assert.strictEqual(entry.type, "command");
-      assert.strictEqual(entry.name, "clawd");
-      assert.ok(entry.command.includes(MARKER));
-      assert.ok(entry.command.includes("/usr/local/bin/node"));
+      assert.strictEqual(entry.matcher, "*");
+      assert.ok(Array.isArray(entry.hooks));
+      assert.strictEqual(entry.hooks.length, 1);
+      const hook = entry.hooks[0];
+      assert.strictEqual(hook.type, "command");
+      assert.strictEqual(hook.name, "clawd");
+      assert.ok(hook.command.includes(MARKER));
+      assert.ok(hook.command.includes("/usr/local/bin/node"));
+      assert.ok(hook.command.endsWith(`" ${event}`));
     }
   });
 
@@ -79,9 +84,35 @@ describe("Gemini hook installer", () => {
 
     assert.ok(result.updated >= 1);
     const settings = readJson(settingsPath);
-    assert.ok(settings.hooks.AfterTool[0].command.includes("/usr/local/bin/node"));
-    assert.ok(!settings.hooks.AfterTool[0].command.includes("/old/path/"));
     assert.strictEqual(settings.hooks.AfterTool.length, 1);
+    assert.ok(settings.hooks.AfterTool[0].hooks[0].command.includes("/usr/local/bin/node"));
+    assert.ok(!settings.hooks.AfterTool[0].hooks[0].command.includes("/old/path/"));
+    assert.ok(settings.hooks.AfterTool[0].hooks[0].command.endsWith('" AfterTool'));
+  });
+
+  it("migrates stale flat Clawd entries into nested Gemini hook shape", () => {
+    const settingsPath = makeTempSettingsFile({
+      hooks: {
+        BeforeTool: [
+          { type: "command", command: '"/old/node" "/old/path/gemini-hook.js"', name: "clawd" },
+        ],
+      },
+    });
+
+    const result = registerGeminiHooks({
+      silent: true,
+      settingsPath,
+      nodeBin: "/usr/local/bin/node",
+    });
+
+    assert.ok(result.updated >= 1);
+    const settings = readJson(settingsPath);
+    assert.strictEqual(settings.hooks.BeforeTool.length, 1);
+    assert.deepStrictEqual(Object.keys(settings.hooks.BeforeTool[0]).sort(), ["hooks", "matcher"]);
+    assert.strictEqual(settings.hooks.BeforeTool[0].matcher, "*");
+    assert.strictEqual(settings.hooks.BeforeTool[0].hooks[0].name, "clawd");
+    assert.ok(settings.hooks.BeforeTool[0].hooks[0].command.includes(MARKER));
+    assert.ok(settings.hooks.BeforeTool[0].hooks[0].command.endsWith('" BeforeTool'));
   });
 
   it("preserves existing node path when detection fails", () => {
@@ -94,11 +125,11 @@ describe("Gemini hook installer", () => {
     registerGeminiHooks({ silent: true, settingsPath, nodeBin: null });
 
     const settings = readJson(settingsPath);
-    assert.ok(settings.hooks.BeforeTool[0].command.includes("/home/user/.nvm/versions/node/v20/bin/node"));
+    assert.ok(settings.hooks.BeforeTool[0].hooks[0].command.includes("/home/user/.nvm/versions/node/v20/bin/node"));
   });
 
   it("preserves third-party hooks", () => {
-    const thirdParty = { type: "command", command: "other-tool --flag", name: "other" };
+    const thirdParty = { matcher: "*", hooks: [{ type: "command", command: "other-tool --flag", name: "other" }] };
     const settingsPath = makeTempSettingsFile({
       hooks: {
         SessionStart: [thirdParty],
@@ -110,7 +141,29 @@ describe("Gemini hook installer", () => {
     const settings = readJson(settingsPath);
     assert.strictEqual(settings.hooks.SessionStart.length, 2);
     assert.deepStrictEqual(settings.hooks.SessionStart[0], thirdParty);
-    assert.ok(settings.hooks.SessionStart[1].command.includes(MARKER));
+    assert.ok(settings.hooks.SessionStart[1].hooks[0].command.includes(MARKER));
+  });
+
+  it("does not force hooksConfig.enabled when the user disabled hooks", () => {
+    const settingsPath = makeTempSettingsFile({
+      hooksConfig: { enabled: false },
+    });
+
+    registerGeminiHooks({ silent: true, settingsPath, nodeBin: "/usr/local/bin/node" });
+
+    const settings = readJson(settingsPath);
+    assert.strictEqual(settings.hooksConfig.enabled, false);
+  });
+
+  it("builds Windows PowerShell commands with the Gemini event argv", () => {
+    const command = __test.buildGeminiHookCommand(
+      "node",
+      "D:/clawd/hooks/gemini-hook.js",
+      "BeforeTool",
+      { platform: "win32" }
+    );
+
+    assert.strictEqual(command, '& "node" "D:/clawd/hooks/gemini-hook.js" BeforeTool');
   });
 
   it("skips when ~/.gemini/ does not exist", () => {

--- a/test/gemini-log-monitor.test.js
+++ b/test/gemini-log-monitor.test.js
@@ -6,6 +6,11 @@ const os = require("os");
 const GeminiLogMonitor = require("../agents/gemini-log-monitor");
 const geminiConfig = require("../agents/gemini-cli");
 
+const LEGACY_GEMINI_LOG_CONFIG = {
+  sessionDir: "~/.gemini/tmp",
+  pollIntervalMs: 1500,
+};
+
 // Helper: create temp dir mimicking ~/.gemini/tmp/{projectDir}/chats/
 function makeTempGeminiDir(projectDir = "animation") {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "gemini-test-"));
@@ -18,7 +23,7 @@ function makeTempGeminiDir(projectDir = "animation") {
 function makeConfig(tmpDir) {
   return {
     ...geminiConfig,
-    logConfig: { ...geminiConfig.logConfig, sessionDir: tmpDir, pollIntervalMs: 100 },
+    logConfig: { ...LEGACY_GEMINI_LOG_CONFIG, sessionDir: tmpDir, pollIntervalMs: 100 },
   };
 }
 

--- a/test/main-gemini-hook-only.test.js
+++ b/test/main-gemini-hook-only.test.js
@@ -1,0 +1,14 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const path = require("path");
+
+describe("main Gemini hook-only integration", () => {
+  it("does not start a Gemini JSON session monitor", () => {
+    const mainSource = fs.readFileSync(path.resolve(__dirname, "..", "src", "main.js"), "utf8");
+
+    assert.ok(!mainSource.includes("GeminiLogMonitor"));
+    assert.ok(!mainSource.includes("_geminiMonitor"));
+    assert.ok(!mainSource.includes("Gemini log monitor"));
+  });
+});

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -152,6 +152,15 @@ describe("Agent Registry", () => {
     assert.strictEqual(cursor.eventMap.stop, "attention");
   });
 
+  it("treats Gemini CLI as a hook-only agent", () => {
+    const gemini = registry.getAgent("gemini-cli");
+
+    assert.strictEqual(gemini.eventSource, "hook");
+    assert.ok(gemini.hookConfig);
+    assert.strictEqual(gemini.hookConfig.configFormat, "gemini-settings-json");
+    assert.strictEqual(gemini.logConfig, undefined);
+  });
+
   it("should have logEventMap for poll-based agents", () => {
     const codex = registry.getAgent("codex");
     assert.strictEqual(codex.logEventMap["session_meta"], "idle");

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -113,6 +113,7 @@ describe("Agent Registry", () => {
     const gemini = registry.getAgent("gemini-cli");
     assert.strictEqual(gemini.capabilities.httpHook, false);
     assert.strictEqual(gemini.capabilities.permissionApproval, false);
+    assert.strictEqual(gemini.capabilities.notificationHook, true);
     assert.strictEqual(gemini.capabilities.sessionEnd, true);
     assert.strictEqual(gemini.capabilities.subagent, false);
 

--- a/test/renderer-low-power.test.js
+++ b/test/renderer-low-power.test.js
@@ -8,9 +8,13 @@ const path = require("node:path");
 const RENDERER = path.join(__dirname, "..", "src", "renderer.js");
 const PRELOAD = path.join(__dirname, "..", "src", "preload.js");
 
+function readNormalized(filePath) {
+  return fs.readFileSync(filePath, "utf8").replace(/\r\n/g, "\n");
+}
+
 describe("renderer low-power idle mode", () => {
   it("waits for an animation boundary before pausing the current SVG", () => {
-    const source = fs.readFileSync(RENDERER, "utf8");
+    const source = readNormalized(RENDERER);
 
     assert.ok(source.includes("function getLowPowerAnimationBoundaryDelayMs(root)"));
     assert.ok(source.includes("root.getAnimations({ subtree: true })"));
@@ -27,14 +31,14 @@ describe("renderer low-power idle mode", () => {
 
 describe("renderer object-channel selection", () => {
   it("allows built-in trusted scripted SVG files to use <object>", () => {
-    const source = fs.readFileSync(RENDERER, "utf8");
+    const source = readNormalized(RENDERER);
 
     assert.ok(source.includes("_trustedScriptedSvgFiles = new Set"));
     assert.ok(source.includes("return needsEyeTracking(state) || _trustedScriptedSvgFiles.has(file);"));
   });
 
   it("keeps eye-tracking attachment state-based only", () => {
-    const source = fs.readFileSync(RENDERER, "utf8");
+    const source = readNormalized(RENDERER);
 
     assert.ok(source.includes("function needsEyeTracking(state)"));
     assert.ok(source.includes("if (state && needsEyeTracking(state)) {\n        attachEyeTracking(next);"));

--- a/test/settings-agent-order.test.js
+++ b/test/settings-agent-order.test.js
@@ -32,7 +32,7 @@ describe("settings agent order", () => {
       { id: "codebuddy", name: "CodeBuddy", capabilities: { permissionApproval: true, notificationHook: true } },
       { id: "copilot-cli", name: "Copilot CLI", capabilities: {} },
       { id: "opencode", name: "OpenCode", capabilities: { permissionApproval: true } },
-      { id: "gemini-cli", name: "Gemini CLI", capabilities: {} },
+      { id: "gemini-cli", name: "Gemini CLI", capabilities: { notificationHook: true } },
       { id: "claude-code", name: "Claude Code", capabilities: { permissionApproval: true, notificationHook: true } },
       { id: "cursor-agent", name: "Cursor Agent", capabilities: {} },
       { id: "codex", name: "Codex CLI", capabilities: { interactiveBubble: true } },
@@ -42,11 +42,11 @@ describe("settings agent order", () => {
     assert.deepStrictEqual(sorted.map((agent) => agent.id), [
       "claude-code",
       "codex",
+      "gemini-cli",
       "kimi-cli",
       "opencode",
       "codebuddy",
       "cursor-agent",
-      "gemini-cli",
       "copilot-cli",
       "kiro-cli",
     ]);

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -637,6 +637,14 @@ describe("settings renderer browser environment", () => {
     assert.ok(agentsSource.includes("sortAgentMetadataForSettings(runtime.agentMetadata"));
   });
 
+  it("keeps Gemini agent detail rows on the generic notificationHook path", () => {
+    const agentsSource = fs.readFileSync(path.join(SRC_DIR, "settings-tab-agents.js"), "utf8");
+    assert.ok(agentsSource.includes("if (caps.notificationHook) {"));
+    assert.ok(agentsSource.includes('flag: "notificationHookEnabled"'));
+    assert.ok(!agentsSource.includes('agent.id === "gemini-cli"'));
+    assert.ok(!agentsSource.includes("Gemini CLI"));
+  });
+
   it("keeps stale sound override prefs resettable from the settings UI", () => {
     const overridesSource = fs.readFileSync(path.join(SRC_DIR, "settings-tab-anim-overrides.js"), "utf8");
     assert.ok(

--- a/test/state-notification-hook-gate.test.js
+++ b/test/state-notification-hook-gate.test.js
@@ -89,6 +89,34 @@ describe("updateSession: Notification hook gate", () => {
     assert.deepStrictEqual(ctx._soundsPlayed, ["confirm"], "confirm sound must play");
   });
 
+  it("mutes Gemini Notification bell + animation when the per-agent flag is off", () => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx({ notificationHookEnabled: false });
+    api = require("../src/state")(ctx);
+
+    api.updateSession("gemini-1", "notification", "Notification", { agentId: "gemini-cli" });
+
+    assert.strictEqual(api.sessions.has("gemini-1"), true, "Gemini session must still be registered");
+    assert.strictEqual(api.sessions.get("gemini-1").state, "idle", "Gemini Notification must still resolve bookkeeping");
+    const stateChanges = ctx._rendererEvents.filter(([ch]) => ch === "state-change");
+    assert.ok(stateChanges.length >= 1, "pet must still get a state-change broadcast");
+    assert.notStrictEqual(stateChanges[0][1], "notification", "Gemini mute must skip notification state");
+    assert.deepStrictEqual(ctx._soundsPlayed, [], "Gemini mute must suppress confirm sound");
+  });
+
+  it("lets Gemini Notification through when the per-agent flag is on", () => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx({ notificationHookEnabled: true });
+    api = require("../src/state")(ctx);
+
+    api.updateSession("gemini-1", "notification", "Notification", { agentId: "gemini-cli" });
+
+    const stateChanges = ctx._rendererEvents.filter(([ch]) => ch === "state-change");
+    assert.ok(stateChanges.length >= 1, "Gemini notification state must be broadcast");
+    assert.strictEqual(stateChanges[0][1], "notification");
+    assert.deepStrictEqual(ctx._soundsPlayed, ["confirm"], "Gemini notification must play confirm sound");
+  });
+
   it("never drops PermissionRequest events even when the flag is off", () => {
     // Permission bubbles must keep their bell regardless of idle-alert prefs.
     // PermissionRequest is handled by the branch before the gate and never


### PR DESCRIPTION
Fixes #201.

## Summary
- switch Gemini CLI integration fully to hook-only runtime behavior and stop starting the legacy JSON session monitor
- register Gemini hooks using the official nested settings shape, preserve user-disabled hook settings, and add coverage for the stdout/argv contract
- teach Doctor to warn when Gemini hooks exist but are disabled, and harden the renderer low-power source inspection test against CRLF/LF differences

## Problem context
- Gemini integration was moving from session-log polling to the official hook system, but the runtime and diagnostics still had gaps.
- Clawd could report Gemini integration as healthy when `hooksConfig.enabled` was `false` or when the `clawd` hook had been disabled, even though no Gemini events would reach Clawd in hook-only mode.
- The local test suite also had a Windows-specific brittle assertion in `renderer-low-power.test.js` that matched only LF newlines.

## What changed
- Gemini hook-only integration
  - mark `gemini-cli` as a hook-only agent in the registry and remove runtime startup/shutdown of the Gemini JSON monitor from `src/main.js`
  - keep the legacy Gemini monitor module as a legacy path, but do not start it in normal runtime flow
  - update the Gemini hook installer to write the official nested Gemini hook shape and migrate stale flat entries in place
  - keep `hooksConfig.enabled` and `hooksConfig.disabled` untouched so user intent is preserved
  - add hook-script coverage for event argv fallback and passive lifecycle stdout responses
- Doctor diagnostics
  - extend agent integration checks to emit `gemini_hooks` supplementary state
  - downgrade Gemini integration from `ok` to `not-connected` when hooks are globally disabled or when the Clawd Gemini hook is explicitly disabled
  - suppress the generic repair action for those Gemini disabled states because reinstalling hooks should not override user-disabled settings
  - remove Gemini from fallback file-mtime activity so the Doctor fallback path reflects hook-only behavior
- Tests and docs
  - add Gemini hook-only tests for installer behavior, Doctor integration summary, hook script contract, and main-process runtime behavior
  - update docs and AGENTS references to describe Gemini as hook-only with the legacy monitor retained only for historical purposes
  - normalize source reads in `renderer-low-power.test.js` so the suite passes on CRLF and LF worktrees

## Behavior after this PR
- Gemini CLI sessions are tracked through official hooks only.
- If Gemini hooks are present and enabled, Clawd receives hook events as before.
- If the user disables Gemini hooks globally or disables the `clawd` Gemini hook, Doctor now reports a warning instead of a false green integration result.
- Clawd still preserves user hook disablement and does not silently re-enable Gemini hooks.
- The legacy Gemini JSON monitor remains in the codebase but is not started by the runtime.

## Validation
- `node --test test/doctor-agent-integrations.test.js test/doctor-report.test.js test/gemini-install.test.js test/gemini-hook.test.js test/main-gemini-hook-only.test.js test/registry.test.js`
- `node --test test/server-hook-management.test.js test/doctor-agent-descriptors.test.js test/doctor-hook-activity.test.js`
- `node --test test/renderer-low-power.test.js`
- `npm test`

## Platform note
- Automated verification ran on Windows with PowerShell 7 in this workspace.
- Manual QA with a real Gemini CLI session is still recommended to confirm live hook delivery outside the test harness.
