### PR TITLE
fix: anchor sessions dashboard from settings

### DIFF
--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -41,6 +41,7 @@ function clampBoundsToWorkArea(bounds, workArea) {
 
 module.exports = function initDashboard(ctx) {
   let dashboardWindow = null;
+  const scheduleLater = typeof ctx.setTimeout === "function" ? ctx.setTimeout : setTimeout;
 
   function getCurrentSnapshot() {
     return typeof ctx.getSessionSnapshot === "function"
@@ -113,6 +114,27 @@ module.exports = function initDashboard(ctx) {
     };
   }
 
+  function applySettingsPlacement(options = {}) {
+    if (options.source !== "settings") return;
+    if (!dashboardWindow || dashboardWindow.isDestroyed()) return;
+    const placement = getDashboardPlacement(options);
+    if (placement.parent && typeof dashboardWindow.setParentWindow === "function") {
+      dashboardWindow.setParentWindow(placement.parent);
+    }
+    if (isUsableBounds(placement.bounds) && typeof dashboardWindow.setBounds === "function") {
+      dashboardWindow.setBounds(placement.bounds);
+    }
+  }
+
+  function scheduleSettingsPlacementSync(options = {}) {
+    if (options.source !== "settings") return;
+    for (const delay of [0, 80]) {
+      scheduleLater(() => {
+        applySettingsPlacement(options);
+      }, delay);
+    }
+  }
+
   function sendSnapshot(snapshot = getCurrentSnapshot()) {
     if (!dashboardWindow || dashboardWindow.isDestroyed()) return;
     if (!dashboardWindow.webContents || dashboardWindow.webContents.isDestroyed()) return;
@@ -163,7 +185,9 @@ module.exports = function initDashboard(ctx) {
     });
     dashboardWindow.once("ready-to-show", () => {
       if (!dashboardWindow || dashboardWindow.isDestroyed()) return;
+      applySettingsPlacement(options);
       dashboardWindow.show();
+      scheduleSettingsPlacementSync(options);
       dashboardWindow.focus();
     });
     dashboardWindow.on("closed", () => {
@@ -184,16 +208,9 @@ module.exports = function initDashboard(ctx) {
   function showDashboard(options = {}) {
     if (dashboardWindow && !dashboardWindow.isDestroyed()) {
       if (dashboardWindow.isMinimized()) dashboardWindow.restore();
-      if (options.source === "settings") {
-        const placement = getDashboardPlacement(options);
-        if (placement.parent && typeof dashboardWindow.setParentWindow === "function") {
-          dashboardWindow.setParentWindow(placement.parent);
-        }
-        if (isUsableBounds(placement.bounds) && typeof dashboardWindow.setBounds === "function") {
-          dashboardWindow.setBounds(placement.bounds);
-        }
-      }
+      applySettingsPlacement(options);
       dashboardWindow.show();
+      scheduleSettingsPlacementSync(options);
       dashboardWindow.focus();
       sendI18n();
       sendSnapshot();

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -14,6 +14,31 @@ function getDashboardBackgroundColor() {
   return nativeTheme.shouldUseDarkColors ? DARK_BACKGROUND : LIGHT_BACKGROUND;
 }
 
+function isUsableBounds(bounds) {
+  return !!bounds
+    && Number.isFinite(bounds.x)
+    && Number.isFinite(bounds.y)
+    && Number.isFinite(bounds.width)
+    && Number.isFinite(bounds.height)
+    && bounds.width > 0
+    && bounds.height > 0;
+}
+
+function clampBoundsToWorkArea(bounds, workArea) {
+  const width = Math.min(bounds.width, workArea.width);
+  const height = Math.min(bounds.height, workArea.height);
+  const minX = workArea.x;
+  const minY = workArea.y;
+  const maxX = workArea.x + workArea.width - width;
+  const maxY = workArea.y + workArea.height - height;
+  return {
+    x: Math.round(Math.min(Math.max(bounds.x, minX), maxX)),
+    y: Math.round(Math.min(Math.max(bounds.y, minY), maxY)),
+    width: Math.round(width),
+    height: Math.round(height),
+  };
+}
+
 module.exports = function initDashboard(ctx) {
   let dashboardWindow = null;
 
@@ -42,6 +67,52 @@ module.exports = function initDashboard(ctx) {
     };
   }
 
+  function getSettingsWindow() {
+    return typeof ctx.getSettingsWindow === "function"
+      ? ctx.getSettingsWindow()
+      : null;
+  }
+
+  function getSettingsBounds(settingsWindow) {
+    if (!settingsWindow || typeof settingsWindow.isDestroyed !== "function") return null;
+    if (settingsWindow.isDestroyed()) return null;
+    if (typeof settingsWindow.isMinimized === "function" && settingsWindow.isMinimized()) return null;
+    if (typeof settingsWindow.getBounds !== "function") return null;
+    const bounds = settingsWindow.getBounds();
+    return isUsableBounds(bounds) ? bounds : null;
+  }
+
+  function computeSettingsAnchoredBounds(settingsBounds) {
+    const cx = settingsBounds.x + settingsBounds.width / 2;
+    const cy = settingsBounds.y + settingsBounds.height / 2;
+    const workArea = typeof ctx.getNearestWorkArea === "function"
+      ? ctx.getNearestWorkArea(cx, cy)
+      : { x: 0, y: 0, width: 1280, height: 800 };
+    const width = Math.max(MIN_WIDTH, Math.min(DEFAULT_WIDTH, settingsBounds.width, workArea.width));
+    const height = Math.max(MIN_HEIGHT, Math.min(settingsBounds.height, workArea.height));
+    return clampBoundsToWorkArea({
+      x: settingsBounds.x + (settingsBounds.width - width) / 2,
+      y: settingsBounds.y,
+      width,
+      height,
+    }, workArea);
+  }
+
+  function getDashboardPlacement(options = {}) {
+    if (options.source !== "settings") {
+      return { bounds: computeInitialBounds(), parent: null };
+    }
+    const settingsWindow = getSettingsWindow();
+    const settingsBounds = getSettingsBounds(settingsWindow);
+    if (!settingsBounds) {
+      return { bounds: computeInitialBounds(), parent: null };
+    }
+    return {
+      bounds: computeSettingsAnchoredBounds(settingsBounds),
+      parent: settingsWindow,
+    };
+  }
+
   function sendSnapshot(snapshot = getCurrentSnapshot()) {
     if (!dashboardWindow || dashboardWindow.isDestroyed()) return;
     if (!dashboardWindow.webContents || dashboardWindow.webContents.isDestroyed()) return;
@@ -55,10 +126,10 @@ module.exports = function initDashboard(ctx) {
     dashboardWindow.webContents.send("dashboard:lang-change", ctx.getI18n());
   }
 
-  function createDashboardWindow() {
-    const bounds = computeInitialBounds();
+  function createDashboardWindow(options = {}) {
+    const placement = getDashboardPlacement(options);
     const opts = {
-      ...bounds,
+      ...placement.bounds,
       minWidth: MIN_WIDTH,
       minHeight: MIN_HEIGHT,
       show: false,
@@ -77,6 +148,10 @@ module.exports = function initDashboard(ctx) {
         contextIsolation: true,
       },
     };
+    if (placement.parent) {
+      opts.parent = placement.parent;
+      opts.modal = false;
+    }
     if (ctx.iconPath) opts.icon = ctx.iconPath;
 
     dashboardWindow = new BrowserWindow(opts);
@@ -106,16 +181,25 @@ module.exports = function initDashboard(ctx) {
     nativeTheme.on("updated", syncThemeBackground);
   }
 
-  function showDashboard() {
+  function showDashboard(options = {}) {
     if (dashboardWindow && !dashboardWindow.isDestroyed()) {
       if (dashboardWindow.isMinimized()) dashboardWindow.restore();
+      if (options.source === "settings") {
+        const placement = getDashboardPlacement(options);
+        if (placement.parent && typeof dashboardWindow.setParentWindow === "function") {
+          dashboardWindow.setParentWindow(placement.parent);
+        }
+        if (isUsableBounds(placement.bounds) && typeof dashboardWindow.setBounds === "function") {
+          dashboardWindow.setBounds(placement.bounds);
+        }
+      }
       dashboardWindow.show();
       dashboardWindow.focus();
       sendI18n();
       sendSnapshot();
       return dashboardWindow;
     }
-    return createDashboardWindow();
+    return createDashboardWindow(options);
   }
 
   function broadcastSessionSnapshot(snapshot) {

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -7,6 +7,7 @@ const DEFAULT_WIDTH = 480;
 const DEFAULT_HEIGHT = 600;
 const MIN_WIDTH = 320;
 const MIN_HEIGHT = 400;
+const SETTINGS_FLOATING_MARGIN = 16;
 const LIGHT_BACKGROUND = "#f5f5f7";
 const DARK_BACKGROUND = "#1c1c1f";
 
@@ -83,17 +84,18 @@ module.exports = function initDashboard(ctx) {
     return isUsableBounds(bounds) ? bounds : null;
   }
 
-  function computeSettingsAnchoredBounds(settingsBounds) {
+  function computeSettingsFloatingBounds(settingsBounds) {
     const cx = settingsBounds.x + settingsBounds.width / 2;
     const cy = settingsBounds.y + settingsBounds.height / 2;
     const workArea = typeof ctx.getNearestWorkArea === "function"
       ? ctx.getNearestWorkArea(cx, cy)
       : { x: 0, y: 0, width: 1280, height: 800 };
     const width = Math.max(MIN_WIDTH, Math.min(DEFAULT_WIDTH, settingsBounds.width, workArea.width));
-    const height = Math.max(MIN_HEIGHT, Math.min(settingsBounds.height, workArea.height));
+    const targetHeight = settingsBounds.height - SETTINGS_FLOATING_MARGIN * 2;
+    const height = Math.max(MIN_HEIGHT, Math.min(targetHeight, workArea.height));
     return clampBoundsToWorkArea({
       x: settingsBounds.x + (settingsBounds.width - width) / 2,
-      y: settingsBounds.y,
+      y: settingsBounds.y + SETTINGS_FLOATING_MARGIN,
       width,
       height,
     }, workArea);
@@ -103,16 +105,16 @@ module.exports = function initDashboard(ctx) {
     if (options.source !== "settings") {
       return { bounds: computeInitialBounds() };
     }
-    // Keep Settings-opened dashboard windows visually attached with absolute
-    // screen bounds. On Windows, using a BrowserWindow parent here can introduce
-    // frame/titlebar coordinate drift that makes the outer window heights differ.
+    // Keep Settings-opened dashboards as a visually attached floating panel.
+    // Matching native outer frames exactly is brittle on Windows because DWM can
+    // add invisible borders and titlebar frame offsets per window.
     const settingsWindow = getSettingsWindow();
     const settingsBounds = getSettingsBounds(settingsWindow);
     if (!settingsBounds) {
       return { bounds: computeInitialBounds() };
     }
     return {
-      bounds: computeSettingsAnchoredBounds(settingsBounds),
+      bounds: computeSettingsFloatingBounds(settingsBounds),
     };
   }
 

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -7,7 +7,6 @@ const DEFAULT_WIDTH = 480;
 const DEFAULT_HEIGHT = 600;
 const MIN_WIDTH = 320;
 const MIN_HEIGHT = 400;
-const SETTINGS_FLOATING_TOP_MARGIN = 16;
 const LIGHT_BACKGROUND = "#f5f5f7";
 const DARK_BACKGROUND = "#1c1c1f";
 
@@ -84,18 +83,17 @@ module.exports = function initDashboard(ctx) {
     return isUsableBounds(bounds) ? bounds : null;
   }
 
-  function computeSettingsFloatingBounds(settingsBounds) {
+  function computeSettingsAnchoredBounds(settingsBounds) {
     const cx = settingsBounds.x + settingsBounds.width / 2;
     const cy = settingsBounds.y + settingsBounds.height / 2;
     const workArea = typeof ctx.getNearestWorkArea === "function"
       ? ctx.getNearestWorkArea(cx, cy)
       : { x: 0, y: 0, width: 1280, height: 800 };
     const width = Math.max(MIN_WIDTH, Math.min(DEFAULT_WIDTH, settingsBounds.width, workArea.width));
-    const targetHeight = settingsBounds.height - SETTINGS_FLOATING_TOP_MARGIN;
-    const height = Math.max(MIN_HEIGHT, Math.min(targetHeight, workArea.height));
+    const height = Math.max(MIN_HEIGHT, Math.min(settingsBounds.height, workArea.height));
     return clampBoundsToWorkArea({
       x: settingsBounds.x + (settingsBounds.width - width) / 2,
-      y: settingsBounds.y + SETTINGS_FLOATING_TOP_MARGIN,
+      y: settingsBounds.y,
       width,
       height,
     }, workArea);
@@ -105,7 +103,7 @@ module.exports = function initDashboard(ctx) {
     if (options.source !== "settings") {
       return { bounds: computeInitialBounds() };
     }
-    // Keep Settings-opened dashboards as a visually attached floating panel.
+    // Keep Settings-opened dashboards visually attached with absolute bounds.
     // Matching native outer frames exactly is brittle on Windows because DWM can
     // add invisible borders and titlebar frame offsets per window.
     const settingsWindow = getSettingsWindow();
@@ -114,7 +112,7 @@ module.exports = function initDashboard(ctx) {
       return { bounds: computeInitialBounds() };
     }
     return {
-      bounds: computeSettingsFloatingBounds(settingsBounds),
+      bounds: computeSettingsAnchoredBounds(settingsBounds),
     };
   }
 

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -7,7 +7,7 @@ const DEFAULT_WIDTH = 480;
 const DEFAULT_HEIGHT = 600;
 const MIN_WIDTH = 320;
 const MIN_HEIGHT = 400;
-const SETTINGS_FLOATING_MARGIN = 16;
+const SETTINGS_FLOATING_TOP_MARGIN = 16;
 const LIGHT_BACKGROUND = "#f5f5f7";
 const DARK_BACKGROUND = "#1c1c1f";
 
@@ -91,11 +91,11 @@ module.exports = function initDashboard(ctx) {
       ? ctx.getNearestWorkArea(cx, cy)
       : { x: 0, y: 0, width: 1280, height: 800 };
     const width = Math.max(MIN_WIDTH, Math.min(DEFAULT_WIDTH, settingsBounds.width, workArea.width));
-    const targetHeight = settingsBounds.height - SETTINGS_FLOATING_MARGIN * 2;
+    const targetHeight = settingsBounds.height - SETTINGS_FLOATING_TOP_MARGIN;
     const height = Math.max(MIN_HEIGHT, Math.min(targetHeight, workArea.height));
     return clampBoundsToWorkArea({
       x: settingsBounds.x + (settingsBounds.width - width) / 2,
-      y: settingsBounds.y + SETTINGS_FLOATING_MARGIN,
+      y: settingsBounds.y + SETTINGS_FLOATING_TOP_MARGIN,
       width,
       height,
     }, workArea);

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -101,16 +101,18 @@ module.exports = function initDashboard(ctx) {
 
   function getDashboardPlacement(options = {}) {
     if (options.source !== "settings") {
-      return { bounds: computeInitialBounds(), parent: null };
+      return { bounds: computeInitialBounds() };
     }
+    // Keep Settings-opened dashboard windows visually attached with absolute
+    // screen bounds. On Windows, using a BrowserWindow parent here can introduce
+    // frame/titlebar coordinate drift that makes the outer window heights differ.
     const settingsWindow = getSettingsWindow();
     const settingsBounds = getSettingsBounds(settingsWindow);
     if (!settingsBounds) {
-      return { bounds: computeInitialBounds(), parent: null };
+      return { bounds: computeInitialBounds() };
     }
     return {
       bounds: computeSettingsAnchoredBounds(settingsBounds),
-      parent: settingsWindow,
     };
   }
 
@@ -118,9 +120,6 @@ module.exports = function initDashboard(ctx) {
     if (options.source !== "settings") return;
     if (!dashboardWindow || dashboardWindow.isDestroyed()) return;
     const placement = getDashboardPlacement(options);
-    if (placement.parent && typeof dashboardWindow.setParentWindow === "function") {
-      dashboardWindow.setParentWindow(placement.parent);
-    }
     if (isUsableBounds(placement.bounds) && typeof dashboardWindow.setBounds === "function") {
       dashboardWindow.setBounds(placement.bounds);
     }
@@ -170,10 +169,6 @@ module.exports = function initDashboard(ctx) {
         contextIsolation: true,
       },
     };
-    if (placement.parent) {
-      opts.parent = placement.parent;
-      opts.modal = false;
-    }
     if (ctx.iconPath) opts.icon = ctx.iconPath;
 
     dashboardWindow = new BrowserWindow(opts);

--- a/src/main.js
+++ b/src/main.js
@@ -1092,6 +1092,7 @@ const _dashboard = require("./dashboard")({
   getI18n: () => getDashboardI18nPayload(),
   getPetWindowBounds,
   getNearestWorkArea,
+  getSettingsWindow: () => settingsWindowRuntime.getWindow(),
   iconPath: settingsWindowRuntime.getIconPath(),
 });
 showDashboard = _dashboard.showDashboard;

--- a/src/main.js
+++ b/src/main.js
@@ -1463,7 +1463,7 @@ registerSessionIpc({
   focusSession: (sessionId, options) => focusDashboardSession(sessionId, options),
   hideSession: (sessionId) => hideDashboardSession(sessionId),
   setSessionAlias: (payload) => _settingsController.applyCommand("setSessionAlias", payload),
-  showDashboard: () => showDashboard(),
+  showDashboard: (options) => showDashboard(options),
   setSessionHudPinned: (value) => {
     const result = _settingsController.applyUpdate("sessionHudPinned", !!value);
     if (result && typeof result.then === "function") {

--- a/src/session-ipc.js
+++ b/src/session-ipc.js
@@ -38,10 +38,10 @@ function registerSessionIpc(options = {}) {
   on("session-hud:focus-session", (_event, sessionId) =>
     focusSession(sessionId, { requestSource: "hud" })
   );
-  on("session-hud:open-dashboard", () => showDashboard());
+  on("session-hud:open-dashboard", () => showDashboard({ source: "hud" }));
   on("session-hud:set-pinned", (_event, value) => setSessionHudPinned(!!value));
 
-  on("settings:open-dashboard", () => showDashboard());
+  on("settings:open-dashboard", () => showDashboard({ source: "settings" }));
   on("show-dashboard", () => showDashboard());
 
   return {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -125,7 +125,7 @@ describe("dashboard window", () => {
     assert.strictEqual(getCreatedWindow().opts.modal, undefined);
   });
 
-  it("visually anchors dashboard windows opened from settings to the settings window", () => {
+  it("floats dashboard windows opened from settings inside the settings window bounds", () => {
     const settingsWindow = {
       isDestroyed: () => false,
       isMinimized: () => false,
@@ -139,16 +139,16 @@ describe("dashboard window", () => {
 
     assert.deepStrictEqual(getCreatedWindow().bounds, {
       x: 260,
-      y: 50,
+      y: 66,
       width: 480,
-      height: 560,
+      height: 528,
     });
     assert.strictEqual(getCreatedWindow().opts.parent, undefined);
     assert.strictEqual(getCreatedWindow().opts.modal, undefined);
     assert.deepStrictEqual(getCreatedWindow().parentWindows, []);
   });
 
-  it("clamps settings-anchored dashboard bounds to the work area", () => {
+  it("clamps settings-floating dashboard bounds to the work area", () => {
     const settingsWindow = {
       isDestroyed: () => false,
       isMinimized: () => false,
@@ -204,14 +204,14 @@ describe("dashboard window", () => {
 
     assert.deepStrictEqual(getCreatedWindow().setBoundsCalls, [{
       x: 260,
-      y: 50,
+      y: 66,
       width: 480,
-      height: 560,
+      height: 528,
     }]);
     assert.deepStrictEqual(getCreatedWindow().parentWindows, []);
   });
 
-  it("re-syncs settings anchored bounds before and after showing the dashboard", () => {
+  it("re-syncs settings floating bounds before and after showing the dashboard", () => {
     let settingsBounds = { x: 100, y: 50, width: 800, height: 560 };
     const settingsWindow = {
       isDestroyed: () => false,
@@ -229,9 +229,9 @@ describe("dashboard window", () => {
     for (const timer of timers) timer.callback();
 
     assert.deepStrictEqual(getCreatedWindow().setBoundsCalls, [
-      { x: 260, y: 50, width: 480, height: 540 },
-      { x: 260, y: 50, width: 480, height: 520 },
-      { x: 260, y: 50, width: 480, height: 520 },
+      { x: 260, y: 66, width: 480, height: 508 },
+      { x: 260, y: 66, width: 480, height: 488 },
+      { x: 260, y: 66, width: 480, height: 488 },
     ]);
     assert.deepStrictEqual(timers.map((timer) => timer.delay), [0, 80]);
   });

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -125,7 +125,7 @@ describe("dashboard window", () => {
     assert.strictEqual(getCreatedWindow().opts.modal, undefined);
   });
 
-  it("floats dashboard windows opened from settings inside the settings window bounds", () => {
+  it("anchors dashboard windows opened from settings to the settings window bounds", () => {
     const settingsWindow = {
       isDestroyed: () => false,
       isMinimized: () => false,
@@ -139,16 +139,16 @@ describe("dashboard window", () => {
 
     assert.deepStrictEqual(getCreatedWindow().bounds, {
       x: 260,
-      y: 66,
+      y: 50,
       width: 480,
-      height: 544,
+      height: 560,
     });
     assert.strictEqual(getCreatedWindow().opts.parent, undefined);
     assert.strictEqual(getCreatedWindow().opts.modal, undefined);
     assert.deepStrictEqual(getCreatedWindow().parentWindows, []);
   });
 
-  it("clamps settings-floating dashboard bounds to the work area", () => {
+  it("clamps settings-anchored dashboard bounds to the work area", () => {
     const settingsWindow = {
       isDestroyed: () => false,
       isMinimized: () => false,
@@ -204,14 +204,14 @@ describe("dashboard window", () => {
 
     assert.deepStrictEqual(getCreatedWindow().setBoundsCalls, [{
       x: 260,
-      y: 66,
+      y: 50,
       width: 480,
-      height: 544,
+      height: 560,
     }]);
     assert.deepStrictEqual(getCreatedWindow().parentWindows, []);
   });
 
-  it("re-syncs settings floating bounds before and after showing the dashboard", () => {
+  it("re-syncs settings anchored bounds before and after showing the dashboard", () => {
     let settingsBounds = { x: 100, y: 50, width: 800, height: 560 };
     const settingsWindow = {
       isDestroyed: () => false,
@@ -229,9 +229,9 @@ describe("dashboard window", () => {
     for (const timer of timers) timer.callback();
 
     assert.deepStrictEqual(getCreatedWindow().setBoundsCalls, [
-      { x: 260, y: 66, width: 480, height: 524 },
-      { x: 260, y: 66, width: 480, height: 504 },
-      { x: 260, y: 66, width: 480, height: 504 },
+      { x: 260, y: 50, width: 480, height: 540 },
+      { x: 260, y: 50, width: 480, height: 520 },
+      { x: 260, y: 50, width: 480, height: 520 },
     ]);
     assert.deepStrictEqual(timers.map((timer) => timer.delay), [0, 80]);
   });

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -125,7 +125,7 @@ describe("dashboard window", () => {
     assert.strictEqual(getCreatedWindow().opts.modal, undefined);
   });
 
-  it("anchors dashboard windows opened from settings to the settings window", () => {
+  it("visually anchors dashboard windows opened from settings to the settings window", () => {
     const settingsWindow = {
       isDestroyed: () => false,
       isMinimized: () => false,
@@ -143,8 +143,9 @@ describe("dashboard window", () => {
       width: 480,
       height: 560,
     });
-    assert.strictEqual(getCreatedWindow().opts.parent, settingsWindow);
-    assert.strictEqual(getCreatedWindow().opts.modal, false);
+    assert.strictEqual(getCreatedWindow().opts.parent, undefined);
+    assert.strictEqual(getCreatedWindow().opts.modal, undefined);
+    assert.deepStrictEqual(getCreatedWindow().parentWindows, []);
   });
 
   it("clamps settings-anchored dashboard bounds to the work area", () => {
@@ -207,7 +208,7 @@ describe("dashboard window", () => {
       width: 480,
       height: 560,
     }]);
-    assert.deepStrictEqual(getCreatedWindow().parentWindows, [settingsWindow]);
+    assert.deepStrictEqual(getCreatedWindow().parentWindows, []);
   });
 
   it("re-syncs settings anchored bounds before and after showing the dashboard", () => {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -28,6 +28,7 @@ describe("dashboard window", () => {
     let createdWindow = null;
     const nativeTheme = new EventEmitter();
     nativeTheme.shouldUseDarkColors = false;
+    const timers = [];
 
     class FakeBrowserWindow {
       constructor(opts) {
@@ -41,6 +42,7 @@ describe("dashboard window", () => {
         this.backgroundColors = [opts.backgroundColor];
         this.parentWindows = [];
         this.setBoundsCalls = [];
+        this.onceCallbacks = new Map();
         this.webContents = {
           isDestroyed: () => false,
           once: () => {},
@@ -55,7 +57,7 @@ describe("dashboard window", () => {
       focus() {}
       setMenuBarVisibility() {}
       loadFile() {}
-      once() {}
+      once(eventName, callback) { this.onceCallbacks.set(eventName, callback); }
       on() {}
       setBackgroundColor(color) { this.backgroundColors.push(color); }
       setBounds(bounds) {
@@ -64,6 +66,10 @@ describe("dashboard window", () => {
       }
       setParentWindow(parentWindow) {
         this.parentWindows.push(parentWindow);
+      }
+      emitReadyToShow() {
+        const callback = this.onceCallbacks.get("ready-to-show");
+        if (callback) callback();
       }
     }
 
@@ -75,6 +81,10 @@ describe("dashboard window", () => {
       getPetWindowBounds: () => ({ x: 100, y: 100, width: 120, height: 120 }),
       getNearestWorkArea: options.getNearestWorkArea || (() => ({ x: 0, y: 0, width: 1280, height: 800 })),
       getSettingsWindow: options.getSettingsWindow,
+      setTimeout: options.setTimeout || ((callback, delay) => {
+        timers.push({ callback, delay });
+        return timers.length;
+      }),
       getSessionSnapshot: () => ({ sessions: [], groups: [] }),
       getI18n: () => ({ lang: "en", translations: {} }),
     });
@@ -82,6 +92,7 @@ describe("dashboard window", () => {
     return {
       dashboard,
       nativeTheme,
+      timers,
       getCreatedWindow: () => createdWindow,
     };
   }
@@ -197,6 +208,31 @@ describe("dashboard window", () => {
       height: 560,
     }]);
     assert.deepStrictEqual(getCreatedWindow().parentWindows, [settingsWindow]);
+  });
+
+  it("re-syncs settings anchored bounds before and after showing the dashboard", () => {
+    let settingsBounds = { x: 100, y: 50, width: 800, height: 560 };
+    const settingsWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      getBounds: () => settingsBounds,
+    };
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+    });
+
+    dashboard.showDashboard({ source: "settings" });
+    settingsBounds = { x: 100, y: 50, width: 800, height: 540 };
+    getCreatedWindow().emitReadyToShow();
+    settingsBounds = { x: 100, y: 50, width: 800, height: 520 };
+    for (const timer of timers) timer.callback();
+
+    assert.deepStrictEqual(getCreatedWindow().setBoundsCalls, [
+      { x: 260, y: 50, width: 480, height: 540 },
+      { x: 260, y: 50, width: 480, height: 520 },
+      { x: 260, y: 50, width: 480, height: 520 },
+    ]);
+    assert.deepStrictEqual(timers.map((timer) => timer.delay), [0, 80]);
   });
 
   it("exposes a Clawd-only hide action instead of a terminal close action", () => {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -141,7 +141,7 @@ describe("dashboard window", () => {
       x: 260,
       y: 66,
       width: 480,
-      height: 528,
+      height: 544,
     });
     assert.strictEqual(getCreatedWindow().opts.parent, undefined);
     assert.strictEqual(getCreatedWindow().opts.modal, undefined);
@@ -206,7 +206,7 @@ describe("dashboard window", () => {
       x: 260,
       y: 66,
       width: 480,
-      height: 528,
+      height: 544,
     }]);
     assert.deepStrictEqual(getCreatedWindow().parentWindows, []);
   });
@@ -229,9 +229,9 @@ describe("dashboard window", () => {
     for (const timer of timers) timer.callback();
 
     assert.deepStrictEqual(getCreatedWindow().setBoundsCalls, [
-      { x: 260, y: 66, width: 480, height: 508 },
-      { x: 260, y: 66, width: 480, height: 488 },
-      { x: 260, y: 66, width: 480, height: 488 },
+      { x: 260, y: 66, width: 480, height: 524 },
+      { x: 260, y: 66, width: 480, height: 504 },
+      { x: 260, y: 66, width: 480, height: 504 },
     ]);
     assert.deepStrictEqual(timers.map((timer) => timer.delay), [0, 80]);
   });

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -24,13 +24,23 @@ function loadDashboardWithElectron(fakeElectron) {
 }
 
 describe("dashboard window", () => {
-  it("updates its background color when native theme changes", () => {
+  function createWindowHarness(options = {}) {
     let createdWindow = null;
+    const nativeTheme = new EventEmitter();
+    nativeTheme.shouldUseDarkColors = false;
 
     class FakeBrowserWindow {
       constructor(opts) {
         this.opts = opts;
+        this.bounds = {
+          x: opts.x,
+          y: opts.y,
+          width: opts.width,
+          height: opts.height,
+        };
         this.backgroundColors = [opts.backgroundColor];
+        this.parentWindows = [];
+        this.setBoundsCalls = [];
         this.webContents = {
           isDestroyed: () => false,
           once: () => {},
@@ -48,29 +58,145 @@ describe("dashboard window", () => {
       once() {}
       on() {}
       setBackgroundColor(color) { this.backgroundColors.push(color); }
+      setBounds(bounds) {
+        this.bounds = { ...bounds };
+        this.setBoundsCalls.push({ ...bounds });
+      }
+      setParentWindow(parentWindow) {
+        this.parentWindows.push(parentWindow);
+      }
     }
 
-    const nativeTheme = new EventEmitter();
-    nativeTheme.shouldUseDarkColors = false;
     const initDashboard = loadDashboardWithElectron({
       BrowserWindow: FakeBrowserWindow,
       nativeTheme,
     });
-
     const dashboard = initDashboard({
       getPetWindowBounds: () => ({ x: 100, y: 100, width: 120, height: 120 }),
-      getNearestWorkArea: () => ({ x: 0, y: 0, width: 1280, height: 800 }),
+      getNearestWorkArea: options.getNearestWorkArea || (() => ({ x: 0, y: 0, width: 1280, height: 800 })),
+      getSettingsWindow: options.getSettingsWindow,
       getSessionSnapshot: () => ({ sessions: [], groups: [] }),
       getI18n: () => ({ lang: "en", translations: {} }),
     });
 
+    return {
+      dashboard,
+      nativeTheme,
+      getCreatedWindow: () => createdWindow,
+    };
+  }
+
+  it("updates its background color when native theme changes", () => {
+    const { dashboard, nativeTheme, getCreatedWindow } = createWindowHarness();
+
     dashboard.showDashboard();
+    const createdWindow = getCreatedWindow();
     assert.strictEqual(createdWindow.opts.backgroundColor, "#f5f5f7");
 
     nativeTheme.shouldUseDarkColors = true;
     nativeTheme.emit("updated");
 
     assert.deepStrictEqual(createdWindow.backgroundColors, ["#f5f5f7", "#1c1c1f"]);
+  });
+
+  it("centers the dashboard on the pet work area by default", () => {
+    const { dashboard, getCreatedWindow } = createWindowHarness();
+
+    dashboard.showDashboard();
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 400,
+      y: 100,
+      width: 480,
+      height: 600,
+    });
+    assert.strictEqual(getCreatedWindow().opts.parent, undefined);
+    assert.strictEqual(getCreatedWindow().opts.modal, undefined);
+  });
+
+  it("anchors dashboard windows opened from settings to the settings window", () => {
+    const settingsWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      getBounds: () => ({ x: 100, y: 50, width: 800, height: 560 }),
+    };
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+    });
+
+    dashboard.showDashboard({ source: "settings" });
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 260,
+      y: 50,
+      width: 480,
+      height: 560,
+    });
+    assert.strictEqual(getCreatedWindow().opts.parent, settingsWindow);
+    assert.strictEqual(getCreatedWindow().opts.modal, false);
+  });
+
+  it("clamps settings-anchored dashboard bounds to the work area", () => {
+    const settingsWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      getBounds: () => ({ x: 900, y: 500, width: 500, height: 700 }),
+    };
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+      getNearestWorkArea: () => ({ x: 0, y: 0, width: 1000, height: 600 }),
+    });
+
+    dashboard.showDashboard({ source: "settings" });
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 520,
+      y: 0,
+      width: 480,
+      height: 600,
+    });
+  });
+
+  it("falls back to pet work area centering when the settings window is unavailable", () => {
+    const settingsWindow = {
+      isDestroyed: () => true,
+      getBounds: () => ({ x: 100, y: 50, width: 800, height: 560 }),
+    };
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+    });
+
+    dashboard.showDashboard({ source: "settings" });
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 400,
+      y: 100,
+      width: 480,
+      height: 600,
+    });
+    assert.strictEqual(getCreatedWindow().opts.parent, undefined);
+  });
+
+  it("repositions an existing dashboard when reopened from settings", () => {
+    const settingsWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      getBounds: () => ({ x: 100, y: 50, width: 800, height: 560 }),
+    };
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+    });
+
+    dashboard.showDashboard();
+    dashboard.showDashboard({ source: "settings" });
+
+    assert.deepStrictEqual(getCreatedWindow().setBoundsCalls, [{
+      x: 260,
+      y: 50,
+      width: 480,
+      height: 560,
+    }]);
+    assert.deepStrictEqual(getCreatedWindow().parentWindows, [settingsWindow]);
   });
 
   it("exposes a Clawd-only hide action instead of a terminal close action", () => {

--- a/test/session-ipc.test.js
+++ b/test/session-ipc.test.js
@@ -148,9 +148,15 @@ test("session IPC owns dashboard open bridges", () => {
 
 test("main forwards dashboard open source options into session IPC", () => {
   const mainSource = fs.readFileSync(path.join(__dirname, "..", "src", "main.js"), "utf8");
-  const registerIndex = mainSource.indexOf("registerSessionIpc({");
-  assert.notStrictEqual(registerIndex, -1);
-  const registerBlock = mainSource.slice(registerIndex, mainSource.indexOf("});", registerIndex) + 3);
+  const preservesOptions = [
+    /registerSessionIpc\(\{[\s\S]*?showDashboard\s*,/,
+    /registerSessionIpc\(\{[\s\S]*?showDashboard:\s*\(\s*([A-Za-z_$][\w$]*)\s*\)\s*=>\s*showDashboard\(\s*\1\s*\)/,
+    /registerSessionIpc\(\{[\s\S]*?showDashboard:\s*\(\s*\.\.\.\s*([A-Za-z_$][\w$]*)\s*\)\s*=>\s*showDashboard\(\s*\.\.\.\s*\1\s*\)/,
+  ].some((pattern) => pattern.test(mainSource));
 
-  assert.match(registerBlock, /showDashboard:\s*\(options\)\s*=>\s*showDashboard\(options\)/);
+  assert.strictEqual(
+    preservesOptions,
+    true,
+    "main.js should preserve dashboard open options when wiring session IPC"
+  );
 });

--- a/test/session-ipc.test.js
+++ b/test/session-ipc.test.js
@@ -2,6 +2,8 @@
 
 const test = require("node:test");
 const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const { registerSessionIpc } = require("../src/session-ipc");
 
@@ -142,4 +144,13 @@ test("session IPC owns dashboard open bridges", () => {
     ["showDashboard", { source: "settings" }],
     ["showDashboard", undefined],
   ]);
+});
+
+test("main forwards dashboard open source options into session IPC", () => {
+  const mainSource = fs.readFileSync(path.join(__dirname, "..", "src", "main.js"), "utf8");
+  const registerIndex = mainSource.indexOf("registerSessionIpc({");
+  assert.notStrictEqual(registerIndex, -1);
+  const registerBlock = mainSource.slice(registerIndex, mainSource.indexOf("});", registerIndex) + 3);
+
+  assert.match(registerBlock, /showDashboard:\s*\(options\)\s*=>\s*showDashboard\(options\)/);
 });

--- a/test/session-ipc.test.js
+++ b/test/session-ipc.test.js
@@ -58,8 +58,8 @@ function createHarness(overrides = {}) {
       calls.push(["setSessionAlias", payload]);
       return { status: "ok", alias: payload.alias };
     }),
-    showDashboard: overrides.showDashboard || (() => {
-      calls.push(["showDashboard"]);
+    showDashboard: overrides.showDashboard || ((options) => {
+      calls.push(["showDashboard", options]);
     }),
     setSessionHudPinned: overrides.setSessionHudPinned || ((value) => {
       calls.push(["setSessionHudPinned", value]);
@@ -138,8 +138,8 @@ test("session IPC owns dashboard open bridges", () => {
   ipcMain.send("show-dashboard");
 
   assert.deepStrictEqual(calls, [
-    ["showDashboard"],
-    ["showDashboard"],
-    ["showDashboard"],
+    ["showDashboard", { source: "hud" }],
+    ["showDashboard", { source: "settings" }],
+    ["showDashboard", undefined],
   ]);
 });


### PR DESCRIPTION
Fixes: N/A.

## Summary
- Makes the Sessions dashboard open as a Settings-attached window when launched from the Settings panel.
- Routes dashboard open requests with an explicit source so Settings, Session HUD, pet, and tray entry points can keep distinct placement behavior.
- Preserves the default centered dashboard behavior for non-Settings entry points and preserves all session data, focus, alias, and hide behavior.

## Problem context
- The Sessions dashboard previously opened as a separate centered window with a default height, which looked visually detached when launched from Settings.
- Early positioning logic did not take effect in the live app because the Settings source option was forwarded by `session-ipc` but dropped by the `main.js` wrapper before reaching `dashboard.showDashboard()`.
- Electron/Windows owned-window positioning also introduced native frame/titlebar drift, so this PR avoids `BrowserWindow` parent/modal ownership and uses absolute bounds instead.

## What changed
- Dashboard placement
  - Adds Settings-specific dashboard placement that reads the live Settings window bounds.
  - Centers the dashboard horizontally over Settings, matches the Settings top/bottom bounds, clamps to the active work area, and re-syncs around show time.
  - Falls back to the existing pet-screen centered placement when Settings is unavailable, destroyed, minimized, or has unusable bounds.
- Entry-point routing
  - `settings:open-dashboard` now calls `showDashboard({ source: "settings" })`.
  - `session-hud:open-dashboard` now calls `showDashboard({ source: "hud" })`.
  - `show-dashboard`, tray, and pet entry points continue to use the default centered behavior.
  - `main.js` now forwards dashboard open options instead of dropping them.
- Tests
  - Adds dashboard placement coverage for default centering, Settings anchoring, work-area clamping, unavailable Settings fallback, existing-window repositioning, and delayed re-sync.
  - Adds IPC coverage that verifies open source options are preserved through `session-ipc` and the `main.js` registration wrapper.

## Behavior after this PR
- Opening Sessions from Settings aligns the dashboard with the Settings window bounds while keeping it an independent native window.
- Opening Sessions from Session HUD, pet click, tray, or generic dashboard command keeps the previous centered `480x600` dashboard behavior.
- If Settings cannot provide valid bounds, the dashboard falls back to the previous centered placement.
- Session list rendering, dashboard buttons, terminal/Codex focus handoff, hidden sessions, aliases, HUD behavior, and preferences remain unchanged.

## Validation
- `node --test test\dashboard.test.js test\session-ipc.test.js`
- `node --check src\dashboard.js`
- `node --check src\main.js`
- `node --check src\session-ipc.js`
- `pwsh -NoLogo -NoProfile -Command "git diff --check"`

## Platform note
- Automated verification ran locally on Windows in the project workspace.
- Electron window positioning should still be manually checked in the app because native frame and DWM behavior can vary by display scaling and Windows theme.
