### PR TITLE
fix: keep General settings switches mounted during updates

### DIFF
--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -6,12 +6,15 @@
     "soundMuted",
     "soundVolume",
     "lowPowerIdleMode",
+    "sessionHudEnabled",
     "sessionHudShowElapsed",
     "sessionHudCleanupDetached",
     "allowEdgePinning",
     "keepSizeAcrossDisplays",
+    "manageClaudeHooksAutomatically",
     "openAtLogin",
     "autoStartWithClaude",
+    "hideBubbles",
     "bubbleFollowPet",
     "permissionBubblesEnabled",
     "notificationBubbleAutoCloseSeconds",
@@ -22,6 +25,13 @@
     "notificationBubbleAutoCloseSeconds",
     "updateBubbleAutoCloseSeconds",
   ]);
+  const SESSION_HUD_CHILD_SWITCH_KEYS = [
+    "sessionHudShowElapsed",
+    "sessionHudCleanupDetached",
+  ];
+  const CLAUDE_HOOK_MANAGEMENT_CHILD_SWITCH_KEYS = [
+    "autoStartWithClaude",
+  ];
   const BUBBLE_SECONDS_AUTO_COMMIT_DELAY_MS = 600;
 
   let state = null;
@@ -891,23 +901,104 @@
     return row;
   }
 
+  function getMountedGeneralSwitch(key) {
+    const meta = state.mountedControls.generalSwitches.get(key);
+    if (!meta || !document.body.contains(meta.element)) return null;
+    return meta;
+  }
+
+  function setGeneralSwitchDisabled(key, disabled) {
+    const meta = getMountedGeneralSwitch(key);
+    if (!meta) return false;
+    meta.element.classList.toggle("disabled", !!disabled);
+    if (disabled) {
+      meta.element.setAttribute("aria-disabled", "true");
+      meta.element.tabIndex = -1;
+    } else {
+      meta.element.classList.remove("disabled");
+      meta.element.removeAttribute("aria-disabled");
+      meta.element.tabIndex = 0;
+    }
+    return true;
+  }
+
+  function setGeneralSwitchExtraDesc(key, descExtraKey) {
+    const meta = getMountedGeneralSwitch(key);
+    if (!meta || !meta.text) return false;
+    if (descExtraKey) {
+      if (!meta.extraElement) {
+        meta.extraElement = document.createElement("span");
+        meta.extraElement.className = "row-desc row-desc-extra";
+        meta.text.appendChild(meta.extraElement);
+      }
+      meta.extraElement.textContent = t(descExtraKey);
+      return true;
+    }
+    if (meta.extraElement) {
+      meta.extraElement.remove();
+      meta.extraElement = null;
+    }
+    return true;
+  }
+
+  function syncSessionHudChildSwitchesDisabled() {
+    const disabled = !(state.snapshot && state.snapshot.sessionHudEnabled);
+    for (const key of SESSION_HUD_CHILD_SWITCH_KEYS) {
+      if (!setGeneralSwitchDisabled(key, disabled)) return false;
+    }
+    return true;
+  }
+
+  function syncClaudeHookManagementChildSwitchesDisabled() {
+    const disabled = !(state.snapshot && state.snapshot.manageClaudeHooksAutomatically);
+    for (const key of CLAUDE_HOOK_MANAGEMENT_CHILD_SWITCH_KEYS) {
+      if (!setGeneralSwitchDisabled(key, disabled)) return false;
+    }
+    return setGeneralSwitchExtraDesc(
+      "autoStartWithClaude",
+      disabled ? "rowStartWithClaudeDisabledDesc" : null
+    );
+  }
+
+  function hasMountedBubblePolicyControls() {
+    const summaryControl = state.mountedControls.bubblePolicySummary;
+    if (!summaryControl || !document.body.contains(summaryControl.element)) return false;
+    for (const key of BUBBLE_POLICY_KEYS) {
+      const meta = state.mountedControls.bubblePolicyControls.get(key);
+      if (!meta || !document.body.contains(meta.row)) return false;
+    }
+    return true;
+  }
+
+  function syncBubblePolicyControlsFromSnapshot() {
+    if (!hasMountedBubblePolicyControls()) return false;
+    for (const key of BUBBLE_POLICY_KEYS) {
+      state.mountedControls.bubblePolicyControls.get(key).syncFromSnapshot();
+    }
+    state.mountedControls.bubblePolicySummary.syncFromSnapshot();
+    return true;
+  }
+
   function patchInPlace(changes) {
     const keys = changes ? Object.keys(changes) : [];
     if (keys.length === 0) return false;
-    if (keys.includes("hideBubbles")) {
-      // Aggregate hiding also changes the policy summary and category controls.
-      const meta = state.mountedControls.generalSwitches.get("hideBubbles");
-      if (meta && document.body.contains(meta.element)) {
-        state.transientUiState.generalSwitches.delete("hideBubbles");
-        helpers.setSwitchVisual(meta.element, readers.readGeneralSwitchVisual("hideBubbles", meta.invert), { pending: false });
-      }
-      return false;
-    }
     if (!keys.every((key) => GENERAL_IN_PLACE_KEYS.has(key))) return false;
     if (keys.includes("size") && !ops.syncMountedSizeControl({ fromBroadcast: true })) return false;
     if (keys.includes("soundVolume") || keys.includes("soundMuted")) {
       const vc = state.mountedControls.soundVolume;
       if (!vc || !document.body.contains(vc.row)) return false;
+    }
+    if (keys.includes("sessionHudEnabled")
+      && !SESSION_HUD_CHILD_SWITCH_KEYS.every((key) => getMountedGeneralSwitch(key))) {
+      return false;
+    }
+    if (keys.includes("manageClaudeHooksAutomatically")
+      && !CLAUDE_HOOK_MANAGEMENT_CHILD_SWITCH_KEYS.every((key) => getMountedGeneralSwitch(key))) {
+      return false;
+    }
+    if ((keys.includes("hideBubbles") || keys.some((key) => BUBBLE_POLICY_KEYS.has(key)))
+      && !hasMountedBubblePolicyControls()) {
+      return false;
     }
     for (const key of keys) {
       if (key === "size" || key === "soundVolume") continue;
@@ -936,11 +1027,11 @@
         state.mountedControls.soundVolume.syncDisabled();
       }
     }
-    if (keys.some((key) => BUBBLE_POLICY_KEYS.has(key))) {
-      const summaryControl = state.mountedControls.bubblePolicySummary;
-      if (!summaryControl || !document.body.contains(summaryControl.element)) return false;
-      summaryControl.syncFromSnapshot();
-    }
+    if (keys.includes("sessionHudEnabled") && !syncSessionHudChildSwitchesDisabled()) return false;
+    if (keys.includes("manageClaudeHooksAutomatically")
+      && !syncClaudeHookManagementChildSwitchesDisabled()) return false;
+    if ((keys.includes("hideBubbles") || keys.some((key) => BUBBLE_POLICY_KEYS.has(key)))
+      && !syncBubblePolicyControlsFromSnapshot()) return false;
     return true;
   }
 

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -915,7 +915,6 @@
       meta.element.setAttribute("aria-disabled", "true");
       meta.element.tabIndex = -1;
     } else {
-      meta.element.classList.remove("disabled");
       meta.element.removeAttribute("aria-disabled");
       meta.element.tabIndex = 0;
     }

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -526,18 +526,20 @@
     row.querySelector(".row-label").textContent = t(labelKey);
     const text = row.querySelector(".row-text");
     row.querySelector(".row-desc").textContent = t(descKey);
+    let extraElement = null;
     if (descExtraKey) {
       const extra = document.createElement("span");
-      extra.className = "row-desc";
+      extra.className = "row-desc row-desc-extra";
       extra.textContent = t(descExtraKey);
       text.appendChild(extra);
+      extraElement = extra;
     }
     const sw = row.querySelector(".switch");
     const control = row.querySelector(".row-control");
     const override = state.transientUiState.generalSwitches.get(key);
     const visualOn = override ? override.visualOn : readGeneralSwitchVisual(key, invert);
     setSwitchVisual(sw, visualOn, { pending: override ? override.pending : false });
-    state.mountedControls.generalSwitches.set(key, { element: sw, invert });
+    state.mountedControls.generalSwitches.set(key, { element: sw, invert, row, text, extraElement });
     if (actionButton) {
       const btn = document.createElement("button");
       btn.type = "button";
@@ -550,7 +552,6 @@
       sw.classList.add("disabled");
       sw.setAttribute("aria-disabled", "true");
       sw.tabIndex = -1;
-      return row;
     }
     attachAnimatedSwitch(sw, {
       getCommittedVisual: () => readGeneralSwitchVisual(key, invert),

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -523,6 +523,30 @@ function loadGeneralTabForTest({
   };
 }
 
+function makeGeneralSnapshot(overrides = {}) {
+  return {
+    lang: "en",
+    size: 50,
+    sessionHudEnabled: true,
+    sessionHudShowElapsed: true,
+    sessionHudCleanupDetached: true,
+    soundMuted: false,
+    soundVolume: 0.5,
+    lowPowerIdleMode: false,
+    allowEdgePinning: true,
+    keepSizeAcrossDisplays: true,
+    manageClaudeHooksAutomatically: true,
+    openAtLogin: false,
+    autoStartWithClaude: false,
+    hideBubbles: false,
+    bubbleFollowPet: true,
+    permissionBubblesEnabled: true,
+    notificationBubbleAutoCloseSeconds: 8,
+    updateBubbleAutoCloseSeconds: 12,
+    ...overrides,
+  };
+}
+
 function loadAgentsTabForTest({
   snapshot,
   agentMetadata,
@@ -1420,6 +1444,215 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(aggregate.classList.contains("on"), true);
     assert.strictEqual(notificationSwitch.classList.contains("on"), false);
     assert.strictEqual(notificationSeconds.disabled, true);
+  });
+
+  it("patches the Session HUD master switch off without rebuilding General content", async () => {
+    const updateCalls = [];
+    const initialSnapshot = makeGeneralSnapshot({ sessionHudEnabled: true });
+    const harness = loadGeneralTabForTest({
+      snapshot: initialSnapshot,
+      settingsAPI: {
+        update: (key, value) => {
+          updateCalls.push({ key, value });
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+    });
+    harness.renderContent();
+
+    const master = harness.getSwitch("sessionHudEnabled");
+    const elapsed = harness.getSwitch("sessionHudShowElapsed");
+    const cleanup = harness.getSwitch("sessionHudCleanupDetached");
+    assert.ok(master);
+    assert.ok(elapsed);
+    assert.ok(cleanup);
+    assert.strictEqual(elapsed.classList.contains("disabled"), false);
+    assert.strictEqual(cleanup.classList.contains("disabled"), false);
+
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { sessionHudEnabled: false },
+      snapshot: { ...initialSnapshot, sessionHudEnabled: false },
+    });
+
+    assert.strictEqual(harness.getContentRenderCount(), beforeRenderCount);
+    assert.strictEqual(harness.getSwitch("sessionHudEnabled"), master);
+    assert.strictEqual(harness.getSwitch("sessionHudShowElapsed"), elapsed);
+    assert.strictEqual(harness.getSwitch("sessionHudCleanupDetached"), cleanup);
+    assert.strictEqual(master.classList.contains("on"), false);
+    assert.strictEqual(elapsed.classList.contains("disabled"), true);
+    assert.strictEqual(elapsed.attributes["aria-disabled"], "true");
+    assert.strictEqual(elapsed.tabIndex, -1);
+    assert.strictEqual(cleanup.classList.contains("disabled"), true);
+    assert.strictEqual(cleanup.attributes["aria-disabled"], "true");
+    assert.strictEqual(cleanup.tabIndex, -1);
+
+    elapsed.eventListeners.click[0]();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepStrictEqual(updateCalls, []);
+  });
+
+  it("patches Claude hook management off and restores the child disabled note", async () => {
+    const updateCalls = [];
+    const initialSnapshot = makeGeneralSnapshot({
+      manageClaudeHooksAutomatically: true,
+      autoStartWithClaude: true,
+    });
+    const harness = loadGeneralTabForTest({
+      snapshot: initialSnapshot,
+      settingsAPI: {
+        update: (key, value) => {
+          updateCalls.push({ key, value });
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+    });
+    harness.renderContent();
+
+    const master = harness.getSwitch("manageClaudeHooksAutomatically");
+    const autoStart = harness.getSwitch("autoStartWithClaude");
+    const autoStartMeta = harness.getSwitchMeta("autoStartWithClaude");
+    assert.ok(master);
+    assert.ok(autoStart);
+    assert.ok(autoStartMeta);
+    assert.strictEqual(autoStart.classList.contains("disabled"), false);
+    assert.strictEqual(autoStartMeta.extraElement, null);
+
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { manageClaudeHooksAutomatically: false },
+      snapshot: { ...initialSnapshot, manageClaudeHooksAutomatically: false },
+    });
+
+    assert.strictEqual(harness.getContentRenderCount(), beforeRenderCount);
+    assert.strictEqual(harness.getSwitch("manageClaudeHooksAutomatically"), master);
+    assert.strictEqual(harness.getSwitch("autoStartWithClaude"), autoStart);
+    assert.strictEqual(master.classList.contains("on"), false);
+    assert.strictEqual(autoStart.classList.contains("disabled"), true);
+    assert.strictEqual(autoStart.attributes["aria-disabled"], "true");
+    assert.strictEqual(autoStart.tabIndex, -1);
+    assert.ok(autoStartMeta.extraElement);
+    assert.strictEqual(
+      autoStartMeta.extraElement.textContent,
+      harness.core.helpers.t("rowStartWithClaudeDisabledDesc")
+    );
+
+    autoStart.eventListeners.click[0]();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepStrictEqual(updateCalls, []);
+  });
+
+  it("patches hide-bubbles aggregate off without rebuilding General content", () => {
+    const initialSnapshot = makeGeneralSnapshot({ hideBubbles: true });
+    const harness = loadGeneralTabForTest({ snapshot: initialSnapshot });
+    harness.renderContent();
+
+    const aggregate = harness.getSwitch("hideBubbles");
+    const notificationPolicy = harness.core.state.mountedControls.bubblePolicyControls.get("notificationBubbleAutoCloseSeconds");
+    const notificationSwitch = notificationPolicy.row.querySelector(".switch");
+    const notificationSeconds = notificationPolicy.row.querySelector("input");
+    const summary = harness.core.state.mountedControls.bubblePolicySummary.element;
+    assert.ok(aggregate);
+    assert.strictEqual(aggregate.classList.contains("on"), true);
+    assert.strictEqual(notificationSwitch.classList.contains("on"), false);
+    assert.strictEqual(notificationSeconds.disabled, true);
+    assert.ok(summary.children.every((chip) => !chip.classList.contains("accent")));
+
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { hideBubbles: false },
+      snapshot: { ...initialSnapshot, hideBubbles: false },
+    });
+
+    assert.strictEqual(harness.getContentRenderCount(), beforeRenderCount);
+    assert.strictEqual(harness.getSwitch("hideBubbles"), aggregate);
+    assert.strictEqual(aggregate.classList.contains("on"), false);
+    assert.strictEqual(notificationSwitch.classList.contains("on"), true);
+    assert.strictEqual(notificationSeconds.disabled, false);
+    assert.strictEqual(notificationSeconds.value, "8");
+    assert.strictEqual(summary.children.length, 3);
+    assert.ok(summary.children.every((chip) => chip.classList.contains("accent")));
+  });
+
+  it("rerenders General content for mixed non-patchable broadcasts", () => {
+    const initialSnapshot = makeGeneralSnapshot({
+      lang: "en",
+      sessionHudEnabled: false,
+    });
+    const harness = loadGeneralTabForTest({ snapshot: initialSnapshot });
+    harness.renderContent();
+
+    const master = harness.getSwitch("sessionHudEnabled");
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { sessionHudEnabled: true, lang: "zh" },
+      snapshot: { ...initialSnapshot, sessionHudEnabled: true, lang: "zh" },
+    });
+
+    assert.strictEqual(harness.getContentRenderCount(), beforeRenderCount + 1);
+    assert.notStrictEqual(harness.getSwitch("sessionHudEnabled"), master);
+    assert.strictEqual(harness.getSwitch("sessionHudEnabled").classList.contains("on"), true);
+  });
+
+  it("patches combined bubble aggregate and seconds broadcasts in place", () => {
+    const initialSnapshot = makeGeneralSnapshot({
+      hideBubbles: false,
+      notificationBubbleAutoCloseSeconds: 8,
+    });
+    const harness = loadGeneralTabForTest({ snapshot: initialSnapshot });
+    harness.renderContent();
+
+    const aggregate = harness.getSwitch("hideBubbles");
+    const notificationPolicy = harness.core.state.mountedControls.bubblePolicyControls.get("notificationBubbleAutoCloseSeconds");
+    const notificationSwitch = notificationPolicy.row.querySelector(".switch");
+    const notificationSeconds = notificationPolicy.row.querySelector("input");
+
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { hideBubbles: true, notificationBubbleAutoCloseSeconds: 0 },
+      snapshot: {
+        ...initialSnapshot,
+        hideBubbles: true,
+        notificationBubbleAutoCloseSeconds: 0,
+      },
+    });
+
+    assert.strictEqual(harness.getContentRenderCount(), beforeRenderCount);
+    assert.strictEqual(harness.getSwitch("hideBubbles"), aggregate);
+    assert.strictEqual(aggregate.classList.contains("on"), true);
+    assert.strictEqual(notificationSwitch.classList.contains("on"), false);
+    assert.strictEqual(notificationSeconds.disabled, true);
+    assert.strictEqual(notificationSeconds.value, "0");
+  });
+
+  it("patches pure bubble policy seconds broadcasts in place", () => {
+    const initialSnapshot = makeGeneralSnapshot({
+      hideBubbles: false,
+      notificationBubbleAutoCloseSeconds: 0,
+    });
+    const harness = loadGeneralTabForTest({ snapshot: initialSnapshot });
+    harness.renderContent();
+
+    const notificationPolicy = harness.core.state.mountedControls.bubblePolicyControls.get("notificationBubbleAutoCloseSeconds");
+    const notificationSwitch = notificationPolicy.row.querySelector(".switch");
+    const notificationSeconds = notificationPolicy.row.querySelector("input");
+    const summary = harness.core.state.mountedControls.bubblePolicySummary.element;
+    assert.strictEqual(notificationSwitch.classList.contains("on"), false);
+    assert.strictEqual(notificationSeconds.disabled, true);
+
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { notificationBubbleAutoCloseSeconds: 5 },
+      snapshot: { ...initialSnapshot, notificationBubbleAutoCloseSeconds: 5 },
+    });
+
+    assert.strictEqual(harness.getContentRenderCount(), beforeRenderCount);
+    assert.strictEqual(notificationSwitch.classList.contains("on"), true);
+    assert.strictEqual(notificationSeconds.disabled, false);
+    assert.strictEqual(notificationSeconds.value, "5");
+    assert.strictEqual(summary.children[1].classList.contains("accent"), true);
   });
 
   it("uses a roomier grid layout for Settings confirmation buttons", () => {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -176,6 +176,21 @@ class FakeElement {
     return child;
   }
 
+  insertBefore(child, reference) {
+    child.parentNode = this;
+    const index = this.children.indexOf(reference);
+    if (index === -1) this.children.push(child);
+    else this.children.splice(index, 0, child);
+    return child;
+  }
+
+  remove() {
+    if (!this.parentNode) return;
+    const index = this.parentNode.children.indexOf(this);
+    if (index !== -1) this.parentNode.children.splice(index, 1);
+    this.parentNode = null;
+  }
+
   setAttribute(name, value) {
     this.attributes[name] = String(value);
     if (name === "class") this.className = String(value);
@@ -186,6 +201,10 @@ class FakeElement {
       const key = name.slice(5).replace(/-([a-z])/g, (_m, ch) => ch.toUpperCase());
       this.dataset[key] = String(value);
     }
+  }
+
+  getAttribute(name) {
+    return this.attributes[name];
   }
 
   removeAttribute(name) {
@@ -397,6 +416,110 @@ function loadGeneralLanguageRowForTest({
     getContentRenderCount: () => contentRenderCount,
     getLanguageTransitionSeenByRender: () => languageTransitionSeenByRender,
     getSegmented: () => content.querySelector(".language-segmented"),
+  };
+}
+
+function loadGeneralTabForTest({
+  snapshot,
+  settingsAPI = {},
+} = {}) {
+  const body = new FakeElement("body");
+  const content = new FakeElement("main");
+  content.id = "content";
+  body.appendChild(content);
+
+  const document = {
+    body,
+    createElement: (tagName) => new FakeElement(tagName),
+    getElementById(id) {
+      if (id === "content") return content;
+      return null;
+    },
+  };
+
+  const context = {
+    console,
+    navigator: { platform: "Win32" },
+    localStorage: {
+      getItem: () => null,
+      setItem: () => {},
+    },
+    document,
+    requestAnimationFrame: (cb) => {
+      cb();
+      return 1;
+    },
+    getComputedStyle: () => ({
+      getPropertyValue: () => "",
+    }),
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    window: null,
+    globalThis: null,
+    settingsAPI: {
+      update: () => Promise.resolve({ status: "ok" }),
+      command: () => Promise.resolve({ status: "ok" }),
+      getPreviewSoundUrl: () => Promise.resolve(null),
+      openDashboard: () => {},
+      ...settingsAPI,
+    },
+    ClawdSettingsSizeSlider: {
+      SIZE_UI_MIN: 1,
+      SIZE_UI_MAX: 100,
+      SIZE_TICK_VALUES: [25, 50, 75, 100],
+      SIZE_SLIDER_THUMB_DIAMETER: 18,
+      prefsSizeToUi: (value) => value,
+      clampSizeUi: (value) => value,
+      sizeUiToPct: (value) => value,
+      getSizeSliderAnchorPx: () => 0,
+      createSizeSliderController: () => ({
+        syncFromSnapshot: () => {},
+        dispose: () => {},
+        pointerDown: () => {},
+        pointerUp: () => {},
+        pointerCancel: () => {},
+        blur: () => {},
+        input: () => {},
+        change: () => {},
+      }),
+    },
+    ClawdSettingsI18n: {
+      STRINGS: loadSettingsI18nForTest(),
+      CONTRIBUTORS: [],
+      MAINTAINERS: [],
+    },
+  };
+  context.window = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(SETTINGS_ANIM_OVERRIDES_MERGE, "utf8"), context);
+  vm.runInContext(fs.readFileSync(SETTINGS_UI_CORE, "utf8"), context);
+  vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-general.js"), "utf8"), context);
+
+  const core = context.ClawdSettingsCore;
+  core.state.snapshot = snapshot || {};
+  core.state.activeTab = "general";
+  context.ClawdSettingsTabGeneral.init(core);
+
+  let contentRenderCount = 0;
+  function renderContent() {
+    contentRenderCount++;
+    core.ops.clearMountedControls();
+    content.innerHTML = "";
+    core.tabs.general.render(content, core);
+  }
+  core.ops.installRenderHooks({ content: renderContent });
+
+  return {
+    core,
+    content,
+    renderContent,
+    getContentRenderCount: () => contentRenderCount,
+    getSwitchMeta: (key) => core.state.mountedControls.generalSwitches.get(key) || null,
+    getSwitch: (key) => {
+      const meta = core.state.mountedControls.generalSwitches.get(key);
+      return meta ? meta.element : null;
+    },
   };
 }
 
@@ -1107,13 +1230,196 @@ describe("settings renderer browser environment", () => {
     assert.ok(clearIndex < renderIndex, "broadcast cleanup must happen before full rerender");
   });
 
-  it("rerenders general tab when the Session HUD parent switch changes", () => {
-    const generalSource = fs.readFileSync(path.join(SRC_DIR, "settings-tab-general.js"), "utf8");
-    const match = generalSource.match(/const GENERAL_IN_PLACE_KEYS = new Set\(\[([\s\S]*?)\]\);/);
-    assert.ok(match, "general in-place key list must be present");
-    assert.ok(!match[1].includes('"sessionHudEnabled"'));
-    assert.ok(match[1].includes('"sessionHudShowElapsed"'));
-    assert.ok(match[1].includes('"sessionHudCleanupDetached"'));
+  it("patches the Session HUD master switch without rebuilding General content", async () => {
+    const updateCalls = [];
+    const initialSnapshot = {
+      lang: "en",
+      size: 50,
+      sessionHudEnabled: false,
+      sessionHudShowElapsed: true,
+      sessionHudCleanupDetached: true,
+      soundMuted: false,
+      soundVolume: 0.5,
+      lowPowerIdleMode: false,
+      allowEdgePinning: true,
+      keepSizeAcrossDisplays: true,
+      manageClaudeHooksAutomatically: false,
+      openAtLogin: false,
+      autoStartWithClaude: false,
+      hideBubbles: false,
+      bubbleFollowPet: true,
+      permissionBubblesEnabled: true,
+      notificationBubbleAutoCloseSeconds: 8,
+      updateBubbleAutoCloseSeconds: 12,
+    };
+    const harness = loadGeneralTabForTest({
+      snapshot: initialSnapshot,
+      settingsAPI: {
+        update: (key, value) => {
+          updateCalls.push({ key, value });
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+    });
+    harness.renderContent();
+
+    const master = harness.getSwitch("sessionHudEnabled");
+    const elapsed = harness.getSwitch("sessionHudShowElapsed");
+    const cleanup = harness.getSwitch("sessionHudCleanupDetached");
+    assert.ok(master);
+    assert.ok(elapsed);
+    assert.ok(cleanup);
+    assert.strictEqual(elapsed.classList.contains("disabled"), true);
+    assert.strictEqual(elapsed.attributes["aria-disabled"], "true");
+    assert.strictEqual(elapsed.tabIndex, -1);
+
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { sessionHudEnabled: true },
+      snapshot: { ...initialSnapshot, sessionHudEnabled: true },
+    });
+
+    assert.strictEqual(
+      harness.getContentRenderCount(),
+      beforeRenderCount,
+      "Session HUD master broadcasts should patch mounted controls instead of rebuilding General"
+    );
+    assert.strictEqual(harness.getSwitch("sessionHudEnabled"), master);
+    assert.strictEqual(harness.getSwitch("sessionHudShowElapsed"), elapsed);
+    assert.strictEqual(harness.getSwitch("sessionHudCleanupDetached"), cleanup);
+    assert.strictEqual(master.classList.contains("on"), true);
+    assert.strictEqual(master.classList.contains("pending"), false);
+    assert.strictEqual(elapsed.classList.contains("disabled"), false);
+    assert.strictEqual(elapsed.attributes["aria-disabled"], undefined);
+    assert.strictEqual(elapsed.tabIndex, 0);
+    assert.strictEqual(cleanup.classList.contains("disabled"), false);
+    assert.strictEqual(cleanup.tabIndex, 0);
+
+    assert.ok(
+      elapsed.eventListeners.click && elapsed.eventListeners.click.length > 0,
+      "Session HUD child switches must remain wired after being enabled in place"
+    );
+    elapsed.eventListeners.click[0]();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepStrictEqual(updateCalls, [{ key: "sessionHudShowElapsed", value: false }]);
+  });
+
+  it("patches Claude hook management child switch state without rebuilding General content", async () => {
+    const updateCalls = [];
+    const initialSnapshot = {
+      lang: "en",
+      size: 50,
+      sessionHudEnabled: true,
+      sessionHudShowElapsed: true,
+      sessionHudCleanupDetached: true,
+      soundMuted: false,
+      soundVolume: 0.5,
+      lowPowerIdleMode: false,
+      allowEdgePinning: true,
+      keepSizeAcrossDisplays: true,
+      manageClaudeHooksAutomatically: false,
+      openAtLogin: false,
+      autoStartWithClaude: false,
+      hideBubbles: false,
+      bubbleFollowPet: true,
+      permissionBubblesEnabled: true,
+      notificationBubbleAutoCloseSeconds: 8,
+      updateBubbleAutoCloseSeconds: 12,
+    };
+    const harness = loadGeneralTabForTest({
+      snapshot: initialSnapshot,
+      settingsAPI: {
+        update: (key, value) => {
+          updateCalls.push({ key, value });
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+    });
+    harness.renderContent();
+
+    const master = harness.getSwitch("manageClaudeHooksAutomatically");
+    const autoStart = harness.getSwitch("autoStartWithClaude");
+    const autoStartMeta = harness.getSwitchMeta("autoStartWithClaude");
+    assert.ok(master);
+    assert.ok(autoStart);
+    assert.ok(autoStartMeta.extraElement);
+    assert.strictEqual(autoStart.classList.contains("disabled"), true);
+
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { manageClaudeHooksAutomatically: true },
+      snapshot: { ...initialSnapshot, manageClaudeHooksAutomatically: true },
+    });
+
+    assert.strictEqual(
+      harness.getContentRenderCount(),
+      beforeRenderCount,
+      "Claude hook management broadcasts should patch the mounted startup switches"
+    );
+    assert.strictEqual(harness.getSwitch("manageClaudeHooksAutomatically"), master);
+    assert.strictEqual(harness.getSwitch("autoStartWithClaude"), autoStart);
+    assert.strictEqual(master.classList.contains("on"), true);
+    assert.strictEqual(autoStart.classList.contains("disabled"), false);
+    assert.strictEqual(autoStart.attributes["aria-disabled"], undefined);
+    assert.strictEqual(autoStart.tabIndex, 0);
+    assert.strictEqual(autoStartMeta.extraElement, null);
+
+    autoStart.eventListeners.click[0]();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepStrictEqual(updateCalls, [{ key: "autoStartWithClaude", value: true }]);
+  });
+
+  it("patches hide-bubbles aggregate changes without rebuilding General content", () => {
+    const initialSnapshot = {
+      lang: "en",
+      size: 50,
+      sessionHudEnabled: true,
+      sessionHudShowElapsed: true,
+      sessionHudCleanupDetached: true,
+      soundMuted: false,
+      soundVolume: 0.5,
+      lowPowerIdleMode: false,
+      allowEdgePinning: true,
+      keepSizeAcrossDisplays: true,
+      manageClaudeHooksAutomatically: true,
+      openAtLogin: false,
+      autoStartWithClaude: false,
+      hideBubbles: false,
+      bubbleFollowPet: true,
+      permissionBubblesEnabled: true,
+      notificationBubbleAutoCloseSeconds: 8,
+      updateBubbleAutoCloseSeconds: 12,
+    };
+    const harness = loadGeneralTabForTest({ snapshot: initialSnapshot });
+    harness.renderContent();
+
+    const aggregate = harness.getSwitch("hideBubbles");
+    const notificationPolicy = harness.core.state.mountedControls.bubblePolicyControls.get("notificationBubbleAutoCloseSeconds");
+    const notificationSwitch = notificationPolicy.row.querySelector(".switch");
+    const notificationSeconds = notificationPolicy.row.querySelector("input");
+    assert.ok(aggregate);
+    assert.ok(notificationSwitch);
+    assert.ok(notificationSeconds);
+    assert.strictEqual(notificationSwitch.classList.contains("on"), true);
+    assert.strictEqual(notificationSeconds.disabled, false);
+
+    const beforeRenderCount = harness.getContentRenderCount();
+    harness.core.ops.applyChanges({
+      changes: { hideBubbles: true },
+      snapshot: { ...initialSnapshot, hideBubbles: true },
+    });
+
+    assert.strictEqual(
+      harness.getContentRenderCount(),
+      beforeRenderCount,
+      "hide-bubbles broadcasts should patch summary and category controls in place"
+    );
+    assert.strictEqual(harness.getSwitch("hideBubbles"), aggregate);
+    assert.strictEqual(aggregate.classList.contains("on"), true);
+    assert.strictEqual(notificationSwitch.classList.contains("on"), false);
+    assert.strictEqual(notificationSeconds.disabled, true);
   });
 
   it("uses a roomier grid layout for Settings confirmation buttons", () => {


### PR DESCRIPTION
## Summary
- Keeps General settings switches mounted while dependent controls update, so switch animations are not interrupted by a full content rebuild.
- Extends the existing General tab in-place patch path for Session HUD, Claude hook management, and aggregate bubble visibility updates.
- Preserves the existing Settings controller, prefs schema, command payloads, pending state, and toast behavior.

## Problem context
- The Session HUD master switch used the shared `.switch` CSS, but its committed broadcast rebuilt the General tab because `sessionHudEnabled` was not patchable in place.
- That rebuild destroyed and recreated the switch DOM, making the animation feel different from other Settings switches.
- The same pattern also existed for two related General controls: `manageClaudeHooksAutomatically` enabling/disabling `autoStartWithClaude`, and `hideBubbles` updating the bubble policy summary and child controls.

## What changed
- General switch rows now retain enough mounted metadata to update extra description text and disabled state without rebuilding the row.
- Disabled General switches are still wired through the shared animated switch handler, so controls that become enabled in place are immediately interactive.
- General tab `patchInPlace()` now handles:
  - `sessionHudEnabled` -> updates `sessionHudShowElapsed` and `sessionHudCleanupDetached` disabled/focus state.
  - `manageClaudeHooksAutomatically` -> updates `autoStartWithClaude` disabled/focus state and helper description.
  - `hideBubbles` and bubble policy keys -> updates the aggregate switch, policy summary, child switches, and seconds inputs in place.
- Added renderer regression coverage for all three dependent-switch paths, including render-count assertions to ensure the mounted DOM is preserved.

## Behavior after this PR
- Toggling Session HUD, Claude hook management, or hide-bubbles aggregate controls no longer tears down the General tab content during the committed settings broadcast.
- The clicked switch keeps its mounted DOM, so the shared switch transition can finish consistently with other Settings switches.
- Child switches and related inputs still reflect committed prefs, disabled state, pending cleanup, and accessibility attributes after broadcasts.
- Settings persistence, controller ownership, command semantics, and preference schema remain unchanged.

## Validation
- `node --test test/settings-renderer-browser-env.test.js`
- `node --test test/settings-renderer-browser-env.test.js test/settings-controller.test.js test/settings-actions.test.js`
- `node --check src/settings-tab-general.js`
- `node --check src/settings-ui-core.js`
- `git diff --check`
- `npm test` -> 1579 passed, 0 failed, 2 skipped

## Platform note
- Automated verification ran locally on Windows with Node's built-in test runner.
- Manual Electron QA is still recommended for final animation feel in the real Settings window, especially the three General-page master switches covered here.
