### PR TITLE
style: polish Settings disclosure chevrons

### DIFF
--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -945,8 +945,8 @@
 
     const chevron = document.createElement("span");
     chevron.className = "anim-override-chevron";
-    chevron.textContent = "\u25B8";
     chevron.setAttribute("aria-hidden", "true");
+    chevron.innerHTML = '<svg viewBox="0 0 20 20" focusable="false"><path d="M8 5l5 5-5 5" /></svg>';
     summary.appendChild(chevron);
 
     const thumb = document.createElement("div");

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -943,10 +943,7 @@
   function buildAnimOverrideSummary(card) {
     const summary = document.createElement("summary");
 
-    const chevron = document.createElement("span");
-    chevron.className = "anim-override-chevron";
-    chevron.setAttribute("aria-hidden", "true");
-    chevron.innerHTML = '<svg viewBox="0 0 20 20" focusable="false"><path d="M8 5l5 5-5 5" /></svg>';
+    const chevron = helpers.createDisclosureChevron("anim-override-chevron");
     summary.appendChild(chevron);
 
     const thumb = document.createElement("div");

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -331,8 +331,8 @@
 
     const chevron = document.createElement("span");
     chevron.className = "collapsible-group-chevron";
-    chevron.textContent = "\u25B8";
     chevron.setAttribute("aria-hidden", "true");
+    chevron.innerHTML = '<svg viewBox="0 0 20 20" focusable="false"><path d="M8 5l5 5-5 5" /></svg>';
     header.appendChild(chevron);
 
     if (headerContent) {

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -305,6 +305,24 @@
     } catch (_) {}
   }
 
+  function createDisclosureChevron(className) {
+    const chevron = document.createElement("span");
+    chevron.className = className;
+    chevron.setAttribute("aria-hidden", "true");
+
+    const createSvgElement = typeof document.createElementNS === "function"
+      ? (tagName) => document.createElementNS("http://www.w3.org/2000/svg", tagName)
+      : (tagName) => document.createElement(tagName);
+    const svg = createSvgElement("svg");
+    svg.setAttribute("viewBox", "0 0 20 20");
+    svg.setAttribute("focusable", "false");
+    const path = createSvgElement("path");
+    path.setAttribute("d", "M8 5l5 5-5 5");
+    svg.appendChild(path);
+    chevron.appendChild(svg);
+    return chevron;
+  }
+
   function buildCollapsibleGroup({
     id,
     title = "",
@@ -329,10 +347,7 @@
     header.setAttribute("role", "button");
     header.setAttribute("tabindex", "0");
 
-    const chevron = document.createElement("span");
-    chevron.className = "collapsible-group-chevron";
-    chevron.setAttribute("aria-hidden", "true");
-    chevron.innerHTML = '<svg viewBox="0 0 20 20" focusable="false"><path d="M8 5l5 5-5 5" /></svg>';
+    const chevron = createDisclosureChevron("collapsible-group-chevron");
     header.appendChild(chevron);
 
     if (headerContent) {
@@ -981,6 +996,7 @@
     buildSwitchRow,
     buildSection,
     buildCollapsibleGroup,
+    createDisclosureChevron,
     attachActivation,
     buildShortcutButton,
     openExternalSafe,

--- a/src/settings.css
+++ b/src/settings.css
@@ -245,7 +245,8 @@ html, body {
   outline: 2px solid var(--accent);
   outline-offset: -2px;
 }
-.collapsible-group-chevron {
+.collapsible-group-chevron,
+.anim-override-chevron {
   flex: 0 0 auto;
   display: inline-flex;
   align-items: center;
@@ -261,13 +262,15 @@ html, body {
     color 0.16s ease,
     opacity 0.16s ease;
 }
-.collapsible-group-chevron svg {
+.collapsible-group-chevron svg,
+.anim-override-chevron svg {
   width: 16px;
   height: 16px;
   display: block;
   overflow: visible;
 }
-.collapsible-group-chevron path {
+.collapsible-group-chevron path,
+.anim-override-chevron path {
   fill: none;
   stroke: currentColor;
   stroke-width: 2.2;
@@ -1224,35 +1227,6 @@ html, body {
 .anim-override-row > summary:hover { background: rgba(0, 0, 0, 0.03); }
 @media (prefers-color-scheme: dark) {
   .anim-override-row > summary:hover { background: rgba(255, 255, 255, 0.04); }
-}
-.anim-override-chevron {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 18px;
-  height: 18px;
-  color: var(--text-tertiary);
-  opacity: 0.72;
-  transform: translateX(-6px) rotate(0deg);
-  transform-origin: center;
-  transition:
-    transform 0.22s cubic-bezier(0.22, 1, 0.36, 1),
-    color 0.16s ease,
-    opacity 0.16s ease;
-}
-.anim-override-chevron svg {
-  width: 16px;
-  height: 16px;
-  display: block;
-  overflow: visible;
-}
-.anim-override-chevron path {
-  fill: none;
-  stroke: currentColor;
-  stroke-width: 2.2;
-  stroke-linecap: round;
-  stroke-linejoin: round;
 }
 .anim-override-row > summary:hover .anim-override-chevron {
   color: var(--text-secondary);

--- a/src/settings.css
+++ b/src/settings.css
@@ -366,6 +366,7 @@ html, body {
 @media (prefers-reduced-motion: reduce) {
   .collapsible-group-header,
   .collapsible-group-chevron,
+  .anim-override-chevron,
   .collapsible-group-summary,
   .collapsible-group-body {
     transition: none;

--- a/src/settings.css
+++ b/src/settings.css
@@ -227,7 +227,7 @@ html, body {
 .collapsible-group-header {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 4px;
   padding: 12px 16px;
   cursor: pointer;
   user-select: none;
@@ -247,15 +247,44 @@ html, body {
 }
 .collapsible-group-chevron {
   flex: 0 0 auto;
-  width: 14px;
-  text-align: center;
-  font-size: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
   color: var(--text-tertiary);
-  transition: transform 0.2s cubic-bezier(0.22, 1, 0.36, 1), color 0.16s ease;
+  opacity: 0.72;
+  transform: translateX(-6px) rotate(0deg);
+  transform-origin: center;
+  transition:
+    transform 0.22s cubic-bezier(0.22, 1, 0.36, 1),
+    color 0.16s ease,
+    opacity 0.16s ease;
+}
+.collapsible-group-chevron svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+  overflow: visible;
+}
+.collapsible-group-chevron path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.collapsible-group-header:hover .collapsible-group-chevron {
+  color: var(--text-secondary);
+  opacity: 0.95;
+}
+.collapsible-group.collapsed .collapsible-group-chevron {
+  transform: translateX(-6px) rotate(0deg);
 }
 .collapsible-group:not(.collapsed) .collapsible-group-chevron {
-  transform: rotate(90deg);
+  transform: translateX(-6px) rotate(90deg);
   color: var(--accent);
+  opacity: 1;
 }
 .collapsible-group-text,
 .collapsible-group-header-content {
@@ -1198,14 +1227,41 @@ html, body {
 }
 .anim-override-chevron {
   flex: 0 0 auto;
-  width: 14px;
-  text-align: center;
-  font-size: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
   color: var(--text-tertiary);
-  transition: transform 0.15s ease;
+  opacity: 0.72;
+  transform: translateX(-6px) rotate(0deg);
+  transform-origin: center;
+  transition:
+    transform 0.22s cubic-bezier(0.22, 1, 0.36, 1),
+    color 0.16s ease,
+    opacity 0.16s ease;
+}
+.anim-override-chevron svg {
+  width: 16px;
+  height: 16px;
+  display: block;
+  overflow: visible;
+}
+.anim-override-chevron path {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.anim-override-row > summary:hover .anim-override-chevron {
+  color: var(--text-secondary);
+  opacity: 0.95;
 }
 .anim-override-row[open] > summary .anim-override-chevron {
-  transform: rotate(90deg);
+  transform: translateX(-6px) rotate(90deg);
+  color: var(--accent);
+  opacity: 1;
 }
 .anim-override-thumb {
   flex: 0 0 auto;
@@ -1218,6 +1274,7 @@ html, body {
   justify-content: center;
   overflow: hidden;
   cursor: pointer;
+  transform: translateX(-3px);
 }
 @media (prefers-color-scheme: dark) {
   .anim-override-thumb { background: rgba(255, 255, 255, 0.04); }
@@ -1263,6 +1320,7 @@ html, body {
   flex-direction: column;
   gap: 2px;
   min-width: 0;
+  transform: translateX(-3px);
 }
 .anim-override-trigger {
   font-size: 13px;

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -1700,6 +1700,7 @@ describe("settings renderer browser environment", () => {
     assert.ok(/\.collapsible-group-header:hover\s+\.collapsible-group-chevron\s*\{[\s\S]*color:\s*var\(--text-secondary\);[\s\S]*opacity:\s*0\.95;/.test(css));
     assert.ok(/\.collapsible-group\.collapsed\s+\.collapsible-group-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);/.test(css));
     assert.ok(/\.collapsible-group:not\(\.collapsed\)\s+\.collapsible-group-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(90deg\);[\s\S]*color:\s*var\(--accent\);[\s\S]*opacity:\s*1;/.test(css));
+    assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.collapsible-group-chevron,[\s\S]*\.anim-override-chevron,[\s\S]*transition:\s*none;/.test(css));
     assert.ok(i18nSource.includes("collapsibleExpand"));
     assert.ok(i18nSource.includes("collapsibleCollapse"));
   });
@@ -2201,6 +2202,7 @@ describe("settings renderer browser environment", () => {
     assert.ok(/\.collapsible-group-chevron path,\s*\.anim-override-chevron path\s*\{[\s\S]*fill:\s*none;[\s\S]*stroke:\s*currentColor;[\s\S]*stroke-width:\s*2\.2;[\s\S]*stroke-linecap:\s*round;[\s\S]*stroke-linejoin:\s*round;/.test(css));
     assert.ok(/\.anim-override-row > summary:hover \.anim-override-chevron\s*\{[\s\S]*color:\s*var\(--text-secondary\);[\s\S]*opacity:\s*0\.95;/.test(css));
     assert.ok(/\.anim-override-row\[open\]\s*>\s*summary\s+\.anim-override-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(90deg\);[\s\S]*color:\s*var\(--accent\);[\s\S]*opacity:\s*1;/.test(css));
+    assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.anim-override-chevron,[\s\S]*transition:\s*none;/.test(css));
     assert.ok(/\.anim-override-thumb\s*\{[\s\S]*transform:\s*translateX\(-3px\);/.test(css));
     assert.ok(/\.anim-override-summary-text\s*\{[\s\S]*transform:\s*translateX\(-3px\);/.test(css));
     assert.ok(!/\.anim-override-summary-change\s*\{[\s\S]*translateX\(-3px\)/.test(css));

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -779,6 +779,12 @@ function loadAnimOverridesTabForTest({
     runtime,
     helpers: {
       t: (key) => key,
+      createDisclosureChevron: (className) => {
+        const chevron = document.createElement("span");
+        chevron.className = className;
+        chevron.setAttribute("aria-hidden", "true");
+        return chevron;
+      },
       attachActivation: (el, invoke) => {
         if (typeof invoke === "function") el.addEventListener("click", () => invoke());
         return el;
@@ -1680,13 +1686,17 @@ describe("settings renderer browser environment", () => {
     assert.ok(coreSource.includes("defaultCollapsed = false"));
     assert.ok(coreSource.includes('header.setAttribute("aria-expanded"'));
     assert.ok(coreSource.includes("collapsibleSummary"));
+    assert.ok(coreSource.includes("function createDisclosureChevron("));
+    assert.ok(coreSource.includes('createDisclosureChevron("collapsible-group-chevron")'));
+    assert.ok(coreSource.includes('svg.setAttribute("viewBox", "0 0 20 20")'));
+    assert.ok(coreSource.includes('path.setAttribute("d", "M8 5l5 5-5 5")'));
     assert.ok(!coreSource.includes('chevron.textContent = "\\u25B8";'));
-    assert.ok(coreSource.includes('chevron.innerHTML = \'<svg viewBox="0 0 20 20" focusable="false"><path d="M8 5l5 5-5 5" /></svg>\';'));
+    assert.ok(!coreSource.includes("chevron.innerHTML"));
     assert.ok(/\.collapsible-group-header\s*\{[\s\S]*gap:\s*4px;/.test(css));
-    assert.ok(/\.collapsible-group-chevron\s*\{[\s\S]*display:\s*inline-flex;[\s\S]*align-items:\s*center;[\s\S]*justify-content:\s*center;[\s\S]*width:\s*18px;[\s\S]*height:\s*18px;[\s\S]*opacity:\s*0\.72;/.test(css));
-    assert.ok(/\.collapsible-group-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);[\s\S]*transition:[\s\S]*transform 0\.22s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\),[\s\S]*color 0\.16s ease,[\s\S]*opacity 0\.16s ease/.test(css));
-    assert.ok(/\.collapsible-group-chevron svg\s*\{[\s\S]*width:\s*16px;[\s\S]*height:\s*16px;[\s\S]*overflow:\s*visible;/.test(css));
-    assert.ok(/\.collapsible-group-chevron path\s*\{[\s\S]*fill:\s*none;[\s\S]*stroke:\s*currentColor;[\s\S]*stroke-width:\s*2\.2;[\s\S]*stroke-linecap:\s*round;[\s\S]*stroke-linejoin:\s*round;/.test(css));
+    assert.ok(/\.collapsible-group-chevron,\s*\.anim-override-chevron\s*\{[\s\S]*display:\s*inline-flex;[\s\S]*align-items:\s*center;[\s\S]*justify-content:\s*center;[\s\S]*width:\s*18px;[\s\S]*height:\s*18px;[\s\S]*opacity:\s*0\.72;/.test(css));
+    assert.ok(/\.collapsible-group-chevron,\s*\.anim-override-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);[\s\S]*transition:[\s\S]*transform 0\.22s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\),[\s\S]*color 0\.16s ease,[\s\S]*opacity 0\.16s ease/.test(css));
+    assert.ok(/\.collapsible-group-chevron svg,\s*\.anim-override-chevron svg\s*\{[\s\S]*width:\s*16px;[\s\S]*height:\s*16px;[\s\S]*overflow:\s*visible;/.test(css));
+    assert.ok(/\.collapsible-group-chevron path,\s*\.anim-override-chevron path\s*\{[\s\S]*fill:\s*none;[\s\S]*stroke:\s*currentColor;[\s\S]*stroke-width:\s*2\.2;[\s\S]*stroke-linecap:\s*round;[\s\S]*stroke-linejoin:\s*round;/.test(css));
     assert.ok(/\.collapsible-group-header:hover\s+\.collapsible-group-chevron\s*\{[\s\S]*color:\s*var\(--text-secondary\);[\s\S]*opacity:\s*0\.95;/.test(css));
     assert.ok(/\.collapsible-group\.collapsed\s+\.collapsible-group-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);/.test(css));
     assert.ok(/\.collapsible-group:not\(\.collapsed\)\s+\.collapsible-group-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(90deg\);[\s\S]*color:\s*var\(--accent\);[\s\S]*opacity:\s*1;/.test(css));
@@ -2183,11 +2193,12 @@ describe("settings renderer browser environment", () => {
     const css = fs.readFileSync(SETTINGS_CSS, "utf8");
 
     assert.ok(!overridesSource.includes('chevron.textContent = "\\u25B8";'));
-    assert.ok(overridesSource.includes('chevron.innerHTML = \'<svg viewBox="0 0 20 20" focusable="false"><path d="M8 5l5 5-5 5" /></svg>\';'));
-    assert.ok(/\.anim-override-chevron\s*\{[\s\S]*display:\s*inline-flex;[\s\S]*align-items:\s*center;[\s\S]*justify-content:\s*center;[\s\S]*width:\s*18px;[\s\S]*height:\s*18px;[\s\S]*opacity:\s*0\.72;/.test(css));
-    assert.ok(/\.anim-override-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);[\s\S]*transition:[\s\S]*transform 0\.22s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\),[\s\S]*color 0\.16s ease,[\s\S]*opacity 0\.16s ease/.test(css));
-    assert.ok(/\.anim-override-chevron svg\s*\{[\s\S]*width:\s*16px;[\s\S]*height:\s*16px;[\s\S]*overflow:\s*visible;/.test(css));
-    assert.ok(/\.anim-override-chevron path\s*\{[\s\S]*fill:\s*none;[\s\S]*stroke:\s*currentColor;[\s\S]*stroke-width:\s*2\.2;[\s\S]*stroke-linecap:\s*round;[\s\S]*stroke-linejoin:\s*round;/.test(css));
+    assert.ok(!overridesSource.includes("chevron.innerHTML"));
+    assert.ok(overridesSource.includes('helpers.createDisclosureChevron("anim-override-chevron")'));
+    assert.ok(/\.collapsible-group-chevron,\s*\.anim-override-chevron\s*\{[\s\S]*display:\s*inline-flex;[\s\S]*align-items:\s*center;[\s\S]*justify-content:\s*center;[\s\S]*width:\s*18px;[\s\S]*height:\s*18px;[\s\S]*opacity:\s*0\.72;/.test(css));
+    assert.ok(/\.collapsible-group-chevron,\s*\.anim-override-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);[\s\S]*transition:[\s\S]*transform 0\.22s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\),[\s\S]*color 0\.16s ease,[\s\S]*opacity 0\.16s ease/.test(css));
+    assert.ok(/\.collapsible-group-chevron svg,\s*\.anim-override-chevron svg\s*\{[\s\S]*width:\s*16px;[\s\S]*height:\s*16px;[\s\S]*overflow:\s*visible;/.test(css));
+    assert.ok(/\.collapsible-group-chevron path,\s*\.anim-override-chevron path\s*\{[\s\S]*fill:\s*none;[\s\S]*stroke:\s*currentColor;[\s\S]*stroke-width:\s*2\.2;[\s\S]*stroke-linecap:\s*round;[\s\S]*stroke-linejoin:\s*round;/.test(css));
     assert.ok(/\.anim-override-row > summary:hover \.anim-override-chevron\s*\{[\s\S]*color:\s*var\(--text-secondary\);[\s\S]*opacity:\s*0\.95;/.test(css));
     assert.ok(/\.anim-override-row\[open\]\s*>\s*summary\s+\.anim-override-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(90deg\);[\s\S]*color:\s*var\(--accent\);[\s\S]*opacity:\s*1;/.test(css));
     assert.ok(/\.anim-override-thumb\s*\{[\s\S]*transform:\s*translateX\(-3px\);/.test(css));

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -1680,8 +1680,16 @@ describe("settings renderer browser environment", () => {
     assert.ok(coreSource.includes("defaultCollapsed = false"));
     assert.ok(coreSource.includes('header.setAttribute("aria-expanded"'));
     assert.ok(coreSource.includes("collapsibleSummary"));
-    assert.ok(css.includes(".collapsible-group-header"));
-    assert.ok(css.includes(".collapsible-group-chevron"));
+    assert.ok(!coreSource.includes('chevron.textContent = "\\u25B8";'));
+    assert.ok(coreSource.includes('chevron.innerHTML = \'<svg viewBox="0 0 20 20" focusable="false"><path d="M8 5l5 5-5 5" /></svg>\';'));
+    assert.ok(/\.collapsible-group-header\s*\{[\s\S]*gap:\s*4px;/.test(css));
+    assert.ok(/\.collapsible-group-chevron\s*\{[\s\S]*display:\s*inline-flex;[\s\S]*align-items:\s*center;[\s\S]*justify-content:\s*center;[\s\S]*width:\s*18px;[\s\S]*height:\s*18px;[\s\S]*opacity:\s*0\.72;/.test(css));
+    assert.ok(/\.collapsible-group-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);[\s\S]*transition:[\s\S]*transform 0\.22s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\),[\s\S]*color 0\.16s ease,[\s\S]*opacity 0\.16s ease/.test(css));
+    assert.ok(/\.collapsible-group-chevron svg\s*\{[\s\S]*width:\s*16px;[\s\S]*height:\s*16px;[\s\S]*overflow:\s*visible;/.test(css));
+    assert.ok(/\.collapsible-group-chevron path\s*\{[\s\S]*fill:\s*none;[\s\S]*stroke:\s*currentColor;[\s\S]*stroke-width:\s*2\.2;[\s\S]*stroke-linecap:\s*round;[\s\S]*stroke-linejoin:\s*round;/.test(css));
+    assert.ok(/\.collapsible-group-header:hover\s+\.collapsible-group-chevron\s*\{[\s\S]*color:\s*var\(--text-secondary\);[\s\S]*opacity:\s*0\.95;/.test(css));
+    assert.ok(/\.collapsible-group\.collapsed\s+\.collapsible-group-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);/.test(css));
+    assert.ok(/\.collapsible-group:not\(\.collapsed\)\s+\.collapsible-group-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(90deg\);[\s\S]*color:\s*var\(--accent\);[\s\S]*opacity:\s*1;/.test(css));
     assert.ok(i18nSource.includes("collapsibleExpand"));
     assert.ok(i18nSource.includes("collapsibleCollapse"));
   });
@@ -2168,6 +2176,23 @@ describe("settings renderer browser environment", () => {
       overridesSource.includes("resetBtn.disabled = !slot.hasStoredOverride;"),
       "sound override row reset must stay enabled when prefs still contain a stale sound override entry"
     );
+  });
+
+  it("uses the shared SVG chevron treatment for Animation Overrides rows", () => {
+    const overridesSource = fs.readFileSync(path.join(SRC_DIR, "settings-tab-anim-overrides.js"), "utf8");
+    const css = fs.readFileSync(SETTINGS_CSS, "utf8");
+
+    assert.ok(!overridesSource.includes('chevron.textContent = "\\u25B8";'));
+    assert.ok(overridesSource.includes('chevron.innerHTML = \'<svg viewBox="0 0 20 20" focusable="false"><path d="M8 5l5 5-5 5" /></svg>\';'));
+    assert.ok(/\.anim-override-chevron\s*\{[\s\S]*display:\s*inline-flex;[\s\S]*align-items:\s*center;[\s\S]*justify-content:\s*center;[\s\S]*width:\s*18px;[\s\S]*height:\s*18px;[\s\S]*opacity:\s*0\.72;/.test(css));
+    assert.ok(/\.anim-override-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(0deg\);[\s\S]*transition:[\s\S]*transform 0\.22s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\),[\s\S]*color 0\.16s ease,[\s\S]*opacity 0\.16s ease/.test(css));
+    assert.ok(/\.anim-override-chevron svg\s*\{[\s\S]*width:\s*16px;[\s\S]*height:\s*16px;[\s\S]*overflow:\s*visible;/.test(css));
+    assert.ok(/\.anim-override-chevron path\s*\{[\s\S]*fill:\s*none;[\s\S]*stroke:\s*currentColor;[\s\S]*stroke-width:\s*2\.2;[\s\S]*stroke-linecap:\s*round;[\s\S]*stroke-linejoin:\s*round;/.test(css));
+    assert.ok(/\.anim-override-row > summary:hover \.anim-override-chevron\s*\{[\s\S]*color:\s*var\(--text-secondary\);[\s\S]*opacity:\s*0\.95;/.test(css));
+    assert.ok(/\.anim-override-row\[open\]\s*>\s*summary\s+\.anim-override-chevron\s*\{[\s\S]*transform:\s*translateX\(-6px\) rotate\(90deg\);[\s\S]*color:\s*var\(--accent\);[\s\S]*opacity:\s*1;/.test(css));
+    assert.ok(/\.anim-override-thumb\s*\{[\s\S]*transform:\s*translateX\(-3px\);/.test(css));
+    assert.ok(/\.anim-override-summary-text\s*\{[\s\S]*transform:\s*translateX\(-3px\);/.test(css));
+    assert.ok(!/\.anim-override-summary-change\s*\{[\s\S]*translateX\(-3px\)/.test(css));
   });
 
   it("uses captured poster previews for trusted scripted animation override SVGs", () => {


### PR DESCRIPTION
## Summary
- Polishes Settings disclosure chevrons so expandable groups use a consistent SVG icon instead of a small text triangle.
- Applies the same visual treatment to shared Settings collapsible groups and Animation / Sound Overrides rows.
- Preserves existing collapse state, row behavior, Settings persistence, and command handling.

## Problem context
- The previous disclosure indicator was a text glyph, so its size, alignment, and rendering depended on font metrics.
- The first CSS-only refinement made the chevron more visible, but the two-line construction could visually overlap at the corner.
- Animation / Sound Overrides used a separate `<details>` implementation, so it still displayed the old unpolished triangle after the shared Settings groups were updated.

## What changed
- Replaced text disclosure triangles with fixed inline SVG chevrons using rounded stroke caps and joins.
- Unified collapsed, hover, and expanded states with the Settings panel motion language: subtle opacity, accent color on expanded state, and a 0.22s transform transition.
- Adjusted chevron and title alignment so the visual start of expandable rows feels cleaner in both shared collapsible groups and Animation / Sound Overrides.
- Added renderer regression coverage for both shared Settings collapsible groups and Animation / Sound Overrides rows.

## Behavior after this PR
- Expandable Settings sections show a cleaner right/down SVG chevron instead of a small text triangle.
- Animation / Sound Overrides rows now match the same disclosure style as the rest of Settings.
- Right-side action buttons in Animation / Sound Overrides are not shifted; only the left content group is optically adjusted.
- Existing collapse persistence, row click behavior, preview controls, and Settings data flow are unchanged.

## Validation
- `node --test test/settings-renderer-browser-env.test.js test/settings-controller.test.js test/settings-actions.test.js`
- `node --check src/settings-tab-anim-overrides.js`
- `node --check src/settings-ui-core.js`
- `git diff --check`
- `npm test`

## Platform note
- Automated verification ran on Windows with Node's built-in test runner.
- Manual Electron Settings review is still recommended for final pixel-level visual judgment, especially on high-DPI displays.
