### PR TITLE
fix: smooth Settings switch animations

### DIFF
--- a/src/settings-tab-agents.js
+++ b/src/settings-tab-agents.js
@@ -88,19 +88,17 @@
   }
 
   function buildAgentDetailRows(agent) {
-    const masterOn = readers.readAgentFlagValue(agent.id, "enabled");
     const rows = [];
     const caps = agent.capabilities || {};
     if (agent.id === "codex") {
-      rows.push(buildCodexPermissionModeRow(agent, !masterOn));
+      rows.push(buildCodexPermissionModeRow(agent, computeAgentSubSwitchDisabled(agent.id, "permissionMode")));
     }
     if (caps.permissionApproval || caps.interactiveBubble) {
-      const codexNativeMode = agent.id === "codex" && readers.readAgentPermissionMode(agent.id) !== "intercept";
       rows.push(buildAgentSwitchRow({
         agent,
         flag: "permissionsEnabled",
         extraClass: "row-sub",
-        disabled: !masterOn || codexNativeMode,
+        disabled: computeAgentSubSwitchDisabled(agent.id, "permissionsEnabled"),
         buildText: (text) => {
           const label = document.createElement("span");
           label.className = "row-label";
@@ -118,7 +116,7 @@
         agent,
         flag: "notificationHookEnabled",
         extraClass: "row-sub",
-        disabled: !masterOn,
+        disabled: computeAgentSubSwitchDisabled(agent.id, "notificationHookEnabled"),
         buildText: (text) => {
           const label = document.createElement("span");
           label.className = "row-label";
@@ -132,6 +130,16 @@
       }));
     }
     return rows;
+  }
+
+  function computeAgentSubSwitchDisabled(agentId, flag) {
+    if (flag === "enabled") return false;
+    const masterOn = readers.readAgentFlagValue(agentId, "enabled");
+    if (!masterOn) return true;
+    if (agentId === "codex" && flag === "permissionsEnabled") {
+      return readers.readAgentPermissionMode(agentId) !== "intercept";
+    }
+    return false;
   }
 
   function buildCodexPermissionModeRow(agent, disabled) {
@@ -281,7 +289,7 @@
     for (const [id, meta] of state.mountedControls.agentSwitches) {
       state.transientUiState.agentSwitches.delete(id);
       if (meta.flag !== "enabled") {
-        meta.syncDisabledState(!readers.readAgentFlagValue(meta.agentId, "enabled"));
+        meta.syncDisabledState(computeAgentSubSwitchDisabled(meta.agentId, meta.flag));
       }
       helpers.setSwitchVisual(meta.element, readers.readAgentFlagValue(meta.agentId, meta.flag), { pending: false });
     }

--- a/src/settings-tab-agents.js
+++ b/src/settings-tab-agents.js
@@ -169,7 +169,7 @@
       btn.disabled = !!disabled;
       btn.addEventListener("click", (ev) => {
         ev.stopPropagation();
-        if (disabled || btn.classList.contains("active")) return;
+        if (btn.disabled || btn.classList.contains("active")) return;
         window.settingsAPI.command("setAgentPermissionMode", {
           agentId: agent.id,
           mode: mode.id,
@@ -186,8 +186,21 @@
     }
     ctrl.appendChild(segmented);
     row.appendChild(ctrl);
-    state.mountedControls.agentPermissionModes.set(agent.id, { row });
+    state.mountedControls.agentPermissionModes.set(agent.id, {
+      row,
+      agentId: agent.id,
+      syncFromSnapshot: () => syncCodexPermissionModeRow(row, agent.id),
+    });
     return row;
+  }
+
+  function syncCodexPermissionModeRow(row, agentId) {
+    const disabled = !readers.readAgentFlagValue(agentId, "enabled");
+    const current = readers.readAgentPermissionMode(agentId);
+    for (const btn of row.querySelectorAll("button")) {
+      btn.classList.toggle("active", btn.dataset.mode === current);
+      btn.disabled = !!disabled;
+    }
   }
 
   function syncAgentSwitchDisabledState(meta, disabled) {
@@ -257,13 +270,13 @@
 
   function patchInPlace(changes) {
     const keys = changes ? Object.keys(changes) : [];
-    if (keys.length === 1 && keys[0] === "agents" && state.mountedControls.agentPermissionModes.size > 0) {
-      return false;
-    }
     if (!(keys.length === 1 && keys[0] === "agents")) return false;
     if (state.mountedControls.agentSwitches.size === 0) return false;
     for (const [, meta] of state.mountedControls.agentSwitches) {
       if (!meta || !document.body.contains(meta.element)) return false;
+    }
+    for (const [, meta] of state.mountedControls.agentPermissionModes) {
+      if (!meta || !meta.row || !document.body.contains(meta.row)) return false;
     }
     for (const [id, meta] of state.mountedControls.agentSwitches) {
       state.transientUiState.agentSwitches.delete(id);
@@ -271,6 +284,9 @@
         meta.syncDisabledState(!readers.readAgentFlagValue(meta.agentId, "enabled"));
       }
       helpers.setSwitchVisual(meta.element, readers.readAgentFlagValue(meta.agentId, meta.flag), { pending: false });
+    }
+    for (const [, meta] of state.mountedControls.agentPermissionModes) {
+      meta.syncFromSnapshot();
     }
     return true;
   }

--- a/src/settings-tab-agents.js
+++ b/src/settings-tab-agents.js
@@ -10,6 +10,10 @@
   let readers = null;
   let helpers = null;
   let ops = null;
+  const CODEX_PERMISSION_MODE_OPTIONS = [
+    { id: "native", labelKey: "codexPermissionModeNative" },
+    { id: "intercept", labelKey: "codexPermissionModeIntercept" },
+  ];
 
   function t(key) {
     return helpers.t(key);
@@ -161,14 +165,11 @@
     const ctrl = document.createElement("div");
     ctrl.className = "row-control";
     const segmented = document.createElement("div");
-    segmented.className = "segmented";
+    segmented.className = "segmented codex-permission-mode-segmented";
     segmented.setAttribute("role", "tablist");
     const current = readers.readAgentPermissionMode(agent.id);
-    const modes = [
-      { id: "native", labelKey: "codexPermissionModeNative" },
-      { id: "intercept", labelKey: "codexPermissionModeIntercept" },
-    ];
-    for (const mode of modes) {
+    segmented.style.setProperty("--codex-permission-mode-active-index", String(getCodexPermissionModeIndex(current)));
+    for (const mode of CODEX_PERMISSION_MODE_OPTIONS) {
       const btn = document.createElement("button");
       btn.type = "button";
       btn.dataset.mode = mode.id;
@@ -205,10 +206,34 @@
   function syncCodexPermissionModeRow(row, agentId) {
     const disabled = !readers.readAgentFlagValue(agentId, "enabled");
     const current = readers.readAgentPermissionMode(agentId);
+    const segmented = row.querySelector(".codex-permission-mode-segmented");
+    const currentIndex = getCodexPermissionModeIndex(current);
+    const previousActive = segmented && [...segmented.querySelectorAll("button")]
+      .find((btn) => btn.classList.contains("active"));
+    const previousIndex = previousActive
+      ? getCodexPermissionModeIndex(previousActive.dataset.mode)
+      : currentIndex;
+    if (segmented) {
+      segmented.style.setProperty("--codex-permission-mode-active-index", String(previousIndex));
+    }
     for (const btn of row.querySelectorAll("button")) {
       btn.classList.toggle("active", btn.dataset.mode === current);
       btn.disabled = !!disabled;
     }
+    if (segmented && previousIndex !== currentIndex) {
+      segmented.classList.add("codex-permission-mode-transitioning");
+      requestAnimationFrame(() => {
+        segmented.getBoundingClientRect();
+        segmented.style.setProperty("--codex-permission-mode-active-index", String(currentIndex));
+        segmented.classList.remove("codex-permission-mode-transitioning");
+      });
+    } else if (segmented) {
+      segmented.style.setProperty("--codex-permission-mode-active-index", String(currentIndex));
+    }
+  }
+
+  function getCodexPermissionModeIndex(mode) {
+    return Math.max(0, CODEX_PERMISSION_MODE_OPTIONS.findIndex((option) => option.id === mode));
   }
 
   function syncAgentSwitchDisabledState(meta, disabled) {

--- a/src/settings-tab-anim-map.js
+++ b/src/settings-tab-anim-map.js
@@ -123,6 +123,7 @@
 
   function patchInPlace(changes) {
     if (!changes || !Object.prototype.hasOwnProperty.call(changes, "themeOverrides")) return false;
+    if (Object.prototype.hasOwnProperty.call(changes, "theme")) return false;
     if (state.mountedControls.animMapSwitches.size === 0) return false;
     for (const [, meta] of state.mountedControls.animMapSwitches) {
       if (!meta || !document.body.contains(meta.element)) return false;

--- a/src/settings-tab-anim-map.js
+++ b/src/settings-tab-anim-map.js
@@ -25,6 +25,14 @@
     return !!(entry && entry.disabled === true);
   }
 
+  function animMapSwitchId(themeId, stateKey) {
+    return `${themeId}:${stateKey}`;
+  }
+
+  function readAnimMapVisualOn(themeId, stateKey) {
+    return !isStateDisabled(themeId, stateKey);
+  }
+
   function buildAnimMapRow(spec, themeId) {
     const row = document.createElement("div");
     row.className = "row";
@@ -38,18 +46,30 @@
     row.querySelector(".row-desc").textContent = t(spec.descKey);
     const sw = row.querySelector(".switch");
 
-    const disabled = isStateDisabled(themeId, spec.stateKey);
-    const visualOn = !disabled;
-    if (visualOn) sw.classList.add("on");
-    sw.setAttribute("aria-checked", visualOn ? "true" : "false");
+    const switchId = animMapSwitchId(themeId, spec.stateKey);
+    const override = state.transientUiState.animMapSwitches.get(switchId);
+    const visualOn = override ? override.visualOn : readAnimMapVisualOn(themeId, spec.stateKey);
+    helpers.setSwitchVisual(sw, visualOn, { pending: override ? override.pending : false });
+    state.mountedControls.animMapSwitches.set(switchId, {
+      element: sw,
+      themeId,
+      stateKey: spec.stateKey,
+    });
 
-    helpers.attachActivation(sw, () => {
-      const nextDisabled = !isStateDisabled(themeId, spec.stateKey);
-      return window.settingsAPI.command("setThemeOverrideDisabled", {
+    helpers.attachAnimatedSwitch(sw, {
+      getCommittedVisual: () => readAnimMapVisualOn(themeId, spec.stateKey),
+      getTransientState: () => state.transientUiState.animMapSwitches.get(switchId) || null,
+      setTransientState: (value) => state.transientUiState.animMapSwitches.set(switchId, value),
+      clearTransientState: (seq) => {
+        const current = state.transientUiState.animMapSwitches.get(switchId);
+        if (!current || (seq !== undefined && current.seq !== seq)) return;
+        state.transientUiState.animMapSwitches.delete(switchId);
+      },
+      invoke: () => window.settingsAPI.command("setThemeOverrideDisabled", {
         themeId,
         stateKey: spec.stateKey,
-        disabled: nextDisabled,
-      });
+        disabled: readAnimMapVisualOn(themeId, spec.stateKey),
+      }),
     });
     return row;
   }
@@ -81,6 +101,13 @@
     resetBtn.className = "theme-delete-btn anim-map-reset-btn";
     resetBtn.textContent = t("animMapResetAll");
     if (!hasAny) resetBtn.disabled = true;
+    state.mountedControls.animMapReset = {
+      element: resetBtn,
+      themeId,
+      syncFromSnapshot: () => {
+        resetBtn.disabled = readers.readThemeOverrideMap(themeId) === null;
+      },
+    };
     helpers.attachActivation(resetBtn, () =>
       window.settingsAPI.command("resetThemeOverrides", { themeId })
         .then((result) => {
@@ -94,6 +121,23 @@
     parent.appendChild(resetWrap);
   }
 
+  function patchInPlace(changes) {
+    if (!changes || !Object.prototype.hasOwnProperty.call(changes, "themeOverrides")) return false;
+    if (state.mountedControls.animMapSwitches.size === 0) return false;
+    for (const [, meta] of state.mountedControls.animMapSwitches) {
+      if (!meta || !document.body.contains(meta.element)) return false;
+    }
+    for (const [id, meta] of state.mountedControls.animMapSwitches) {
+      state.transientUiState.animMapSwitches.delete(id);
+      helpers.setSwitchVisual(meta.element, readAnimMapVisualOn(meta.themeId, meta.stateKey), { pending: false });
+    }
+    const reset = state.mountedControls.animMapReset;
+    if (reset && document.body.contains(reset.element)) {
+      reset.syncFromSnapshot();
+    }
+    return true;
+  }
+
   function init(core) {
     state = core.state;
     helpers = core.helpers;
@@ -101,6 +145,7 @@
     readers = core.readers;
     core.tabs.animMap = {
       render,
+      patchInPlace,
     };
   }
 

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -24,9 +24,12 @@
   const BUBBLE_SECONDS_AUTO_COMMIT_DELAY_MS = 600;
 
   let state = null;
+  let runtime = null;
   let readers = null;
   let helpers = null;
   let ops = null;
+
+  const LANGUAGE_OPTIONS = ["en", "zh", "ko", "ja"];
 
   function t(key) {
     return helpers.t(key);
@@ -169,7 +172,7 @@
         `<span class="row-desc"></span>` +
       `</div>` +
       `<div class="row-control">` +
-        `<div class="segmented" role="tablist">` +
+        `<div class="segmented language-segmented" role="tablist">` +
           `<button data-lang="en"></button>` +
           `<button data-lang="zh"></button>` +
           `<button data-lang="ko"></button>` +
@@ -184,6 +187,22 @@
     buttons[2].textContent = t("langKorean");
     buttons[3].textContent = t("langJapanese");
     const current = readers.getLang();
+    const segmented = row.querySelector(".language-segmented");
+    const transition = runtime && runtime.languageTransition;
+    const currentIndex = Math.max(0, LANGUAGE_OPTIONS.indexOf(current));
+    const fromIndex = transition && transition.to === current
+      ? Math.max(0, LANGUAGE_OPTIONS.indexOf(transition.from))
+      : currentIndex;
+    segmented.style.setProperty("--language-active-index", String(fromIndex));
+    if (fromIndex !== currentIndex) {
+      segmented.classList.add("language-segmented-transitioning");
+      requestAnimationFrame(() => {
+        segmented.getBoundingClientRect();
+        segmented.style.setProperty("--language-active-index", String(currentIndex));
+        segmented.classList.remove("language-segmented-transitioning");
+      });
+      runtime.languageTransition = null;
+    }
     for (const btn of buttons) {
       if (btn.dataset.lang === current) btn.classList.add("active");
       btn.addEventListener("click", () => {
@@ -913,6 +932,7 @@
 
   function init(core) {
     state = core.state;
+    runtime = core.runtime;
     readers = core.readers;
     helpers = core.helpers;
     ops = core.ops;

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -879,7 +879,7 @@
     const changes = payload && payload.changes;
     if (changes && Object.prototype.hasOwnProperty.call(changes, "lang")) {
       const nextLang = getLang();
-      runtime.languageTransition = previousLang !== nextLang
+      runtime.languageTransition = state.activeTab === "general" && previousLang !== nextLang
         ? { from: previousLang, to: nextLang }
         : null;
     }

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -51,6 +51,7 @@
     transientUiState: {
       generalSwitches: new Map(),
       agentSwitches: new Map(),
+      animMapSwitches: new Map(),
       size: {
         draftUi: null,
         dragging: false,
@@ -63,6 +64,8 @@
       bubblePolicyControls: new Map(),
       agentSwitches: new Map(),
       agentPermissionModes: new Map(),
+      animMapSwitches: new Map(),
+      animMapReset: null,
       bubblePolicySummary: null,
       size: null,
       soundVolume: null,
@@ -94,6 +97,7 @@
       clickCount: 0,
       contributorsExpanded: false,
     },
+    languageTransition: null,
   };
 
   const renderHooks = {
@@ -601,6 +605,8 @@
     state.mountedControls.bubblePolicyControls.clear();
     state.mountedControls.agentSwitches.clear();
     state.mountedControls.agentPermissionModes.clear();
+    state.mountedControls.animMapSwitches.clear();
+    state.mountedControls.animMapReset = null;
     state.mountedControls.bubblePolicySummary = null;
     state.mountedControls.size = null;
     state.mountedControls.soundVolume = null;
@@ -856,9 +862,13 @@
     if (Object.prototype.hasOwnProperty.call(changes, "agents")) {
       state.transientUiState.agentSwitches.clear();
     }
+    if (Object.prototype.hasOwnProperty.call(changes, "themeOverrides")) {
+      state.transientUiState.animMapSwitches.clear();
+    }
   }
 
   function applyChanges(payload) {
+    const previousLang = getLang();
     if (payload && payload.snapshot) {
       state.snapshot = payload.snapshot;
     } else if (payload && payload.changes && state.snapshot) {
@@ -867,6 +877,12 @@
     if (!state.snapshot) return;
 
     const changes = payload && payload.changes;
+    if (changes && Object.prototype.hasOwnProperty.call(changes, "lang")) {
+      const nextLang = getLang();
+      runtime.languageTransition = previousLang !== nextLang
+        ? { from: previousLang, to: nextLang }
+        : null;
+    }
     clearTransientStateForChanges(changes);
     const needsAnimOverridesRefresh = !!(changes && (
       "theme" in changes || "themeVariant" in changes || "themeOverrides" in changes
@@ -887,8 +903,10 @@
         });
         return;
       }
-      requestRender({ sidebar: true, content: true });
-      return;
+      if (state.activeTab !== "animMap") {
+        requestRender({ sidebar: true, content: true });
+        return;
+      }
     }
 
     if (needsAnimOverridesRefresh && (state.activeTab === "animOverrides" || runtime.assetPicker.state)) {

--- a/src/settings.html
+++ b/src/settings.html
@@ -439,6 +439,7 @@ html, body {
 
 /* ── Switch (iOS-style) ── */
 .switch {
+  --switch-knob-x: 0;
   position: relative;
   width: 40px;
   height: 24px;
@@ -446,7 +447,7 @@ html, body {
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0)), var(--switch-off);
   cursor: pointer;
   box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.06), inset 0 1px 3px rgba(0, 0, 0, 0.14);
-  transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.12s ease;
+  transition: background 0.26s ease, box-shadow 0.26s ease, transform 0.16s ease;
   flex-shrink: 0;
 }
 .switch::after {
@@ -459,17 +460,21 @@ html, body {
   border-radius: 50%;
   background: var(--switch-knob);
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.22);
-  transition: left 0.24s cubic-bezier(0.22, 1, 0.36, 1), transform 0.14s ease, box-shadow 0.18s ease;
+  transform: translateX(0) scale(1);
+  transition: transform 0.28s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.2s ease;
 }
 .switch.on {
+  --switch-knob-x: 16px;
   background: linear-gradient(180deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0)), var(--switch-on);
 }
-.switch.on::after { left: 18px; }
+.switch.on::after {
+  transform: translateX(16px) scale(1);
+}
 .switch:not(.disabled):hover::after {
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.26);
 }
 .switch:not(.disabled):active::after {
-  transform: scale(0.92);
+  transform: translateX(var(--switch-knob-x, 0)) scale(0.94);
 }
 .switch.pending {
   opacity: 0.82;
@@ -482,6 +487,12 @@ html, body {
 .switch:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .switch,
+  .switch::after {
+    transition: none;
+  }
 }
 
 /* ── Size slider ── */
@@ -720,6 +731,8 @@ html, body {
   .segmented { background: rgba(255, 255, 255, 0.08); }
 }
 .segmented button {
+  position: relative;
+  z-index: 1;
   border: none;
   background: transparent;
   padding: 4px 12px;
@@ -739,6 +752,42 @@ html, body {
 .segmented button:disabled {
   opacity: 0.48;
   cursor: not-allowed;
+}
+.language-segmented {
+  --language-active-index: 0;
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+}
+.language-segmented::before {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  top: 2px;
+  bottom: 2px;
+  left: 2px;
+  width: calc((100% - 4px) / 4);
+  border-radius: 5px;
+  background: var(--panel-bg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  transform: translateX(calc(var(--language-active-index) * 100%));
+  transition: transform 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.language-segmented button {
+  min-width: 56px;
+  background: transparent;
+  white-space: nowrap;
+}
+.language-segmented button.active {
+  background: transparent;
+  box-shadow: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  .language-segmented::before {
+    transition: none;
+  }
 }
 
 /* ── Coming soon placeholder ── */

--- a/src/settings.html
+++ b/src/settings.html
@@ -753,6 +753,7 @@ html, body {
   opacity: 0.48;
   cursor: not-allowed;
 }
+/* language-segmented intentionally overrides .segmented display so the sliding pill can use equal-width grid tracks. */
 .language-segmented {
   --language-active-index: 0;
   position: relative;

--- a/src/settings.html
+++ b/src/settings.html
@@ -785,8 +785,39 @@ html, body {
   background: transparent;
   box-shadow: none;
 }
+.codex-permission-mode-segmented {
+  --codex-permission-mode-active-index: 0;
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0;
+  overflow: hidden;
+}
+.codex-permission-mode-segmented::before {
+  content: "";
+  position: absolute;
+  z-index: 0;
+  top: 2px;
+  bottom: 2px;
+  left: 2px;
+  width: calc((100% - 4px) / 2);
+  border-radius: 5px;
+  background: var(--panel-bg);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  transform: translateX(calc(var(--codex-permission-mode-active-index) * 100%));
+  transition: transform 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.codex-permission-mode-segmented button {
+  background: transparent;
+  white-space: nowrap;
+}
+.codex-permission-mode-segmented button.active {
+  background: transparent;
+  box-shadow: none;
+}
 @media (prefers-reduced-motion: reduce) {
-  .language-segmented::before {
+  .language-segmented::before,
+  .codex-permission-mode-segmented::before {
     transition: none;
   }
 }

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -1060,6 +1060,64 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(permissionsSwitch.element.attributes.tabindex, "-1");
   });
 
+  it("slides the Codex permission mode pill when mode broadcasts patch in place", () => {
+    const harness = loadAgentsTabForTest({
+      snapshot: {
+        agents: {
+          codex: {
+            enabled: true,
+            permissionsEnabled: true,
+            permissionMode: "intercept",
+          },
+        },
+      },
+      agentMetadata: [{
+        id: "codex",
+        name: "Codex",
+        eventSource: "hook",
+        capabilities: {
+          permissionApproval: true,
+        },
+      }],
+      collapsedGroups: {
+        "agents:codex": false,
+      },
+    });
+
+    harness.core.ops.requestRender({ content: true });
+    harness.raf.flush();
+    const segmented = harness.content.querySelector(".codex-permission-mode-segmented");
+    assert.ok(segmented, "Codex permission mode should use the sliding segmented control");
+    assert.strictEqual(segmented.style.getPropertyValue("--codex-permission-mode-active-index"), "1");
+
+    harness.core.ops.applyChanges({
+      changes: {
+        agents: {
+          codex: {
+            enabled: true,
+            permissionsEnabled: true,
+            permissionMode: "native",
+          },
+        },
+      },
+      snapshot: {
+        agents: {
+          codex: {
+            enabled: true,
+            permissionsEnabled: true,
+            permissionMode: "native",
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(segmented.style.getPropertyValue("--codex-permission-mode-active-index"), "1");
+    assert.strictEqual(segmented.classList.contains("codex-permission-mode-transitioning"), true);
+    harness.raf.flush();
+    assert.strictEqual(segmented.style.getPropertyValue("--codex-permission-mode-active-index"), "0");
+    assert.strictEqual(segmented.classList.contains("codex-permission-mode-transitioning"), false);
+  });
+
   it("patches agent-only broadcasts in place without requiring Codex-specific rows", () => {
     const harness = loadAgentsTabForTest({
       snapshot: {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -579,6 +579,46 @@ describe("settings renderer browser environment", () => {
     assert.ok(!/\.size-bubble::after\s*\{[\s\S]*margin-top:\s*-1px;/.test(html));
   });
 
+  it("uses transform-based Settings switch motion with a calmer shared timing", () => {
+    const html = fs.readFileSync(SETTINGS_HTML, "utf8");
+    const switchRule = html.match(/\.switch\s*\{([\s\S]*?)\n\}/);
+    const knobRule = html.match(/\.switch::after\s*\{([\s\S]*?)\n\}/);
+    const onKnobRule = html.match(/\.switch\.on::after\s*\{([\s\S]*?)\n\}/);
+    assert.ok(switchRule, "settings.html should define the switch track");
+    assert.ok(knobRule, "settings.html should define the switch knob");
+    assert.ok(onKnobRule, "settings.html should define the on-state knob transform");
+    assert.ok(/transition:\s*background 0\.26s ease,\s*box-shadow 0\.26s ease,\s*transform 0\.16s ease;/.test(switchRule[1]));
+    assert.ok(/transform:\s*translateX\(0\)\s+scale\(1\);/.test(knobRule[1]));
+    assert.ok(!/transition:\s*left\b/.test(knobRule[1]));
+    assert.ok(/transition:\s*transform 0\.28s cubic-bezier\(0\.2,\s*0\.8,\s*0\.2,\s*1\),\s*box-shadow 0\.2s ease;/.test(knobRule[1]));
+    assert.ok(/transform:\s*translateX\(16px\)\s+scale\(1\);/.test(onKnobRule[1]));
+    assert.ok(!html.includes(".switch.on::after { left: 18px; }"));
+    assert.ok(/\.switch:not\(\.disabled\):active::after\s*\{[\s\S]*transform:\s*translateX\(var\(--switch-knob-x,\s*0\)\)\s+scale\(0\.94\);/.test(html));
+    assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.switch,[\s\S]*\.switch::after\s*\{[\s\S]*transition:\s*none;/.test(html));
+  });
+
+  it("animates the Settings language segmented control with a sliding active pill", () => {
+    const generalSource = fs.readFileSync(path.join(SRC_DIR, "settings-tab-general.js"), "utf8");
+    const coreSource = fs.readFileSync(SETTINGS_UI_CORE, "utf8");
+    const html = fs.readFileSync(SETTINGS_HTML, "utf8");
+
+    assert.ok(generalSource.includes("const LANGUAGE_OPTIONS = [\"en\", \"zh\", \"ko\", \"ja\"];"));
+    assert.ok(generalSource.includes("language-segmented"));
+    assert.ok(generalSource.includes("runtime.languageTransition"));
+    assert.ok(generalSource.includes('segmented.style.setProperty("--language-active-index", String(fromIndex));'));
+    assert.ok(generalSource.includes("requestAnimationFrame(() => {"));
+    assert.ok(generalSource.includes("segmented.getBoundingClientRect();"));
+    assert.ok(generalSource.includes('segmented.style.setProperty("--language-active-index", String(currentIndex));'));
+    assert.ok(coreSource.includes("languageTransition: null"));
+    assert.ok(coreSource.includes("const previousLang = getLang();"));
+    assert.ok(coreSource.includes('Object.prototype.hasOwnProperty.call(changes, "lang")'));
+    assert.ok(coreSource.includes("runtime.languageTransition = previousLang !== nextLang"));
+    assert.ok(/\.language-segmented\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*repeat\(4,\s*minmax\(0,\s*1fr\)\);/.test(html));
+    assert.ok(/\.language-segmented::before\s*\{[\s\S]*transform:\s*translateX\(calc\(var\(--language-active-index\)\s*\*\s*100%\)\);[\s\S]*transition:\s*transform 0\.24s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\);/.test(html));
+    assert.ok(/\.language-segmented button\.active\s*\{[\s\S]*background:\s*transparent;[\s\S]*box-shadow:\s*none;/.test(html));
+    assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.language-segmented::before\s*\{[\s\S]*transition:\s*none;/.test(html));
+  });
+
   it("exposes aggregate and split bubble controls in the General tab", () => {
     const generalSource = fs.readFileSync(path.join(SRC_DIR, "settings-tab-general.js"), "utf8");
     const i18nSource = fs.readFileSync(SETTINGS_I18N, "utf8");
@@ -808,6 +848,64 @@ describe("settings renderer browser environment", () => {
     assert.ok(!agentsSource.includes('agent.id === "gemini-cli"'));
     assert.ok(!agentsSource.includes('agent.id !== "gemini-cli"'));
     assert.ok(!agentsSource.includes("Gemini CLI"));
+    assert.ok(!agentsSource.includes("if (disabled || btn.classList.contains(\"active\")) return;"));
+    assert.ok(agentsSource.includes("if (btn.disabled || btn.classList.contains(\"active\")) return;"));
+  });
+
+  it("keeps Agent management switch broadcasts in place even when Codex permission rows are mounted", () => {
+    const harness = loadAgentsTabForTest({
+      snapshot: {
+        agents: {
+          codex: {
+            enabled: true,
+            permissionsEnabled: true,
+            permissionMode: "intercept",
+          },
+        },
+      },
+      agentMetadata: [{
+        id: "codex",
+        name: "Codex",
+        eventSource: "hook",
+        capabilities: {
+          permissionApproval: true,
+        },
+      }],
+      collapsedGroups: {
+        "agents:codex": false,
+      },
+    });
+
+    harness.core.ops.requestRender({ content: true });
+    harness.raf.flush();
+    const before = harness.getContentRenderCount();
+
+    harness.core.ops.applyChanges({
+      changes: {
+        agents: {
+          codex: {
+            enabled: false,
+            permissionsEnabled: true,
+            permissionMode: "intercept",
+          },
+        },
+      },
+      snapshot: {
+        agents: {
+          codex: {
+            enabled: false,
+            permissionsEnabled: true,
+            permissionMode: "intercept",
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(
+      harness.getContentRenderCount(),
+      before,
+      "Codex agent broadcasts should patch mounted switches instead of rebuilding and truncating switch motion"
+    );
   });
 
   it("patches agent-only broadcasts in place without requiring Codex-specific rows", () => {
@@ -894,6 +992,22 @@ describe("settings renderer browser environment", () => {
       "0px",
       "expanded groups should not paint one frame at 0px height before the next animation frame runs"
     );
+  });
+
+  it("uses animated switches and local theme override patching in Animation Map", () => {
+    const animMapSource = fs.readFileSync(path.join(SRC_DIR, "settings-tab-anim-map.js"), "utf8");
+    const coreSource = fs.readFileSync(SETTINGS_UI_CORE, "utf8");
+    assert.ok(animMapSource.includes("state.transientUiState.animMapSwitches"));
+    assert.ok(animMapSource.includes("state.mountedControls.animMapSwitches"));
+    assert.ok(animMapSource.includes("helpers.attachAnimatedSwitch(sw, {"));
+    assert.ok(animMapSource.includes('command("setThemeOverrideDisabled"'));
+    assert.ok(!animMapSource.includes("helpers.attachActivation(sw"));
+    assert.ok(animMapSource.includes("function patchInPlace(changes)"));
+    assert.ok(animMapSource.includes('Object.prototype.hasOwnProperty.call(changes, "themeOverrides")'));
+    assert.ok(animMapSource.includes("helpers.setSwitchVisual(meta.element, readAnimMapVisualOn(meta.themeId, meta.stateKey), { pending: false });"));
+    assert.ok(animMapSource.includes("patchInPlace,"));
+    assert.ok(coreSource.includes('if (state.activeTab !== "animMap") {'));
+    assert.ok(coreSource.includes("activeTab.patchInPlace(changes)"));
   });
 
   it("keeps stale sound override prefs resettable from the settings UI", () => {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -347,6 +347,82 @@ function loadAgentsTabForTest({
   };
 }
 
+function loadAnimMapTabForTest({
+  snapshot,
+} = {}) {
+  const body = new FakeElement("body");
+  const content = new FakeElement("main");
+  body.appendChild(content);
+
+  const document = {
+    body,
+    createElement: (tagName) => new FakeElement(tagName),
+    getElementById(id) {
+      if (id === "content") return content;
+      return null;
+    },
+  };
+
+  const context = {
+    console,
+    navigator: { platform: "Win32" },
+    localStorage: {
+      getItem: () => null,
+      setItem: () => {},
+    },
+    document,
+    requestAnimationFrame: (cb) => {
+      cb();
+      return 1;
+    },
+    window: null,
+    globalThis: null,
+    settingsAPI: {
+      command: () => Promise.resolve({ status: "ok" }),
+    },
+    ClawdSettingsSizeSlider: {
+      SIZE_UI_MIN: 1,
+      SIZE_UI_MAX: 100,
+      SIZE_TICK_VALUES: [25, 50, 75, 100],
+      SIZE_SLIDER_THUMB_DIAMETER: 18,
+      prefsSizeToUi: (value) => value,
+      clampSizeUi: (value) => value,
+      sizeUiToPct: (value) => value,
+      getSizeSliderAnchorPx: () => 0,
+      createSizeSliderController: () => ({}),
+    },
+    ClawdSettingsI18n: {
+      STRINGS: { en: {} },
+      CONTRIBUTORS: [],
+      MAINTAINERS: [],
+    },
+  };
+  context.window = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(SETTINGS_ANIM_OVERRIDES_MERGE, "utf8"), context);
+  vm.runInContext(fs.readFileSync(SETTINGS_UI_CORE, "utf8"), context);
+  vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-anim-map.js"), "utf8"), context);
+
+  const core = context.ClawdSettingsCore;
+  core.state.snapshot = snapshot || { theme: "clawd", themeOverrides: {} };
+  core.state.activeTab = "animMap";
+  context.ClawdSettingsTabAnimMap.init(core);
+
+  let contentRenderCount = 0;
+  core.ops.installRenderHooks({
+    content: () => {
+      contentRenderCount++;
+    },
+  });
+
+  return {
+    core,
+    content,
+    getContentRenderCount: () => contentRenderCount,
+  };
+}
+
 function loadAnimOverridesTabForTest({ runtime, modalRoot }) {
   const document = {
     body: new FakeElement("body"),
@@ -612,11 +688,29 @@ describe("settings renderer browser environment", () => {
     assert.ok(coreSource.includes("languageTransition: null"));
     assert.ok(coreSource.includes("const previousLang = getLang();"));
     assert.ok(coreSource.includes('Object.prototype.hasOwnProperty.call(changes, "lang")'));
-    assert.ok(coreSource.includes("runtime.languageTransition = previousLang !== nextLang"));
+    assert.ok(coreSource.includes('runtime.languageTransition = state.activeTab === "general" && previousLang !== nextLang'));
     assert.ok(/\.language-segmented\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-columns:\s*repeat\(4,\s*minmax\(0,\s*1fr\)\);/.test(html));
+    assert.ok(html.includes("language-segmented intentionally overrides .segmented display"));
     assert.ok(/\.language-segmented::before\s*\{[\s\S]*transform:\s*translateX\(calc\(var\(--language-active-index\)\s*\*\s*100%\)\);[\s\S]*transition:\s*transform 0\.24s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\);/.test(html));
     assert.ok(/\.language-segmented button\.active\s*\{[\s\S]*background:\s*transparent;[\s\S]*box-shadow:\s*none;/.test(html));
     assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.language-segmented::before\s*\{[\s\S]*transition:\s*none;/.test(html));
+  });
+
+  it("does not keep a stale language slide transition when language changes off the General tab", () => {
+    const core = loadSettingsCoreForTest({});
+    core.state.activeTab = "agents";
+    core.state.snapshot = { lang: "en" };
+
+    core.ops.applyChanges({
+      changes: { lang: "zh" },
+      snapshot: { lang: "zh" },
+    });
+
+    assert.strictEqual(
+      core.runtime.languageTransition,
+      null,
+      "language changes outside General should not animate later when returning to General"
+    );
   });
 
   it("exposes aggregate and split bubble controls in the General tab", () => {
@@ -908,6 +1002,64 @@ describe("settings renderer browser environment", () => {
     );
   });
 
+  it("disables the Codex Permissions switch in place when Permission mode changes to Native", () => {
+    const harness = loadAgentsTabForTest({
+      snapshot: {
+        agents: {
+          codex: {
+            enabled: true,
+            permissionsEnabled: true,
+            permissionMode: "intercept",
+          },
+        },
+      },
+      agentMetadata: [{
+        id: "codex",
+        name: "Codex",
+        eventSource: "hook",
+        capabilities: {
+          permissionApproval: true,
+        },
+      }],
+      collapsedGroups: {
+        "agents:codex": false,
+      },
+    });
+
+    harness.core.ops.requestRender({ content: true });
+    harness.raf.flush();
+    const before = harness.getContentRenderCount();
+
+    harness.core.ops.applyChanges({
+      changes: {
+        agents: {
+          codex: {
+            enabled: true,
+            permissionsEnabled: true,
+            permissionMode: "native",
+          },
+        },
+      },
+      snapshot: {
+        agents: {
+          codex: {
+            enabled: true,
+            permissionsEnabled: true,
+            permissionMode: "native",
+          },
+        },
+      },
+    });
+
+    const permissionsSwitch = [...harness.core.state.mountedControls.agentSwitches.values()]
+      .find((meta) => meta.agentId === "codex" && meta.flag === "permissionsEnabled");
+    assert.ok(permissionsSwitch, "Codex Permissions switch should stay mounted");
+    assert.strictEqual(harness.getContentRenderCount(), before);
+    assert.strictEqual(permissionsSwitch.element.classList.contains("disabled"), true);
+    assert.strictEqual(permissionsSwitch.element.attributes["aria-disabled"], "true");
+    assert.strictEqual(permissionsSwitch.element.attributes.tabindex, "-1");
+  });
+
   it("patches agent-only broadcasts in place without requiring Codex-specific rows", () => {
     const harness = loadAgentsTabForTest({
       snapshot: {
@@ -1008,6 +1160,103 @@ describe("settings renderer browser environment", () => {
     assert.ok(animMapSource.includes("patchInPlace,"));
     assert.ok(coreSource.includes('if (state.activeTab !== "animMap") {'));
     assert.ok(coreSource.includes("activeTab.patchInPlace(changes)"));
+  });
+
+  it("keeps Animation Map theme override broadcasts in place and syncs the mounted switch", () => {
+    const harness = loadAnimMapTabForTest({
+      snapshot: {
+        theme: "clawd",
+        themeOverrides: {
+          clawd: {
+            states: {
+              error: { disabled: false },
+            },
+          },
+        },
+      },
+    });
+    const sw = new FakeElement("div");
+    sw.className = "switch on";
+    harness.content.appendChild(sw);
+    harness.core.state.mountedControls.animMapSwitches.set("clawd:error", {
+      element: sw,
+      themeId: "clawd",
+      stateKey: "error",
+    });
+    const before = harness.getContentRenderCount();
+
+    harness.core.ops.applyChanges({
+      changes: {
+        themeOverrides: {
+          clawd: {
+            states: {
+              error: { disabled: true },
+            },
+          },
+        },
+      },
+      snapshot: {
+        theme: "clawd",
+        themeOverrides: {
+          clawd: {
+            states: {
+              error: { disabled: true },
+            },
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(harness.getContentRenderCount(), before);
+    assert.strictEqual(sw.classList.contains("on"), false);
+    assert.strictEqual(sw.attributes["aria-checked"], "false");
+  });
+
+  it("rebuilds Animation Map instead of patching with stale theme ids when the theme changes", () => {
+    const harness = loadAnimMapTabForTest({
+      snapshot: {
+        theme: "clawd",
+        themeOverrides: {},
+      },
+    });
+    const sw = new FakeElement("div");
+    sw.className = "switch on";
+    harness.content.appendChild(sw);
+    harness.core.state.mountedControls.animMapSwitches.set("clawd:error", {
+      element: sw,
+      themeId: "clawd",
+      stateKey: "error",
+    });
+    const before = harness.getContentRenderCount();
+
+    harness.core.ops.applyChanges({
+      changes: {
+        theme: "calico",
+        themeOverrides: {
+          calico: {
+            states: {
+              error: { disabled: true },
+            },
+          },
+        },
+      },
+      snapshot: {
+        theme: "calico",
+        themeOverrides: {
+          calico: {
+            states: {
+              error: { disabled: true },
+            },
+          },
+        },
+      },
+    });
+
+    assert.strictEqual(
+      harness.getContentRenderCount(),
+      before + 1,
+      "theme changes should force a rebuild so Animation Map switches use the new theme id"
+    );
   });
 
   it("keeps stale sound override prefs resettable from the settings UI", () => {


### PR DESCRIPTION
No linked issue.

## Summary
- Smooths Settings switch motion across General, Agent management, and Animation Map so toggle feedback feels consistent instead of abrupt.
- Moves the shared switch knob animation to transform-based motion and reuses the existing animated switch path where tab-specific controls previously bypassed it.
- Preserves the existing Settings controller, prefs schema, command shape, and committed-state broadcast model.

## Problem context
- The General page switch felt smoother than Agent management and Animation Map because some tabs either rebuilt their content after broadcasts or used a direct activation handler instead of the shared optimistic switch behavior.
- In expanded Agent management groups, toggling a switch could be visually interrupted by a full content rebuild, which produced a close/reopen flash.
- Animation Map switches were also rebuilt after theme override broadcasts, so the improved switch CSS could be cut off before the motion was visible.

## What changed
- Shared Settings switch motion
  - Switched the knob movement from `left` updates to `transform: translateX(...)` for more stable animation.
  - Tuned track, knob, hover, active, pending, and reduced-motion behavior around one shared switch style.
- Language selector motion
  - Added a sliding active pill for the language segmented control instead of a direct visual jump.
  - Tracks the previous and next language during Settings broadcasts so the pill can animate between positions.
- Agent management patching
  - Keeps agent switch broadcasts on the mounted DOM instead of rebuilding when Codex permission mode rows are present.
  - Syncs master/sub-switch state and Codex permission-mode button state in place after broadcasts.
- Animation Map patching
  - Routes Animation Map toggles through `attachAnimatedSwitch()` so they get the same optimistic pending behavior as other Settings switches.
  - Patches `themeOverrides` changes in place for the current Animation Map controls instead of rebuilding the tab and truncating the animation.
  - Keeps the reset button disabled state in sync after local patching.
- Regression coverage
  - Added renderer browser-environment tests for transform-based switch CSS, reduced-motion handling, language sliding behavior, Agent management patching, and Animation Map local patching.

## Behavior after this PR
- Settings switches now use one calmer animation path across the affected tabs.
- Agent management groups stay expanded while switch broadcasts are applied, avoiding the previous flash caused by content teardown and rebuild.
- Animation Map switches visibly slide and keep pending feedback until the command result is reflected by the Settings snapshot.
- Failed switch updates still rely on the existing rollback/toast behavior; no new persistence fields or Settings controller behavior are introduced.
- Reduced-motion users get switch and language-selector transitions disabled through the existing CSS media query path.

## Validation
- `node --test test/settings-renderer-browser-env.test.js test/settings-controller.test.js test/settings-actions.test.js`
- `git diff --check`
- `npm test`

## Platform note
- Automated verification ran locally on Windows with the Node built-in test runner.
- A final manual pass in the Electron Settings window is still recommended for visual timing, especially `Settings -> General`, `Settings -> Agent management`, and `Settings -> Animation Map`.
