### PR TITLE
Show Codex renamed session titles

### DIFF
--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -18,6 +18,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const CodexSubagentClassifier = require("./codex-subagent-classifier");
+const { readCodexThreadName } = require("../hooks/codex-session-index");
 
 const APPROVAL_HEURISTIC_MS = 2000;
 const MAX_TRACKED_FILES = 50;
@@ -49,6 +50,7 @@ class CodexLogMonitor {
     // Map<filePath, { offset, sessionId, cwd, lastEventTime, lastState, partial }>
     this._tracked = new Map();
     this._baseDir = this._resolveBaseDir();
+    this._codexDir = options.codexDir || null;
     this._recentDayDirsCache = [];
     this._recentDayDirsCacheAt = 0;
     this._recentDayDirsDateKey = "";
@@ -382,6 +384,10 @@ class CodexLogMonitor {
     const extractedTitle = this._extractSessionTitle(obj);
     if (extractedTitle && extractedTitle !== tracked.sessionTitle) {
       tracked.sessionTitle = extractedTitle;
+    }
+    const threadName = readCodexThreadName(tracked.sessionId, { codexDir: this._codexDir });
+    if (threadName && threadName !== tracked.sessionTitle) {
+      tracked.sessionTitle = threadName;
     }
 
     // Approval heuristic: exec_command_end / function_call_output means command finished.

--- a/docs/guides/setup-guide.md
+++ b/docs/guides/setup-guide.md
@@ -68,7 +68,7 @@ If you run Claude Code inside WSL while Clawd runs on the Windows host, hooks ca
 mkdir -p ~/.claude/hooks
 
 # Copy hook files from the Windows-side repo (adjust the /mnt/ path to your Clawd location)
-cp /mnt/d/animation/hooks/{server-config,json-utils,shared-process,clawd-hook,install,codex-hook,codex-install,codex-install-utils,codex-remote-monitor,codex-subagent-fields}.js ~/.claude/hooks/
+cp /mnt/d/animation/hooks/{server-config,json-utils,shared-process,clawd-hook,install,codex-hook,codex-install,codex-install-utils,codex-remote-monitor,codex-session-index,codex-subagent-fields}.js ~/.claude/hooks/
 
 # Register Claude hooks in remote mode
 node ~/.claude/hooks/install.js --remote

--- a/docs/guides/setup-guide.zh-CN.md
+++ b/docs/guides/setup-guide.zh-CN.md
@@ -68,7 +68,7 @@ Host my-server
 mkdir -p ~/.claude/hooks
 
 # 从 Windows 侧的 Clawd 仓库复制 hook 文件（按实际路径调整 /mnt/ 前缀）
-cp /mnt/d/animation/hooks/{server-config,json-utils,shared-process,clawd-hook,install,codex-hook,codex-install,codex-install-utils,codex-remote-monitor,codex-subagent-fields}.js ~/.claude/hooks/
+cp /mnt/d/animation/hooks/{server-config,json-utils,shared-process,clawd-hook,install,codex-hook,codex-install,codex-install-utils,codex-remote-monitor,codex-session-index,codex-subagent-fields}.js ~/.claude/hooks/
 
 # 以远程模式注册 Claude hooks
 node ~/.claude/hooks/install.js --remote

--- a/hooks/codex-hook.js
+++ b/hooks/codex-hook.js
@@ -16,6 +16,7 @@ const {
   classifyHookPayload,
   classifySessionMeta,
 } = require("./codex-subagent-fields");
+const { readCodexThreadName } = require("./codex-session-index");
 
 const TOOL_MATCH_STRING_MAX = 240;
 const TOOL_MATCH_ARRAY_MAX = 16;
@@ -265,9 +266,10 @@ function buildStateBody(payload, resolve) {
   if (!state) return null;
   if (event === "Stop" && payload.stop_hook_active === true) return null;
 
+  const sessionId = normalizeCodexSessionId(payload.session_id, payload.transcript_path);
   const body = {
     state,
-    session_id: normalizeCodexSessionId(payload.session_id, payload.transcript_path),
+    session_id: sessionId,
     event,
     agent_id: "codex",
     hook_source: "codex-official",
@@ -288,6 +290,8 @@ function buildStateBody(payload, resolve) {
   }
 
   const sessionMeta = readFirstSessionMeta(payload.transcript_path);
+  const threadName = readCodexThreadName(sessionId);
+  if (threadName) body.session_title = threadName;
   const codexRole = resolveCodexSessionRole(payload, sessionMeta);
   if (codexRole !== ROLE_UNKNOWN) body.codex_session_role = codexRole;
   applyCodexUpstreamFields(body, payload, sessionMeta);

--- a/hooks/codex-session-index.js
+++ b/hooks/codex-session-index.js
@@ -1,0 +1,74 @@
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const SESSION_INDEX_READ_MAX_BYTES = 512 * 1024;
+
+function getCodexDir() {
+  const configured = process.env.CODEX_HOME;
+  if (typeof configured === "string" && configured.trim()) {
+    return configured.trim();
+  }
+  return path.join(os.homedir(), ".codex");
+}
+
+function bareCodexSessionId(sessionId) {
+  if (typeof sessionId !== "string") return null;
+  const trimmed = sessionId.trim();
+  if (!trimmed) return null;
+  return trimmed.startsWith("codex:") ? trimmed.slice("codex:".length) : trimmed;
+}
+
+function normalizeThreadName(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function readTail(filePath, maxBytes = SESSION_INDEX_READ_MAX_BYTES) {
+  let fd;
+  try {
+    const stat = fs.statSync(filePath);
+    const start = Math.max(0, stat.size - maxBytes);
+    const len = stat.size - start;
+    if (len <= 0) return "";
+    fd = fs.openSync(filePath, "r");
+    const buf = Buffer.allocUnsafe(len);
+    fs.readSync(fd, buf, 0, len, start);
+    return buf.toString("utf8");
+  } catch {
+    return "";
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch {}
+    }
+  }
+}
+
+function readCodexThreadName(sessionId, options = {}) {
+  const id = bareCodexSessionId(sessionId);
+  if (!id) return null;
+  const codexDir = typeof options.codexDir === "string" && options.codexDir
+    ? options.codexDir
+    : getCodexDir();
+  const indexPath = path.join(codexDir, "session_index.jsonl");
+  const content = readTail(indexPath, options.maxBytes);
+  if (!content) return null;
+
+  let latest = null;
+  for (const line of content.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const entry = JSON.parse(line);
+      if (!entry || entry.id !== id) continue;
+      const name = normalizeThreadName(entry.thread_name);
+      if (name) latest = name;
+    } catch {}
+  }
+  return latest;
+}
+
+module.exports = {
+  bareCodexSessionId,
+  readCodexThreadName,
+};

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -51,6 +51,7 @@ FILES=(
   "$HOOKS_DIR/codex-install.js"
   "$HOOKS_DIR/codex-install-utils.js"
   "$HOOKS_DIR/codex-remote-monitor.js"
+  "$HOOKS_DIR/codex-session-index.js"
   "$HOOKS_DIR/codex-subagent-fields.js"
 )
 

--- a/src/state.js
+++ b/src/state.js
@@ -8,6 +8,7 @@ const fs = require("fs");
 const { pathToFileURL } = require("url");
 const { VISUAL_FALLBACK_STATES } = require("./theme-loader");
 const { sessionAliasKey } = require("./session-alias");
+const { readCodexThreadName } = require("../hooks/codex-session-index");
 
 // ── Agent icons (official logos from assets/icons/agents/) ──
 const AGENT_ICON_DIR = path.join(__dirname, "..", "assets", "icons", "agents");
@@ -695,11 +696,19 @@ function getSessionAliasEntry(id, sessionLike, sessionAliases = {}) {
 function sessionDisplayTitle(id, sessionLike, sessionAliases = {}) {
   const alias = getSessionAliasEntry(id, sessionLike, sessionAliases);
   if (alias && typeof alias.title === "string" && alias.title) return alias.title;
-  const title = normalizeTitle(sessionLike && sessionLike.sessionTitle);
+  const title = getEffectiveSessionTitle(id, sessionLike);
   if (title) return title;
   const cwd = sessionLike && sessionLike.cwd;
   if (cwd) return path.basename(cwd);
   return id && id.length > 6 ? `${id.slice(0, 6)}..` : id;
+}
+
+function getEffectiveSessionTitle(id, sessionLike) {
+  if (sessionLike && sessionLike.agentId === "codex" && !sessionLike.host) {
+    const threadName = normalizeTitle(readCodexThreadName(id));
+    if (threadName) return threadName;
+  }
+  return normalizeTitle(sessionLike && sessionLike.sessionTitle);
 }
 
 function sessionMenuComparator(a, b) {
@@ -730,7 +739,7 @@ function buildSessionSnapshotEntry(id, session, sessionAliases = {}) {
     state: (session && session.state) || "idle",
     badge: deriveSessionBadge(session),
     hasAlias: !!(alias && typeof alias.title === "string" && alias.title),
-    sessionTitle: normalizeTitle(session && session.sessionTitle),
+    sessionTitle: getEffectiveSessionTitle(id, session),
     displayTitle: sessionDisplayTitle(id, session, sessionAliases),
     cwd: (session && session.cwd) || "",
     updatedAt: sessionUpdatedAt(session),

--- a/test/codex-hook.test.js
+++ b/test/codex-hook.test.js
@@ -15,6 +15,7 @@ const {
   readFirstSessionMeta,
   sanitizeCodexPermissionOutput,
 } = require("../hooks/codex-hook");
+const { readCodexThreadName } = require("../hooks/codex-session-index");
 
 const mockResolve = () => ({
   stablePid: 123,
@@ -29,6 +30,16 @@ function withTempTranscript(lines, fn) {
   fs.writeFileSync(file, lines.join("\n") + "\n", "utf8");
   try {
     return fn(file);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+function withTempCodexIndex(lines, fn) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-index-"));
+  fs.writeFileSync(path.join(dir, "session_index.jsonl"), lines.join("\n") + "\n", "utf8");
+  try {
+    return fn(dir);
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -80,6 +91,40 @@ describe("Codex official hook", () => {
     assert.strictEqual(body.agent_pid, 456);
     assert.strictEqual(body.editor, "code");
     assert.deepStrictEqual(body.pid_chain, [789, 456, 123]);
+  });
+
+  it("reads Codex /rename thread_name from session_index.jsonl", () => {
+    withTempCodexIndex([
+      JSON.stringify({ id: "019d23d4-f1a9-7633-b9c7-758327137228", thread_name: "Old Name" }),
+      JSON.stringify({ id: "other", thread_name: "Other" }),
+      JSON.stringify({ id: "019d23d4-f1a9-7633-b9c7-758327137228", thread_name: "요구사항개선" }),
+    ], (codexDir) => {
+      assert.strictEqual(
+        readCodexThreadName("codex:019d23d4-f1a9-7633-b9c7-758327137228", { codexDir }),
+        "요구사항개선"
+      );
+    });
+  });
+
+  it("sends Codex /rename thread_name as session_title", () => {
+    withTempCodexIndex([
+      JSON.stringify({ id: "019d23d4-f1a9-7633-b9c7-758327137228", thread_name: "요구사항개선" }),
+    ], (codexDir) => {
+      const oldCodexHome = process.env.CODEX_HOME;
+      process.env.CODEX_HOME = codexDir;
+      try {
+        const body = buildStateBody({
+          hook_event_name: "SessionStart",
+          session_id: "official-session",
+          transcript_path: "/tmp/rollout-2026-03-25T15-10-51-019d23d4-f1a9-7633-b9c7-758327137228.jsonl",
+        }, mockResolve);
+
+        assert.strictEqual(body.session_title, "요구사항개선");
+      } finally {
+        if (oldCodexHome === undefined) delete process.env.CODEX_HOME;
+        else process.env.CODEX_HOME = oldCodexHome;
+      }
+    });
   });
 
   it("passes through tool metadata without raw tool_input", () => {

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -755,6 +755,33 @@ describe("CodexLogMonitor", () => {
       });
       monitor.start();
     });
+
+    it("uses Codex /rename thread_name from session_index.jsonl", (_, done) => {
+      const testFile = path.join(dateDir, TEST_FILENAME);
+      fs.writeFileSync(testFile, [
+        '{"type":"turn_context","payload":{"summary":"Auto Summary"}}',
+        '{"type":"session_meta","payload":{"cwd":"/projects/foo"}}',
+      ].join("\n") + "\n");
+      const codexDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-index-"));
+      fs.writeFileSync(path.join(codexDir, "session_index.jsonl"), [
+        JSON.stringify({
+          id: "019d23d4-f1a9-7633-b9c7-758327137228",
+          thread_name: "요구사항개선",
+        }),
+      ].join("\n") + "\n", "utf8");
+
+      const config = makeConfig(tmpDir);
+      monitor = new CodexLogMonitor(config, (sid, state, event, extra) => {
+        if (state !== "idle") return;
+        try {
+          assert.strictEqual(extra.sessionTitle, "요구사항개선");
+          done();
+        } finally {
+          fs.rmSync(codexDir, { recursive: true, force: true });
+        }
+      }, { codexDir });
+      monitor.start();
+    });
   });
 
   it("should process recent existing day dirs even if not today/yesterday", (_, done) => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,10 +1,13 @@
 // test/state.test.js — Unit tests for src/state.js core logic
 const { describe, it, beforeEach, afterEach, mock } = require("node:test");
 const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 
 // Load default theme for test ctx
 const themeLoader = require("../src/theme-loader");
-themeLoader.init(require("path").join(__dirname, "..", "src"));
+themeLoader.init(path.join(__dirname, "..", "src"));
 const _defaultTheme = themeLoader.loadTheme("clawd");
 const _calicoTheme = themeLoader.loadTheme("calico");
 const { createTranslator } = require("../src/i18n");
@@ -1144,6 +1147,34 @@ describe("buildSessionSnapshot", () => {
     assert.strictEqual(codex.displayTitle, "Codex follow-up");
     assert.strictEqual(codex.cwd, "d:/animation/");
     assert.strictEqual(snapshot.hudLastTitle, "Claude review");
+  });
+
+  it("uses Codex thread_name from session_index.jsonl for local session displayTitle", () => {
+    const codexDir = fs.mkdtempSync(path.join(os.tmpdir(), "codex-index-"));
+    fs.writeFileSync(path.join(codexDir, "session_index.jsonl"), [
+      JSON.stringify({
+        id: "019d23d4-f1a9-7633-b9c7-758327137228",
+        thread_name: "요구사항개선",
+      }),
+    ].join("\n") + "\n", "utf8");
+    const oldCodexHome = process.env.CODEX_HOME;
+    process.env.CODEX_HOME = codexDir;
+    try {
+      api.sessions.set("codex:019d23d4-f1a9-7633-b9c7-758327137228", rawSession("thinking", {
+        updatedAt: 1000,
+        cwd: "D:\\repository\\spms",
+        agentId: "codex",
+        sessionTitle: "Auto Summary",
+      }));
+
+      const snapshot = api.buildSessionSnapshot();
+      assert.strictEqual(snapshot.sessions[0].sessionTitle, "요구사항개선");
+      assert.strictEqual(snapshot.sessions[0].displayTitle, "요구사항개선");
+    } finally {
+      if (oldCodexHome === undefined) delete process.env.CODEX_HOME;
+      else process.env.CODEX_HOME = oldCodexHome;
+      fs.rmSync(codexDir, { recursive: true, force: true });
+    }
   });
 
   it("keeps session aliases scoped by host, agent, and session id", () => {


### PR DESCRIPTION
## Summary
- read Codex thread names from ~/.codex/session_index.jsonl
- pass renamed Codex titles through official hooks and JSONL fallback monitoring
- prefer Codex thread_name in session dashboard/HUD display titles

## Tests
- node --test test/codex-hook.test.js test/codex-log-monitor.test.js test/state.test.js