### PR TITLE
feat: fade theme switching

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1315,6 +1315,8 @@ let requestFastTick = () => {};
 let themeReloadInProgress = false;
 let themeSwitchTransitionSeq = 0;
 let themeSwitchFadeFallbackTimer = null;
+let themeSwitchOpacityCancelSignal = null;
+let themeSwitchReloadListenerCleanup = null;
 let repositionSessionHud = () => {};
 let syncSessionHudVisibility = () => {};
 let broadcastSessionHudSnapshot = () => {};
@@ -4643,32 +4645,77 @@ function clearThemeSwitchFadeFallback() {
   }
 }
 
-function scheduleThemeSwitchFadeFallback(seq) {
+function cancelThemeSwitchOpacityAnimation() {
+  if (themeSwitchOpacityCancelSignal) {
+    themeSwitchOpacityCancelSignal.cancelled = true;
+    themeSwitchOpacityCancelSignal = null;
+  }
+}
+
+function clearThemeSwitchReloadListeners() {
+  if (themeSwitchReloadListenerCleanup) {
+    themeSwitchReloadListenerCleanup();
+    themeSwitchReloadListenerCleanup = null;
+  }
+}
+
+function scheduleThemeSwitchFadeFallback(seq, onFallback) {
   clearThemeSwitchFadeFallback();
   themeSwitchFadeFallbackTimer = setTimeout(() => {
     themeSwitchFadeFallbackTimer = null;
     if (seq !== themeSwitchTransitionSeq) return;
-    setWindowOpacity(win, 1);
+    if (typeof onFallback === "function") {
+      onFallback();
+    } else {
+      setWindowOpacity(win, 1);
+    }
   }, THEME_SWITCH_FADE_FALLBACK_MS);
+}
+
+function animateThemeWindowOpacity(seq, targetOpacity, durationMs) {
+  if (seq !== themeSwitchTransitionSeq) return Promise.resolve(false);
+  cancelThemeSwitchOpacityAnimation();
+  const cancelSignal = { cancelled: false };
+  themeSwitchOpacityCancelSignal = cancelSignal;
+  return animateWindowOpacity(win, targetOpacity, { durationMs, cancelSignal })
+    .finally(() => {
+      if (themeSwitchOpacityCancelSignal === cancelSignal) {
+        themeSwitchOpacityCancelSignal = null;
+      }
+    });
 }
 
 function fadeInThemeWindow(seq) {
   if (seq !== themeSwitchTransitionSeq) return;
   clearThemeSwitchFadeFallback();
-  animateWindowOpacity(win, 1, { durationMs: THEME_SWITCH_FADE_IN_MS }).then((ok) => {
+  animateThemeWindowOpacity(seq, 1, THEME_SWITCH_FADE_IN_MS).then((ok) => {
     if (!ok && seq === themeSwitchTransitionSeq) setWindowOpacity(win, 1);
   });
 }
 
-function reloadThemeWindowsAfterFade(seq) {
+function reloadThemeWindowsAfterFade(seq, onReady, onFallback) {
   if (seq !== themeSwitchTransitionSeq) return;
   if (!win || win.isDestroyed() || !hitWin || hitWin.isDestroyed()) {
-    setWindowOpacity(win, 1);
+    if (typeof onFallback === "function") onFallback();
+    else setWindowOpacity(win, 1);
     return;
   }
-  scheduleThemeSwitchFadeFallback(seq);
-  win.webContents.reload();
-  hitWin.webContents.reload();
+  clearThemeSwitchReloadListeners();
+  const renderContents = win.webContents;
+  const hitContents = hitWin.webContents;
+  renderContents.once("did-finish-load", onReady);
+  hitContents.once("did-finish-load", onReady);
+  themeSwitchReloadListenerCleanup = () => {
+    renderContents.removeListener("did-finish-load", onReady);
+    hitContents.removeListener("did-finish-load", onReady);
+  };
+  scheduleThemeSwitchFadeFallback(seq, onFallback);
+  try {
+    renderContents.reload();
+    hitContents.reload();
+  } catch {
+    if (typeof onFallback === "function") onFallback();
+  }
 }
 
 function activateTheme(themeId, variantId) {
@@ -4731,15 +4778,20 @@ function activateTheme(themeId, variantId) {
   if (_mini.getMiniMode()) _mini.handleDisplayChange();
 
   const transitionSeq = ++themeSwitchTransitionSeq;
+  cancelThemeSwitchOpacityAnimation();
   clearThemeSwitchFadeFallback();
+  clearThemeSwitchReloadListeners();
   themeReloadInProgress = true;
 
   let ready = 0;
-  const onReady = () => {
-    if (transitionSeq !== themeSwitchTransitionSeq) return;
-    if (++ready < 2) return;
+  let reloadSettled = false;
+  const finishThemeReload = ({ force = false } = {}) => {
+    if (transitionSeq !== themeSwitchTransitionSeq || reloadSettled) return;
+    reloadSettled = true;
+    clearThemeSwitchFadeFallback();
+    clearThemeSwitchReloadListeners();
     themeReloadInProgress = false;
-    if (preservedVirtualBounds && !_mini.getMiniTransitioning()) {
+    if (!force && preservedVirtualBounds && !_mini.getMiniTransitioning() && win && !win.isDestroyed()) {
       applyPetWindowBounds(preservedVirtualBounds);
       const clamped = computeFinalDragBounds(
         getPetWindowBounds(),
@@ -4748,19 +4800,28 @@ function activateTheme(themeId, variantId) {
       );
       if (clamped) applyPetWindowBounds(clamped);
     }
-    syncHitStateAfterLoad();
-    syncRendererStateAfterLoad({ includeStartupRecovery: false });
-    syncHitWin();
+    if (hitWin && !hitWin.isDestroyed()) syncHitStateAfterLoad();
+    if (win && !win.isDestroyed()) {
+      syncRendererStateAfterLoad({ includeStartupRecovery: false });
+      syncHitWin();
+    }
     syncSessionHudVisibility();
-    startMainTick();
+    if (win && !win.isDestroyed()) startMainTick();
     _runPendingPostReloadTasks();
     fadeInThemeWindow(transitionSeq);
   };
-  win.webContents.once("did-finish-load", onReady);
-  hitWin.webContents.once("did-finish-load", onReady);
+  const onReady = () => {
+    if (transitionSeq !== themeSwitchTransitionSeq) return;
+    if (++ready < 2) return;
+    finishThemeReload();
+  };
 
-  animateWindowOpacity(win, 0, { durationMs: THEME_SWITCH_FADE_OUT_MS }).then(() => {
-    reloadThemeWindowsAfterFade(transitionSeq);
+  animateThemeWindowOpacity(transitionSeq, 0, THEME_SWITCH_FADE_OUT_MS).then(() => {
+    reloadThemeWindowsAfterFade(
+      transitionSeq,
+      onReady,
+      () => finishThemeReload({ force: true })
+    );
   });
 
   flushRuntimeStateToPrefs();

--- a/src/main.js
+++ b/src/main.js
@@ -44,6 +44,10 @@ const {
   getProportionalPixelSize,
 } = require("./size-utils");
 const { keepOutOfTaskbar } = require("./taskbar");
+const {
+  animateWindowOpacity,
+  setWindowOpacity,
+} = require("./window-opacity-transition");
 
 // ── Autoplay policy: allow sound playback without user gesture ──
 // MUST be set before any BrowserWindow is created (before app.whenReady)
@@ -53,6 +57,9 @@ const isMac = process.platform === "darwin";
 const isLinux = process.platform === "linux";
 const isWin = process.platform === "win32";
 const LINUX_WINDOW_TYPE = "toolbar";
+const THEME_SWITCH_FADE_OUT_MS = 140;
+const THEME_SWITCH_FADE_IN_MS = 180;
+const THEME_SWITCH_FADE_FALLBACK_MS = 4000;
 
 applyWindowsAppUserModelId(app, process.platform);
 
@@ -1306,6 +1313,8 @@ let forceEyeResend = false;
 let forceEyeResendBoostUntil = 0;
 let requestFastTick = () => {};
 let themeReloadInProgress = false;
+let themeSwitchTransitionSeq = 0;
+let themeSwitchFadeFallbackTimer = null;
 let repositionSessionHud = () => {};
 let syncSessionHudVisibility = () => {};
 let broadcastSessionHudSnapshot = () => {};
@@ -4627,6 +4636,41 @@ Object.defineProperties(this || {}, {}); // no-op placeholder
 // controller rejects the commit — otherwise prefs would record a theme id
 // that can't actually render. Does NOT write `theme` back to prefs; the
 // controller commits after this returns (writing here would infinite-loop).
+function clearThemeSwitchFadeFallback() {
+  if (themeSwitchFadeFallbackTimer) {
+    clearTimeout(themeSwitchFadeFallbackTimer);
+    themeSwitchFadeFallbackTimer = null;
+  }
+}
+
+function scheduleThemeSwitchFadeFallback(seq) {
+  clearThemeSwitchFadeFallback();
+  themeSwitchFadeFallbackTimer = setTimeout(() => {
+    themeSwitchFadeFallbackTimer = null;
+    if (seq !== themeSwitchTransitionSeq) return;
+    setWindowOpacity(win, 1);
+  }, THEME_SWITCH_FADE_FALLBACK_MS);
+}
+
+function fadeInThemeWindow(seq) {
+  if (seq !== themeSwitchTransitionSeq) return;
+  clearThemeSwitchFadeFallback();
+  animateWindowOpacity(win, 1, { durationMs: THEME_SWITCH_FADE_IN_MS }).then((ok) => {
+    if (!ok && seq === themeSwitchTransitionSeq) setWindowOpacity(win, 1);
+  });
+}
+
+function reloadThemeWindowsAfterFade(seq) {
+  if (seq !== themeSwitchTransitionSeq) return;
+  if (!win || win.isDestroyed() || !hitWin || hitWin.isDestroyed()) {
+    setWindowOpacity(win, 1);
+    return;
+  }
+  scheduleThemeSwitchFadeFallback(seq);
+  win.webContents.reload();
+  hitWin.webContents.reload();
+}
+
 function activateTheme(themeId, variantId) {
   if (!win || win.isDestroyed()) {
     throw new Error("theme switch requires ready windows");
@@ -4686,12 +4730,13 @@ function activateTheme(themeId, variantId) {
   _tick.refreshTheme();
   if (_mini.getMiniMode()) _mini.handleDisplayChange();
 
+  const transitionSeq = ++themeSwitchTransitionSeq;
+  clearThemeSwitchFadeFallback();
   themeReloadInProgress = true;
-  win.webContents.reload();
-  hitWin.webContents.reload();
 
   let ready = 0;
   const onReady = () => {
+    if (transitionSeq !== themeSwitchTransitionSeq) return;
     if (++ready < 2) return;
     themeReloadInProgress = false;
     if (preservedVirtualBounds && !_mini.getMiniTransitioning()) {
@@ -4709,9 +4754,14 @@ function activateTheme(themeId, variantId) {
     syncSessionHudVisibility();
     startMainTick();
     _runPendingPostReloadTasks();
+    fadeInThemeWindow(transitionSeq);
   };
   win.webContents.once("did-finish-load", onReady);
   hitWin.webContents.once("did-finish-load", onReady);
+
+  animateWindowOpacity(win, 0, { durationMs: THEME_SWITCH_FADE_OUT_MS }).then(() => {
+    reloadThemeWindowsAfterFade(transitionSeq);
+  });
 
   flushRuntimeStateToPrefs();
 

--- a/src/main.js
+++ b/src/main.js
@@ -4785,13 +4785,13 @@ function activateTheme(themeId, variantId) {
 
   let ready = 0;
   let reloadSettled = false;
-  const finishThemeReload = ({ force = false } = {}) => {
+  const finishThemeReload = () => {
     if (transitionSeq !== themeSwitchTransitionSeq || reloadSettled) return;
     reloadSettled = true;
     clearThemeSwitchFadeFallback();
     clearThemeSwitchReloadListeners();
     themeReloadInProgress = false;
-    if (!force && preservedVirtualBounds && !_mini.getMiniTransitioning() && win && !win.isDestroyed()) {
+    if (preservedVirtualBounds && !_mini.getMiniTransitioning() && win && !win.isDestroyed()) {
       applyPetWindowBounds(preservedVirtualBounds);
       const clamped = computeFinalDragBounds(
         getPetWindowBounds(),
@@ -4800,6 +4800,8 @@ function activateTheme(themeId, variantId) {
       );
       if (clamped) applyPetWindowBounds(clamped);
     }
+    // Fallback can reach this path before both reload events arrive; the sync
+    // helpers are window-guarded and serve as a best-effort state resend.
     if (hitWin && !hitWin.isDestroyed()) syncHitStateAfterLoad();
     if (win && !win.isDestroyed()) {
       syncRendererStateAfterLoad({ includeStartupRecovery: false });
@@ -4820,7 +4822,7 @@ function activateTheme(themeId, variantId) {
     reloadThemeWindowsAfterFade(
       transitionSeq,
       onReady,
-      () => finishThemeReload({ force: true })
+      () => finishThemeReload()
     );
   });
 

--- a/src/window-opacity-transition.js
+++ b/src/window-opacity-transition.js
@@ -35,6 +35,10 @@ function easeInOut(t) {
   return x < 0.5 ? 2 * x * x : 1 - ((-2 * x + 2) ** 2) / 2;
 }
 
+function isCancelled(signal) {
+  return !!(signal && signal.cancelled);
+}
+
 function animateWindowOpacity(win, targetOpacity, options = {}) {
   if (!isUsableWindow(win)) return Promise.resolve(false);
 
@@ -43,8 +47,11 @@ function animateWindowOpacity(win, targetOpacity, options = {}) {
   const now = typeof options.now === "function" ? options.now : Date.now;
   const setTimer = typeof options.setTimeout === "function" ? options.setTimeout : setTimeout;
   const clearTimer = typeof options.clearTimeout === "function" ? options.clearTimeout : clearTimeout;
+  const cancelSignal = options.cancelSignal || null;
   const from = getWindowOpacity(win);
   const to = clampOpacity(targetOpacity);
+
+  if (isCancelled(cancelSignal)) return Promise.resolve(false);
 
   if (durationMs <= 0 || Math.abs(from - to) < 0.001) {
     return Promise.resolve(setWindowOpacity(win, to));
@@ -66,6 +73,10 @@ function animateWindowOpacity(win, targetOpacity, options = {}) {
     };
 
     const step = () => {
+      if (isCancelled(cancelSignal)) {
+        finish(false);
+        return;
+      }
       if (!isUsableWindow(win)) {
         finish(false);
         return;

--- a/src/window-opacity-transition.js
+++ b/src/window-opacity-transition.js
@@ -1,0 +1,95 @@
+"use strict";
+
+function clampOpacity(value) {
+  if (!Number.isFinite(value)) return 1;
+  return Math.max(0, Math.min(1, value));
+}
+
+function isUsableWindow(win) {
+  if (!win || typeof win.setOpacity !== "function") return false;
+  if (typeof win.isDestroyed === "function" && win.isDestroyed()) return false;
+  return true;
+}
+
+function getWindowOpacity(win) {
+  if (!win || typeof win.getOpacity !== "function") return 1;
+  try {
+    return clampOpacity(win.getOpacity());
+  } catch {
+    return 1;
+  }
+}
+
+function setWindowOpacity(win, value) {
+  if (!isUsableWindow(win)) return false;
+  try {
+    win.setOpacity(clampOpacity(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function easeInOut(t) {
+  const x = Math.max(0, Math.min(1, t));
+  return x < 0.5 ? 2 * x * x : 1 - ((-2 * x + 2) ** 2) / 2;
+}
+
+function animateWindowOpacity(win, targetOpacity, options = {}) {
+  if (!isUsableWindow(win)) return Promise.resolve(false);
+
+  const durationMs = Math.max(0, Number(options.durationMs) || 0);
+  const frameMs = Math.max(1, Number(options.frameMs) || 16);
+  const now = typeof options.now === "function" ? options.now : Date.now;
+  const setTimer = typeof options.setTimeout === "function" ? options.setTimeout : setTimeout;
+  const clearTimer = typeof options.clearTimeout === "function" ? options.clearTimeout : clearTimeout;
+  const from = getWindowOpacity(win);
+  const to = clampOpacity(targetOpacity);
+
+  if (durationMs <= 0 || Math.abs(from - to) < 0.001) {
+    return Promise.resolve(setWindowOpacity(win, to));
+  }
+
+  const startedAt = now();
+  return new Promise((resolve) => {
+    let timer = null;
+    let settled = false;
+
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      if (timer) {
+        clearTimer(timer);
+        timer = null;
+      }
+      resolve(ok);
+    };
+
+    const step = () => {
+      if (!isUsableWindow(win)) {
+        finish(false);
+        return;
+      }
+      const elapsed = Math.max(0, now() - startedAt);
+      const progress = Math.min(1, elapsed / durationMs);
+      const nextOpacity = from + (to - from) * easeInOut(progress);
+      if (!setWindowOpacity(win, progress >= 1 ? to : nextOpacity)) {
+        finish(false);
+        return;
+      }
+      if (progress >= 1) {
+        finish(true);
+        return;
+      }
+      timer = setTimer(step, frameMs);
+    };
+
+    step();
+  });
+}
+
+module.exports = {
+  animateWindowOpacity,
+  clampOpacity,
+  setWindowOpacity,
+};

--- a/test/main-theme-transition.test.js
+++ b/test/main-theme-transition.test.js
@@ -1,0 +1,38 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MAIN_JS = path.join(__dirname, "..", "src", "main.js");
+
+describe("main theme transition wiring", () => {
+  it("fades the render window out before theme reload and back in after load", () => {
+    const source = fs.readFileSync(MAIN_JS, "utf8");
+
+    assert.ok(
+      source.includes('require("./window-opacity-transition")'),
+      "main should use the shared BrowserWindow opacity transition helper"
+    );
+    assert.match(source, /THEME_SWITCH_FADE_OUT_MS\s*=\s*140/);
+    assert.match(source, /THEME_SWITCH_FADE_IN_MS\s*=\s*180/);
+
+    const activateIndex = source.indexOf("function activateTheme(");
+    const fadeOutIndex = source.indexOf("animateWindowOpacity(win, 0", activateIndex);
+    const reloadHelperIndex = source.indexOf("function reloadThemeWindowsAfterFade(");
+    const reloadCallIndex = source.indexOf("reloadThemeWindowsAfterFade(transitionSeq)", fadeOutIndex);
+    const syncIndex = source.indexOf("syncRendererStateAfterLoad({ includeStartupRecovery: false })", activateIndex);
+    const fadeInHelperIndex = source.indexOf("function fadeInThemeWindow(");
+    const fadeInCallIndex = source.indexOf("fadeInThemeWindow(transitionSeq)", syncIndex);
+
+    assert.ok(fadeOutIndex > activateIndex, "activateTheme should start by fading out the current render window");
+    assert.ok(reloadHelperIndex > 0, "theme reload should be wrapped so it can run after fade-out");
+    assert.ok(source.indexOf("win.webContents.reload()", reloadHelperIndex) > reloadHelperIndex);
+    assert.ok(reloadCallIndex > fadeOutIndex, "theme reload should happen after the fade-out path");
+    assert.ok(source.indexOf("animateWindowOpacity(win, 1", fadeInHelperIndex) > fadeInHelperIndex);
+    assert.ok(fadeInCallIndex > syncIndex, "new theme should fade in only after renderer state has been synced");
+    assert.ok(
+      source.includes("THEME_SWITCH_FADE_FALLBACK_MS"),
+      "theme transition should have an opacity fallback so the window cannot stay transparent"
+    );
+  });
+});

--- a/test/main-theme-transition.test.js
+++ b/test/main-theme-transition.test.js
@@ -37,7 +37,7 @@ describe("main theme transition wiring", () => {
       "theme transition should have an opacity fallback so the window cannot stay transparent"
     );
     assert.match(source, /scheduleThemeSwitchFadeFallback\(seq,\s*onFallback\)/);
-    assert.match(source, /finishThemeReload\(\{\s*force:\s*true\s*\}\)/);
+    assert.match(source, /const finishThemeReload = \(\) =>/);
     assert.ok(
       source.includes("cancelThemeSwitchOpacityAnimation()"),
       "starting a newer theme switch should cancel stale opacity timers"

--- a/test/main-theme-transition.test.js
+++ b/test/main-theme-transition.test.js
@@ -17,22 +17,30 @@ describe("main theme transition wiring", () => {
     assert.match(source, /THEME_SWITCH_FADE_IN_MS\s*=\s*180/);
 
     const activateIndex = source.indexOf("function activateTheme(");
-    const fadeOutIndex = source.indexOf("animateWindowOpacity(win, 0", activateIndex);
+    const fadeOutIndex = source.indexOf("animateThemeWindowOpacity(transitionSeq, 0", activateIndex);
     const reloadHelperIndex = source.indexOf("function reloadThemeWindowsAfterFade(");
-    const reloadCallIndex = source.indexOf("reloadThemeWindowsAfterFade(transitionSeq)", fadeOutIndex);
+    const reloadCallIndex = source.indexOf("reloadThemeWindowsAfterFade(", fadeOutIndex);
     const syncIndex = source.indexOf("syncRendererStateAfterLoad({ includeStartupRecovery: false })", activateIndex);
     const fadeInHelperIndex = source.indexOf("function fadeInThemeWindow(");
     const fadeInCallIndex = source.indexOf("fadeInThemeWindow(transitionSeq)", syncIndex);
+    const finishIndex = source.indexOf("const finishThemeReload = ", activateIndex);
 
     assert.ok(fadeOutIndex > activateIndex, "activateTheme should start by fading out the current render window");
     assert.ok(reloadHelperIndex > 0, "theme reload should be wrapped so it can run after fade-out");
-    assert.ok(source.indexOf("win.webContents.reload()", reloadHelperIndex) > reloadHelperIndex);
+    assert.ok(source.indexOf("renderContents.reload()", reloadHelperIndex) > reloadHelperIndex);
     assert.ok(reloadCallIndex > fadeOutIndex, "theme reload should happen after the fade-out path");
-    assert.ok(source.indexOf("animateWindowOpacity(win, 1", fadeInHelperIndex) > fadeInHelperIndex);
+    assert.ok(source.indexOf("animateThemeWindowOpacity(seq, 1", fadeInHelperIndex) > fadeInHelperIndex);
     assert.ok(fadeInCallIndex > syncIndex, "new theme should fade in only after renderer state has been synced");
+    assert.ok(finishIndex > activateIndex, "theme reload should have one guarded finish path");
     assert.ok(
       source.includes("THEME_SWITCH_FADE_FALLBACK_MS"),
       "theme transition should have an opacity fallback so the window cannot stay transparent"
+    );
+    assert.match(source, /scheduleThemeSwitchFadeFallback\(seq,\s*onFallback\)/);
+    assert.match(source, /finishThemeReload\(\{\s*force:\s*true\s*\}\)/);
+    assert.ok(
+      source.includes("cancelThemeSwitchOpacityAnimation()"),
+      "starting a newer theme switch should cancel stale opacity timers"
     );
   });
 });

--- a/test/window-opacity-transition.test.js
+++ b/test/window-opacity-transition.test.js
@@ -78,4 +78,32 @@ describe("window opacity transition", () => {
     assert.strictEqual(result, true);
     assert.strictEqual(values.at(-1), 1);
   });
+
+  it("stops writing opacity after cancellation", async () => {
+    const timers = createFakeTimers();
+    const values = [];
+    const cancelSignal = { cancelled: false };
+    const win = {
+      isDestroyed: () => false,
+      getOpacity: () => values.at(-1) ?? 1,
+      setOpacity: (value) => values.push(value),
+    };
+
+    const done = animateWindowOpacity(win, 0, {
+      durationMs: 100,
+      frameMs: 20,
+      now: timers.now,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+      cancelSignal,
+    });
+
+    timers.advance(20);
+    cancelSignal.cancelled = true;
+    const countAfterCancel = values.length;
+    timers.advance(20);
+
+    assert.strictEqual(await done, false);
+    assert.strictEqual(values.length, countAfterCancel);
+  });
 });

--- a/test/window-opacity-transition.test.js
+++ b/test/window-opacity-transition.test.js
@@ -1,0 +1,81 @@
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const { animateWindowOpacity } = require("../src/window-opacity-transition");
+
+function createFakeTimers() {
+  let now = 0;
+  const timers = [];
+  return {
+    now: () => now,
+    setTimeout: (fn, delay) => {
+      const timer = { fn, due: now + delay, cancelled: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeout: (timer) => {
+      if (timer) timer.cancelled = true;
+    },
+    advance(ms) {
+      now += ms;
+      timers.sort((a, b) => a.due - b.due);
+      for (const timer of [...timers]) {
+        const index = timers.indexOf(timer);
+        if (index >= 0) timers.splice(index, 1);
+        if (!timer.cancelled && timer.due <= now) timer.fn();
+      }
+    },
+  };
+}
+
+describe("window opacity transition", () => {
+  it("animates a BrowserWindow opacity to the target value", async () => {
+    const timers = createFakeTimers();
+    const opacityValues = [];
+    const win = {
+      isDestroyed: () => false,
+      getOpacity: () => opacityValues.at(-1) ?? 1,
+      setOpacity: (value) => opacityValues.push(value),
+    };
+
+    const done = animateWindowOpacity(win, 0, {
+      durationMs: 40,
+      frameMs: 20,
+      now: timers.now,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    timers.advance(20);
+    timers.advance(20);
+    assert.strictEqual(await done, true);
+    assert.ok(opacityValues.length >= 2);
+    assert.strictEqual(opacityValues.at(-1), 0);
+  });
+
+  it("resolves false without leaving pending timers when the window is unavailable", async () => {
+    const timers = createFakeTimers();
+    const result = await animateWindowOpacity(null, 0, {
+      durationMs: 40,
+      now: timers.now,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    assert.strictEqual(result, false);
+  });
+
+  it("clamps opacity targets to Electron's valid range", async () => {
+    const values = [];
+    const win = {
+      isDestroyed: () => false,
+      getOpacity: () => 0.5,
+      setOpacity: (value) => values.push(value),
+    };
+
+    const result = await animateWindowOpacity(win, 2, { durationMs: 0 });
+
+    assert.strictEqual(result, true);
+    assert.strictEqual(values.at(-1), 1);
+  });
+});


### PR DESCRIPTION
Fixes: N/A (no linked issue).

## Summary
- Adds a smooth fade-out / fade-in transition around runtime theme switching so the pet no longer disappears and reappears abruptly during theme reload.
- Uses a small BrowserWindow opacity transition helper instead of changing the Settings controller, theme loader, renderer asset channel, or hit-window geometry model.
- Preserves the existing full reload semantics for theme, variant, hitbox, mini-mode, renderer config, and state synchronization.

## Problem context
- Theme switching currently runs through `activateTheme()`, which loads the target theme and then reloads both the render window and hit window.
- Normal animation state changes already use per-file transition metadata, but the theme switch path bypasses that by tearing down the renderer webContents.
- The result is visually abrupt: the current pet frame vanishes during reload and the new theme appears after renderer state sync.
- A true dual-theme crossfade would require keeping two full theme runtimes alive at once, including asset roots, object scaling, eye tracking, mini layout, and hitbox semantics, which is much higher risk than the requested polish requires.

## What changed
- Theme switch transition flow:
  - Fades the main render BrowserWindow from opacity `1` to `0` before reloading theme windows.
  - Reloads the render and hit windows after fade-out completes.
  - Runs the existing post-load sync path first, then fades the render BrowserWindow back to opacity `1`.
  - Uses a transition sequence guard so stale callbacks from an earlier theme switch cannot affect a newer switch.
- Safety behavior:
  - Adds a fallback timer that restores opacity if reload completion does not reach the fade-in path.
  - Restores opacity immediately if the render or hit window becomes unavailable before reload.
  - Keeps `themeReloadInProgress`, post-reload task handling, hit-window reload, Session HUD sync, and runtime prefs flush semantics unchanged.
- Testability:
  - Adds `window-opacity-transition` as a small helper with injectable timers for deterministic unit tests.
  - Adds main-process wiring tests that lock the intended ordering: fade out, reload, state sync, fade in.

## Behavior after this PR
- Switching themes from Settings now fades the current pet out, reloads the new theme, then fades the new pet in after state synchronization.
- If the transition cannot complete normally, the render window opacity is restored to `1` rather than leaving the pet invisible.
- Hitbox, mini mode, theme variant resolution, animation overrides, state refresh, and renderer reload behavior remain on the existing code paths.
- Settings prefs, IPC command shape, Settings controller behavior, theme schema, and renderer animation swapping are unchanged.

## Validation
- `node --check src/main.js`
- `node --check src/window-opacity-transition.js`
- `node --test test/main-theme-transition.test.js test/window-opacity-transition.test.js test/settings-actions.test.js test/settings-controller.test.js`
- `git diff --check`
- `npm test` passed with 1581 tests passing, 0 failing, 0 cancelled, and 2 skipped.
- `npm run build:win:x64` completed successfully and built the Windows x64 NSIS installer.

## Platform note
- Automated verification and Windows x64 packaging ran locally on Windows with Node.js `v22.22.2` and Electron Builder `26.8.1`.
- Manual Electron QA is still recommended for final visual timing across real theme switches, especially on transparent always-on-top windows and slower machines.
