### PR TITLE
Fix Claude auto-start session handoff

### DIFF
--- a/hooks/auto-start.js
+++ b/hooks/auto-start.js
@@ -9,16 +9,56 @@ const path = require("path");
 const { discoverClawdPort } = require("./server-config");
 const { buildElectronLaunchConfig } = require("./shared-process");
 
-const TIMEOUT_MS = 300;
+const INITIAL_DISCOVER_TIMEOUT_MS = 300;
+const STARTUP_READY_TIMEOUT_MS = 6000;
+const STARTUP_DISCOVER_TIMEOUT_MS = 100;
+const STARTUP_POLL_INTERVAL_MS = 100;
 
-discoverClawdPort({ timeoutMs: TIMEOUT_MS }, (port) => {
-  if (port) {
-    process.exit(0);
-    return;
+function waitForClawdPort(options, callback) {
+  const discover = options.discoverClawdPort || discoverClawdPort;
+  const setTimeoutFn = options.setTimeout || setTimeout;
+  const nowFn = options.now || Date.now;
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : STARTUP_READY_TIMEOUT_MS;
+  const discoverTimeoutMs = Number.isFinite(options.discoverTimeoutMs)
+    ? options.discoverTimeoutMs
+    : STARTUP_DISCOVER_TIMEOUT_MS;
+  const intervalMs = Number.isFinite(options.intervalMs) ? options.intervalMs : STARTUP_POLL_INTERVAL_MS;
+  const deadline = nowFn() + Math.max(0, timeoutMs);
+
+  function probe() {
+    discover({ timeoutMs: discoverTimeoutMs }, (port) => {
+      if (port || nowFn() >= deadline) {
+        callback(port || null);
+        return;
+      }
+      setTimeoutFn(probe, intervalMs);
+    });
   }
-  launchApp();
-  process.exit(0);
-});
+
+  probe();
+}
+
+function main(deps = {}) {
+  const discover = deps.discoverClawdPort || discoverClawdPort;
+  const launch = deps.launchApp || launchApp;
+  const exit = deps.exit || ((code) => process.exit(code));
+
+  discover({ timeoutMs: INITIAL_DISCOVER_TIMEOUT_MS }, (port) => {
+    if (port) {
+      exit(0);
+      return;
+    }
+    launch();
+    waitForClawdPort({
+      discoverClawdPort: discover,
+      setTimeout: deps.setTimeout,
+      now: deps.now,
+      timeoutMs: deps.startupReadyTimeoutMs,
+      discoverTimeoutMs: deps.startupDiscoverTimeoutMs,
+      intervalMs: deps.startupPollIntervalMs,
+    }, () => exit(0));
+  });
+}
 
 function launchApp() {
   const isPackaged = __dirname.includes("app.asar");
@@ -74,3 +114,15 @@ function launchApp() {
     process.stderr.write(`clawd auto-start: ${err.message}\n`);
   }
 }
+
+if (require.main === module) main();
+
+module.exports = {
+  INITIAL_DISCOVER_TIMEOUT_MS,
+  STARTUP_READY_TIMEOUT_MS,
+  STARTUP_DISCOVER_TIMEOUT_MS,
+  STARTUP_POLL_INTERVAL_MS,
+  waitForClawdPort,
+  launchApp,
+  main,
+};

--- a/test/auto-start.test.js
+++ b/test/auto-start.test.js
@@ -1,0 +1,109 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert");
+
+const {
+  INITIAL_DISCOVER_TIMEOUT_MS,
+  STARTUP_DISCOVER_TIMEOUT_MS,
+  waitForClawdPort,
+  main,
+} = require("../hooks/auto-start");
+
+test("auto-start exits without launching when Clawd is already listening", async () => {
+  const calls = [];
+
+  await new Promise((resolve) => {
+    main({
+      discoverClawdPort(options, callback) {
+        calls.push(["discover", options.timeoutMs]);
+        callback(23333);
+      },
+      launchApp() {
+        calls.push(["launch"]);
+      },
+      exit(code) {
+        calls.push(["exit", code]);
+        resolve();
+      },
+    });
+  });
+
+  assert.deepStrictEqual(calls, [
+    ["discover", INITIAL_DISCOVER_TIMEOUT_MS],
+    ["exit", 0],
+  ]);
+});
+
+test("auto-start waits for the cold-launched app before exiting", async () => {
+  const calls = [];
+  const ports = [null, null, 23333];
+
+  await new Promise((resolve) => {
+    main({
+      discoverClawdPort(options, callback) {
+        calls.push(["discover", options.timeoutMs]);
+        callback(ports.shift() || null);
+      },
+      launchApp() {
+        calls.push(["launch"]);
+      },
+      setTimeout(callback) {
+        calls.push(["timer"]);
+        callback();
+        return 1;
+      },
+      exit(code) {
+        calls.push(["exit", code]);
+        resolve();
+      },
+    });
+  });
+
+  assert.deepStrictEqual(calls, [
+    ["discover", INITIAL_DISCOVER_TIMEOUT_MS],
+    ["launch"],
+    ["discover", STARTUP_DISCOVER_TIMEOUT_MS],
+    ["timer"],
+    ["discover", STARTUP_DISCOVER_TIMEOUT_MS],
+    ["exit", 0],
+  ]);
+});
+
+test("waitForClawdPort gives up after the startup deadline", async () => {
+  const calls = [];
+  let now = 0;
+
+  await new Promise((resolve) => {
+    waitForClawdPort({
+      timeoutMs: 250,
+      intervalMs: 100,
+      discoverTimeoutMs: 10,
+      now: () => now,
+      discoverClawdPort(options, callback) {
+        calls.push(["discover", options.timeoutMs, now]);
+        callback(null);
+      },
+      setTimeout(callback, delayMs) {
+        calls.push(["timer", delayMs]);
+        now += delayMs;
+        callback();
+        return 1;
+      },
+    }, (port) => {
+      calls.push(["done", port, now]);
+      resolve();
+    });
+  });
+
+  assert.deepStrictEqual(calls, [
+    ["discover", 10, 0],
+    ["timer", 100],
+    ["discover", 10, 100],
+    ["timer", 100],
+    ["discover", 10, 200],
+    ["timer", 100],
+    ["discover", 10, 300],
+    ["done", null, 300],
+  ]);
+});


### PR DESCRIPTION
## Summary
- wait for the Clawd HTTP server after Claude auto-start launches the app
- preserve the existing fast exit when Clawd is already running
- add tests for already-running, cold-start wait, and timeout paths

## Tests
- node --test test/auto-start.test.js
- npm test