### PR TITLE
fix: fill readme contributors table row

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -268,9 +268,9 @@ Clawd をより良くしてくれたすべての方に感謝します。
     <td align="center" valign="top" width="110"><a href="https://github.com/joshua-wu"><img src="https://github.com/joshua-wu.png" width="50" style="border-radius:50%" /><br /><sub>joshua-wu</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/nmsn"><img src="https://github.com/nmsn.png" width="50" style="border-radius:50%" /><br /><sub>nmsn</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/sunnysonx"><img src="https://github.com/sunnysonx.png" width="50" style="border-radius:50%" /><br /><sub>sunnysonx</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/YuChenYunn"><img src="https://github.com/YuChenYunn.png" width="50" style="border-radius:50%" /><br /><sub>YuChenYunn</sub></a></td>
   </tr>
   <tr>
-    <td align="center" valign="top" width="110"><a href="https://github.com/YuChenYunn"><img src="https://github.com/YuChenYunn.png" width="50" style="border-radius:50%" /><br /><sub>YuChenYunn</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/jhseo-b"><img src="https://github.com/jhseo-b.png" width="50" style="border-radius:50%" /><br /><sub>jhseo-b</sub></a></td>
   </tr>
 </table>

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -266,9 +266,9 @@ Clawd를 더 좋게 만드는 데 도움을 준 모든 분들께 감사합니다
     <td align="center" valign="top" width="110"><a href="https://github.com/joshua-wu"><img src="https://github.com/joshua-wu.png" width="50" style="border-radius:50%" /><br /><sub>joshua-wu</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/nmsn"><img src="https://github.com/nmsn.png" width="50" style="border-radius:50%" /><br /><sub>nmsn</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/sunnysonx"><img src="https://github.com/sunnysonx.png" width="50" style="border-radius:50%" /><br /><sub>sunnysonx</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/YuChenYunn"><img src="https://github.com/YuChenYunn.png" width="50" style="border-radius:50%" /><br /><sub>YuChenYunn</sub></a></td>
   </tr>
   <tr>
-    <td align="center" valign="top" width="110"><a href="https://github.com/YuChenYunn"><img src="https://github.com/YuChenYunn.png" width="50" style="border-radius:50%" /><br /><sub>YuChenYunn</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/jhseo-b"><img src="https://github.com/jhseo-b.png" width="50" style="border-radius:50%" /><br /><sub>jhseo-b</sub></a></td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -269,9 +269,9 @@ Thanks to everyone who has helped make Clawd better:
     <td align="center" valign="top" width="110"><a href="https://github.com/joshua-wu"><img src="https://github.com/joshua-wu.png" width="50" style="border-radius:50%" /><br /><sub>joshua-wu</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/nmsn"><img src="https://github.com/nmsn.png" width="50" style="border-radius:50%" /><br /><sub>nmsn</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/sunnysonx"><img src="https://github.com/sunnysonx.png" width="50" style="border-radius:50%" /><br /><sub>sunnysonx</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/YuChenYunn"><img src="https://github.com/YuChenYunn.png" width="50" style="border-radius:50%" /><br /><sub>YuChenYunn</sub></a></td>
   </tr>
   <tr>
-    <td align="center" valign="top" width="110"><a href="https://github.com/YuChenYunn"><img src="https://github.com/YuChenYunn.png" width="50" style="border-radius:50%" /><br /><sub>YuChenYunn</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/jhseo-b"><img src="https://github.com/jhseo-b.png" width="50" style="border-radius:50%" /><br /><sub>jhseo-b</sub></a></td>
   </tr>
 </table>

--- a/test/readme-contributors.test.js
+++ b/test/readme-contributors.test.js
@@ -9,14 +9,18 @@ const ROOT = path.join(__dirname, "..");
 const TABLE_READMES = ["README.md", "README.ko-KR.md", "README.ja-JP.md"];
 
 function extractContributorTable(markdown, filename) {
-  const tables = [...markdown.matchAll(/<table>[\s\S]*?<\/table>/g)].map(
-    (match) => match[0],
-  );
-  const match = tables.find(
-    (table) => table.includes("PixelCookie-zyf") && table.includes("jhseo-b"),
-  );
-  assert.ok(match, `${filename} should contain the contributors table`);
-  return match;
+  const tables = [...markdown.matchAll(/<table>[\s\S]*?<\/table>/g)]
+    .map((match) => match[0])
+    .map((table) => ({
+      table,
+      cellCount: countCells(table),
+      githubAvatarCount: (table.match(/https:\/\/github\.com\/[^"\s]+\.png/g) || [])
+        .length,
+    }))
+    .filter((candidate) => candidate.githubAvatarCount > 0)
+    .sort((left, right) => right.cellCount - left.cellCount);
+  assert.ok(tables.length > 0, `${filename} should contain a contributors table`);
+  return tables[0].table;
 }
 
 function getRows(table) {
@@ -27,20 +31,37 @@ function countCells(row) {
   return (row.match(/<td\s/g) || []).length;
 }
 
-for (const filename of TABLE_READMES) {
-  test(`${filename} fills the penultimate contributors row`, () => {
-    const markdown = fs.readFileSync(path.join(ROOT, filename), "utf8");
-    const rows = getRows(extractContributorTable(markdown, filename));
-    const cellCounts = rows.map(countCells);
-    const totalCells = cellCounts.reduce((sum, count) => sum + count, 0);
-    const penultimateRow = rows[rows.length - 2];
-    const finalRow = rows[rows.length - 1];
+function getContributorShape(filename) {
+  const markdown = fs.readFileSync(path.join(ROOT, filename), "utf8");
+  const rows = getRows(extractContributorTable(markdown, filename));
+  const cellCounts = rows.map(countCells);
+  const totalCells = cellCounts.reduce((sum, count) => sum + count, 0);
 
-    assert.strictEqual(totalCells, 43);
-    assert.strictEqual(cellCounts[cellCounts.length - 2], 7);
-    assert.match(penultimateRow, /sunnysonx/);
-    assert.match(penultimateRow, /YuChenYunn/);
-    assert.strictEqual(cellCounts[cellCounts.length - 1], 1);
-    assert.match(finalRow, /jhseo-b/);
-  });
+  assert.ok(rows.length >= 2, `${filename} should have at least two contributor rows`);
+  assert.ok(totalCells > 0, `${filename} should contain contributor cells`);
+
+  for (const [index, count] of cellCounts.slice(0, -1).entries()) {
+    assert.strictEqual(count, 7, `${filename} row ${index + 1} should be full`);
+  }
+
+  const finalRowCount = cellCounts[cellCounts.length - 1];
+  assert.ok(
+    finalRowCount >= 1 && finalRowCount <= 7,
+    `${filename} final row should contain between 1 and 7 contributors`,
+  );
+
+  return cellCounts;
 }
+
+test("table-based README contributor grids are filled consistently", () => {
+  const [baselineFile, ...localizedFiles] = TABLE_READMES;
+  const baselineShape = getContributorShape(baselineFile);
+
+  for (const filename of localizedFiles) {
+    assert.deepStrictEqual(
+      getContributorShape(filename),
+      baselineShape,
+      `${filename} should match ${baselineFile}'s contributor row shape`,
+    );
+  }
+});

--- a/test/readme-contributors.test.js
+++ b/test/readme-contributors.test.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const ROOT = path.join(__dirname, "..");
+const TABLE_READMES = ["README.md", "README.ko-KR.md", "README.ja-JP.md"];
+
+function extractContributorTable(markdown, filename) {
+  const tables = [...markdown.matchAll(/<table>[\s\S]*?<\/table>/g)].map(
+    (match) => match[0],
+  );
+  const match = tables.find(
+    (table) => table.includes("PixelCookie-zyf") && table.includes("jhseo-b"),
+  );
+  assert.ok(match, `${filename} should contain the contributors table`);
+  return match;
+}
+
+function getRows(table) {
+  return [...table.matchAll(/<tr>([\s\S]*?)<\/tr>/g)].map((match) => match[1]);
+}
+
+function countCells(row) {
+  return (row.match(/<td\s/g) || []).length;
+}
+
+for (const filename of TABLE_READMES) {
+  test(`${filename} fills the penultimate contributors row`, () => {
+    const markdown = fs.readFileSync(path.join(ROOT, filename), "utf8");
+    const rows = getRows(extractContributorTable(markdown, filename));
+    const cellCounts = rows.map(countCells);
+    const totalCells = cellCounts.reduce((sum, count) => sum + count, 0);
+    const penultimateRow = rows[rows.length - 2];
+    const finalRow = rows[rows.length - 1];
+
+    assert.strictEqual(totalCells, 43);
+    assert.strictEqual(cellCounts[cellCounts.length - 2], 7);
+    assert.match(penultimateRow, /sunnysonx/);
+    assert.match(penultimateRow, /YuChenYunn/);
+    assert.strictEqual(cellCounts[cellCounts.length - 1], 1);
+    assert.match(finalRow, /jhseo-b/);
+  });
+}


### PR DESCRIPTION
## Summary
- Fixes the blank final cell in the penultimate contributors row shown in the README contributors grid.
- Moves `YuChenYunn` into the previous table row so the 7-column contributors table remains visually filled before the final carry-over row.
- Keeps the contributor list and ordering otherwise unchanged across the table-based README variants.

## Problem context
- The English, Korean, and Japanese READMEs render contributors as a 7-column HTML table.
- The penultimate row previously contained only six contributors, while `YuChenYunn` started the final row with `jhseo-b`.
- GitHub table rendering therefore showed an empty cell at the end of the penultimate row, matching the visible blank space in the contributors section.

## What changed
- Updated `README.md`, `README.ko-KR.md`, and `README.ja-JP.md` so `YuChenYunn` fills the last cell of the penultimate row.
- Left `jhseo-b` as the only contributor in the final row.
- Added a README contributors regression test that finds the table-based contributors grids, verifies every non-final row is full, and checks localized README row shapes stay consistent with the English README without hard-coding the contributor count.

## Behavior after this PR
- The contributors grid no longer shows a blank final cell in the penultimate row.
- Future contributor additions/removals should not require updating a fixed test count as long as the table shape remains valid.
- The Chinese README is unchanged because it uses a non-table inline avatar layout and does not have this blank-cell issue.

## Validation
- `node --test test/readme-contributors.test.js`
- `git diff --check`
- `npm test` passed locally with 2082 passing tests, 0 failures, and 2 skipped tests.

## Platform note
- Automated verification ran on Windows in the local repository.
- No Electron manual QA is required because this PR only changes README table markup and a Node-based regression test.
