### PR TITLE
fix: prevent agent submenu flash on toggle

### DIFF
--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -362,6 +362,10 @@
       return `${body.scrollHeight}px`;
     }
 
+    function isGroupConnected() {
+      return !!(document.body && document.body.contains(group));
+    }
+
     function setExpandedBodyHeight() {
       body.style.setProperty("--collapsible-body-height", measureCollapsibleBodyHeight());
     }
@@ -401,7 +405,16 @@
       if (!animate) {
         group.classList.toggle("collapsed", collapsed);
         setBodyInteractivity(collapsed);
-        body.style.setProperty("--collapsible-body-height", collapsed ? "0px" : measureCollapsibleBodyHeight());
+        if (collapsed) {
+          body.style.setProperty("--collapsible-body-height", "0px");
+        } else {
+          // Detached groups report scrollHeight=0 in some engines. Keep the
+          // body fully expanded until the post-mount RAF can measure a real height.
+          body.style.setProperty(
+            "--collapsible-body-height",
+            isGroupConnected() ? measureCollapsibleBodyHeight() : "none"
+          );
+        }
         return;
       }
 

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -80,6 +80,22 @@ function loadSettingsCoreForTest(settingsAPI) {
   return context.ClawdSettingsCore;
 }
 
+function createQueuedRaf() {
+  const queue = [];
+  return {
+    requestAnimationFrame(cb) {
+      queue.push(cb);
+      return queue.length;
+    },
+    flush() {
+      while (queue.length) {
+        const cb = queue.shift();
+        cb();
+      }
+    },
+  };
+}
+
 class FakeClassList {
   constructor(el) {
     this.el = el;
@@ -133,7 +149,16 @@ class FakeElement {
     this.disabled = false;
     this.open = false;
     this.parentNode = null;
-    this.style = { setProperty: () => {} };
+    this.scrollTop = 0;
+    this.style = {
+      _values: {},
+      setProperty(name, value) {
+        this._values[name] = String(value);
+      },
+      getPropertyValue(name) {
+        return this._values[name] || "";
+      },
+    };
     this.classList = new FakeClassList(this);
   }
 
@@ -146,6 +171,13 @@ class FakeElement {
   setAttribute(name, value) {
     this.attributes[name] = String(value);
     if (name === "class") this.className = String(value);
+    if (name === "id") this.id = String(value);
+  }
+
+  removeAttribute(name) {
+    delete this.attributes[name];
+    if (name === "class") this.className = "";
+    if (name === "id") delete this.id;
   }
 
   addEventListener(type, cb) {
@@ -186,6 +218,133 @@ class FakeElement {
     if (target === this) return true;
     return this.children.some((child) => child.contains(target));
   }
+
+  getBoundingClientRect() {
+    return { top: 0, left: 0, width: 0, height: 0, right: 0, bottom: 0 };
+  }
+
+  get isConnected() {
+    let current = this;
+    while (current) {
+      if (current.tagName === "BODY") return true;
+      current = current.parentNode;
+    }
+    return false;
+  }
+
+  get scrollHeight() {
+    if (!this.isConnected) return 0;
+    return Math.max(40, this.children.length * 40);
+  }
+}
+
+function loadAgentsTabForTest({
+  snapshot,
+  agentMetadata,
+  collapsedGroups = {},
+} = {}) {
+  const raf = createQueuedRaf();
+  const body = new FakeElement("body");
+  const content = new FakeElement("main");
+  content.id = "content";
+  body.appendChild(content);
+
+  const localStorageData = {
+    "clawd.settings.collapsedGroups.v1": JSON.stringify(collapsedGroups),
+  };
+
+  const document = {
+    body,
+    createElement: (tagName) => new FakeElement(tagName),
+    getElementById(id) {
+      if (id === "content") return content;
+      return null;
+    },
+  };
+
+  const context = {
+    console,
+    navigator: { platform: "Win32" },
+    localStorage: {
+      getItem: (key) => (Object.prototype.hasOwnProperty.call(localStorageData, key) ? localStorageData[key] : null),
+      setItem: (key, value) => {
+        localStorageData[key] = String(value);
+      },
+    },
+    document,
+    requestAnimationFrame: (cb) => raf.requestAnimationFrame(cb),
+    window: null,
+    globalThis: null,
+    settingsAPI: {
+      command: () => Promise.resolve({ status: "ok" }),
+    },
+    ClawdSettingsSizeSlider: {
+      SIZE_UI_MIN: 1,
+      SIZE_UI_MAX: 100,
+      SIZE_TICK_VALUES: [25, 50, 75, 100],
+      SIZE_SLIDER_THUMB_DIAMETER: 18,
+      prefsSizeToUi: (value) => value,
+      clampSizeUi: (value) => value,
+      sizeUiToPct: (value) => value,
+      getSizeSliderAnchorPx: () => 0,
+      createSizeSliderController: () => ({}),
+    },
+    ClawdSettingsI18n: {
+      STRINGS: {
+        en: {
+          agentsTitle: "Agents",
+          agentsSubtitle: "subtitle",
+          agentsEmpty: "empty",
+          rowAgentIdleAlerts: "Idle alerts",
+          rowAgentIdleAlertsDesc: "Idle alert desc",
+          rowAgentPermissions: "Permissions",
+          rowAgentPermissionsDesc: "Permissions desc",
+          rowCodexPermissionMode: "Permission mode",
+          rowCodexPermissionModeDesc: "Permission mode desc",
+          codexPermissionModeNative: "Native",
+          codexPermissionModeIntercept: "Intercept",
+          badgePermissionBubble: "Permission bubble",
+          eventSourceHook: "Hook",
+          eventSourceLogPoll: "Log poll",
+          eventSourcePlugin: "Plugin",
+          collapsibleExpand: "Expand",
+          collapsibleCollapse: "Collapse",
+          toastSaveFailed: "Failed: ",
+        },
+      },
+      CONTRIBUTORS: [],
+      MAINTAINERS: [],
+    },
+  };
+  context.window = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(SETTINGS_ANIM_OVERRIDES_MERGE, "utf8"), context);
+  vm.runInContext(fs.readFileSync(SETTINGS_UI_CORE, "utf8"), context);
+  vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-agent-order.js"), "utf8"), context);
+  vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-agents.js"), "utf8"), context);
+
+  const core = context.ClawdSettingsCore;
+  core.state.snapshot = snapshot || { agents: {} };
+  core.state.activeTab = "agents";
+  core.runtime.agentMetadata = Array.isArray(agentMetadata) ? agentMetadata : [];
+  context.ClawdSettingsTabAgents.init(core);
+
+  let contentRenderCount = 0;
+  function renderContent() {
+    contentRenderCount++;
+    core.ops.clearMountedControls();
+    content.innerHTML = "";
+    core.tabs.agents.render(content, core);
+  }
+  core.ops.installRenderHooks({ content: renderContent });
+
+  return {
+    core,
+    content,
+    raf,
+    getContentRenderCount: () => contentRenderCount,
+  };
 }
 
 function loadAnimOverridesTabForTest({ runtime, modalRoot }) {
@@ -649,6 +808,92 @@ describe("settings renderer browser environment", () => {
     assert.ok(!agentsSource.includes('agent.id === "gemini-cli"'));
     assert.ok(!agentsSource.includes('agent.id !== "gemini-cli"'));
     assert.ok(!agentsSource.includes("Gemini CLI"));
+  });
+
+  it("patches agent-only broadcasts in place without requiring Codex-specific rows", () => {
+    const harness = loadAgentsTabForTest({
+      snapshot: {
+        agents: {
+          "gemini-cli": {
+            enabled: true,
+            notificationHookEnabled: true,
+          },
+        },
+      },
+      agentMetadata: [{
+        id: "gemini-cli",
+        name: "Gemini CLI",
+        eventSource: "hook",
+        capabilities: {
+          notificationHook: true,
+        },
+      }],
+      collapsedGroups: {
+        "agents:gemini-cli": false,
+      },
+    });
+
+    harness.core.ops.requestRender({ content: true });
+    harness.raf.flush();
+    const before = harness.getContentRenderCount();
+
+    harness.core.ops.applyChanges({
+      changes: {
+        agents: {
+          "gemini-cli": {
+            enabled: true,
+            notificationHookEnabled: false,
+          },
+        },
+      },
+      snapshot: {
+        agents: {
+          "gemini-cli": {
+            enabled: true,
+            notificationHookEnabled: false,
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(
+      harness.getContentRenderCount(),
+      before,
+      "agent-only broadcasts should update mounted controls in place instead of rebuilding the expanded group"
+    );
+  });
+
+  it("does not initialize an expanded agent group at 0px height during rerender", () => {
+    const harness = loadAgentsTabForTest({
+      snapshot: {
+        agents: {
+          "gemini-cli": {
+            enabled: true,
+            notificationHookEnabled: true,
+          },
+        },
+      },
+      agentMetadata: [{
+        id: "gemini-cli",
+        name: "Gemini CLI",
+        eventSource: "hook",
+        capabilities: {
+          notificationHook: true,
+        },
+      }],
+      collapsedGroups: {
+        "agents:gemini-cli": false,
+      },
+    });
+
+    harness.core.ops.requestRender({ content: true });
+    const expandedBody = harness.content.querySelector(".collapsible-group-body");
+    assert.ok(expandedBody, "agent group body should render");
+    assert.notStrictEqual(
+      expandedBody.style.getPropertyValue("--collapsible-body-height"),
+      "0px",
+      "expanded groups should not paint one frame at 0px height before the next animation frame runs"
+    );
   });
 
   it("keeps stale sound override prefs resettable from the settings UI", () => {


### PR DESCRIPTION
## Summary
- prevents expanded Agent management submenus from flashing closed and reopened when a switch is toggled inside the group
- keeps the existing collapsible animation model, but avoids initializing expanded groups with a transient `0px` body height while they are still detached from the DOM
- preserves the current Settings update flow: agent flag changes still clear transient pending state, patch mounted controls in place when possible, and reuse the existing post-mount height measurement path

## Problem context
- the bug reproduced in `Settings -> Agent management` when an agent submenu was already expanded and a switch inside that submenu was toggled
- visually, the submenu appeared to collapse for one frame and then reopen, which read as a flicker even though the collapsed state itself was not being persisted or intentionally toggled
- the root cause was in the shared `buildCollapsibleGroup()` helper: an expanded group could be rendered before it was connected to `document.body`, and some engines report `scrollHeight = 0` in that state
- that detached first paint wrote `--collapsible-body-height: 0px`, then the existing `requestAnimationFrame()` measurement corrected it on the next frame, producing the visible close-then-open flash

## What changed
- adjusted the shared collapsible group helper so expanded groups no longer initialize to `0px` height while detached
  - collapsed groups still initialize to `0px`
  - expanded groups now keep the body unconstrained until the element is connected, then the existing measured-height path takes over
- added browser-environment regression coverage for the Agent management path
  - built a small DOM harness for the settings agents tab so the test can exercise mounted controls, queued RAF callbacks, and collapsible body height state
  - added a regression test that asserts an expanded agent group does not paint one frame at `0px` height during rerender
  - kept a companion test that confirms agent-only broadcasts still patch mounted controls in place instead of forcing a full content rebuild

## Behavior after this PR
- toggling a switch inside an already-expanded Agent management subgroup keeps the submenu visually open without the close-and-reopen flash
- the existing collapsible animation is preserved for real expand and collapse interactions
- agent toggles still use the current Settings transient pending and broadcast flow; this PR does not change persistence semantics, controller behavior, or agent side-effect wiring

## Validation
- `node --test test/settings-renderer-browser-env.test.js test/settings-controller.test.js test/settings-actions.test.js`
- `npm test`
- `git diff --check`

## Platform note
- automated verification ran on Windows in the local development environment
- because this is an Electron renderer interaction bug, a quick manual check in the real Settings window is still recommended to confirm the submenu stays visually stable during hover and toggle interactions
