### PR TITLE
fix: stabilize animation override controls

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -207,6 +207,8 @@ const _settingsController = createSettingsController({
     // Theme runtime is wired after theme-loader.init(); keep these closures
     // lazy so settings actions never capture a pre-init runtime reference.
     activateTheme: (id, variantId, overrideMap) => themeRuntime.activateTheme(id, variantId, overrideMap),
+    refreshActiveThemeHitboxOverrides: (id, overrideMap) =>
+      themeRuntime.refreshActiveThemeHitboxOverrides(id, overrideMap),
     getThemeInfo: (id) => themeRuntime.getThemeInfo(id),
     removeThemeDir: (id) => themeRuntime.removeThemeDir(id),
     globalShortcut,

--- a/src/settings-actions-theme-overrides.js
+++ b/src/settings-actions-theme-overrides.js
@@ -130,6 +130,11 @@ function normalizeTransitionPayload(transition) {
   return Object.keys(out).length > 0 ? out : null;
 }
 
+function transitionMatchesThemeDefault(transition, defaultTransition) {
+  if (!transition || !defaultTransition) return false;
+  return transition.in === defaultTransition.in && transition.out === defaultTransition.out;
+}
+
 const _validateThemeOverrideThemeId = requireString("setThemeOverrideDisabled.themeId");
 function setThemeOverrideDisabled(payload, deps) {
   if (!payload || typeof payload !== "object") {
@@ -213,6 +218,13 @@ function setAnimationOverride(payload, deps) {
   if (touchesTransition && payload.transition !== null && !normalizeTransitionPayload(payload.transition)) {
     return { status: "error", message: "setAnimationOverride.transition must contain finite non-negative in/out values" };
   }
+  const normalizedTransition = touchesTransition && payload.transition !== null
+    ? normalizeTransitionPayload(payload.transition)
+    : null;
+  const normalizedTransitionDefault = normalizeTransitionPayload(payload.transitionThemeDefault);
+  const transitionMatchesDefault = !!(touchesTransition
+    && normalizedTransition
+    && transitionMatchesThemeDefault(normalizedTransition, normalizedTransitionDefault));
   if (touchesAutoReturn && payload.autoReturnMs !== null) {
     if (typeof payload.autoReturnMs !== "number" || !Number.isFinite(payload.autoReturnMs)) {
       return { status: "error", message: "setAnimationOverride.autoReturnMs must be null or a finite number" };
@@ -260,8 +272,8 @@ function setAnimationOverride(payload, deps) {
       }
     }
     if (touchesTransition) {
-      if (payload.transition === null) delete nextEntry.transition;
-      else nextEntry.transition = normalizeTransitionPayload(payload.transition);
+      if (payload.transition === null || transitionMatchesDefault) delete nextEntry.transition;
+      else nextEntry.transition = normalizedTransition;
     }
     if (Object.keys(nextEntry).length > 0) nextStates[stateKey] = nextEntry;
     else delete nextStates[stateKey];
@@ -295,8 +307,8 @@ function setAnimationOverride(payload, deps) {
       }
     }
     if (touchesTransition) {
-      if (payload.transition === null) delete nextEntry.transition;
-      else nextEntry.transition = normalizeTransitionPayload(payload.transition);
+      if (payload.transition === null || transitionMatchesDefault) delete nextEntry.transition;
+      else nextEntry.transition = normalizedTransition;
     }
     if (Object.keys(nextEntry).length > 0) tierMap[originalFile] = nextEntry;
     else delete tierMap[originalFile];
@@ -318,8 +330,8 @@ function setAnimationOverride(payload, deps) {
       }
     }
     if (touchesTransition) {
-      if (payload.transition === null) delete nextEntry.transition;
-      else nextEntry.transition = normalizeTransitionPayload(payload.transition);
+      if (payload.transition === null || transitionMatchesDefault) delete nextEntry.transition;
+      else nextEntry.transition = normalizedTransition;
     }
     if (touchesDuration) {
       if (payload.durationMs === null) delete nextEntry.durationMs;
@@ -348,8 +360,8 @@ function setAnimationOverride(payload, deps) {
       }
     }
     if (touchesTransition) {
-      if (payload.transition === null) delete nextEntry.transition;
-      else nextEntry.transition = normalizeTransitionPayload(payload.transition);
+      if (payload.transition === null || transitionMatchesDefault) delete nextEntry.transition;
+      else nextEntry.transition = normalizedTransition;
     }
     if (touchesDuration) {
       if (payload.durationMs === null) delete nextEntry.durationMs;
@@ -504,11 +516,21 @@ function setWideHitboxOverride(payload, deps) {
 
   const activeThemeId = snapshot.theme;
   if (themeId === activeThemeId) {
-    if (!deps || typeof deps.activateTheme !== "function") {
-      return { status: "error", message: "setWideHitboxOverride effect requires activateTheme dep" };
+    if (!deps || (
+      typeof deps.refreshActiveThemeHitboxOverrides !== "function"
+      && typeof deps.activateTheme !== "function"
+    )) {
+      return {
+        status: "error",
+        message: "setWideHitboxOverride effect requires refreshActiveThemeHitboxOverrides or activateTheme dep",
+      };
     }
     try {
-      deps.activateTheme(themeId, null, nextThemeMap);
+      if (typeof deps.refreshActiveThemeHitboxOverrides === "function") {
+        deps.refreshActiveThemeHitboxOverrides(themeId, nextThemeMap);
+      } else {
+        deps.activateTheme(themeId, null, nextThemeMap);
+      }
     } catch (err) {
       return { status: "error", message: `setWideHitboxOverride: ${err && err.message}` };
     }

--- a/src/settings-animation-overrides-main.js
+++ b/src/settings-animation-overrides-main.js
@@ -261,14 +261,18 @@ function createSettingsAnimationOverridesMain(options = {}) {
   function computeCardHitboxInfo(currentFile, themeOverrideMap) {
     const activeTheme = getActiveTheme();
     if (!currentFile || !activeTheme) {
-      return { wideHitboxEnabled: false, wideHitboxOverridden: false };
+      return { wideHitboxEnabled: false, wideHitboxOverridden: false, wideHitboxThemeDefault: false };
     }
     const wideFiles = Array.isArray(activeTheme.wideHitboxFiles) ? activeTheme.wideHitboxFiles : [];
+    const baseWideFiles = Array.isArray(activeTheme._baseWideHitboxFiles)
+      ? activeTheme._baseWideHitboxFiles
+      : wideFiles;
     const wideHitboxEnabled = wideFiles.includes(currentFile);
+    const wideHitboxThemeDefault = baseWideFiles.includes(currentFile);
     const overrideWide = themeOverrideMap && themeOverrideMap.hitbox && themeOverrideMap.hitbox.wide;
     const wideHitboxOverridden = !!(overrideWide
       && Object.prototype.hasOwnProperty.call(overrideWide, currentFile));
-    return { wideHitboxEnabled, wideHitboxOverridden };
+    return { wideHitboxEnabled, wideHitboxOverridden, wideHitboxThemeDefault };
   }
 
   function resolveAnimationAssetsDir(theme = getActiveTheme()) {
@@ -629,13 +633,26 @@ function createSettingsAnimationOverridesMain(options = {}) {
     return assets;
   }
 
-  function readResolvedTransition(file) {
-    const activeTheme = getActiveTheme();
-    const entry = activeTheme && activeTheme.transitions && activeTheme.transitions[file];
+  function readTransitionFromMap(file, map) {
+    const entry = map && map[file];
     return {
       in: entry && Number.isFinite(entry.in) ? entry.in : 150,
       out: entry && Number.isFinite(entry.out) ? entry.out : 150,
     };
+  }
+
+  function readResolvedTransition(file) {
+    const activeTheme = getActiveTheme();
+    return readTransitionFromMap(file, activeTheme && activeTheme.transitions);
+  }
+
+  function readThemeDefaultTransition(file) {
+    const activeTheme = getActiveTheme();
+    return readTransitionFromMap(file, activeTheme && activeTheme._baseTransitions);
+  }
+
+  function hasTransitionOverride(entry) {
+    return !!(entry && Object.prototype.hasOwnProperty.call(entry, "transition"));
   }
 
   function hasOwnStateFiles(stateKey) {
@@ -651,7 +668,15 @@ function createSettingsAnimationOverridesMain(options = {}) {
     return false;
   }
 
-  function buildTierCardGroup(tierGroup, triggerKind, resolvedTiers, baseTiers, baseHintMap, sectionId = "work") {
+  function buildTierCardGroup(
+    tierGroup,
+    triggerKind,
+    resolvedTiers,
+    baseTiers,
+    baseHintMap,
+    sectionId = "work",
+    themeOverrideMap = null
+  ) {
     if (!Array.isArray(resolvedTiers)) return [];
     return resolvedTiers.map((tier, index) => {
       const baseTier = Array.isArray(baseTiers) ? baseTiers[index] : null;
@@ -679,6 +704,13 @@ function createSettingsAnimationOverridesMain(options = {}) {
         previewPosterPending: preview.previewPosterPending,
         bindingLabel: `${tierGroup}[${originalFile}]`,
         transition: readResolvedTransition(tier.file),
+        transitionThemeDefault: readThemeDefaultTransition(tier.file),
+        hasTransitionOverride: hasTransitionOverride(
+          themeOverrideMap
+          && themeOverrideMap.tiers
+          && themeOverrideMap.tiers[tierGroup]
+          && themeOverrideMap.tiers[tierGroup][originalFile]
+        ),
         supportsAutoReturn: false,
         supportsDuration: false,
         autoReturnMs: null,
@@ -764,6 +796,12 @@ function createSettingsAnimationOverridesMain(options = {}) {
         ? `${bindingPathPrefix}.${stateKey}.fallbackTo -> ${fallbackTargetState}`
         : `${bindingPathPrefix}.${stateKey}[0]`,
       transition: readResolvedTransition(currentFile),
+      transitionThemeDefault: readThemeDefaultTransition(currentFile),
+      hasTransitionOverride: hasTransitionOverride(
+        themeOverrideMap
+        && themeOverrideMap.states
+        && themeOverrideMap.states[stateKey]
+      ),
       supportsAutoReturn,
       supportsDuration: false,
       autoReturnMs: resolvedAutoReturnMs,
@@ -807,6 +845,8 @@ function createSettingsAnimationOverridesMain(options = {}) {
           previewPosterPending: preview.previewPosterPending,
           bindingLabel: `idleAnimations[${index}] (${originalFile})`,
           transition: readResolvedTransition(entry.file),
+          transitionThemeDefault: readThemeDefaultTransition(entry.file),
+          hasTransitionOverride: hasTransitionOverride(overrideMap && overrideMap[originalFile]),
           supportsAutoReturn: false,
           supportsDuration: true,
           autoReturnMs: null,
@@ -858,6 +898,8 @@ function createSettingsAnimationOverridesMain(options = {}) {
         previewPosterPending: preview.previewPosterPending,
         bindingLabel: `reactions.${spec.key}`,
         transition: readResolvedTransition(currentFile),
+        transitionThemeDefault: readThemeDefaultTransition(currentFile),
+        hasTransitionOverride: hasTransitionOverride(overrideEntry),
         supportsAutoReturn: false,
         supportsDuration: spec.supportsDuration,
         autoReturnMs: null,
@@ -896,7 +938,8 @@ function createSettingsAnimationOverridesMain(options = {}) {
       activeTheme.workingTiers || [],
       baseBindings.workingTiers || [],
       baseBindings.displayHintMap || {},
-      "work"
+      "work",
+      themeOverrideMap
     ));
     workCards.push(...buildTierCardGroup(
       "jugglingTiers",
@@ -904,7 +947,8 @@ function createSettingsAnimationOverridesMain(options = {}) {
       activeTheme.jugglingTiers || [],
       baseBindings.jugglingTiers || [],
       baseBindings.displayHintMap || {},
-      "work"
+      "work",
+      themeOverrideMap
     ));
     pushSection(sections, "work", null, workCards);
 
@@ -980,9 +1024,14 @@ function createSettingsAnimationOverridesMain(options = {}) {
       if (!section || !Array.isArray(section.cards)) continue;
       if (section.id === "reactions") continue;
       for (const card of section.cards) {
-        const { wideHitboxEnabled, wideHitboxOverridden } = computeCardHitboxInfo(card.currentFile, themeOverrideMap);
+        const {
+          wideHitboxEnabled,
+          wideHitboxOverridden,
+          wideHitboxThemeDefault,
+        } = computeCardHitboxInfo(card.currentFile, themeOverrideMap);
         card.wideHitboxEnabled = wideHitboxEnabled;
         card.wideHitboxOverridden = wideHitboxOverridden;
+        card.wideHitboxThemeDefault = wideHitboxThemeDefault;
         card.aspectRatioWarning = computeAspectRatioWarning(card.baseFile, card.currentFile);
       }
     }

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -1307,7 +1307,7 @@
         syncMountedWideHitboxToggles();
         syncMountedOverrideStatusControls();
         if (result && result.status === "error") {
-          ops.showToast(t("toastSaveFailed") + ((result && result.message) || ""), { error: true });
+          ops.showToast(t("toastSaveFailed") + (result.message || "unknown error"), { error: true });
         }
         return result;
       }
@@ -1325,7 +1325,7 @@
       clearPendingWideHitboxOverrideEdit(pendingToken);
       syncMountedWideHitboxToggles();
       syncMountedOverrideStatusControls();
-      ops.showToast(t("toastSaveFailed") + ((err && err.message) || ""), { error: true });
+      ops.showToast(t("toastSaveFailed") + ((err && err.message) || "unknown error"), { error: true });
       return { status: "error", message: err && err.message };
     });
   }
@@ -1368,6 +1368,7 @@
     input.type = "checkbox";
     input.checked = !!card.wideHitboxEnabled;
     input.disabled = pending;
+    input.setAttribute("aria-label", t("animOverridesWideHitboxToggle"));
     const label = document.createElement("div");
     label.className = "anim-override-toggle-label";
     const title = document.createElement("div");
@@ -1884,9 +1885,9 @@
             if (previewPromise) {
               previewPromise.then((previewResult) => {
                 if (!previewResult || previewResult.status === "ok") return;
-                ops.showToast(t("toastSaveFailed") + previewResult.message, { error: true });
+                ops.showToast(t("toastSaveFailed") + (previewResult.message || "unknown error"), { error: true });
               }).catch((err) => {
-                ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
+                ops.showToast(t("toastSaveFailed") + ((err && err.message) || "unknown error"), { error: true });
               });
             }
           }

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -1281,6 +1281,7 @@
     const pending = pendingToken && getPendingWideHitboxOverrideEdits().get(card.id);
     if (!pending) return Promise.resolve({ status: "noop" });
     syncMountedWideHitboxToggles();
+    syncMountedOverrideStatusControls();
     return window.settingsAPI.command("setWideHitboxOverride", {
       themeId,
       file: card.currentFile,
@@ -1289,6 +1290,7 @@
       if (!result || result.status !== "ok" || result.noop) {
         clearPendingWideHitboxOverrideEdit(pendingToken);
         syncMountedWideHitboxToggles();
+        syncMountedOverrideStatusControls();
         if (result && result.status === "error") {
           ops.showToast(t("toastSaveFailed") + ((result && result.message) || ""), { error: true });
         }
@@ -1299,6 +1301,7 @@
         ops.normalizeAssetPickerSelection();
         if (state.activeTab === "animOverrides") {
           syncMountedWideHitboxToggles();
+          syncMountedOverrideStatusControls();
         }
         ops.requestRender({ modal: true });
         return result;
@@ -1306,6 +1309,7 @@
     }).catch((err) => {
       clearPendingWideHitboxOverrideEdit(pendingToken);
       syncMountedWideHitboxToggles();
+      syncMountedOverrideStatusControls();
       ops.showToast(t("toastSaveFailed") + ((err && err.message) || ""), { error: true });
       return { status: "error", message: err && err.message };
     });

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -170,7 +170,7 @@
 
   function wideHitboxResetVisible(card) {
     if (!card) return false;
-    return !!card.wideHitboxEnabled !== !!card.wideHitboxThemeDefault;
+    return !!card.wideHitboxOverridden || !!card.wideHitboxEnabled !== !!card.wideHitboxThemeDefault;
   }
 
   function recordPendingWideHitboxOverrideEdit(card, targetEnabled) {

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -71,6 +71,13 @@
     return runtime.pendingWideHitboxOverrideEdits;
   }
 
+  function getPendingAnimationOverrideResets() {
+    if (!runtime.pendingAnimationOverrideResets || typeof runtime.pendingAnimationOverrideResets.has !== "function") {
+      runtime.pendingAnimationOverrideResets = new Set();
+    }
+    return runtime.pendingAnimationOverrideResets;
+  }
+
   function getMountedWideHitboxToggles() {
     if (!state.mountedControls || typeof state.mountedControls !== "object") {
       state.mountedControls = {};
@@ -315,8 +322,10 @@
       }
       const card = applyPendingAnimOverrideCard(getAnimOverrideCardById(cardId) || control.card);
       const overridden = isCardOverridden(card);
+      const hitboxPending = getPendingWideHitboxOverrideEdits().has(cardId);
+      const resetPending = getPendingAnimationOverrideResets().has(cardId);
       control.card = card || control.card;
-      if (control.resetBtn) control.resetBtn.disabled = !overridden;
+      if (control.resetBtn) control.resetBtn.disabled = !overridden || hitboxPending || resetPending;
       setSummaryOverrideBadge(control.summaryBadges, overridden);
     }
   }
@@ -324,6 +333,7 @@
   function syncMountedWideHitboxToggles() {
     const controls = getMountedWideHitboxToggles();
     const pendingEdits = getPendingWideHitboxOverrideEdits();
+    const pendingResets = getPendingAnimationOverrideResets();
     for (const [cardId, control] of controls) {
       if (!control || !control.row || !control.row.parentNode) {
         controls.delete(cardId);
@@ -331,12 +341,13 @@
       }
       const card = applyPendingWideHitboxOverrideEdit(getAnimOverrideCardById(cardId) || control.card);
       const pending = pendingEdits.get(cardId);
+      const blocked = !!pending || pendingResets.has(cardId);
       control.card = card || control.card;
       control.input.checked = !!(card && card.wideHitboxEnabled);
-      control.input.disabled = !!pending;
+      control.input.disabled = blocked;
       control.badge.hidden = !wideHitboxResetVisible(card);
-      control.badge.disabled = !!pending || !wideHitboxResetVisible(card);
-      control.row.classList.toggle("pending", !!pending);
+      control.badge.disabled = blocked || !wideHitboxResetVisible(card);
+      control.row.classList.toggle("pending", blocked);
     }
   }
 
@@ -801,6 +812,7 @@
     }
 
     reconcilePendingAnimationOverrideEdits();
+    reconcilePendingWideHitboxOverrideEdits();
     const data = runtime.animationOverridesData;
 
     parent.appendChild(buildSubtabSwitcher());
@@ -1273,9 +1285,12 @@
     return summary;
   }
 
-  function runWideHitboxCommand(card, enabled) {
+  function runWideHitboxCommand(card, enabled, options = {}) {
     const themeId = getCurrentOverrideThemeId();
     if (!themeId || !card || !card.id || !card.currentFile) return Promise.resolve({ status: "noop" });
+    if (getPendingAnimationOverrideResets().has(card.id) && !options.allowDuringReset) {
+      return Promise.resolve({ status: "ok", noop: true });
+    }
     if (getPendingWideHitboxOverrideEdits().has(card.id)) return Promise.resolve({ status: "noop" });
     const pendingToken = recordPendingWideHitboxOverrideEdit(card, enabled);
     const pending = pendingToken && getPendingWideHitboxOverrideEdits().get(card.id);
@@ -1316,6 +1331,14 @@
   }
 
   function resetAnimationOverrideCard(card) {
+    if (!card || !card.id) return Promise.resolve({ status: "noop" });
+    const pendingResets = getPendingAnimationOverrideResets();
+    if (pendingResets.has(card.id) || getPendingWideHitboxOverrideEdits().has(card.id)) {
+      return Promise.resolve({ status: "ok", noop: true });
+    }
+    pendingResets.add(card.id);
+    syncMountedWideHitboxToggles();
+    syncMountedOverrideStatusControls();
     const patch = {
       file: null,
       transition: null,
@@ -1326,14 +1349,21 @@
       if (result && result.status === "error") return result;
       const currentCard = applyPendingWideHitboxOverrideEdit(getAnimOverrideCardById(card.id) || card);
       if (currentCard.slotType === "reaction" || !currentCard.wideHitboxOverridden) return result;
-      return runWideHitboxCommand(currentCard, !!currentCard.wideHitboxThemeDefault);
+      return runWideHitboxCommand(currentCard, !!currentCard.wideHitboxThemeDefault, { allowDuringReset: true });
+    }).finally(() => {
+      pendingResets.delete(card.id);
+      syncMountedWideHitboxToggles();
+      syncMountedOverrideStatusControls();
     });
   }
 
   function buildAnimWideHitboxToggle(card) {
     const row = document.createElement("div");
     row.className = "anim-override-toggle-row";
-    const pending = !!(card && card.id && getPendingWideHitboxOverrideEdits().has(card.id));
+    const pending = !!(card && card.id && (
+      getPendingWideHitboxOverrideEdits().has(card.id)
+      || getPendingAnimationOverrideResets().has(card.id)
+    ));
     const input = document.createElement("input");
     input.type = "checkbox";
     input.checked = !!card.wideHitboxEnabled;
@@ -1520,7 +1550,9 @@
     resetBtn.type = "button";
     resetBtn.className = "soft-btn";
     resetBtn.textContent = t("animOverridesReset");
-    resetBtn.disabled = !isCardOverridden(card);
+    resetBtn.disabled = !isCardOverridden(card)
+      || getPendingWideHitboxOverrideEdits().has(card.id)
+      || getPendingAnimationOverrideResets().has(card.id);
     helpers.attachActivation(resetBtn, () => resetAnimationOverrideCard(card));
     footer.appendChild(resetBtn);
     drawer.appendChild(footer);

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -53,6 +53,35 @@
     return state.mountedControls.animOverrideTimingSliders;
   }
 
+  function getMountedOverrideStatusControls() {
+    if (!state.mountedControls || typeof state.mountedControls !== "object") {
+      state.mountedControls = {};
+    }
+    if (!state.mountedControls.animOverrideStatusControls
+      || typeof state.mountedControls.animOverrideStatusControls.get !== "function") {
+      state.mountedControls.animOverrideStatusControls = new Map();
+    }
+    return state.mountedControls.animOverrideStatusControls;
+  }
+
+  function getPendingWideHitboxOverrideEdits() {
+    if (!runtime.pendingWideHitboxOverrideEdits || typeof runtime.pendingWideHitboxOverrideEdits.get !== "function") {
+      runtime.pendingWideHitboxOverrideEdits = new Map();
+    }
+    return runtime.pendingWideHitboxOverrideEdits;
+  }
+
+  function getMountedWideHitboxToggles() {
+    if (!state.mountedControls || typeof state.mountedControls !== "object") {
+      state.mountedControls = {};
+    }
+    if (!state.mountedControls.animOverrideWideHitboxToggles
+      || typeof state.mountedControls.animOverrideWideHitboxToggles.get !== "function") {
+      state.mountedControls.animOverrideWideHitboxToggles = new Map();
+    }
+    return state.mountedControls.animOverrideWideHitboxToggles;
+  }
+
   function timingControlKey(cardId, field) {
     return `${cardId}:${field}`;
   }
@@ -130,6 +159,48 @@
     edits.delete(token.id);
   }
 
+  function transitionMatchesThemeDefault(transition, defaultTransition) {
+    if (!transition || !defaultTransition) return false;
+    return transition.in === defaultTransition.in && transition.out === defaultTransition.out;
+  }
+
+  function hasTransitionOverride(entry) {
+    return !!(entry && Object.prototype.hasOwnProperty.call(entry, "transition"));
+  }
+
+  function wideHitboxResetVisible(card) {
+    if (!card) return false;
+    return !!card.wideHitboxEnabled !== !!card.wideHitboxThemeDefault;
+  }
+
+  function recordPendingWideHitboxOverrideEdit(card, targetEnabled) {
+    if (!card || !card.id || !card.currentFile) return null;
+    const edits = getPendingWideHitboxOverrideEdits();
+    const seq = Number.isFinite(runtime.nextWideHitboxOverrideEditSeq)
+      ? runtime.nextWideHitboxOverrideEditSeq
+      : 1;
+    runtime.nextWideHitboxOverrideEditSeq = seq + 1;
+    const themeDefault = !!card.wideHitboxThemeDefault;
+    const effectiveEnabled = !!targetEnabled;
+    const commandEnabled = effectiveEnabled === themeDefault ? null : effectiveEnabled;
+    edits.set(card.id, {
+      seq,
+      currentFile: card.currentFile,
+      themeDefault,
+      effectiveEnabled,
+      commandEnabled,
+    });
+    return { id: card.id, seq };
+  }
+
+  function clearPendingWideHitboxOverrideEdit(token) {
+    if (!token || !token.id) return;
+    const edits = getPendingWideHitboxOverrideEdits();
+    const current = edits.get(token.id);
+    if (!current || current.seq !== token.seq) return;
+    edits.delete(token.id);
+  }
+
   function applyPendingAnimationOverrideEdit(card) {
     if (!card || !card.id) return card;
     const pending = getPendingAnimationOverrideEdits().get(card.id);
@@ -137,9 +208,28 @@
     return {
       ...card,
       transition: pending.transition ? { ...pending.transition } : card.transition,
+      ...(pending.transition ? {
+        hasTransitionOverride: !transitionMatchesThemeDefault(pending.transition, card.transitionThemeDefault),
+      } : {}),
       ...(Object.prototype.hasOwnProperty.call(pending, "autoReturnMs") ? { autoReturnMs: pending.autoReturnMs } : {}),
       ...(Object.prototype.hasOwnProperty.call(pending, "durationMs") ? { durationMs: pending.durationMs } : {}),
     };
+  }
+
+  function applyPendingWideHitboxOverrideEdit(card) {
+    if (!card || !card.id) return card;
+    const pending = getPendingWideHitboxOverrideEdits().get(card.id);
+    if (!pending) return card;
+    return {
+      ...card,
+      wideHitboxEnabled: pending.effectiveEnabled,
+      wideHitboxOverridden: pending.commandEnabled !== null,
+      wideHitboxThemeDefault: pending.themeDefault,
+    };
+  }
+
+  function applyPendingAnimOverrideCard(card) {
+    return applyPendingWideHitboxOverrideEdit(applyPendingAnimationOverrideEdit(card));
   }
 
   function cardReflectsPendingEdit(card, pending) {
@@ -167,6 +257,24 @@
     }
   }
 
+  function cardReflectsPendingWideHitboxOverride(card, pending) {
+    if (!card || !pending) return false;
+    return (
+      !!card.wideHitboxEnabled === pending.effectiveEnabled
+      && !!card.wideHitboxThemeDefault === pending.themeDefault
+      && !!card.wideHitboxOverridden === (pending.commandEnabled !== null)
+    );
+  }
+
+  function reconcilePendingWideHitboxOverrideEdits() {
+    const edits = getPendingWideHitboxOverrideEdits();
+    if (!edits.size) return;
+    for (const [id, pending] of edits) {
+      const card = getAnimOverrideCardById(id);
+      if (cardReflectsPendingWideHitboxOverride(card, pending)) edits.delete(id);
+    }
+  }
+
   function syncMountedTimingSliders() {
     const controls = getMountedTimingSliders();
     for (const [key, control] of controls) {
@@ -177,6 +285,58 @@
       const card = applyPendingAnimationOverrideEdit(getAnimOverrideCardById(control.cardId));
       const value = getCardTimingValue(card, control.field);
       if (Number.isFinite(value)) control.setValue(value);
+    }
+  }
+
+  function setSummaryOverrideBadge(container, visible) {
+    if (!container) return;
+    const existingDot = container.querySelector(".anim-override-badge-dot");
+    const existingWrap = existingDot && existingDot.parentNode;
+    if (!visible) {
+      if (existingWrap && typeof existingWrap.remove === "function") existingWrap.remove();
+      return;
+    }
+    if (existingDot) return;
+    const dotWrap = document.createElement("span");
+    dotWrap.className = "anim-override-badge";
+    dotWrap.title = t("animOverridesOverriddenTooltip");
+    const dot = document.createElement("span");
+    dot.className = "anim-override-badge-dot";
+    dotWrap.appendChild(dot);
+    container.appendChild(dotWrap);
+  }
+
+  function syncMountedOverrideStatusControls() {
+    const controls = getMountedOverrideStatusControls();
+    for (const [cardId, control] of controls) {
+      if (!control || !control.row || !control.row.parentNode) {
+        controls.delete(cardId);
+        continue;
+      }
+      const card = applyPendingAnimOverrideCard(getAnimOverrideCardById(cardId) || control.card);
+      const overridden = isCardOverridden(card);
+      control.card = card || control.card;
+      if (control.resetBtn) control.resetBtn.disabled = !overridden;
+      setSummaryOverrideBadge(control.summaryBadges, overridden);
+    }
+  }
+
+  function syncMountedWideHitboxToggles() {
+    const controls = getMountedWideHitboxToggles();
+    const pendingEdits = getPendingWideHitboxOverrideEdits();
+    for (const [cardId, control] of controls) {
+      if (!control || !control.row || !control.row.parentNode) {
+        controls.delete(cardId);
+        continue;
+      }
+      const card = applyPendingWideHitboxOverrideEdit(getAnimOverrideCardById(cardId) || control.card);
+      const pending = pendingEdits.get(cardId);
+      control.card = card || control.card;
+      control.input.checked = !!(card && card.wideHitboxEnabled);
+      control.input.disabled = !!pending;
+      control.badge.hidden = !wideHitboxResetVisible(card);
+      control.badge.disabled = !!pending || !wideHitboxResetVisible(card);
+      control.row.classList.toggle("pending", !!pending);
     }
   }
 
@@ -222,6 +382,10 @@
     }
     pruneEmptyObject(themeMap, "idleAnimations");
     pruneEmptyObject(themeMap, "reactions");
+    if (themeMap.hitbox && typeof themeMap.hitbox === "object") {
+      pruneEmptyObject(themeMap.hitbox, "wide");
+      pruneEmptyObject(themeMap, "hitbox");
+    }
   }
 
   function ensureThemeOverrideEntry(themeMap, pending) {
@@ -275,16 +439,33 @@
     return true;
   }
 
+  function applyPendingWideHitboxEditToThemeOverrides(themeMap, pending) {
+    if (!themeMap || !pending || !pending.currentFile) return false;
+    themeMap.hitbox = themeMap.hitbox || {};
+    themeMap.hitbox.wide = themeMap.hitbox.wide || {};
+    if (pending.commandEnabled === null) {
+      delete themeMap.hitbox.wide[pending.currentFile];
+    } else {
+      themeMap.hitbox.wide[pending.currentFile] = pending.commandEnabled;
+    }
+    pruneThemeOverrideMap(themeMap);
+    return true;
+  }
+
   function pendingEditsMatchThemeOverrideBroadcast(previousSnapshot, nextSnapshot) {
     const themeId = getCurrentOverrideThemeId();
     if (!themeId || !previousSnapshot || !nextSnapshot) return false;
     const edits = getPendingAnimationOverrideEdits();
-    if (!edits.size) return false;
+    const wideHitboxEdits = getPendingWideHitboxOverrideEdits();
+    if (!edits.size && !wideHitboxEdits.size) return false;
     const expectedOverrides = clonePlainObject(previousSnapshot.themeOverrides || {});
     const expectedThemeMap = expectedOverrides[themeId] || {};
     expectedOverrides[themeId] = expectedThemeMap;
     for (const pending of edits.values()) {
       if (!applyPendingEditToThemeOverrides(expectedThemeMap, pending)) return false;
+    }
+    for (const pending of wideHitboxEdits.values()) {
+      if (!applyPendingWideHitboxEditToThemeOverrides(expectedThemeMap, pending)) return false;
     }
     pruneThemeOverrideMap(expectedThemeMap);
     pruneEmptyObject(expectedOverrides, themeId);
@@ -397,12 +578,16 @@
     } else {
       base.stateKey = card.stateKey;
     }
-    return { ...base, ...patch };
+    const request = { ...base, ...patch };
+    if (patch && patch.transition && card.transitionThemeDefault) {
+      request.transitionThemeDefault = { ...card.transitionThemeDefault };
+    }
+    return request;
   }
 
   function getCurrentAnimationOverrideCard(card) {
     if (!card || !card.id) return card;
-    return applyPendingAnimationOverrideEdit(getAnimOverrideCardById(card.id) || card);
+    return applyPendingAnimOverrideCard(getAnimOverrideCardById(card.id) || card);
   }
 
   function runAnimationOverrideCommand(card, patch) {
@@ -412,14 +597,19 @@
     return window.settingsAPI.command("setAnimationOverride", payload).then((result) => {
       if (!result || result.status !== "ok" || result.noop) {
         clearPendingAnimationOverrideEdit(pendingToken);
-        if (timingOnly) syncMountedTimingSliders();
+        if (timingOnly) {
+          syncMountedTimingSliders();
+          syncMountedOverrideStatusControls();
+        }
         return result;
       }
       return ops.fetchAnimationOverridesData().then(() => {
         reconcilePendingAnimationOverrideEdits();
+        reconcilePendingWideHitboxOverrideEdits();
         ops.normalizeAssetPickerSelection();
         if (timingOnly && state.activeTab === "animOverrides") {
           syncMountedTimingSliders();
+          syncMountedOverrideStatusControls();
         } else if (state.activeTab === "animOverrides") {
           ops.requestRender({ content: true });
         }
@@ -440,13 +630,16 @@
     if (runtime.assetPicker.state) return false;
     if (runtime.animOverridesSubtab !== "animations") return false;
     if (!runtime.animationOverridesData) return false;
-    if (!getPendingAnimationOverrideEdits().size) return false;
+    if (!getPendingAnimationOverrideEdits().size && !getPendingWideHitboxOverrideEdits().size) return false;
     if (!pendingEditsMatchThemeOverrideBroadcast(context.previousSnapshot, context.snapshot)) return false;
 
     ops.fetchAnimationOverridesData().then(() => {
       reconcilePendingAnimationOverrideEdits();
+      reconcilePendingWideHitboxOverrideEdits();
       ops.normalizeAssetPickerSelection();
       syncMountedTimingSliders();
+      syncMountedWideHitboxToggles();
+      syncMountedOverrideStatusControls();
       ops.requestRender({ modal: true });
     });
     return true;
@@ -924,24 +1117,57 @@
   function isCardOverridden(card) {
     const themeId = getCurrentOverrideThemeId();
     if (!themeId) return false;
+    const hasTransitionFlag = Object.prototype.hasOwnProperty.call(card, "hasTransitionOverride");
+    const hasAutoReturnFlag = Object.prototype.hasOwnProperty.call(card, "hasAutoReturnOverride");
+    const hasDurationFlag = Object.prototype.hasOwnProperty.call(card, "hasDurationOverride");
+    const hasWideHitboxFlag = Object.prototype.hasOwnProperty.call(card, "wideHitboxOverridden");
+    const cardFlagOverride = !!(
+      (hasTransitionFlag && card.hasTransitionOverride)
+      || (hasAutoReturnFlag && card.hasAutoReturnOverride)
+      || (hasDurationFlag && card.hasDurationOverride)
+      || (hasWideHitboxFlag && card.wideHitboxOverridden)
+    );
     const map = readers.readThemeOverrideMap(themeId);
-    if (!map) return false;
+    if (!map) return cardFlagOverride;
+    const hasMaterialEntryOverride = (entry) => {
+      if (!entry || typeof entry !== "object") return false;
+      return Object.keys(entry).some((key) => key !== "transition" && key !== "durationMs");
+    };
     if (card.slotType === "tier") {
       const group = map.tiers && map.tiers[card.tierGroup];
-      return !!(group && group[card.originalFile]);
+      const entry = group && group[card.originalFile];
+      return !!(hasMaterialEntryOverride(entry)
+        || (hasTransitionFlag ? card.hasTransitionOverride : hasTransitionOverride(entry)));
     }
     if (card.slotType === "idleAnimation") {
       const group = map.idleAnimations;
-      return !!(group && group[card.originalFile]);
+      const entry = group && group[card.originalFile];
+      return !!(hasMaterialEntryOverride(entry)
+        || (hasTransitionFlag ? card.hasTransitionOverride : hasTransitionOverride(entry))
+        || (hasDurationFlag ? card.hasDurationOverride : (entry && Object.prototype.hasOwnProperty.call(entry, "durationMs"))));
+    }
+    if (card.slotType === "reaction") {
+      const entry = map.reactions && map.reactions[card.reactionKey];
+      return !!(hasMaterialEntryOverride(entry)
+        || (hasTransitionFlag ? card.hasTransitionOverride : hasTransitionOverride(entry))
+        || (hasDurationFlag ? card.hasDurationOverride : (entry && Object.prototype.hasOwnProperty.call(entry, "durationMs"))));
     }
     const entry = map.states && map.states[card.stateKey];
-    if (entry) return true;
+    if (entry && hasMaterialEntryOverride(entry)) return true;
+    if (hasTransitionFlag ? card.hasTransitionOverride : hasTransitionOverride(entry)) return true;
     const autoReturn = map.timings && map.timings.autoReturn;
-    return !!(autoReturn && Object.prototype.hasOwnProperty.call(autoReturn, card.stateKey));
+    if (hasAutoReturnFlag ? card.hasAutoReturnOverride : (autoReturn && Object.prototype.hasOwnProperty.call(autoReturn, card.stateKey))) {
+      return true;
+    }
+    const wideHitbox = map.hitbox && map.hitbox.wide;
+    if (hasWideHitboxFlag) return !!card.wideHitboxOverridden;
+    return !!(card.currentFile
+      && wideHitbox
+      && Object.prototype.hasOwnProperty.call(wideHitbox, card.currentFile));
   }
 
   function buildAnimOverrideRow(card) {
-    card = applyPendingAnimationOverrideEdit(card);
+    card = applyPendingAnimOverrideCard(card);
     const row = document.createElement("details");
     row.className = "anim-override-row";
     if (card.fallbackTargetState) row.classList.add("inherited");
@@ -954,6 +1180,11 @@
 
     row.appendChild(buildAnimOverrideSummary(card));
     row.appendChild(buildAnimOverrideDrawer(card));
+    if (card && card.id) {
+      const controls = getMountedOverrideStatusControls();
+      const current = controls.get(card.id) || { cardId: card.id };
+      controls.set(card.id, { ...current, row, card });
+    }
     return row;
   }
 
@@ -1022,6 +1253,11 @@
       badges.appendChild(dotWrap);
     }
     summary.appendChild(badges);
+    if (card && card.id) {
+      const controls = getMountedOverrideStatusControls();
+      const current = controls.get(card.id) || { cardId: card.id };
+      controls.set(card.id, { ...current, summaryBadges: badges, card });
+    }
 
     const changeBtn = document.createElement("button");
     changeBtn.type = "button";
@@ -1039,25 +1275,65 @@
 
   function runWideHitboxCommand(card, enabled) {
     const themeId = getCurrentOverrideThemeId();
-    if (!themeId || !card.currentFile) return;
-    window.settingsAPI.command("setWideHitboxOverride", {
+    if (!themeId || !card || !card.id || !card.currentFile) return Promise.resolve({ status: "noop" });
+    if (getPendingWideHitboxOverrideEdits().has(card.id)) return Promise.resolve({ status: "noop" });
+    const pendingToken = recordPendingWideHitboxOverrideEdit(card, enabled);
+    const pending = pendingToken && getPendingWideHitboxOverrideEdits().get(card.id);
+    if (!pending) return Promise.resolve({ status: "noop" });
+    syncMountedWideHitboxToggles();
+    return window.settingsAPI.command("setWideHitboxOverride", {
       themeId,
       file: card.currentFile,
-      enabled,
+      enabled: pending.commandEnabled,
     }).then((result) => {
-      if (!result || result.status !== "ok" || result.noop) return;
+      if (!result || result.status !== "ok" || result.noop) {
+        clearPendingWideHitboxOverrideEdit(pendingToken);
+        syncMountedWideHitboxToggles();
+        if (result && result.status === "error") {
+          ops.showToast(t("toastSaveFailed") + ((result && result.message) || ""), { error: true });
+        }
+        return result;
+      }
       return ops.fetchAnimationOverridesData().then(() => {
-        if (state.activeTab === "animOverrides") ops.requestRender({ content: true });
+        reconcilePendingWideHitboxOverrideEdits();
+        ops.normalizeAssetPickerSelection();
+        if (state.activeTab === "animOverrides") {
+          syncMountedWideHitboxToggles();
+        }
+        ops.requestRender({ modal: true });
+        return result;
       });
+    }).catch((err) => {
+      clearPendingWideHitboxOverrideEdit(pendingToken);
+      syncMountedWideHitboxToggles();
+      ops.showToast(t("toastSaveFailed") + ((err && err.message) || ""), { error: true });
+      return { status: "error", message: err && err.message };
+    });
+  }
+
+  function resetAnimationOverrideCard(card) {
+    const patch = {
+      file: null,
+      transition: null,
+      ...(card.supportsAutoReturn ? { autoReturnMs: null } : {}),
+      ...(card.supportsDuration ? { durationMs: null } : {}),
+    };
+    return runAnimationOverrideCommand(card, patch).then((result) => {
+      if (result && result.status === "error") return result;
+      const currentCard = applyPendingWideHitboxOverrideEdit(getAnimOverrideCardById(card.id) || card);
+      if (currentCard.slotType === "reaction" || !currentCard.wideHitboxOverridden) return result;
+      return runWideHitboxCommand(currentCard, !!currentCard.wideHitboxThemeDefault);
     });
   }
 
   function buildAnimWideHitboxToggle(card) {
-    const row = document.createElement("label");
+    const row = document.createElement("div");
     row.className = "anim-override-toggle-row";
+    const pending = !!(card && card.id && getPendingWideHitboxOverrideEdits().has(card.id));
     const input = document.createElement("input");
     input.type = "checkbox";
     input.checked = !!card.wideHitboxEnabled;
+    input.disabled = pending;
     const label = document.createElement("div");
     label.className = "anim-override-toggle-label";
     const title = document.createElement("div");
@@ -1068,22 +1344,37 @@
     desc.className = "anim-override-toggle-desc";
     desc.textContent = t("animOverridesWideHitboxDesc");
     label.appendChild(desc);
-    if (card.wideHitboxOverridden) {
-      const badge = document.createElement("button");
-      badge.type = "button";
-      badge.className = "anim-override-reset-chip";
-      badge.textContent = t("animOverridesWideHitboxResetToTheme");
-      badge.addEventListener("click", (e) => {
-        e.preventDefault();
-        runWideHitboxCommand(card, null);
-      });
-      label.appendChild(badge);
-    }
+
+    const badge = document.createElement("button");
+    badge.type = "button";
+    badge.className = "anim-override-reset-chip";
+    badge.textContent = t("animOverridesWideHitboxResetToTheme");
+    badge.hidden = !wideHitboxResetVisible(card);
+    badge.disabled = pending || !wideHitboxResetVisible(card);
+    badge.addEventListener("click", (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const currentCard = applyPendingWideHitboxOverrideEdit(getAnimOverrideCardById(card.id) || card);
+      runWideHitboxCommand(currentCard, !!currentCard.wideHitboxThemeDefault);
+    });
+    label.appendChild(badge);
+
     input.addEventListener("change", () => {
-      runWideHitboxCommand(card, input.checked);
+      const currentCard = applyPendingWideHitboxOverrideEdit(getAnimOverrideCardById(card.id) || card);
+      runWideHitboxCommand(currentCard, input.checked);
     });
     row.appendChild(input);
     row.appendChild(label);
+    row.classList.toggle("pending", pending);
+    if (card && card.id) {
+      getMountedWideHitboxToggles().set(card.id, {
+        row,
+        input,
+        badge,
+        cardId: card.id,
+        card,
+      });
+    }
     return row;
   }
 
@@ -1226,17 +1517,14 @@
     resetBtn.className = "soft-btn";
     resetBtn.textContent = t("animOverridesReset");
     resetBtn.disabled = !isCardOverridden(card);
-    helpers.attachActivation(resetBtn, () => {
-      const patch = {
-        file: null,
-        transition: null,
-        ...(card.supportsAutoReturn ? { autoReturnMs: null } : {}),
-        ...(card.supportsDuration ? { durationMs: null } : {}),
-      };
-      return runAnimationOverrideCommand(card, patch);
-    });
+    helpers.attachActivation(resetBtn, () => resetAnimationOverrideCard(card));
     footer.appendChild(resetBtn);
     drawer.appendChild(footer);
+    if (card && card.id) {
+      const controls = getMountedOverrideStatusControls();
+      const current = controls.get(card.id) || { cardId: card.id };
+      controls.set(card.id, { ...current, resetBtn, card });
+    }
 
     return drawer;
   }

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -89,6 +89,21 @@
     return state.mountedControls.animOverrideWideHitboxToggles;
   }
 
+  function isTimingControlBlocked(cardId) {
+    return !!(cardId && (
+      getPendingWideHitboxOverrideEdits().has(cardId)
+      || getPendingAnimationOverrideResets().has(cardId)
+    ));
+  }
+
+  function isWideHitboxControlBlocked(cardId) {
+    return !!(cardId && (
+      getPendingWideHitboxOverrideEdits().has(cardId)
+      || getPendingAnimationOverrideResets().has(cardId)
+      || getPendingAnimationOverrideEdits().has(cardId)
+    ));
+  }
+
   function timingControlKey(cardId, field) {
     return `${cardId}:${field}`;
   }
@@ -143,6 +158,11 @@
     let storedTimingValue = false;
     if (patch.transition && typeof patch.transition === "object") {
       next.transition = { ...patch.transition };
+      if (card.transitionThemeDefault && typeof card.transitionThemeDefault === "object") {
+        next.transitionThemeDefault = { ...card.transitionThemeDefault };
+      } else {
+        delete next.transitionThemeDefault;
+      }
       storedTimingValue = true;
     }
     if (Number.isFinite(patch.autoReturnMs)) {
@@ -169,6 +189,13 @@
   function transitionMatchesThemeDefault(transition, defaultTransition) {
     if (!transition || !defaultTransition) return false;
     return transition.in === defaultTransition.in && transition.out === defaultTransition.out;
+  }
+
+  function pendingTransitionMatchesThemeDefault(pending) {
+    return !!(pending
+      && pending.transition
+      && pending.transitionThemeDefault
+      && transitionMatchesThemeDefault(pending.transition, pending.transitionThemeDefault));
   }
 
   function hasTransitionOverride(entry) {
@@ -292,6 +319,9 @@
       const card = applyPendingAnimationOverrideEdit(getAnimOverrideCardById(control.cardId));
       const value = getCardTimingValue(card, control.field);
       if (Number.isFinite(value)) control.setValue(value);
+      const blocked = isTimingControlBlocked(control.cardId);
+      if (control.range) control.range.disabled = blocked;
+      if (control.number) control.number.disabled = blocked;
     }
   }
 
@@ -332,16 +362,13 @@
 
   function syncMountedWideHitboxToggles() {
     const controls = getMountedWideHitboxToggles();
-    const pendingEdits = getPendingWideHitboxOverrideEdits();
-    const pendingResets = getPendingAnimationOverrideResets();
     for (const [cardId, control] of controls) {
       if (!control || !control.row || !control.row.parentNode) {
         controls.delete(cardId);
         continue;
       }
       const card = applyPendingWideHitboxOverrideEdit(getAnimOverrideCardById(cardId) || control.card);
-      const pending = pendingEdits.get(cardId);
-      const blocked = !!pending || pendingResets.has(cardId);
+      const blocked = isWideHitboxControlBlocked(cardId);
       control.card = card || control.card;
       control.input.checked = !!(card && card.wideHitboxEnabled);
       control.input.disabled = blocked;
@@ -429,13 +456,79 @@
     return null;
   }
 
+  function readThemeOverrideEntry(themeMap, pending) {
+    if (!themeMap || !pending || !pending.slotType) return null;
+    if (pending.slotType === "state") {
+      return pending.stateKey && themeMap.states ? themeMap.states[pending.stateKey] || null : null;
+    }
+    if (pending.slotType === "tier") {
+      const group = pending.tierGroup && themeMap.tiers && themeMap.tiers[pending.tierGroup];
+      return group && pending.originalFile ? group[pending.originalFile] || null : null;
+    }
+    if (pending.slotType === "idleAnimation") {
+      return pending.originalFile && themeMap.idleAnimations ? themeMap.idleAnimations[pending.originalFile] || null : null;
+    }
+    if (pending.slotType === "reaction") {
+      return pending.reactionKey && themeMap.reactions ? themeMap.reactions[pending.reactionKey] || null : null;
+    }
+    return null;
+  }
+
+  function prunePendingThemeOverrideEntry(themeMap, pending) {
+    if (!themeMap || !pending || !pending.slotType) return;
+    if (pending.slotType === "state") {
+      if (themeMap.states && pending.stateKey && themeMap.states[pending.stateKey]
+        && !Object.keys(themeMap.states[pending.stateKey]).length) {
+        delete themeMap.states[pending.stateKey];
+      }
+      pruneEmptyObject(themeMap, "states");
+      return;
+    }
+    if (pending.slotType === "tier") {
+      const group = pending.tierGroup && themeMap.tiers && themeMap.tiers[pending.tierGroup];
+      if (group && pending.originalFile && group[pending.originalFile] && !Object.keys(group[pending.originalFile]).length) {
+        delete group[pending.originalFile];
+      }
+      if (themeMap.tiers) {
+        pruneEmptyObject(themeMap.tiers, "workingTiers");
+        pruneEmptyObject(themeMap.tiers, "jugglingTiers");
+        pruneEmptyObject(themeMap, "tiers");
+      }
+      return;
+    }
+    if (pending.slotType === "idleAnimation") {
+      if (themeMap.idleAnimations && pending.originalFile && themeMap.idleAnimations[pending.originalFile]
+        && !Object.keys(themeMap.idleAnimations[pending.originalFile]).length) {
+        delete themeMap.idleAnimations[pending.originalFile];
+      }
+      pruneEmptyObject(themeMap, "idleAnimations");
+      return;
+    }
+    if (pending.slotType === "reaction") {
+      if (themeMap.reactions && pending.reactionKey && themeMap.reactions[pending.reactionKey]
+        && !Object.keys(themeMap.reactions[pending.reactionKey]).length) {
+        delete themeMap.reactions[pending.reactionKey];
+      }
+      pruneEmptyObject(themeMap, "reactions");
+    }
+  }
+
   function applyPendingEditToThemeOverrides(themeMap, pending) {
     let entry = null;
-    if (pending.transition || Object.prototype.hasOwnProperty.call(pending, "durationMs")) {
+    const transitionClearsDefault = pendingTransitionMatchesThemeDefault(pending);
+    if ((pending.transition && !transitionClearsDefault)
+      || Object.prototype.hasOwnProperty.call(pending, "durationMs")) {
       entry = ensureThemeOverrideEntry(themeMap, pending);
       if (!entry) return false;
     }
-    if (pending.transition) entry.transition = { ...pending.transition };
+    if (pending.transition) {
+      if (transitionClearsDefault) {
+        const existingEntry = entry || readThemeOverrideEntry(themeMap, pending);
+        if (existingEntry) delete existingEntry.transition;
+      } else {
+        entry.transition = { ...pending.transition };
+      }
+    }
     if (Object.prototype.hasOwnProperty.call(pending, "autoReturnMs")) {
       if (pending.slotType !== "state" || !pending.stateKey) return false;
       themeMap.timings = themeMap.timings || {};
@@ -446,6 +539,7 @@
       if (pending.slotType !== "idleAnimation" && pending.slotType !== "reaction") return false;
       entry.durationMs = pending.durationMs;
     }
+    prunePendingThemeOverrideEntry(themeMap, pending);
     pruneThemeOverrideMap(themeMap);
     return true;
   }
@@ -605,11 +699,16 @@
     const payload = buildAnimOverrideRequest(card, patch);
     const timingOnly = isTimingOnlyPatch(patch);
     const pendingToken = timingOnly ? recordPendingAnimationOverrideEdit(card, patch) : null;
+    if (timingOnly && pendingToken) {
+      syncMountedWideHitboxToggles();
+      syncMountedOverrideStatusControls();
+    }
     return window.settingsAPI.command("setAnimationOverride", payload).then((result) => {
       if (!result || result.status !== "ok" || result.noop) {
         clearPendingAnimationOverrideEdit(pendingToken);
         if (timingOnly) {
           syncMountedTimingSliders();
+          syncMountedWideHitboxToggles();
           syncMountedOverrideStatusControls();
         }
         return result;
@@ -620,6 +719,7 @@
         ops.normalizeAssetPickerSelection();
         if (timingOnly && state.activeTab === "animOverrides") {
           syncMountedTimingSliders();
+          syncMountedWideHitboxToggles();
           syncMountedOverrideStatusControls();
         } else if (state.activeTab === "animOverrides") {
           ops.requestRender({ content: true });
@@ -1291,10 +1391,14 @@
     if (getPendingAnimationOverrideResets().has(card.id) && !options.allowDuringReset) {
       return Promise.resolve({ status: "ok", noop: true });
     }
+    if (getPendingAnimationOverrideEdits().has(card.id) && !options.allowDuringReset) {
+      return Promise.resolve({ status: "ok", noop: true });
+    }
     if (getPendingWideHitboxOverrideEdits().has(card.id)) return Promise.resolve({ status: "noop" });
     const pendingToken = recordPendingWideHitboxOverrideEdit(card, enabled);
     const pending = pendingToken && getPendingWideHitboxOverrideEdits().get(card.id);
     if (!pending) return Promise.resolve({ status: "noop" });
+    syncMountedTimingSliders();
     syncMountedWideHitboxToggles();
     syncMountedOverrideStatusControls();
     return window.settingsAPI.command("setWideHitboxOverride", {
@@ -1304,6 +1408,7 @@
     }).then((result) => {
       if (!result || result.status !== "ok" || result.noop) {
         clearPendingWideHitboxOverrideEdit(pendingToken);
+        syncMountedTimingSliders();
         syncMountedWideHitboxToggles();
         syncMountedOverrideStatusControls();
         if (result && result.status === "error") {
@@ -1315,6 +1420,7 @@
         reconcilePendingWideHitboxOverrideEdits();
         ops.normalizeAssetPickerSelection();
         if (state.activeTab === "animOverrides") {
+          syncMountedTimingSliders();
           syncMountedWideHitboxToggles();
           syncMountedOverrideStatusControls();
         }
@@ -1323,6 +1429,7 @@
       });
     }).catch((err) => {
       clearPendingWideHitboxOverrideEdit(pendingToken);
+      syncMountedTimingSliders();
       syncMountedWideHitboxToggles();
       syncMountedOverrideStatusControls();
       ops.showToast(t("toastSaveFailed") + ((err && err.message) || "unknown error"), { error: true });
@@ -1345,11 +1452,24 @@
       ...(card.supportsAutoReturn ? { autoReturnMs: null } : {}),
       ...(card.supportsDuration ? { durationMs: null } : {}),
     };
+    const resetHitboxFile = card.slotType !== "reaction" && card.currentFile && card.wideHitboxOverridden
+      ? card.currentFile
+      : null;
+    const resetHitboxThemeDefault = !!card.wideHitboxThemeDefault;
     return runAnimationOverrideCommand(card, patch).then((result) => {
       if (result && result.status === "error") return result;
       const currentCard = applyPendingWideHitboxOverrideEdit(getAnimOverrideCardById(card.id) || card);
-      if (currentCard.slotType === "reaction" || !currentCard.wideHitboxOverridden) return result;
-      return runWideHitboxCommand(currentCard, !!currentCard.wideHitboxThemeDefault, { allowDuringReset: true });
+      if (currentCard.slotType === "reaction" || !resetHitboxFile) return result;
+      return runWideHitboxCommand(
+        {
+          ...currentCard,
+          currentFile: resetHitboxFile,
+          wideHitboxOverridden: true,
+          wideHitboxThemeDefault: resetHitboxThemeDefault,
+        },
+        resetHitboxThemeDefault,
+        { allowDuringReset: true }
+      );
     }).finally(() => {
       pendingResets.delete(card.id);
       syncMountedWideHitboxToggles();
@@ -1360,10 +1480,7 @@
   function buildAnimWideHitboxToggle(card) {
     const row = document.createElement("div");
     row.className = "anim-override-toggle-row";
-    const pending = !!(card && card.id && (
-      getPendingWideHitboxOverrideEdits().has(card.id)
-      || getPendingAnimationOverrideResets().has(card.id)
-    ));
+    const pending = isWideHitboxControlBlocked(card && card.id);
     const input = document.createElement("input");
     input.type = "checkbox";
     input.checked = !!card.wideHitboxEnabled;
@@ -1617,6 +1734,7 @@
     let committedValue = Number.isFinite(Number(value)) ? Number(value) : null;
     const commitValue = (v) => {
       if (!Number.isFinite(v)) return;
+      if (isTimingControlBlocked(cardId)) return;
       if (pendingValue === v || committedValue === v) return;
       pendingValue = v;
       const result = onCommit(v);
@@ -1647,6 +1765,10 @@
       number.value = range.value;
       syncRangeFill();
     });
+    const initialBlocked = isTimingControlBlocked(cardId);
+    range.disabled = initialBlocked;
+    number.disabled = initialBlocked;
+
     range.addEventListener("change", () => {
       const v = Number(range.value);
       commitValue(v);

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -927,6 +927,9 @@
       if (runtime.pendingWideHitboxOverrideEdits && typeof runtime.pendingWideHitboxOverrideEdits.clear === "function") {
         runtime.pendingWideHitboxOverrideEdits.clear();
       }
+      if (runtime.pendingAnimationOverrideResets && typeof runtime.pendingAnimationOverrideResets.clear === "function") {
+        runtime.pendingAnimationOverrideResets.clear();
+      }
       if (state.mountedControls.animOverrideTimingSliders
         && typeof state.mountedControls.animOverrideTimingSliders.clear === "function") {
         state.mountedControls.animOverrideTimingSliders.clear();

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -181,6 +181,12 @@
     const all = state.snapshot && state.snapshot.themeOverrides;
     const map = all && all[themeId];
     if (!map || typeof map !== "object") return false;
+    const hitboxKeys = [];
+    if (map.hitbox && typeof map.hitbox === "object") {
+      for (const group of Object.values(map.hitbox)) {
+        if (group && typeof group === "object") hitboxKeys.push(...Object.keys(group));
+      }
+    }
     const keys = [
       ...(map.states ? Object.keys(map.states) : []),
       ...(map.tiers && map.tiers.workingTiers ? Object.keys(map.tiers.workingTiers) : []),
@@ -188,7 +194,7 @@
       ...(map.timings && map.timings.autoReturn ? Object.keys(map.timings.autoReturn) : []),
       ...(map.idleAnimations ? Object.keys(map.idleAnimations) : []),
       ...(map.reactions ? Object.keys(map.reactions) : []),
-      ...(map.hitbox ? Object.keys(map.hitbox) : []),
+      ...hitboxKeys,
       ...(map.sounds ? Object.keys(map.sounds) : []),
     ];
     return keys.length > 0;
@@ -918,9 +924,20 @@
       if (runtime.pendingAnimationOverrideEdits && typeof runtime.pendingAnimationOverrideEdits.clear === "function") {
         runtime.pendingAnimationOverrideEdits.clear();
       }
+      if (runtime.pendingWideHitboxOverrideEdits && typeof runtime.pendingWideHitboxOverrideEdits.clear === "function") {
+        runtime.pendingWideHitboxOverrideEdits.clear();
+      }
       if (state.mountedControls.animOverrideTimingSliders
         && typeof state.mountedControls.animOverrideTimingSliders.clear === "function") {
         state.mountedControls.animOverrideTimingSliders.clear();
+      }
+      if (state.mountedControls.animOverrideWideHitboxToggles
+        && typeof state.mountedControls.animOverrideWideHitboxToggles.clear === "function") {
+        state.mountedControls.animOverrideWideHitboxToggles.clear();
+      }
+      if (state.mountedControls.animOverrideStatusControls
+        && typeof state.mountedControls.animOverrideStatusControls.clear === "function") {
+        state.mountedControls.animOverrideStatusControls.clear();
       }
     }
     const shouldPreserveAnimOverridesData = !!(

--- a/src/settings.css
+++ b/src/settings.css
@@ -1467,8 +1467,6 @@ html, body {
   padding: 8px 10px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  cursor: pointer;
-  user-select: none;
 }
 .anim-override-toggle-row input[type="checkbox"] {
   margin: 3px 0 0 0;
@@ -1500,6 +1498,9 @@ html, body {
   border-radius: 999px;
   padding: 2px 8px;
   cursor: pointer;
+}
+.anim-override-reset-chip[hidden] {
+  display: none;
 }
 .anim-override-reset-chip:hover {
   color: var(--text-primary);

--- a/src/theme-loader.js
+++ b/src/theme-loader.js
@@ -187,6 +187,20 @@ function loadTheme(themeId, opts = {}) {
   theme._variantId = resolvedId;
   theme._userOverrides = userOverrides;
   theme._bindingBase = _buildBaseBindingMetadata(afterVariant);
+  theme._baseTransitions = {};
+  if (afterVariant.transitions && typeof afterVariant.transitions === "object") {
+    for (const [file, transition] of Object.entries(afterVariant.transitions)) {
+      const name = _basenameOnly(file);
+      if (!name || !transition || typeof transition !== "object") continue;
+      const clean = {};
+      if (Number.isFinite(transition.in)) clean.in = transition.in;
+      if (Number.isFinite(transition.out)) clean.out = transition.out;
+      if (Object.keys(clean).length > 0) theme._baseTransitions[name] = clean;
+    }
+  }
+  theme._baseWideHitboxFiles = Array.isArray(afterVariant.wideHitboxFiles)
+    ? [...new Set(afterVariant.wideHitboxFiles.map((file) => _basenameOnly(file)).filter(Boolean))]
+    : [];
   theme._capabilities = _buildCapabilities(theme);
 
   // For external themes: sanitize SVGs + resolve asset paths

--- a/src/theme-runtime.js
+++ b/src/theme-runtime.js
@@ -229,6 +229,34 @@ function createThemeRuntime(options = {}) {
     return { themeId, variantId: newTheme._variantId };
   }
 
+  function refreshActiveThemeHitboxOverrides(themeId, overrideMap) {
+    if (!activeTheme || activeTheme._id !== themeId) {
+      throw new Error("hitbox refresh requires the requested theme to already be active");
+    }
+
+    const targetVariant = activeTheme._variantId || "default";
+    const targetOverrideSignature = JSON.stringify(overrideMap || {});
+    if ((activeTheme._overrideSignature || "{}") === targetOverrideSignature) {
+      return { themeId, variantId: targetVariant };
+    }
+
+    const newTheme = themeLoader.loadTheme(themeId, {
+      strict: true,
+      variant: targetVariant,
+      overrides: overrideMap,
+    });
+    newTheme._overrideSignature = targetOverrideSignature;
+    setActiveTheme(newTheme);
+
+    const stateRuntime = getStateRuntime();
+    callMethod(stateRuntime, "refreshTheme");
+    if (isLiveWindow(getHitWindow())) syncHitStateAfterLoad();
+    if (isLiveWindow(getRenderWindow())) syncHitWin();
+    flushRuntimeStateToPrefs();
+
+    return { themeId, variantId: newTheme._variantId };
+  }
+
   function getThemeInfo(themeId) {
     const all = themeLoader.discoverThemes();
     const entry = all.find((theme) => theme.id === themeId);
@@ -265,6 +293,7 @@ function createThemeRuntime(options = {}) {
   return {
     loadInitialTheme,
     activateTheme,
+    refreshActiveThemeHitboxOverrides,
     getActiveTheme,
     getActiveThemeContext,
     getActiveThemeId,

--- a/test/settings-actions-theme-overrides.test.js
+++ b/test/settings-actions-theme-overrides.test.js
@@ -68,6 +68,71 @@ test("settings theme override actions update an active state slot with explicit 
   ]);
 });
 
+test("settings theme override actions clear transition overrides that match the theme default", () => {
+  const calls = [];
+  const snapshot = {
+    theme: "clawd",
+    themeOverrides: {
+      clawd: {
+        states: {
+          thinking: {
+            transition: { in: 160, out: 150 },
+          },
+        },
+      },
+    },
+  };
+
+  const result = themeOverrideCommands.setAnimationOverride(
+    {
+      themeId: "clawd",
+      slotType: "state",
+      stateKey: "thinking",
+      transition: { in: 150, out: 150 },
+      transitionThemeDefault: { in: 150, out: 150 },
+    },
+    {
+      snapshot,
+      activateTheme: (themeId, variantId, overrideMap) => {
+        calls.push({ themeId, variantId, overrideMap });
+      },
+    }
+  );
+
+  assert.strictEqual(result.status, "ok");
+  assert.strictEqual(result.commit.themeOverrides.clawd, undefined);
+  assert.deepStrictEqual(calls, [
+    {
+      themeId: "clawd",
+      variantId: null,
+      overrideMap: {},
+    },
+  ]);
+});
+
+test("settings theme override actions keep transition overrides that differ from the theme default", () => {
+  const result = themeOverrideCommands.setAnimationOverride(
+    {
+      themeId: "clawd",
+      slotType: "state",
+      stateKey: "thinking",
+      transition: { in: 160, out: 150 },
+      transitionThemeDefault: { in: 150, out: 150 },
+    },
+    {
+      snapshot: { theme: "other", themeOverrides: {} },
+      activateTheme: () => {
+        throw new Error("inactive theme should not reload");
+      },
+    }
+  );
+
+  assert.strictEqual(result.status, "ok");
+  assert.deepStrictEqual(result.commit.themeOverrides.clawd.states.thinking, {
+    transition: { in: 160, out: 150 },
+  });
+});
+
 test("settings theme override actions preserve animation and hitbox data when changing sound overrides", () => {
   const snapshot = {
     theme: "calico",

--- a/test/settings-actions.test.js
+++ b/test/settings-actions.test.js
@@ -1597,6 +1597,32 @@ describe("setWideHitboxOverride command", () => {
       hitbox: { wide: { "foo.svg": true } },
     });
   });
+
+  it("prefers refreshActiveThemeHitboxOverrides over activateTheme for active theme changes", () => {
+    let refreshedWith = null;
+    let activated = false;
+    const snapshot = { theme: "clawd", themeOverrides: {} };
+    const r = commandRegistry.setWideHitboxOverride(
+      { themeId: "clawd", file: "foo.svg", enabled: true },
+      {
+        snapshot,
+        refreshActiveThemeHitboxOverrides: (id, overrideMap) => {
+          refreshedWith = { id, overrideMap };
+        },
+        activateTheme: () => {
+          activated = true;
+        },
+      }
+    );
+    assert.strictEqual(r.status, "ok");
+    assert.deepStrictEqual(refreshedWith, {
+      id: "clawd",
+      overrideMap: {
+        hitbox: { wide: { "foo.svg": true } },
+      },
+    });
+    assert.strictEqual(activated, false);
+  });
 });
 
 describe("theme override subtree preservation", () => {

--- a/test/settings-animation-overrides-main.test.js
+++ b/test/settings-animation-overrides-main.test.js
@@ -51,6 +51,7 @@ function makeTheme(root, overrides = {}) {
       jugglingTiers: [],
       displayHintMap: {},
     },
+    _baseTransitions: {},
     _stateBindings: {
       idle: { files: ["idle.svg"] },
       thinking: { files: ["scripted.svg"] },
@@ -82,7 +83,9 @@ function createRuntimeHarness(overrides = {}) {
 
   const stateCalls = [];
   let themeReloadInProgress = !!overrides.themeReloadInProgress;
-  const activeTheme = overrides.activeTheme || makeTheme(root, overrides.themeOverrides);
+  const activeTheme = typeof overrides.activeThemeFactory === "function"
+    ? overrides.activeThemeFactory(root)
+    : (overrides.activeTheme || makeTheme(root, overrides.themeOverrides));
   const runtime = createSettingsAnimationOverridesMain({
     app: { isPackaged: false, getVersion: () => "1.2.3" },
     BrowserWindow: FakeBrowserWindow,
@@ -102,7 +105,7 @@ function createRuntimeHarness(overrides = {}) {
       probeAssetCycle: () => ({ ms: null, status: "unavailable", source: null }),
     },
     settingsController: {
-      getSnapshot: () => ({ themeOverrides: {} }),
+      getSnapshot: () => (overrides.snapshot || { themeOverrides: {} }),
       applyCommand: async () => ({ status: "ok", importedThemeCount: 0 }),
     },
     getActiveTheme: () => activeTheme,
@@ -318,6 +321,118 @@ test("animation preview requests defer while theme reload is in progress", () =>
     harness.runtime.runPendingPostReloadTasks();
 
     assert.deepStrictEqual(harness.stateCalls[0], ["applyState", "thinking", "scripted.svg"]);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("animation override cards expose theme-default wide hitbox state separately from the effective override state", () => {
+  const harness = createRuntimeHarness({
+    snapshot: {
+      themeOverrides: {
+        cloudling: {
+          hitbox: {
+            wide: {
+              "scripted.svg": false,
+            },
+          },
+        },
+      },
+    },
+    activeThemeFactory: (root) => makeTheme(root, {
+      wideHitboxFiles: [],
+      _baseWideHitboxFiles: ["scripted.svg"],
+    }),
+  });
+  try {
+    const data = harness.runtime.buildAnimationOverrideData();
+    const thinkingCard = data.cards.find((card) => card.stateKey === "thinking");
+
+    assert.ok(thinkingCard);
+    assert.strictEqual(thinkingCard.wideHitboxEnabled, false);
+    assert.strictEqual(thinkingCard.wideHitboxThemeDefault, true);
+    assert.strictEqual(thinkingCard.wideHitboxOverridden, true);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("animation override cards expose theme-default transition state separately from effective timing", () => {
+  const harness = createRuntimeHarness({
+    snapshot: {
+      themeOverrides: {
+        cloudling: {
+          states: {
+            thinking: {
+              transition: { in: 160, out: 150 },
+            },
+          },
+        },
+      },
+    },
+    activeThemeFactory: (root) => makeTheme(root, {
+      transitions: {
+        "scripted.svg": { in: 160, out: 150 },
+      },
+      _baseTransitions: {
+        "scripted.svg": { in: 150, out: 150 },
+      },
+    }),
+  });
+  try {
+    const data = harness.runtime.buildAnimationOverrideData();
+    const thinkingCard = data.cards.find((card) => card.stateKey === "thinking");
+
+    assert.ok(thinkingCard);
+    assert.deepStrictEqual(thinkingCard.transition, { in: 160, out: 150 });
+    assert.deepStrictEqual(thinkingCard.transitionThemeDefault, { in: 150, out: 150 });
+    assert.strictEqual(thinkingCard.hasTransitionOverride, true);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test("animation override data builds tier cards with transition override metadata", () => {
+  const harness = createRuntimeHarness({
+    snapshot: {
+      themeOverrides: {
+        cloudling: {
+          tiers: {
+            workingTiers: {
+              "scripted.svg": {
+                transition: { in: 180, out: 150 },
+              },
+            },
+          },
+        },
+      },
+    },
+    activeThemeFactory: (root) => makeTheme(root, {
+      _bindingBase: {
+        states: { idle: "idle.svg", thinking: "scripted.svg", sleeping: "sleep.svg" },
+        workingTiers: [{ originalFile: "scripted.svg" }],
+        jugglingTiers: [],
+        displayHintMap: {},
+      },
+      workingTiers: [
+        { file: "scripted.svg", minSessions: 2 },
+      ],
+      transitions: {
+        "scripted.svg": { in: 180, out: 150 },
+      },
+      _baseTransitions: {
+        "scripted.svg": { in: 150, out: 150 },
+      },
+    }),
+  });
+  try {
+    const data = harness.runtime.buildAnimationOverrideData();
+    const tierCard = data.cards.find((card) => card.id === "workingTiers:scripted.svg");
+
+    assert.ok(tierCard);
+    assert.strictEqual(tierCard.hasTransitionOverride, true);
+    assert.deepStrictEqual(tierCard.transition, { in: 180, out: 150 });
+    assert.deepStrictEqual(tierCard.transitionThemeDefault, { in: 150, out: 150 });
   } finally {
     harness.cleanup();
   }

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -3213,11 +3213,17 @@ describe("settings renderer browser environment", () => {
     for (const listener of toggle.eventListeners.change || []) listener();
     await Promise.resolve();
     await Promise.resolve();
+    let resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
+    assert.ok(parent.querySelector(".anim-override-badge-dot"), "wide-hitbox commit should update the summary changed badge in place");
+    assert.strictEqual(resetButton.disabled, false, "wide-hitbox commit should enable reset affordance in place");
 
     toggle.checked = false;
     for (const listener of toggle.eventListeners.change || []) listener();
     await Promise.resolve();
     await Promise.resolve();
+    resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
+    assert.strictEqual(parent.querySelector(".anim-override-badge-dot"), null, "theme-default hitbox commit should clear the changed badge in place");
+    assert.strictEqual(resetButton.disabled, true, "theme-default hitbox commit should disable reset affordance in place");
 
     assert.strictEqual(payloads.length, 2);
     assert.strictEqual(payloads[0].enabled, true);

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -3148,10 +3148,12 @@ describe("settings renderer browser environment", () => {
     core.tabs.animOverrides.render(parent, core);
 
     const row = parent.querySelector(".anim-override-toggle-row");
+    const input = parent.querySelectorAll("input").find((candidate) => candidate.type === "checkbox");
     const title = parent.querySelector(".anim-override-toggle-title");
 
     assert.ok(row, "expanded animation override row should render a wide-hitbox toggle row");
     assert.strictEqual(row.tagName, "DIV");
+    assert.strictEqual(input.getAttribute("aria-label"), "animOverridesWideHitboxToggle");
     assert.ok(title);
     assert.strictEqual((title.eventListeners.click || []).length, 0);
   });
@@ -3248,6 +3250,33 @@ describe("settings renderer browser environment", () => {
     assert.ok(resetChip, "wide-hitbox reset chip should render for stale no-op overrides");
     assert.strictEqual(resetChip.hidden, false);
     assert.strictEqual(resetChip.disabled, false);
+  });
+
+  it("shows a fallback error detail when wide hitbox saves fail without a message", async () => {
+    const card = createAnimOverrideCard();
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const toasts = [];
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: () => Promise.resolve({ status: "error" }),
+      },
+      opsOverrides: {
+        showToast: (message) => toasts.push(message),
+      },
+    });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    toggle.checked = true;
+    for (const listener of toggle.eventListeners.change || []) listener();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.ok(toasts.some((message) => String(message).includes("unknown error")));
   });
 
   it("preserves pending wide hitbox state across full Animation Overrides rerenders", async () => {
@@ -3751,6 +3780,7 @@ describe("settings renderer browser environment", () => {
       seq: 1,
     });
     core.state.mountedControls.animOverrideTimingSliders.set("state:thinking:transition.in", { row: {} });
+    core.runtime.pendingAnimationOverrideResets = new Set(["state:thinking"]);
 
     core.ops.applyChanges({
       changes: { theme: "calico" },
@@ -3762,6 +3792,7 @@ describe("settings renderer browser environment", () => {
     });
 
     assert.strictEqual(core.runtime.pendingAnimationOverrideEdits.size, 0);
+    assert.strictEqual(core.runtime.pendingAnimationOverrideResets.size, 0);
     assert.strictEqual(core.state.mountedControls.animOverrideTimingSliders.size, 0);
   });
 

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -3300,12 +3300,16 @@ describe("settings renderer browser environment", () => {
     toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
     const resetChip = parent.querySelectorAll("button")
       .find((button) => button.textContent === "animOverridesWideHitboxResetToTheme");
+    let resetButton = parent.querySelectorAll("button")
+      .find((button) => button.textContent === "animOverridesReset");
     assert.ok(toggle, "wide-hitbox checkbox should still exist after rerender");
     assert.strictEqual(toggle.checked, true, "pending wide-hitbox toggles should stay on across rerenders");
     assert.strictEqual(toggle.disabled, true, "pending wide-hitbox toggles should stay disabled across rerenders");
     assert.ok(resetChip, "wide-hitbox reset chip should still exist after rerender");
     assert.strictEqual(resetChip.hidden, false, "pending wide-hitbox rerenders should keep the reset chip visible");
     assert.strictEqual(resetChip.disabled, true, "pending wide-hitbox rerenders should keep the reset chip disabled");
+    assert.ok(resetButton, "pending wide-hitbox rerenders should keep the slot reset button mounted");
+    assert.strictEqual(resetButton.disabled, true, "slot reset should stay disabled while a wide-hitbox edit is pending");
 
     resolveCommand({ status: "ok" });
     await Promise.resolve();
@@ -3313,8 +3317,41 @@ describe("settings renderer browser environment", () => {
     await Promise.resolve();
 
     toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    resetButton = parent.querySelectorAll("button")
+      .find((button) => button.textContent === "animOverridesReset");
     assert.strictEqual(toggle.checked, true);
     assert.strictEqual(toggle.disabled, false);
+    assert.strictEqual(resetButton.disabled, false);
+  });
+
+  it("reconciles acknowledged pending wide hitbox edits during Animation Overrides render", () => {
+    const card = createAnimOverrideCard({
+      wideHitboxEnabled: true,
+      wideHitboxOverridden: true,
+      wideHitboxThemeDefault: false,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    runtime.pendingWideHitboxOverrideEdits = new Map([[
+      card.id,
+      {
+        seq: 1,
+        currentFile: card.currentFile,
+        themeDefault: false,
+        effectiveEnabled: true,
+        commandEnabled: true,
+      },
+    ]]);
+    const modalRoot = new FakeElement("div");
+    const { core } = loadAnimOverridesTabForTest({ runtime, modalRoot });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    const resetButton = parent.querySelectorAll("button")
+      .find((button) => button.textContent === "animOverridesReset");
+    assert.strictEqual(runtime.pendingWideHitboxOverrideEdits.size, 0);
+    assert.strictEqual(toggle.disabled, false);
+    assert.strictEqual(resetButton.disabled, false);
   });
 
   it("treats hitbox-only overrides as overridden for summary badges and reset actions", () => {
@@ -3359,12 +3396,18 @@ describe("settings renderer browser environment", () => {
     const runtime = createAnimOverridesRuntime(card);
     const modalRoot = new FakeElement("div");
     const calls = [];
+    let resolveAnimationReset;
     const { core } = loadAnimOverridesTabForTest({
       runtime,
       modalRoot,
       settingsAPI: {
         command: (name, payload) => {
           calls.push({ name, payload });
+          if (name === "setAnimationOverride") {
+            return new Promise((resolve) => {
+              resolveAnimationReset = resolve;
+            });
+          }
           return Promise.resolve({ status: "ok" });
         },
       },
@@ -3387,6 +3430,17 @@ describe("settings renderer browser environment", () => {
     const resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
     assert.ok(resetButton, "expanded row should render a reset button");
     for (const listener of resetButton.eventListeners.click || []) listener();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const toggleWhileResetPending = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    const resetChipWhileResetPending = parent.querySelectorAll("button")
+      .find((button) => button.textContent === "animOverridesWideHitboxResetToTheme");
+    assert.strictEqual(toggleWhileResetPending.disabled, true, "slot reset should block wide-hitbox toggles while pending");
+    assert.strictEqual(resetChipWhileResetPending.disabled, true, "slot reset should block wide-hitbox reset chips while pending");
+
+    resolveAnimationReset({ status: "ok" });
+    await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();
     await Promise.resolve();

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -3353,6 +3353,76 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(resetButton.disabled, false);
   });
 
+  it("blocks wide hitbox edits while a same-card timing edit is pending", async () => {
+    const card = createAnimOverrideCard();
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const calls = [];
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: (name, payload) => {
+          calls.push({ name, payload });
+          return new Promise(() => {});
+        },
+      },
+    });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const range = parent.querySelectorAll("input").find((input) => input.type === "range");
+    const toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    range.value = "260";
+    for (const listener of range.eventListeners.change || []) listener();
+
+    assert.strictEqual(toggle.disabled, true, "wide-hitbox toggle should be blocked while timing is pending");
+    toggle.checked = true;
+    for (const listener of toggle.eventListeners.change || []) listener();
+    await Promise.resolve();
+
+    assert.deepStrictEqual(
+      calls.map((call) => call.name),
+      ["setAnimationOverride"],
+      "blocked wide-hitbox changes should not enqueue a second override command"
+    );
+  });
+
+  it("blocks timing edits while a same-card wide hitbox edit is pending", async () => {
+    const card = createAnimOverrideCard();
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const calls = [];
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: (name, payload) => {
+          calls.push({ name, payload });
+          return new Promise(() => {});
+        },
+      },
+    });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    const range = parent.querySelectorAll("input").find((input) => input.type === "range");
+    toggle.checked = true;
+    for (const listener of toggle.eventListeners.change || []) listener();
+
+    assert.strictEqual(range.disabled, true, "timing slider should be blocked while wide-hitbox is pending");
+    range.value = "260";
+    for (const listener of range.eventListeners.change || []) listener();
+    await Promise.resolve();
+
+    assert.deepStrictEqual(
+      calls.map((call) => call.name),
+      ["setWideHitboxOverride"],
+      "blocked timing changes should not enqueue a second override command"
+    );
+  });
+
   it("reconciles acknowledged pending wide hitbox edits during Animation Overrides render", () => {
     const card = createAnimOverrideCard({
       wideHitboxEnabled: true,
@@ -3480,6 +3550,88 @@ describe("settings renderer browser environment", () => {
       calls.map((call) => call.name),
       ["setAnimationOverride", "setWideHitboxOverride"]
     );
+    assert.strictEqual(calls[1].payload.enabled, null);
+  });
+
+  it("clears hitbox overrides for the pre-reset replacement file when resetting a slot", async () => {
+    const replacementFile = "replacement-thinking.svg";
+    const baseFile = "cloudling-thinking.svg";
+    const card = createAnimOverrideCard({
+      currentFile: replacementFile,
+      wideHitboxEnabled: true,
+      wideHitboxOverridden: true,
+      wideHitboxThemeDefault: false,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const calls = [];
+    let resolveAnimationReset;
+    let fetchCount = 0;
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: (name, payload) => {
+          calls.push({ name, payload });
+          if (name === "setAnimationOverride") {
+            return new Promise((resolve) => {
+              resolveAnimationReset = resolve;
+            });
+          }
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+      opsOverrides: {
+        fetchAnimationOverridesData: () => {
+          fetchCount++;
+          if (fetchCount === 1) {
+            Object.assign(runtime.animationOverridesData.cards[0], {
+              currentFile: baseFile,
+              wideHitboxEnabled: false,
+              wideHitboxOverridden: false,
+              wideHitboxThemeDefault: false,
+            });
+          }
+          return Promise.resolve(runtime.animationOverridesData);
+        },
+      },
+      readersOverrides: {
+        readThemeOverrideMap: () => ({
+          states: {
+            thinking: {
+              file: replacementFile,
+            },
+          },
+          hitbox: {
+            wide: {
+              [replacementFile]: true,
+            },
+          },
+        }),
+      },
+    });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
+    assert.ok(resetButton, "expanded row should render a reset button");
+    for (const listener of resetButton.eventListeners.click || []) listener();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    resolveAnimationReset({ status: "ok" });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.deepStrictEqual(
+      calls.map((call) => call.name),
+      ["setAnimationOverride", "setWideHitboxOverride"]
+    );
+    assert.strictEqual(calls[1].payload.file, replacementFile);
     assert.strictEqual(calls[1].payload.enabled, null);
   });
 
@@ -3713,6 +3865,81 @@ describe("settings renderer browser environment", () => {
 
     assert.strictEqual(contentRenderCount, 0, "matching timing ack should avoid rebuilding content");
     assert.strictEqual(modalRenderCount, 0, "modal render happens after the async fetch settles");
+  });
+
+  it("routes default-matching timing broadcasts through applyChanges in place", () => {
+    const core = loadSettingsCoreForTest({
+      getAnimationOverridesData: () => Promise.resolve({
+        theme: { id: "cloudling", name: "Cloudling" },
+        assets: [],
+        sections: [],
+        cards: [{
+          id: "state:thinking",
+          slotType: "state",
+          stateKey: "thinking",
+          transition: { in: 150, out: 150 },
+          transitionThemeDefault: { in: 150, out: 150 },
+          hasTransitionOverride: false,
+        }],
+        sounds: [],
+      }),
+    });
+    core.state.activeTab = "animOverrides";
+    core.state.snapshot = {
+      theme: "cloudling",
+      themeOverrides: {
+        cloudling: {
+          states: {
+            thinking: {
+              transition: { in: 160, out: 150 },
+            },
+          },
+        },
+      },
+    };
+    core.runtime.animationOverridesData = {
+      theme: { id: "cloudling", name: "Cloudling" },
+      assets: [],
+      sections: [],
+      cards: [{
+        id: "state:thinking",
+        slotType: "state",
+        stateKey: "thinking",
+        transition: { in: 160, out: 150 },
+        transitionThemeDefault: { in: 150, out: 150 },
+        hasTransitionOverride: true,
+      }],
+      sounds: [],
+    };
+    core.runtime.animOverridesSubtab = "animations";
+    core.runtime.assetPicker.state = null;
+    core.runtime.pendingAnimationOverrideEdits.set("state:thinking", {
+      seq: 1,
+      slotType: "state",
+      stateKey: "thinking",
+      transition: { in: 150, out: 150 },
+      transitionThemeDefault: { in: 150, out: 150 },
+    });
+
+    let contentRenderCount = 0;
+    core.ops.installRenderHooks({
+      sidebar: () => {},
+      content: () => {
+        contentRenderCount++;
+      },
+      modal: () => {},
+    });
+
+    const nextSnapshot = {
+      theme: "cloudling",
+      themeOverrides: {},
+    };
+    core.ops.applyChanges({
+      changes: { themeOverrides: nextSnapshot.themeOverrides },
+      snapshot: nextSnapshot,
+    });
+
+    assert.strictEqual(contentRenderCount, 0, "default timing ack should avoid rebuilding content");
   });
 
   it("does not patch mixed-key Animation Overrides broadcasts in place", () => {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -3231,6 +3231,25 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(contentRenderCount, 1, "wide-hitbox toggle commits should not rebuild the content pane");
   });
 
+  it("shows the wide hitbox reset chip for stale overrides that already match the theme default", () => {
+    const card = createAnimOverrideCard({
+      wideHitboxEnabled: false,
+      wideHitboxOverridden: true,
+      wideHitboxThemeDefault: false,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const { core } = loadAnimOverridesTabForTest({ runtime, modalRoot });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const resetChip = parent.querySelectorAll("button")
+      .find((button) => button.textContent === "animOverridesWideHitboxResetToTheme");
+    assert.ok(resetChip, "wide-hitbox reset chip should render for stale no-op overrides");
+    assert.strictEqual(resetChip.hidden, false);
+    assert.strictEqual(resetChip.disabled, false);
+  });
+
   it("preserves pending wide hitbox state across full Animation Overrides rerenders", async () => {
     const card = createAnimOverrideCard({
       wideHitboxEnabled: false,

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -843,6 +843,7 @@ function createAnimOverrideCard(overrides = {}) {
     fallbackTargetState: null,
     wideHitboxEnabled: false,
     wideHitboxOverridden: false,
+    wideHitboxThemeDefault: false,
     aspectRatioWarning: null,
     ...overrides,
   };
@@ -2523,6 +2524,24 @@ describe("settings renderer browser environment", () => {
     );
   });
 
+  it("does not treat an empty hitbox override group as a reset-all override", () => {
+    const core = loadSettingsCoreForTest({});
+    core.state.snapshot = {
+      themeOverrides: {
+        cloudling: {
+          hitbox: {
+            wide: {},
+          },
+        },
+      },
+    };
+
+    assert.strictEqual(core.readers.hasAnyThemeOverride("cloudling"), false);
+
+    core.state.snapshot.themeOverrides.cloudling.hitbox.wide["cloudling-thinking.svg"] = true;
+    assert.strictEqual(core.readers.hasAnyThemeOverride("cloudling"), true);
+  });
+
   it("keeps current Animation Overrides data visible while theme override refresh is pending", () => {
     const deferred = createDeferred();
     const core = loadSettingsCoreForTest({
@@ -2869,6 +2888,134 @@ describe("settings renderer browser environment", () => {
     );
   });
 
+  it("updates Animation Overrides reset affordances after the first timing commit", async () => {
+    const card = createAnimOverrideCard({
+      transition: { in: 150, out: 150 },
+      transitionThemeDefault: { in: 150, out: 150 },
+      hasTransitionOverride: false,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const payloads = [];
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: (_name, payload) => {
+          payloads.push(payload);
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+      opsOverrides: {
+        fetchAnimationOverridesData: () => {
+          Object.assign(runtime.animationOverridesData.cards[0], {
+            transition: { in: 160, out: 150 },
+            transitionThemeDefault: { in: 150, out: 150 },
+            hasTransitionOverride: true,
+          });
+          return Promise.resolve(runtime.animationOverridesData);
+        },
+      },
+    });
+    const parent = new FakeElement("main");
+    let contentRenderCount = 0;
+    const renderContent = () => {
+      contentRenderCount++;
+      parent.innerHTML = "";
+      core.tabs.animOverrides.render(parent, core);
+    };
+    core.ops.requestRender = ({ content = false, modal = false } = {}) => {
+      if (content) renderContent();
+      if (modal && typeof core.renderHooks.modal === "function") core.renderHooks.modal();
+    };
+    renderContent();
+
+    const range = parent.querySelectorAll("input").find((input) => input.type === "range");
+    const resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
+    assert.ok(range);
+    assert.ok(resetButton);
+    assert.strictEqual(resetButton.disabled, true);
+    assert.strictEqual(parent.querySelector(".anim-override-badge-dot"), null);
+
+    range.value = "160";
+    for (const listener of range.eventListeners.input || []) listener();
+    for (const listener of range.eventListeners.change || []) listener();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.strictEqual(payloads.length, 1);
+    assert.strictEqual(payloads[0].transitionThemeDefault.in, 150);
+    assert.strictEqual(payloads[0].transitionThemeDefault.out, 150);
+    assert.strictEqual(contentRenderCount, 1, "timing-only commits should keep the content DOM mounted");
+    assert.strictEqual(resetButton.disabled, false, "first timing commit should enable the slot reset button");
+    assert.ok(parent.querySelector(".anim-override-badge-dot"), "first timing commit should show the changed badge");
+  });
+
+  it("clears Animation Overrides reset affordances when timing returns to the theme default", async () => {
+    const card = createAnimOverrideCard({
+      transition: { in: 160, out: 150 },
+      transitionThemeDefault: { in: 150, out: 150 },
+      hasTransitionOverride: true,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const payloads = [];
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: (_name, payload) => {
+          payloads.push(payload);
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+      opsOverrides: {
+        fetchAnimationOverridesData: () => {
+          Object.assign(runtime.animationOverridesData.cards[0], {
+            transition: { in: 150, out: 150 },
+            transitionThemeDefault: { in: 150, out: 150 },
+            hasTransitionOverride: false,
+          });
+          return Promise.resolve(runtime.animationOverridesData);
+        },
+      },
+      readersOverrides: {
+        readThemeOverrideMap: () => ({
+          states: {
+            thinking: {
+              transition: { in: 160, out: 150 },
+            },
+          },
+        }),
+      },
+    });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const range = parent.querySelectorAll("input").find((input) => input.type === "range");
+    const resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
+    assert.ok(range);
+    assert.ok(resetButton);
+    assert.strictEqual(resetButton.disabled, false);
+    assert.ok(parent.querySelector(".anim-override-badge-dot"));
+
+    range.value = "150";
+    for (const listener of range.eventListeners.input || []) listener();
+    for (const listener of range.eventListeners.change || []) listener();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.strictEqual(payloads.length, 1);
+    assert.strictEqual(payloads[0].transition.in, 150);
+    assert.strictEqual(payloads[0].transition.out, 150);
+    assert.strictEqual(payloads[0].transitionThemeDefault.in, 150);
+    assert.strictEqual(payloads[0].transitionThemeDefault.out, 150);
+    assert.strictEqual(resetButton.disabled, true, "returning to default timing should disable slot reset");
+    assert.strictEqual(parent.querySelector(".anim-override-badge-dot"), null);
+  });
+
   it("keeps sequential fade timing commits from reverting the previous side", async () => {
     const card = createAnimOverrideCard();
     const runtime = createAnimOverridesRuntime(card);
@@ -2990,6 +3137,279 @@ describe("settings renderer browser environment", () => {
     await Promise.resolve();
 
     assert.strictEqual(commandCount, 1);
+  });
+
+  it("renders the wide hitbox control as a scoped toggle instead of a full-row label", () => {
+    const card = createAnimOverrideCard();
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const { core } = loadAnimOverridesTabForTest({ runtime, modalRoot });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const row = parent.querySelector(".anim-override-toggle-row");
+    const title = parent.querySelector(".anim-override-toggle-title");
+
+    assert.ok(row, "expanded animation override row should render a wide-hitbox toggle row");
+    assert.strictEqual(row.tagName, "DIV");
+    assert.ok(title);
+    assert.strictEqual((title.eventListeners.click || []).length, 0);
+  });
+
+  it("uses null to clear wide hitbox overrides that match the theme default and avoids rebuilding content", async () => {
+    const card = createAnimOverrideCard({
+      wideHitboxEnabled: false,
+      wideHitboxOverridden: false,
+      wideHitboxThemeDefault: false,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const payloads = [];
+    let fetchCount = 0;
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: (_name, payload) => {
+          payloads.push(payload);
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+      opsOverrides: {
+        fetchAnimationOverridesData: () => {
+          fetchCount++;
+          Object.assign(runtime.animationOverridesData.cards[0], fetchCount === 1
+            ? {
+                wideHitboxEnabled: true,
+                wideHitboxOverridden: true,
+                wideHitboxThemeDefault: false,
+              }
+            : {
+                wideHitboxEnabled: false,
+                wideHitboxOverridden: false,
+                wideHitboxThemeDefault: false,
+              });
+          return Promise.resolve(runtime.animationOverridesData);
+        },
+      },
+    });
+    const parent = new FakeElement("main");
+    let contentRenderCount = 0;
+    const renderContent = () => {
+      contentRenderCount++;
+      parent.innerHTML = "";
+      core.tabs.animOverrides.render(parent, core);
+    };
+    core.ops.requestRender = ({ content = false, modal = false } = {}) => {
+      if (content) renderContent();
+      if (modal && typeof core.renderHooks.modal === "function") core.renderHooks.modal();
+    };
+    renderContent();
+
+    const toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    assert.ok(toggle, "expanded animation override row should render a wide-hitbox checkbox");
+
+    toggle.checked = true;
+    for (const listener of toggle.eventListeners.change || []) listener();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    toggle.checked = false;
+    for (const listener of toggle.eventListeners.change || []) listener();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.strictEqual(payloads.length, 2);
+    assert.strictEqual(payloads[0].enabled, true);
+    assert.strictEqual(payloads[1].enabled, null);
+    assert.strictEqual(contentRenderCount, 1, "wide-hitbox toggle commits should not rebuild the content pane");
+  });
+
+  it("preserves pending wide hitbox state across full Animation Overrides rerenders", async () => {
+    const card = createAnimOverrideCard({
+      wideHitboxEnabled: false,
+      wideHitboxOverridden: false,
+      wideHitboxThemeDefault: false,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    let resolveCommand;
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: () => new Promise((resolve) => {
+          resolveCommand = resolve;
+        }),
+      },
+      opsOverrides: {
+        fetchAnimationOverridesData: () => {
+          Object.assign(runtime.animationOverridesData.cards[0], {
+            wideHitboxEnabled: true,
+            wideHitboxOverridden: true,
+            wideHitboxThemeDefault: false,
+          });
+          return Promise.resolve(runtime.animationOverridesData);
+        },
+      },
+    });
+    const parent = new FakeElement("main");
+    const renderContent = () => {
+      parent.innerHTML = "";
+      core.tabs.animOverrides.render(parent, core);
+    };
+    core.ops.requestRender = ({ content = false, modal = false } = {}) => {
+      if (content) renderContent();
+      if (modal && typeof core.renderHooks.modal === "function") core.renderHooks.modal();
+    };
+    renderContent();
+
+    let toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    assert.ok(toggle, "expanded animation override row should render a wide-hitbox checkbox");
+
+    toggle.checked = true;
+    for (const listener of toggle.eventListeners.change || []) listener();
+
+    renderContent();
+
+    toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    const resetChip = parent.querySelectorAll("button")
+      .find((button) => button.textContent === "animOverridesWideHitboxResetToTheme");
+    assert.ok(toggle, "wide-hitbox checkbox should still exist after rerender");
+    assert.strictEqual(toggle.checked, true, "pending wide-hitbox toggles should stay on across rerenders");
+    assert.strictEqual(toggle.disabled, true, "pending wide-hitbox toggles should stay disabled across rerenders");
+    assert.ok(resetChip, "wide-hitbox reset chip should still exist after rerender");
+    assert.strictEqual(resetChip.hidden, false, "pending wide-hitbox rerenders should keep the reset chip visible");
+    assert.strictEqual(resetChip.disabled, true, "pending wide-hitbox rerenders should keep the reset chip disabled");
+
+    resolveCommand({ status: "ok" });
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    toggle = parent.querySelectorAll("input").find((input) => input.type === "checkbox");
+    assert.strictEqual(toggle.checked, true);
+    assert.strictEqual(toggle.disabled, false);
+  });
+
+  it("treats hitbox-only overrides as overridden for summary badges and reset actions", () => {
+    const card = createAnimOverrideCard({
+      wideHitboxEnabled: true,
+      wideHitboxOverridden: true,
+      wideHitboxThemeDefault: false,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      readersOverrides: {
+        hasAnyThemeOverride: () => true,
+        readThemeOverrideMap: () => ({
+          hitbox: {
+            wide: {
+              "cloudling-thinking.svg": true,
+            },
+          },
+        }),
+      },
+    });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const summaryDot = parent.querySelector(".anim-override-badge-dot");
+    const resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
+
+    assert.ok(summaryDot, "hitbox-only overrides should still show the overridden summary badge");
+    assert.ok(resetButton, "expanded row should render a reset button");
+    assert.strictEqual(resetButton.disabled, false, "hitbox-only overrides should enable the reset button");
+  });
+
+  it("clears hitbox-only overrides when resetting an animation override slot", async () => {
+    const card = createAnimOverrideCard({
+      wideHitboxEnabled: true,
+      wideHitboxOverridden: true,
+      wideHitboxThemeDefault: false,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const calls = [];
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      settingsAPI: {
+        command: (name, payload) => {
+          calls.push({ name, payload });
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+      opsOverrides: {
+        fetchAnimationOverridesData: () => Promise.resolve(runtime.animationOverridesData),
+      },
+      readersOverrides: {
+        readThemeOverrideMap: () => ({
+          hitbox: {
+            wide: {
+              "cloudling-thinking.svg": true,
+            },
+          },
+        }),
+      },
+    });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
+    assert.ok(resetButton, "expanded row should render a reset button");
+    for (const listener of resetButton.eventListeners.click || []) listener();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.deepStrictEqual(
+      calls.map((call) => call.name),
+      ["setAnimationOverride", "setWideHitboxOverride"]
+    );
+    assert.strictEqual(calls[1].payload.enabled, null);
+  });
+
+  it("treats reaction-only overrides as overridden for summary badges and reset actions", () => {
+    const card = createAnimOverrideCard({
+      id: "reaction:clickLeft",
+      slotType: "reaction",
+      reactionKey: "clickLeft",
+      stateKey: undefined,
+      supportsDuration: true,
+      durationMs: 1600,
+      hasDurationOverride: true,
+    });
+    const runtime = createAnimOverridesRuntime(card);
+    const modalRoot = new FakeElement("div");
+    const { core } = loadAnimOverridesTabForTest({
+      runtime,
+      modalRoot,
+      readersOverrides: {
+        hasAnyThemeOverride: () => true,
+        readThemeOverrideMap: () => ({
+          reactions: {
+            clickLeft: {
+              durationMs: 1600,
+            },
+          },
+        }),
+      },
+    });
+    const parent = new FakeElement("main");
+    core.tabs.animOverrides.render(parent, core);
+
+    const summaryDot = parent.querySelector(".anim-override-badge-dot");
+    const resetButton = parent.querySelectorAll("button").find((button) => button.textContent === "animOverridesReset");
+
+    assert.ok(summaryDot, "reaction-only overrides should show the overridden summary badge");
+    assert.ok(resetButton, "expanded row should render a reset button");
+    assert.strictEqual(resetButton.disabled, false, "reaction-only overrides should enable the reset button");
   });
 
   it("does not keep reset-slot null timing values as pending slider edits", async () => {

--- a/test/theme-runtime.test.js
+++ b/test/theme-runtime.test.js
@@ -259,6 +259,29 @@ describe("theme-runtime active ownership", () => {
     ]);
   });
 
+  it("refreshes active theme hitbox overrides without running the full reload protocol", () => {
+    makeFixture();
+    const { runtime, calls } = createRuntime();
+    runtime.loadInitialTheme("clawd");
+
+    const result = runtime.refreshActiveThemeHitboxOverrides("clawd", {
+      hitbox: {
+        wide: {
+          "thinking.svg": true,
+        },
+      },
+    });
+
+    assert.deepStrictEqual(result, { themeId: "clawd", variantId: "default" });
+    assert.deepStrictEqual(runtime.getActiveTheme().wideHitboxFiles, ["thinking.svg"]);
+    assert.deepStrictEqual(calls, [
+      "state.refreshTheme",
+      "syncHitState",
+      "syncHitWin",
+      "flushPrefs",
+    ]);
+  });
+
   it("applies clamped preserved bounds after theme reload when the clamp path adjusts them", () => {
     makeFixture();
     const { runtime, calls } = createRuntime({


### PR DESCRIPTION
## Summary
- Stabilizes `Settings -> 动画 / 音效替换` so timing slider edits update the visible slider, reset affordance, and changed badge without tearing down the whole content pane.
- Makes the wide-hitbox toggle behave as a scoped control instead of a card-wide click target, with pending state, rollback, and theme-default reset semantics.
- Preserves the existing theme override schema and existing animation/sound replacement command shapes; this only tightens how the renderer and theme runtime apply those overrides.

## Problem context
- Timing edits previously caused visible flicker because successful saves and `themeOverrides` broadcasts could rebuild the Animation Overrides tab while the user was still interacting with a mounted slider.
- The first timing edit could leave the “changed” badge and reset button stale because the active card status was only refreshed after a full render.
- Returning a fade timing to the theme default could still look overridden because the command stored an override equal to the base theme value instead of clearing it.
- Wide-hitbox toggles used heavier theme reload behavior and could leave reset affordances visible when the effective value had returned to the theme default.
- During review I also found a tier-card regression: `clawd` working/juggling tier rows could fail while building transition metadata, leaving the page with only the header/actions visible.

## What changed
- Timing slider state
  - Tracks mounted timing controls and pending edits by card/field.
  - Applies matching `themeOverrides` broadcasts in place when they acknowledge the pending timing edit.
  - Updates reset buttons and changed badges from mounted controls so the first edit and return-to-default cases are reflected immediately.
  - Clears transition overrides when the requested timing matches the theme default.

- Wide-hitbox controls
  - Converts the wide-hitbox row into a scoped checkbox plus a dedicated “reset to theme” chip, instead of making the whole card area clickable.
  - Records pending wide-hitbox edits and syncs the mounted checkbox, reset chip, and summary badge without forcing a content rebuild.
  - Sends `enabled: null` when the effective value matches the theme default so stale hitbox override entries are removed.
  - Makes the slot reset path clear hitbox-only overrides as well, so an enabled reset button always actually restores the slot.

- Theme/runtime metadata
  - Exposes base transition and base wide-hitbox metadata from the theme loader so Settings can compare effective values against theme defaults.
  - Adds a lightweight active-theme hitbox refresh path for active theme hitbox changes, avoiding a full theme reload and pet fade cycle for a checkbox-only change.
  - Keeps existing full theme reload behavior for changes that still need it, such as animation file replacement and broader theme/variant changes.

- Loading and blank-page resilience
  - Keeps the previous Animation Overrides data visible while a theme override refresh is pending.
  - Adds visible loading copy for the initial Animation Overrides fetch.
  - Fixes tier-card transition metadata generation so `clawd` tier rows build normally instead of failing the data payload.

## Behavior after this PR
- Dragging or entering fade/return timing values keeps the current row mounted and updates the visible slider/input without flashing back to the previous value.
- The first timing edit immediately enables the reset affordance and changed badge; returning the timing to the theme default clears them.
- Wide-hitbox toggles no longer trigger the pet’s full fade/reload path and no longer rely on clicking the whole row.
- Resetting a slot clears animation/timing changes and hitbox-only changes consistently.
- Animation file replacement, sound replacement, asset picker behavior, theme switching, and prefs schema remain unchanged.

## Validation
- `node --test test/settings-renderer-browser-env.test.js test/settings-actions-theme-overrides.test.js test/settings-actions.test.js test/settings-animation-overrides-main.test.js test/theme-runtime.test.js`
- `node --test --test-name-pattern "clears hitbox-only|Animation Overrides reset affordances|wide hitbox" test/settings-renderer-browser-env.test.js`
- `git diff --check`
- `npm test` passed with `2113` passing, `0` failing, and `2` skipped tests.
- Direct runtime smoke check against the built-in `clawd` theme successfully built `31` animation cards and `2` sound items for the Animation Overrides payload.

## Platform note
- Automated verification ran locally on Windows with Node's built-in test runner.
- Manual Electron QA is still recommended for the final feel of slider dragging and wide-hitbox toggle interaction in the real Settings window.
