### PR TITLE
feat(copilot-hook): forward Copilot CLI session name to Clawd

### DIFF
--- a/docs/guides/copilot-setup.md
+++ b/docs/guides/copilot-setup.md
@@ -14,3 +14,7 @@ Create `~/.copilot/hooks/hooks.json` with the following content. Replace `/path/
   }
 }
 ```
+
+## Session rename
+
+Copilot CLI stores the current session name in `~/.copilot/session-state/<sessionId>/workspace.yaml` (`name:` field). The hook reads that file on every event and forwards the name to Clawd as the session title, so `/rename` inside Copilot CLI propagates to the Session HUD and Dashboard on the next hook event (next user message, tool run, etc.). Auto-generated names (`user_named: false`) are used as-is, matching Codex thread-name behavior.

--- a/hooks/copilot-hook.js
+++ b/hooks/copilot-hook.js
@@ -3,8 +3,103 @@
 // Usage: node copilot-hook.js <event_name>
 // Reads stdin JSON from Copilot CLI for sessionId (camelCase)
 
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
 const { postStateToRunningServer } = require("./server-config");
 const { createPidResolver, readStdinJson, getPlatformConfig } = require("./shared-process");
+
+const SESSION_TITLE_CONTROL_RE = /[\u0000-\u001F\u007F-\u009F]+/g;
+const SESSION_TITLE_MAX = 80;
+const WORKSPACE_YAML_MAX_BYTES = 16384; // 16 KB — workspace.yaml is tiny
+
+function normalizeTitle(value) {
+  if (typeof value !== "string") return null;
+  const collapsed = value
+    .replace(SESSION_TITLE_CONTROL_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!collapsed) return null;
+  return collapsed.length > SESSION_TITLE_MAX
+    ? `${collapsed.slice(0, SESSION_TITLE_MAX - 1)}\u2026`
+    : collapsed;
+}
+
+// Strip a single layer of matching surrounding quotes from a YAML scalar.
+function stripYamlQuotes(value) {
+  if (value.length < 2) return value;
+  const first = value[0];
+  const last = value[value.length - 1];
+  if ((first === '"' || first === "'") && first === last) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+// Parse the top-level `name:` scalar from Copilot's workspace.yaml.
+// workspace.yaml is a flat key:value file (no nesting), so a per-line
+// regex is sufficient and avoids pulling in a YAML dependency.
+function parseWorkspaceYamlName(text) {
+  if (typeof text !== "string" || !text) return null;
+  const lines = text.split(/\r?\n/);
+  for (const raw of lines) {
+    const match = raw.match(/^name:\s*(.*?)\s*$/);
+    if (!match) continue;
+    let value = match[1];
+    // Drop trailing inline comments on unquoted scalars
+    if (value && value[0] !== '"' && value[0] !== "'") {
+      const hashIdx = value.indexOf(" #");
+      if (hashIdx >= 0) value = value.slice(0, hashIdx).trimEnd();
+    }
+    value = stripYamlQuotes(value);
+    return value || null;
+  }
+  return null;
+}
+
+// Read the renamed session title from Copilot's workspace.yaml.
+// Returns null if the session id is missing/invalid, the file doesn't
+// exist, or it has no usable `name:` field.
+//
+// Path traversal is blocked by three layers:
+//   1. Charset gate: only [A-Za-z0-9._-] (no separators, no NUL, no
+//      drive letters, no whitespace).
+//   2. Pure-dot rejection: ".", "..", "..." etc. pass the charset gate
+//      but resolve to ancestors of session-state/, so reject them
+//      explicitly.
+//   3. Containment check: after path.resolve, the session directory
+//      must lie strictly under the resolved session-state/ base, even
+//      if a future change loosens layers 1 or 2.
+function readCopilotSessionTitle(sessionId, options = {}) {
+  if (typeof sessionId !== "string") return null;
+  const trimmed = sessionId.trim();
+  if (!trimmed) return null;
+  if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) return null;
+  if (/^\.+$/.test(trimmed)) return null;
+  const homeDir = options.homeDir || os.homedir();
+  if (!homeDir) return null;
+  const baseDir = path.resolve(path.join(homeDir, ".copilot", "session-state"));
+  const sessionDir = path.resolve(path.join(baseDir, trimmed));
+  if (!sessionDir.startsWith(baseDir + path.sep)) return null;
+  const filePath = path.join(sessionDir, "workspace.yaml");
+  let fd = null;
+  let data;
+  try {
+    const stat = fs.statSync(filePath);
+    fd = fs.openSync(filePath, "r");
+    const readLen = Math.min(stat.size, WORKSPACE_YAML_MAX_BYTES);
+    const buf = Buffer.alloc(readLen);
+    fs.readSync(fd, buf, 0, readLen, 0);
+    data = buf.toString("utf8");
+  } catch {
+    return null;
+  } finally {
+    if (fd !== null) {
+      try { fs.closeSync(fd); } catch {}
+    }
+  }
+  return normalizeTitle(parseWorkspaceYamlName(data));
+}
 
 const EVENT_TO_STATE = {
   sessionStart: "idle",
@@ -19,38 +114,66 @@ const EVENT_TO_STATE = {
   preCompact: "sweeping",
 };
 
-const event = process.argv[2];
-const state = EVENT_TO_STATE[event];
-if (!state) process.exit(0);
+function buildStateBody(event, payload, resolve) {
+  const state = EVENT_TO_STATE[event];
+  if (!state) return null;
 
-const config = getPlatformConfig();
-const resolve = createPidResolver({
-  agentNames: { win: new Set(["copilot.exe"]), mac: new Set(["copilot"]) },
-  agentCmdlineCheck: (cmd) => cmd.includes("@github/copilot"),
-  platformConfig: config,
-});
-
-// Pre-resolve on sessionStart
-if (event === "sessionStart") resolve();
-
-readStdinJson().then((payload) => {
   // Copilot CLI uses camelCase: sessionId, not session_id
   const sessionId = payload.sessionId || payload.session_id || "default";
   const cwd = payload.cwd || "";
 
-  const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
-
   const body = { state, session_id: sessionId, event };
   body.agent_id = "copilot-cli";
   if (cwd) body.cwd = cwd;
+
+  // Session title: prefer payload field if present, otherwise read the
+  // renamed name from ~/.copilot/session-state/<sid>/workspace.yaml so
+  // /rename in Copilot CLI propagates to Clawd on the next hook event.
+  const sessionTitle =
+    normalizeTitle(payload.session_title) ||
+    normalizeTitle(payload.sessionTitle) ||
+    readCopilotSessionTitle(sessionId);
+  if (sessionTitle) body.session_title = sessionTitle;
+
+  const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
   body.source_pid = stablePid;
   if (detectedEditor) body.editor = detectedEditor;
   if (agentPid) body.agent_pid = agentPid;
   if (pidChain.length) body.pid_chain = pidChain;
 
-  postStateToRunningServer(
-    JSON.stringify(body),
-    { timeoutMs: 100 },
-    () => process.exit(0)
-  );
-});
+  return body;
+}
+
+function main() {
+  const event = process.argv[2];
+  if (!EVENT_TO_STATE[event]) process.exit(0);
+
+  const config = getPlatformConfig();
+  const resolve = createPidResolver({
+    agentNames: { win: new Set(["copilot.exe"]), mac: new Set(["copilot"]) },
+    agentCmdlineCheck: (cmd) => cmd.includes("@github/copilot"),
+    platformConfig: config,
+  });
+
+  // Pre-resolve on sessionStart
+  if (event === "sessionStart") resolve();
+
+  readStdinJson().then((payload) => {
+    const body = buildStateBody(event, payload || {}, resolve);
+    if (!body) process.exit(0);
+    postStateToRunningServer(
+      JSON.stringify(body),
+      { timeoutMs: 100 },
+      () => process.exit(0)
+    );
+  });
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  buildStateBody,
+  normalizeTitle,
+  parseWorkspaceYamlName,
+  readCopilotSessionTitle,
+};

--- a/test/copilot-hook.test.js
+++ b/test/copilot-hook.test.js
@@ -1,0 +1,241 @@
+"use strict";
+
+// Unit tests for hooks/copilot-hook.js pure helpers.
+// Tests buildStateBody, parseWorkspaceYamlName, readCopilotSessionTitle,
+// and normalizeTitle. The top-level main() path (stdin read + HTTP post)
+// is exercised by manual / end-to-end runs only.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const {
+  buildStateBody,
+  normalizeTitle,
+  parseWorkspaceYamlName,
+  readCopilotSessionTitle,
+} = require("../hooks/copilot-hook.js");
+
+function makeFakeHome(sessionId, contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-hook-test-"));
+  if (contents !== null) {
+    const sessionDir = path.join(dir, ".copilot", "session-state", sessionId);
+    fs.mkdirSync(sessionDir, { recursive: true });
+    fs.writeFileSync(path.join(sessionDir, "workspace.yaml"), contents);
+  }
+  return dir;
+}
+
+const mockResolve = () => ({
+  stablePid: 1234,
+  agentPid: 5678,
+  detectedEditor: null,
+  pidChain: [1234, 5678],
+});
+
+describe("normalizeTitle", () => {
+  it("trims whitespace and collapses runs", () => {
+    assert.strictEqual(normalizeTitle("  hello   world  "), "hello world");
+  });
+
+  it("strips control characters", () => {
+    assert.strictEqual(normalizeTitle("foo\u0000bar\u001fbaz"), "foo bar baz");
+  });
+
+  it("returns null for empty / whitespace-only / non-string", () => {
+    assert.strictEqual(normalizeTitle(""), null);
+    assert.strictEqual(normalizeTitle("   "), null);
+    assert.strictEqual(normalizeTitle(null), null);
+    assert.strictEqual(normalizeTitle(123), null);
+  });
+
+  it("truncates with ellipsis past 80 chars", () => {
+    const out = normalizeTitle("a".repeat(120));
+    assert.strictEqual(out.length, 80);
+    assert.strictEqual(out.endsWith("\u2026"), true);
+  });
+});
+
+describe("parseWorkspaceYamlName", () => {
+  it("extracts unquoted name", () => {
+    const yaml = "id: abc\nname: Fix Session Rename Bug\nuser_named: false\n";
+    assert.strictEqual(parseWorkspaceYamlName(yaml), "Fix Session Rename Bug");
+  });
+
+  it("extracts double-quoted name with embedded colon", () => {
+    const yaml = 'name: "Foo: bar"\n';
+    assert.strictEqual(parseWorkspaceYamlName(yaml), "Foo: bar");
+  });
+
+  it("extracts single-quoted name", () => {
+    const yaml = "name: 'My Task'\n";
+    assert.strictEqual(parseWorkspaceYamlName(yaml), "My Task");
+  });
+
+  it("ignores indented name keys (top-level only)", () => {
+    const yaml = "  name: nested\nid: x\n";
+    assert.strictEqual(parseWorkspaceYamlName(yaml), null);
+  });
+
+  it("returns null when no name field", () => {
+    assert.strictEqual(parseWorkspaceYamlName("id: x\ncwd: /tmp\n"), null);
+  });
+
+  it("returns null for empty/non-string input", () => {
+    assert.strictEqual(parseWorkspaceYamlName(""), null);
+    assert.strictEqual(parseWorkspaceYamlName(null), null);
+    assert.strictEqual(parseWorkspaceYamlName(undefined), null);
+  });
+
+  it("strips trailing inline comment on unquoted scalar", () => {
+    assert.strictEqual(parseWorkspaceYamlName("name: hello # auto\n"), "hello");
+  });
+
+  it("preserves '#' inside quoted scalar", () => {
+    assert.strictEqual(parseWorkspaceYamlName('name: "tag #1"\n'), "tag #1");
+  });
+
+  it("treats name with empty value as null", () => {
+    assert.strictEqual(parseWorkspaceYamlName("name: \nid: x\n"), null);
+    assert.strictEqual(parseWorkspaceYamlName('name: ""\n'), null);
+  });
+
+  it("returns first matching top-level name (CRLF tolerant)", () => {
+    const yaml = "id: x\r\nname: First\r\nname: Second\r\n";
+    assert.strictEqual(parseWorkspaceYamlName(yaml), "First");
+  });
+});
+
+describe("readCopilotSessionTitle", () => {
+  it("returns name from workspace.yaml under fake home", () => {
+    const sid = "81301938-900f-47e2-b28d-25717f6eeafd";
+    const home = makeFakeHome(sid, "id: x\nname: Hello World\nuser_named: true\n");
+    assert.strictEqual(
+      readCopilotSessionTitle(sid, { homeDir: home }),
+      "Hello World"
+    );
+  });
+
+  it("returns null when file missing", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-hook-test-"));
+    assert.strictEqual(
+      readCopilotSessionTitle("00000000-0000-0000-0000-000000000000", { homeDir: home }),
+      null
+    );
+  });
+
+  it("returns null when name field absent", () => {
+    const sid = "no-name-session";
+    const home = makeFakeHome(sid, "id: no-name-session\ncwd: /tmp\n");
+    assert.strictEqual(readCopilotSessionTitle(sid, { homeDir: home }), null);
+  });
+
+  it("normalizes (trim + collapse + truncate) the result", () => {
+    const sid = "session-with-long-name";
+    const yaml = `id: x\nname: "${"x".repeat(100)}"\n`;
+    const home = makeFakeHome(sid, yaml);
+    const out = readCopilotSessionTitle(sid, { homeDir: home });
+    assert.strictEqual(out.length, 80);
+    assert.strictEqual(out.endsWith("\u2026"), true);
+  });
+
+  it("rejects sessionIds containing path separators or empty/null", () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-hook-test-"));
+    assert.strictEqual(readCopilotSessionTitle("../../../etc", { homeDir: home }), null);
+    assert.strictEqual(readCopilotSessionTitle("a/b", { homeDir: home }), null);
+    assert.strictEqual(readCopilotSessionTitle("", { homeDir: home }), null);
+    assert.strictEqual(readCopilotSessionTitle(null, { homeDir: home }), null);
+  });
+
+  it('rejects sessionId ".." even when ~/.copilot/workspace.yaml exists (regression: dot-segment bypass)', () => {
+    // sessionId=".." would resolve to ~/.copilot/session-state/../workspace.yaml
+    // = ~/.copilot/workspace.yaml. Plant that file and assert the read is
+    // refused so the hook never leaks a name from outside session-state/.
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-hook-test-"));
+    fs.mkdirSync(path.join(home, ".copilot", "session-state"), { recursive: true });
+    fs.writeFileSync(path.join(home, ".copilot", "workspace.yaml"), "name: leaked\n");
+    assert.strictEqual(readCopilotSessionTitle("..", { homeDir: home }), null);
+  });
+
+  it('rejects sessionId "." even when ~/.copilot/session-state/workspace.yaml exists (regression: dot-segment bypass)', () => {
+    // sessionId="." would resolve to ~/.copilot/session-state/./workspace.yaml
+    // = ~/.copilot/session-state/workspace.yaml. Plant that file and assert
+    // the read is refused (the file is not under any session id).
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-hook-test-"));
+    fs.mkdirSync(path.join(home, ".copilot", "session-state"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, ".copilot", "session-state", "workspace.yaml"),
+      "name: leaked\n"
+    );
+    assert.strictEqual(readCopilotSessionTitle(".", { homeDir: home }), null);
+  });
+
+  it('rejects pure-dot sessionIds ("...", "....", etc.)', () => {
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-hook-test-"));
+    assert.strictEqual(readCopilotSessionTitle("...", { homeDir: home }), null);
+    assert.strictEqual(readCopilotSessionTitle("....", { homeDir: home }), null);
+  });
+});
+
+describe("buildStateBody (Copilot)", () => {
+  it("returns null for unknown event", () => {
+    assert.strictEqual(buildStateBody("unknownEvent", {}, mockResolve), null);
+  });
+
+  it("maps userPromptSubmitted to thinking and includes core fields", () => {
+    const body = buildStateBody(
+      "userPromptSubmitted",
+      { sessionId: "sid-1", cwd: "/tmp/p" },
+      mockResolve
+    );
+    assert.strictEqual(body.state, "thinking");
+    assert.strictEqual(body.session_id, "sid-1");
+    assert.strictEqual(body.event, "userPromptSubmitted");
+    assert.strictEqual(body.agent_id, "copilot-cli");
+    assert.strictEqual(body.cwd, "/tmp/p");
+    assert.strictEqual(body.source_pid, 1234);
+    assert.strictEqual(body.agent_pid, 5678);
+    assert.deepStrictEqual(body.pid_chain, [1234, 5678]);
+  });
+
+  it("falls back to default sessionId if none provided", () => {
+    const body = buildStateBody("sessionStart", {}, mockResolve);
+    assert.strictEqual(body.session_id, "default");
+  });
+
+  it("prefers payload.session_title over workspace.yaml lookup", () => {
+    const body = buildStateBody(
+      "userPromptSubmitted",
+      { sessionId: "anything", session_title: "Payload Title" },
+      mockResolve
+    );
+    assert.strictEqual(body.session_title, "Payload Title");
+  });
+
+  it("uses payload.sessionTitle (camelCase) too", () => {
+    const body = buildStateBody(
+      "userPromptSubmitted",
+      { sessionId: "anything", sessionTitle: "Camel Title" },
+      mockResolve
+    );
+    assert.strictEqual(body.session_title, "Camel Title");
+  });
+
+  it("omits session_title when no payload field and no workspace.yaml on disk", () => {
+    // sessionId here points at a definitely-nonexistent path under real home;
+    // even if the user actually has Copilot installed, this UUID is unlikely.
+    const body = buildStateBody(
+      "sessionStart",
+      { sessionId: "deadbeef-0000-0000-0000-000000000000" },
+      mockResolve
+    );
+    assert.strictEqual("session_title" in body, false);
+  });
+
+  it("does not set cwd when missing", () => {
+    const body = buildStateBody("sessionStart", { sessionId: "s" }, mockResolve);
+    assert.strictEqual("cwd" in body, false);
+  });
+});


### PR DESCRIPTION
 ## Problem
 
 Renaming a Copilot CLI session via `/rename` updates
 `~/.copilot/session-state/<sid>/workspace.yaml` (`name:` field), but
 `hooks/copilot-hook.js` never read it — so `body.session_title` was never
 set and Clawd's HUD / Dashboard kept falling back to `path.basename(cwd)`.
 Multiple Copilot sessions in the same repo were indistinguishable.
 
 Codex (`readCodexThreadName`) and Claude Code
 (`extractSessionTitleFromTranscript`) already forward their renamed
 titles; Copilot CLI was just unimplemented.
 
 ## Fix
 
 The hook now reads `name:` from `workspace.yaml` on every event and sends
 it as `session_title`. State plumbing already supports this field
 (`displayTitle` priority: alias > sessionTitle > cwd basename > id), so
 **no `src/` changes needed**.
 
 Notes:
 - Lazy refresh, same as Claude Code: takes effect on the next hook event
   after rename.
 - Auto-generated names (`user_named: false`) used as-is (matches Codex
   thread-name behavior).
 - User-set Dashboard alias still wins.
 - Path traversal blocked (`^[A-Za-z0-9._-]+$` on session id),
   `workspace.yaml` read capped at 16 KB, zero new dependencies.
 - Hook refactored into pure helpers + `require.main === module` guard
   for testability — same shape as `hooks/clawd-hook.js`.
 
 ## Tests & docs
 
 - `test/copilot-hook.test.js`: 26 new unit tests covering YAML parsing
   edge cases (quoted/unquoted/inline-comment/CRLF/indented), file
   lookup, path-traversal rejection, and `buildStateBody` branches.
   `npm test` clean modulo 10 pre-existing failures unrelated to this
   change (verified via `git stash`).
 - `docs/guides/copilot-setup.md`: adds a "Session rename" section.