### PR TITLE
fix: preserve third-party hooks on suspicious settings.json shrink

### DIFF
--- a/src/claude-settings-watcher.js
+++ b/src/claude-settings-watcher.js
@@ -178,6 +178,23 @@ function createClaudeSettingsWatcher(ctx = {}) {
     if (settingsWatcher) return false;
     const settingsDir = getClaudeSettingsDir();
     const settingsPath = getClaudeSettingsPath();
+    // Seed the trusted baseline from the current settings.json before the watcher starts,
+    // so the very first watcher event after Clawd boots (e.g. an external CLI minimize
+    // landing right after syncClawdHooks() ran) can be compared against a real snapshot
+    // instead of null. Wrapped in its own try/catch so a missing or unreadable file
+    // (fresh install, permission error) cannot prevent the watcher from starting.
+    // The settingsNeedClaudeHookResync guard inside this block also prevents seeding
+    // from a polluted state if an external CLI raced ahead of this read.
+    try {
+      const seedRaw = fsApi.readFileSync(settingsPath, "utf-8");
+      const seedPort = typeof ctx.getHookServerPort === "function" ? ctx.getHookServerPort() : null;
+      const seedExpectedPermissionUrl = buildPermissionUrl(seedPort);
+      if (!settingsNeedClaudeHookResync(seedRaw, seedExpectedPermissionUrl)) {
+        lastTrustedSnapshot = takeSnapshot(seedRaw);
+      }
+    } catch (err) {
+      console.warn("Clawd: could not seed settings baseline:", err.message);
+    }
     try {
       settingsWatcher = fsApi.watch(settingsDir, (_event, filename) => {
         if (filename && filename !== SETTINGS_FILENAME) return;

--- a/src/claude-settings-watcher.js
+++ b/src/claude-settings-watcher.js
@@ -56,6 +56,80 @@ function settingsNeedClaudeHookResync(rawSettings, expectedPermissionUrl) {
   return !hasManagedCommandHook || !hasManagedPermissionHook;
 }
 
+function countCommandHooksInEntries(entries) {
+  if (!Array.isArray(entries)) return 0;
+  let count = 0;
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") continue;
+    if (entry.type === "http") continue;
+    if (typeof entry.command === "string") count += 1;
+    if (!Array.isArray(entry.hooks)) continue;
+    for (const hook of entry.hooks) {
+      if (!hook || typeof hook !== "object") continue;
+      if (hook.type === "http") continue;
+      if (typeof hook.command === "string") count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Count total command hooks across every event in the hooks object.
+ * Handles both nested format (entry.hooks[].command) and flat format (entry.command).
+ * HTTP hooks (type: "http") are excluded because they cannot encode the marker.
+ * @param {object|null|undefined} hooks
+ * @returns {number}
+ */
+function countAllHooks(hooks) {
+  if (!hooks || typeof hooks !== "object") return 0;
+  let total = 0;
+  for (const entries of Object.values(hooks)) {
+    total += countCommandHooksInEntries(entries);
+  }
+  return total;
+}
+
+/**
+ * Capture a snapshot of top-level key count and command hook count from settings.json text.
+ * Returns null when the payload is not a parseable JSON object so callers can skip comparisons.
+ * @param {string} raw
+ * @returns {{keyCount: number, hookCount: number}|null}
+ */
+function takeSnapshot(raw) {
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  return {
+    keyCount: Object.keys(parsed).length,
+    hookCount: countAllHooks(parsed.hooks),
+  };
+}
+
+/**
+ * Decide whether the shrink between two snapshots looks suspicious.
+ * Two independent OR triggers — hook drop ratio reaches shrinkRatio, or top-level key drop reaches keyLossThreshold.
+ * Either snapshot missing returns false because insufficient history cannot prove an attack.
+ * @param {{keyCount: number, hookCount: number}|null} prev
+ * @param {{keyCount: number, hookCount: number}|null} curr
+ * @param {number} shrinkRatio
+ * @param {number} keyLossThreshold
+ * @returns {boolean}
+ */
+function isSuspiciousShrink(prev, curr, shrinkRatio, keyLossThreshold) {
+  if (!prev || !curr) return false;
+  const keyDrop = prev.keyCount - curr.keyCount;
+  if (keyDrop >= keyLossThreshold) return true;
+  if (prev.hookCount <= 0) return false;
+  const hookDrop = prev.hookCount - curr.hookCount;
+  if (hookDrop <= 0) return false;
+  return (hookDrop / prev.hookCount) >= shrinkRatio;
+}
+
 function createClaudeSettingsWatcher(ctx = {}) {
   const fsApi = ctx.fs || fs;
   const pathApi = ctx.path || path;
@@ -65,10 +139,13 @@ function createClaudeSettingsWatcher(ctx = {}) {
   const nowFn = typeof ctx.now === "function" ? ctx.now : Date.now;
   const settingsWatchDebounceMs = Number.isFinite(ctx.settingsWatchDebounceMs) ? ctx.settingsWatchDebounceMs : 1000;
   const settingsWatchRateLimitMs = Number.isFinite(ctx.settingsWatchRateLimitMs) ? ctx.settingsWatchRateLimitMs : 5000;
+  const suspiciousShrinkRatio = Number.isFinite(ctx.suspiciousShrinkRatio) ? ctx.suspiciousShrinkRatio : 0.5;
+  const suspiciousKeyLossThreshold = Number.isFinite(ctx.suspiciousKeyLossThreshold) ? ctx.suspiciousKeyLossThreshold : 3;
 
   let settingsWatcher = null;
   let settingsWatchDebounceTimer = null;
   let settingsWatchLastSyncTime = 0;
+  let lastTrustedSnapshot = null;
 
   function getClaudeSettingsDir() {
     return typeof ctx.claudeSettingsDir === "string"
@@ -88,6 +165,7 @@ function createClaudeSettingsWatcher(ctx = {}) {
       settingsWatchDebounceTimer = null;
     }
     settingsWatchLastSyncTime = 0;
+    lastTrustedSnapshot = null;
     if (!settingsWatcher) return false;
     try {
       settingsWatcher.close();
@@ -114,10 +192,24 @@ function createClaudeSettingsWatcher(ctx = {}) {
             const raw = fsApi.readFileSync(settingsPath, "utf-8");
             const port = typeof ctx.getHookServerPort === "function" ? ctx.getHookServerPort() : null;
             const expectedPermissionUrl = buildPermissionUrl(port);
+            const currentSnapshot = takeSnapshot(raw);
             if (settingsNeedClaudeHookResync(raw, expectedPermissionUrl)) {
+              // Snapshot guard — refuse to resync when settings.json shrank too much,
+              // since an external CLI may have minimized it and re-registering would
+              // drop third-party hooks. See PR description for the production race.
+              if (isSuspiciousShrink(lastTrustedSnapshot, currentSnapshot, suspiciousShrinkRatio, suspiciousKeyLossThreshold)) {
+                console.warn("Clawd: settings.json shrank suspiciously — skipping auto-resync to preserve third-party hooks");
+                if (typeof ctx.notifySuspiciousShrink === "function") {
+                  ctx.notifySuspiciousShrink(lastTrustedSnapshot, currentSnapshot);
+                }
+                return;
+              }
               console.log("Clawd: hooks missing from settings.json — re-registering");
               settingsWatchLastSyncTime = nowFn();
               if (typeof ctx.syncClawdHooks === "function") ctx.syncClawdHooks();
+            } else if (currentSnapshot) {
+              // Trust this state — refresh the baseline only when the file looks healthy.
+              lastTrustedSnapshot = currentSnapshot;
             }
           } catch {}
         }, settingsWatchDebounceMs);
@@ -147,5 +239,8 @@ module.exports = {
   entriesContainCommandMarker,
   entriesContainHttpHookUrl,
   settingsNeedClaudeHookResync,
+  countAllHooks,
+  takeSnapshot,
+  isSuspiciousShrink,
   createClaudeSettingsWatcher,
 };

--- a/test/claude-settings-watcher.test.js
+++ b/test/claude-settings-watcher.test.js
@@ -52,11 +52,13 @@ function makeFakeTimers() {
 }
 
 function makeWatcher(overrides = {}) {
+  // initialSettingsRaw is a harness option, not a ctx option — extract it before passing the rest to the watcher.
+  const { initialSettingsRaw, ...ctxOverrides } = overrides;
   const timers = makeFakeTimers();
   const syncCalls = [];
   let watchedDir = null;
   let lastWatcher = null;
-  let settingsRaw = JSON.stringify({
+  let settingsRaw = initialSettingsRaw !== undefined ? initialSettingsRaw : JSON.stringify({
     hooks: {
       Stop: [
         {
@@ -97,7 +99,7 @@ function makeWatcher(overrides = {}) {
     shouldManageClaudeHooks: () => true,
     isAgentEnabled: () => true,
     syncClawdHooks: () => syncCalls.push("claude"),
-    ...overrides,
+    ...ctxOverrides,
   });
 
   return {
@@ -166,7 +168,11 @@ describe("createClaudeSettingsWatcher", () => {
   });
 
   it("re-syncs missing hooks when management and Claude Code are enabled", () => {
-    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher();
+    // Start from a non-healthy initial payload so the startup baseline seeding
+    // does not pre-trip the suspicious-shrink guard for this legacy scenario.
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher({
+      initialSettingsRaw: '{"hooks":{}}',
+    });
 
     watcher.start();
     setSettingsRaw('{"hooks":{}}');
@@ -259,8 +265,14 @@ describe("createClaudeSettingsWatcher — suspicious shrink protection", () => {
     assert.strictEqual(notifyCalls.length, 1);
   });
 
-  it("allows resync on first tick when no trusted snapshot exists yet (fresh install)", () => {
-    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher();
+  it("allows resync on first tick when start() found no healthy baseline to seed", () => {
+    // If Clawd boots while settings.json is already unhealthy (fresh install,
+    // marker missing, parse error), the seed step skips and lastTrustedSnapshot
+    // stays null. In that state the watcher must still resync on the first
+    // event, otherwise Clawd hooks would never get reinstalled.
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher({
+      initialSettingsRaw: '{"hooks":{}}',
+    });
 
     watcher.start();
     setSettingsRaw(MINIMIZED_SETTINGS);
@@ -327,5 +339,78 @@ describe("createClaudeSettingsWatcher — suspicious shrink protection", () => {
 
     assert.strictEqual(notifications.length, 1);
     assert.ok(notifications[0].before.hookCount > notifications[0].after.hookCount);
+  });
+
+  it("seeds the baseline on start so the very first watcher event can trip the guard", () => {
+    // Cold start: Clawd just synced healthy hooks, then an external CLI minimizes
+    // settings.json before the watcher has observed any healthy fs event itself.
+    // Without seeding on start(), the first comparison would have a null baseline
+    // and the guard would let the destructive resync through.
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher({
+      initialSettingsRaw: HEALTHY_SETTINGS,
+    });
+
+    watcher.start();
+
+    setSettingsRaw(MINIMIZED_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.deepStrictEqual(syncCalls, []);
+  });
+
+  it("keeps blocking resync while the shrunk state persists across watcher events", () => {
+    // Recovery from a guarded shrink is intentionally out of scope for this PR —
+    // once the baseline is healthy and the file becomes suspiciously small, every
+    // subsequent watcher event for that same shrunk file must keep skipping resync
+    // until either the file becomes healthy again or the user toggles via Settings UI.
+    const notifications = [];
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher({
+      initialSettingsRaw: HEALTHY_SETTINGS,
+      notifySuspiciousShrink: (before, after) => notifications.push({ before, after }),
+    });
+
+    watcher.start();
+
+    setSettingsRaw(MINIMIZED_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    // Second event for the same shrunk file — still blocked, baseline unchanged.
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    // Third event — same result.
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.deepStrictEqual(syncCalls, []);
+    assert.strictEqual(notifications.length, 3);
+  });
+
+  it("treats non-object JSON payloads (null, array) as unparseable and allows resync", () => {
+    // takeSnapshot returns null for `null` and `[]` payloads (any non-object JSON).
+    // settingsNeedClaudeHookResync still returns true, but the shrink guard sees
+    // currentSnapshot=null and bails out, letting the regular resync path run.
+    // Treating malformed payloads as "not an attack" is intentional — they may
+    // come from a partially-written file or an unrelated tool, and aggressively
+    // skipping resync there would leave Clawd unable to recover its own hooks.
+    // Rate limit is disabled here so both payloads can independently fire resync.
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher({
+      initialSettingsRaw: HEALTHY_SETTINGS,
+      settingsWatchRateLimitMs: 0,
+    });
+
+    watcher.start();
+
+    setSettingsRaw("null");
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    setSettingsRaw("[]");
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.deepStrictEqual(syncCalls, ["claude", "claude"]);
   });
 });

--- a/test/claude-settings-watcher.test.js
+++ b/test/claude-settings-watcher.test.js
@@ -176,3 +176,156 @@ describe("createClaudeSettingsWatcher", () => {
     assert.deepStrictEqual(syncCalls, ["claude"]);
   });
 });
+
+describe("createClaudeSettingsWatcher — suspicious shrink protection", () => {
+  // Healthy baseline — marker present, 5 top-level keys, 13 command hooks (3 Stop + 10 PreToolUse).
+  const HEALTHY_SETTINGS = JSON.stringify({
+    env: { FOO: "bar" },
+    permissions: { allow: ["*"], deny: [], defaultMode: "ask" },
+    enabledPlugins: { a: 1, b: 2 },
+    skillOverrides: { sk1: true },
+    hooks: {
+      Stop: [{
+        matcher: "",
+        hooks: [
+          { type: "command", command: 'node "/tmp/clawd-hook.js" Stop' },
+          { type: "command", command: "node /home/u/.claude/hooks/maestro-audit.mjs" },
+          { type: "command", command: "node /home/u/.claude/hooks/secret-guard.js" },
+        ],
+      }],
+      PreToolUse: [{
+        matcher: "",
+        hooks: Array.from({ length: 10 }, (_, i) => ({
+          type: "command",
+          command: `node /home/u/.claude/hooks/guard-${i}.js`,
+        })),
+      }],
+      PermissionRequest: [{
+        matcher: "",
+        hooks: [{ type: "http", url: "http://127.0.0.1:23333/permission", timeout: 600 }],
+      }],
+    },
+  });
+
+  // Production-observed minimize state — marker absent, 4 top-level keys lost, all command hooks lost.
+  const MINIMIZED_SETTINGS = JSON.stringify({
+    skipDangerousModePermissionPrompt: true,
+  });
+
+  // Marker-removed minor shrink — user removes clawd hook only; one command hook lost (13 -> 12), keys unchanged.
+  const SETTINGS_AFTER_USER_REMOVES_ONE_HOOK = JSON.stringify({
+    env: { FOO: "bar" },
+    permissions: { allow: ["*"], deny: [], defaultMode: "ask" },
+    enabledPlugins: { a: 1, b: 2 },
+    skillOverrides: { sk1: true },
+    hooks: {
+      Stop: [{
+        matcher: "",
+        hooks: [
+          { type: "command", command: "node /home/u/.claude/hooks/maestro-audit.mjs" },
+          { type: "command", command: "node /home/u/.claude/hooks/secret-guard.js" },
+        ],
+      }],
+      PreToolUse: [{
+        matcher: "",
+        hooks: Array.from({ length: 10 }, (_, i) => ({
+          type: "command",
+          command: `node /home/u/.claude/hooks/guard-${i}.js`,
+        })),
+      }],
+      PermissionRequest: [{
+        matcher: "",
+        hooks: [{ type: "http", url: "http://127.0.0.1:23333/permission", timeout: 600 }],
+      }],
+    },
+  });
+
+  it("skips auto-resync when settings.json shrinks suspiciously (race with external CLI)", () => {
+    const notifyCalls = [];
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher({
+      notifySuspiciousShrink: (before, after) => notifyCalls.push({ before, after }),
+    });
+
+    watcher.start();
+    setSettingsRaw(HEALTHY_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    setSettingsRaw(MINIMIZED_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.deepStrictEqual(syncCalls, []);
+    assert.strictEqual(notifyCalls.length, 1);
+  });
+
+  it("allows resync on first tick when no trusted snapshot exists yet (fresh install)", () => {
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher();
+
+    watcher.start();
+    setSettingsRaw(MINIMIZED_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.deepStrictEqual(syncCalls, ["claude"]);
+  });
+
+  it("allows resync on minor shrink (user removes a single hook)", () => {
+    const notifyCalls = [];
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher({
+      notifySuspiciousShrink: (before, after) => notifyCalls.push({ before, after }),
+    });
+
+    watcher.start();
+    setSettingsRaw(HEALTHY_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    setSettingsRaw(SETTINGS_AFTER_USER_REMOVES_ONE_HOOK);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.deepStrictEqual(syncCalls, ["claude"]);
+    assert.strictEqual(notifyCalls.length, 0);
+  });
+
+  it("respects ctx.suspiciousShrinkRatio and ctx.suspiciousKeyLossThreshold tuning", () => {
+    const notifyCalls = [];
+    const { watcher, timers, syncCalls, getWatcher, setSettingsRaw } = makeWatcher({
+      suspiciousShrinkRatio: 0.05,
+      suspiciousKeyLossThreshold: 1,
+      notifySuspiciousShrink: (before, after) => notifyCalls.push({ before, after }),
+    });
+
+    watcher.start();
+    setSettingsRaw(HEALTHY_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    setSettingsRaw(SETTINGS_AFTER_USER_REMOVES_ONE_HOOK);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.deepStrictEqual(syncCalls, []);
+    assert.strictEqual(notifyCalls.length, 1);
+  });
+
+  it("notifies suspicious-shrink callback when guard trips", () => {
+    const notifications = [];
+    const { watcher, timers, getWatcher, setSettingsRaw } = makeWatcher({
+      notifySuspiciousShrink: (before, after) => notifications.push({ before, after }),
+    });
+    watcher.start();
+
+    setSettingsRaw(HEALTHY_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    setSettingsRaw(MINIMIZED_SETTINGS);
+    getWatcher().emitChange("settings.json");
+    timers.flush();
+
+    assert.strictEqual(notifications.length, 1);
+    assert.ok(notifications[0].before.hookCount > notifications[0].after.hookCount);
+  });
+});


### PR DESCRIPTION
## Summary

Skip auto-resync when `~/.claude/settings.json` shrinks suspiciously between
watcher ticks, preserving third-party hooks (maestro, secret-guard, etc.) when
external tools (e.g. `claude mcp remove --scope user`, CC-Switch) edit the file.

## Problem

When an external CLI modifies `settings.json`, the modification may leave the
file with the Clawd hook marker missing alongside other top-level keys (`env`,
`permissions`, `enabledPlugins`) and third-party hooks. The current watcher
reads this state, sees no `clawd-hook.js` marker, and triggers
`syncClawdHooks()`. `registerHooks()` then writes back a config containing only
Clawd's hooks — silently dropping user-authored and third-party hooks.

Observed in production: 33 hooks / 18 top-level keys reduced to 14 Clawd-only
hooks / 2 keys after `claude mcp remove promptbin && claude mcp add` ran in a
separate terminal while Clawd's watcher was active.

This violates the contract from #107 ("preserves third-party hooks") and the
AGENTS.md "Constraints" guarantee:

> 注册 Claude Code hook 时只能追加，不能覆盖用户已有 hook 数组
>
> (Translation: "Registering Claude Code hooks must only append, not overwrite
> the user's existing hook array")

## Fix

Maintain an in-memory snapshot of the last trusted `{ keyCount, hookCount }`.
On each watcher tick that would trigger resync, compare against the snapshot.
If the new state shows a suspicious shrink (configurable via `ctx`: default
50% hook loss or 3+ top-level keys lost), log a warning and skip the resync.

The baseline is seeded from settings.json at `start()` time when the file is
healthy, so the very first watcher event after Clawd boots can be compared
against a real snapshot (closes the cold-start race surfaced in review).

The user can recover by inspecting via Settings > Doctor, restarting Clawd,
or explicitly toggling `manageClaudeHooksAutomatically` OFF→ON in Settings
(which deliberately bypasses this guard — see Tradeoffs).

### Threshold rationale

The default 50% hook loss / 3 keys lost was calibrated against the observed
production case (33 → 14 hooks = 0.42 ratio, 18 → 2 keys = 16 lost) and
intentionally kept conservative so that a user pruning ~half of their hooks
on purpose is not blocked. Operators who want stricter or laxer behavior
can tune `ctx.suspiciousShrinkRatio` and `ctx.suspiciousKeyLossThreshold`
when constructing the watcher.

## Tradeoffs

- **Cold-start race (resolved per review feedback)** — see Fix section.
- **User intent vs external tool indistinguishable** — both trigger sync
  suspension. User can re-trigger sync manually if intentional.
- **Toggle paths bypass this guard** — when users explicitly toggle
  `manageClaudeHooksAutomatically` OFF→ON, re-enable claude-code, or otherwise
  invoke `syncClaudeHooksNow()` through the Settings UI, the resync runs
  outside the watcher callback and the snapshot check does not apply. This is
  intentional: any sync path that originates from a Settings UI action is
  treated as explicit user consent. External CLI side-effects (where the
  user's intent was managing something else, like MCP servers) are the only
  defended path.

## Tests

New cases added to existing `test/claude-settings-watcher.test.js`:

- skips auto-resync on suspicious shrink (the production race scenario)
- allows resync on first tick when `start()` found no healthy baseline to
  seed (fresh install / settings unhealthy at boot)
- allows resync on minor shrink (user removes 1 hook intentionally)
- threshold tuning via `ctx.suspiciousShrinkRatio` /
  `ctx.suspiciousKeyLossThreshold`
- optional `ctx.notifySuspiciousShrink(prev, curr)` callback fires when the
  guard trips (currently used in tests; reserved for future Doctor IPC
  integration)
- seeds the baseline on `start()` so the very first watcher event can trip
  the guard (cold-start race coverage)
- keeps blocking resync while the shrunk state persists across watcher events
  (stuck-state is intentional; recovery via Settings UI toggle is out of
  scope for this PR)
- treats non-object JSON payloads (`null`, `[]`) as unparseable and allows
  resync (malformed payloads are not treated as attacks)

Existing tests pass unchanged.

## Reproduction

Manually reproduced the destructive path both with and without this patch
on a development machine to confirm the fix targets the exact bug.

**Setup.** Healthy `~/.claude/settings.json` (18406 bytes, 17 top-level
keys, 14 `clawd-hook.js` markers, plus third-party hook commands from
`maestro-audit` and `secret-guard`). File backed up beforehand and
restored byte-wise after each run.

**Without this patch (HEAD before this commit):**

Wrote `{ "skipDangerousModePermissionPrompt": true }` (47 bytes) to
settings.json to simulate an external CLI minimize. ~1s after the write
the Electron console logged:

```
Clawd: hooks missing from settings.json — re-registering
Clawd: synced hooks (added 16, updated 0, removed 0)
```

Final state: 4716 bytes, 2 top-level keys, 14 `clawd-hook.js` markers,
**no `maestro-audit` or `secret-guard` entries — third-party hooks lost.**

**With this patch (same machine, same simulation):**

Same minimize write. ~1s after the write the console logged:

```
Clawd: settings.json shrank suspiciously — skipping auto-resync to preserve third-party hooks
```

Final state after a 10-second hold (much longer than the 1s watcher
debounce window): 47 bytes unchanged — no re-registration, third-party
entries preserved (then restored from backup as part of cleanup).

## Related

- contributes to #107 (third-party hooks preservation)
- AGENTS.md "Constraints" — append-only guarantee
- aa371b8 (Claude hook management controls) introduced safe ENOENT handling
  in `unregisterHooks`; this PR extends the same preservation guarantee to the
  watcher path
