### PR TITLE
Fix Windows uninstall Claude hook cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           node-version: 20
       - run: npm install
+      - run: npm test
       - run: npx electron-builder --win --publish never
       - uses: actions/upload-artifact@v4
         with:

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,14 @@
+!macro customInstall
+  SetOutPath "$INSTDIR"
+  File "/oname=$INSTDIR\uninstall-claude-hooks.ps1" "${BUILD_RESOURCES_DIR}\uninstall-claude-hooks.ps1"
+  FileOpen $0 "$INSTDIR\.clawd-install-user-home" w
+  FileWrite $0 "$PROFILE"
+  FileClose $0
+!macroend
+
+!macro customUnInstall
+  IfFileExists "$INSTDIR\uninstall-claude-hooks.ps1" 0 clawd_uninstall_hooks_done
+    nsExec::ExecToLog 'powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$INSTDIR\uninstall-claude-hooks.ps1" -InstallDir "$INSTDIR"'
+    Pop $0
+  clawd_uninstall_hooks_done:
+!macroend

--- a/build/uninstall-claude-hooks.ps1
+++ b/build/uninstall-claude-hooks.ps1
@@ -1,0 +1,284 @@
+param(
+  [string]$InstallDir = $PSScriptRoot
+)
+
+$ErrorActionPreference = "Stop"
+$Utf8NoBom = New-Object System.Text.UTF8Encoding -ArgumentList $false
+$ClawdPermissionPorts = @(23333, 23334, 23335, 23336, 23337)
+$ClawdCommandMarkers = @("clawd-hook.js", "auto-start.js", "auto-start.sh")
+
+function Normalize-PathForCompare {
+  param([string]$PathValue)
+  if ([string]::IsNullOrWhiteSpace($PathValue)) { return $null }
+  try {
+    $fullPath = [System.IO.Path]::GetFullPath($PathValue.Trim().Trim('"'))
+    $fullPath = $fullPath.Replace("/", "\")
+    return ($fullPath -replace "\\+$", "").ToLowerInvariant()
+  } catch {
+    return $null
+  }
+}
+
+function Resolve-PlausibleUserHome {
+  param([string]$PathValue)
+  if ([string]::IsNullOrWhiteSpace($PathValue)) { return $null }
+
+  $candidate = $PathValue.Trim().Trim('"')
+  if (-not [System.IO.Path]::IsPathRooted($candidate)) { return $null }
+  if (-not [System.IO.Directory]::Exists($candidate)) { return $null }
+
+  $normalized = Normalize-PathForCompare $candidate
+  if ([string]::IsNullOrWhiteSpace($normalized)) { return $null }
+
+  $blockedRoots = @($env:SystemRoot, $env:windir)
+  foreach ($blockedRoot in $blockedRoots) {
+    $blocked = Normalize-PathForCompare $blockedRoot
+    if ([string]::IsNullOrWhiteSpace($blocked)) { continue }
+    if ($normalized -eq $blocked -or $normalized.StartsWith($blocked + "\")) { return $null }
+  }
+
+  if ($normalized -match "\\(systemprofile|localservice|networkservice)$") { return $null }
+  if ($normalized -match "\\serviceprofiles\\(localservice|networkservice)$") { return $null }
+
+  return [System.IO.Path]::GetFullPath($candidate)
+}
+
+function Test-ProcessElevated {
+  try {
+    $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+    $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+    return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+  } catch {
+    return $false
+  }
+}
+
+function Read-TrimmedTextCandidates {
+  param([string]$PathValue)
+  $values = New-Object System.Collections.ArrayList
+  $encodings = @($Utf8NoBom, [System.Text.Encoding]::Unicode, [System.Text.Encoding]::Default)
+
+  foreach ($encoding in $encodings) {
+    try {
+      $value = [System.IO.File]::ReadAllText($PathValue, $encoding)
+      if ([string]::IsNullOrWhiteSpace($value)) { continue }
+      [void]$values.Add($value.TrimStart([char]0xFEFF).Trim())
+    } catch {
+    }
+  }
+
+  return [object[]]$values.ToArray()
+}
+
+function Resolve-TargetUserHome {
+  $markerPath = Join-Path $InstallDir ".clawd-install-user-home"
+  if ([System.IO.File]::Exists($markerPath)) {
+    foreach ($candidateText in (Read-TrimmedTextCandidates $markerPath)) {
+      $resolved = Resolve-PlausibleUserHome $candidateText
+      if (-not [string]::IsNullOrWhiteSpace($resolved)) { return $resolved }
+    }
+  }
+
+  if (-not (Test-ProcessElevated)) {
+    return Resolve-PlausibleUserHome $env:USERPROFILE
+  }
+
+  return $null
+}
+
+function Get-JsonProperty {
+  param(
+    [object]$ObjectValue,
+    [string]$Name
+  )
+
+  if ($null -eq $ObjectValue -or $null -eq $ObjectValue.PSObject) { return $null }
+  $matches = $ObjectValue.PSObject.Properties.Match($Name)
+  if ($matches.Count -eq 0) { return $null }
+  return $matches[0]
+}
+
+function Get-StringPropertyValue {
+  param(
+    [object]$ObjectValue,
+    [string]$Name
+  )
+
+  $property = Get-JsonProperty $ObjectValue $Name
+  if ($null -eq $property -or -not ($property.Value -is [string])) { return $null }
+  return $property.Value
+}
+
+function Test-ClawdCommand {
+  param([string]$Command)
+  if ([string]::IsNullOrWhiteSpace($Command)) { return $false }
+
+  foreach ($marker in $ClawdCommandMarkers) {
+    if ($Command.IndexOf($marker, [System.StringComparison]::Ordinal) -ge 0) {
+      return $true
+    }
+  }
+
+  return $false
+}
+
+function Test-ClawdPermissionUrl {
+  param([string]$Url)
+  if ([string]::IsNullOrWhiteSpace($Url)) { return $false }
+
+  try {
+    $uri = [System.Uri]$Url
+    return $uri.IsAbsoluteUri `
+      -and $uri.Scheme -eq "http" `
+      -and $uri.Host -eq "127.0.0.1" `
+      -and $uri.AbsolutePath -eq "/permission" `
+      -and [string]::IsNullOrEmpty($uri.Query) `
+      -and [string]::IsNullOrEmpty($uri.Fragment) `
+      -and [string]::IsNullOrEmpty($uri.UserInfo) `
+      -and ($ClawdPermissionPorts -contains $uri.Port)
+  } catch {
+    return $false
+  }
+}
+
+function Test-ClawdHttpHook {
+  param([object]$Hook)
+
+  $type = Get-StringPropertyValue $Hook "type"
+  if ($type -ne "http") { return $false }
+
+  $url = Get-StringPropertyValue $Hook "url"
+  return Test-ClawdPermissionUrl $url
+}
+
+function Remove-ClawdHooksFromEntries {
+  param([object[]]$Entries)
+
+  $nextEntries = New-Object System.Collections.ArrayList
+  $removed = 0
+  $changed = $false
+
+  foreach ($entry in $Entries) {
+    if ($null -eq $entry -or $null -eq $entry.PSObject) {
+      [void]$nextEntries.Add($entry)
+      continue
+    }
+
+    $entryCommand = Get-StringPropertyValue $entry "command"
+    if (Test-ClawdCommand $entryCommand) {
+      $removed++
+      $changed = $true
+      continue
+    }
+
+    if (Test-ClawdHttpHook $entry) {
+      $removed++
+      $changed = $true
+      continue
+    }
+
+    $hooksProperty = Get-JsonProperty $entry "hooks"
+    if ($null -eq $hooksProperty -or -not ($hooksProperty.Value -is [System.Array])) {
+      [void]$nextEntries.Add($entry)
+      continue
+    }
+
+    $nextHooks = New-Object System.Collections.ArrayList
+    $entryHooksChanged = $false
+
+    foreach ($hook in ([object[]]$hooksProperty.Value)) {
+      $removeHook = $false
+      if ($null -ne $hook -and $null -ne $hook.PSObject) {
+        $hookCommand = Get-StringPropertyValue $hook "command"
+        if (Test-ClawdCommand $hookCommand) {
+          $removeHook = $true
+        } elseif (Test-ClawdHttpHook $hook) {
+          $removeHook = $true
+        }
+      }
+
+      if ($removeHook) {
+        $removed++
+        $changed = $true
+        $entryHooksChanged = $true
+      } else {
+        [void]$nextHooks.Add($hook)
+      }
+    }
+
+    if ($entryHooksChanged) {
+      $nextHookArray = [object[]]$nextHooks.ToArray()
+      $entryType = Get-StringPropertyValue $entry "type"
+      if ($nextHookArray.Count -eq 0 -and [string]::IsNullOrEmpty($entryCommand) -and $entryType -ne "http") {
+        continue
+      }
+      $hooksProperty.Value = [object[]]$nextHookArray
+    }
+
+    [void]$nextEntries.Add($entry)
+  }
+
+  return [pscustomobject]@{
+    Entries = [object[]]$nextEntries.ToArray()
+    Removed = $removed
+    Changed = $changed
+  }
+}
+
+function Remove-ClawdHooksFromSettings {
+  param([object]$Settings)
+
+  $hooksProperty = Get-JsonProperty $Settings "hooks"
+  if ($null -eq $hooksProperty -or $null -eq $hooksProperty.Value -or $null -eq $hooksProperty.Value.PSObject) {
+    return $false
+  }
+
+  $changed = $false
+  $eventProperties = @($hooksProperty.Value.PSObject.Properties)
+
+  foreach ($eventProperty in $eventProperties) {
+    if (-not ($eventProperty.Value -is [System.Array])) { continue }
+
+    $result = Remove-ClawdHooksFromEntries -Entries ([object[]]$eventProperty.Value)
+    if (-not $result.Changed) { continue }
+
+    $changed = $true
+    $nextEntries = [object[]]$result.Entries
+    if ($nextEntries.Count -gt 0) {
+      $eventProperty.Value = [object[]]$nextEntries
+    } else {
+      $hooksProperty.Value.PSObject.Properties.Remove($eventProperty.Name)
+    }
+  }
+
+  return $changed
+}
+
+try {
+  $userHome = Resolve-TargetUserHome
+  if ([string]::IsNullOrWhiteSpace($userHome)) { exit 0 }
+
+  $settingsPath = Join-Path (Join-Path $userHome ".claude") "settings.json"
+  if (-not [System.IO.File]::Exists($settingsPath)) { exit 0 }
+
+  $rawSettings = [System.IO.File]::ReadAllText($settingsPath, $Utf8NoBom)
+  $rawSettings = $rawSettings.TrimStart([char]0xFEFF)
+  try {
+    $settings = ConvertFrom-Json -InputObject $rawSettings
+  } catch {
+    exit 0
+  }
+
+  if ($null -eq $settings) { exit 0 }
+  if (-not (Remove-ClawdHooksFromSettings $settings)) { exit 0 }
+
+  $backupName = "settings.json.clawd-uninstall-{0}.bak" -f (Get-Date -Format "yyyyMMdd-HHmmss-fff")
+  $backupPath = Join-Path (Split-Path -Parent $settingsPath) $backupName
+  [System.IO.File]::Copy($settingsPath, $backupPath, $false)
+
+  $json = ConvertTo-Json -InputObject $settings -Depth 100
+  [System.IO.File]::WriteAllText($settingsPath, $json + [Environment]::NewLine, $Utf8NoBom)
+  exit 0
+} catch {
+  exit 0
+}

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -7,7 +7,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const childProcess = require("child_process");
-const { buildPermissionUrl, DEFAULT_SERVER_PORT, PERMISSION_PATH, readRuntimePort, resolveNodeBin, resolveNodeBinAsync } = require("./server-config");
+const { buildPermissionUrl, DEFAULT_SERVER_PORT, PERMISSION_PATH, readRuntimePort, resolveNodeBin, resolveNodeBinAsync, SERVER_PORTS } = require("./server-config");
 const { writeJsonAtomic, writeJsonAtomicAsync, asarUnpackedPath } = require("./json-utils");
 
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".claude");
@@ -542,9 +542,16 @@ function isClawdPermissionUrl(url) {
   if (typeof url !== "string" || !url) return false;
   try {
     const parsed = new URL(url);
+    const port = Number(parsed.port);
     return parsed.protocol === "http:"
       && parsed.hostname === "127.0.0.1"
-      && parsed.pathname === HTTP_MARKER;
+      && parsed.pathname === HTTP_MARKER
+      && parsed.search === ""
+      && parsed.hash === ""
+      && parsed.username === ""
+      && parsed.password === ""
+      && Number.isInteger(port)
+      && SERVER_PORTS.includes(port);
   } catch {
     return false;
   }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
       "buildUniversalInstaller": false,
       "installerIcon": "assets/icon.ico",
       "uninstallerIcon": "assets/icon.ico",
-      "installerHeaderIcon": "assets/icon.ico"
+      "installerHeaderIcon": "assets/icon.ico",
+      "include": "build/installer.nsh"
     },
     "files": [
       "NOTICE.md",

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const { registerHooks, unregisterHooks, registerHooksAsync, unregisterHooksAsync, __test } = require("../hooks/install");
+const { buildPermissionUrl, SERVER_PORTS } = require("../hooks/server-config");
 const {
   parseClaudeVersion,
   getWindowsClaudePathSuffixes,
@@ -16,6 +17,7 @@ const {
   readClaudeVersionFallback,
   readClaudeVersionFallbackAsync,
   getClaudeVersionAsync,
+  isClawdPermissionUrl,
 } = __test;
 
 const tempDirs = [];
@@ -1000,6 +1002,84 @@ describe("Hook installer version compatibility", () => {
   });
 });
 
+describe("Claude permission hook ownership", () => {
+  it("recognizes only exact Clawd PermissionRequest URLs on managed ports", () => {
+    for (const port of SERVER_PORTS) {
+      assert.strictEqual(
+        isClawdPermissionUrl(`http://127.0.0.1:${port}/permission`),
+        true,
+        `expected managed port ${port} to be Clawd-owned`
+      );
+    }
+
+    assert.strictEqual(isClawdPermissionUrl("http://127.0.0.1:8080/permission"), false);
+    assert.strictEqual(isClawdPermissionUrl("http://localhost:23333/permission"), false);
+    assert.strictEqual(isClawdPermissionUrl("https://127.0.0.1:23333/permission"), false);
+    assert.strictEqual(isClawdPermissionUrl("http://127.0.0.1:23333/permission?x=1"), false);
+    assert.strictEqual(isClawdPermissionUrl("http://127.0.0.1:23333/permission#frag"), false);
+    assert.strictEqual(isClawdPermissionUrl("http://user@127.0.0.1:23333/permission"), false);
+    assert.strictEqual(isClawdPermissionUrl("http://127.0.0.1/permission"), false);
+  });
+
+  it("preserves third-party local PermissionRequest URLs while adding Clawd HTTP hook", () => {
+    const clawdUrl = buildPermissionUrl(SERVER_PORTS[0]);
+    const settingsPath = makeTempSettings({
+      hooks: {
+        PermissionRequest: [
+          {
+            matcher: "",
+            hooks: [{ type: "http", url: "http://127.0.0.1:8080/permission", timeout: 100 }],
+          },
+          {
+            matcher: "",
+            hooks: [{ type: "http", url: "http://localhost:8080/permission", timeout: 100 }],
+          },
+        ],
+      },
+    });
+
+    registerHooks({
+      silent: true,
+      settingsPath,
+      port: SERVER_PORTS[0],
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    assert.deepStrictEqual(getHttpUrls(settings, "PermissionRequest"), [
+      "http://127.0.0.1:8080/permission",
+      "http://localhost:8080/permission",
+      clawdUrl,
+    ]);
+  });
+
+  it("updates stale Clawd PermissionRequest URLs on managed fallback ports", () => {
+    const expectedUrl = buildPermissionUrl(SERVER_PORTS[0]);
+    const staleUrl = buildPermissionUrl(SERVER_PORTS[SERVER_PORTS.length - 1]);
+    const settingsPath = makeTempSettings({
+      hooks: {
+        PermissionRequest: [
+          {
+            matcher: "",
+            hooks: [{ type: "http", url: staleUrl, timeout: 600 }],
+          },
+        ],
+      },
+    });
+
+    const result = registerHooks({
+      silent: true,
+      settingsPath,
+      port: SERVER_PORTS[0],
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    assert.ok(result.updated >= 1);
+    assert.deepStrictEqual(getHttpUrls(settings, "PermissionRequest"), [expectedUrl]);
+  });
+});
+
 describe("Hook installer deprecated hook cleanup", () => {
   it("does not register WorktreeCreate on fresh install (issue #127)", () => {
     const settingsPath = makeTempSettings({});
@@ -1105,6 +1185,10 @@ describe("Hook installer unregisterHooks", () => {
             matcher: "",
             hooks: [{ type: "http", url: "http://localhost:8080/permission", timeout: 100 }],
           },
+          {
+            matcher: "",
+            hooks: [{ type: "http", url: "http://127.0.0.1:8080/permission", timeout: 100 }],
+          },
         ],
       },
     });
@@ -1119,7 +1203,10 @@ describe("Hook installer unregisterHooks", () => {
       settings.hooks.SessionStart[0].hooks[0].command,
       'node "/tmp/third-party.js" SessionStart'
     );
-    assert.deepStrictEqual(getHttpUrls(settings, "PermissionRequest"), ["http://localhost:8080/permission"]);
+    assert.deepStrictEqual(getHttpUrls(settings, "PermissionRequest"), [
+      "http://localhost:8080/permission",
+      "http://127.0.0.1:8080/permission",
+    ]);
     assert.ok(!Object.prototype.hasOwnProperty.call(settings.hooks, "Stop"));
   });
 
@@ -1131,6 +1218,10 @@ describe("Hook installer unregisterHooks", () => {
             matcher: "",
             hooks: [{ type: "http", url: "http://localhost:8080/permission", timeout: 600 }],
           },
+          {
+            matcher: "",
+            hooks: [{ type: "http", url: "http://127.0.0.1:8080/permission", timeout: 600 }],
+          },
         ],
       },
     });
@@ -1139,7 +1230,10 @@ describe("Hook installer unregisterHooks", () => {
     const settings = readSettings(settingsPath);
 
     assert.deepStrictEqual(result, { removed: 0, changed: false });
-    assert.deepStrictEqual(getHttpUrls(settings, "PermissionRequest"), ["http://localhost:8080/permission"]);
+    assert.deepStrictEqual(getHttpUrls(settings, "PermissionRequest"), [
+      "http://localhost:8080/permission",
+      "http://127.0.0.1:8080/permission",
+    ]);
   });
 
   it("recognizes stale Clawd PermissionRequest URLs on any managed port", () => {

--- a/test/windows-uninstall-cleanup.test.js
+++ b/test/windows-uninstall-cleanup.test.js
@@ -1,0 +1,329 @@
+const assert = require("node:assert");
+const { describe, it } = require("node:test");
+const childProcess = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const pkg = require("../package.json");
+const { SERVER_PORTS } = require("../hooks/server-config");
+
+const ROOT = path.join(__dirname, "..");
+const NSIS_INCLUDE = path.join(ROOT, "build", "installer.nsh");
+const CLEANUP_SCRIPT = path.join(ROOT, "build", "uninstall-claude-hooks.ps1");
+
+function readText(filePath) {
+  return fs.readFileSync(filePath, "utf8");
+}
+
+function writeUtf8Bom(filePath, text) {
+  fs.writeFileSync(filePath, Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from(text, "utf8"),
+  ]));
+}
+
+function writeUtf16LeBom(filePath, text) {
+  fs.writeFileSync(filePath, Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    Buffer.from(text, "utf16le"),
+  ]));
+}
+
+function makeFixture(settingsText, options = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-uninstall-"));
+  const home = path.join(root, "User With Space 中文");
+  const claudeDir = path.join(home, ".claude");
+  const installDir = path.join(root, "Clawd Install Dir");
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.mkdirSync(installDir, { recursive: true });
+
+  const markerPath = path.join(installDir, ".clawd-install-user-home");
+  if (options.markerEncoding === "utf16le-bom") {
+    writeUtf16LeBom(markerPath, home);
+  } else {
+    fs.writeFileSync(markerPath, home, "utf8");
+  }
+
+  const settingsPath = path.join(claudeDir, "settings.json");
+  if (settingsText !== undefined) {
+    if (options.settingsEncoding === "utf8-bom") {
+      writeUtf8Bom(settingsPath, settingsText);
+    } else {
+      fs.writeFileSync(settingsPath, settingsText, "utf8");
+    }
+  }
+
+  return {
+    root,
+    home,
+    claudeDir,
+    installDir,
+    settingsPath,
+    cleanup() {
+      fs.rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function runCleanup(fixture) {
+  const result = childProcess.spawnSync("powershell.exe", [
+    "-NoProfile",
+    "-NonInteractive",
+    "-ExecutionPolicy",
+    "Bypass",
+    "-File",
+    CLEANUP_SCRIPT,
+    "-InstallDir",
+    fixture.installDir,
+  ], { encoding: "utf8" });
+
+  assert.strictEqual(
+    result.status,
+    0,
+    `cleanup failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+  );
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function assertNoUtf8Bom(filePath) {
+  const buffer = fs.readFileSync(filePath);
+  assert.notDeepStrictEqual(
+    Array.from(buffer.subarray(0, 3)),
+    [0xef, 0xbb, 0xbf],
+    `${filePath} should be UTF-8 without BOM`
+  );
+}
+
+describe("Windows NSIS Claude hook uninstall cleanup", () => {
+  it("wires the NSIS include and cleanup script into package config", () => {
+    assert.strictEqual(pkg.build.nsis && pkg.build.nsis.include, "build/installer.nsh");
+    assert.ok(fs.existsSync(NSIS_INCLUDE), "build/installer.nsh should exist");
+    assert.ok(fs.existsSync(CLEANUP_SCRIPT), "build/uninstall-claude-hooks.ps1 should exist");
+
+    const nsis = readText(NSIS_INCLUDE);
+    assert.match(nsis, /!macro customInstall/);
+    assert.match(nsis, /!macro customUnInstall/);
+    assert.match(nsis, /File "\/oname=\$INSTDIR\\uninstall-claude-hooks\.ps1"/);
+    assert.match(nsis, /FileWrite \$0 "\$PROFILE"/);
+    assert.match(nsis, /nsExec::ExecToLog 'powershell\.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "\$INSTDIR\\uninstall-claude-hooks\.ps1" -InstallDir "\$INSTDIR"'/);
+  });
+
+  it("keeps the PowerShell permission port list in sync with SERVER_PORTS", () => {
+    const script = readText(CLEANUP_SCRIPT);
+    const match = script.match(/\$ClawdPermissionPorts\s*=\s*@\(([^)]*)\)/);
+    assert.ok(match, "PowerShell script should use an explicit @(...) permission port literal");
+
+    const ports = match[1]
+      .split(",")
+      .map((value) => Number(value.trim()))
+      .filter((value) => Number.isInteger(value));
+
+    assert.deepStrictEqual(ports, SERVER_PORTS);
+    assert.strictEqual(ports.length, SERVER_PORTS.length);
+  });
+
+  it("contains PowerShell 5.1 JSON hardening requirements", () => {
+    const script = readText(CLEANUP_SCRIPT);
+    assert.match(script, /New-Object System\.Text\.UTF8Encoding -ArgumentList \$false/);
+    assert.match(script, /\.TrimStart\(\[char\]0xFEFF\)\.Trim\(\)/);
+    assert.match(script, /\$rawSettings = \$rawSettings\.TrimStart\(\[char\]0xFEFF\)/);
+    assert.match(script, /\[System\.IO\.File\]::ReadAllText\(\$settingsPath, \$Utf8NoBom\)/);
+    assert.match(script, /\[System\.IO\.File\]::WriteAllText\(\$settingsPath, \$json \+ \[Environment\]::NewLine, \$Utf8NoBom\)/);
+    assert.match(script, /ConvertTo-Json -InputObject \$settings -Depth 100/);
+    assert.match(script, /\.PSObject\.Properties/);
+    assert.match(script, /\[object\[\]\]\$nextEntries\.ToArray\(\)/);
+  });
+
+  it("removes only Clawd hooks while preserving third-party hooks and array shape", {
+    skip: process.platform !== "win32" ? "requires Windows PowerShell" : false,
+  }, () => {
+    const fixture = makeFixture(JSON.stringify({
+      metadata: { note: "non-ascii 中文 path" },
+      hooks: {
+        SessionStart: [
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: '& "node" "C:\\Clawd\\hooks\\auto-start.js"' }],
+          },
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: 'node "C:\\third-party.js" SessionStart' }],
+          },
+        ],
+        Stop: [
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: '& "node" "C:\\Clawd\\hooks\\clawd-hook.js" Stop' }],
+          },
+        ],
+        PreToolUse: [
+          {
+            matcher: "",
+            hooks: [
+              { type: "command", command: 'node "C:\\third-party.js" PreToolUse' },
+              { type: "command", command: '& "node" "C:\\Clawd\\hooks\\clawd-hook.js" PreToolUse' },
+            ],
+          },
+        ],
+        PermissionRequest: [
+          {
+            matcher: "",
+            hooks: [
+              { type: "http", url: "http://127.0.0.1:23337/permission", timeout: 600 },
+              { type: "http", url: "http://127.0.0.1:8080/permission", timeout: 100 },
+            ],
+          },
+          {
+            type: "http",
+            url: "http://localhost:8080/permission",
+            timeout: 100,
+          },
+        ],
+      },
+    }, null, 2));
+
+    try {
+      runCleanup(fixture);
+      const settings = readJson(fixture.settingsPath);
+
+      assert.strictEqual(settings.metadata.note, "non-ascii 中文 path");
+      assert.ok(!Object.prototype.hasOwnProperty.call(settings.hooks, "Stop"));
+      assert.ok(Array.isArray(settings.hooks.SessionStart));
+      assert.strictEqual(settings.hooks.SessionStart.length, 1);
+      assert.ok(Array.isArray(settings.hooks.SessionStart[0].hooks));
+      assert.strictEqual(settings.hooks.SessionStart[0].hooks.length, 1);
+      assert.strictEqual(settings.hooks.SessionStart[0].hooks[0].command, 'node "C:\\third-party.js" SessionStart');
+
+      assert.ok(Array.isArray(settings.hooks.PreToolUse));
+      assert.strictEqual(settings.hooks.PreToolUse.length, 1);
+      assert.ok(Array.isArray(settings.hooks.PreToolUse[0].hooks));
+      assert.strictEqual(settings.hooks.PreToolUse[0].hooks.length, 1);
+      assert.strictEqual(settings.hooks.PreToolUse[0].hooks[0].command, 'node "C:\\third-party.js" PreToolUse');
+
+      assert.ok(Array.isArray(settings.hooks.PermissionRequest));
+      assert.strictEqual(settings.hooks.PermissionRequest.length, 2);
+      assert.deepStrictEqual(
+        settings.hooks.PermissionRequest[0].hooks.map((hook) => hook.url),
+        ["http://127.0.0.1:8080/permission"]
+      );
+      assert.strictEqual(settings.hooks.PermissionRequest[1].url, "http://localhost:8080/permission");
+
+      const backups = fs.readdirSync(fixture.claudeDir).filter((name) => /^settings\.json\.clawd-uninstall-.*\.bak$/.test(name));
+      assert.strictEqual(backups.length, 1);
+      assertNoUtf8Bom(fixture.settingsPath);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("reads an NSIS-style UTF-16LE BOM user-home marker", {
+    skip: process.platform !== "win32" ? "requires Windows PowerShell" : false,
+  }, () => {
+    const fixture = makeFixture(JSON.stringify({
+      hooks: {
+        Stop: [
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: '& "node" "C:\\Clawd\\hooks\\clawd-hook.js" Stop' }],
+          },
+        ],
+      },
+    }, null, 2), { markerEncoding: "utf16le-bom" });
+
+    try {
+      runCleanup(fixture);
+      const settings = readJson(fixture.settingsPath);
+      assert.deepStrictEqual(settings.hooks, {});
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("cleans a UTF-8 BOM settings.json and rewrites it without BOM", {
+    skip: process.platform !== "win32" ? "requires Windows PowerShell" : false,
+  }, () => {
+    const fixture = makeFixture(JSON.stringify({
+      hooks: {
+        PermissionRequest: [
+          {
+            matcher: "",
+            hooks: [
+              { type: "http", url: "http://127.0.0.1:23333/permission", timeout: 600 },
+              { type: "http", url: "http://127.0.0.1:8080/permission", timeout: 100 },
+            ],
+          },
+        ],
+      },
+    }, null, 2), { settingsEncoding: "utf8-bom" });
+
+    try {
+      runCleanup(fixture);
+      const settings = readJson(fixture.settingsPath);
+      assert.deepStrictEqual(
+        settings.hooks.PermissionRequest[0].hooks.map((hook) => hook.url),
+        ["http://127.0.0.1:8080/permission"]
+      );
+      assertNoUtf8Bom(fixture.settingsPath);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("keeps command marker matching case-sensitive to match JS cleanup semantics", {
+    skip: process.platform !== "win32" ? "requires Windows PowerShell" : false,
+  }, () => {
+    const fixture = makeFixture(JSON.stringify({
+      hooks: {
+        Stop: [
+          {
+            matcher: "",
+            hooks: [{ type: "command", command: '& "node" "C:\\User\\Clawd-Hook.js" Stop' }],
+          },
+        ],
+      },
+    }, null, 2));
+
+    try {
+      runCleanup(fixture);
+      const settings = readJson(fixture.settingsPath);
+      assert.strictEqual(settings.hooks.Stop[0].hooks[0].command, '& "node" "C:\\User\\Clawd-Hook.js" Stop');
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("leaves malformed settings untouched", {
+    skip: process.platform !== "win32" ? "requires Windows PowerShell" : false,
+  }, () => {
+    const malformed = "{ not valid json\n";
+    const fixture = makeFixture(malformed);
+
+    try {
+      runCleanup(fixture);
+      assert.strictEqual(fs.readFileSync(fixture.settingsPath, "utf8"), malformed);
+      const backups = fs.readdirSync(fixture.claudeDir).filter((name) => name.includes("clawd-uninstall"));
+      assert.deepStrictEqual(backups, []);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("treats missing settings.json as a silent no-op", {
+    skip: process.platform !== "win32" ? "requires Windows PowerShell" : false,
+  }, () => {
+    const fixture = makeFixture(undefined);
+
+    try {
+      runCleanup(fixture);
+      assert.strictEqual(fs.existsSync(fixture.settingsPath), false);
+      const files = fs.readdirSync(fixture.claudeDir);
+      assert.deepStrictEqual(files, []);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add an NSIS uninstall hook that runs a PowerShell cleanup script before deleting Clawd files
- remove Clawd-owned Claude Code hooks from ~/.claude/settings.json while preserving third-party hooks
- tighten PermissionRequest ownership to 127.0.0.1 ports from SERVER_PORTS and add Windows PowerShell regression coverage
- run npm test in the Windows release build job before packaging

## Verification
- node --test test/windows-uninstall-cleanup.test.js
- node --test test/install.test.js test/windows-uninstall-cleanup.test.js test/package-build-config.test.js
- npm test
- built local x64 NSIS installer: dist/Clawd-on-Desk-Setup-0.7.1-x64.exe
- manual admin install/run/uninstall passed: Clawd hooks removed from C:\\Users\\Ruller\\.claude\\settings.json, third-party Claude hooks preserved, Program Files install dir removed