### PR TITLE
feat: route Go to Terminal to Superset / iTerm2 / Ghostty

### DIFF
--- a/src/bubble.html
+++ b/src/bubble.html
@@ -973,7 +973,7 @@ function renderElicitationTerminalFallback() {
   btn.addEventListener("click", () => {
     btn.textContent = "...";
     disableAll();
-    window.bubbleAPI.decide("deny");
+    window.bubbleAPI.decide("deny-and-focus");
   });
   suggestionsContainer.appendChild(btn);
 }

--- a/src/focus.js
+++ b/src/focus.js
@@ -11,6 +11,229 @@ const isMac = process.platform === "darwin";
 const isWin = process.platform === "win32";
 const isLinux = process.platform === "linux";
 
+// Shared between the closure-scoped focus pipeline below and the
+// module-level helpers further down.
+const MAC_FOCUS_TIMEOUT_MS = 1500;
+
+// ── Mac-only: specialized focus paths ────────────────────────────────────────
+// These cover terminal hosts the generic `set frontmost of process` script
+// cannot reach correctly:
+//   • Superset.app — multi-workspace Electron host. Generic frontmost only
+//     activates the app, not the specific worktree workspace. Resolved via the
+//     reverse-engineered `superset://workspace/<id>` URL scheme (observed
+//     2026-05-08). `open` is given `-b com.superset.desktop` so a stale DMG
+//     copy registered with LaunchServices cannot intercept the deep link.
+//   • iTerm2 — multiple sessions per window. Match by tty so the right tab
+//     is selected even when many shells share one window.
+//   • Ghostty — public AppleScript dictionary; pick the terminal whose
+//     `working directory` matches cwd and call `focus` on it (raises window
+//     and selects the matching terminal in one step).
+//
+// Pure helpers (no side effects beyond stat / sqlite3 read) are exported via
+// `module.exports.__test` so unit tests can exercise them without standing up
+// the full Electron context.
+
+const SUPERSET_BUNDLE_ID = "com.superset.desktop";
+
+function findSupersetDataDirs(homeDir) {
+  // Superset by default lives in ~/.superset, but custom instances use
+  // `~/.superset-<name>` and the matching URL scheme `superset-<name>://`.
+  const home = homeDir || os.homedir();
+  try {
+    return fs.readdirSync(home, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name.startsWith(".superset"))
+      .map((e) => path.join(home, e.name))
+      .filter((dir) => {
+        try { return fs.existsSync(path.join(dir, "local.db")); }
+        catch { return false; }
+      });
+  } catch { return []; }
+}
+
+function supersetSchemeForDir(dir) {
+  const base = path.basename(dir);
+  if (base === ".superset") return "superset";
+  if (base.startsWith(".superset-")) return `superset-${base.slice(".superset-".length)}`;
+  return null;
+}
+
+function querySupersetWorkspaceId(dbPath, cwd) {
+  if (!cwd) return null;
+  const candidates = [cwd];
+  try {
+    const real = fs.realpathSync(cwd);
+    if (real && real !== cwd) candidates.push(real);
+  } catch {}
+  for (const candidate of candidates) {
+    const escaped = candidate.replace(/'/g, "''");
+    const sql = `SELECT ws.id FROM workspaces ws JOIN worktrees w ON w.id = ws.worktree_id WHERE w.path = '${escaped}' ORDER BY COALESCE(ws.last_opened_at, 0) DESC LIMIT 1;`;
+    try {
+      const out = execFileSync("sqlite3", ["-readonly", dbPath, sql], {
+        encoding: "utf8",
+        timeout: 1500,
+      }).trim();
+      if (out) return out;
+    } catch {}
+  }
+  return null;
+}
+
+function tryFocusSuperset(cwd, callback) {
+  if (!cwd) return callback(false);
+  const dirs = findSupersetDataDirs();
+  if (!dirs.length) return callback(false);
+  for (const dir of dirs) {
+    const id = querySupersetWorkspaceId(path.join(dir, "local.db"), cwd);
+    if (!id) continue;
+    const scheme = supersetSchemeForDir(dir);
+    if (!scheme) continue;
+    const url = `${scheme}://workspace/${id}`;
+    // `-b` pins the deep link to the running Superset bundle. Without it,
+    // LaunchServices may route the URL to a stale DMG copy that still claims
+    // the `superset://` scheme.
+    execFile("/usr/bin/open", ["-b", SUPERSET_BUNDLE_ID, url], { timeout: 1500 }, (err) => {
+      if (err) console.warn("focusSuperset failed:", err.message);
+      callback(!err);
+    });
+    return;
+  }
+  callback(false);
+}
+
+function getTtyFromPids(pids) {
+  if (!Array.isArray(pids)) return null;
+  for (const pid of pids) {
+    if (!Number.isFinite(pid) || pid <= 0) continue;
+    try {
+      const out = execFileSync("ps", ["-o", "tty=", "-p", String(pid)], {
+        encoding: "utf8",
+        timeout: 500,
+      }).trim();
+      if (out && out !== "??" && out !== "?" && out !== "-") return out;
+    } catch {}
+  }
+  return null;
+}
+
+function isAppRunning(processName, callback) {
+  const escaped = processName.replace(/"/g, '\\"');
+  const script = `tell application "System Events" to return (name of processes) contains "${escaped}"`;
+  execFile("osascript", ["-e", script], { timeout: 1000 }, (err, stdout) => {
+    if (err) return callback(false);
+    callback(/true/i.test(String(stdout).trim()));
+  });
+}
+
+function tryFocusITerm(pidCandidates, callback) {
+  isAppRunning("iTerm2", (running) => {
+    if (!running) return callback(false);
+    const tty = getTtyFromPids(pidCandidates);
+    if (!tty) return callback(false);
+    // tty from `ps` is "ttys001"; iTerm exposes "/dev/ttys001". Match by suffix.
+    const ttyEsc = tty.replace(/"/g, '\\"');
+    const script = `
+      tell application "iTerm2"
+        activate
+        repeat with w in windows
+          repeat with t in tabs of w
+            repeat with s in sessions of t
+              if tty of s ends with "${ttyEsc}" then
+                select s
+                return "ok"
+              end if
+            end repeat
+          end repeat
+        end repeat
+        return "miss"
+      end tell`;
+    execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err, stdout) => {
+      if (err) return callback(false);
+      callback(/^ok/.test(String(stdout).trim()));
+    });
+  });
+}
+
+function tryFocusGhostty(cwd, callback) {
+  if (!cwd) return callback(false);
+  // Ghostty's macOS bundle name (and AppleScript identifier) is "Ghostty".
+  isAppRunning("Ghostty", (running) => {
+    if (!running) return callback(false);
+    // Ghostty's scripting dictionary exposes `working directory` on terminal
+    // objects and a `focus` command that activates the surface and raises the
+    // owning window — match cwd directly instead of falling back to title
+    // heuristics. Try realpath as well so symlinked cwds still resolve.
+    const candidates = [cwd];
+    try {
+      const real = fs.realpathSync(cwd);
+      if (real && real !== cwd) candidates.push(real);
+    } catch {}
+    const escapeAS = (s) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const literalList = candidates.map((c) => `"${escapeAS(c)}"`).join(", ");
+    const script = `
+      tell application "Ghostty"
+        set targetCwds to {${literalList}}
+        repeat with cwdLiteral in targetCwds
+          set matches to every terminal whose working directory is cwdLiteral
+          if (count of matches) > 0 then
+            focus (item 1 of matches)
+            return "ok"
+          end if
+        end repeat
+        return "miss"
+      end tell`;
+    execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err, stdout) => {
+      if (err) return callback(false);
+      callback(/^ok/.test(String(stdout).trim()));
+    });
+  });
+}
+
+function buildPidCandidates(sourcePid, pidChain) {
+  const out = [];
+  if (Number.isFinite(sourcePid) && sourcePid > 0) out.push(sourcePid);
+  if (Array.isArray(pidChain)) {
+    for (const pid of pidChain) {
+      if (!Number.isFinite(pid) || pid <= 0 || out.includes(pid)) continue;
+      out.push(pid);
+    }
+  }
+  return out;
+}
+
+function trySpecialMacFocus(sourcePid, cwd, pidChain, callback) {
+  const pidCandidates = buildPidCandidates(sourcePid, pidChain);
+  tryFocusSuperset(cwd, (ok) => {
+    if (ok) return callback(true, pidCandidates);
+    tryFocusITerm(pidCandidates, (ok2) => {
+      if (ok2) return callback(true, pidCandidates);
+      tryFocusGhostty(cwd, (ok3) => callback(!!ok3, pidCandidates));
+    });
+  });
+}
+
+function runGenericMacFocus(pidCandidates, onDone) {
+  if (!pidCandidates || !pidCandidates.length) {
+    if (onDone) onDone();
+    return;
+  }
+  const applePidList = pidCandidates.join(", ");
+  const script = `
+    tell application "System Events"
+      repeat with targetPid in {${applePidList}}
+        set pidValue to contents of targetPid
+        set pList to every process whose unix id is pidValue
+        if (count of pList) > 0 then
+          set frontmost of item 1 of pList to true
+          exit repeat
+        end if
+      end repeat
+    end tell`;
+  execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err) => {
+    if (err) console.warn("focusTerminal macOS failed:", err.message);
+    if (onDone) onDone();
+  });
+}
+
 module.exports = function initFocus(ctx) {
 
 const PS_FOCUS_ADDTYPE = `
@@ -122,7 +345,9 @@ if (-not $focused) {${wtTitleMatch}
 let psProc = null;
 // macOS Accessibility/System Events calls can pile up fast, so serialize focus attempts.
 const MAC_FOCUS_THROTTLE_MS = 1500;
-const MAC_FOCUS_TIMEOUT_MS = 1500;
+// MAC_FOCUS_TIMEOUT_MS is declared at module scope above so the
+// closure-internal mac focus pipeline and the top-level Superset/iTerm/Ghostty
+// helpers share the same value.
 let macFocusInFlight = false;
 let macFocusLastRunAt = 0;
 let macFocusLastPid = null;
@@ -261,208 +486,14 @@ function focusTerminalWindow(sourcePid, cwd, editor, pidChain) {
   scheduleTerminalTabFocus(editor, pidChain);
 }
 
-// ── Mac-only: specialized focus paths ────────────────────────────────────────
-// These cover terminal hosts the generic `set frontmost of process` script
-// cannot reach correctly:
-//   • Superset.app — multi-workspace Electron host. Generic frontmost only
-//     activates the app, not the specific worktree workspace. Resolved via the
-//     reverse-engineered `superset://workspace/<id>` URL scheme (observed
-//     2026-05-08).
-//   • iTerm2 — multiple sessions per window. Match by tty so the right tab
-//     is selected even when many shells share one window.
-//   • Ghostty — no public IPC; rely on window title containing the cwd
-//     basename. Users need a shell prompt that updates the OSC 2 title.
-
-function findSupersetDataDirs() {
-  // Superset by default lives in ~/.superset, but custom instances use
-  // `~/.superset-<name>` and the matching URL scheme `superset-<name>://`.
-  try {
-    const home = os.homedir();
-    return fs.readdirSync(home, { withFileTypes: true })
-      .filter((e) => e.isDirectory() && e.name.startsWith(".superset"))
-      .map((e) => path.join(home, e.name))
-      .filter((dir) => {
-        try { return fs.existsSync(path.join(dir, "local.db")); }
-        catch { return false; }
-      });
-  } catch { return []; }
-}
-
-function supersetSchemeForDir(dir) {
-  const base = path.basename(dir);
-  return base === ".superset" ? "superset" : `superset-${base.slice(".superset-".length)}`;
-}
-
-function querySupersetWorkspaceId(dbPath, cwd) {
-  if (!cwd) return null;
-  const candidates = [cwd];
-  try {
-    const real = fs.realpathSync(cwd);
-    if (real && real !== cwd) candidates.push(real);
-  } catch {}
-  for (const candidate of candidates) {
-    const escaped = candidate.replace(/'/g, "''");
-    const sql = `SELECT ws.id FROM workspaces ws JOIN worktrees w ON w.id = ws.worktree_id WHERE w.path = '${escaped}' ORDER BY COALESCE(ws.last_opened_at, 0) DESC LIMIT 1;`;
-    try {
-      const out = execFileSync("sqlite3", ["-readonly", dbPath, sql], {
-        encoding: "utf8",
-        timeout: 1500,
-      }).trim();
-      if (out) return out;
-    } catch {}
-  }
-  return null;
-}
-
-function tryFocusSuperset(cwd, callback) {
-  if (!cwd) return callback(false);
-  const dirs = findSupersetDataDirs();
-  if (!dirs.length) return callback(false);
-  for (const dir of dirs) {
-    const id = querySupersetWorkspaceId(path.join(dir, "local.db"), cwd);
-    if (!id) continue;
-    const url = `${supersetSchemeForDir(dir)}://workspace/${id}`;
-    execFile("/usr/bin/open", [url], { timeout: 1500 }, (err) => {
-      if (err) console.warn("focusSuperset failed:", err.message);
-      callback(!err);
-    });
-    return;
-  }
-  callback(false);
-}
-
-function getTtyFromPids(pids) {
-  for (const pid of pids) {
-    if (!Number.isFinite(pid) || pid <= 0) continue;
-    try {
-      const out = execFileSync("ps", ["-o", "tty=", "-p", String(pid)], {
-        encoding: "utf8",
-        timeout: 500,
-      }).trim();
-      if (out && out !== "??" && out !== "?" && out !== "-") return out;
-    } catch {}
-  }
-  return null;
-}
-
-function isAppRunning(processName, callback) {
-  const escaped = processName.replace(/"/g, '\\"');
-  const script = `tell application "System Events" to return (name of processes) contains "${escaped}"`;
-  execFile("osascript", ["-e", script], { timeout: 1000 }, (err, stdout) => {
-    if (err) return callback(false);
-    callback(/true/i.test(String(stdout).trim()));
-  });
-}
-
-function tryFocusITerm(pidCandidates, callback) {
-  isAppRunning("iTerm2", (running) => {
-    if (!running) return callback(false);
-    const tty = getTtyFromPids(pidCandidates);
-    if (!tty) return callback(false);
-    // tty from `ps` is "ttys001"; iTerm exposes "/dev/ttys001". Match by suffix.
-    const ttyEsc = tty.replace(/"/g, '\\"');
-    const script = `
-      tell application "iTerm2"
-        activate
-        repeat with w in windows
-          repeat with t in tabs of w
-            repeat with s in sessions of t
-              if tty of s ends with "${ttyEsc}" then
-                select s
-                return "ok"
-              end if
-            end repeat
-          end repeat
-        end repeat
-        return "miss"
-      end tell`;
-    execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err, stdout) => {
-      if (err) return callback(false);
-      callback(/^ok/.test(String(stdout).trim()));
-    });
-  });
-}
-
-function tryFocusGhostty(cwd, callback) {
-  if (!cwd) return callback(false);
-  isAppRunning("ghostty", (running) => {
-    if (!running) return callback(false);
-    const title = path.basename(cwd);
-    if (!title) return callback(false);
-    const titleEsc = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
-    const script = `
-      tell application "ghostty" to activate
-      tell application "System Events"
-        tell process "ghostty"
-          repeat with w in windows
-            try
-              if title of w contains "${titleEsc}" then
-                perform action "AXRaise" of w
-                return "ok"
-              end if
-            end try
-          end repeat
-        end tell
-      end tell
-      return "miss"`;
-    execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err, stdout) => {
-      if (err) return callback(false);
-      callback(/^ok/.test(String(stdout).trim()));
-    });
-  });
-}
-
-function trySpecialMacFocus(sourcePid, cwd, pidChain, callback) {
-  const pidCandidates = [sourcePid];
-  if (Array.isArray(pidChain)) {
-    for (const pid of pidChain) {
-      if (!Number.isFinite(pid) || pid <= 0 || pidCandidates.includes(pid)) continue;
-      pidCandidates.push(pid);
-    }
-  }
-  tryFocusSuperset(cwd, (ok) => {
-    if (ok) return callback(true);
-    tryFocusITerm(pidCandidates, (ok2) => {
-      if (ok2) return callback(true);
-      tryFocusGhostty(cwd, (ok3) => callback(!!ok3));
-    });
-  });
-}
-
-function runGenericMacFocus(pidCandidates, onDone) {
-  const applePidList = pidCandidates.join(", ");
-  const script = `
-    tell application "System Events"
-      repeat with targetPid in {${applePidList}}
-        set pidValue to contents of targetPid
-        set pList to every process whose unix id is pidValue
-        if (count of pList) > 0 then
-          set frontmost of item 1 of pList to true
-          exit repeat
-        end if
-      end repeat
-    end tell`;
-  execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err) => {
-    if (err) console.warn("focusTerminal macOS failed:", err.message);
-    if (onDone) onDone();
-  });
-}
-
 function focusTerminalWindowLegacy(sourcePid, cwd, onDone, pidChain) {
   if (isMac) {
-    const pidCandidates = [sourcePid];
-    if (Array.isArray(pidChain)) {
-      for (const pid of pidChain) {
-        if (!Number.isFinite(pid) || pid <= 0 || pidCandidates.includes(pid)) continue;
-        pidCandidates.push(pid);
-        if (pidCandidates.length >= 3) break;
-      }
-    }
-
     // Try Superset / iTerm2 / Ghostty in order; fall back to generic
     // osascript frontmost when no specialized path matches. Each step is
-    // best-effort and short-circuits the chain on success.
-    trySpecialMacFocus(sourcePid, cwd, pidChain, (focused) => {
+    // best-effort and short-circuits the chain on success. The chain builds
+    // the pid candidate list once and hands it to the generic fallback so
+    // there is exactly one source of truth for which pids to try.
+    trySpecialMacFocus(sourcePid, cwd, pidChain, (focused, pidCandidates) => {
       if (focused) { if (onDone) onDone(); return; }
       runGenericMacFocus(pidCandidates, onDone);
     });
@@ -537,4 +568,14 @@ function cleanup() {
 
 return { initFocusHelper, killFocusHelper, focusTerminalWindow, clearMacFocusCooldownTimer, cleanup };
 
+};
+
+// Exposed for unit tests — these helpers do not depend on the closure state
+// and can be exercised in isolation.
+module.exports.__test = {
+  findSupersetDataDirs,
+  supersetSchemeForDir,
+  querySupersetWorkspaceId,
+  getTtyFromPids,
+  buildPidCandidates,
 };

--- a/src/focus.js
+++ b/src/focus.js
@@ -1,9 +1,11 @@
 // src/focus.js — Terminal focus system (PowerShell persistent process + macOS osascript)
 // Extracted from main.js L1030-1335
 
+const fs = require("fs");
 const http = require("http");
+const os = require("os");
 const path = require("path");
-const { execFile, spawn } = require("child_process");
+const { execFile, execFileSync, spawn } = require("child_process");
 
 const isMac = process.platform === "darwin";
 const isWin = process.platform === "win32";
@@ -259,6 +261,193 @@ function focusTerminalWindow(sourcePid, cwd, editor, pidChain) {
   scheduleTerminalTabFocus(editor, pidChain);
 }
 
+// ── Mac-only: specialized focus paths ────────────────────────────────────────
+// These cover terminal hosts the generic `set frontmost of process` script
+// cannot reach correctly:
+//   • Superset.app — multi-workspace Electron host. Generic frontmost only
+//     activates the app, not the specific worktree workspace. Resolved via the
+//     reverse-engineered `superset://workspace/<id>` URL scheme (observed
+//     2026-05-08).
+//   • iTerm2 — multiple sessions per window. Match by tty so the right tab
+//     is selected even when many shells share one window.
+//   • Ghostty — no public IPC; rely on window title containing the cwd
+//     basename. Users need a shell prompt that updates the OSC 2 title.
+
+function findSupersetDataDirs() {
+  // Superset by default lives in ~/.superset, but custom instances use
+  // `~/.superset-<name>` and the matching URL scheme `superset-<name>://`.
+  try {
+    const home = os.homedir();
+    return fs.readdirSync(home, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name.startsWith(".superset"))
+      .map((e) => path.join(home, e.name))
+      .filter((dir) => {
+        try { return fs.existsSync(path.join(dir, "local.db")); }
+        catch { return false; }
+      });
+  } catch { return []; }
+}
+
+function supersetSchemeForDir(dir) {
+  const base = path.basename(dir);
+  return base === ".superset" ? "superset" : `superset-${base.slice(".superset-".length)}`;
+}
+
+function querySupersetWorkspaceId(dbPath, cwd) {
+  if (!cwd) return null;
+  const candidates = [cwd];
+  try {
+    const real = fs.realpathSync(cwd);
+    if (real && real !== cwd) candidates.push(real);
+  } catch {}
+  for (const candidate of candidates) {
+    const escaped = candidate.replace(/'/g, "''");
+    const sql = `SELECT ws.id FROM workspaces ws JOIN worktrees w ON w.id = ws.worktree_id WHERE w.path = '${escaped}' ORDER BY COALESCE(ws.last_opened_at, 0) DESC LIMIT 1;`;
+    try {
+      const out = execFileSync("sqlite3", ["-readonly", dbPath, sql], {
+        encoding: "utf8",
+        timeout: 1500,
+      }).trim();
+      if (out) return out;
+    } catch {}
+  }
+  return null;
+}
+
+function tryFocusSuperset(cwd, callback) {
+  if (!cwd) return callback(false);
+  const dirs = findSupersetDataDirs();
+  if (!dirs.length) return callback(false);
+  for (const dir of dirs) {
+    const id = querySupersetWorkspaceId(path.join(dir, "local.db"), cwd);
+    if (!id) continue;
+    const url = `${supersetSchemeForDir(dir)}://workspace/${id}`;
+    execFile("/usr/bin/open", [url], { timeout: 1500 }, (err) => {
+      if (err) console.warn("focusSuperset failed:", err.message);
+      callback(!err);
+    });
+    return;
+  }
+  callback(false);
+}
+
+function getTtyFromPids(pids) {
+  for (const pid of pids) {
+    if (!Number.isFinite(pid) || pid <= 0) continue;
+    try {
+      const out = execFileSync("ps", ["-o", "tty=", "-p", String(pid)], {
+        encoding: "utf8",
+        timeout: 500,
+      }).trim();
+      if (out && out !== "??" && out !== "?" && out !== "-") return out;
+    } catch {}
+  }
+  return null;
+}
+
+function isAppRunning(processName, callback) {
+  const escaped = processName.replace(/"/g, '\\"');
+  const script = `tell application "System Events" to return (name of processes) contains "${escaped}"`;
+  execFile("osascript", ["-e", script], { timeout: 1000 }, (err, stdout) => {
+    if (err) return callback(false);
+    callback(/true/i.test(String(stdout).trim()));
+  });
+}
+
+function tryFocusITerm(pidCandidates, callback) {
+  isAppRunning("iTerm2", (running) => {
+    if (!running) return callback(false);
+    const tty = getTtyFromPids(pidCandidates);
+    if (!tty) return callback(false);
+    // tty from `ps` is "ttys001"; iTerm exposes "/dev/ttys001". Match by suffix.
+    const ttyEsc = tty.replace(/"/g, '\\"');
+    const script = `
+      tell application "iTerm2"
+        activate
+        repeat with w in windows
+          repeat with t in tabs of w
+            repeat with s in sessions of t
+              if tty of s ends with "${ttyEsc}" then
+                select s
+                return "ok"
+              end if
+            end repeat
+          end repeat
+        end repeat
+        return "miss"
+      end tell`;
+    execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err, stdout) => {
+      if (err) return callback(false);
+      callback(/^ok/.test(String(stdout).trim()));
+    });
+  });
+}
+
+function tryFocusGhostty(cwd, callback) {
+  if (!cwd) return callback(false);
+  isAppRunning("ghostty", (running) => {
+    if (!running) return callback(false);
+    const title = path.basename(cwd);
+    if (!title) return callback(false);
+    const titleEsc = title.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+    const script = `
+      tell application "ghostty" to activate
+      tell application "System Events"
+        tell process "ghostty"
+          repeat with w in windows
+            try
+              if title of w contains "${titleEsc}" then
+                perform action "AXRaise" of w
+                return "ok"
+              end if
+            end try
+          end repeat
+        end tell
+      end tell
+      return "miss"`;
+    execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err, stdout) => {
+      if (err) return callback(false);
+      callback(/^ok/.test(String(stdout).trim()));
+    });
+  });
+}
+
+function trySpecialMacFocus(sourcePid, cwd, pidChain, callback) {
+  const pidCandidates = [sourcePid];
+  if (Array.isArray(pidChain)) {
+    for (const pid of pidChain) {
+      if (!Number.isFinite(pid) || pid <= 0 || pidCandidates.includes(pid)) continue;
+      pidCandidates.push(pid);
+    }
+  }
+  tryFocusSuperset(cwd, (ok) => {
+    if (ok) return callback(true);
+    tryFocusITerm(pidCandidates, (ok2) => {
+      if (ok2) return callback(true);
+      tryFocusGhostty(cwd, (ok3) => callback(!!ok3));
+    });
+  });
+}
+
+function runGenericMacFocus(pidCandidates, onDone) {
+  const applePidList = pidCandidates.join(", ");
+  const script = `
+    tell application "System Events"
+      repeat with targetPid in {${applePidList}}
+        set pidValue to contents of targetPid
+        set pList to every process whose unix id is pidValue
+        if (count of pList) > 0 then
+          set frontmost of item 1 of pList to true
+          exit repeat
+        end if
+      end repeat
+    end tell`;
+  execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err) => {
+    if (err) console.warn("focusTerminal macOS failed:", err.message);
+    if (onDone) onDone();
+  });
+}
+
 function focusTerminalWindowLegacy(sourcePid, cwd, onDone, pidChain) {
   if (isMac) {
     const pidCandidates = [sourcePid];
@@ -269,21 +458,13 @@ function focusTerminalWindowLegacy(sourcePid, cwd, onDone, pidChain) {
         if (pidCandidates.length >= 3) break;
       }
     }
-    const applePidList = pidCandidates.join(", ");
-    const script = `
-      tell application "System Events"
-        repeat with targetPid in {${applePidList}}
-          set pidValue to contents of targetPid
-          set pList to every process whose unix id is pidValue
-          if (count of pList) > 0 then
-            set frontmost of item 1 of pList to true
-            exit repeat
-          end if
-        end repeat
-      end tell`;
-    execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err) => {
-      if (err) console.warn("focusTerminal macOS failed:", err.message);
-      if (onDone) onDone();
+
+    // Try Superset / iTerm2 / Ghostty in order; fall back to generic
+    // osascript frontmost when no specialized path matches. Each step is
+    // best-effort and short-circuits the chain on success.
+    trySpecialMacFocus(sourcePid, cwd, pidChain, (focused) => {
+      if (focused) { if (onDone) onDone(); return; }
+      runGenericMacFocus(pidCandidates, onDone);
     });
     return;
   }

--- a/test/bubble-elicitation-stepper.test.js
+++ b/test/bubble-elicitation-stepper.test.js
@@ -68,7 +68,7 @@ describe("AskUserQuestion bubble stepper", () => {
     const body = functionBody("renderElicitationTerminalFallback");
     assert.match(body, /btn\.className = "btn-suggestion";/);
     assert.match(body, /btn\.textContent = bubbleText\(currentLang, "goToTerminal"\);/);
-    assert.match(body, /window\.bubbleAPI\.decide\("deny"\);/);
+    assert.match(body, /window\.bubbleAPI\.decide\("deny-and-focus"\);/);
   });
 
   it("does not recalculate submit state twice when a non-Other radio hides the Other textarea", () => {

--- a/test/focus-helpers.test.js
+++ b/test/focus-helpers.test.js
@@ -1,0 +1,129 @@
+// Unit tests for the pure helpers exposed by src/focus.js.
+//
+// These cover the deterministic parts of the Mac specialized focus chain
+// (Superset workspace lookup, scheme derivation, pid candidate construction)
+// so regressions in the lookup path get caught at CI time. AppleScript
+// execution paths still rely on manual testing.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const focus = require("../src/focus");
+const {
+  findSupersetDataDirs,
+  supersetSchemeForDir,
+  querySupersetWorkspaceId,
+  buildPidCandidates,
+} = focus.__test;
+
+test.describe("focus helpers", () => {
+  test.describe("supersetSchemeForDir", () => {
+    test("returns 'superset' for the default install dir", () => {
+      assert.equal(supersetSchemeForDir("/Users/x/.superset"), "superset");
+    });
+
+    test("returns the namespaced scheme for custom instances", () => {
+      assert.equal(supersetSchemeForDir("/Users/x/.superset-staging"), "superset-staging");
+    });
+
+    test("returns null for unrelated paths", () => {
+      assert.equal(supersetSchemeForDir("/Users/x/Documents"), null);
+      assert.equal(supersetSchemeForDir("/tmp/.supersettings"), null);
+    });
+  });
+
+  test.describe("findSupersetDataDirs", () => {
+    test("returns dirs whose name starts with .superset and contain local.db", () => {
+      const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "focus-superset-"));
+      try {
+        const matchA = path.join(tmp, ".superset");
+        const matchB = path.join(tmp, ".superset-foo");
+        const noDb = path.join(tmp, ".superset-empty");
+        const unrelated = path.join(tmp, "supersettings");
+        for (const dir of [matchA, matchB, noDb, unrelated]) fs.mkdirSync(dir);
+        fs.writeFileSync(path.join(matchA, "local.db"), "");
+        fs.writeFileSync(path.join(matchB, "local.db"), "");
+
+        const found = findSupersetDataDirs(tmp).sort();
+        assert.deepEqual(found, [matchA, matchB].sort());
+      } finally {
+        fs.rmSync(tmp, { recursive: true, force: true });
+      }
+    });
+
+    test("returns [] when the home dir cannot be read", () => {
+      const missing = path.join(os.tmpdir(), "focus-superset-missing-" + Date.now());
+      assert.deepEqual(findSupersetDataDirs(missing), []);
+    });
+  });
+
+  test.describe("querySupersetWorkspaceId", () => {
+    let tmp;
+    let dbPath;
+    let sqlite3Available = true;
+
+    test.before(() => {
+      try {
+        execFileSync("sqlite3", ["-version"], { timeout: 1000 });
+      } catch {
+        sqlite3Available = false;
+        return;
+      }
+      tmp = fs.mkdtempSync(path.join(os.tmpdir(), "focus-superset-db-"));
+      dbPath = path.join(tmp, "local.db");
+      // Minimal schema mirroring the Superset tables we read.
+      execFileSync("sqlite3", [dbPath, `
+        CREATE TABLE worktrees (id TEXT PRIMARY KEY, path TEXT NOT NULL);
+        CREATE TABLE workspaces (id TEXT PRIMARY KEY, worktree_id TEXT, last_opened_at INTEGER);
+        INSERT INTO worktrees VALUES ('w1', '/tmp/foo');
+        INSERT INTO worktrees VALUES ('w2', '/tmp/bar');
+        INSERT INTO workspaces VALUES ('ws-old', 'w1', 100);
+        INSERT INTO workspaces VALUES ('ws-recent', 'w1', 999);
+        INSERT INTO workspaces VALUES ('ws-bar', 'w2', 500);
+      `]);
+    });
+
+    test.after(() => {
+      if (tmp) fs.rmSync(tmp, { recursive: true, force: true });
+    });
+
+    test("returns the most recently opened workspace for a path", (t) => {
+      if (!sqlite3Available) return t.skip("sqlite3 CLI unavailable");
+      assert.equal(querySupersetWorkspaceId(dbPath, "/tmp/foo"), "ws-recent");
+    });
+
+    test("returns null for an unknown path", (t) => {
+      if (!sqlite3Available) return t.skip("sqlite3 CLI unavailable");
+      assert.equal(querySupersetWorkspaceId(dbPath, "/tmp/missing"), null);
+    });
+
+    test("returns null when cwd is empty", () => {
+      assert.equal(querySupersetWorkspaceId(dbPath, ""), null);
+      assert.equal(querySupersetWorkspaceId(dbPath, null), null);
+    });
+  });
+
+  test.describe("buildPidCandidates", () => {
+    test("starts with sourcePid and dedupes pidChain", () => {
+      assert.deepEqual(buildPidCandidates(100, [200, 100, 300]), [100, 200, 300]);
+    });
+
+    test("drops invalid pids", () => {
+      assert.deepEqual(buildPidCandidates(100, [0, -1, NaN, "x", 200]), [100, 200]);
+    });
+
+    test("handles missing sourcePid", () => {
+      assert.deepEqual(buildPidCandidates(null, [200]), [200]);
+      assert.deepEqual(buildPidCandidates(0, [200]), [200]);
+    });
+
+    test("handles missing pidChain", () => {
+      assert.deepEqual(buildPidCandidates(100, null), [100]);
+      assert.deepEqual(buildPidCandidates(100, undefined), [100]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fix the AskUserQuestion bubble's **Go to Terminal** button — it was sending `decide("deny")` instead of `decide("deny-and-focus")`, so the focus path that Plan Review uses never ran. Users could not jump back to the originating terminal session.
- Add a Mac-only specialized focus chain (in `src/focus.js`) that runs before the generic `set frontmost of process` script:
  - **Superset.app** — looks up `workspaces.id` for the current cwd in `~/.superset*/local.db` (sqlite3 readonly) and opens `superset[-name]://workspace/<id>`. The renderer routes to that workspace and `focusMainWindow()` brings the app forward. Custom instances (`.superset-<name>`) are auto-detected.
  - **iTerm2** — picks the tty from the source/agent process tree (`ps -o tty=`) and selects the matching session via AppleScript `tty of session ends with …`.
  - **Ghostty** — no public IPC, so match the window title against the cwd basename via System Events + `AXRaise`. Requires a shell that sets OSC 2 titles.
- Each step short-circuits on success; if none match, falls through to the existing generic `set frontmost of process whose unix id is N` AppleScript — Terminal.app / Cursor / VS Code users see no change.

## Why
The generic frontmost script could only bring the parent app forward, not navigate to the specific session that triggered the permission request. The most painful case was Superset.app, where every worktree shares one Electron window — focus snapped to whichever workspace happened to be on top. iTerm2 and Ghostty have similar problems with multi-tab/window setups.

## Test plan
- [x] Existing test suite passes (`node --test test/bubble-elicitation-stepper.test.js` — 8/8)
- [x] **Superset URL scheme verified at runtime** — `open superset://workspace/<id>` correctly navigates the running Superset instance to the matching workspace; invalid IDs surface the app's 404 page, confirming the deep-link handler is reached
- [ ] iTerm2 tty match — implementation only, **not verified at runtime** (iTerm2 was not running locally)
- [ ] Ghostty title match — implementation only, **not verified at runtime**; depends on the user's shell sending OSC 2 titles
- [ ] Full-app smoke test (start the app, click Go to Terminal in an AskUserQuestion bubble) — **not run**

## Notes
- Generic frontmost fallback is intact, so platforms outside the specialized chain keep their prior behavior.
- LaunchServices may have multiple Superset claims (e.g., a leftover mounted DMG). The implementation calls `/usr/bin/open <url>` without `-a`, relying on the default handler. If a stale DMG outranks the running app, the deep link routes to the inactive copy. Workaround: `hdiutil detach /Volumes/Superset*` to clear duplicate registrations.
- `sqlite3` CLI is used (no native module dependency added). DB is opened read-only with `-readonly` to stay safe with the WAL connection Superset holds.
- Superset deep-link path discovered via static analysis of `app.asar` on 2026-05-08 — internal scheme, no stability guarantee. Pinned in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)