### PR TITLE
fix: keep bubble policy summary inline

### DIFF
--- a/src/settings.css
+++ b/src/settings.css
@@ -337,6 +337,11 @@ html, body {
   flex: 0 0 auto;
   max-width: none;
 }
+.bubble-policy-collapsible .collapsible-group-summary {
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  max-width: none;
+}
 .collapsible-group:not(.collapsed) .collapsible-group-summary {
   opacity: 0.72;
   transform: translateX(2px);

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -1319,6 +1319,9 @@ describe("settings renderer browser environment", () => {
     assert.ok(/\.session-hud-collapsible \.collapsible-summary-chip,[\s\S]*\.sound-collapsible \.collapsible-summary-chip\s*\{[\s\S]*max-width:\s*min\(280px,\s*100%\);/.test(css));
     assert.ok(/\.session-hud-collapsible \.collapsible-group-summary\s*\{[\s\S]*flex:\s*0 0 auto;[\s\S]*max-width:\s*none;/.test(css));
     assert.ok(/\.sound-collapsible \.collapsible-group-summary\s*\{[\s\S]*flex:\s*0 0 auto;[\s\S]*max-width:\s*none;/.test(css));
+    assert.ok(/\.bubble-policy-collapsible \.collapsible-group-summary\s*\{[^}]*flex:\s*0 0 auto;[^}]*flex-wrap:\s*nowrap;[^}]*max-width:\s*none;[^}]*\}/.test(css));
+    assert.ok(!/\.session-hud-collapsible \.collapsible-group-summary\s*\{[^}]*flex-wrap:\s*nowrap;/.test(css));
+    assert.ok(!/\.sound-collapsible \.collapsible-group-summary\s*\{[^}]*flex-wrap:\s*nowrap;/.test(css));
     assert.ok(/\.session-hud-summary-control\s*\{[\s\S]*grid-template-columns:\s*repeat\(4,\s*max-content\);/.test(css));
     assert.ok(/\.session-hud-summary-control\.compact\s*\{[\s\S]*display:\s*inline-flex;[\s\S]*width:\s*auto;/.test(css));
     assert.ok(/@media \(max-width:\s*720px\)\s*\{[\s\S]*\.session-hud-summary-control\s*\{[\s\S]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*width:\s*min\(238px,\s*42vw\);/.test(css));


### PR DESCRIPTION
## Summary
- Keep the General tab bubble policy summary chips on one line.
- Add a scoped CSS override for the bubble policy collapsible group only.
- Preserve the existing chip labels, child controls, preference behavior, Session HUD layout, and sound summary layout.

## Problem context
- The bubble policy row shows three summary chips for permission bubbles, notification auto-close, and update auto-close.
- The shared collapsible summary layout allowed wrapping and limited the summary area to 48%, so the third chip could fall onto a second line even with enough remaining row space.
- This made the row look uneven compared with the previous single-line presentation.

## What changed
- Added a `.bubble-policy-collapsible .collapsible-group-summary` rule with fixed content sizing and `flex-wrap: nowrap`.
- Left the generic collapsible summary behavior unchanged for other groups.
- Added renderer-source regression assertions to ensure the nowrap rule stays scoped away from Session HUD and sound collapsibles.

## Behavior after this PR
- The bubble policy row keeps `权限开/关`, `通知最多 N 秒`, and `更新 N 秒` on one line in the normal Settings desktop width.
- The left description continues using the existing two-line clamp and can shrink before the chip group wraps.
- There are no preference schema, IPC, persistence, or auto-close behavior changes.

## Validation
- `node --test test\settings-renderer-browser-env.test.js`
- `git diff --check`

## Platform note
- Automated verification ran locally on Windows with Node's built-in test runner.
- Browser automation was not run, per this Electron project's UI verification convention; final visual QA should be done manually in Settings.
