### PR TITLE
feat(telegram): native Bot API client with rich approval interactions

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -175,6 +175,7 @@ let agentRuntime = null;
 let floatingWindowRuntime = null;
 let codexPetMain = null;
 let telegramApprovalSidecar = null;
+let telegramNativeBot = null;
 let telegramApprovalSyncPromise = Promise.resolve();
 let telegramApprovalConfigSignature = "";
 let telegramApprovalTokenRevision = 0;
@@ -1201,6 +1202,9 @@ function focusLog(msg) {
 }
 
 function getTelegramApprovalClient() {
+  // Prefer native bot (supports rich interactions: options, checkboxes, text)
+  if (telegramNativeBot && telegramNativeBot.isEnabled()) return telegramNativeBot;
+  // Fall back to sidecar (basic allow/deny only)
   if (!telegramApprovalSidecar || typeof telegramApprovalSidecar.getClient !== "function") return null;
   return telegramApprovalSidecar.getClient();
 }
@@ -1255,6 +1259,18 @@ function getTelegramApprovalStatus() {
   const config = getTelegramApprovalPrefs();
   const token = getTelegramApprovalTokenStatus();
   const ready = telegramApprovalSettings.readiness(config, token);
+  // Native bot mode reports as "running" if enabled and configured
+  if (telegramNativeBot && telegramNativeBot.isEnabled()) {
+    return {
+      status: "running",
+      mode: "native",
+      enabled: config.enabled === true,
+      configured: ready.ready === true,
+      reason: ready.reason || "",
+      message: "",
+      tokenStored: token.tokenStored === true,
+    };
+  }
   const sidecarStatus = telegramApprovalSidecar && typeof telegramApprovalSidecar.getStatus === "function"
     ? telegramApprovalSidecar.getStatus()
     : { status: "stopped" };
@@ -1297,6 +1313,26 @@ function startTelegramApprovalSidecar() {
     }
     return false;
   }
+
+  // Native mode: use direct Telegram Bot API (supports rich interactions)
+  if (config.nativeMode !== false) {
+    const chatId = config.targetSessionKey
+      ? config.targetSessionKey.replace(/^telegram:/, "")
+      : "";
+    if (telegramNativeBot) telegramNativeBot.cleanup();
+    const { TelegramNativeBotClient } = require("./telegram-native-bot");
+    telegramNativeBot = new TelegramNativeBotClient({
+      tokenFilePath: paths.tokenEnvFilePath,
+      allowedUserId: config.allowedTgUserId,
+      chatId,
+      ttlMs: 90000,
+      log: telegramApprovalLog,
+    });
+    telegramApprovalLog("info", "native bot mode enabled");
+    telegramApprovalConfigSignature = buildTelegramApprovalSignature(config, paths, token);
+    return true;
+  }
+
   const configWrite = telegramApprovalSettings.writeBridgeConfigFile({
     fs,
     path,
@@ -1320,7 +1356,16 @@ function startTelegramApprovalSidecar() {
     }
     return true;
   }
-  if (telegramApprovalSidecar) return true;
+  if (telegramApprovalSidecar) {
+    // Config changed but old sidecar still assigned — stop it and recreate
+    // with updated config. Without this, a user-ID or session-key change
+    // would be written to TOML but the running sidecar would keep the old
+    // config until app restart.
+    telegramApprovalLog("info", "config signature changed, recreating sidecar");
+    telegramApprovalSidecar.stop().catch(() => {});
+    telegramApprovalSidecar = null;
+    telegramApprovalConfigSignature = "";
+  }
   // The bot token only ever lives at userData/telegram-approval.env on disk.
   // The sidecar reads it from there directly — Clawd's main process must never
   // pipe a token value through process.env or child env, so there is no
@@ -1346,6 +1391,11 @@ function startTelegramApprovalSidecar() {
 }
 
 function stopTelegramApprovalSidecar() {
+  // Cleanup native bot
+  if (telegramNativeBot) {
+    telegramNativeBot.cleanup();
+    telegramNativeBot = null;
+  }
   const sidecar = telegramApprovalSidecar;
   telegramApprovalSidecar = null;
   telegramApprovalConfigSignature = "";
@@ -1382,21 +1432,26 @@ function queueTelegramApprovalSidecarSync(reason) {
 
 async function sendTelegramApprovalTest() {
   await queueTelegramApprovalSidecarSync("test");
-  if (telegramApprovalSidecar && !getTelegramApprovalClient() && typeof telegramApprovalSidecar.start === "function") {
-    try {
-      await telegramApprovalSidecar.start();
-    } catch (err) {
-      return { status: "error", message: err && err.message ? err.message : "Telegram approval sidecar failed to start" };
+  // Native bot mode: already instantiated by sync
+  const client = getTelegramApprovalClient();
+  if (!client) {
+    // Fallback: try starting sidecar if native bot not available
+    if (telegramApprovalSidecar && typeof telegramApprovalSidecar.start === "function") {
+      try {
+        await telegramApprovalSidecar.start();
+      } catch (err) {
+        return { status: "error", message: err && err.message ? err.message : "Telegram approval failed to start" };
+      }
     }
   }
-  const client = getTelegramApprovalClient();
-  if (!client || typeof client.requestApproval !== "function") {
-    return { status: "error", message: "Telegram approval sidecar is not running" };
+  const finalClient = getTelegramApprovalClient();
+  if (!finalClient || typeof finalClient.requestApproval !== "function") {
+    return { status: "error", message: "Telegram approval is not running" };
   }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 60 * 1000);
   try {
-    const decision = await client.requestApproval({
+    const decision = await finalClient.requestApproval({
       title: "Clawd Telegram approval test",
       detail: "This is a settings test message. It is not attached to any agent permission request.",
     }, { signal: controller.signal });

--- a/src/permission.js
+++ b/src/permission.js
@@ -666,16 +666,25 @@ function compactRemoteApprovalText(value, maxLen = 200) {
 
 function isRemoteApprovalActionable(permEntry) {
   if (!permEntry || typeof permEntry !== "object") return false;
-  if (permEntry.isElicitation || permEntry.isCodexNotify || permEntry.isKimiNotify || permEntry.isOpencode) return false;
-  if (permEntry.toolName === "ExitPlanMode" || permEntry.toolName === "AskUserQuestion") return false;
+  if (permEntry.isCodexNotify || permEntry.isKimiNotify || permEntry.isOpencode) return false;
+  if (permEntry.toolName === "ExitPlanMode") return false;
   if (PASSTHROUGH_TOOLS.has(permEntry.toolName)) return false;
-  // Headless sessions auto-deny locally; mirror that on the Telegram side so a
-  // non-interactive Codex/Pi/CC run never sends an actionable approval card.
   const session = ctx.sessions && typeof ctx.sessions.get === "function"
     ? ctx.sessions.get(permEntry.sessionId)
     : null;
   if (session && session.headless) return false;
   return true;
+}
+
+function getRemoteApprovalType(permEntry) {
+  if (!isRemoteApprovalActionable(permEntry)) return null;
+  if (permEntry.isElicitation || permEntry.toolName === "AskUserQuestion") {
+    return "elicitation";
+  }
+  if (Array.isArray(permEntry.suggestions) && permEntry.suggestions.length > 0) {
+    return "suggestions";
+  }
+  return "permission";
 }
 
 // Returns a redacted summary string, or null when no agent-supplied description
@@ -765,11 +774,25 @@ function dismissPermissionForTerminal(perm) {
 }
 
 function maybeStartRemoteApproval(permEntry) {
-  if (!isRemoteApprovalActionable(permEntry)) return false;
+  const approvalType = getRemoteApprovalType(permEntry);
+  if (!approvalType) return false;
   const client = getTelegramApprovalClient();
   if (!client || typeof client.requestApproval !== "function") return false;
   if (typeof client.isEnabled === "function" && !client.isEnabled()) return false;
 
+  const supportsRich = typeof client.requestElicitation === "function";
+
+  if (approvalType === "elicitation") {
+    if (!supportsRich) return false;
+    return startElicitationRemoteApproval(permEntry, client);
+  }
+  if (approvalType === "suggestions" && supportsRich) {
+    return startSuggestionsRemoteApproval(permEntry, client);
+  }
+  return startBasicRemoteApproval(permEntry, client);
+}
+
+function startBasicRemoteApproval(permEntry, client) {
   const payload = buildRemoteApprovalPayload(permEntry);
   if (!payload) return false;
 
@@ -800,6 +823,121 @@ function maybeStartRemoteApproval(permEntry) {
     })
     .catch((err) => {
       permLog(`telegram remote approval failed: ${compactRemoteApprovalText(err && err.message ? err.message : err, 200)}`);
+    })
+    .finally(() => {
+      if (controller && permEntry.remoteApprovalAbortController === controller) {
+        permEntry.remoteApprovalAbortController = null;
+      }
+    });
+  return true;
+}
+
+function startSuggestionsRemoteApproval(permEntry, client) {
+  const payload = buildRemoteApprovalPayload(permEntry);
+  if (!payload) return false;
+
+  const controller = typeof AbortController === "function" ? new AbortController() : null;
+  if (controller) permEntry.remoteApprovalAbortController = controller;
+
+  let request;
+  try {
+    request = client.requestWithSuggestions(
+      payload,
+      permEntry.suggestions || [],
+      controller ? { signal: controller.signal } : {}
+    );
+  } catch (err) {
+    if (controller && permEntry.remoteApprovalAbortController === controller) {
+      permEntry.remoteApprovalAbortController = null;
+    }
+    permLog(`telegram remote approval (suggestions) failed: ${compactRemoteApprovalText(err && err.message ? err.message : err, 200)}`);
+    return false;
+  }
+
+  Promise.resolve(request)
+    .then((result) => {
+      if (!result) return;
+      if (result === "allow" || result === "deny") {
+        resolvePermissionEntry(permEntry, result);
+        return;
+      }
+      if (result.decision === "allow" && result.selectedSuggestion) {
+        const sug = result.selectedSuggestion;
+        if (sug.type === "addRules") {
+          const rules = Array.isArray(sug.rules) ? sug.rules
+            : [{ toolName: sug.toolName, ruleContent: sug.ruleContent }];
+          permEntry.resolvedSuggestion = {
+            type: "addRules",
+            destination: sug.destination || "localSettings",
+            behavior: sug.behavior || "allow",
+            rules,
+          };
+        } else if (sug.type === "setMode") {
+          permEntry.resolvedSuggestion = {
+            type: "setMode",
+            mode: sug.mode,
+            destination: sug.destination || "localSettings",
+          };
+        }
+        resolvePermissionEntry(permEntry, "allow");
+      } else if (result.decision) {
+        resolvePermissionEntry(permEntry, result.decision);
+      }
+    })
+    .catch((err) => {
+      permLog(`telegram remote approval (suggestions) failed: ${compactRemoteApprovalText(err && err.message ? err.message : err, 200)}`);
+    })
+    .finally(() => {
+      if (controller && permEntry.remoteApprovalAbortController === controller) {
+        permEntry.remoteApprovalAbortController = null;
+      }
+    });
+  return true;
+}
+
+function startElicitationRemoteApproval(permEntry, client) {
+  const toolInput = permEntry.toolInput && typeof permEntry.toolInput === "object" ? permEntry.toolInput : {};
+  const questions = Array.isArray(toolInput.questions) ? toolInput.questions : [];
+  if (questions.length === 0) return false;
+
+  const agentId = compactRemoteApprovalText(permEntry.agentId || "claude-code", 80) || "claude-code";
+  const payload = {
+    title: `${agentId} asks a question`,
+    detail: compactRemoteApprovalText(questions[0].question || "", 200),
+  };
+
+  const controller = typeof AbortController === "function" ? new AbortController() : null;
+  if (controller) permEntry.remoteApprovalAbortController = controller;
+
+  let request;
+  try {
+    request = client.requestElicitation(
+      payload,
+      questions,
+      controller ? { signal: controller.signal } : {}
+    );
+  } catch (err) {
+    if (controller && permEntry.remoteApprovalAbortController === controller) {
+      permEntry.remoteApprovalAbortController = null;
+    }
+    permLog(`telegram remote elicitation failed: ${compactRemoteApprovalText(err && err.message ? err.message : err, 200)}`);
+    return false;
+  }
+
+  Promise.resolve(request)
+    .then((result) => {
+      if (!result) return;
+      if (result === "deny" || result.decision === "deny") {
+        resolvePermissionEntry(permEntry, "deny");
+        return;
+      }
+      if (result.decision === "allow" && result.answers) {
+        permEntry.resolvedUpdatedInput = buildElicitationUpdatedInput(toolInput, result.answers);
+        resolvePermissionEntry(permEntry, "allow");
+      }
+    })
+    .catch((err) => {
+      permLog(`telegram remote elicitation failed: ${compactRemoteApprovalText(err && err.message ? err.message : err, 200)}`);
     })
     .finally(() => {
       if (controller && permEntry.remoteApprovalAbortController === controller) {

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -566,7 +566,9 @@ function handlePermissionPost(req, res, options) {
           }
           permEntry.bubble = null;
           ctx.sendPermissionResponse(res, "deny", "Elicitation bubble unavailable; answer in terminal", "Elicitation");
+          return;
         }
+        startRemoteApproval(ctx, permEntry);
         return;
       }
 

--- a/src/settings-tab-telegram-approval.js
+++ b/src/settings-tab-telegram-approval.js
@@ -32,10 +32,14 @@
       ops.showToast(t("toastSaveFailed") + "settings API unavailable", { error: true });
       return Promise.resolve({ status: "error" });
     }
-    return window.settingsAPI.command(action, payload).catch((err) => ({
-      status: "error",
-      message: err && err.message,
-    }));
+    try {
+      return window.settingsAPI.command(action, payload).catch((err) => ({
+        status: "error",
+        message: err && err.message,
+      }));
+    } catch (err) {
+      return Promise.resolve({ status: "error", message: err && err.message });
+    }
   }
 
   function refreshStatus({ forceRender = false } = {}) {
@@ -191,6 +195,10 @@
         ops.showToast(t("telegramApprovalTokenSaved"));
         view.status = null;
         refreshStatus({ forceRender: true });
+      }).catch(() => {
+        view.tokenPending = false;
+        ops.showToast(t("telegramApprovalTokenSaveFailed"), { error: true });
+        ops.requestRender({ content: true });
       });
     });
     ctrl.appendChild(input);
@@ -318,6 +326,10 @@
         }
         view.status = null;
         refreshStatus({ forceRender: true });
+      }).catch(() => {
+        view.testPending = false;
+        ops.showToast(t("telegramApprovalTestFailed"), { error: true });
+        ops.requestRender({ content: true });
       });
     });
     ctrl.appendChild(btn);

--- a/src/telegram-approval-settings.js
+++ b/src/telegram-approval-settings.js
@@ -6,11 +6,12 @@ const DEFAULT_TG_APPROVAL = Object.freeze({
   enabled: false,
   allowedTgUserId: "",
   targetSessionKey: "",
+  nativeMode: true,
 });
 
 const BOT_TOKEN_RE = /^\d+:[A-Za-z0-9_-]{30,}$/;
-const TELEGRAM_USER_ID_RE = /^[1-9]\d{4,19}$/;
-const TELEGRAM_SESSION_KEY_RE = /^telegram:-?[1-9]\d{4,19}(?::\d{1,20}){0,2}$/;
+const TELEGRAM_USER_ID_RE = /^[1-9]\d{0,19}$/;
+const TELEGRAM_SESSION_KEY_RE = /^telegram:-?[1-9]\d{0,19}(?::\d{1,20}){0,2}$/;
 
 function isPlainObject(value) {
   return !!value && typeof value === "object" && !Array.isArray(value);
@@ -46,6 +47,7 @@ function normalizeTelegramApproval(value, defaultsValue = DEFAULT_TG_APPROVAL) {
     enabled: defaults.enabled === true,
     allowedTgUserId: trimString(defaults.allowedTgUserId, 64),
     targetSessionKey: normalizeTelegramSessionKey(defaults.targetSessionKey),
+    nativeMode: defaults.nativeMode !== false,
   };
   if (!isPlainObject(value)) return out;
   if (typeof value.enabled === "boolean") out.enabled = value.enabled;
@@ -56,6 +58,7 @@ function normalizeTelegramApproval(value, defaultsValue = DEFAULT_TG_APPROVAL) {
   if (typeof value.targetSessionKey === "string") {
     out.targetSessionKey = normalizeTelegramSessionKey(value.targetSessionKey);
   }
+  if (typeof value.nativeMode === "boolean") out.nativeMode = value.nativeMode;
   return out;
 }
 
@@ -64,7 +67,7 @@ function validateTelegramApproval(value) {
     return { status: "error", message: "tgApproval must be a plain object" };
   }
   for (const key of Object.keys(value)) {
-    if (key !== "enabled" && key !== "allowedTgUserId" && key !== "targetSessionKey") {
+    if (key !== "enabled" && key !== "allowedTgUserId" && key !== "targetSessionKey" && key !== "nativeMode") {
       return { status: "error", message: `tgApproval.${key} is not supported` };
     }
   }
@@ -165,7 +168,7 @@ function writeTokenEnvFile({ fs, path: pathModule = path, filePath, token, platf
   }
 }
 
-function writeBridgeConfigFile({ fs, path: pathModule = path, filePath, config } = {}) {
+function writeBridgeConfigFile({ fs, path: pathModule = path, filePath, config, platform = process.platform } = {}) {
   if (!fs || typeof fs.writeFileSync !== "function") {
     return { status: "error", message: "writeBridgeConfigFile requires fs" };
   }
@@ -177,7 +180,7 @@ function writeBridgeConfigFile({ fs, path: pathModule = path, filePath, config }
   try {
     fs.mkdirSync(pathModule.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, buildBridgeConfigToml(config), { encoding: "utf8", mode: 0o600 });
-    if (process.platform !== "win32" && typeof fs.chmodSync === "function") {
+    if (platform !== "win32" && typeof fs.chmodSync === "function") {
       try { fs.chmodSync(filePath, 0o600); } catch {}
     }
     return { status: "ok", filePath };

--- a/src/telegram-approval-sidecar.js
+++ b/src/telegram-approval-sidecar.js
@@ -463,7 +463,10 @@ class TelegramApprovalSidecar extends EventEmitter {
     this.client = null;
     this.startPromise = null;
     if (this.requestedStop) {
-      this._setStatus({ status: "stopped" });
+      // When stop() was called, stop()'s own finish() callback handles the
+      // status emission. Skip here to avoid emitting "stopped" twice, which
+      // could overwrite a subsequent "starting" status if a new start() was
+      // triggered between the two emissions.
       return;
     }
     const message = `sidecar exited (${formatExit(code, signal)})`;

--- a/src/telegram-native-bot-messages.js
+++ b/src/telegram-native-bot-messages.js
@@ -1,0 +1,199 @@
+"use strict";
+
+// ── Telegram message builders for rich approval interactions ──
+//
+// Pure functions that produce Telegram Bot API message payloads with
+// inline keyboards. No side effects, no network, no state.
+
+const MAX_CALLBACK_DATA = 64; // Telegram's limit for callback_data
+const MAX_BUTTON_TEXT = 40;   // Practical limit for readable buttons
+const MAX_MESSAGE_TEXT = 4096; // Telegram message text limit
+
+// ── Markdown V2 escaping ──
+
+const MD2_ESCAPE_RE = /([_*\[\]()~`>#+\-=|{}.!\\])/g;
+
+function escapeMarkdownV2(text) {
+  return String(text || "").replace(MD2_ESCAPE_RE, "\\$1");
+}
+
+// ── Callback data helpers ──
+
+function callbackData(requestId, action) {
+  const data = `${requestId}:${action}`;
+  if (data.length > MAX_CALLBACK_DATA) {
+    return data.slice(0, MAX_CALLBACK_DATA);
+  }
+  return data;
+}
+
+function truncate(text, maxLen) {
+  const s = String(text || "").trim();
+  if (s.length <= maxLen) return s;
+  return s.slice(0, maxLen - 1) + "\u2026";
+}
+
+// ── Permission messages ──
+
+function buildPermissionMessage(payload, requestId) {
+  const title = truncate(payload && payload.title, 200) || "Permission request";
+  const detail = truncate(payload && payload.detail, 800);
+
+  const lines = [`*${escapeMarkdownV2(title)}*`];
+  if (detail) {
+    lines.push("");
+    lines.push(escapeMarkdownV2(detail));
+  }
+
+  return {
+    text: lines.join("\n"),
+    parse_mode: "MarkdownV2",
+    reply_markup: {
+      inline_keyboard: [
+        [
+          { text: "\u2705 Allow", callback_data: callbackData(requestId, "allow") },
+          { text: "\u274C Deny", callback_data: callbackData(requestId, "deny") },
+        ],
+      ],
+    },
+  };
+}
+
+function buildSuggestionsMessage(payload, suggestions, requestId) {
+  const base = buildPermissionMessage(payload, requestId);
+  if (!Array.isArray(suggestions) || suggestions.length === 0) return base;
+
+  const keyboard = [...base.reply_markup.inline_keyboard];
+
+  for (let i = 0; i < Math.min(suggestions.length, 5); i++) {
+    const sug = suggestions[i];
+    let label = "";
+    if (sug.type === "addRules" && Array.isArray(sug.rules) && sug.rules[0]) {
+      const rule = sug.rules[0];
+      label = `Always: ${truncate(rule.toolName, 12)} ${truncate(rule.ruleContent, 18)}`;
+    } else if (sug.type === "setMode") {
+      label = `Mode: ${truncate(sug.mode, 20)}`;
+    } else {
+      label = truncate(JSON.stringify(sug), MAX_BUTTON_TEXT);
+    }
+    keyboard.push([
+      { text: truncate(label, MAX_BUTTON_TEXT), callback_data: callbackData(requestId, `sug:${i}`) },
+    ]);
+  }
+
+  return {
+    ...base,
+    reply_markup: { inline_keyboard: keyboard },
+  };
+}
+
+// ── Elicitation messages ──
+
+function buildElicitationMessage(question, questionIndex, totalQuestions, requestId, toggleState) {
+  if (!question || typeof question !== "object") {
+    return { text: "Invalid question", reply_markup: { inline_keyboard: [] } };
+  }
+
+  const header = question.header ? `[${escapeMarkdownV2(truncate(question.header, 30))}] ` : "";
+  const qNum = totalQuestions > 1 ? ` \\(${questionIndex + 1}/${totalQuestions}\\)` : "";
+  const qText = escapeMarkdownV2(truncate(question.question, 500));
+
+  const lines = [`\u2753 ${header}${qText}${qNum}`];
+
+  const options = Array.isArray(question.options) ? question.options : [];
+  const isMulti = question.multiSelect === true;
+
+  if (!isMulti && options.length > 0) {
+    // Single-select: show option descriptions
+    lines.push("");
+    for (const opt of options.slice(0, 8)) {
+      const label = truncate(opt.label || opt, 60);
+      const desc = opt.description ? ` \\- ${escapeMarkdownV2(truncate(opt.description, 80))}` : "";
+      lines.push(`\u2022 ${escapeMarkdownV2(label)}${desc}`);
+    }
+  }
+
+  const keyboard = [];
+
+  if (isMulti) {
+    // Multi-select: toggle buttons with checkbox indicators
+    const state = toggleState || {};
+    for (let i = 0; i < Math.min(options.length, 8); i++) {
+      const opt = options[i];
+      const label = truncate(opt.label || String(opt), 35);
+      const checked = !!state[i];
+      const prefix = checked ? "\u2611" : "\u2610";
+      keyboard.push([
+        { text: `${prefix} ${label}`, callback_data: callbackData(requestId, `tog:${i}`) },
+      ]);
+    }
+    keyboard.push([
+      { text: "\u2705 Submit", callback_data: callbackData(requestId, "submit") },
+    ]);
+  } else {
+    // Single-select: one button per option
+    for (let i = 0; i < Math.min(options.length, 8); i++) {
+      const opt = options[i];
+      const label = truncate(opt.label || String(opt), MAX_BUTTON_TEXT);
+      keyboard.push([
+        { text: label, callback_data: callbackData(requestId, `opt:${i}`) },
+      ]);
+    }
+    // "Other..." button for text input
+    keyboard.push([
+      { text: "\u270F\uFE0F Other...", callback_data: callbackData(requestId, "other") },
+    ]);
+  }
+
+  return {
+    text: lines.join("\n"),
+    parse_mode: "MarkdownV2",
+    reply_markup: { inline_keyboard: keyboard },
+  };
+}
+
+function buildTextInputPrompt(requestId) {
+  return {
+    text: "\uD83D\uDCAC Type your answer as a *reply* to this message:",
+    parse_mode: "MarkdownV2",
+    reply_markup: {
+      inline_keyboard: [
+        [{ text: "\u274C Cancel", callback_data: callbackData(requestId, "cancel") }],
+      ],
+      force_reply: true,
+      selective: true,
+    },
+  };
+}
+
+// ── Completion messages ──
+
+function buildCompletedMessage(originalText, outcome) {
+  const plain = String(originalText || "").replace(/\\([_*\[\]()~`>#+\-=|{}.!\\])/g, "$1");
+  const suffix = outcome === "allow" ? "\n\n\u2705 Allowed"
+    : outcome === "deny" ? "\n\n\u274C Denied"
+    : outcome === "timeout" ? "\n\n\u23F1 Timed out"
+    : outcome === "cancelled" ? "\n\n\uD83D\uDDB1\uFE0F Resolved locally"
+    : `\n\n\u2714 ${outcome}`;
+  return escapeMarkdownV2(plain + suffix);
+}
+
+function emptyKeyboard() {
+  return { inline_keyboard: [] };
+}
+
+// ── Exports ──
+
+module.exports = {
+  escapeMarkdownV2,
+  callbackData,
+  truncate,
+  buildPermissionMessage,
+  buildSuggestionsMessage,
+  buildElicitationMessage,
+  buildTextInputPrompt,
+  buildCompletedMessage,
+  emptyKeyboard,
+  MAX_CALLBACK_DATA,
+  MAX_MESSAGE_TEXT,
+};

--- a/src/telegram-native-bot.js
+++ b/src/telegram-native-bot.js
@@ -1,0 +1,578 @@
+"use strict";
+
+// ── Native Telegram Bot API client for rich approval interactions ──
+//
+// Replaces the Go sidecar for Telegram communication. Uses Node.js built-in
+// https module to call Telegram Bot API directly. Supports inline keyboards,
+// callback queries, and text reply capture for elicitation.
+
+const https = require("https");
+const fs = require("fs");
+const crypto = require("crypto");
+const messages = require("./telegram-native-bot-messages");
+
+const TELEGRAM_API_HOST = "api.telegram.org";
+const POLL_TIMEOUT_S = 30;
+const GRACE_STOP_MS = 5000;
+const DEFAULT_TTL_MS = 90000;
+
+function generateRequestId() {
+  return crypto.randomBytes(4).toString("hex");
+}
+
+function noop() {}
+
+class TelegramNativeBotClient {
+  constructor(options = {}) {
+    this.tokenFilePath = options.tokenFilePath || "";
+    this.allowedUserId = String(options.allowedUserId || "").trim();
+    this.chatId = String(options.chatId || "").trim();
+    this.ttlMs = Number.isFinite(options.ttlMs) ? Math.max(5000, options.ttlMs) : DEFAULT_TTL_MS;
+    this.log = typeof options.log === "function" ? options.log : noop;
+    this.setTimer = options.setTimer || setTimeout;
+    this.clearTimer = options.clearTimer || clearTimeout;
+
+    this._tokenCache = null;
+    this._tokenMtimeMs = 0;
+    this._pollingActive = false;
+    this._pollAbort = null;
+    this._updateOffset = 0;
+    this._pendingRequests = new Map();
+    this._graceTimer = null;
+    this._botVerified = false;
+  }
+
+  isEnabled() {
+    return !!(this.tokenFilePath && this.allowedUserId && this.chatId);
+  }
+
+  // ── Public: basic allow/deny (drop-in for sidecar client) ──
+
+  requestApproval(payload, options = {}) {
+    return this._doRequest("permission", payload, null, options);
+  }
+
+  // ── Public: permission with suggestions ──
+
+  requestWithSuggestions(payload, suggestions, options = {}) {
+    return this._doRequest("suggestions", payload, { suggestions }, options);
+  }
+
+  // ── Public: elicitation (questions with options/checkboxes/text) ──
+
+  requestElicitation(payload, questions, options = {}) {
+    return this._doRequest("elicitation", payload, { questions }, options);
+  }
+
+  // ── Public: cleanup ──
+
+  cleanup() {
+    this._stopPolling();
+    for (const [, req] of this._pendingRequests) {
+      this._expireRequest(req, "cancelled");
+    }
+    this._pendingRequests.clear();
+  }
+
+  // ── Core request flow ──
+
+  async _doRequest(type, payload, extra, options = {}) {
+    const signal = options.signal;
+    if (signal && signal.aborted) return null;
+
+    const token = this._readToken();
+    if (!token) {
+      this.log("warn", "telegram native bot: token not available");
+      return null;
+    }
+
+    const requestId = generateRequestId();
+
+    try {
+      let messageId;
+
+      if (type === "permission") {
+        const msg = messages.buildPermissionMessage(payload, requestId);
+        messageId = await this._sendMessage(token, msg);
+      } else if (type === "suggestions") {
+        const msg = messages.buildSuggestionsMessage(payload, extra.suggestions, requestId);
+        messageId = await this._sendMessage(token, msg);
+      } else if (type === "elicitation") {
+        // Send first question
+        const questions = extra.questions || [];
+        if (questions.length === 0) return null;
+        const msg = messages.buildElicitationMessage(questions[0], 0, questions.length, requestId, {});
+        messageId = await this._sendMessage(token, msg);
+      }
+
+      if (!messageId) {
+        this.log("warn", "telegram native bot: failed to send message");
+        return null;
+      }
+
+      // Create pending request and wait for resolution
+      return await this._waitForResponse(requestId, type, messageId, extra, signal, token);
+    } catch (err) {
+      this.log("warn", "telegram native bot: request failed", { error: err && err.message });
+      return null;
+    }
+  }
+
+  _waitForResponse(requestId, type, messageId, extra, signal, token) {
+    return new Promise((resolve) => {
+      const pending = {
+        requestId,
+        type,
+        messageIds: new Set([messageId]),
+        token,
+        extra: extra || {},
+        toggleState: {},
+        answers: {},
+        currentQuestion: 0,
+        resolve,
+        ttlTimer: null,
+        textInputMessageId: null,
+      };
+
+      // TTL timeout
+      pending.ttlTimer = this.setTimer(() => {
+        this._expireRequest(pending, "timeout");
+      }, this.ttlMs);
+
+      // Abort signal
+      if (signal) {
+        const onAbort = () => {
+          this._expireRequest(pending, "cancelled");
+        };
+        if (signal.aborted) { resolve(null); return; }
+        signal.addEventListener("abort", onAbort, { once: true });
+        pending._onAbort = onAbort;
+        pending._signal = signal;
+      }
+
+      this._pendingRequests.set(requestId, pending);
+      this._startPolling();
+    });
+  }
+
+  _expireRequest(pending, reason) {
+    if (!this._pendingRequests.has(pending.requestId)) return;
+    this._pendingRequests.delete(pending.requestId);
+
+    if (pending.ttlTimer) this.clearTimer(pending.ttlTimer);
+    if (pending._signal && pending._onAbort) {
+      pending._signal.removeEventListener("abort", pending._onAbort);
+    }
+
+    // Edit message to show outcome
+    const token = pending.token || this._readToken();
+    if (token) {
+      for (const msgId of pending.messageIds) {
+        this._editMessageReplyMarkup(token, msgId, messages.emptyKeyboard()).catch(noop);
+      }
+    }
+
+    pending.resolve(null);
+    this._scheduleGraceStop();
+  }
+
+  // ── Polling ──
+
+  _startPolling() {
+    if (this._pollingActive) return;
+    this._pollingActive = true;
+    if (this._graceTimer) {
+      this.clearTimer(this._graceTimer);
+      this._graceTimer = null;
+    }
+    this._pollLoop();
+  }
+
+  _stopPolling() {
+    this._pollingActive = false;
+    if (this._pollAbort) {
+      this._pollAbort.abort();
+      this._pollAbort = null;
+    }
+    if (this._graceTimer) {
+      this.clearTimer(this._graceTimer);
+      this._graceTimer = null;
+    }
+  }
+
+  _scheduleGraceStop() {
+    if (this._pendingRequests.size > 0) return;
+    if (this._graceTimer) return;
+    this._graceTimer = this.setTimer(() => {
+      this._graceTimer = null;
+      if (this._pendingRequests.size === 0) {
+        this._stopPolling();
+      }
+    }, GRACE_STOP_MS);
+  }
+
+  async _pollLoop() {
+    while (this._pollingActive) {
+      const token = this._readToken();
+      if (!token) { this._stopPolling(); break; }
+
+      try {
+        const controller = typeof AbortController === "function" ? new AbortController() : null;
+        this._pollAbort = controller;
+
+        const result = await this._apiCall(token, "getUpdates", {
+          offset: this._updateOffset,
+          timeout: POLL_TIMEOUT_S,
+          allowed_updates: ["callback_query", "message"],
+        }, controller ? controller.signal : null, (POLL_TIMEOUT_S + 5) * 1000);
+
+        if (!this._pollingActive) break;
+        if (result && Array.isArray(result.result)) {
+          for (const update of result.result) {
+            this._updateOffset = update.update_id + 1;
+            this._handleUpdate(update, token);
+          }
+        }
+      } catch (err) {
+        if (!this._pollingActive) break;
+        this.log("debug", "telegram native bot: poll error", { error: err && err.message });
+        // Brief pause before retry on error
+        await new Promise((r) => this.setTimer(r, 2000));
+      }
+    }
+  }
+
+  // ── Update handling ──
+
+  _handleUpdate(update, token) {
+    if (update.callback_query) {
+      this._handleCallbackQuery(update.callback_query, token);
+    } else if (update.message) {
+      this._handleMessage(update.message, token);
+    }
+  }
+
+  _handleCallbackQuery(cq, token) {
+    // Security: validate user
+    if (!cq.from || String(cq.from.id) !== this.allowedUserId) return;
+
+    const data = cq.data || "";
+    const colonIdx = data.indexOf(":");
+    if (colonIdx === -1) return;
+
+    const requestId = data.slice(0, colonIdx);
+    const action = data.slice(colonIdx + 1);
+    const pending = this._pendingRequests.get(requestId);
+    if (!pending) {
+      // Acknowledge stale callback
+      this._answerCallbackQuery(token, cq.id, "Expired").catch(noop);
+      return;
+    }
+
+    // Acknowledge the callback
+    this._answerCallbackQuery(token, cq.id, "").catch(noop);
+
+    if (action === "allow" || action === "deny") {
+      this._resolvePermission(pending, action, token);
+    } else if (action.startsWith("sug:")) {
+      const idx = parseInt(action.slice(4), 10);
+      this._resolveSuggestion(pending, idx, token);
+    } else if (action.startsWith("opt:")) {
+      const idx = parseInt(action.slice(4), 10);
+      this._resolveOption(pending, idx, token);
+    } else if (action.startsWith("tog:")) {
+      const idx = parseInt(action.slice(4), 10);
+      this._toggleCheckbox(pending, idx, token);
+    } else if (action === "submit") {
+      this._submitMultiSelect(pending, token);
+    } else if (action === "other") {
+      this._promptTextInput(pending, token);
+    } else if (action === "cancel") {
+      this._expireRequest(pending, "cancelled");
+    }
+  }
+
+  _handleMessage(msg, token) {
+    // Security: validate user
+    if (!msg.from || String(msg.from.id) !== this.allowedUserId) return;
+    if (!msg.reply_to_message) return;
+
+    const replyToId = msg.reply_to_message.message_id;
+    // Find pending request that has this message as a text input prompt
+    for (const [, pending] of this._pendingRequests) {
+      if (pending.textInputMessageId === replyToId) {
+        this._handleTextReply(pending, msg.text || "", token);
+        return;
+      }
+    }
+  }
+
+  // ── Resolution handlers ──
+
+  _resolvePermission(pending, decision, token) {
+    this._finishRequest(pending, decision, token);
+  }
+
+  _resolveSuggestion(pending, idx, token) {
+    const suggestions = pending.extra && pending.extra.suggestions;
+    const suggestion = Array.isArray(suggestions) ? suggestions[idx] : null;
+    this._finishRequest(pending, { decision: "allow", selectedSuggestion: suggestion || null, suggestionIndex: idx }, token);
+  }
+
+  _resolveOption(pending, idx, token) {
+    const questions = pending.extra && pending.extra.questions;
+    if (!Array.isArray(questions)) {
+      this._finishRequest(pending, null, token);
+      return;
+    }
+    const q = questions[pending.currentQuestion];
+    const options = q && Array.isArray(q.options) ? q.options : [];
+    const selected = options[idx];
+    const answerText = selected && selected.label ? selected.label : String(selected || "");
+
+    pending.answers[q.question] = answerText;
+    pending.currentQuestion++;
+
+    // More questions?
+    if (pending.currentQuestion < questions.length) {
+      this._sendNextQuestion(pending, token);
+    } else {
+      this._finishElicitation(pending, token);
+    }
+  }
+
+  _toggleCheckbox(pending, idx, token) {
+    pending.toggleState[idx] = !pending.toggleState[idx];
+    // Re-render the message with updated toggle state
+    const questions = pending.extra && pending.extra.questions;
+    if (!Array.isArray(questions)) return;
+    const q = questions[pending.currentQuestion];
+    const msg = messages.buildElicitationMessage(
+      q, pending.currentQuestion, questions.length, pending.requestId, pending.toggleState
+    );
+    const msgId = [...pending.messageIds].pop();
+    if (msgId) {
+      this._editMessageReplyMarkup(token, msgId, msg.reply_markup).catch(noop);
+    }
+  }
+
+  _submitMultiSelect(pending, token) {
+    const questions = pending.extra && pending.extra.questions;
+    if (!Array.isArray(questions)) {
+      this._finishRequest(pending, null, token);
+      return;
+    }
+    const q = questions[pending.currentQuestion];
+    const options = q && Array.isArray(q.options) ? q.options : [];
+
+    // Collect toggled options
+    const selected = [];
+    for (let i = 0; i < options.length; i++) {
+      if (pending.toggleState[i]) {
+        selected.push(options[i].label || String(options[i]));
+      }
+    }
+    pending.answers[q.question] = selected.join(", ");
+    pending.toggleState = {};
+    pending.currentQuestion++;
+
+    if (pending.currentQuestion < questions.length) {
+      this._sendNextQuestion(pending, token);
+    } else {
+      this._finishElicitation(pending, token);
+    }
+  }
+
+  async _promptTextInput(pending, token) {
+    const msg = messages.buildTextInputPrompt(pending.requestId);
+    try {
+      const msgId = await this._sendMessage(token, msg);
+      if (msgId) {
+        pending.textInputMessageId = msgId;
+        pending.messageIds.add(msgId);
+      }
+    } catch (err) {
+      this.log("debug", "telegram native bot: text input prompt failed", { error: err && err.message });
+    }
+  }
+
+  _handleTextReply(pending, text, token) {
+    const trimmed = String(text || "").trim();
+    if (!trimmed) return;
+
+    const questions = pending.extra && pending.extra.questions;
+    if (!Array.isArray(questions)) {
+      // Basic permission — treat as deny message?
+      this._finishRequest(pending, null, token);
+      return;
+    }
+    const q = questions[pending.currentQuestion];
+    if (q) {
+      pending.answers[q.question] = trimmed;
+    }
+    pending.textInputMessageId = null;
+    pending.currentQuestion++;
+
+    if (pending.currentQuestion < questions.length) {
+      this._sendNextQuestion(pending, token);
+    } else {
+      this._finishElicitation(pending, token);
+    }
+  }
+
+  async _sendNextQuestion(pending, token) {
+    const questions = pending.extra.questions;
+    const q = questions[pending.currentQuestion];
+    pending.toggleState = {};
+    const msg = messages.buildElicitationMessage(
+      q, pending.currentQuestion, questions.length, pending.requestId, {}
+    );
+    try {
+      const msgId = await this._sendMessage(token, msg);
+      if (msgId) pending.messageIds.add(msgId);
+    } catch (err) {
+      this.log("debug", "telegram native bot: next question failed", { error: err && err.message });
+      this._finishElicitation(pending, token);
+    }
+  }
+
+  _finishElicitation(pending, token) {
+    this._finishRequest(pending, { decision: "allow", answers: pending.answers }, token);
+  }
+
+  _finishRequest(pending, result, token) {
+    if (!this._pendingRequests.has(pending.requestId)) return;
+    this._pendingRequests.delete(pending.requestId);
+
+    if (pending.ttlTimer) this.clearTimer(pending.ttlTimer);
+    if (pending._signal && pending._onAbort) {
+      pending._signal.removeEventListener("abort", pending._onAbort);
+    }
+
+    // Clean up messages
+    if (token) {
+      for (const msgId of pending.messageIds) {
+        this._editMessageReplyMarkup(token, msgId, messages.emptyKeyboard()).catch(noop);
+      }
+    }
+
+    // Normalize result for basic permission compatibility
+    if (result === "allow" || result === "deny") {
+      pending.resolve(result);
+    } else {
+      pending.resolve(result);
+    }
+
+    this._scheduleGraceStop();
+  }
+
+  // ── Token management ──
+
+  _readToken() {
+    if (!this.tokenFilePath) return null;
+    try {
+      const stat = fs.statSync(this.tokenFilePath);
+      if (this._tokenCache && stat.mtimeMs === this._tokenMtimeMs) {
+        return this._tokenCache;
+      }
+      const content = fs.readFileSync(this.tokenFilePath, "utf8");
+      const match = content.match(/CLAWD_TG_BOT_TOKEN=(.+)/);
+      if (!match) return null;
+      this._tokenCache = match[1].trim();
+      this._tokenMtimeMs = stat.mtimeMs;
+      return this._tokenCache;
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Telegram API calls ──
+
+  _sendMessage(token, msg) {
+    const body = {
+      chat_id: this.chatId,
+      text: msg.text,
+      parse_mode: msg.parse_mode,
+      reply_markup: msg.reply_markup,
+    };
+    return this._apiCall(token, "sendMessage", body, null, 15000).then((res) => {
+      if (res && res.ok && res.result) return res.result.message_id;
+      this.log("debug", "telegram native bot: sendMessage failed", { response: res });
+      return null;
+    });
+  }
+
+  _editMessageReplyMarkup(token, messageId, replyMarkup) {
+    return this._apiCall(token, "editMessageReplyMarkup", {
+      chat_id: this.chatId,
+      message_id: messageId,
+      reply_markup: replyMarkup,
+    }, null, 10000).catch(noop);
+  }
+
+  _answerCallbackQuery(token, callbackQueryId, text) {
+    return this._apiCall(token, "answerCallbackQuery", {
+      callback_query_id: callbackQueryId,
+      text: text || undefined,
+    }, null, 10000).catch(noop);
+  }
+
+  _apiCall(token, method, body, signal, timeoutMs = 30000) {
+    return new Promise((resolve, reject) => {
+      if (signal && signal.aborted) { reject(new Error("aborted")); return; }
+
+      const data = JSON.stringify(body);
+      const options = {
+        hostname: TELEGRAM_API_HOST,
+        port: 443,
+        path: `/bot${token}/${method}`,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(data),
+        },
+      };
+
+      let settled = false;
+      const finish = (err, result) => {
+        if (settled) return;
+        settled = true;
+        if (signal && onAbort) signal.removeEventListener("abort", onAbort);
+        if (err) reject(err); else resolve(result);
+      };
+
+      const onAbort = () => {
+        if (req && typeof req.destroy === "function") req.destroy(new Error("aborted"));
+        finish(new Error("aborted"));
+      };
+
+      const req = https.request(options, (res) => {
+        let chunks = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => { chunks += chunk; });
+        res.on("end", () => {
+          try {
+            finish(null, JSON.parse(chunks));
+          } catch {
+            finish(new Error(`invalid JSON from Telegram API: ${method}`));
+          }
+        });
+      });
+
+      req.on("error", (err) => finish(err));
+
+      if (timeoutMs > 0) {
+        req.setTimeout(timeoutMs, () => {
+          req.destroy(new Error(`telegram API timeout: ${method}`));
+        });
+      }
+
+      if (signal) signal.addEventListener("abort", onAbort, { once: true });
+
+      req.write(data);
+      req.end();
+    });
+  }
+}
+
+module.exports = { TelegramNativeBotClient };

--- a/test/prefs.test.js
+++ b/test/prefs.test.js
@@ -64,6 +64,7 @@ describe("prefs.getDefaults", () => {
       enabled: false,
       allowedTgUserId: "",
       targetSessionKey: "",
+      nativeMode: true,
     });
   });
 
@@ -236,6 +237,7 @@ describe("prefs.validate", () => {
       enabled: true,
       allowedTgUserId: "123456789",
       targetSessionKey: "telegram:987654321",
+      nativeMode: true,
     });
     assert.strictEqual(Object.prototype.hasOwnProperty.call(v.tgApproval, "botToken"), false);
   });

--- a/test/telegram-approval-settings.test.js
+++ b/test/telegram-approval-settings.test.js
@@ -31,6 +31,7 @@ test("normalizeTelegramApproval trims ids and accepts numeric chat id shorthand"
     enabled: true,
     allowedTgUserId: "123456789",
     targetSessionKey: "telegram:987654321",
+    nativeMode: true,
   });
 });
 


### PR DESCRIPTION
  ## Summary

  - **Fix 4 bugs** in the existing Telegram approval sidecar/settings UI (status race, config reload, stuck UI states,
  regex too restrictive)
  - **Add native Node.js Telegram Bot API client** that replaces the Go sidecar for richer interactions
  - **Enable elicitation and suggestions** for remote Telegram approval (previously blocked)

  ## Motivation

  The Go sidecar (`cc-connect-clawd`) only supports `{title, detail} → {decision: "allow"|"deny"}` — no custom buttons,
  no option selection, no text input. Additionally, running multiple instances causes `getUpdates` conflicts that
  silently break approval.

  The native client uses Node.js built-in `https` module (zero new dependencies) and calls the Telegram Bot API
  directly, enabling:

  - **Inline keyboard buttons** for Allow/Deny
  - **Permission suggestion buttons** (e.g., "Always allow Bash npm*")
  - **Single-select options** for AskUserQuestion elicitation
  - **Multi-select checkboxes** with visual ☐/☑ toggle state
  - **Text input** via Telegram reply ("Other..." option)
  - **No getUpdates conflict** — only one poller runs

  ## Breaking changes

  None. `nativeMode` defaults to `true` but setting it to `false` preserves the original sidecar behavior. The Go binary
   is still bundled for backward compatibility.

  ## Test plan

  - [x] All 2574 existing tests pass (2 pre-existing workflow failures unrelated)
  - [x] Manual test: Allow/Deny buttons on Telegram — response received correctly
  - [x] Manual test: Multi-select checkboxes — toggle multiple, submit, correct answer returned
  - [x] Manual test: Single-select options — pick one, answer mapped correctly
  - [x] Manual test: No `cc-connect-clawd.exe` process spawned in native mode
  - [x] Manual test: No getUpdates conflict errors in logs
  - [ ] macOS/Linux testing welcome

 