### PR TITLE
fix: replace wmic with PowerShell Get-CimInstance

### DIFF
--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -171,16 +171,21 @@ function buildStateBody(event, payload, resolve) {
     if (agentPid) {
       body.agent_pid = agentPid;
       body.claude_pid = agentPid; // backward compat with older Clawd versions
-      // Check if claude process is running in non-interactive (-p/--print) mode
+      // Check if claude process is running in non-interactive (-p/--print) mode.
+      // Windows 11 24H2+ removed wmic, so fall back to PowerShell Get-CimInstance.
       try {
-        const { execSync } = require("child_process");
+        const { execFileSync } = require("child_process");
         const isWin = process.platform === "win32";
         const cmdOut = isWin
-          ? execSync(
-              `wmic process where "ProcessId=${agentPid}" get CommandLine /format:csv`,
+          ? execFileSync(
+              "powershell.exe",
+              [
+                "-NoProfile", "-NonInteractive", "-Command",
+                `(Get-CimInstance Win32_Process -Filter "ProcessId=${agentPid}" -ErrorAction SilentlyContinue).CommandLine`,
+              ],
               { encoding: "utf8", timeout: 500, windowsHide: true }
             )
-          : execSync(`ps -o command= -p ${agentPid}`, { encoding: "utf8", timeout: 500 });
+          : execFileSync("ps", ["-o", "command=", "-p", String(agentPid)], { encoding: "utf8", timeout: 500 });
         if (/\s(-p|--print)(\s|$)/.test(cmdOut)) body.headless = true;
       } catch {}
     }

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -165,29 +165,17 @@ function buildStateBody(event, payload, resolve) {
   if (process.env.CLAWD_REMOTE) {
     body.host = readHostPrefix();
   } else {
-    const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
+    const { stablePid, agentPid, agentCommandLine, detectedEditor, pidChain } = resolve();
     body.source_pid = stablePid;
     if (detectedEditor) body.editor = detectedEditor;
     if (agentPid) {
       body.agent_pid = agentPid;
       body.claude_pid = agentPid; // backward compat with older Clawd versions
-      // Check if claude process is running in non-interactive (-p/--print) mode.
-      // Windows 11 24H2+ removed wmic, so fall back to PowerShell Get-CimInstance.
-      try {
-        const { execFileSync } = require("child_process");
-        const isWin = process.platform === "win32";
-        const cmdOut = isWin
-          ? execFileSync(
-              "powershell.exe",
-              [
-                "-NoProfile", "-NonInteractive", "-Command",
-                `(Get-CimInstance Win32_Process -Filter "ProcessId=${agentPid}" -ErrorAction SilentlyContinue).CommandLine`,
-              ],
-              { encoding: "utf8", timeout: 500, windowsHide: true }
-            )
-          : execFileSync("ps", ["-o", "command=", "-p", String(agentPid)], { encoding: "utf8", timeout: 500 });
-        if (/\s(-p|--print)(\s|$)/.test(cmdOut)) body.headless = true;
-      } catch {}
+      // Headless (-p/--print) detection reuses the agentCommandLine captured by
+      // the resolver — no extra spawn here. See hooks/shared-process.js.
+      if (agentCommandLine && /\s(-p|--print)(\s|$)/.test(agentCommandLine)) {
+        body.headless = true;
+      }
     }
     if (pidChain.length) body.pid_chain = pidChain;
   }

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -171,8 +171,6 @@ function buildStateBody(event, payload, resolve) {
     if (agentPid) {
       body.agent_pid = agentPid;
       body.claude_pid = agentPid; // backward compat with older Clawd versions
-      // Headless (-p/--print) detection reuses the agentCommandLine captured by
-      // the resolver — no extra spawn here. See hooks/shared-process.js.
       if (agentCommandLine && /\s(-p|--print)(\s|$)/.test(agentCommandLine)) {
         body.headless = true;
       }

--- a/hooks/opencode-plugin/index.mjs
+++ b/hooks/opencode-plugin/index.mjs
@@ -25,7 +25,7 @@ import { readFileSync, writeFileSync, mkdirSync, promises as fsp } from "fs";
 import { homedir, platform } from "os";
 import { join } from "path";
 import { randomBytes, timingSafeEqual } from "crypto";
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 
 const CLAWD_DIR = join(homedir(), ".clawd");
 const RUNTIME_CONFIG_PATH = join(CLAWD_DIR, "runtime.json");
@@ -168,13 +168,46 @@ function getPortCandidates() {
   return ordered;
 }
 
+// Snapshot the entire Windows process table in one PowerShell call. wmic was
+// removed from Win 11 24H2 default installs (FoD), and a per-PID PS query
+// cold-starts the runtime every ancestor (~270 ms each). One snapshot keeps
+// the walk near the wmic-era timing.
+function getWindowsProcessSnapshot() {
+  try {
+    const out = execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile", "-NonInteractive", "-Command",
+        "Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, Name | ConvertTo-Json -Compress",
+      ],
+      { encoding: "utf8", timeout: 3000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 }
+    );
+    const trimmed = (out || "").trim();
+    if (!trimmed) return new Map();
+    const parsed = JSON.parse(trimmed);
+    const list = Array.isArray(parsed) ? parsed : [parsed];
+    const map = new Map();
+    for (const proc of list) {
+      const pid = Number(proc && proc.ProcessId);
+      if (!Number.isFinite(pid)) continue;
+      map.set(pid, {
+        name: typeof proc.Name === "string" ? proc.Name.toLowerCase() : "",
+        ppid: Number(proc.ParentProcessId) || 0,
+      });
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
 // Walk the process tree from process.pid until we hit a terminal app (for
 // window focus) or a system boundary (explorer.exe / launchd / systemd). The
 // walk keeps going past the first terminal match so we can pick the OUTERMOST
 // terminal — matters for Electron terminals like Antigravity where the chain
 // shows renderer→main, and we want the main process so Clawd can activate the
-// right window. Synchronous + cached; runs once at plugin init (~700-950ms on
-// Windows, 4-6 wmic shellouts). Never throws — returns null if the walk
+// right window. Synchronous + cached; runs once at plugin init (one PS spawn
+// on Windows after the 24H2 fix). Never throws — returns null if the walk
 // completely fails.
 //
 // Mirrors hooks/clawd-hook.js getStablePid() but starts at process.pid (plugin
@@ -194,20 +227,21 @@ function getStablePid() {
   _pidChain = [];
   _detectedEditor = null;
 
+  // Windows: snapshot all processes once. Win 11 24H2 dropped wmic from the
+  // default install, and PowerShell cold-starts at ~270 ms — one spawn per
+  // ancestor would push the walk past 1 s. Single snapshot keeps it close to
+  // the wmic-era timing.
+  const winSnapshot = isWin ? getWindowsProcessSnapshot() : null;
+
   for (let i = 0; i < 10 && pid && pid > 1; i++) {
     let name = "";
     let parentPid = 0;
     try {
       if (isWin) {
-        const out = execSync(
-          `wmic process where "ProcessId=${pid}" get Name,ParentProcessId /format:csv`,
-          { encoding: "utf8", timeout: 1500, windowsHide: true }
-        );
-        const lines = out.trim().split("\n").filter((l) => l.includes(","));
-        if (!lines.length) break;
-        const parts = lines[lines.length - 1].split(",");
-        name = (parts[1] || "").trim().toLowerCase();
-        parentPid = parseInt(parts[2], 10) || 0;
+        const info = winSnapshot.get(pid);
+        if (!info) break;
+        name = info.name;
+        parentPid = info.ppid;
       } else {
         const commOut = execSync(`ps -o comm= -p ${pid}`, { encoding: "utf8", timeout: 1000 }).trim();
         name = commOut.split("/").pop().toLowerCase();
@@ -551,9 +585,10 @@ export default async (ctx) => {
   _ctxClient = ctx && ctx.client ? ctx.client : null;
   _cwd = ctx && typeof ctx.directory === "string" ? ctx.directory : "";
   debugLog(`INIT directory=${_cwd} serverUrl=${_serverUrl} pid=${process.pid} hasClient=${!!_ctxClient}`);
-  // Resolve terminal PID synchronously at init. ~700-950ms wmic walk on
-  // Windows is acceptable because opencode's TUI is still booting — the user
-  // never sees it. After init, every POST reads the cached result.
+  // Resolve terminal PID synchronously at init. One PowerShell snapshot call
+  // on Windows (~300-500 ms) is acceptable because opencode's TUI is still
+  // booting — the user never sees it. After init, every POST reads the cached
+  // result.
   getStablePid();
   startBridge();
 

--- a/hooks/opencode-plugin/index.mjs
+++ b/hooks/opencode-plugin/index.mjs
@@ -168,10 +168,8 @@ function getPortCandidates() {
   return ordered;
 }
 
-// Snapshot the entire Windows process table in one PowerShell call. wmic was
-// removed from Win 11 24H2 default installs (FoD), and a per-PID PS query
-// cold-starts the runtime every ancestor (~270 ms each). One snapshot keeps
-// the walk near the wmic-era timing.
+// One PS spawn per resolve, not per ancestor — PowerShell cold-start (~270 ms)
+// would dominate the walk otherwise. Returns empty Map on failure.
 function getWindowsProcessSnapshot() {
   try {
     const out = execFileSync(
@@ -201,18 +199,10 @@ function getWindowsProcessSnapshot() {
   }
 }
 
-// Walk the process tree from process.pid until we hit a terminal app (for
-// window focus) or a system boundary (explorer.exe / launchd / systemd). The
-// walk keeps going past the first terminal match so we can pick the OUTERMOST
-// terminal — matters for Electron terminals like Antigravity where the chain
-// shows renderer→main, and we want the main process so Clawd can activate the
-// right window. Synchronous + cached; runs once at plugin init (one PS spawn
-// on Windows after the 24H2 fix). Never throws — returns null if the walk
-// completely fails.
-//
-// Mirrors hooks/clawd-hook.js getStablePid() but starts at process.pid (plugin
-// is in-process with opencode, not a child hook script) and skips the
-// Claude-specific binary detection.
+// Walks past the first terminal match to pick the OUTERMOST terminal —
+// matters for Electron terminals like Antigravity where the chain shows
+// renderer→main and we want the main process so Clawd activates the right
+// window. Cached after first call.
 function getStablePid() {
   if (_stablePid) return _stablePid;
   const isWin = platform() === "win32";
@@ -227,10 +217,6 @@ function getStablePid() {
   _pidChain = [];
   _detectedEditor = null;
 
-  // Windows: snapshot all processes once. Win 11 24H2 dropped wmic from the
-  // default install, and PowerShell cold-starts at ~270 ms — one spawn per
-  // ancestor would push the walk past 1 s. Single snapshot keeps it close to
-  // the wmic-era timing.
   const winSnapshot = isWin ? getWindowsProcessSnapshot() : null;
 
   for (let i = 0; i < 10 && pid && pid > 1; i++) {
@@ -585,10 +571,7 @@ export default async (ctx) => {
   _ctxClient = ctx && ctx.client ? ctx.client : null;
   _cwd = ctx && typeof ctx.directory === "string" ? ctx.directory : "";
   debugLog(`INIT directory=${_cwd} serverUrl=${_serverUrl} pid=${process.pid} hasClient=${!!_ctxClient}`);
-  // Resolve terminal PID synchronously at init. One PowerShell snapshot call
-  // on Windows (~300-500 ms) is acceptable because opencode's TUI is still
-  // booting — the user never sees it. After init, every POST reads the cached
-  // result.
+  // Sync init blocks the TUI boot path; later POSTs hit the cached result.
   getStablePid();
   startBridge();
 

--- a/hooks/pi-extension.ts
+++ b/hooks/pi-extension.ts
@@ -287,31 +287,42 @@ function detectEditor(name: string, editorByProcess: Map<string, "code" | "curso
   return undefined;
 }
 
-function parseWindowsProcessInfo(pid: number, raw: string): ProcessInfo | null {
-  let name = "";
-  let ppid = 0;
-  for (const line of raw.split(/\r?\n/)) {
-    const idx = line.indexOf("=");
-    if (idx === -1) continue;
-    const key = line.slice(0, idx).trim().toLowerCase();
-    const value = line.slice(idx + 1).trim();
-    if (key === "name") name = value;
-    if (key === "parentprocessid") ppid = Number(value);
+// Windows 11 24H2+ no longer ships wmic. Take one Get-CimInstance snapshot of
+// all processes and walk it in memory — saves N PowerShell cold-starts (~270 ms
+// each) on a chain of depth N.
+type WinProcessRecord = { name: string; rawName: string; ppid: number };
+
+function getWindowsProcessSnapshot(): Map<number, WinProcessRecord> {
+  try {
+    const raw = childProcess.execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile", "-NonInteractive", "-Command",
+        "Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, Name | ConvertTo-Json -Compress",
+      ],
+      { encoding: "utf8", timeout: 3000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 }
+    );
+    const trimmed = (raw || "").trim();
+    if (!trimmed) return new Map();
+    const parsed = JSON.parse(trimmed);
+    const list: any[] = Array.isArray(parsed) ? parsed : [parsed];
+    const map = new Map<number, WinProcessRecord>();
+    for (const proc of list) {
+      const pid = Number(proc && proc.ProcessId);
+      if (!Number.isFinite(pid)) continue;
+      const rawName = typeof proc.Name === "string" ? proc.Name : "";
+      const ppid = Number(proc.ParentProcessId) || 0;
+      if (!rawName) continue;
+      map.set(pid, { rawName, name: normalizeProcessName(rawName), ppid: Math.floor(ppid) });
+    }
+    return map;
+  } catch {
+    return new Map();
   }
-  if (!name || !Number.isFinite(ppid) || ppid <= 0) return null;
-  return { pid, ppid: Math.floor(ppid), name: normalizeProcessName(name), rawName: name };
 }
 
-function getProcessInfo(pid: number): ProcessInfo | null {
+function getUnixProcessInfo(pid: number): ProcessInfo | null {
   try {
-    if (process.platform === "win32") {
-      const raw = childProcess.execFileSync(
-        "wmic",
-        ["process", "where", `ProcessId=${pid}`, "get", "Name,ParentProcessId", "/format:list"],
-        { encoding: "utf8", timeout: 1000, windowsHide: true }
-      );
-      return parseWindowsProcessInfo(pid, raw);
-    }
     const raw = childProcess.execFileSync(
       "ps",
       ["-o", "ppid=", "-o", "comm=", "-p", String(pid)],
@@ -340,9 +351,19 @@ function getProcessMetadata(): ProcessMetadata {
   let editor: "code" | "cursor" | undefined;
   let pid = process.pid;
   const { terminalNames, systemBoundary, editorByProcess } = getPlatformProcessConfig();
+  const isWin = process.platform === "win32";
+  const winSnapshot = isWin ? getWindowsProcessSnapshot() : null;
 
   for (let depth = 0; depth < 12; depth++) {
-    const info = getProcessInfo(pid);
+    let info: ProcessInfo | null;
+    if (isWin) {
+      const snap = winSnapshot!.get(pid);
+      info = snap && snap.ppid > 0
+        ? { pid, ppid: snap.ppid, name: snap.name, rawName: snap.rawName }
+        : null;
+    } else {
+      info = getUnixProcessInfo(pid);
+    }
     if (!info) break;
     pidChain.push(info.pid);
 

--- a/hooks/pi-extension.ts
+++ b/hooks/pi-extension.ts
@@ -287,9 +287,6 @@ function detectEditor(name: string, editorByProcess: Map<string, "code" | "curso
   return undefined;
 }
 
-// Windows 11 24H2+ no longer ships wmic. Take one Get-CimInstance snapshot of
-// all processes and walk it in memory — saves N PowerShell cold-starts (~270 ms
-// each) on a chain of depth N.
 type WinProcessRecord = { name: string; rawName: string; ppid: number };
 
 function getWindowsProcessSnapshot(): Map<number, WinProcessRecord> {

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -81,6 +81,43 @@ function getPlatformConfig(options) {
 //   startPid             — number (default process.ppid)
 //   maxDepth             — number (default 8)
 
+// Windows: snapshot the entire process table in a single PowerShell invocation.
+// `wmic` was removed from Win 11 24H2 default installs (FoD), and PowerShell
+// cold-start is heavy (~270 ms), so spawning one PS per ancestor walked would
+// make the resolver multi-second. One snapshot + in-memory Map walk keeps the
+// total cost to a single PS spawn regardless of chain depth.
+//
+// Returns Map<pid, { name, ppid, commandLine }>. Empty Map on failure.
+function getWindowsProcessSnapshot(execFileSync) {
+  try {
+    const out = execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile", "-NonInteractive", "-Command",
+        "Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, Name, CommandLine | ConvertTo-Json -Compress",
+      ],
+      { encoding: "utf8", timeout: 3000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 }
+    );
+    const trimmed = (out || "").trim();
+    if (!trimmed) return new Map();
+    const parsed = JSON.parse(trimmed);
+    const list = Array.isArray(parsed) ? parsed : [parsed];
+    const map = new Map();
+    for (const proc of list) {
+      const pid = Number(proc && proc.ProcessId);
+      if (!Number.isFinite(pid)) continue;
+      map.set(pid, {
+        name: typeof proc.Name === "string" ? proc.Name.toLowerCase() : "",
+        ppid: Number(proc.ParentProcessId) || 0,
+        commandLine: typeof proc.CommandLine === "string" ? proc.CommandLine : "",
+      });
+    }
+    return map;
+  } catch {
+    return new Map();
+  }
+}
+
 function createPidResolver(options) {
   const { platformConfig } = options;
   const { terminalNames, systemBoundary, editorMap, editorPathChecks } = platformConfig;
@@ -101,33 +138,25 @@ function createPidResolver(options) {
     if (_cached) return _cached;
 
     const { execFileSync } = require("child_process");
+    const winSnapshot = isWin ? getWindowsProcessSnapshot(execFileSync) : null;
+
     let pid = startPid;
     let lastGoodPid = pid;
     let terminalPid = null;
     let detectedEditor = null;
     let agentPid = null;
+    let agentCommandLine = "";
     const pidChain = [];
 
     for (let i = 0; i < maxDepth; i++) {
-      let name, parentPid;
+      let name, parentPid, commandLine = "";
       try {
         if (isWin) {
-          // Windows 11 24H2+ removed wmic from the default install. Use
-          // PowerShell Get-CimInstance for the same fields.
-          const out = execFileSync(
-            "powershell.exe",
-            [
-              "-NoProfile", "-NonInteractive", "-Command",
-              `Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" | Select-Object Name, ParentProcessId | ConvertTo-Json -Compress`,
-            ],
-            { encoding: "utf8", timeout: 1500, windowsHide: true }
-          );
-          const trimmed = (out || "").trim();
-          if (!trimmed) break;
-          const info = JSON.parse(trimmed);
+          const info = winSnapshot.get(pid);
           if (!info) break;
-          name = typeof info.Name === "string" ? info.Name.toLowerCase() : "";
-          parentPid = Number(info.ParentProcessId) || 0;
+          name = info.name;
+          parentPid = info.ppid;
+          commandLine = info.commandLine;
         } else {
           const ppidOut = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000 }).trim();
           const commOut = execFileSync("ps", ["-o", "comm=", "-p", String(pid)], { encoding: "utf8", timeout: 1000 }).trim();
@@ -145,19 +174,27 @@ function createPidResolver(options) {
       pidChain.push(pid);
       if (!detectedEditor && editorMap[name]) detectedEditor = editorMap[name];
 
-      // Agent process detection
+      // Agent process detection. agentCommandLine is captured here so callers
+      // (e.g. clawd-hook headless detection) can reuse it without re-spawning.
       if (!agentPid) {
         if (agentNameSet && agentNameSet.has(name)) {
           agentPid = pid;
+          if (isWin) {
+            agentCommandLine = commandLine;
+          } else {
+            try {
+              agentCommandLine = execFileSync("ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8", timeout: 500 });
+            } catch {}
+          }
         } else if (agentCmdlineCheck && (name === "node.exe" || name === "node")) {
           try {
             const cmdOut = isWin
-              ? execFileSync("powershell.exe", [
-                  "-NoProfile", "-NonInteractive", "-Command",
-                  `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" -ErrorAction SilentlyContinue).CommandLine`,
-                ], { encoding: "utf8", timeout: 500, windowsHide: true })
+              ? commandLine
               : execFileSync("ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8", timeout: 500 });
-            if (agentCmdlineCheck(cmdOut)) agentPid = pid;
+            if (agentCmdlineCheck(cmdOut)) {
+              agentPid = pid;
+              agentCommandLine = cmdOut;
+            }
           } catch {}
         }
       }
@@ -169,7 +206,7 @@ function createPidResolver(options) {
       pid = parentPid;
     }
 
-    _cached = { stablePid: terminalPid || lastGoodPid, agentPid, detectedEditor, pidChain };
+    _cached = { stablePid: terminalPid || lastGoodPid, agentPid, agentCommandLine, detectedEditor, pidChain };
     return _cached;
   };
 }

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -112,15 +112,21 @@ function createPidResolver(options) {
       let name, parentPid;
       try {
         if (isWin) {
+          // Windows 11 24H2+ removed wmic from the default install. Use
+          // PowerShell Get-CimInstance for the same fields.
           const out = execFileSync(
-            "wmic", ["process", "where", `ProcessId=${pid}`, "get", "Name,ParentProcessId", "/format:csv"],
+            "powershell.exe",
+            [
+              "-NoProfile", "-NonInteractive", "-Command",
+              `Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" | Select-Object Name, ParentProcessId | ConvertTo-Json -Compress`,
+            ],
             { encoding: "utf8", timeout: 1500, windowsHide: true }
           );
-          const lines = out.trim().split("\n").filter(l => l.includes(","));
-          if (!lines.length) break;
-          const parts = lines[lines.length - 1].split(",");
-          name = (parts[1] || "").trim().toLowerCase();
-          parentPid = parseInt(parts[2], 10);
+          const trimmed = (out || "").trim();
+          if (!trimmed) break;
+          const info = JSON.parse(trimmed);
+          name = typeof info.Name === "string" ? info.Name.toLowerCase() : "";
+          parentPid = Number(info.ParentProcessId) || 0;
         } else {
           const ppidOut = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 1000 }).trim();
           const commOut = execFileSync("ps", ["-o", "comm=", "-p", String(pid)], { encoding: "utf8", timeout: 1000 }).trim();
@@ -145,8 +151,10 @@ function createPidResolver(options) {
         } else if (agentCmdlineCheck && (name === "node.exe" || name === "node")) {
           try {
             const cmdOut = isWin
-              ? execFileSync("wmic", ["process", "where", `ProcessId=${pid}`, "get", "CommandLine", "/format:csv"],
-                  { encoding: "utf8", timeout: 500, windowsHide: true })
+              ? execFileSync("powershell.exe", [
+                  "-NoProfile", "-NonInteractive", "-Command",
+                  `(Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" -ErrorAction SilentlyContinue).CommandLine`,
+                ], { encoding: "utf8", timeout: 500, windowsHide: true })
               : execFileSync("ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8", timeout: 500 });
             if (agentCmdlineCheck(cmdOut)) agentPid = pid;
           } catch {}

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -125,6 +125,7 @@ function createPidResolver(options) {
           const trimmed = (out || "").trim();
           if (!trimmed) break;
           const info = JSON.parse(trimmed);
+          if (!info) break;
           name = typeof info.Name === "string" ? info.Name.toLowerCase() : "";
           parentPid = Number(info.ParentProcessId) || 0;
         } else {

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -81,13 +81,8 @@ function getPlatformConfig(options) {
 //   startPid             — number (default process.ppid)
 //   maxDepth             — number (default 8)
 
-// Windows: snapshot the entire process table in a single PowerShell invocation.
-// `wmic` was removed from Win 11 24H2 default installs (FoD), and PowerShell
-// cold-start is heavy (~270 ms), so spawning one PS per ancestor walked would
-// make the resolver multi-second. One snapshot + in-memory Map walk keeps the
-// total cost to a single PS spawn regardless of chain depth.
-//
-// Returns Map<pid, { name, ppid, commandLine }>. Empty Map on failure.
+// One PS spawn per resolve, not per ancestor — PowerShell cold-start (~270 ms)
+// would dominate the walk otherwise. Returns empty Map on failure.
 function getWindowsProcessSnapshot(execFileSync) {
   try {
     const out = execFileSync(
@@ -174,8 +169,6 @@ function createPidResolver(options) {
       pidChain.push(pid);
       if (!detectedEditor && editorMap[name]) detectedEditor = editorMap[name];
 
-      // Agent process detection. agentCommandLine is captured here so callers
-      // (e.g. clawd-hook headless detection) can reuse it without re-spawning.
       if (!agentPid) {
         if (agentNameSet && agentNameSet.has(name)) {
           agentPid = pid;

--- a/src/state.js
+++ b/src/state.js
@@ -1091,8 +1091,6 @@ function detectRunningAgentProcesses(callback) {
   }
   const { execFile, exec } = require("child_process");
   if (process.platform === "win32") {
-    // wmic was removed from Windows 11 24H2 default installs. Use PowerShell
-    // Get-CimInstance for the equivalent agent-process probe.
     const psScript =
       "$names = 'claude.exe','codex.exe','copilot.exe','gemini.exe','codebuddy.exe','kiro-cli.exe','kimi.exe','opencode.exe','pi.exe','hermes.exe'; " +
       "$match = Get-CimInstance Win32_Process | Where-Object { " +

--- a/src/state.js
+++ b/src/state.js
@@ -1089,11 +1089,20 @@ function detectRunningAgentProcesses(callback) {
     done(false);
     return;
   }
-  const { exec } = require("child_process");
+  const { execFile, exec } = require("child_process");
   if (process.platform === "win32") {
-    exec(
-      'wmic process where "(Name=\'node.exe\' and CommandLine like \'%claude-code%\') or Name=\'claude.exe\' or Name=\'codex.exe\' or Name=\'copilot.exe\' or Name=\'gemini.exe\' or Name=\'codebuddy.exe\' or Name=\'kiro-cli.exe\' or Name=\'kimi.exe\' or Name=\'opencode.exe\' or Name=\'pi.exe\' or Name=\'hermes.exe\'" get ProcessId /format:csv',
-      { encoding: "utf8", timeout: 5000, windowsHide: true },
+    // wmic was removed from Windows 11 24H2 default installs. Use PowerShell
+    // Get-CimInstance for the equivalent agent-process probe.
+    const psScript =
+      "$names = 'claude.exe','codex.exe','copilot.exe','gemini.exe','codebuddy.exe','kiro-cli.exe','kimi.exe','opencode.exe','pi.exe','hermes.exe'; " +
+      "$match = Get-CimInstance Win32_Process | Where-Object { " +
+        "$names -contains $_.Name -or ($_.Name -eq 'node.exe' -and $_.CommandLine -like '*claude-code*') " +
+      "} | Select-Object -First 1; " +
+      "if ($match) { $match.ProcessId }";
+    execFile(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", psScript],
+      { encoding: "utf8", timeout: 5000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 },
       (err, stdout) => done(!err && /\d+/.test(stdout))
     );
   } else {

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -146,22 +146,13 @@ describe("buildStateBody", () => {
   });
 
   describe("agentPid and headless detection", () => {
-    const childProcess = require("child_process");
-    const makeResolve = (agentPid) =>
-      () => ({ stablePid: 1, agentPid, detectedEditor: null, pidChain: [] });
-
-    function withMockedExec(mockFn, cb) {
-      const orig = childProcess.execFileSync;
-      childProcess.execFileSync = mockFn;
-      try { cb(); } finally { childProcess.execFileSync = orig; }
-    }
+    const makeResolve = (agentPid, agentCommandLine = "") =>
+      () => ({ stablePid: 1, agentPid, agentCommandLine, detectedEditor: null, pidChain: [] });
 
     it("sets agent_pid and claude_pid when agentPid is present", () => {
-      withMockedExec(() => "", () => {
-        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(42));
-        assert.strictEqual(body.agent_pid, 42);
-        assert.strictEqual(body.claude_pid, 42);
-      });
+      const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(42));
+      assert.strictEqual(body.agent_pid, 42);
+      assert.strictEqual(body.claude_pid, 42);
     });
 
     it("omits agent_pid and claude_pid when agentPid is absent", () => {
@@ -170,47 +161,38 @@ describe("buildStateBody", () => {
       assert.ok(!("claude_pid" in body));
     });
 
-    it("sets headless when cmdline ends with -p", () => {
-      withMockedExec(() => "node claude-code -p", () => {
-        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
-        assert.strictEqual(body.headless, true);
-      });
+    it("sets headless when agentCommandLine ends with -p", () => {
+      const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99, "node claude-code -p"));
+      assert.strictEqual(body.headless, true);
     });
 
-    it("sets headless when cmdline has -p followed by a space", () => {
-      withMockedExec(() => "node claude-code -p some-prompt", () => {
-        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
-        assert.strictEqual(body.headless, true);
-      });
+    it("sets headless when agentCommandLine has -p followed by a space", () => {
+      const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99, "node claude-code -p some-prompt"));
+      assert.strictEqual(body.headless, true);
     });
 
-    it("sets headless when cmdline contains --print", () => {
-      withMockedExec(() => "node claude-code --print", () => {
-        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
-        assert.strictEqual(body.headless, true);
-      });
+    it("sets headless when agentCommandLine contains --print", () => {
+      const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99, "node claude-code --print"));
+      assert.strictEqual(body.headless, true);
     });
 
     it("does not set headless when -p is a prefix of a longer option", () => {
-      withMockedExec(() => "node claude-code --port 3000", () => {
-        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
-        assert.ok(!("headless" in body));
-      });
+      const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99, "node claude-code --port 3000"));
+      assert.ok(!("headless" in body));
     });
 
-    it("does not set headless when cmdline is empty", () => {
-      withMockedExec(() => "", () => {
-        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
-        assert.ok(!("headless" in body));
-      });
+    it("does not set headless when agentCommandLine is empty", () => {
+      const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99, ""));
+      assert.ok(!("headless" in body));
     });
 
-    it("keeps agent_pid set when execFileSync throws", () => {
-      withMockedExec(() => { throw new Error("ENOENT"); }, () => {
-        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(77));
-        assert.strictEqual(body.agent_pid, 77);
-        assert.ok(!("headless" in body));
-      });
+    it("does not set headless when agentCommandLine is missing from resolve()", () => {
+      // Backward compat: a resolver that never populates agentCommandLine must
+      // not crash and must not set headless.
+      const resolve = () => ({ stablePid: 1, agentPid: 77, detectedEditor: null, pidChain: [] });
+      const body = buildStateBody("PreToolUse", { session_id: "s" }, resolve);
+      assert.strictEqual(body.agent_pid, 77);
+      assert.ok(!("headless" in body));
     });
   });
 

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -145,6 +145,75 @@ describe("buildStateBody", () => {
     assert.ok(!("pid_chain" in body));
   });
 
+  describe("agentPid and headless detection", () => {
+    const childProcess = require("child_process");
+    const makeResolve = (agentPid) =>
+      () => ({ stablePid: 1, agentPid, detectedEditor: null, pidChain: [] });
+
+    function withMockedExec(mockFn, cb) {
+      const orig = childProcess.execFileSync;
+      childProcess.execFileSync = mockFn;
+      try { cb(); } finally { childProcess.execFileSync = orig; }
+    }
+
+    it("sets agent_pid and claude_pid when agentPid is present", () => {
+      withMockedExec(() => "", () => {
+        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(42));
+        assert.strictEqual(body.agent_pid, 42);
+        assert.strictEqual(body.claude_pid, 42);
+      });
+    });
+
+    it("omits agent_pid and claude_pid when agentPid is absent", () => {
+      const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(null));
+      assert.ok(!("agent_pid" in body));
+      assert.ok(!("claude_pid" in body));
+    });
+
+    it("sets headless when cmdline ends with -p", () => {
+      withMockedExec(() => "node claude-code -p", () => {
+        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
+        assert.strictEqual(body.headless, true);
+      });
+    });
+
+    it("sets headless when cmdline has -p followed by a space", () => {
+      withMockedExec(() => "node claude-code -p some-prompt", () => {
+        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
+        assert.strictEqual(body.headless, true);
+      });
+    });
+
+    it("sets headless when cmdline contains --print", () => {
+      withMockedExec(() => "node claude-code --print", () => {
+        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
+        assert.strictEqual(body.headless, true);
+      });
+    });
+
+    it("does not set headless when -p is a prefix of a longer option", () => {
+      withMockedExec(() => "node claude-code --port 3000", () => {
+        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
+        assert.ok(!("headless" in body));
+      });
+    });
+
+    it("does not set headless when cmdline is empty", () => {
+      withMockedExec(() => "", () => {
+        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(99));
+        assert.ok(!("headless" in body));
+      });
+    });
+
+    it("keeps agent_pid set when execFileSync throws", () => {
+      withMockedExec(() => { throw new Error("ENOENT"); }, () => {
+        const body = buildStateBody("PreToolUse", { session_id: "s" }, makeResolve(77));
+        assert.strictEqual(body.agent_pid, 77);
+        assert.ok(!("headless" in body));
+      });
+    });
+  });
+
   it("passes through tool metadata for tool events", () => {
     const payload = {
       session_id: "s",

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -172,25 +172,31 @@ describe("createPidResolver() — Windows PowerShell path", { skip: process.plat
     try { cb(); } finally { childProcess.execFileSync = orig; }
   }
 
-  function psJson(name, parentPid) {
-    return JSON.stringify({ Name: name, ParentProcessId: parentPid });
+  // Builds the JSON the snapshot helper expects: one ConvertTo-Json array of
+  // process records. Each record: { pid, name, ppid, cmd? }
+  function snapshotJson(procs) {
+    return JSON.stringify(procs.map((p) => ({
+      ProcessId: p.pid,
+      Name: p.name,
+      ParentProcessId: p.ppid,
+      CommandLine: typeof p.cmd === "string" ? p.cmd : null,
+    })));
   }
 
-  it("populates pidChain by walking PS JSON output", () => {
+  it("populates pidChain by walking the snapshot Map", () => {
     const cfg = getPlatformConfig();
     const resolve = createPidResolver({ platformConfig: cfg, startPid: 1000 });
-    withMockedExec((_cmd, args) => {
-      if (args[3].includes("ProcessId=1000")) return psJson("cmd.exe", 1001);
-      if (args[3].includes("ProcessId=1001")) return psJson("explorer.exe", 0);
-      return "";
-    }, () => {
+    withMockedExec(() => snapshotJson([
+      { pid: 1000, name: "cmd.exe", ppid: 1001 },
+      { pid: 1001, name: "explorer.exe", ppid: 0 },
+    ]), () => {
       const { pidChain } = resolve();
       assert.ok(pidChain.includes(1000));
       assert.ok(pidChain.includes(1001));
     });
   });
 
-  it("breaks the walk immediately when PS returns empty (process not found)", () => {
+  it("breaks the walk immediately when the snapshot is empty", () => {
     const cfg = getPlatformConfig();
     const resolve = createPidResolver({ platformConfig: cfg, startPid: 9999 });
     withMockedExec(() => "", () => {
@@ -211,10 +217,9 @@ describe("createPidResolver() — Windows PowerShell path", { skip: process.plat
   it("sets stablePid to the terminal PID when a terminal process is found", () => {
     const cfg = getPlatformConfig();
     const resolve = createPidResolver({ platformConfig: cfg, startPid: 500 });
-    withMockedExec((_cmd, args) => {
-      if (args[3].includes("ProcessId=500")) return psJson("windowsterminal.exe", 0);
-      return "";
-    }, () => {
+    withMockedExec(() => snapshotJson([
+      { pid: 500, name: "windowsterminal.exe", ppid: 0 },
+    ]), () => {
       const { stablePid } = resolve();
       assert.strictEqual(stablePid, 500);
     });
@@ -223,10 +228,9 @@ describe("createPidResolver() — Windows PowerShell path", { skip: process.plat
   it("detects editor from process name", () => {
     const cfg = getPlatformConfig();
     const resolve = createPidResolver({ platformConfig: cfg, startPid: 200 });
-    withMockedExec((_cmd, args) => {
-      if (args[3].includes("ProcessId=200")) return psJson("code.exe", 0);
-      return "";
-    }, () => {
+    withMockedExec(() => snapshotJson([
+      { pid: 200, name: "code.exe", ppid: 0 },
+    ]), () => {
       const { detectedEditor } = resolve();
       assert.strictEqual(detectedEditor, "code");
     });
@@ -235,15 +239,31 @@ describe("createPidResolver() — Windows PowerShell path", { skip: process.plat
   it("stops the walk at a system boundary process (explorer.exe)", () => {
     const cfg = getPlatformConfig();
     const resolve = createPidResolver({ platformConfig: cfg, startPid: 300 });
-    let callCount = 0;
+    withMockedExec(() => snapshotJson([
+      { pid: 300, name: "cmd.exe", ppid: 301 },
+      { pid: 301, name: "explorer.exe", ppid: 302 },
+      { pid: 302, name: "unreachable.exe", ppid: 0 },
+    ]), () => {
+      const { pidChain } = resolve();
+      assert.ok(pidChain.includes(301), "explorer.exe must be in the chain");
+      assert.ok(!pidChain.includes(302), "walk must stop after the system boundary");
+    });
+  });
+
+  it("uses a single PowerShell spawn for the snapshot regardless of chain depth", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: 100 });
+    let spawnCount = 0;
     withMockedExec(() => {
-      callCount++;
-      if (callCount === 1) return psJson("cmd.exe", 301);
-      if (callCount === 2) return psJson("explorer.exe", 0);
-      return psJson("unreachable.exe", 0);
+      spawnCount++;
+      return snapshotJson([
+        { pid: 100, name: "cmd.exe", ppid: 101 },
+        { pid: 101, name: "powershell.exe", ppid: 102 },
+        { pid: 102, name: "windowsterminal.exe", ppid: 0 },
+      ]);
     }, () => {
       resolve();
-      assert.strictEqual(callCount, 2, "must stop at system boundary");
+      assert.strictEqual(spawnCount, 1, "snapshot must be taken exactly once");
     });
   });
 
@@ -254,33 +274,29 @@ describe("createPidResolver() — Windows PowerShell path", { skip: process.plat
       startPid: 400,
       agentNames: { win: new Set(["claude.exe"]), mac: new Set(["claude"]) },
     });
-    withMockedExec((_cmd, args) => {
-      if (args[3].includes("ProcessId=400")) return psJson("node.exe", 401);
-      if (args[3].includes("ProcessId=401")) return psJson("claude.exe", 0);
-      return "";
-    }, () => {
-      const { agentPid } = resolve();
+    withMockedExec(() => snapshotJson([
+      { pid: 400, name: "node.exe", ppid: 401 },
+      { pid: 401, name: "claude.exe", ppid: 0, cmd: "C:\\Program Files\\claude\\claude.exe" },
+    ]), () => {
+      const { agentPid, agentCommandLine } = resolve();
       assert.strictEqual(agentPid, 401);
+      assert.ok(agentCommandLine.includes("claude.exe"), "agentCommandLine must come from the snapshot");
     });
   });
 
-  it("detects agentPid via agentCmdlineCheck on node.exe", () => {
+  it("detects agentPid via agentCmdlineCheck on node.exe using snapshot CommandLine", () => {
     const cfg = getPlatformConfig();
     const resolve = createPidResolver({
       platformConfig: cfg,
       startPid: 600,
       agentCmdlineCheck: (cmdline) => cmdline.includes("claude-code"),
     });
-    withMockedExec((_cmd, args) => {
-      const command = args[3];
-      if (command.includes("Select-Object")) {
-        if (command.includes("ProcessId=600")) return psJson("node.exe", 0);
-        return "";
-      }
-      return "node C:\\Users\\x\\AppData\\Local\\claude-code\\index.js";
-    }, () => {
-      const { agentPid } = resolve();
+    withMockedExec(() => snapshotJson([
+      { pid: 600, name: "node.exe", ppid: 0, cmd: "node C:\\Users\\x\\AppData\\Local\\claude-code\\index.js" },
+    ]), () => {
+      const { agentPid, agentCommandLine } = resolve();
       assert.strictEqual(agentPid, 600);
+      assert.ok(agentCommandLine.includes("claude-code"));
     });
   });
 });

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -159,6 +159,132 @@ describe("buildElectronLaunchConfig()", () => {
   });
 });
 
+// ═════════════════════════════════════════════════════════════════════════════
+// createPidResolver() — Windows PowerShell / Get-CimInstance path (win32 only)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("createPidResolver() — Windows PowerShell path", { skip: process.platform !== "win32" }, () => {
+  const childProcess = require("child_process");
+
+  function withMockedExec(mockFn, cb) {
+    const orig = childProcess.execFileSync;
+    childProcess.execFileSync = mockFn;
+    try { cb(); } finally { childProcess.execFileSync = orig; }
+  }
+
+  function psJson(name, parentPid) {
+    return JSON.stringify({ Name: name, ParentProcessId: parentPid });
+  }
+
+  it("populates pidChain by walking PS JSON output", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: 1000 });
+    withMockedExec((_cmd, args) => {
+      if (args[3].includes("ProcessId=1000")) return psJson("cmd.exe", 1001);
+      if (args[3].includes("ProcessId=1001")) return psJson("explorer.exe", 0);
+      return "";
+    }, () => {
+      const { pidChain } = resolve();
+      assert.ok(pidChain.includes(1000));
+      assert.ok(pidChain.includes(1001));
+    });
+  });
+
+  it("breaks the walk immediately when PS returns empty (process not found)", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: 9999 });
+    withMockedExec(() => "", () => {
+      const { pidChain } = resolve();
+      assert.strictEqual(pidChain.length, 0);
+    });
+  });
+
+  it("breaks the walk cleanly when ConvertTo-Json outputs 'null'", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: 9000 });
+    withMockedExec(() => "null", () => {
+      const { pidChain } = resolve();
+      assert.strictEqual(pidChain.length, 0, "'null' PS output must abort the walk");
+    });
+  });
+
+  it("sets stablePid to the terminal PID when a terminal process is found", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: 500 });
+    withMockedExec((_cmd, args) => {
+      if (args[3].includes("ProcessId=500")) return psJson("windowsterminal.exe", 0);
+      return "";
+    }, () => {
+      const { stablePid } = resolve();
+      assert.strictEqual(stablePid, 500);
+    });
+  });
+
+  it("detects editor from process name", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: 200 });
+    withMockedExec((_cmd, args) => {
+      if (args[3].includes("ProcessId=200")) return psJson("code.exe", 0);
+      return "";
+    }, () => {
+      const { detectedEditor } = resolve();
+      assert.strictEqual(detectedEditor, "code");
+    });
+  });
+
+  it("stops the walk at a system boundary process (explorer.exe)", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: 300 });
+    let callCount = 0;
+    withMockedExec(() => {
+      callCount++;
+      if (callCount === 1) return psJson("cmd.exe", 301);
+      if (callCount === 2) return psJson("explorer.exe", 0);
+      return psJson("unreachable.exe", 0);
+    }, () => {
+      resolve();
+      assert.strictEqual(callCount, 2, "must stop at system boundary");
+    });
+  });
+
+  it("detects agentPid when agentNameSet matches a process name", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({
+      platformConfig: cfg,
+      startPid: 400,
+      agentNames: { win: new Set(["claude.exe"]), mac: new Set(["claude"]) },
+    });
+    withMockedExec((_cmd, args) => {
+      if (args[3].includes("ProcessId=400")) return psJson("node.exe", 401);
+      if (args[3].includes("ProcessId=401")) return psJson("claude.exe", 0);
+      return "";
+    }, () => {
+      const { agentPid } = resolve();
+      assert.strictEqual(agentPid, 401);
+    });
+  });
+
+  it("detects agentPid via agentCmdlineCheck on node.exe", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({
+      platformConfig: cfg,
+      startPid: 600,
+      agentCmdlineCheck: (cmdline) => cmdline.includes("claude-code"),
+    });
+    withMockedExec((_cmd, args) => {
+      const command = args[3];
+      if (command.includes("Select-Object")) {
+        if (command.includes("ProcessId=600")) return psJson("node.exe", 0);
+        return "";
+      }
+      return "node C:\\Users\\x\\AppData\\Local\\claude-code\\index.js";
+    }, () => {
+      const { agentPid } = resolve();
+      assert.strictEqual(agentPid, 600);
+    });
+  });
+});
+
 // readStdinJson() is not unit-tested here — it attaches listeners to
 // process.stdin (singleton) which prevents process exit. Validated by
 // real agent integration tests + the finishOnce/timeout logic is trivial.

--- a/test/state-startup-recovery-detect.test.js
+++ b/test/state-startup-recovery-detect.test.js
@@ -43,24 +43,29 @@ function makeCtx(overrides = {}) {
 describe("detectRunningAgentProcesses() agent coverage", () => {
   let api;
   let originalExec;
+  let originalExecFile;
   let originalPlatform;
 
   beforeEach(() => {
     originalExec = childProcess.exec;
+    originalExecFile = childProcess.execFile;
     originalPlatform = process.platform;
     api = require("../src/state")(makeCtx());
   });
 
   afterEach(() => {
     childProcess.exec = originalExec;
+    childProcess.execFile = originalExecFile;
     Object.defineProperty(process, "platform", { value: originalPlatform });
     api.cleanup();
   });
 
-  it("includes kimi.exe and pi.exe in Windows process query", async () => {
-    let seenCommand = "";
-    childProcess.exec = (cmd, opts, cb) => {
-      seenCommand = cmd;
+  it("includes kimi.exe and pi.exe in the Windows PowerShell process query", async () => {
+    let seenFile = "";
+    let seenScript = "";
+    childProcess.execFile = (file, args, opts, cb) => {
+      seenFile = file;
+      seenScript = args[args.length - 1];
       cb(null, "12345");
     };
     Object.defineProperty(process, "platform", { value: "win32" });
@@ -70,8 +75,10 @@ describe("detectRunningAgentProcesses() agent coverage", () => {
     });
 
     assert.strictEqual(found, true);
-    assert.match(seenCommand, /Name='kimi\.exe'/);
-    assert.match(seenCommand, /Name='pi\.exe'/);
+    assert.strictEqual(seenFile, "powershell.exe");
+    assert.match(seenScript, /'kimi\.exe'/);
+    assert.match(seenScript, /'pi\.exe'/);
+    assert.match(seenScript, /Get-CimInstance Win32_Process/);
   });
 
   it("includes kimi and Pi package markers in macOS/Linux pgrep query", async () => {


### PR DESCRIPTION
 ## Problem

  Windows 11 24H2 (build 26200+) removed `wmic` from the default install.

  The hook's parent-process-chain walk called `wmic` on every PID iteration.
  On affected builds the very first call throws `ENOENT`, the `catch { break }` fires immediately,
  and `pidChain` comes back empty. `stablePid` then resolves to the hook's own short-lived PID — 
  silently breaking Dashboard / HUD session focus and every PID-dependent feature.

  ---

  ## Solution

  Replace both `wmic` call sites with `Get-CimInstance Win32_Process` — the same WMI class, different query interface.

  ### `hooks/shared-process.js` — per-iteration parent-process walk

  ```powershell
  Get-CimInstance Win32_Process -Filter "ProcessId=<pid>" |
    Select-Object Name, ParentProcessId |
    ConvertTo-Json -Compress
  ```

  No process found → empty stdout → `if (!trimmed) break` (same guard as before).
  Added an explicit `if (!info) break` after `JSON.parse` to handle the edge case where
  `ConvertTo-Json` outputs the literal string `"null"` for a null object.

  ### `hooks/clawd-hook.js` — headless (`-p`/`--print`) detection

  ```powershell
  (Get-CimInstance Win32_Process -Filter "ProcessId=<pid>" -ErrorAction SilentlyContinue).CommandLine
  ```

  Also swaps `execSync` → `execFileSync` (argument array, no shell) on both the Windows and macOS/Linux branches.

  ---

  ## Compatibility

  | Platform | Before | After |
  |---|---|---|
  | Win 11 24H2+ (build 26200+) | `pidChain=[]`, session focus broken | Restored |
  | Win 11 23H2 and below | wmic worked | PowerShell path, identical output |
  | macOS / Linux | `ps` path unchanged | No logic change |

  Timeouts are unchanged (main query 1500 ms, cmdline check 500 ms). PowerShell cold-start on affected builds is ~270 ms.

  ---

  ## Tests

  ### `test/clawd-hook.test.js` — 8 new cases (`agentPid` and headless detection)

  Previously this branch was never exercised. `execFileSync` is monkey-patched per test:

  - `agentPid` present → `agent_pid` + `claude_pid` set
  - `agentPid` absent → both fields absent
  - cmdline ends with `-p` → `headless: true`
  - cmdline has `-p <arg>` → `headless: true`
  - cmdline has `--print` → `headless: true`
  - cmdline has `--port` (prefix match) → no `headless`
  - cmdline is empty → no `headless`
  - `execFileSync` throws → `agent_pid` still set, no `headless`

  ### `test/shared-process.test.js` — 8 new cases (win32-only, skipped on other platforms)

  The PowerShell + JSON parsing path in `createPidResolver()` had no unit coverage:

  - pidChain populated by walking PS JSON output
  - walk breaks immediately on empty PS output (process not found)
  - walk breaks cleanly on `ConvertTo-Json` `"null"` output
  - `stablePid` set to terminal PID when terminal process is found
  - `detectedEditor` resolved from process name (`code.exe` → `"code"`)
  - walk stops at system boundary (`explorer.exe`), callCount asserted
  - `agentPid` detected via `agentNameSet` name match
  - `agentPid` detected via `agentCmdlineCheck` on `node.exe` cmdline probe

  **66 / 66 pass.**

  ---

  ## Note

  Per-iteration `powershell.exe` spawn is acknowledged. A single process-table snapshot to amortize startup cost is intentionally deferred to a follow-up commit — this PR is a minimal, safe drop-in replacement.

  ## References

  - [wmic deprecation — Windows deprecated features](https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features)
  - [Working with WMI — PowerShell 101](https://learn.microsoft.com/en-us/powershell/scripting/learn/ps101/07-working-with-wmi)