### PR TITLE
fix: recover pet after fullscreen window switches

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -6,6 +6,8 @@ const container = document.getElementById("pet-container");
 let clawdEl = document.getElementById("clawd");
 let pendingNext = null;
 const LOW_POWER_IDLE_PAUSE_MS = 5000;
+const SWAP_LOAD_FALLBACK_MS = 3000;
+const SWAP_VISIBILITY_RESCUE_BUFFER_MS = 750;
 const LOW_POWER_PAUSE_STYLE_ID = "clawd-low-power-pause-svg";
 const LOW_POWER_PAUSE_STATES = new Set(["idle", "mini-idle", "dozing"]);
 const LOW_POWER_BOUNDARY_EPSILON_MS = 80;
@@ -629,6 +631,8 @@ let currentDisplayedSvg = getObjectSvgName(clawdEl);
 let currentDisplayedAssetUrl = null;
 let pendingSvgFile = null; // tracks the SVG currently being loaded (for dedup)
 let pendingAssetUrl = null;
+let activeSwapToken = 0;
+let swapVisibilityRescueTimer = null;
 currentIdleSvg = currentDisplayedSvg;
 
 /**
@@ -647,7 +651,75 @@ function fadeOutAndRemove(el, durationMs) {
   }, durationMs);
 }
 
-function swapToFile(file, state, useObjectChannel) {
+function getPetMediaElements() {
+  return [...container.querySelectorAll("object, img.clawd-img")];
+}
+
+function isVisiblyOpaque(el) {
+  if (!el || !el.isConnected) return false;
+  let opacity = 1;
+  try {
+    const style = window.getComputedStyle ? window.getComputedStyle(el) : null;
+    opacity = Number.parseFloat((style && style.opacity) || el.style.opacity || "1");
+  } catch {
+    opacity = Number.parseFloat(el.style.opacity || "1");
+  }
+  return !Number.isFinite(opacity) || opacity > 0.05;
+}
+
+function hasVisiblePetElement() {
+  return getPetMediaElements().some(isVisiblyOpaque);
+}
+
+function forceVisiblePetElement(el) {
+  if (!el || !el.isConnected) return false;
+  el.style.transition = "none";
+  el.style.opacity = "1";
+  return true;
+}
+
+function clearSwapVisibilityRescueTimer() {
+  if (swapVisibilityRescueTimer) {
+    clearTimeout(swapVisibilityRescueTimer);
+    swapVisibilityRescueTimer = null;
+  }
+}
+
+function getSwapVisibilityRescueDelay(file) {
+  const fadeInMs = (_transitions[file] && _transitions[file].in) || 0;
+  return Math.max(SWAP_LOAD_FALLBACK_MS + SWAP_VISIBILITY_RESCUE_BUFFER_MS, fadeInMs + SWAP_VISIBILITY_RESCUE_BUFFER_MS);
+}
+
+function scheduleSwapVisibilityRescue(token, file, state) {
+  clearSwapVisibilityRescueTimer();
+  const timer = setTimeout(() => {
+    if (swapVisibilityRescueTimer === timer) swapVisibilityRescueTimer = null;
+    if (token !== activeSwapToken) return;
+    if (hasVisiblePetElement()) return;
+
+    if (pendingNext && pendingSvgFile === file) {
+      forceImageChannelReload(file, state);
+      return;
+    }
+
+    if (forceVisiblePetElement(clawdEl)) return;
+    forceImageChannelReload(file, state);
+  }, getSwapVisibilityRescueDelay(file));
+  swapVisibilityRescueTimer = timer;
+}
+
+function forceImageChannelReload(file, state, allowImageFallback = true) {
+  if (!allowImageFallback) return false;
+  if (!file) return false;
+  if (hasVisiblePetElement()) return false;
+  console.warn("Clawd: animation stayed invisible; reloading through the image channel:", file);
+  swapToFile(file, state, false, { allowImageFallback: false });
+  return true;
+}
+
+function swapToFile(file, state, useObjectChannel, options = {}) {
+  const swapToken = ++activeSwapToken;
+  const allowImageFallback = options.allowImageFallback !== false;
   if (pendingNext) {
     if (pendingNext.tagName === "OBJECT") releaseObject(pendingNext);
     else releaseImg(pendingNext);
@@ -670,6 +742,7 @@ function swapToFile(file, state, useObjectChannel) {
 
     const swap = () => {
       if (pendingNext !== next) return;
+      if (swapToken === activeSwapToken) clearSwapVisibilityRescueTimer();
       const fadeInMs = (_transitions[file] && _transitions[file].in) || 0;
       const fadeOutMs = (currentDisplayedSvg && _transitions[currentDisplayedSvg] && _transitions[currentDisplayedSvg].out) || 0;
 
@@ -709,6 +782,7 @@ function swapToFile(file, state, useObjectChannel) {
     next.data = url;
     container.appendChild(next);
     pendingNext = next;
+    scheduleSwapVisibilityRescue(swapToken, file, state);
     setTimeout(() => {
       if (pendingNext !== next) return;
       try {
@@ -717,11 +791,12 @@ function swapToFile(file, state, useObjectChannel) {
           pendingNext = null;
           pendingSvgFile = null;
           pendingAssetUrl = null;
+          forceImageChannelReload(file, state, allowImageFallback);
           return;
         }
       } catch {}
       swap();
-    }, 3000);
+    }, SWAP_LOAD_FALLBACK_MS);
   } else {
     // Img channel: <img> for pure playback (all formats)
     const next = document.createElement("img");
@@ -733,6 +808,7 @@ function swapToFile(file, state, useObjectChannel) {
 
     const swap = () => {
       if (pendingNext !== next) return;
+      if (swapToken === activeSwapToken) clearSwapVisibilityRescueTimer();
       const fadeInMs = (_transitions[file] && _transitions[file].in) || 0;
       const fadeOutMs = (currentDisplayedSvg && _transitions[currentDisplayedSvg] && _transitions[currentDisplayedSvg].out) || 0;
 
@@ -775,11 +851,12 @@ function swapToFile(file, state, useObjectChannel) {
     next.src = `${url}${url.includes("?") ? "&" : "?"}_t=${cacheBust}`;
     container.appendChild(next);
     pendingNext = next;
+    scheduleSwapVisibilityRescue(swapToken, file, state);
     // Timeout fallback for images that fail to load
     setTimeout(() => {
       if (pendingNext !== next) return;
       swap();
-    }, 3000);
+    }, SWAP_LOAD_FALLBACK_MS);
   }
 }
 

--- a/src/theme-fade-sequencer.js
+++ b/src/theme-fade-sequencer.js
@@ -141,7 +141,10 @@ function createThemeFadeSequencer(options = {}) {
       finish("loaded");
     };
 
+    scheduleFadeFallback(seq, () => finish("fallback"));
+
     animateOpacity(seq, 0, fadeOutMs).then(() => {
+      if (!isCurrent(seq) || settled) return;
       reloadAfterFade(seq, onReady, () => finish("fallback"));
     });
 

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -49,6 +49,7 @@ function createTopmostRuntime(options = {}) {
 
   let topmostWatchdog = null;
   let hwndRecoveryTimer = null;
+  let pendingNudgeRestore = null;
 
   function reassertWinTopmost() {
     if (!isWin) return;
@@ -107,8 +108,44 @@ function createTopmostRuntime(options = {}) {
       const win = getWin();
       if (!isLiveWindow(win)) return;
       reassertWinTopmost();
+      if (!isDragLocked() && !isMiniAnimating() && !isMiniTransitioning()) {
+        restorePendingNudge();
+      } else {
+        pendingNudgeRestore = null;
+      }
       setForceEyeResend(true);
     }, hwndRecoveryDelayMs);
+  }
+
+  function restorePendingNudge(options = {}) {
+    if (!pendingNudgeRestore) return false;
+    const pending = pendingNudgeRestore;
+    const clear = options.clear !== false;
+    const current = getPetWindowBounds();
+    if (!current) {
+      if (clear) pendingNudgeRestore = null;
+      return false;
+    }
+
+    const stillAtNudgedPosition = current.x === pending.nudgedX && current.y === pending.y;
+    const movedElsewhere = current.x !== pending.x || current.y !== pending.y;
+    if (stillAtNudgedPosition) {
+      if (clear) pendingNudgeRestore = null;
+      applyPetWindowPosition(pending.x, pending.y);
+      syncHitWin();
+      return true;
+    }
+
+    if (movedElsewhere || clear) pendingNudgeRestore = null;
+    return false;
+  }
+
+  function applyFreshNudge(bounds) {
+    if (!bounds) return false;
+    pendingNudgeRestore = { x: bounds.x, y: bounds.y, nudgedX: bounds.x + 1 };
+    applyPetWindowPosition(bounds.x + 1, bounds.y);
+    applyPetWindowPosition(bounds.x, bounds.y);
+    return true;
   }
 
   function guardAlwaysOnTop(winToGuard) {
@@ -124,9 +161,14 @@ function createTopmostRuntime(options = {}) {
       ) {
         setForceEyeResend(true);
         const bounds = getPetWindowBounds();
-        if (bounds) {
-          applyPetWindowPosition(bounds.x + 1, bounds.y);
-          applyPetWindowPosition(bounds.x, bounds.y);
+        if (bounds && !pendingNudgeRestore) {
+          applyFreshNudge(bounds);
+        } else if (pendingNudgeRestore) {
+          const handled = restorePendingNudge({ clear: false });
+          if (!handled && !pendingNudgeRestore) {
+            const fresh = getPetWindowBounds();
+            applyFreshNudge(fresh);
+          }
         }
         syncHitWin();
         scheduleHwndRecovery();
@@ -183,6 +225,7 @@ function createTopmostRuntime(options = {}) {
       clearTimeoutFn(hwndRecoveryTimer);
       hwndRecoveryTimer = null;
     }
+    pendingNudgeRestore = null;
   }
 
   return {

--- a/test/renderer-low-power.test.js
+++ b/test/renderer-low-power.test.js
@@ -4,6 +4,7 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const fs = require("node:fs");
 const path = require("node:path");
+const vm = require("node:vm");
 
 const RENDERER = path.join(__dirname, "..", "src", "renderer.js");
 const PRELOAD = path.join(__dirname, "..", "src", "preload.js");
@@ -17,6 +18,144 @@ function matchSource(source, pattern, message) {
   const match = source.match(pattern);
   assert.ok(match, message || `missing pattern ${pattern}`);
   return match;
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = tagName.toUpperCase();
+    this.style = {};
+    this.attributes = new Map();
+    this.children = [];
+    this.parentNode = null;
+    this.isConnected = false;
+    this.className = "";
+    this.id = "";
+    this.data = "";
+    this.src = "";
+    this.contentDocument = null;
+    this.contentWindow = {};
+    this.listeners = new Map();
+  }
+
+  get offsetHeight() {
+    return 1;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+    if (name === "data") this.data = String(value);
+    if (name === "src") this.src = String(value);
+  }
+
+  getAttribute(name) {
+    if (name === "data") return this.data || this.attributes.get(name) || "";
+    if (name === "src") return this.src || this.attributes.get(name) || "";
+    return this.attributes.get(name) || "";
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    child.isConnected = true;
+    this.children.push(child);
+    return child;
+  }
+
+  remove() {
+    this.isConnected = false;
+    if (this.parentNode) {
+      this.parentNode.children = this.parentNode.children.filter((child) => child !== this);
+      this.parentNode = null;
+    }
+  }
+
+  addEventListener(event, callback) {
+    this.listeners.set(event, callback);
+  }
+
+  querySelectorAll() {
+    return this.children.filter((child) => (
+      child.tagName === "OBJECT"
+      || (child.tagName === "IMG" && String(child.className).split(/\s+/).includes("clawd-img"))
+    ));
+  }
+}
+
+function createRendererHarness() {
+  const timers = [];
+  const container = new FakeElement("div");
+  container.id = "pet-container";
+  container.isConnected = true;
+  const clawd = new FakeElement("object");
+  clawd.id = "clawd";
+  clawd.data = "../assets/svg/current.svg";
+  clawd.style.opacity = "0";
+  container.appendChild(clawd);
+
+  const document = {
+    getElementById(id) {
+      if (id === "pet-container") return container;
+      if (id === "clawd") return clawd;
+      return null;
+    },
+    createElement(tagName) {
+      return new FakeElement(tagName);
+    },
+  };
+  const electronAPI = new Proxy({}, {
+    get() {
+      return () => {};
+    },
+  });
+  const context = {
+    document,
+    window: {
+      themeConfig: {
+        assetsPath: "../assets/svg",
+        eyeTracking: { states: ["idle"] },
+      },
+      electronAPI,
+      getComputedStyle: (el) => ({ opacity: el.style.opacity || "1" }),
+    },
+    console: { warn() {} },
+    setTimeout(callback, ms) {
+      const timer = { callback, ms, cleared: false };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeout(timer) {
+      if (timer) timer.cleared = true;
+    },
+    requestAnimationFrame(callback) {
+      return context.setTimeout(callback, 16);
+    },
+    cancelAnimationFrame(timer) {
+      context.clearTimeout(timer);
+    },
+    Audio: function FakeAudio() {
+      return { play: () => Promise.resolve(), volume: 1, currentTime: 0 };
+    },
+  };
+  context.globalThis = context;
+
+  const source = `${readNormalized(RENDERER)}
+globalThis.__rendererTest = {
+  swapToFile,
+  getPetMediaElements,
+  get pendingNext() { return pendingNext; },
+  get pendingSvgFile() { return pendingSvgFile; },
+  get activeSwapToken() { return activeSwapToken; },
+  get clawdEl() { return clawdEl; },
+};`;
+  vm.runInNewContext(source, context);
+
+  return {
+    context,
+    container,
+    clawd,
+    timers,
+    api: context.__rendererTest,
+    activeTimers: () => timers.filter((timer) => !timer.cleared),
+  };
 }
 
 describe("renderer low-power idle mode", () => {
@@ -127,6 +266,45 @@ describe("renderer object-channel selection", () => {
     assert.ok(source.includes("const desiredAssetUrl = getAssetUrl(svg);"));
     assert.ok(source.includes("currentDisplayedAssetUrl === desiredAssetUrl"));
     assert.ok(source.includes("pendingAssetUrl === desiredAssetUrl"));
+  });
+
+  it("rescues an invisible object-channel pending swap by reloading through the img channel", () => {
+    const harness = createRendererHarness();
+
+    harness.api.swapToFile("next.svg", "idle", true);
+    const rescue = harness.activeTimers().find((timer) => timer.ms === 3750);
+    rescue.callback();
+
+    assert.strictEqual(harness.api.pendingNext.tagName, "IMG");
+    assert.strictEqual(harness.api.pendingSvgFile, "next.svg");
+    assert.strictEqual(
+      harness.container.querySelectorAll().some((el) => el.tagName === "OBJECT" && el !== harness.clawd),
+      false
+    );
+  });
+
+  it("ignores stale rescue timers after a newer swap starts", () => {
+    const harness = createRendererHarness();
+
+    harness.api.swapToFile("old.svg", "idle", true);
+    const staleRescue = harness.activeTimers().find((timer) => timer.ms === 3750);
+    harness.api.swapToFile("new.svg", "idle", true);
+    staleRescue.callback();
+
+    assert.strictEqual(harness.api.pendingNext.tagName, "OBJECT");
+    assert.strictEqual(harness.api.pendingSvgFile, "new.svg");
+  });
+
+  it("does not rescue over an already visible pet element", () => {
+    const harness = createRendererHarness();
+    harness.clawd.style.opacity = "1";
+
+    harness.api.swapToFile("next.svg", "idle", true);
+    const rescue = harness.activeTimers().find((timer) => timer.ms === 3750);
+    rescue.callback();
+
+    assert.strictEqual(harness.api.pendingNext.tagName, "OBJECT");
+    assert.strictEqual(harness.api.pendingSvgFile, "next.svg");
   });
 });
 

--- a/test/theme-fade-sequencer.test.js
+++ b/test/theme-fade-sequencer.test.js
@@ -52,6 +52,10 @@ function flushMicrotasks() {
   return new Promise((resolve) => setImmediate(resolve));
 }
 
+function activeTimeout(timers) {
+  return timers.timeouts.find((timer) => !timer.cleared);
+}
+
 function createHarness(options = {}) {
   const renderWin = new FakeWindow();
   const hitWin = new FakeWindow();
@@ -126,7 +130,7 @@ describe("theme fade sequencer", () => {
     await flushMicrotasks();
 
     renderWin.webContents.emit("did-finish-load");
-    timers.timeouts[0].fn();
+    activeTimeout(timers).fn();
     await flushMicrotasks();
 
     assert.deepStrictEqual(events, ["fallback"]);
@@ -165,6 +169,26 @@ describe("theme fade sequencer", () => {
     assert.strictEqual(animations[1].targetOpacity, 0);
   });
 
+  it("uses fallback if fade-out never settles", async () => {
+    const { animations, renderWin, sequencer, timers } = createHarness({ autoResolveAnimation: false });
+    const events = [];
+
+    sequencer.run({
+      onReloadFinished: () => events.push("loaded"),
+      onFallback: (info) => events.push(info.reason),
+    });
+
+    assert.strictEqual(animations.length, 1);
+    assert.strictEqual(animations[0].targetOpacity, 0);
+    activeTimeout(timers).fn();
+    await flushMicrotasks();
+
+    assert.deepStrictEqual(events, ["fallback"]);
+    assert.deepStrictEqual(renderWin.opacityWrites, []);
+    assert.strictEqual(animations.length, 2);
+    assert.strictEqual(animations[1].targetOpacity, 1);
+  });
+
   it("does not leak prior opacity writes after mid-ramp cancellation", async () => {
     const { animations, hitWin, renderWin, sequencer } = createHarness({ autoResolveAnimation: false });
 
@@ -188,11 +212,12 @@ describe("theme fade sequencer", () => {
 
     assert.strictEqual(renderWin.webContents.listenerCountForLoad(), 1);
     assert.strictEqual(hitWin.webContents.listenerCountForLoad(), 1);
-    assert.strictEqual(timers.timeouts.length, 1);
+    assert.strictEqual(timers.timeouts.length, 2);
+    assert.strictEqual(timers.timeouts.filter((timer) => !timer.cleared).length, 1);
 
     sequencer.cleanup();
 
-    assert.strictEqual(timers.timeouts[0].cleared, true);
+    assert.ok(timers.timeouts.every((timer) => timer.cleared));
     assert.strictEqual(renderWin.webContents.listenerCountForLoad(), 0);
     assert.strictEqual(hitWin.webContents.listenerCountForLoad(), 0);
   });

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -102,6 +102,151 @@ describe("topmost runtime Windows recovery", () => {
     timers.timeouts[0].fn();
     assert.deepStrictEqual(forceEye, [true, true]);
     assert.strictEqual(win.calls.length, 2);
+    assert.deepStrictEqual(positions, [[11, 20], [10, 20]]);
+  });
+
+  it("does not accumulate repeated topmost nudges while recovery is pending", () => {
+    const timers = makeTimers();
+    const win = new FakeWindow();
+    const positions = [];
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => win,
+      getPetWindowBounds: () => ({ x: 10, y: 20, width: 100, height: 100 }),
+      applyPetWindowPosition: (x, y) => positions.push([x, y]),
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    runtime.guardAlwaysOnTop(win);
+    win.emit("always-on-top-changed", null, false);
+    win.emit("always-on-top-changed", null, false);
+
+    assert.deepStrictEqual(positions, [
+      [11, 20],
+      [10, 20],
+    ]);
+
+    timers.timeouts.at(-1).fn();
+    assert.deepStrictEqual(positions, [
+      [11, 20],
+      [10, 20],
+    ]);
+  });
+
+  it("restores the original position only when the immediate nudge-back was swallowed", () => {
+    const timers = makeTimers();
+    const win = new FakeWindow();
+    const positions = [];
+    const current = { x: 10, y: 20, width: 100, height: 100 };
+    let swallowImmediateRestore = true;
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => win,
+      getPetWindowBounds: () => ({ ...current }),
+      applyPetWindowPosition: (x, y) => {
+        positions.push([x, y]);
+        if (swallowImmediateRestore && x === 10 && y === 20) return;
+        current.x = x;
+        current.y = y;
+      },
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    runtime.guardAlwaysOnTop(win);
+    win.emit("always-on-top-changed", null, false);
+    assert.deepStrictEqual(current, { x: 11, y: 20, width: 100, height: 100 });
+
+    swallowImmediateRestore = false;
+    timers.timeouts[0].fn();
+
+    assert.deepStrictEqual(positions, [[11, 20], [10, 20], [10, 20]]);
+    assert.deepStrictEqual(current, { x: 10, y: 20, width: 100, height: 100 });
+  });
+
+  it("does not restore stale nudge coordinates after the pet legitimately moved", () => {
+    const timers = makeTimers();
+    const win = new FakeWindow();
+    const positions = [];
+    const current = { x: 10, y: 20, width: 100, height: 100 };
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => win,
+      getPetWindowBounds: () => ({ ...current }),
+      applyPetWindowPosition: (x, y) => {
+        positions.push([x, y]);
+        current.x = x;
+        current.y = y;
+      },
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    runtime.guardAlwaysOnTop(win);
+    win.emit("always-on-top-changed", null, false);
+    current.x = 500;
+    current.y = 500;
+    timers.timeouts[0].fn();
+
+    assert.deepStrictEqual(positions, [[11, 20], [10, 20]]);
+    assert.deepStrictEqual(current, { x: 500, y: 500, width: 100, height: 100 });
+  });
+
+  it("starts a fresh nudge for a repeated topmost loss after the pet legitimately moved", () => {
+    const timers = makeTimers();
+    const win = new FakeWindow();
+    const positions = [];
+    const current = { x: 10, y: 20, width: 100, height: 100 };
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => win,
+      getPetWindowBounds: () => ({ ...current }),
+      applyPetWindowPosition: (x, y) => {
+        positions.push([x, y]);
+        current.x = x;
+        current.y = y;
+      },
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    runtime.guardAlwaysOnTop(win);
+    win.emit("always-on-top-changed", null, false);
+    current.x = 500;
+    current.y = 500;
+    win.emit("always-on-top-changed", null, false);
+
+    assert.deepStrictEqual(positions, [
+      [11, 20],
+      [10, 20],
+      [501, 500],
+      [500, 500],
+    ]);
+    assert.deepStrictEqual(current, { x: 500, y: 500, width: 100, height: 100 });
+  });
+
+  it("does not restore a topmost nudge over an active drag", () => {
+    const timers = makeTimers();
+    const win = new FakeWindow();
+    const positions = [];
+    let dragging = false;
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => win,
+      getPetWindowBounds: () => ({ x: 10, y: 20, width: 100, height: 100 }),
+      applyPetWindowPosition: (x, y) => positions.push([x, y]),
+      isDragLocked: () => dragging,
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    runtime.guardAlwaysOnTop(win);
+    win.emit("always-on-top-changed", null, false);
+    dragging = true;
+    timers.timeouts[0].fn();
+
+    assert.deepStrictEqual(positions, [[11, 20], [10, 20]]);
   });
 
   it("skips the nudge path while dragging or mini transitions own movement", () => {


### PR DESCRIPTION
## Summary
- prevent Windows topmost recovery nudges from accumulating or restoring stale pet coordinates
- add fade fallback coverage so theme reloads cannot leave the render window transparent
- add renderer-side invisible animation rescue with image-channel fallback and behavior tests

## Tests
- node --test test\topmost-runtime.test.js test\theme-fade-sequencer.test.js test\renderer-low-power.test.js
- npm test