### PR TITLE
fix: clip mini-mode pet at multi-monitor display seams

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -7,8 +7,10 @@
   <title>Clawd</title>
 </head>
 <body>
-  <div id="pet-container">
-    <object id="clawd" type="image/svg+xml"></object>
+  <div id="pet-clip">
+    <div id="pet-container">
+      <object id="clawd" type="image/svg+xml"></object>
+    </div>
   </div>
   <script src="renderer.js"></script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -481,6 +481,7 @@ const petWindowRuntime = createPetWindowRuntime({
   getCurrentHitBox: () => _state.getCurrentHitBox(),
   getMiniMode: () => _mini.getMiniMode(),
   getMiniTransitioning: () => _mini.getMiniTransitioning(),
+  getMiniContainedSeam: () => _mini.getContainedSeam(),
   getMiniPeekOffset: () => _mini.PEEK_OFFSET,
   getCurrentPixelSize: () => getCurrentPixelSize(),
   getEffectiveCurrentPixelSize: (workArea) => getEffectiveCurrentPixelSize(workArea),
@@ -627,6 +628,10 @@ function syncRendererStateAfterLoad({ includeStartupRecovery = true } = {}) {
   sendToRenderer("low-power-idle-mode-change", lowPowerIdleMode);
   if (_mini.getMiniMode()) {
     sendToRenderer("mini-mode-change", true, _mini.getMiniEdge());
+    // mini-clip is a renderer inline style — a renderer/theme reload (and
+    // startup recovery) drops it. Re-send the current seam clip so a
+    // contained mini stays clipped instead of bleeding onto the neighbour.
+    _mini.syncContainedClip();
   }
   if (doNotDisturb) {
     sendToRenderer("dnd-change", true);

--- a/src/mini.js
+++ b/src/mini.js
@@ -192,6 +192,11 @@ function seamBoundary(wa, yMid, edge) {
 let containedBoundary = null;
 
 function syncContainedClip() {
+  // Startup recovery computes the seam state before the render window
+  // exists; theme/renderer reload can also tear the window down briefly.
+  // Bail out rather than dereference a missing window — the clip is
+  // (re)sent from syncRendererStateAfterLoad() once the renderer is up.
+  if (!ctx.win || ctx.win.isDestroyed()) return;
   if (!miniMode || containedBoundary == null) {
     ctx.sendToRenderer("mini-clip", null);
     return;
@@ -491,6 +496,14 @@ function refreshContainedBoundary(wa, yMid) {
   containedBoundary = seamBoundary(wa, yMid, miniEdge);
 }
 
+// Internal-seam state for the hit (input) window. When non-null the hit
+// rect must be clipped to the same seam so the transparent input surface
+// does not keep capturing clicks over the neighbouring display.
+function getContainedSeam() {
+  if (containedBoundary == null) return null;
+  return { boundary: containedBoundary, edge: miniEdge };
+}
+
 function handleDisplayChange() {
   if (!ctx.win || ctx.win.isDestroyed()) return;
   if (!miniMode) return;
@@ -541,8 +554,10 @@ function restoreFromPrefs(prefs, size) {
   miniTransitioning = false;
   miniSleepPeeked = false;
   miniPeeked = false;
+  // Compute the seam state only — the render window does not exist yet at
+  // startup restore. The renderer clip is (re)sent by
+  // syncRendererStateAfterLoad() once the renderer has finished loading.
   refreshContainedBoundary(wa, startY + size.height / 2);
-  syncContainedClip();
   return { x: currentMiniX, y: startY, width: size.width, height: size.height };
 }
 
@@ -569,6 +584,7 @@ return {
   miniPeekIn, miniPeekOut, checkMiniModeSnap, cancelMiniTransition,
   animateWindowX, animateWindowParabola,
   refreshTheme,
+  syncContainedClip, getContainedSeam,
   handleDisplayChange, handleResize, restoreFromPrefs,
   getMiniMode, getMiniEdge, getMiniTransitioning, getMiniSleepPeeked, setMiniSleepPeeked, getMiniPeeked, setMiniPeeked,
   getIsAnimating, getPreMiniX, getPreMiniY, getCurrentMiniX, getMiniSnap,

--- a/src/mini.js
+++ b/src/mini.js
@@ -90,6 +90,7 @@ function animateWindowX(targetX, durationMs, onDone) {
     }
     ctx.syncHitWin();
     repositionSessionHud();
+    syncContainedClip();
     // Throttle bubble reposition to every 3rd frame (~20fps) — visually identical, less overhead
     if (ctx.bubbleFollowPet && ctx.pendingPermissions.length && (++frameCount % 3 === 0 || t >= 1)) ctx.repositionBubbles();
     if (t < 1) {
@@ -143,6 +144,7 @@ function animateWindowParabola(targetX, targetY, durationMs, onDone) {
     }
     ctx.syncHitWin();
     repositionSessionHud();
+    syncContainedClip();
     // Throttle bubble reposition to every 3rd frame (~20fps) — visually identical, less overhead
     if (ctx.bubbleFollowPet && ctx.pendingPermissions.length && (++frameCount % 3 === 0 || t >= 1)) ctx.repositionBubbles();
     if (t < 1) {
@@ -154,6 +156,53 @@ function animateWindowParabola(targetX, targetY, durationMs, onDone) {
     }
   };
   step();
+}
+
+// When the mini pet at `wa`/`yMid` sits at an internal seam in `edge`
+// direction, returns the seam X — the local display's *bounds* edge, which
+// is the physical boundary the neighbouring monitor begins at (and the same
+// place a single-display mini gets physically cut off by the screen edge).
+// Returns null at an outer screen edge (single display, or no neighbour at
+// the pet's vertical band). The 4px tolerance absorbs OS-side rounding.
+function seamBoundary(wa, yMid, edge) {
+  const displays = screen.getAllDisplays();
+  const cx = wa.x + wa.width / 2;
+  const cy = wa.y + wa.height / 2;
+  const local = displays.find((d) =>
+    cx >= d.workArea.x && cx <= d.workArea.x + d.workArea.width &&
+    cy >= d.workArea.y && cy <= d.workArea.y + d.workArea.height);
+  const lb = local ? local.bounds : wa;
+  const seam = edge === "right" ? lb.x + lb.width : lb.x;
+  const overlapsY = (d) => {
+    if (!Number.isFinite(yMid)) return false;
+    return yMid >= d.bounds.y && yMid <= d.bounds.y + d.bounds.height;
+  };
+  const hasNeighbour = displays.some((d) => {
+    if (d === local || !overlapsY(d)) return false;
+    const dEdge = edge === "right" ? d.bounds.x : d.bounds.x + d.bounds.width;
+    return Math.abs(dEdge - seam) <= 4;
+  });
+  return hasNeighbour ? seam : null;
+}
+
+// Multi-monitor seam state: when the mini pet sits at an internal seam, the
+// half that pokes past `containedBoundary` (the display 1 edge in screen X)
+// gets clip-pathed away in the renderer so it doesn't show on the neighbour.
+// `null` outside contained mini.
+let containedBoundary = null;
+
+function syncContainedClip() {
+  if (!miniMode || containedBoundary == null) {
+    ctx.sendToRenderer("mini-clip", null);
+    return;
+  }
+  const bounds = ctx.win.getBounds();
+  if (!bounds.width) return;
+  const fraction = (containedBoundary - bounds.x) / bounds.width;
+  ctx.sendToRenderer("mini-clip", {
+    fraction: Math.max(0, Math.min(1, fraction)),
+    edge: miniEdge,
+  });
 }
 
 // Shared X-position formula for mini mode (eliminates duplication across 4+ call sites)
@@ -264,6 +313,12 @@ function enterMiniMode(wa, viaMenu, edge) {
   lastMiniWorkArea = wa;
   miniSnap = { y: bounds.y, width: size.width, height: size.height };
 
+  // Multi-monitor seam detection — when active, the renderer clips the half
+  // of the window that crosses the seam so the neighbouring display stays
+  // clean while the local display still shows the natural half-body peek.
+  containedBoundary = seamBoundary(wa, bounds.y + size.height / 2, miniEdge);
+  syncContainedClip();
+
   ctx.stopWakePoll();
 
   ctx.sendToRenderer("mini-mode-change", true, miniEdge);
@@ -276,16 +331,23 @@ function enterMiniMode(wa, viaMenu, edge) {
   const enterSvgState = ctx.doNotDisturb ? "mini-enter-sleep" : "mini-enter";
 
   if (viaMenu) {
-    const displays = screen.getAllDisplays();
+    const adjacent = containedBoundary != null;
     let jumpTarget;
-    if (miniEdge === "right") {
-      let maxRight = 0;
-      for (const d of displays) maxRight = Math.max(maxRight, d.bounds.x + d.bounds.width);
-      jumpTarget = maxRight;
+    if (adjacent) {
+      // Internal seam: skip fly-off-screen; arc lands at the contained mini X
+      // so the parabola never crosses onto the neighbouring display.
+      jumpTarget = currentMiniX;
     } else {
-      let minLeft = Infinity;
-      for (const d of displays) minLeft = Math.min(minLeft, d.bounds.x);
-      jumpTarget = minLeft - size.width;
+      const displays = screen.getAllDisplays();
+      if (miniEdge === "right") {
+        let maxRight = 0;
+        for (const d of displays) maxRight = Math.max(maxRight, d.bounds.x + d.bounds.width);
+        jumpTarget = maxRight;
+      } else {
+        let minLeft = Infinity;
+        for (const d of displays) minLeft = Math.min(minLeft, d.bounds.x);
+        jumpTarget = minLeft - size.width;
+      }
     }
     animateWindowParabola(jumpTarget, bounds.y, JUMP_DURATION, () => {
       const enterDurationMs = getMiniEnterDurationMs(enterSvgState);
@@ -295,6 +357,7 @@ function enterMiniMode(wa, viaMenu, edge) {
         ctx.win.setBounds({ x: currentMiniX, y: miniSnap.y, width: miniSnap.width, height: miniSnap.height });
         ctx.syncHitWin();
         syncSessionHudVisibility();
+        syncContainedClip();
         finishMiniEntry(enterDurationMs);
         return;
       }
@@ -304,6 +367,7 @@ function enterMiniMode(wa, viaMenu, edge) {
         miniTransitionTimer = null;
         ctx.syncHitWin();
         syncSessionHudVisibility();
+        syncContainedClip();
         finishMiniEntry(enterDurationMs);
       }, MINI_ENTER_PRELOAD_MS);
     });
@@ -355,6 +419,8 @@ function exitMiniMode() {
   animateWindowParabola(clamped.x, clamped.y, JUMP_DURATION, () => {
     miniMode = false;
     miniTransitioning = false;
+    containedBoundary = null;
+    ctx.sendToRenderer("mini-clip", null);
     ctx.sendToRenderer("mini-mode-change", false);
     ctx.sendToHitWin("hit-state-sync", { miniMode: false });
     ctx.buildContextMenu();
@@ -403,11 +469,14 @@ function enterMiniViaMenu() {
 
   ctx.applyState("mini-crabwalk");
 
+  const adjacent = seamBoundary(wa, bounds.y + size.height / 2, edge) != null;
   let edgeX;
   if (edge === "right") {
-    edgeX = wa.x + wa.width - size.width + Math.round(size.width * 0.25);
+    edgeX = adjacent
+      ? wa.x + wa.width - size.width
+      : wa.x + wa.width - size.width + Math.round(size.width * 0.25);
   } else {
-    edgeX = wa.x - Math.round(size.width * 0.25);
+    edgeX = adjacent ? wa.x : wa.x - Math.round(size.width * 0.25);
   }
   const walkDist = Math.abs(bounds.x - edgeX);
   const walkDuration = walkDist / CRABWALK_SPEED;
@@ -416,6 +485,10 @@ function enterMiniViaMenu() {
   miniTransitionTimer = setTimeout(() => {
     enterMiniMode(wa, true, edge);
   }, walkDuration + 50);
+}
+
+function refreshContainedBoundary(wa, yMid) {
+  containedBoundary = seamBoundary(wa, yMid, miniEdge);
 }
 
 function handleDisplayChange() {
@@ -432,6 +505,8 @@ function handleDisplayChange() {
   const clampedY = Math.max(wa.y, Math.min(snapY, wa.y + wa.height - size.height));
   miniSnap = { y: clampedY, width: size.width, height: size.height };
   ctx.win.setBounds({ x: currentMiniX, y: clampedY, width: size.width, height: size.height });
+  refreshContainedBoundary(wa, clampedY + size.height / 2);
+  syncContainedClip();
   syncSessionHudVisibility();
 }
 
@@ -446,6 +521,8 @@ function handleResize(sizeKey) {
   const clampedY = Math.max(wa.y, Math.min(curY, wa.y + wa.height - size.height));
   miniSnap = { y: clampedY, width: size.width, height: size.height };
   ctx.win.setBounds({ x: currentMiniX, y: clampedY, width: size.width, height: size.height });
+  refreshContainedBoundary(wa, clampedY + size.height / 2);
+  syncContainedClip();
   syncSessionHudVisibility();
   return true;
 }
@@ -464,6 +541,8 @@ function restoreFromPrefs(prefs, size) {
   miniTransitioning = false;
   miniSleepPeeked = false;
   miniPeeked = false;
+  refreshContainedBoundary(wa, startY + size.height / 2);
+  syncContainedClip();
   return { x: currentMiniX, y: startY, width: size.width, height: size.height };
 }
 

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -46,6 +46,7 @@ function createPetWindowRuntime(options = {}) {
   const getCurrentHitBox = options.getCurrentHitBox || (() => null);
   const getMiniMode = options.getMiniMode || (() => false);
   const getMiniTransitioning = options.getMiniTransitioning || (() => false);
+  const getMiniContainedSeam = options.getMiniContainedSeam || (() => null);
   const getMiniPeekOffset = options.getMiniPeekOffset || (() => 0);
   const getCurrentPixelSize = options.getCurrentPixelSize || (() => null);
   const getEffectiveCurrentPixelSize = options.getEffectiveCurrentPixelSize || getCurrentPixelSize;
@@ -341,6 +342,24 @@ function createPetWindowRuntime(options = {}) {
     return needsFinalClampAdjustmentRaw(bounds, size, clampPosition);
   }
 
+  // At an internal multi-monitor seam the render window is clip-pathed so its
+  // seam-crossing half shows nothing — but the hit (input) window is a
+  // transparent surface and would keep capturing clicks over the neighbouring
+  // display. Clip the hit rect to the same seam so those clicks fall through.
+  // The clamps keep the rect from inverting when the whole hit rect is past
+  // the seam; the w<=0 guard in the callers then drops the degenerate result.
+  function clipHitRectToMiniSeam(hit) {
+    if (!hit) return hit;
+    const seam = getMiniContainedSeam();
+    if (!seam || !Number.isFinite(seam.boundary)) return hit;
+    if (seam.edge === "right") {
+      if (hit.right <= seam.boundary) return hit;
+      return { ...hit, right: Math.max(hit.left, seam.boundary) };
+    }
+    if (hit.left >= seam.boundary) return hit;
+    return { ...hit, left: Math.min(hit.right, seam.boundary) };
+  }
+
   function syncHitWin() {
     const hitWin = getHitWindow();
     const win = getRenderWindow();
@@ -349,7 +368,7 @@ function createPetWindowRuntime(options = {}) {
     // window mid-drag can break pointer capture on Windows.
     if (dragLocked) return;
     const bounds = getPetWindowBounds();
-    const hit = getHitRectScreen(bounds);
+    const hit = clipHitRectToMiniSeam(getHitRectScreen(bounds));
     if (!hit) return;
     const x = Math.round(hit.left);
     const y = Math.round(hit.top);
@@ -367,7 +386,7 @@ function createPetWindowRuntime(options = {}) {
   }
 
   function getInitialHitWindowBounds(renderBounds = getPetWindowBounds()) {
-    const hit = getHitRectScreen(renderBounds);
+    const hit = clipHitRectToMiniSeam(getHitRectScreen(renderBounds));
     if (!hit) return null;
     return {
       x: Math.round(hit.left),

--- a/src/preload.js
+++ b/src/preload.js
@@ -18,6 +18,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onWakeFromDoze: (callback) => ipcRenderer.on("wake-from-doze", () => callback()),
   onDndChange: (callback) => ipcRenderer.on("dnd-change", (_, enabled) => callback(enabled)),
   onMiniModeChange: (cb) => ipcRenderer.on("mini-mode-change", (_, enabled, edge, options) => cb(enabled, edge, options)),
+  onMiniClip: (cb) => ipcRenderer.on("mini-clip", (_, info) => cb(info)),
   onLowPowerIdleModeChange: (cb) => ipcRenderer.on("low-power-idle-mode-change", (_, enabled) => cb(enabled)),
   // Reaction control (from main, relayed from hit window)
   onStartDragReaction: (cb) => ipcRenderer.on("start-drag-reaction", () => cb()),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,6 +3,7 @@
 // Reactions are triggered via IPC from main (relayed from hit window).
 
 const container = document.getElementById("pet-container");
+const clipLayer = document.getElementById("pet-clip");
 let clawdEl = document.getElementById("clawd");
 let pendingNext = null;
 const LOW_POWER_IDLE_PAUSE_MS = 5000;
@@ -440,19 +441,24 @@ window.electronAPI.onMiniModeChange((enabled, edge, options) => {
 // fraction of the window width that falls on the local display. We clip the
 // rest away so the half that physically crosses onto the neighbouring
 // monitor renders nothing there — the local display keeps the half-body peek.
+//
+// The clip is applied to #pet-clip, which (unlike #pet-container) never
+// carries transform: scaleX(-1). A clip-path on the flipped container would
+// be mirrored too, so a left-edge clip would land on the wrong half; the
+// unflipped wrapper keeps `inset()` in screen space for both edges.
 function applyMiniClip(info) {
-  if (!container) return;
+  if (!clipLayer) return;
   if (!info || !Number.isFinite(info.fraction)) {
-    container.style.clipPath = "";
+    clipLayer.style.clipPath = "";
     return;
   }
   const f = Math.max(0, Math.min(1, info.fraction));
   if (info.edge === "left") {
     // Local display lies to the RIGHT of the seam — keep [f, 1], clip the left.
-    container.style.clipPath = `inset(0 0 0 ${f * 100}%)`;
+    clipLayer.style.clipPath = `inset(0 0 0 ${f * 100}%)`;
   } else {
     // Local display lies to the LEFT of the seam — keep [0, f], clip the right.
-    container.style.clipPath = `inset(0 ${(1 - f) * 100}% 0 0)`;
+    clipLayer.style.clipPath = `inset(0 ${(1 - f) * 100}% 0 0)`;
   }
 }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -430,10 +430,35 @@ window.electronAPI.onMiniModeChange((enabled, edge, options) => {
   } else {
     removeGlyphFlipCompensation(clawdEl);
   }
+  if (!enabled) applyMiniClip(null);
   if (shouldUseCloudlingPointerBridge(currentState, currentDisplayedSvg) && lastCloudlingPointerPayload) {
     applyCloudlingPointerBridge(lastCloudlingPointerPayload);
   }
 });
+
+// Multi-monitor seam clip: in mini mode at an internal seam, main sends the
+// fraction of the window width that falls on the local display. We clip the
+// rest away so the half that physically crosses onto the neighbouring
+// monitor renders nothing there — the local display keeps the half-body peek.
+function applyMiniClip(info) {
+  if (!container) return;
+  if (!info || !Number.isFinite(info.fraction)) {
+    container.style.clipPath = "";
+    return;
+  }
+  const f = Math.max(0, Math.min(1, info.fraction));
+  if (info.edge === "left") {
+    // Local display lies to the RIGHT of the seam — keep [f, 1], clip the left.
+    container.style.clipPath = `inset(0 0 0 ${f * 100}%)`;
+  } else {
+    // Local display lies to the LEFT of the seam — keep [0, f], clip the right.
+    container.style.clipPath = `inset(0 ${(1 - f) * 100}% 0 0)`;
+  }
+}
+
+if (window.electronAPI && typeof window.electronAPI.onMiniClip === "function") {
+  window.electronAPI.onMiniClip(applyMiniClip);
+}
 
 // Counter-flip asymmetric pixel-art glyphs (Zzz) inside SVG defs so they
 // render correctly when the container has scaleX(-1). Only the glyph shape

--- a/src/styles.css
+++ b/src/styles.css
@@ -14,6 +14,15 @@ html, body {
   background: transparent;
 }
 
+/* Seam clip layer — wraps #pet-container so the multi-monitor seam
+   clip-path is applied in screen space. #pet-container itself carries
+   transform: scaleX(-1) in left-edge mini mode, which would mirror a
+   clip-path applied directly to it; this outer layer is never flipped. */
+#pet-clip {
+  width: 100%;
+  height: 100%;
+}
+
 #pet-container {
   width: 100%;
   height: 100%;

--- a/test/mini.test.js
+++ b/test/mini.test.js
@@ -346,4 +346,127 @@ describe("mini mode multi-monitor seam clip", () => {
     assert.equal(miniClips(rendererEvents).at(-1), null, "clip cleared on exit");
     assert.equal(mini.getMiniMode(), false);
   });
+
+  it("clips at a seam on a secondary display with negative coordinates", () => {
+    // D1 sits to the left of the origin: [-800,0). D2 is the primary [0,800).
+    loader = loadMiniWithElectron({
+      getAllDisplays() {
+        return [
+          { bounds: { x: -800, y: 0, width: 800, height: 600 }, workArea: { x: -800, y: 0, width: 800, height: 600 } },
+          { bounds: { x: 0, y: 0, width: 800, height: 600 }, workArea: { x: 0, y: 0, width: 800, height: 600 } },
+        ];
+      },
+    });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 60);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    // Pet on D2, snapping to D2's left edge — an internal seam with D1 at x=0.
+    mini.enterMiniMode({ x: 0, y: 0, width: 800, height: 600 }, false, "left");
+    mock.timers.tick(120);
+
+    const last = miniClips(rendererEvents).at(-1);
+    assert.ok(last, "expected a non-null clip at the negative-coord seam");
+    assert.equal(last.edge, "left");
+    const expected = (0 - mini.getCurrentMiniX()) / 120;
+    assert.ok(Math.abs(last.fraction - expected) < 1e-9, `fraction ${last.fraction} ≈ ${expected}`);
+    assert.ok(last.fraction > 0 && last.fraction < 1, "clip keeps a partial window");
+  });
+
+  it("cuts the clip at the physical bounds edge, not the inset workArea", () => {
+    // D1's workArea is narrower/shorter than its bounds (docks/panels). The
+    // seam is the *physical* monitor boundary, so the clip must use bounds.
+    loader = loadMiniWithElectron({
+      getAllDisplays() {
+        return [
+          { bounds: { x: 0, y: 0, width: 800, height: 600 }, workArea: { x: 0, y: 0, width: 770, height: 560 } },
+          { bounds: { x: 800, y: 0, width: 800, height: 600 }, workArea: { x: 830, y: 0, width: 770, height: 560 } },
+        ];
+      },
+    });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 200);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    // Pet on D1, snapping to D1's right edge — seam with D2.
+    mini.enterMiniMode({ x: 0, y: 0, width: 770, height: 560 }, false, "right");
+    mock.timers.tick(120);
+
+    const last = miniClips(rendererEvents).at(-1);
+    assert.ok(last, "expected a non-null clip at the seam");
+    assert.equal(last.edge, "right");
+    // Seam is D1's bounds edge (x=800), not its workArea edge (x=770).
+    const atBounds = (800 - mini.getCurrentMiniX()) / 120;
+    const atWorkArea = (770 - mini.getCurrentMiniX()) / 120;
+    assert.ok(Math.abs(last.fraction - atBounds) < 1e-9, `fraction ${last.fraction} ≈ ${atBounds}`);
+    assert.ok(Math.abs(last.fraction - atWorkArea) > 1e-3, "must not cut at the workArea edge");
+  });
+
+  it("clips when a vertically offset neighbour still overlaps the pet's band", () => {
+    loader = loadMiniWithElectron({
+      getAllDisplays() {
+        return [
+          { bounds: { x: 0, y: 0, width: 800, height: 600 }, workArea: { x: 0, y: 0, width: 800, height: 600 } },
+          // D2 shifted down 150px — still overlaps D1's vertical band at yMid≈240.
+          { bounds: { x: 800, y: 150, width: 800, height: 600 }, workArea: { x: 800, y: 150, width: 800, height: 600 } },
+        ];
+      },
+    });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 600);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    mini.enterMiniMode({ x: 0, y: 0, width: 800, height: 600 }, false, "right");
+    mock.timers.tick(120);
+
+    const last = miniClips(rendererEvents).at(-1);
+    assert.ok(last, "vertically overlapping neighbour → clip");
+    assert.equal(last.edge, "right");
+    assert.ok(last.fraction > 0 && last.fraction < 1, "clip keeps a partial window");
+  });
+
+  it("restoreFromPrefs computes the seam without sending renderer IPC", () => {
+    loader = loadMiniWithElectron({ getAllDisplays() { return SIDE_BY_SIDE; } });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 600);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    // Startup recovery of a contained mini on D1's right edge.
+    const restored = mini.restoreFromPrefs(
+      { x: 700, y: 180, preMiniX: 200, preMiniY: 180, miniEdge: "right" },
+      { width: 120, height: 120 },
+    );
+    assert.equal(mini.getMiniMode(), true);
+    // restore must not touch the renderer — the render window may not exist yet.
+    assert.equal(miniClips(rendererEvents).length, 0, "restore sent no mini-clip IPC");
+    const seam = mini.getContainedSeam();
+    assert.ok(seam && seam.edge === "right", "seam state computed during restore");
+
+    // Once the renderer is up, syncContainedClip re-sends the current clip.
+    ctx.win.setBounds(restored);
+    mini.syncContainedClip();
+    const last = miniClips(rendererEvents).at(-1);
+    assert.ok(last && last.edge === "right", "syncContainedClip re-sends the clip");
+    assert.ok(last.fraction > 0 && last.fraction < 1, "re-sent clip keeps a partial window");
+  });
+
+  it("syncContainedClip is a no-op when the render window is absent", () => {
+    loader = loadMiniWithElectron({ getAllDisplays() { return SIDE_BY_SIDE; } });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 600);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    mini.enterMiniMode({ x: 0, y: 0, width: 800, height: 600 }, false, "right");
+    mock.timers.tick(120);
+    rendererEvents.length = 0;
+
+    ctx.win = null;
+    assert.doesNotThrow(() => mini.syncContainedClip());
+    assert.equal(rendererEvents.length, 0, "no IPC sent without a render window");
+  });
 });

--- a/test/mini.test.js
+++ b/test/mini.test.js
@@ -212,3 +212,138 @@ describe("mini mode entry timing", () => {
     assert.equal(mini.getMiniMode(), true);
   });
 });
+
+// Two displays tiled side by side: D1 [0,800) and D2 [800,1600), same height.
+const SIDE_BY_SIDE = [
+  { bounds: { x: 0, y: 0, width: 800, height: 600 }, workArea: { x: 0, y: 0, width: 800, height: 600 } },
+  { bounds: { x: 800, y: 0, width: 800, height: 600 }, workArea: { x: 800, y: 0, width: 800, height: 600 } },
+];
+
+function miniClips(rendererEvents) {
+  return rendererEvents.filter((e) => e[0] === "mini-clip").map((e) => e[1]);
+}
+
+describe("mini mode multi-monitor seam clip", () => {
+  let loader;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"] });
+  });
+
+  afterEach(() => {
+    if (loader) loader.restore();
+    mock.timers.reset();
+    loader = null;
+  });
+
+  it("does not clip on a single display", () => {
+    loader = loadMiniWithElectron({
+      getAllDisplays() {
+        return [{ bounds: { x: 0, y: 0, width: 800, height: 600 }, workArea: { x: 0, y: 0, width: 800, height: 600 } }];
+      },
+    });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 600);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    mini.enterMiniMode({ x: 0, y: 0, width: 800, height: 600 }, false, "right");
+    mock.timers.tick(120);
+
+    const clips = miniClips(rendererEvents);
+    assert.ok(clips.length > 0, "expected mini-clip events");
+    assert.ok(clips.every((c) => c === null), "single display must never clip");
+  });
+
+  it("clips the seam-crossing half at an internal monitor seam (right edge)", () => {
+    loader = loadMiniWithElectron({ getAllDisplays() { return SIDE_BY_SIDE; } });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 600);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    // Pet lives on D1, snaps to D1's right edge — an internal seam with D2.
+    mini.enterMiniMode({ x: 0, y: 0, width: 800, height: 600 }, false, "right");
+    mock.timers.tick(120);
+
+    const last = miniClips(rendererEvents).at(-1);
+    assert.ok(last, "expected a non-null clip at the seam");
+    assert.equal(last.edge, "right");
+    // The window straddles the seam (original peek X) and the clip cuts at
+    // D1's bounds edge (x=800): fraction is the visible part on D1.
+    const expected = (800 - mini.getCurrentMiniX()) / 120;
+    assert.ok(Math.abs(last.fraction - expected) < 1e-9, `fraction ${last.fraction} ≈ ${expected}`);
+    assert.ok(last.fraction > 0 && last.fraction < 1, "clip keeps a partial window");
+  });
+
+  it("does not clip at the outer edge of the virtual desktop", () => {
+    loader = loadMiniWithElectron({ getAllDisplays() { return SIDE_BY_SIDE; } });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 1400);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    // Pet on D2, snaps to D2's right edge — the outer edge, no neighbour.
+    mini.enterMiniMode({ x: 800, y: 0, width: 800, height: 600 }, false, "right");
+    mock.timers.tick(120);
+
+    const clips = miniClips(rendererEvents);
+    assert.ok(clips.every((c) => c === null), "outer edge must not clip");
+  });
+
+  it("clips the left half at a left-side seam", () => {
+    loader = loadMiniWithElectron({ getAllDisplays() { return SIDE_BY_SIDE; } });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 1000);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    // Pet on D2, snaps to D2's left edge — an internal seam with D1.
+    mini.enterMiniMode({ x: 800, y: 0, width: 800, height: 600 }, false, "left");
+    mock.timers.tick(120);
+
+    const last = miniClips(rendererEvents).at(-1);
+    assert.ok(last, "expected a non-null clip at the left seam");
+    assert.equal(last.edge, "left");
+    assert.ok(last.fraction > 0 && last.fraction < 1, "clip keeps a partial window");
+  });
+
+  it("does not clip when the neighbour does not overlap the pet's vertical band", () => {
+    loader = loadMiniWithElectron({
+      getAllDisplays() {
+        return [
+          { bounds: { x: 0, y: 0, width: 800, height: 600 }, workArea: { x: 0, y: 0, width: 800, height: 600 } },
+          // Neighbour starts below the pet (pet's yMid ≈ 240, this display starts at y=400).
+          { bounds: { x: 800, y: 400, width: 800, height: 600 }, workArea: { x: 800, y: 400, width: 800, height: 600 } },
+        ];
+      },
+    });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 600);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    mini.enterMiniMode({ x: 0, y: 0, width: 800, height: 600 }, false, "right");
+    mock.timers.tick(120);
+
+    const clips = miniClips(rendererEvents);
+    assert.ok(clips.every((c) => c === null), "no vertical overlap → no clip");
+  });
+
+  it("clears the clip when leaving mini mode", () => {
+    loader = loadMiniWithElectron({ getAllDisplays() { return SIDE_BY_SIDE; } });
+    const rendererEvents = [];
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 600);
+    ctx.sendToRenderer = (...args) => rendererEvents.push(args);
+    const mini = loader.initMini(ctx);
+
+    mini.enterMiniMode({ x: 0, y: 0, width: 800, height: 600 }, false, "right");
+    mock.timers.tick(1140);
+    assert.ok(miniClips(rendererEvents).at(-1), "clip active while in contained mini");
+
+    mini.exitMiniMode();
+    mock.timers.tick(400);
+    assert.equal(miniClips(rendererEvents).at(-1), null, "clip cleared on exit");
+    assert.equal(mini.getMiniMode(), false);
+  });
+});

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -89,6 +89,7 @@ function createRuntime(overrides = {}) {
     getCurrentHitBox: () => overrides.hitBox || null,
     getMiniMode: () => overrides.miniMode || false,
     getMiniTransitioning: () => overrides.miniTransitioning || false,
+    getMiniContainedSeam: () => overrides.miniContainedSeam || null,
     getMiniPeekOffset: () => 0,
     getCurrentPixelSize: () => overrides.currentPixelSize || { width: 100, height: 100 },
     getEffectiveCurrentPixelSize: () => overrides.effectivePixelSize || { width: 100, height: 100 },
@@ -243,6 +244,52 @@ describe("pet-window-runtime", () => {
     harness.runtime.syncHitWin();
 
     assert.deepStrictEqual(harness.hitWin.calls, []);
+  });
+
+  it("clips the hit window to a right-side internal monitor seam", () => {
+    const renderWin = makeWindow({ x: 40, y: 0, width: 120, height: 120 });
+    const harness = createRuntime({
+      renderWin,
+      miniMode: true,
+      miniContainedSeam: { boundary: 100, edge: "right" },
+    });
+
+    harness.runtime.syncHitWin();
+
+    // Full hit rect [40,160) clipped at the seam → keep the local half [40,100).
+    assert.deepStrictEqual(
+      harness.hitWin.calls.find((call) => call[0] === "setBounds"),
+      ["setBounds", { x: 40, y: 0, width: 60, height: 120 }]
+    );
+  });
+
+  it("clips the hit window from the left at a left-side internal seam", () => {
+    const renderWin = makeWindow({ x: 40, y: 0, width: 120, height: 120 });
+    const harness = createRuntime({
+      renderWin,
+      miniMode: true,
+      miniContainedSeam: { boundary: 100, edge: "left" },
+    });
+
+    harness.runtime.syncHitWin();
+
+    // Full hit rect [40,160) clipped at the seam → keep the local half [100,160).
+    assert.deepStrictEqual(
+      harness.hitWin.calls.find((call) => call[0] === "setBounds"),
+      ["setBounds", { x: 100, y: 0, width: 60, height: 120 }]
+    );
+  });
+
+  it("leaves the hit window unclipped when no internal seam is active", () => {
+    const renderWin = makeWindow({ x: 40, y: 0, width: 120, height: 120 });
+    const harness = createRuntime({ renderWin, miniMode: true });
+
+    harness.runtime.syncHitWin();
+
+    assert.deepStrictEqual(
+      harness.hitWin.calls.find((call) => call[0] === "setBounds"),
+      ["setBounds", { x: 40, y: 0, width: 120, height: 120 }]
+    );
   });
 
   it("reasserts Windows topmost when drag movement lands near a work-area edge", () => {


### PR DESCRIPTION
## Summary

双显示器（布局 `1|2`）下，把极简模式桌宠拖到显示器 1 的右边缘进入 mini 模式时，本该「半身藏在屏外」的那半个身子会渲染到相邻的显示器 2 上。原因是 mini 模式的「半身露出」效果依赖窗口有一半在物理屏幕之外——单屏时这一半不可见，但在两屏接缝处，「屏外」恰好就是邻屏的屏内。

本 PR 让 renderer 在接缝处用 `clip-path` 把跨过接缝的那一半裁掉：本地显示器保持原本的半身 peek 视觉，邻屏完全干净。

## 问题分析

mini 模式右边缘的窗口定位公式（`src/mini.js` 的 `calcMiniX`）：

```js
return wa.x + wa.width - Math.round(size.width * (1 - MINI_OFFSET_RATIO));
```

窗口右边缘落在 `wa.x + wa.width + MINI_OFFSET_RATIO * size.width`——即工作区右边缘往外 `MINI_OFFSET_RATIO`（clawd 主题为 `0.486`）那么多。单屏时这一段在物理屏幕之外不可见，mini SVG 也正是据此设计成「角色半身探出屏幕边缘」的 peek 姿态。

但在 `1|2` 双屏布局里，显示器 1 的右边缘 = 显示器 2 的左边缘。那「屏外」的半个窗口就直接画到了显示器 2 上 → 邻屏出现半个桌宠。左边缘吸附在 `2|1` 布局下对称地有同样问题。

## 解决方案

窗口定位**保持不变**（仍横跨接缝，保留自然的半身 peek），改为在 renderer 端裁剪：

1. **`seamBoundary()`**（`src/mini.js`）— 判断当前吸附边是否为显示器之间的内部接缝。用 `display.bounds`（物理边界，而非 `workArea`）计算接缝 X，使裁切位置与单屏 mini 被物理屏幕边缘切掉的位置完全一致；垂直方向不重叠的邻屏不算接缝。
2. **`syncContainedClip()`** — 每次 mini 窗口移动后，把「接缝在窗口中的相对位置」（fraction）通过新增的 `mini-clip` IPC 通道发给 renderer。
3. **`applyMiniClip()`**（`src/renderer.js`）— 在 `#pet-container` 上应用 `clip-path: inset(...)`，把跨过接缝那一半裁掉。

## 改前 vs 改后

| 场景 | 改前 | 改后 |
|---|---|---|
| 单显示器 mini | 半身 peek，屏外不可见 | 一样（`seamBoundary` 返回 `null`，不裁剪）|
| 多屏，桌宠在虚拟桌面最外缘 | 半身 peek | 一样（无邻屏，不裁剪）|
| 多屏，桌宠在内部接缝 | 半身溢出到邻屏 | 半身 peek 留在本屏，邻屏 0 像素 |
| peek 招手动画 | 溢出部分跟着动 | 裁剪线逐帧跟踪接缝 |

## 影响范围

- `src/mini.js` — 新增 `seamBoundary()` / `syncContainedClip()` / `refreshContainedBoundary()` 与 `containedBoundary` 状态；进入 mini / 动画每帧 / 显示器变化 / resize / 启动恢复时同步裁剪比例，退出时清除。
- `src/preload.js` — 新增 `onMiniClip` IPC 通道。
- `src/renderer.js` — 新增 `applyMiniClip()` 与监听器；退出 mini 时清除 `clip-path`。

单显示器用户和多屏最外缘吸附场景行为完全不变（`seamBoundary` 返回 `null` → `mini-clip` 恒为 `null` → `clip-path` 恒为空）。

## Test plan

- [x] 新增 `test/mini.test.js` → `describe("mini mode multi-monitor seam clip")`，6 个测试：单屏不裁剪 / 内部接缝（右）裁剪比例正确 / 虚拟桌面最外缘不裁剪 / 左侧接缝裁剪 / 邻屏垂直不重叠不裁剪 / 退出 mini 清除裁剪
- [x] `node --test test/mini.test.js` — 10/10 通过
- [x] 全套件 `node --test test/*.test.js` — 2451 个测试，其中 6 个为本 PR 新增，无回归（10 个失败在 `main` 上完全相同，均为 macOS 上预存在的 Windows 路径 / Claude 版本探测测试，与本 PR 无关）
- [x] 手动验证（macOS，双屏 `1|2`）：拖入接缝进 mini / 悬停 peek / 右键菜单进 mini —— 显示器 1 半身贴边，显示器 2 全程干净
- [ ] 未给 renderer 的 `applyMiniClip()` 加单测：`renderer.js` 为浏览器侧、仓库无对应测试框架；其 `clip-path` 字符串逻辑较简单，已靠手动验证。如需覆盖可把公式抽成纯函数

🤖 Generated with [Claude Code](https://claude.com/claude-code)