### PR TITLE
fix: polish settings language picker presentation

### DIFF
--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -250,6 +250,7 @@
         return;
       }
       if (next === readers.getLang()) {
+        syncDisplay(next);
         setOpen(false);
         return;
       }

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -195,7 +195,7 @@
             `<span class="language-picker-value"></span>` +
             `<span class="language-picker-chevron" aria-hidden="true"></span>` +
           `</button>` +
-          `<div class="language-picker-menu" role="listbox"></div>` +
+          `<div class="language-picker-menu" role="listbox" aria-hidden="true"></div>` +
         `</div>` +
       `</div>`;
     row.querySelector(".row-label").textContent = t("rowLanguage");
@@ -227,16 +227,19 @@
       const selectedLang = LANGUAGE_OPTIONS.includes(lang) ? lang : LANGUAGE_OPTIONS[0];
       activeLang = selectedLang;
       valueEl.textContent = getLabel(selectedLang);
+      const open = picker.classList.contains("open");
       for (const option of options) {
         const selected = option.dataset.lang === selectedLang;
         option.classList.toggle("selected", selected);
         option.setAttribute("aria-selected", selected ? "true" : "false");
-        option.tabIndex = selected ? 0 : -1;
+        option.tabIndex = open && selected ? 0 : -1;
       }
     }
     function setOpen(open) {
       picker.classList.toggle("open", open);
       trigger.setAttribute("aria-expanded", open ? "true" : "false");
+      menu.setAttribute("aria-hidden", open ? "false" : "true");
+      syncDisplay(activeLang);
       if (!open) return;
       const option = getOption(activeLang);
       if (option && typeof option.focus === "function") option.focus();

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -190,26 +190,66 @@
         `<span class="row-desc"></span>` +
       `</div>` +
       `<div class="row-control">` +
-        `<select class="language-select" aria-label=""></select>` +
+        `<div class="language-picker">` +
+          `<button type="button" class="language-picker-trigger" aria-haspopup="listbox" aria-expanded="false">` +
+            `<span class="language-picker-value"></span>` +
+            `<span class="language-picker-chevron" aria-hidden="true"></span>` +
+          `</button>` +
+          `<div class="language-picker-menu" role="listbox"></div>` +
+        `</div>` +
       `</div>`;
     row.querySelector(".row-label").textContent = t("rowLanguage");
     row.querySelector(".row-desc").textContent = t("rowLanguageDesc");
-    const select = row.querySelector(".language-select");
-    select.setAttribute("aria-label", t("rowLanguage"));
+    const picker = row.querySelector(".language-picker");
+    const trigger = row.querySelector(".language-picker-trigger");
+    const valueEl = row.querySelector(".language-picker-value");
+    const menu = row.querySelector(".language-picker-menu");
+    trigger.setAttribute("aria-label", t("rowLanguage"));
     const currentLang = readers.getLang();
+    let activeLang = currentLang;
+    const getLabel = (lang) => t(LANGUAGE_LABEL_KEYS[lang] || "langEnglish");
+    const options = [];
     for (const lang of LANGUAGE_OPTIONS) {
-      const opt = document.createElement("option");
-      opt.setAttribute("value", lang);
-      opt.textContent = t(LANGUAGE_LABEL_KEYS[lang] || "langEnglish");
-      if (lang === currentLang) opt.setAttribute("selected", "");
-      select.appendChild(opt);
+      const option = document.createElement("button");
+      option.type = "button";
+      option.className = "language-picker-option";
+      option.setAttribute("role", "option");
+      option.setAttribute("data-lang", lang);
+      option.setAttribute("aria-selected", lang === currentLang ? "true" : "false");
+      option.textContent = getLabel(lang);
+      menu.appendChild(option);
+      options.push(option);
     }
-    select.value = currentLang;
-    select.addEventListener("change", () => {
-      const next = select.value;
-      if (next === readers.getLang()) return;
+    function getOption(lang) {
+      return options.find((option) => option.dataset.lang === lang) || options[0] || null;
+    }
+    function syncDisplay(lang) {
+      const selectedLang = LANGUAGE_OPTIONS.includes(lang) ? lang : LANGUAGE_OPTIONS[0];
+      activeLang = selectedLang;
+      valueEl.textContent = getLabel(selectedLang);
+      for (const option of options) {
+        const selected = option.dataset.lang === selectedLang;
+        option.classList.toggle("selected", selected);
+        option.setAttribute("aria-selected", selected ? "true" : "false");
+        option.tabIndex = selected ? 0 : -1;
+      }
+    }
+    function setOpen(open) {
+      picker.classList.toggle("open", open);
+      trigger.setAttribute("aria-expanded", open ? "true" : "false");
+      if (!open) return;
+      const option = getOption(activeLang);
+      if (option && typeof option.focus === "function") option.focus();
+    }
+    function chooseLanguage(next) {
+      if (next === readers.getLang()) {
+        setOpen(false);
+        return;
+      }
+      syncDisplay(next);
+      setOpen(false);
       const revertIfStillPending = () => {
-        if (select.value === next) select.value = readers.getLang();
+        if (activeLang === next) syncDisplay(readers.getLang());
       };
       window.settingsAPI.update("lang", next).then((result) => {
         if (!result || result.status !== "ok") {
@@ -221,7 +261,62 @@
         ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
         revertIfStillPending();
       });
+    }
+    trigger.addEventListener("click", () => {
+      setOpen(!picker.classList.contains("open"));
     });
+    trigger.addEventListener("keydown", (event) => {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        setOpen(true);
+      }
+    });
+    for (const option of options) {
+      option.addEventListener("click", () => chooseLanguage(option.dataset.lang));
+      option.addEventListener("keydown", (event) => {
+        const index = options.indexOf(option);
+        if (event.key === "Escape") {
+          event.preventDefault();
+          setOpen(false);
+          if (typeof trigger.focus === "function") trigger.focus();
+          return;
+        }
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          chooseLanguage(option.dataset.lang);
+          return;
+        }
+        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+          event.preventDefault();
+          const delta = event.key === "ArrowDown" ? 1 : -1;
+          const nextOption = options[(index + delta + options.length) % options.length];
+          if (nextOption && typeof nextOption.focus === "function") nextOption.focus();
+        }
+      });
+    }
+    const closeOnOutsideClick = (event) => {
+      if (!picker.classList.contains("open")) return;
+      if (picker.contains(event.target)) return;
+      setOpen(false);
+    };
+    const closeOnEscape = (event) => {
+      if (event.key !== "Escape" || !picker.classList.contains("open")) return;
+      event.preventDefault();
+      setOpen(false);
+    };
+    if (document && typeof document.addEventListener === "function") {
+      document.addEventListener("click", closeOnOutsideClick);
+      document.addEventListener("keydown", closeOnEscape);
+      state.mountedControls.languagePicker = {
+        dispose: () => {
+          if (typeof document.removeEventListener === "function") {
+            document.removeEventListener("click", closeOnOutsideClick);
+            document.removeEventListener("keydown", closeOnEscape);
+          }
+        },
+      };
+    }
+    syncDisplay(currentLang);
     return row;
   }
 

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -245,6 +245,10 @@
       if (option && typeof option.focus === "function") option.focus();
     }
     function chooseLanguage(next) {
+      if (next === activeLang) {
+        setOpen(false);
+        return;
+      }
       if (next === readers.getLang()) {
         setOpen(false);
         return;

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -69,6 +69,7 @@
       animOverrideTimingSliders: new Map(),
       bubblePolicySummary: null,
       sessionHudSummary: null,
+      languagePicker: null,
       size: null,
       soundSummary: null,
       soundVolume: null,
@@ -627,6 +628,9 @@
   }
 
   function clearMountedControls() {
+    if (state.mountedControls.languagePicker && typeof state.mountedControls.languagePicker.dispose === "function") {
+      state.mountedControls.languagePicker.dispose();
+    }
     if (state.mountedControls.size && typeof state.mountedControls.size.dispose === "function") {
       Promise.resolve(state.mountedControls.size.dispose()).catch(() => {});
     }
@@ -642,6 +646,7 @@
     state.mountedControls.animOverrideTimingSliders.clear();
     state.mountedControls.bubblePolicySummary = null;
     state.mountedControls.sessionHudSummary = null;
+    state.mountedControls.languagePicker = null;
     state.mountedControls.size = null;
     state.mountedControls.soundSummary = null;
     state.mountedControls.soundVolume = null;

--- a/src/settings.css
+++ b/src/settings.css
@@ -938,26 +938,128 @@ html, body {
   opacity: 0.48;
   cursor: not-allowed;
 }
-.language-select {
-  padding: 6px 28px 6px 10px;
-  border: 1px solid var(--border);
-  border-radius: 7px;
-  background: var(--panel-bg);
-  color: var(--text-primary);
+.language-picker {
+  position: relative;
+  width: 128px;
   font-size: 13px;
-  font-family: inherit;
-  cursor: pointer;
-  appearance: none;
-  -webkit-appearance: none;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 12' fill='none' stroke='%23808080' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='3 5 6 8 9 5'/></svg>");
-  background-repeat: no-repeat;
-  background-position: right 8px center;
-  background-size: 12px 12px;
 }
-.language-select:focus {
-  outline: 2px solid var(--accent);
-  outline-offset: 1px;
+.language-picker-trigger {
+  width: 100%;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 0 11px 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--panel-bg) 92%, var(--bg));
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  transition: border-color 0.14s ease, box-shadow 0.14s ease, background 0.14s ease;
+}
+.language-picker-trigger:hover,
+.language-picker.open .language-picker-trigger {
+  border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
+  background: var(--panel-bg);
+  box-shadow: 0 6px 18px rgba(217, 119, 87, 0.12);
+}
+.language-picker-trigger:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 78%, transparent);
+  outline-offset: 2px;
+}
+.language-picker-value {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.language-picker-chevron {
+  width: 7px;
+  height: 7px;
+  flex: 0 0 auto;
+  border-right: 1.5px solid var(--text-secondary);
+  border-bottom: 1.5px solid var(--text-secondary);
+  transform: translateY(-1px) rotate(45deg);
+  transition: transform 0.14s ease, border-color 0.14s ease;
+}
+.language-picker.open .language-picker-chevron {
+  transform: translateY(2px) rotate(225deg);
   border-color: var(--accent);
+}
+.language-picker-menu {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 100%;
+  padding: 5px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--panel-bg);
+  box-shadow: 0 14px 34px rgba(0, 0, 0, 0.14), 0 3px 8px rgba(0, 0, 0, 0.08);
+  opacity: 0;
+  transform: translateY(-4px) scale(0.98);
+  transform-origin: top right;
+  pointer-events: none;
+  transition: opacity 0.14s ease, transform 0.14s ease;
+}
+.language-picker.open .language-picker-menu {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  pointer-events: auto;
+}
+.language-picker-option {
+  position: relative;
+  width: 100%;
+  min-height: 30px;
+  display: flex;
+  align-items: center;
+  padding: 0 9px 0 24px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.language-picker-option::before {
+  content: "";
+  position: absolute;
+  left: 9px;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: transparent;
+}
+.language-picker-option:hover,
+.language-picker-option:focus-visible {
+  outline: none;
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
+.language-picker-option.selected {
+  background: color-mix(in srgb, var(--accent) 14%, transparent);
+  color: var(--accent);
+  font-weight: 600;
+}
+.language-picker-option.selected::before {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+@media (prefers-color-scheme: dark) {
+  .language-picker-menu {
+    box-shadow: 0 14px 34px rgba(0, 0, 0, 0.36), 0 3px 8px rgba(0, 0, 0, 0.22);
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .language-picker-trigger,
+  .language-picker-chevron,
+  .language-picker-menu {
+    transition: none;
+  }
 }
 .codex-permission-mode-segmented {
   --codex-permission-mode-active-index: 0;

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -349,6 +349,7 @@ function loadGeneralLanguageRowForTest({
   toastStack.id = "toastStack";
   body.appendChild(toastStack);
 
+  const documentListeners = new Map();
   const document = {
     body,
     createElement: (tagName) => new FakeElement(tagName),
@@ -356,6 +357,16 @@ function loadGeneralLanguageRowForTest({
       if (id === "content") return content;
       if (id === "toastStack") return toastStack;
       return null;
+    },
+    addEventListener(type, cb) {
+      if (!documentListeners.has(type)) documentListeners.set(type, []);
+      documentListeners.get(type).push(cb);
+    },
+    removeEventListener(type, cb) {
+      const listeners = documentListeners.get(type);
+      if (!listeners) return;
+      const index = listeners.indexOf(cb);
+      if (index !== -1) listeners.splice(index, 1);
     },
   };
 
@@ -448,7 +459,14 @@ function loadGeneralLanguageRowForTest({
     settingsAPI,
     updateCalls,
     getContentRenderCount: () => contentRenderCount,
-    getLangSelect: () => content.querySelector(".language-select"),
+    getLangPicker: () => content.querySelector(".language-picker"),
+    getLangTrigger: () => content.querySelector(".language-picker-trigger"),
+    getLangValue: () => content.querySelector(".language-picker-value"),
+    getLangOptions: () => content.querySelectorAll(".language-picker-option"),
+    getDocumentListenerCount: (type) => {
+      const listeners = documentListeners.get(type);
+      return listeners ? listeners.length : 0;
+    },
     getToastText: () => {
       const toast = toastStack.querySelector(".toast");
       return toast ? toast.textContent : "";
@@ -1338,64 +1356,94 @@ describe("settings renderer browser environment", () => {
       SUPPORTED_LANGS.map((lang) => String.raw`"${lang}"`).join(String.raw`,\s*`) +
       String.raw`\];`
     ).test(generalSource));
-    assert.ok(generalSource.includes(`<select class="language-select"`));
+    assert.ok(generalSource.includes(`class="language-picker"`));
+    assert.ok(generalSource.includes(`aria-haspopup="listbox"`));
+    assert.ok(generalSource.includes(`role="listbox"`));
+    assert.ok(generalSource.includes(`role", "option"`));
+    assert.ok(!generalSource.includes(`<select class="language-select"`));
     assert.ok(!generalSource.includes("language-segmented"));
     assert.ok(!generalSource.includes("runtime.languageTransition"));
     assert.ok(!generalSource.includes("--language-active-index"));
     assert.ok(!coreSource.includes("languageTransition"));
-    assert.ok(/\.language-select\s*\{[\s\S]*appearance:\s*none;/.test(css));
-    assert.ok(/\.language-select:focus\s*\{[\s\S]*outline:\s*2px solid var\(--accent\);/.test(css));
+    assert.ok(/\.language-picker-menu\s*\{[\s\S]*box-shadow:/.test(css));
+    assert.ok(/\.language-picker-option:hover,[\s\S]*\.language-picker-option:focus-visible\s*\{[\s\S]*background:/.test(css));
+    assert.ok(/\.language-picker-option\.selected\s*\{[\s\S]*color:\s*var\(--accent\);/.test(css));
+    assert.ok(/@media \(prefers-color-scheme:\s*dark\)\s*\{[\s\S]*\.language-picker-menu/.test(css));
+    assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.language-picker-trigger,[\s\S]*\.language-picker-chevron,[\s\S]*\.language-picker-menu[\s\S]*transition:\s*none;/.test(css));
     assert.ok(!css.includes(".language-segmented"));
   });
 
-  it("populates the language dropdown with current selection and propagates change events", () => {
+  it("populates the language picker with current selection and propagates click changes", () => {
     const harness = loadGeneralLanguageRowForTest({
       snapshot: { lang: "en" },
     });
 
     harness.core.ops.requestRender({ content: true });
     assert.strictEqual(harness.getContentRenderCount(), 1);
-    const select = harness.getLangSelect();
-    assert.ok(select, "language dropdown should be rendered");
-    const options = select.querySelectorAll("option");
+    const picker = harness.getLangPicker();
+    const trigger = harness.getLangTrigger();
+    assert.ok(picker, "language picker should be rendered");
+    assert.ok(trigger, "language picker trigger should be rendered");
+    assert.strictEqual(harness.getLangValue().textContent, "English");
+    const options = harness.getLangOptions();
     assert.strictEqual(options.length, SUPPORTED_LANGS.length);
     for (let i = 0; i < SUPPORTED_LANGS.length; i++) {
-      assert.strictEqual(options[i].getAttribute("value"), SUPPORTED_LANGS[i]);
+      assert.strictEqual(options[i].dataset.lang, SUPPORTED_LANGS[i]);
     }
-    assert.strictEqual(select.value, "en");
+    assert.strictEqual(options[0].attributes["aria-selected"], "true");
 
-    select.value = "zh";
-    select.dispatchEvent({ type: "change" });
+    trigger.dispatchEvent({ type: "click" });
+    assert.strictEqual(picker.classList.contains("open"), true);
+    options[1].dispatchEvent({ type: "click" });
 
     assert.deepStrictEqual(
       harness.updateCalls,
       [{ key: "lang", value: "zh" }],
-      "changing the dropdown should call settingsAPI.update with the new lang"
+      "clicking a language option should call settingsAPI.update with the new lang"
     );
+    assert.strictEqual(picker.classList.contains("open"), false);
+    assert.strictEqual(harness.getLangValue().textContent, "Chinese");
 
     harness.core.ops.applyChanges({
       changes: { lang: "zh" },
       snapshot: { lang: "zh" },
     });
     assert.strictEqual(harness.getContentRenderCount(), 2);
-    assert.strictEqual(harness.getLangSelect().value, "zh");
+    assert.strictEqual(harness.getLangValue().textContent, "Chinese");
+    assert.strictEqual(harness.getLangOptions()[1].attributes["aria-selected"], "true");
   });
 
-  it("reverts the language dropdown when saving the selection fails", async () => {
+  it("supports keyboard language selection and reverts when saving fails", async () => {
     const harness = loadGeneralLanguageRowForTest({
       snapshot: { lang: "en" },
       update: () => Promise.resolve({ status: "error", message: "synthetic failure" }),
     });
 
     harness.core.ops.requestRender({ content: true });
-    const select = harness.getLangSelect();
-    select.value = "zh";
-    select.dispatchEvent({ type: "change" });
+    const trigger = harness.getLangTrigger();
+    trigger.dispatchEvent(createKeyboardEventForTest("ArrowDown"));
+    assert.strictEqual(harness.getLangPicker().classList.contains("open"), true);
+    const options = harness.getLangOptions();
+    options[1].dispatchEvent(createKeyboardEventForTest("Enter"));
     await Promise.resolve();
 
     assert.deepStrictEqual(harness.updateCalls, [{ key: "lang", value: "zh" }]);
-    assert.strictEqual(select.value, "en");
+    assert.strictEqual(harness.getLangValue().textContent, "English");
     assert.strictEqual(harness.getToastText(), "Failed: synthetic failure");
+  });
+
+  it("cleans up language picker document listeners across re-renders", () => {
+    const harness = loadGeneralLanguageRowForTest({
+      snapshot: { lang: "en" },
+    });
+
+    harness.core.ops.requestRender({ content: true });
+    assert.strictEqual(harness.getDocumentListenerCount("click"), 1);
+    assert.strictEqual(harness.getDocumentListenerCount("keydown"), 1);
+
+    harness.core.ops.requestRender({ content: true });
+    assert.strictEqual(harness.getDocumentListenerCount("click"), 1);
+    assert.strictEqual(harness.getDocumentListenerCount("keydown"), 1);
   });
 
   it("exposes aggregate and split bubble controls in the General tab", () => {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -1420,6 +1420,16 @@ describe("settings renderer browser environment", () => {
       "clicking the already displayed pending language should not submit a duplicate update"
     );
 
+    trigger.dispatchEvent({ type: "click" });
+    options[0].dispatchEvent({ type: "click" });
+    assert.deepStrictEqual(
+      harness.updateCalls,
+      [{ key: "lang", value: "zh" }],
+      "clicking back to the committed language while pending should not submit a duplicate update"
+    );
+    assert.strictEqual(harness.getLangValue().textContent, "English");
+    assert.strictEqual(options[0].attributes["aria-selected"], "true");
+
     harness.core.ops.applyChanges({
       changes: { lang: "zh" },
       snapshot: { lang: "zh" },

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -461,6 +461,7 @@ function loadGeneralLanguageRowForTest({
     getContentRenderCount: () => contentRenderCount,
     getLangPicker: () => content.querySelector(".language-picker"),
     getLangTrigger: () => content.querySelector(".language-picker-trigger"),
+    getLangMenu: () => content.querySelector(".language-picker-menu"),
     getLangValue: () => content.querySelector(".language-picker-value"),
     getLangOptions: () => content.querySelectorAll(".language-picker-option"),
     getDocumentListenerCount: (type) => {
@@ -1359,6 +1360,7 @@ describe("settings renderer browser environment", () => {
     assert.ok(generalSource.includes(`class="language-picker"`));
     assert.ok(generalSource.includes(`aria-haspopup="listbox"`));
     assert.ok(generalSource.includes(`role="listbox"`));
+    assert.ok(generalSource.includes(`aria-hidden="true"`));
     assert.ok(generalSource.includes(`role", "option"`));
     assert.ok(!generalSource.includes(`<select class="language-select"`));
     assert.ok(!generalSource.includes("language-segmented"));
@@ -1385,15 +1387,19 @@ describe("settings renderer browser environment", () => {
     assert.ok(picker, "language picker should be rendered");
     assert.ok(trigger, "language picker trigger should be rendered");
     assert.strictEqual(harness.getLangValue().textContent, "English");
+    assert.strictEqual(harness.getLangMenu().attributes["aria-hidden"], "true");
     const options = harness.getLangOptions();
     assert.strictEqual(options.length, SUPPORTED_LANGS.length);
     for (let i = 0; i < SUPPORTED_LANGS.length; i++) {
       assert.strictEqual(options[i].dataset.lang, SUPPORTED_LANGS[i]);
+      assert.strictEqual(options[i].tabIndex, -1);
     }
     assert.strictEqual(options[0].attributes["aria-selected"], "true");
 
     trigger.dispatchEvent({ type: "click" });
     assert.strictEqual(picker.classList.contains("open"), true);
+    assert.strictEqual(harness.getLangMenu().attributes["aria-hidden"], "false");
+    assert.strictEqual(options[0].tabIndex, 0);
     options[1].dispatchEvent({ type: "click" });
 
     assert.deepStrictEqual(
@@ -1402,6 +1408,8 @@ describe("settings renderer browser environment", () => {
       "clicking a language option should call settingsAPI.update with the new lang"
     );
     assert.strictEqual(picker.classList.contains("open"), false);
+    assert.strictEqual(harness.getLangMenu().attributes["aria-hidden"], "true");
+    for (const option of options) assert.strictEqual(option.tabIndex, -1);
     assert.strictEqual(harness.getLangValue().textContent, "Chinese");
 
     harness.core.ops.applyChanges({

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -1412,6 +1412,14 @@ describe("settings renderer browser environment", () => {
     for (const option of options) assert.strictEqual(option.tabIndex, -1);
     assert.strictEqual(harness.getLangValue().textContent, "Chinese");
 
+    trigger.dispatchEvent({ type: "click" });
+    options[1].dispatchEvent({ type: "click" });
+    assert.deepStrictEqual(
+      harness.updateCalls,
+      [{ key: "lang", value: "zh" }],
+      "clicking the already displayed pending language should not submit a duplicate update"
+    );
+
     harness.core.ops.applyChanges({
       changes: { lang: "zh" },
       snapshot: { lang: "zh" },


### PR DESCRIPTION
## Summary
- Polish the Settings language picker presentation so it visually matches the rest of the General panel.
- Keep the existing `lang` persistence flow, supported language list, and save-failure rollback behavior unchanged.
- Tighten keyboard and accessibility behavior so the closed menu is not reachable or announced as visible.

## Problem context
- The previous language picker presentation looked visually inconsistent on Windows/Electron and used a harsh platform-selected state.
- The Settings panel needs a calmer in-panel language menu with stable sizing, panel-consistent hover states, and predictable keyboard behavior.
- The General tab can rerender after settings broadcasts, so any document-level picker handlers need lifecycle cleanup.

## What changed
- Added an in-panel language picker menu with a styled trigger, option list, selected indicator, hover state, dark-mode shadow tuning, and reduced-motion support.
- Preserved the existing `window.settingsAPI.update("lang", next)` write path and reverted the visible language when saving fails.
- Added arrow key, Enter/Space, Escape, outside-click, and rerender cleanup handling.
- Hid the closed menu from assistive technology with `aria-hidden` and removed closed options from the Tab order.
- Updated renderer tests to cover picker structure, click and keyboard selection, failure rollback, accessibility state, and document listener cleanup.

## Behavior after this PR
- The language selector has a softer Settings-native display instead of the platform-styled dropdown appearance.
- Selecting a language still updates the same preference and keeps the same rollback semantics on save failure.
- Closed options are not tabbable, while opening the menu restores focus to the selected option.
- General tab rerenders no longer accumulate stale picker-level document listeners.

## Validation
- `node --check src\settings-tab-general.js`
- `node --check src\settings-ui-core.js`
- `node --test test\settings-renderer-browser-env.test.js`
- `git diff --check`

## Platform note
- Automated verification ran on Windows in the local Electron project workspace.
- No browser automation was used for this PR because this repository treats Settings UI validation as Electron manual QA.
- Manual verification is still recommended for the live Settings window on Windows, especially popup alignment and keyboard interaction.
