### PR TITLE
feat: add nano-agent (Go) integration

### DIFF
--- a/agents/nano-agent.js
+++ b/agents/nano-agent.js
@@ -1,0 +1,44 @@
+// Nano Agent configuration
+// Hook-based integration via nano-agent's pkg/hookservice.
+// Hooks are registered under `security.hooks` in ~/.config/nano/config.yaml
+// and receive event/payload via NANO_HOOK_INPUT env (JSON), with NANO_TOOL_NAME
+// and NANO_TOOL_INPUT as legacy env vars. Event names are snake_case (e.g.
+// `pre_tool_use`); we normalize to PascalCase before reporting state.
+// Docs: nano-agent/docs/features/HOOKS.md
+
+module.exports = {
+  id: "nano-agent",
+  name: "Nano Agent",
+  processNames: { win: ["nano.exe"], mac: ["nano"], linux: ["nano"] },
+  eventSource: "hook",
+  // PascalCase event names — normalized from nano-agent's snake_case events
+  // by hooks/nano-agent-hook.js before posting to /state.
+  eventMap: {
+    SessionStart:       "idle",
+    SessionEnd:         "sleeping",
+    UserPromptSubmit:   "thinking",
+    PreToolUse:         "working",
+    PostToolUse:        "working",
+    PostToolUseFailure: "error",
+    Stop:               "attention",
+    StopFailure:        "error",
+    SubagentStart:      "juggling",
+    SubagentStop:       "working",
+    PreCompact:         "sweeping",
+    PostCompact:        "attention",
+    Notification:       "notification",
+    PermissionRequest:  "notification",
+  },
+  capabilities: {
+    httpHook: true,            // nano-agent hookservice supports type:http
+    permissionApproval: true,  // permission_request flows through HTTP hook
+    notificationHook: true,
+    sessionEnd: true,
+    subagent: true,
+  },
+  hookConfig: {
+    configFormat: "nano-yaml",
+  },
+  stdinFormat: "nanoHookEnv",
+  pidField: "nano_pid",
+};

--- a/agents/registry.js
+++ b/agents/registry.js
@@ -13,6 +13,7 @@ const opencode = require("./opencode");
 const pi = require("./pi");
 const openclaw = require("./openclaw");
 const hermes = require("./hermes");
+const nanoAgent = require("./nano-agent");
 
 const AGENTS = [
   claudeCode,
@@ -27,6 +28,7 @@ const AGENTS = [
   pi,
   openclaw,
   hermes,
+  nanoAgent,
 ];
 const AGENT_MAP = new Map(AGENTS.map((a) => [a.id, a]));
 

--- a/hooks/nano-agent-hook.js
+++ b/hooks/nano-agent-hook.js
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+// Clawd Desktop Pet — Nano Agent Hook Script
+// Usage: node nano-agent-hook.js [event_name]
+//
+// nano-agent's pkg/hookservice injects payload via the NANO_HOOK_INPUT env var
+// (JSON), with NANO_TOOL_NAME and NANO_TOOL_INPUT as legacy companions.
+// stdin is not used by nano-agent for command hooks. We accept the event name
+// from argv, NANO_HOOK_EVENT, or the parsed envelope's `event` / `hook_event_name`
+// field, normalize snake_case to PascalCase, and report state to the running
+// Clawd server via /state.
+
+const crypto = require("crypto");
+const { postStateToRunningServer, readHostPrefix } = require("./server-config");
+const { createPidResolver, getPlatformConfig } = require("./shared-process");
+
+const TOOL_MATCH_STRING_MAX = 240;
+const TOOL_MATCH_ARRAY_MAX = 16;
+const TOOL_MATCH_OBJECT_KEYS_MAX = 32;
+const TOOL_MATCH_DEPTH_MAX = 6;
+
+// snake_case → PascalCase event normalization. Mirrors nano-agent's
+// hookservice.hookEventName() in pkg/hookservice/service.go.
+function snakeToPascal(name) {
+  if (typeof name !== "string" || !name) return null;
+  return name
+    .split("_")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join("");
+}
+
+const EVENT_TO_STATE = {
+  SessionStart:       "idle",
+  SessionEnd:         "sleeping",
+  UserPromptSubmit:   "thinking",
+  PreToolUse:         "working",
+  PostToolUse:        "working",
+  PostToolUseFailure: "error",
+  Stop:               "attention",
+  StopFailure:        "error",
+  SubagentStart:      "juggling",
+  SubagentStop:       "working",
+  PreCompact:         "sweeping",
+  PostCompact:        "attention",
+  Notification:       "notification",
+  // PermissionRequest is wired as type:http (blocking) — the command hook here
+  // would only fire if someone configured it; map it for safety.
+  PermissionRequest:  "notification",
+};
+
+function normalizeToolUseId(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
+}
+
+function normalizeToolMatchValue(value, depth = 0) {
+  if (depth > TOOL_MATCH_DEPTH_MAX) return null;
+  if (Array.isArray(value)) {
+    return value
+      .slice(0, TOOL_MATCH_ARRAY_MAX)
+      .map((entry) => normalizeToolMatchValue(entry, depth + 1));
+  }
+  if (value && typeof value === "object") {
+    const out = {};
+    for (const key of Object.keys(value).sort().slice(0, TOOL_MATCH_OBJECT_KEYS_MAX)) {
+      out[key] = normalizeToolMatchValue(value[key], depth + 1);
+    }
+    return out;
+  }
+  if (typeof value === "string") {
+    return value.length > TOOL_MATCH_STRING_MAX
+      ? `${value.slice(0, TOOL_MATCH_STRING_MAX - 1)}…`
+      : value;
+  }
+  return value;
+}
+
+function buildToolInputFingerprint(toolInput) {
+  if (!toolInput || typeof toolInput !== "object") return null;
+  const normalized = normalizeToolMatchValue(toolInput);
+  return crypto
+    .createHash("sha1")
+    .update(JSON.stringify(normalized))
+    .digest("hex");
+}
+
+function parseEnvJson(raw) {
+  if (typeof raw !== "string" || !raw.trim()) return null;
+  try { return JSON.parse(raw); } catch { return null; }
+}
+
+function readNanoHookEnvelope(env) {
+  const e = env || process.env;
+  const envelope = parseEnvJson(e.NANO_HOOK_INPUT) || {};
+  // Legacy fallback: NANO_TOOL_INPUT carries just the tool params (no envelope).
+  if (!envelope.params) {
+    const legacyParams = parseEnvJson(e.NANO_TOOL_INPUT);
+    if (legacyParams && typeof legacyParams === "object") envelope.params = legacyParams;
+  }
+  if (!envelope.tool_name && typeof e.NANO_TOOL_NAME === "string") {
+    envelope.tool_name = e.NANO_TOOL_NAME;
+  }
+  return envelope;
+}
+
+function resolveEvent(argv, env, envelope) {
+  const fromArgv = typeof argv[2] === "string" ? argv[2] : "";
+  const fromEnv = typeof env.NANO_HOOK_EVENT === "string" ? env.NANO_HOOK_EVENT : "";
+  const fromEnvelope = envelope && (envelope.hook_event_name || envelope.event);
+  const candidates = [fromArgv, fromEnv, fromEnvelope].filter(Boolean);
+  for (const cand of candidates) {
+    // Already PascalCase or snake_case — both routes go through normalization
+    if (EVENT_TO_STATE[cand]) return cand;
+    const normalized = snakeToPascal(cand);
+    if (normalized && EVENT_TO_STATE[normalized]) return normalized;
+  }
+  return null;
+}
+
+function isTaskToolStart(event, params) {
+  // Hook payload may surface a Task-like delegation as PreToolUse without a
+  // matching SubagentStart. Use juggling for any tool name that looks like a
+  // delegation (Task/main_agent/spawn) so the pet reflects parallel work.
+  if (event !== "PreToolUse" || !params) return false;
+  const toolName = typeof params.tool_name === "string" ? params.tool_name : "";
+  if (!toolName) return false;
+  return toolName === "Task" || toolName === "main_agent" || toolName === "spawn_agent";
+}
+
+function buildStateBody(event, envelope, resolve) {
+  const state = EVENT_TO_STATE[event];
+  if (!state) return null;
+
+  const params = (envelope && typeof envelope.params === "object" && envelope.params) || {};
+  const sessionId = envelope.session_id || params.session_id || "default";
+  const cwd = envelope.cwd || envelope.working_dir || params.cwd || "";
+  const syntheticSubagentStart = isTaskToolStart(event, { tool_name: envelope.tool_name || params.tool_name });
+  const resolvedState = syntheticSubagentStart ? "juggling" : state;
+  const resolvedEvent = syntheticSubagentStart ? "SubagentStart" : event;
+
+  const body = {
+    state: resolvedState,
+    session_id: sessionId,
+    event: resolvedEvent,
+    agent_id: "nano-agent",
+  };
+  if (cwd) body.cwd = cwd;
+
+  const toolName = typeof envelope.tool_name === "string" && envelope.tool_name
+    ? envelope.tool_name
+    : (typeof params.tool_name === "string" && params.tool_name ? params.tool_name : null);
+  const toolUseId = normalizeToolUseId(
+    envelope.tool_use_id ?? params.tool_use_id ?? params.toolUseId ?? params.toolUseID
+  );
+  const toolInput = (params.tool_input && typeof params.tool_input === "object") ? params.tool_input : null;
+  const toolInputFingerprint = buildToolInputFingerprint(toolInput);
+  if (toolName) body.tool_name = toolName;
+  if (toolUseId) body.tool_use_id = toolUseId;
+  if (toolInputFingerprint) body.tool_input_fingerprint = toolInputFingerprint;
+
+  if (process.env.CLAWD_REMOTE) {
+    body.host = readHostPrefix();
+  } else {
+    const { stablePid, agentPid, agentCommandLine, detectedEditor, pidChain } = resolve();
+    body.source_pid = stablePid;
+    if (detectedEditor) body.editor = detectedEditor;
+    if (agentPid) {
+      body.agent_pid = agentPid;
+      body.nano_pid = agentPid;
+      // Match clawd-hook headless detection: -p / --print are headless flags
+      // in many CLIs; nano binary mode passes the prompt as positional arg, so
+      // this is mostly a safety net for daemon CLI flags.
+      if (agentCommandLine && /\s(-p|--print)(\s|$)/.test(agentCommandLine)) {
+        body.headless = true;
+      }
+    }
+    if (pidChain && pidChain.length) body.pid_chain = pidChain;
+  }
+
+  return body;
+}
+
+function main() {
+  const envelope = readNanoHookEnvelope(process.env);
+  const event = resolveEvent(process.argv, process.env, envelope);
+  if (!event) process.exit(0);
+
+  const config = getPlatformConfig();
+  const resolve = createPidResolver({
+    agentNames: { win: new Set(["nano.exe"]), mac: new Set(["nano"]) },
+    agentCmdlineCheck: (cmd) => /\bnano(-agent)?\b/.test(cmd) && /\bnano-agent\b/.test(cmd),
+    platformConfig: config,
+  });
+
+  if (event === "SessionStart" && !process.env.CLAWD_REMOTE) resolve();
+
+  const body = buildStateBody(event, envelope, resolve);
+  if (!body) process.exit(0);
+  postStateToRunningServer(
+    JSON.stringify(body),
+    { timeoutMs: 100 },
+    () => process.exit(0)
+  );
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  EVENT_TO_STATE,
+  buildStateBody,
+  readNanoHookEnvelope,
+  resolveEvent,
+  snakeToPascal,
+};

--- a/hooks/nano-agent-install.js
+++ b/hooks/nano-agent-install.js
@@ -1,0 +1,344 @@
+#!/usr/bin/env node
+"use strict";
+
+// Merge Clawd nano-agent hooks into nano-agent's user config (append-only,
+// idempotent). nano-agent's hookservice loads `security.hooks` from
+// `~/.config/nano/config.yaml` (global) or `.nano.yaml` (project). We touch
+// the global path by default so per-project overrides remain user-owned.
+//
+// Each registered entry uses a stable `clawd-on-desk:<event>` name so we can
+// recognise our own entries on re-install / uninstall without disturbing
+// user-authored hooks. Per AGENTS.md, hook scripts may only depend on Node
+// built-ins; this installer runs in the main app and may load js-yaml.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const yaml = require("js-yaml");
+const {
+  resolveNodeBin,
+  buildPermissionUrl,
+  DEFAULT_SERVER_PORT,
+  readRuntimePort,
+} = require("./server-config");
+const { asarUnpackedPath } = require("./json-utils");
+
+const HOOK_NAME_PREFIX = "clawd-on-desk:";
+const HOOK_SCRIPT_MARKER = "nano-agent-hook.js";
+const DEFAULT_CONFIG_PATH = path.join(os.homedir(), ".config", "nano", "config.yaml");
+
+// Events nano-agent fires that map cleanly onto Clawd states. Mirrors the
+// EVENT_TO_STATE table in nano-agent-hook.js. Use snake_case (nano-agent's
+// canonical event identifier).
+const NANO_COMMAND_HOOK_EVENTS = [
+  "session_start",
+  "session_end",
+  "user_prompt_submit",
+  "pre_tool_use",
+  "post_tool_use",
+  "post_tool_use_failure",
+  "stop",
+  "stop_failure",
+  "subagent_start",
+  "subagent_stop",
+  "pre_compact",
+  "post_compact",
+  "notification",
+];
+
+// Event names that participate in approval / blocking flows. They pair best
+// with HTTP hooks so the server can hold the connection open while the user
+// decides; the command path here would only short-circuit to allow.
+const NANO_HTTP_HOOK_EVENTS = [
+  "permission_request",
+];
+
+function quoteForShell(value) {
+  // hookservice runs the command via `sh -c` — single-quote with POSIX
+  // ' -> '\'' escape for paths that may contain spaces or apostrophes.
+  return "'" + String(value).replace(/'/g, "'\\''") + "'";
+}
+
+function buildHookCommand(nodeBin, scriptPath, eventName, options = {}) {
+  // The event name is duplicated as argv[2] for parity with the Claude Code
+  // hook contract; the script also reads NANO_HOOK_INPUT.event as a fallback.
+  const command = [
+    quoteForShell(nodeBin),
+    quoteForShell(scriptPath),
+    quoteForShell(eventName),
+  ].join(" ");
+  // Remote SSH deployment: nano-agent runs on the remote machine but Clawd
+  // listens locally. Prepending CLAWD_REMOTE=1 tells the hook script to use
+  // the SSH tunnel host prefix instead of resolving local PIDs (and matches
+  // hooks/install.js:buildCommandHookSpec for the Claude Code path).
+  return options.remote ? `CLAWD_REMOTE=1 ${command}` : command;
+}
+
+function buildCommandHookEntry(eventName, command, statusMessage) {
+  return {
+    name: `${HOOK_NAME_PREFIX}${eventName}`,
+    event: eventName,
+    pattern: "*",
+    type: "command",
+    command,
+    enabled: true,
+    failure_policy: "allow", // never block the user because Clawd is offline
+    async: true,             // fire-and-forget; we only care about state side-effects
+    env_whitelist: [
+      "PATH", "HOME", "USER", "SHELL", "LANG", "LC_ALL",
+      "CLAWD_REMOTE",
+    ],
+    status_message: statusMessage,
+  };
+}
+
+function buildHttpHookEntry(eventName, url, statusMessage) {
+  return {
+    name: `${HOOK_NAME_PREFIX}${eventName}`,
+    event: eventName,
+    pattern: "*",
+    type: "http",
+    enabled: true,
+    failure_policy: "allow",
+    http: {
+      url,
+      method: "POST",
+      timeout_seconds: 600,
+    },
+    status_message: statusMessage,
+  };
+}
+
+function isOurEntry(entry) {
+  return !!(entry && typeof entry === "object" && typeof entry.name === "string"
+    && entry.name.startsWith(HOOK_NAME_PREFIX));
+}
+
+function entriesEquivalent(a, b) {
+  // Cheap structural equality check — sufficient because we always emit
+  // entries via the same builders. Uses JSON.stringify for canonicalization.
+  try { return JSON.stringify(a) === JSON.stringify(b); } catch { return false; }
+}
+
+function ensureSecurityHooksArray(config) {
+  if (!config || typeof config !== "object") return null;
+  if (config.security == null) config.security = {};
+  if (typeof config.security !== "object" || Array.isArray(config.security)) {
+    return null;
+  }
+  if (!Array.isArray(config.security.hooks)) {
+    if (config.security.hooks == null) {
+      config.security.hooks = [];
+    } else {
+      return null;
+    }
+  }
+  return config.security.hooks;
+}
+
+function loadConfig(configPath, fsImpl) {
+  const raw = fsImpl.readFileSync(configPath, "utf8");
+  const parsed = yaml.load(raw);
+  if (parsed == null) return {};
+  if (typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`nano-agent config at ${configPath} is not a YAML mapping`);
+  }
+  return parsed;
+}
+
+function dumpConfig(config) {
+  return yaml.dump(config, {
+    indent: 2,
+    lineWidth: 120,
+    noRefs: true,
+    sortKeys: false,
+  });
+}
+
+function writeYamlAtomic(filePath, contents, fsImpl) {
+  const dir = path.dirname(filePath);
+  const base = path.basename(filePath);
+  const tmpPath = path.join(dir, `.${base}.${process.pid}.${Date.now()}.tmp`);
+  fsImpl.mkdirSync(dir, { recursive: true });
+  try {
+    fsImpl.writeFileSync(tmpPath, contents, "utf8");
+    fsImpl.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fsImpl.unlinkSync(tmpPath); } catch {}
+    throw err;
+  }
+}
+
+function resolveScriptPath(baseDir) {
+  const dir = path.resolve(baseDir || __dirname).replace(/\\/g, "/");
+  return asarUnpackedPath(path.join(dir, "nano-agent-hook.js").replace(/\\/g, "/"));
+}
+
+function summarizeStatusMessage(eventName) {
+  return `clawd-on-desk: report ${eventName} state`;
+}
+
+/**
+ * Register Clawd hooks into nano-agent's config (idempotent).
+ *
+ * @param {object} [options]
+ * @param {string} [options.configPath]    - override target YAML path (default ~/.config/nano/config.yaml)
+ * @param {string} [options.scriptPath]    - override hook script path
+ * @param {string} [options.nodeBin]       - override node binary (default from resolveNodeBin)
+ * @param {number} [options.port]          - override Clawd HTTP server port
+ * @param {object} [options.fs]            - inject fs for tests
+ * @param {boolean} [options.silent]
+ * @returns {{ status: string, configPath: string, added: number, updated: number, skipped: number, reason?: string }}
+ */
+function registerNanoAgentHooks(options = {}) {
+  const fsImpl = options.fs || fs;
+  const configPath = options.configPath || DEFAULT_CONFIG_PATH;
+
+  let exists = true;
+  try { fsImpl.statSync(configPath); } catch { exists = false; }
+  if (!exists) {
+    if (!options.silent) {
+      console.log(`Clawd: ${configPath} not found — skipping nano-agent hook registration`);
+    }
+    return { status: "skipped", reason: "config-missing", configPath, added: 0, updated: 0, skipped: 0 };
+  }
+
+  let config;
+  try {
+    config = loadConfig(configPath, fsImpl);
+  } catch (err) {
+    if (!options.silent) console.warn(`Clawd: failed to parse ${configPath}: ${err.message}`);
+    return { status: "error", reason: "config-parse-failed", message: err.message, configPath, added: 0, updated: 0, skipped: 0 };
+  }
+
+  const hooks = ensureSecurityHooksArray(config);
+  if (hooks == null) {
+    if (!options.silent) console.warn(`Clawd: ${configPath} has incompatible security/security.hooks shape`);
+    return { status: "error", reason: "config-shape-incompatible", configPath, added: 0, updated: 0, skipped: 0 };
+  }
+
+  const scriptPath = options.scriptPath || resolveScriptPath();
+  const resolvedNode = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
+  const nodeBin = resolvedNode || "node";
+  const port = options.port || readRuntimePort() || DEFAULT_SERVER_PORT;
+  const permissionUrl = buildPermissionUrl(port);
+
+  const desiredCommandEntries = NANO_COMMAND_HOOK_EVENTS.map((eventName) =>
+    buildCommandHookEntry(
+      eventName,
+      buildHookCommand(nodeBin, scriptPath, eventName, { remote: !!options.remote }),
+      summarizeStatusMessage(eventName)
+    )
+  );
+  const desiredHttpEntries = NANO_HTTP_HOOK_EVENTS.map((eventName) =>
+    buildHttpHookEntry(eventName, permissionUrl, summarizeStatusMessage(eventName))
+  );
+  const desiredAll = [...desiredCommandEntries, ...desiredHttpEntries];
+  const desiredByName = new Map(desiredAll.map((entry) => [entry.name, entry]));
+
+  let added = 0;
+  let updated = 0;
+  let skipped = 0;
+  let changed = false;
+
+  for (let i = 0; i < hooks.length; i++) {
+    const entry = hooks[i];
+    if (!isOurEntry(entry)) continue;
+    const desired = desiredByName.get(entry.name);
+    if (!desired) continue; // a stale entry for an event we no longer emit; uninstall pass cleans these
+    if (entriesEquivalent(entry, desired)) {
+      skipped++;
+    } else {
+      hooks[i] = desired;
+      updated++;
+      changed = true;
+    }
+    desiredByName.delete(entry.name);
+  }
+
+  for (const entry of desiredByName.values()) {
+    hooks.push(entry);
+    added++;
+    changed = true;
+  }
+
+  if (changed) {
+    writeYamlAtomic(configPath, dumpConfig(config), fsImpl);
+  }
+
+  if (!options.silent) {
+    console.log(`Clawd nano-agent hooks → ${configPath}`);
+    console.log(`  Added: ${added}, updated: ${updated}, skipped: ${skipped}`);
+  }
+
+  return { status: "ok", configPath, added, updated, skipped };
+}
+
+/**
+ * Remove all clawd-on-desk hook entries from nano-agent's config.
+ */
+function unregisterNanoAgentHooks(options = {}) {
+  const fsImpl = options.fs || fs;
+  const configPath = options.configPath || DEFAULT_CONFIG_PATH;
+
+  let exists = true;
+  try { fsImpl.statSync(configPath); } catch { exists = false; }
+  if (!exists) {
+    return { status: "skipped", reason: "config-missing", configPath, removed: 0 };
+  }
+
+  let config;
+  try {
+    config = loadConfig(configPath, fsImpl);
+  } catch (err) {
+    return { status: "error", reason: "config-parse-failed", message: err.message, configPath, removed: 0 };
+  }
+
+  const security = config && config.security;
+  const hooks = security && Array.isArray(security.hooks) ? security.hooks : null;
+  if (!hooks) {
+    return { status: "skipped", reason: "no-hooks-array", configPath, removed: 0 };
+  }
+
+  const before = hooks.length;
+  const filtered = hooks.filter((entry) => !isOurEntry(entry));
+  const removed = before - filtered.length;
+  if (removed === 0) {
+    return { status: "ok", configPath, removed: 0 };
+  }
+  config.security.hooks = filtered;
+  writeYamlAtomic(configPath, dumpConfig(config), fsImpl);
+  if (!options.silent) {
+    console.log(`Clawd nano-agent hooks ← removed ${removed} entries from ${configPath}`);
+  }
+  return { status: "ok", configPath, removed };
+}
+
+module.exports = {
+  DEFAULT_CONFIG_PATH,
+  HOOK_NAME_PREFIX,
+  HOOK_SCRIPT_MARKER,
+  NANO_COMMAND_HOOK_EVENTS,
+  NANO_HTTP_HOOK_EVENTS,
+  buildCommandHookEntry,
+  buildHookCommand,
+  buildHttpHookEntry,
+  ensureSecurityHooksArray,
+  isOurEntry,
+  registerNanoAgentHooks,
+  unregisterNanoAgentHooks,
+};
+
+if (require.main === module) {
+  try {
+    const remote = process.argv.includes("--remote");
+    if (process.argv.includes("--uninstall")) {
+      unregisterNanoAgentHooks({});
+    } else {
+      registerNanoAgentHooks({ remote });
+    }
+  } catch (err) {
+    console.error(err && err.message ? err.message : err);
+    process.exit(1);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "uninstall:codex-debug-hooks": "node hooks/codex-debug-install.js --uninstall",
     "install:hermes-plugin": "node hooks/hermes-install.js",
     "uninstall:hermes-plugin": "node hooks/hermes-install.js --uninstall",
+    "install:nano-hooks": "node hooks/nano-agent-install.js",
+    "uninstall:nano-hooks": "node hooks/nano-agent-install.js --uninstall",
     "register-protocol:dev": "node launch.js --register-protocol"
   },
   "keywords": [
@@ -152,6 +154,7 @@
   "dependencies": {
     "electron-updater": "^6.8.3",
     "htmlparser2": "^12.0.0",
+    "js-yaml": "^4.1.0",
     "koffi": "^2.15.2"
   }
 }

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -143,6 +143,18 @@ FILES=(
   "$HOOKS_DIR/codex-subagent-fields.js"
   "$HOOKS_DIR/copilot-hook.js"
   "$HOOKS_DIR/copilot-install.js"
+  "$HOOKS_DIR/nano-agent-hook.js"
+  "$HOOKS_DIR/nano-agent-install.js"
+)
+
+# js-yaml (and its only dep argparse) is required by nano-agent-install.js to
+# edit nano-agent's YAML config. We scp both packages alongside the hook
+# scripts so the remote install never needs npm. Missing locally => skip
+# nano-agent registration with a warning rather than failing the whole deploy.
+NODE_MODULES_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/node_modules"
+NANO_NODE_MODULE_DIRS=(
+  "$NODE_MODULES_DIR/js-yaml"
+  "$NODE_MODULES_DIR/argparse"
 )
 
 # ── Local port detection ──
@@ -244,6 +256,44 @@ echo "Registering Copilot CLI hooks (remote mode)..."
 ssh "$SSH_TARGET" "$(remote_node_command copilot-install.js --remote)" || {
   echo "WARNING: Copilot CLI hook registration failed (Copilot CLI may not be installed on remote)"
 }
+
+# ── nano-agent ──
+# nano-agent-install.js requires js-yaml. Ship js-yaml + argparse as a
+# self-contained bundle next to the hooks so `require("js-yaml")` resolves
+# without needing npm on the remote host.
+NANO_DEPLOY_OK=1
+for dep_dir in "${NANO_NODE_MODULE_DIRS[@]}"; do
+  if [ ! -d "$dep_dir" ]; then
+    echo "WARNING: missing $dep_dir — skipping nano-agent hook registration"
+    echo "         run \`npm install\` locally before re-running remote-deploy"
+    NANO_DEPLOY_OK=0
+    break
+  fi
+done
+
+if [ "$NANO_DEPLOY_OK" = "1" ]; then
+  echo "Copying nano-agent runtime deps (js-yaml, argparse)..."
+  ssh "$SSH_TARGET" "mkdir -p ~/.claude/hooks/node_modules" || {
+    echo "WARNING: failed to create remote node_modules dir — skipping nano-agent registration"
+    NANO_DEPLOY_OK=0
+  }
+fi
+
+if [ "$NANO_DEPLOY_OK" = "1" ]; then
+  if ! scp -q -r "${NANO_NODE_MODULE_DIRS[@]}" "$SSH_TARGET:~/.claude/hooks/node_modules/"; then
+    echo "WARNING: failed to copy nano-agent deps — skipping nano-agent registration"
+    NANO_DEPLOY_OK=0
+  else
+    echo "  [OK] Deps copied to ~/.claude/hooks/node_modules/"
+  fi
+fi
+
+if [ "$NANO_DEPLOY_OK" = "1" ]; then
+  echo "Registering nano-agent hooks (remote mode)..."
+  ssh "$SSH_TARGET" "$(remote_node_command nano-agent-install.js --remote)" || {
+    echo "WARNING: nano-agent hook registration failed (nano-agent may not be installed or its config is missing)"
+  }
+fi
 
 # ── Print SSH configuration ──
 

--- a/src/integration-sync.js
+++ b/src/integration-sync.js
@@ -223,6 +223,24 @@ function createIntegrationSyncRuntime(options = {}) {
     }
   }
 
+  function syncNanoAgentHooks() {
+    try {
+      if (typeof ctx.syncNanoAgentHooksImpl === "function") return ctx.syncNanoAgentHooksImpl();
+      const { registerNanoAgentHooks } = require("../hooks/nano-agent-install.js");
+      const result = registerNanoAgentHooks({
+        silent: true,
+        port: getHookServerPort(),
+      });
+      if (result && (result.added > 0 || result.updated > 0)) {
+        console.log(`Clawd: synced nano-agent hooks (added ${result.added}, updated ${result.updated})`);
+      }
+      return result && typeof result === "object" ? result : { status: "ok" };
+    } catch (err) {
+      console.warn("Clawd: failed to sync nano-agent hooks:", err.message);
+      return { status: "error", message: err && err.message ? err.message : "Failed to sync nano-agent hooks" };
+    }
+  }
+
   function syncHermesPlugin() {
     try {
       if (typeof ctx.syncHermesPluginImpl === "function") return ctx.syncHermesPluginImpl();
@@ -263,6 +281,7 @@ function createIntegrationSyncRuntime(options = {}) {
     pi: syncPiExtension,
     openclaw: syncOpenClawPlugin,
     hermes: syncHermesPlugin,
+    "nano-agent": syncNanoAgentHooks,
   });
 
   const AGENT_INTEGRATION_REPAIRERS = Object.freeze({
@@ -323,6 +342,7 @@ function createIntegrationSyncRuntime(options = {}) {
     syncPiExtension,
     syncOpenClawPlugin,
     syncHermesPlugin,
+    syncNanoAgentHooks,
     repairCodexHooks,
     repairOpenClawPlugin,
     syncIntegrationForAgent,

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -144,6 +144,7 @@ const SCHEMA = {
       "pi": { enabled: true, permissionsEnabled: true, notificationHookEnabled: true },
       "openclaw": { enabled: true, permissionsEnabled: false, notificationHookEnabled: true },
       "hermes": { enabled: true },
+      "nano-agent": { enabled: true, permissionsEnabled: true, notificationHookEnabled: true },
     }),
     normalize: normalizeAgents,
   },

--- a/test/integration-sync.test.js
+++ b/test/integration-sync.test.js
@@ -33,6 +33,7 @@ function makeRuntime(overrides = {}) {
       return { status: "ok", message: "done" };
     },
     syncHermesPluginImpl: () => calls.push({ name: "hermes" }),
+    syncNanoAgentHooksImpl: () => calls.push({ name: "nano-agent" }),
     ...(overrides.ctx || {}),
   };
   const runtime = createIntegrationSyncRuntime({
@@ -81,6 +82,7 @@ describe("integration sync runtime", () => {
       "pi",
       "openclaw",
       "hermes",
+      "nano-agent",
     ]);
   });
 

--- a/test/nano-agent-hook.test.js
+++ b/test/nano-agent-hook.test.js
@@ -1,0 +1,160 @@
+// test/nano-agent-hook.test.js — Verifies state-body construction and event
+// normalization for the nano-agent hook script. Hook script consumes the
+// envelope from NANO_HOOK_INPUT (env var), not stdin, so we exercise the
+// pure helpers directly.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+const {
+  EVENT_TO_STATE,
+  buildStateBody,
+  readNanoHookEnvelope,
+  resolveEvent,
+  snakeToPascal,
+} = require("../hooks/nano-agent-hook");
+
+const fakeResolve = () => ({
+  stablePid: 4242,
+  agentPid: 9999,
+  agentCommandLine: "/usr/local/bin/nano chat",
+  detectedEditor: null,
+  pidChain: [4242, 9999],
+});
+
+describe("snakeToPascal", () => {
+  it("converts snake_case to PascalCase", () => {
+    assert.strictEqual(snakeToPascal("pre_tool_use"), "PreToolUse");
+    assert.strictEqual(snakeToPascal("session_start"), "SessionStart");
+  });
+  it("returns null for empty / non-string input", () => {
+    assert.strictEqual(snakeToPascal(""), null);
+    assert.strictEqual(snakeToPascal(undefined), null);
+  });
+  it("preserves single-word PascalCase tokens", () => {
+    assert.strictEqual(snakeToPascal("stop"), "Stop");
+    assert.strictEqual(snakeToPascal("Stop"), "Stop"); // already PascalCase
+  });
+});
+
+describe("readNanoHookEnvelope", () => {
+  it("parses NANO_HOOK_INPUT JSON envelope", () => {
+    const env = {
+      NANO_HOOK_INPUT: JSON.stringify({
+        event: "pre_tool_use",
+        session_id: "sess-1",
+        tool_name: "shell",
+        params: { tool_input: { command: "ls" } },
+      }),
+    };
+    const envelope = readNanoHookEnvelope(env);
+    assert.strictEqual(envelope.event, "pre_tool_use");
+    assert.strictEqual(envelope.session_id, "sess-1");
+    assert.strictEqual(envelope.tool_name, "shell");
+    assert.deepStrictEqual(envelope.params.tool_input, { command: "ls" });
+  });
+
+  it("falls back to legacy NANO_TOOL_INPUT / NANO_TOOL_NAME when envelope is missing", () => {
+    const env = {
+      NANO_TOOL_NAME: "write_file",
+      NANO_TOOL_INPUT: JSON.stringify({ path: "/tmp/x" }),
+    };
+    const envelope = readNanoHookEnvelope(env);
+    assert.strictEqual(envelope.tool_name, "write_file");
+    assert.deepStrictEqual(envelope.params, { path: "/tmp/x" });
+  });
+
+  it("ignores malformed JSON gracefully", () => {
+    const envelope = readNanoHookEnvelope({ NANO_HOOK_INPUT: "{not json" });
+    assert.deepStrictEqual(envelope, {});
+  });
+});
+
+describe("resolveEvent", () => {
+  it("prefers argv over env / envelope", () => {
+    const env = { NANO_HOOK_EVENT: "session_start" };
+    const envelope = { event: "stop" };
+    const event = resolveEvent(["node", "hook.js", "PreToolUse"], env, envelope);
+    assert.strictEqual(event, "PreToolUse");
+  });
+
+  it("normalizes snake_case event from env", () => {
+    const event = resolveEvent(["node", "hook.js"], { NANO_HOOK_EVENT: "pre_tool_use" }, {});
+    assert.strictEqual(event, "PreToolUse");
+  });
+
+  it("falls back to envelope.hook_event_name", () => {
+    const event = resolveEvent(["node", "hook.js"], {}, { hook_event_name: "PostCompact" });
+    assert.strictEqual(event, "PostCompact");
+  });
+
+  it("returns null for unknown events", () => {
+    const event = resolveEvent(["node", "hook.js", "BogusEvent"], {}, {});
+    assert.strictEqual(event, null);
+  });
+});
+
+describe("buildStateBody", () => {
+  it("emits expected shape for pre_tool_use", () => {
+    const envelope = {
+      session_id: "abc",
+      cwd: "/work",
+      tool_name: "shell",
+      params: { tool_input: { command: "ls" }, tool_use_id: "use-1" },
+    };
+    const body = buildStateBody("PreToolUse", envelope, fakeResolve);
+    assert.strictEqual(body.state, "working");
+    assert.strictEqual(body.event, "PreToolUse");
+    assert.strictEqual(body.agent_id, "nano-agent");
+    assert.strictEqual(body.session_id, "abc");
+    assert.strictEqual(body.cwd, "/work");
+    assert.strictEqual(body.tool_name, "shell");
+    assert.strictEqual(body.tool_use_id, "use-1");
+    assert.ok(body.tool_input_fingerprint, "expected sha1 fingerprint");
+    assert.strictEqual(body.source_pid, 4242);
+    assert.strictEqual(body.agent_pid, 9999);
+    assert.strictEqual(body.nano_pid, 9999);
+  });
+
+  it("treats Task delegations as juggling", () => {
+    const envelope = { session_id: "x", tool_name: "Task", params: {} };
+    const body = buildStateBody("PreToolUse", envelope, fakeResolve);
+    assert.strictEqual(body.state, "juggling");
+    assert.strictEqual(body.event, "SubagentStart");
+  });
+
+  it("uses default session id when missing", () => {
+    const body = buildStateBody("SessionStart", {}, fakeResolve);
+    assert.strictEqual(body.session_id, "default");
+    assert.strictEqual(body.state, "idle");
+  });
+
+  it("returns null for unknown events", () => {
+    assert.strictEqual(buildStateBody("Bogus", {}, fakeResolve), null);
+  });
+
+  it("emits remote host instead of pids when CLAWD_REMOTE is set", () => {
+    const original = process.env.CLAWD_REMOTE;
+    process.env.CLAWD_REMOTE = "1";
+    try {
+      const body = buildStateBody("Stop", { session_id: "s" }, fakeResolve);
+      assert.strictEqual(body.state, "attention");
+      assert.ok(typeof body.host === "string");
+      assert.strictEqual(body.source_pid, undefined);
+      assert.strictEqual(body.agent_pid, undefined);
+    } finally {
+      if (original === undefined) delete process.env.CLAWD_REMOTE;
+      else process.env.CLAWD_REMOTE = original;
+    }
+  });
+});
+
+describe("EVENT_TO_STATE coverage", () => {
+  it("includes all snake_case events emitted by the installer", () => {
+    const installerEvents = require("../hooks/nano-agent-install").NANO_COMMAND_HOOK_EVENTS;
+    for (const ev of installerEvents) {
+      const pascal = snakeToPascal(ev);
+      assert.ok(EVENT_TO_STATE[pascal], `missing EVENT_TO_STATE entry for ${ev} → ${pascal}`);
+    }
+  });
+});

--- a/test/nano-agent-install.test.js
+++ b/test/nano-agent-install.test.js
@@ -1,0 +1,209 @@
+// test/nano-agent-install.test.js — Verifies the nano-agent installer merges
+// hooks into ~/.config/nano/config.yaml without disturbing user content.
+
+const { describe, it, afterEach } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+const yaml = require("js-yaml");
+
+const {
+  HOOK_NAME_PREFIX,
+  NANO_COMMAND_HOOK_EVENTS,
+  NANO_HTTP_HOOK_EVENTS,
+  registerNanoAgentHooks,
+  unregisterNanoAgentHooks,
+} = require("../hooks/nano-agent-install");
+
+const tempDirs = [];
+
+function makeTempConfig(initial) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-nano-"));
+  const configPath = path.join(tmpDir, "config.yaml");
+  if (initial !== undefined) {
+    const text = typeof initial === "string" ? initial : yaml.dump(initial);
+    fs.writeFileSync(configPath, text, "utf8");
+  }
+  tempDirs.push(tmpDir);
+  return configPath;
+}
+
+function readYaml(filePath) {
+  return yaml.load(fs.readFileSync(filePath, "utf8"));
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+describe("nano-agent installer", () => {
+  it("skips silently when the config file is missing", () => {
+    const result = registerNanoAgentHooks({
+      silent: true,
+      configPath: path.join(os.tmpdir(), "clawd-nano-missing-" + Date.now(), "config.yaml"),
+    });
+    assert.strictEqual(result.status, "skipped");
+    assert.strictEqual(result.reason, "config-missing");
+    assert.strictEqual(result.added, 0);
+  });
+
+  it("registers all command + HTTP hooks on a fresh config", () => {
+    const configPath = makeTempConfig({ api_key: "test", model: "deepseek-chat" });
+    const result = registerNanoAgentHooks({
+      silent: true,
+      configPath,
+      nodeBin: "/usr/local/bin/node",
+      scriptPath: "/opt/clawd/hooks/nano-agent-hook.js",
+      port: 23333,
+    });
+
+    const expectedCount = NANO_COMMAND_HOOK_EVENTS.length + NANO_HTTP_HOOK_EVENTS.length;
+    assert.strictEqual(result.status, "ok");
+    assert.strictEqual(result.added, expectedCount);
+    assert.strictEqual(result.updated, 0);
+    assert.strictEqual(result.skipped, 0);
+
+    const config = readYaml(configPath);
+    assert.strictEqual(config.api_key, "test");
+    assert.strictEqual(config.model, "deepseek-chat");
+    assert.ok(config.security && Array.isArray(config.security.hooks));
+    assert.strictEqual(config.security.hooks.length, expectedCount);
+
+    for (const ev of NANO_COMMAND_HOOK_EVENTS) {
+      const entry = config.security.hooks.find((h) => h.name === `${HOOK_NAME_PREFIX}${ev}`);
+      assert.ok(entry, `expected entry for ${ev}`);
+      assert.strictEqual(entry.event, ev);
+      assert.strictEqual(entry.type, "command");
+      assert.ok(entry.command.includes("/opt/clawd/hooks/nano-agent-hook.js"));
+      assert.ok(entry.command.includes("/usr/local/bin/node"));
+      assert.ok(entry.enabled);
+    }
+    for (const ev of NANO_HTTP_HOOK_EVENTS) {
+      const entry = config.security.hooks.find((h) => h.name === `${HOOK_NAME_PREFIX}${ev}`);
+      assert.ok(entry, `expected entry for ${ev}`);
+      assert.strictEqual(entry.type, "http");
+      assert.ok(entry.http.url.includes("/permission"));
+      assert.ok(entry.http.url.includes("23333"));
+    }
+  });
+
+  it("is idempotent on a second run", () => {
+    const configPath = makeTempConfig({});
+    const opts = {
+      silent: true,
+      configPath,
+      nodeBin: "/usr/local/bin/node",
+      scriptPath: "/opt/clawd/hooks/nano-agent-hook.js",
+      port: 23333,
+    };
+    const first = registerNanoAgentHooks(opts);
+    const second = registerNanoAgentHooks(opts);
+    assert.strictEqual(second.added, 0);
+    assert.strictEqual(second.updated, 0);
+    assert.strictEqual(second.skipped, first.added);
+  });
+
+  it("updates stale entries when nodeBin or port changes", () => {
+    const configPath = makeTempConfig({});
+    registerNanoAgentHooks({
+      silent: true,
+      configPath,
+      nodeBin: "/usr/local/bin/node",
+      scriptPath: "/opt/clawd/hooks/nano-agent-hook.js",
+      port: 23333,
+    });
+    const result = registerNanoAgentHooks({
+      silent: true,
+      configPath,
+      nodeBin: "/opt/homebrew/bin/node",
+      scriptPath: "/opt/clawd/hooks/nano-agent-hook.js",
+      port: 23337,
+    });
+    const total = NANO_COMMAND_HOOK_EVENTS.length + NANO_HTTP_HOOK_EVENTS.length;
+    assert.strictEqual(result.added, 0);
+    assert.strictEqual(result.updated, total);
+
+    const config = readYaml(configPath);
+    const cmdEntry = config.security.hooks.find((h) => h.event === "pre_tool_use");
+    assert.ok(cmdEntry.command.includes("/opt/homebrew/bin/node"));
+    const httpEntry = config.security.hooks.find((h) => h.event === "permission_request");
+    assert.ok(httpEntry.http.url.includes("23337"));
+  });
+
+  it("preserves user-authored entries in security.hooks", () => {
+    const configPath = makeTempConfig({
+      security: {
+        allow_rules: ["Bash(git status:*)"],
+        hooks: [
+          {
+            name: "user-block-rm",
+            event: "pre_tool_use",
+            pattern: "shell:rm*",
+            command: "exit 2",
+            enabled: true,
+          },
+        ],
+      },
+    });
+    registerNanoAgentHooks({
+      silent: true,
+      configPath,
+      nodeBin: "/usr/local/bin/node",
+      scriptPath: "/opt/clawd/hooks/nano-agent-hook.js",
+    });
+
+    const config = readYaml(configPath);
+    assert.deepStrictEqual(config.security.allow_rules, ["Bash(git status:*)"]);
+    const userEntry = config.security.hooks.find((h) => h.name === "user-block-rm");
+    assert.ok(userEntry, "user hook must survive merge");
+    assert.strictEqual(userEntry.command, "exit 2");
+  });
+
+  it("rejects an incompatible security shape", () => {
+    const configPath = makeTempConfig({ security: "not-an-object" });
+    const result = registerNanoAgentHooks({ silent: true, configPath });
+    assert.strictEqual(result.status, "error");
+    assert.strictEqual(result.reason, "config-shape-incompatible");
+  });
+
+  it("remote mode prefixes commands with CLAWD_REMOTE=1", () => {
+    const configPath = makeTempConfig({});
+    registerNanoAgentHooks({
+      silent: true,
+      configPath,
+      nodeBin: "/usr/bin/node",
+      scriptPath: "/home/user/.claude/hooks/nano-agent-hook.js",
+      remote: true,
+    });
+    const config = readYaml(configPath);
+    const cmd = config.security.hooks.find((h) => h.event === "pre_tool_use").command;
+    assert.ok(cmd.startsWith("CLAWD_REMOTE=1 "), `expected CLAWD_REMOTE prefix, got: ${cmd}`);
+    assert.ok(cmd.includes("/home/user/.claude/hooks/nano-agent-hook.js"));
+  });
+
+  it("uninstall removes only clawd-on-desk entries", () => {
+    const configPath = makeTempConfig({
+      security: {
+        hooks: [
+          { name: "user-block-rm", event: "pre_tool_use", pattern: "shell:rm*", command: "exit 2", enabled: true },
+        ],
+      },
+    });
+    registerNanoAgentHooks({
+      silent: true,
+      configPath,
+      nodeBin: "/usr/local/bin/node",
+      scriptPath: "/opt/clawd/hooks/nano-agent-hook.js",
+    });
+    const total = NANO_COMMAND_HOOK_EVENTS.length + NANO_HTTP_HOOK_EVENTS.length;
+    const removed = unregisterNanoAgentHooks({ silent: true, configPath });
+    assert.strictEqual(removed.removed, total);
+
+    const config = readYaml(configPath);
+    assert.strictEqual(config.security.hooks.length, 1);
+    assert.strictEqual(config.security.hooks[0].name, "user-block-rm");
+  });
+});


### PR DESCRIPTION
Wires nano-agent's pkg/hookservice events into Clawd's state machine and adds remote SSH deployment for the nano hook stack.

- agents/nano-agent.js: PascalCase event map -> Clawd states; httpHook
  + permissionApproval capabilities
- hooks/nano-agent-hook.js: read NANO_HOOK_INPUT env, normalize snake_case -> PascalCase, treat Task/main_agent/spawn_agent as juggling, POST to /state
- hooks/nano-agent-install.js: idempotent merge into ~/.config/nano/config.yaml security.hooks; --remote prepends CLAWD_REMOTE=1; --uninstall strips clawd-on-desk:* entries
- src/integration-sync.js: register syncNanoAgentHooks in AGENT_INTEGRATION_SYNCERS so startup auto-syncs the user's nano config
- src/prefs.js, agents/registry.js: register the new agent
- scripts/remote-deploy.sh: ship nano-agent-hook.js + nano-agent-install.js + js-yaml/argparse vendor and run installer in --remote mode (skips with a warning when deps are missing)
- package.json: install:nano-hooks / uninstall:nano-hooks scripts; js-yaml ^4.1.0 in dependencies
- test: 25 new cases covering hook payload parsing, state body shape, installer idempotency / stale-update / user-hook preservation, remote mode, and uninstall