### PR TITLE
fix: share Electron launch config for auto-start

### DIFF
--- a/hooks/auto-start.js
+++ b/hooks/auto-start.js
@@ -7,6 +7,7 @@
 const { spawn } = require("child_process");
 const path = require("path");
 const { discoverClawdPort } = require("./server-config");
+const { buildElectronLaunchConfig } = require("./shared-process");
 
 const TIMEOUT_MS = 300;
 
@@ -56,24 +57,18 @@ function launchApp() {
         }
       }
     } else {
-      // Source / development mode
+      // Source / development mode: start Electron directly so Windows does not
+      // flash a console through the cmd/npm/launch.js process chain.
       const projectDir = path.resolve(__dirname, "..");
-      if (isWin) {
-        // On Windows, .cmd files cannot be spawned directly with detached:true
-        // (EINVAL). Wrap with cmd.exe /c instead.
-        spawn("cmd.exe", ["/c", "npm.cmd", "start"], {
-          cwd: projectDir,
-          detached: true,
-          stdio: "ignore",
-          windowsHide: true,
-        }).unref();
-      } else {
-        spawn("npm", ["start"], {
-          cwd: projectDir,
-          detached: true,
-          stdio: "ignore",
-        }).unref();
-      }
+      const electron = require("electron");
+      const launchConfig = buildElectronLaunchConfig(projectDir);
+      spawn(electron, launchConfig.args, {
+        cwd: launchConfig.cwd,
+        detached: true,
+        stdio: "ignore",
+        windowsHide: true,
+        env: launchConfig.env,
+      }).unref();
     }
   } catch (err) {
     process.stderr.write(`clawd auto-start: ${err.message}\n`);

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -196,4 +196,29 @@ function readStdinJson() {
   });
 }
 
-module.exports = { getPlatformConfig, createPidResolver, readStdinJson };
+function buildElectronLaunchConfig(projectDir, options = {}) {
+  const platform = options.platform || process.platform;
+  const env = { ...(options.env || process.env) };
+  delete env.ELECTRON_RUN_AS_NODE;
+
+  const disableSandbox = platform === "linux" && env.CLAWD_DISABLE_SANDBOX === "1";
+  if (disableSandbox) {
+    env.ELECTRON_DISABLE_SANDBOX = "1";
+    env.CHROME_DEVEL_SANDBOX = "";
+  }
+
+  const entry = typeof options.entry === "string" ? options.entry : ".";
+  const forwardedArgs = Array.isArray(options.forwardedArgs) ? options.forwardedArgs : [];
+  const args = disableSandbox
+    ? [entry, "--no-sandbox", "--disable-setuid-sandbox", ...forwardedArgs]
+    : [entry, ...forwardedArgs];
+
+  return { args, env, cwd: projectDir };
+}
+
+module.exports = {
+  getPlatformConfig,
+  createPidResolver,
+  readStdinJson,
+  buildElectronLaunchConfig,
+};

--- a/launch.js
+++ b/launch.js
@@ -9,25 +9,15 @@
 // This launcher strips that variable before spawning the real Electron binary.
 
 const { spawn } = require("child_process");
-const path = require("path");
 const electron = require("electron");
-
-const env = { ...process.env };
-delete env.ELECTRON_RUN_AS_NODE;
-const disableSandbox = process.platform === "linux" && process.env.CLAWD_DISABLE_SANDBOX === "1";
-if (disableSandbox) {
-  env.ELECTRON_DISABLE_SANDBOX = "1";
-  env.CHROME_DEVEL_SANDBOX = "";
-}
+const { buildElectronLaunchConfig } = require("./hooks/shared-process");
 
 const forwardedArgs = process.argv.slice(2);
-const args = disableSandbox
-  ? [".", "--no-sandbox", "--disable-setuid-sandbox", ...forwardedArgs]
-  : [".", ...forwardedArgs];
-const child = spawn(electron, args, {
+const launchConfig = buildElectronLaunchConfig(__dirname, { forwardedArgs });
+const child = spawn(electron, launchConfig.args, {
   stdio: "inherit",
-  env,
-  cwd: __dirname,
+  env: launchConfig.env,
+  cwd: launchConfig.cwd,
 });
 
 child.on("close", (code) => process.exit(code ?? 0));

--- a/test/main-codex-pet-protocol.test.js
+++ b/test/main-codex-pet-protocol.test.js
@@ -7,6 +7,7 @@ const ROOT = path.join(__dirname, "..");
 const MAIN = path.join(ROOT, "src", "main.js");
 const PACKAGE_JSON = path.join(ROOT, "package.json");
 const LAUNCH = path.join(ROOT, "launch.js");
+const SHARED_PROCESS = path.join(ROOT, "hooks", "shared-process.js");
 
 test("main wires clawd:// protocol dispatch through the Codex Pet importer", () => {
   const source = fs.readFileSync(MAIN, "utf8");
@@ -27,10 +28,12 @@ test("main wires clawd:// protocol dispatch through the Codex Pet importer", () 
 test("package metadata registers the clawd protocol and exposes dev registration", () => {
   const pkg = JSON.parse(fs.readFileSync(PACKAGE_JSON, "utf8"));
   const launchSource = fs.readFileSync(LAUNCH, "utf8");
+  const sharedProcessSource = fs.readFileSync(SHARED_PROCESS, "utf8");
   const protocols = (((pkg || {}).build || {}).protocols || []);
 
   assert.ok(pkg.scripts["register-protocol:dev"].includes("--register-protocol"));
   assert.ok(protocols.some((entry) => Array.isArray(entry.schemes) && entry.schemes.includes("clawd")));
   assert.ok(launchSource.includes("process.argv.slice(2)"));
-  assert.ok(launchSource.includes("...forwardedArgs"));
+  assert.ok(launchSource.includes("buildElectronLaunchConfig(__dirname, { forwardedArgs })"));
+  assert.ok(sharedProcessSource.includes("...forwardedArgs"));
 });

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -2,7 +2,12 @@
 const { describe, it, beforeEach, mock } = require("node:test");
 const assert = require("node:assert");
 
-const { getPlatformConfig, createPidResolver, readStdinJson } = require("../hooks/shared-process");
+const {
+  getPlatformConfig,
+  createPidResolver,
+  readStdinJson,
+  buildElectronLaunchConfig,
+} = require("../hooks/shared-process");
 
 // ═════════════════════════════════════════════════════════════════════════════
 // getPlatformConfig()
@@ -109,6 +114,48 @@ describe("createPidResolver()", () => {
     const resolve = createPidResolver({ platformConfig: cfg, startPid: process.pid, maxDepth: 1 });
     const { pidChain } = resolve();
     assert.ok(pidChain.length <= 1);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// buildElectronLaunchConfig()
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("buildElectronLaunchConfig()", () => {
+  it("strips ELECTRON_RUN_AS_NODE and preserves forwarded args", () => {
+    const sourceEnv = {
+      ELECTRON_RUN_AS_NODE: "1",
+      CLAWD_DISABLE_SANDBOX: "0",
+      KEEP_ME: "yes",
+    };
+
+    const cfg = buildElectronLaunchConfig("D:\\app", {
+      platform: "win32",
+      env: sourceEnv,
+      forwardedArgs: ["--register-protocol"],
+    });
+
+    assert.deepStrictEqual(cfg.args, [".", "--register-protocol"]);
+    assert.strictEqual(cfg.cwd, "D:\\app");
+    assert.strictEqual(cfg.env.ELECTRON_RUN_AS_NODE, undefined);
+    assert.strictEqual(cfg.env.KEEP_ME, "yes");
+    assert.strictEqual(sourceEnv.ELECTRON_RUN_AS_NODE, "1");
+  });
+
+  it("keeps the Linux sandbox fallback when requested", () => {
+    const cfg = buildElectronLaunchConfig("/app", {
+      platform: "linux",
+      env: {
+        CLAWD_DISABLE_SANDBOX: "1",
+        ELECTRON_RUN_AS_NODE: "1",
+      },
+      forwardedArgs: ["--foo"],
+    });
+
+    assert.deepStrictEqual(cfg.args, [".", "--no-sandbox", "--disable-setuid-sandbox", "--foo"]);
+    assert.strictEqual(cfg.env.ELECTRON_RUN_AS_NODE, undefined);
+    assert.strictEqual(cfg.env.ELECTRON_DISABLE_SANDBOX, "1");
+    assert.strictEqual(cfg.env.CHROME_DEVEL_SANDBOX, "");
   });
 });
 


### PR DESCRIPTION
## Summary
- share Electron launch args/env between launch.js and source-mode auto-start
- source auto-start now spawns Electron directly, avoiding the Windows cmd/npm/launch.js console chain
- keep ELECTRON_RUN_AS_NODE stripping, Linux CLAWD_DISABLE_SANDBOX fallback, and launch.js forwarded args behavior

## Test
- npm test

Follow-up to #221.