### PR TITLE
Fetch Telegram sidecar for source launches

### DIFF
--- a/bin/cc-connect-clawd/README.md
+++ b/bin/cc-connect-clawd/README.md
@@ -19,14 +19,16 @@ Clawd release builds fetch the pinned public fork release with:
   npm run fetch:sidecars
 
 Source checkouts run a lightweight preflight before `npm start`. It downloads
-the current platform's pinned sidecar when missing, verifies checksums, and then
-continues launching Clawd. To skip that network preflight, set
+the current platform's pinned sidecar when missing, verifies the downloaded
+archive and extracted binary against SHA256 values pinned in
+`scripts/fetch-sidecar-binaries.js`, and then continues launching Clawd. To skip that network preflight, set
 `CLAWD_SKIP_SIDECAR_FETCH=1`. Setting `CLAWD_CC_CONNECT_CLAWD_PATH` to an
 existing executable or containing directory also skips the preflight fetch.
 
 The fetch script downloads release archives from
-`rullerzhou-afk/cc-connect-clawd`, verifies `checksums.txt`, and extracts the
-binaries into this directory layout. Do not use upstream latest artifacts.
+`rullerzhou-afk/cc-connect-clawd`, verifies the source-pinned checksums, and
+extracts the binaries into this directory layout. Do not use upstream latest
+artifacts.
 
 Upstream `chenhg5/cc-connect` updates are not consumed automatically. To update
 the sidecar dependency, sync the public `cc-connect-clawd` fork from upstream,

--- a/bin/cc-connect-clawd/README.md
+++ b/bin/cc-connect-clawd/README.md
@@ -21,7 +21,8 @@ Clawd release builds fetch the pinned public fork release with:
 Source checkouts run a lightweight preflight before `npm start`. It downloads
 the current platform's pinned sidecar when missing, verifies checksums, and then
 continues launching Clawd. To skip that network preflight, set
-`CLAWD_SKIP_SIDECAR_FETCH=1`.
+`CLAWD_SKIP_SIDECAR_FETCH=1`. Setting `CLAWD_CC_CONNECT_CLAWD_PATH` to an
+existing executable or containing directory also skips the preflight fetch.
 
 The fetch script downloads release archives from
 `rullerzhou-afk/cc-connect-clawd`, verifies `checksums.txt`, and extracts the

--- a/bin/cc-connect-clawd/README.md
+++ b/bin/cc-connect-clawd/README.md
@@ -18,6 +18,11 @@ Clawd release builds fetch the pinned public fork release with:
 
   npm run fetch:sidecars
 
+Source checkouts run a lightweight preflight before `npm start`. It downloads
+the current platform's pinned sidecar when missing, verifies checksums, and then
+continues launching Clawd. To skip that network preflight, set
+`CLAWD_SKIP_SIDECAR_FETCH=1`.
+
 The fetch script downloads release archives from
 `rullerzhou-afk/cc-connect-clawd`, verifies `checksums.txt`, and extracts the
 binaries into this directory layout. Do not use upstream latest artifacts.

--- a/docs/project/release-process.md
+++ b/docs/project/release-process.md
@@ -16,8 +16,8 @@ node scripts/verify-sidecar-binaries.js prebuild:all
 4. Run the `Build & Release` workflow manually on `main`.
 
 Manual workflow dispatch builds Windows, macOS, and Linux artifacts, fetches the
-pinned `cc-connect-clawd` sidecar release, verifies checksums, and uploads build
-artifacts. It does not publish a GitHub Release.
+pinned `cc-connect-clawd` sidecar release, verifies source-pinned checksums, and
+uploads build artifacts. It does not publish a GitHub Release.
 
 ## Draft Release
 
@@ -41,8 +41,8 @@ bad draft release.
 
 Clawd release builds do not consume upstream `cc-connect` latest artifacts. They
 download the fixed `cc-connect-clawd` fork release pinned by
-`scripts/fetch-sidecar-binaries.js`, verify `checksums.txt`, and package those
-binaries into app resources.
+`scripts/fetch-sidecar-binaries.js`, verify SHA256 values pinned in that script,
+and package those binaries into app resources.
 
 When the sidecar needs an upstream update, publish a new fixed sidecar release
 from the fork first, then update the Clawd pin and rerun the fetch/verify tests.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A desktop pet that reacts to your Claude Code sessions in real-time.",
   "main": "src/main.js",
   "scripts": {
-    "start": "node launch.js",
+    "start": "node scripts/ensure-sidecar-binaries.js && node launch.js",
     "build": "electron-builder --win",
     "build:win:x64": "electron-builder --win nsis:x64",
     "build:win:arm64": "electron-builder --win nsis:arm64",

--- a/scripts/ensure-sidecar-binaries.js
+++ b/scripts/ensure-sidecar-binaries.js
@@ -76,6 +76,10 @@ function write(stream, message) {
   if (stream && typeof stream.write === "function") stream.write(message);
 }
 
+function skipPreflightHint() {
+  return `Set ${SKIP_ENV}=1 before running npm start to skip the sidecar preflight.`;
+}
+
 async function ensureCurrentPlatformSidecar(options = {}) {
   const env = options.env || process.env;
   const fsModule = options.fs || fs;
@@ -92,9 +96,12 @@ async function ensureCurrentPlatformSidecar(options = {}) {
     if (isExistingFile(fsModule, overridePath)) {
       return { ok: true, skipped: true, reason: "override-path", path: overridePath };
     }
+    const launchMessage = options.strict
+      ? "Strict mode will stop launch until the override path is fixed, or unset to allow automatic sidecar fetch."
+      : "Clawd will still launch. Fix the override path, or unset it to allow automatic sidecar fetch.";
     write(stderr, [
       `${OVERRIDE_ENV} is set but no sidecar executable was found: ${overridePath || env[OVERRIDE_ENV]}`,
-      "Clawd will still launch. Fix the override path, or unset it to allow automatic sidecar fetch.",
+      launchMessage,
       "",
     ].join("\n"));
     return { ok: false, skipped: true, reason: "override-path-missing", path: overridePath || String(env[OVERRIDE_ENV]) };
@@ -134,7 +141,7 @@ async function ensureCurrentPlatformSidecar(options = {}) {
     write(stderr, [
       "Telegram approval sidecar is missing and could not be fetched automatically.",
       `Run: ${command}`,
-      `Skip next time: ${SKIP_ENV}=1 npm start`,
+      skipPreflightHint(),
       `Reason: ${message}`,
       "",
     ].join("\n"));
@@ -193,6 +200,7 @@ module.exports = {
   sidecarFetchCommand,
   runtimeExecutableName,
   resolveOverridePath,
+  skipPreflightHint,
   ensureCurrentPlatformSidecar,
   parseArgs,
 };

--- a/scripts/ensure-sidecar-binaries.js
+++ b/scripts/ensure-sidecar-binaries.js
@@ -11,6 +11,7 @@ const {
 const ENSURE_COMMAND = "node scripts/ensure-sidecar-binaries.js";
 const SKIP_ENV = "CLAWD_SKIP_SIDECAR_FETCH";
 const OVERRIDE_ENV = "CLAWD_CC_CONNECT_CLAWD_PATH";
+const DEFAULT_PREFLIGHT_REQUEST_TIMEOUT_MS = 30000;
 
 function runtimePlatformName(platform = process.platform) {
   if (platform === "win32") return "windows";
@@ -48,6 +49,29 @@ function sidecarFetchCommand(targetDir) {
   return `npm run fetch:sidecars -- --target ${targetDir}`;
 }
 
+function runtimeExecutableName(platform = process.platform) {
+  return platform === "win32" ? "cc-connect-clawd.exe" : "cc-connect-clawd";
+}
+
+function resolveOverridePath(rawValue, options = {}) {
+  const value = String(rawValue || "").trim();
+  if (!value) return "";
+  const fsModule = options.fs || fs;
+  const platform = options.platform || process.platform;
+  try {
+    if (fsModule && typeof fsModule.statSync === "function") {
+      const stat = fsModule.statSync(value);
+      if (stat && typeof stat.isDirectory === "function" && stat.isDirectory()) {
+        return path.join(value, runtimeExecutableName(platform));
+      }
+    }
+  } catch {
+    // Treat the override as a direct executable path below.
+  }
+  if (/[\\/]$/.test(value)) return path.join(value, runtimeExecutableName(platform));
+  return value;
+}
+
 function write(stream, message) {
   if (stream && typeof stream.write === "function") stream.write(message);
 }
@@ -64,7 +88,16 @@ async function ensureCurrentPlatformSidecar(options = {}) {
     return { ok: true, skipped: true, reason: "env-skip" };
   }
   if (env[OVERRIDE_ENV]) {
-    return { ok: true, skipped: true, reason: "override-path" };
+    const overridePath = resolveOverridePath(env[OVERRIDE_ENV], { fs: fsModule, platform: options.platform });
+    if (isExistingFile(fsModule, overridePath)) {
+      return { ok: true, skipped: true, reason: "override-path", path: overridePath };
+    }
+    write(stderr, [
+      `${OVERRIDE_ENV} is set but no sidecar executable was found: ${overridePath || env[OVERRIDE_ENV]}`,
+      "Clawd will still launch. Fix the override path, or unset it to allow automatic sidecar fetch.",
+      "",
+    ].join("\n"));
+    return { ok: false, skipped: true, reason: "override-path-missing", path: overridePath || String(env[OVERRIDE_ENV]) };
   }
   if (!target) {
     return {
@@ -89,13 +122,19 @@ async function ensureCurrentPlatformSidecar(options = {}) {
   write(stdout, `Missing ${target.dir} cc-connect-clawd sidecar; fetching pinned binary...\n`);
   try {
     const fetch = options.fetchSidecarBinaries || fetchSidecarBinaries;
-    await fetch({ rootDir, target: target.dir, fs: fsModule });
+    await fetch({
+      rootDir,
+      target: target.dir,
+      fs: fsModule,
+      requestTimeoutMs: options.requestTimeoutMs || DEFAULT_PREFLIGHT_REQUEST_TIMEOUT_MS,
+    });
     return { ok: true, fetched: true, target: target.dir, path: binaryPath };
   } catch (err) {
     const message = err && err.message ? err.message : String(err);
     write(stderr, [
       "Telegram approval sidecar is missing and could not be fetched automatically.",
       `Run: ${command}`,
+      `Skip next time: ${SKIP_ENV}=1 npm start`,
       `Reason: ${message}`,
       "",
     ].join("\n"));
@@ -146,11 +185,14 @@ module.exports = {
   ENSURE_COMMAND,
   SKIP_ENV,
   OVERRIDE_ENV,
+  DEFAULT_PREFLIGHT_REQUEST_TIMEOUT_MS,
   runtimePlatformName,
   runtimeSidecarTarget,
   truthyEnv,
   isExistingFile,
   sidecarFetchCommand,
+  runtimeExecutableName,
+  resolveOverridePath,
   ensureCurrentPlatformSidecar,
   parseArgs,
 };

--- a/scripts/ensure-sidecar-binaries.js
+++ b/scripts/ensure-sidecar-binaries.js
@@ -1,0 +1,156 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const {
+  TARGETS,
+  fetchSidecarBinaries,
+  targetBinaryPath,
+} = require("./fetch-sidecar-binaries");
+
+const ENSURE_COMMAND = "node scripts/ensure-sidecar-binaries.js";
+const SKIP_ENV = "CLAWD_SKIP_SIDECAR_FETCH";
+const OVERRIDE_ENV = "CLAWD_CC_CONNECT_CLAWD_PATH";
+
+function runtimePlatformName(platform = process.platform) {
+  if (platform === "win32") return "windows";
+  if (platform === "darwin") return "darwin";
+  if (platform === "linux") return "linux";
+  return "";
+}
+
+function runtimeSidecarTarget(options = {}) {
+  const platformName = runtimePlatformName(options.platform);
+  const arch = String(options.arch || process.arch || "").trim();
+  if (!platformName || !arch) return null;
+  const dir = `${platformName}-${arch}`;
+  const target = TARGETS.find((item) => item.dir === dir);
+  return target ? { ...target } : null;
+}
+
+function truthyEnv(value) {
+  const text = String(value == null ? "" : value).trim().toLowerCase();
+  return !!text && text !== "0" && text !== "false" && text !== "no";
+}
+
+function isExistingFile(fsModule, filePath) {
+  try {
+    if (!fsModule.existsSync(filePath)) return false;
+    if (typeof fsModule.statSync !== "function") return true;
+    const stat = fsModule.statSync(filePath);
+    return !stat || typeof stat.isFile !== "function" || stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
+function sidecarFetchCommand(targetDir) {
+  return `npm run fetch:sidecars -- --target ${targetDir}`;
+}
+
+function write(stream, message) {
+  if (stream && typeof stream.write === "function") stream.write(message);
+}
+
+async function ensureCurrentPlatformSidecar(options = {}) {
+  const env = options.env || process.env;
+  const fsModule = options.fs || fs;
+  const rootDir = options.rootDir || path.join(__dirname, "..");
+  const stdout = options.stdout || process.stdout;
+  const stderr = options.stderr || process.stderr;
+  const target = options.target || runtimeSidecarTarget(options);
+
+  if (truthyEnv(env[SKIP_ENV])) {
+    return { ok: true, skipped: true, reason: "env-skip" };
+  }
+  if (env[OVERRIDE_ENV]) {
+    return { ok: true, skipped: true, reason: "override-path" };
+  }
+  if (!target) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: "unsupported-runtime",
+      platform: options.platform || process.platform,
+      arch: options.arch || process.arch,
+    };
+  }
+
+  const binaryPath = targetBinaryPath(rootDir, target);
+  if (isExistingFile(fsModule, binaryPath)) {
+    return { ok: true, existing: true, target: target.dir, path: binaryPath };
+  }
+
+  const command = sidecarFetchCommand(target.dir);
+  if (options.dryRun) {
+    return { ok: false, missing: true, target: target.dir, path: binaryPath, command };
+  }
+
+  write(stdout, `Missing ${target.dir} cc-connect-clawd sidecar; fetching pinned binary...\n`);
+  try {
+    const fetch = options.fetchSidecarBinaries || fetchSidecarBinaries;
+    await fetch({ rootDir, target: target.dir, fs: fsModule });
+    return { ok: true, fetched: true, target: target.dir, path: binaryPath };
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    write(stderr, [
+      "Telegram approval sidecar is missing and could not be fetched automatically.",
+      `Run: ${command}`,
+      `Reason: ${message}`,
+      "",
+    ].join("\n"));
+    return { ok: false, missing: true, target: target.dir, path: binaryPath, command, error: message };
+  }
+}
+
+function parseArgs(argv = []) {
+  const out = { strict: false, dryRun: false };
+  for (const arg of argv) {
+    if (arg === "--strict") out.strict = true;
+    else if (arg === "--dry-run") out.dryRun = true;
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return out;
+}
+
+function printHelp(stdout = process.stdout) {
+  stdout.write(`Usage: ${ENSURE_COMMAND} [--strict] [--dry-run]\n`);
+}
+
+async function main() {
+  let args;
+  try {
+    args = parseArgs(process.argv.slice(2));
+  } catch (err) {
+    console.error(err && err.message ? err.message : err);
+    process.exitCode = 1;
+    return;
+  }
+  if (args.help) {
+    printHelp();
+    return;
+  }
+  const result = await ensureCurrentPlatformSidecar({ strict: args.strict, dryRun: args.dryRun });
+  if (!result.ok && args.strict) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err && err.message ? err.message : err);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  ENSURE_COMMAND,
+  SKIP_ENV,
+  OVERRIDE_ENV,
+  runtimePlatformName,
+  runtimeSidecarTarget,
+  truthyEnv,
+  isExistingFile,
+  sidecarFetchCommand,
+  ensureCurrentPlatformSidecar,
+  parseArgs,
+};

--- a/scripts/fetch-sidecar-binaries.js
+++ b/scripts/fetch-sidecar-binaries.js
@@ -23,6 +23,19 @@ const TARGETS = Object.freeze([
   Object.freeze({ platform: "linux", arch: "x64", dir: "linux-x64", exe: "cc-connect-clawd", archiveExt: ".tar.gz" }),
 ]);
 
+const PINNED_CHECKSUMS = Object.freeze({
+  "windows-x64/cc-connect-clawd.exe": "a6c6303d0f4321d33d450e72d8d5bc02bcf7dcb8a4b3b7e4bcd6e5ae16f45d8c",
+  "cc-connect-clawd-windows-x64.zip": "70c7283f94dc55b974ca50a1ce2c564f0bf94092946f254d22bbe5e5f07fd4a7",
+  "windows-arm64/cc-connect-clawd.exe": "f9366d967a58756f4351e37cbed5c54c8b34080fe82a1d50b878b6d0b43b5ce6",
+  "cc-connect-clawd-windows-arm64.zip": "1433cb84364892b9e276c28e7b5775d0e126bc66f60b70f4549d02b275d8f368",
+  "darwin-x64/cc-connect-clawd": "2e2fd34b7cb9cf9311c8ce80cd1782b2ddd52b148615e8922de765013cdf9cc2",
+  "cc-connect-clawd-darwin-x64.tar.gz": "f1300292143f3f98d959303b62d5627a195c726c018a0eecf2ee2bd2616f7c0a",
+  "darwin-arm64/cc-connect-clawd": "f81133bbf1eabe995f7095359d959478a2923576adc68c5be1f18e398f0d4b69",
+  "cc-connect-clawd-darwin-arm64.tar.gz": "3cd949b0aff2fbf87c1a437a541be38cb1be028b104d4a037519b3873582d468",
+  "linux-x64/cc-connect-clawd": "81af234300c0e401368000027e19f4a81859a9377ed0e40e6c3909eca2631c57",
+  "cc-connect-clawd-linux-x64.tar.gz": "fba4ab2c0ae68230cdd03727795b1b1ac3ff9270bd4c742c42fb80c3e00a7efa",
+});
+
 function archiveName(target) {
   return `cc-connect-clawd-${target.dir}${target.archiveExt}`;
 }
@@ -37,6 +50,12 @@ function releaseAssetUrl(assetName, release = DEFAULT_RELEASE) {
 
 function targetBinaryPath(rootDir, target) {
   return path.join(rootDir, SIDECAR_ROOT, target.dir, target.exe);
+}
+
+function checksumFor(name, checksums = PINNED_CHECKSUMS) {
+  const expected = checksums && checksums[name];
+  if (!expected) throw new Error(`Missing pinned checksum for ${name}`);
+  return String(expected).toLowerCase();
 }
 
 function selectTargets(raw) {
@@ -61,23 +80,23 @@ function selectTargets(raw) {
 function buildReleaseManifest(options = {}) {
   const rootDir = options.rootDir || path.join(__dirname, "..");
   const release = options.release || DEFAULT_RELEASE;
+  const checksums = options.checksums || PINNED_CHECKSUMS;
   const targets = selectTargets(options.target || "all").map((target) => {
     const archive = archiveName(target);
+    const binaryChecksum = binaryChecksumName(target);
     return {
       ...target,
       archive,
       archiveUrl: releaseAssetUrl(archive, release),
       archiveChecksumName: archive,
-      binaryChecksumName: binaryChecksumName(target),
+      archiveSha256: checksumFor(archive, checksums),
+      binaryChecksumName: binaryChecksum,
+      binarySha256: checksumFor(binaryChecksum, checksums),
       binaryPath: targetBinaryPath(rootDir, target),
     };
   });
   return {
     release,
-    checksums: {
-      name: "checksums.txt",
-      url: releaseAssetUrl("checksums.txt", release),
-    },
     targets,
   };
 }
@@ -248,17 +267,20 @@ async function fetchSidecarBinaries(options = {}) {
     ...(options.release || {}),
     tag: options.tag || (options.release && options.release.tag) || DEFAULT_RELEASE.tag,
   };
-  const manifest = buildReleaseManifest({ rootDir, release, target: options.target || "all" });
+  const manifest = buildReleaseManifest({
+    rootDir,
+    release,
+    target: options.target || "all",
+    checksums: options.checksums || PINNED_CHECKSUMS,
+  });
   if (options.dryRun) return { ok: true, manifest, installed: [] };
 
-  const checksumsBuffer = await download(manifest.checksums.url);
-  const checksums = parseChecksums(checksumsBuffer.toString("utf8"));
   const installed = [];
   for (const target of manifest.targets) {
     const archiveBuffer = await download(target.archiveUrl);
-    verifyChecksum(archiveBuffer, checksums.get(target.archiveChecksumName), target.archiveChecksumName);
+    verifyChecksum(archiveBuffer, target.archiveSha256, target.archiveChecksumName);
     const binaryBuffer = extractSidecarBinary(archiveBuffer, target);
-    verifyChecksum(binaryBuffer, checksums.get(target.binaryChecksumName), target.binaryChecksumName);
+    verifyChecksum(binaryBuffer, target.binarySha256, target.binaryChecksumName);
     installBinary(fsModule, target.binaryPath, binaryBuffer);
     installed.push({ target: target.dir, path: target.binaryPath });
   }
@@ -348,10 +370,12 @@ module.exports = {
   FETCH_COMMAND,
   DEFAULT_RELEASE,
   TARGETS,
+  PINNED_CHECKSUMS,
   archiveName,
   binaryChecksumName,
   releaseAssetUrl,
   targetBinaryPath,
+  checksumFor,
   selectTargets,
   buildReleaseManifest,
   parseChecksums,

--- a/scripts/fetch-sidecar-binaries.js
+++ b/scripts/fetch-sidecar-binaries.js
@@ -241,7 +241,7 @@ function installBinary(fsModule, filePath, buffer) {
 
 async function fetchSidecarBinaries(options = {}) {
   const fsModule = options.fs || fs;
-  const download = options.download || downloadBuffer;
+  const download = options.download || ((url) => downloadBuffer(url, 0, options.requestTimeoutMs));
   const rootDir = options.rootDir || path.join(__dirname, "..");
   const release = {
     ...DEFAULT_RELEASE,
@@ -265,7 +265,7 @@ async function fetchSidecarBinaries(options = {}) {
   return { ok: true, manifest, installed };
 }
 
-function downloadBuffer(url, redirects = 0) {
+function downloadBuffer(url, redirects = 0, timeoutMs = 120000) {
   if (redirects > 5) return Promise.reject(new Error(`Too many redirects while downloading ${url}`));
   return new Promise((resolve, reject) => {
     const req = https.get(url, {
@@ -278,7 +278,7 @@ function downloadBuffer(url, redirects = 0) {
       if (status >= 300 && status < 400 && res.headers.location) {
         res.resume();
         const next = new URL(res.headers.location, url).toString();
-        downloadBuffer(next, redirects + 1).then(resolve, reject);
+        downloadBuffer(next, redirects + 1, timeoutMs).then(resolve, reject);
         return;
       }
       if (status !== 200) {
@@ -291,7 +291,7 @@ function downloadBuffer(url, redirects = 0) {
       res.on("end", () => resolve(Buffer.concat(chunks)));
     });
     req.on("error", reject);
-    req.setTimeout(120000, () => {
+    req.setTimeout(timeoutMs || 120000, () => {
       req.destroy(new Error(`Download timed out for ${url}`));
     });
   });
@@ -361,6 +361,7 @@ module.exports = {
   extractTarGzEntry,
   extractSidecarBinary,
   installBinary,
+  downloadBuffer,
   fetchSidecarBinaries,
   parseArgs,
 };

--- a/src/telegram-approval-sidecar.js
+++ b/src/telegram-approval-sidecar.js
@@ -17,6 +17,7 @@ const SIDECAR_ENV_TOKEN_FILE = "CLAWD_TG_BOT_TOKEN_FILE";
 const SIDECAR_PATH_ENV = "CLAWD_CC_CONNECT_CLAWD_PATH";
 const SIDECAR_BINARY_BASENAME = "cc-connect-clawd";
 const SIDECAR_RESOURCE_ROOT = path.join("sidecars", "cc-connect-clawd");
+const DEV_FETCH_TARGETS = new Set(["windows-x64", "windows-arm64", "darwin-x64", "darwin-arm64", "linux-x64"]);
 // Note: the sidecar reads the token from the env-file at SIDECAR_ENV_TOKEN_FILE
 // (which itself contains a line like `CLAWD_TG_BOT_TOKEN=<token>`). Clawd's
 // main process MUST NOT pipe a token into the child env directly — that path
@@ -122,6 +123,14 @@ function sidecarResourceRelativePath(options = {}) {
     sidecarPlatformArchDir(options),
     sidecarExecutableName(options.platform)
   );
+}
+
+function devSidecarFetchHint(options = {}) {
+  const target = sidecarPlatformArchDir(options);
+  if (DEV_FETCH_TARGETS.has(target)) {
+    return `For source checkouts, run: npm run fetch:sidecars -- --target ${target}`;
+  }
+  return `No pinned Telegram approval sidecar is available for ${target}; set ${SIDECAR_PATH_ENV} to a compatible sidecar executable.`;
 }
 
 function resolveOverrideBinaryPath(rawValue, options = {}) {
@@ -394,7 +403,7 @@ class TelegramApprovalSidecar extends EventEmitter {
     } catch {}
     const message = `telegram approval sidecar binary not found: ${this.binaryPath}`;
     if (this.binaryPathSource === "dev") {
-      return `${message}. For source checkouts, run: npm run fetch:sidecars -- --target ${sidecarPlatformArchDir({ platform: this.platform, arch: this.arch })}`;
+      return `${message}. ${devSidecarFetchHint({ platform: this.platform, arch: this.arch })}`;
     }
     return message;
   }
@@ -552,6 +561,7 @@ module.exports = {
   sidecarArchName,
   sidecarPlatformArchDir,
   sidecarResourceRelativePath,
+  devSidecarFetchHint,
   defaultConfigPath,
   defaultTokenEnvFilePath,
   redactText,

--- a/src/telegram-approval-sidecar.js
+++ b/src/telegram-approval-sidecar.js
@@ -193,6 +193,7 @@ class TelegramApprovalSidecar extends EventEmitter {
     this.clearTimer = options.clearTimeout || clearTimeout;
     this.now = options.now || (() => Date.now());
     this.platform = options.platform || process.platform;
+    this.arch = options.arch || process.arch;
     this.baseEnv = options.baseEnv || process.env;
     this.startupTimeoutMs = options.startupTimeoutMs == null ? DEFAULT_STARTUP_TIMEOUT_MS : Number(options.startupTimeoutMs);
     this.stopGraceMs = options.stopGraceMs == null ? DEFAULT_STOP_GRACE_MS : Number(options.stopGraceMs);
@@ -207,7 +208,7 @@ class TelegramApprovalSidecar extends EventEmitter {
       binaryPath: options.binaryPath,
       env: options.env || this.baseEnv,
       platform: this.platform,
-      arch: options.arch || process.arch,
+      arch: this.arch,
       resourcesPath: options.resourcesPath,
       isPackaged: options.isPackaged,
       fs: this.fs,
@@ -391,7 +392,11 @@ class TelegramApprovalSidecar extends EventEmitter {
     try {
       if (this.fs.existsSync(this.binaryPath)) return "";
     } catch {}
-    return `telegram approval sidecar binary not found: ${this.binaryPath}`;
+    const message = `telegram approval sidecar binary not found: ${this.binaryPath}`;
+    if (this.binaryPathSource === "dev") {
+      return `${message}. For source checkouts, run: npm run fetch:sidecars -- --target ${sidecarPlatformArchDir({ platform: this.platform, arch: this.arch })}`;
+    }
+    return message;
   }
 
   _handleStdout(chunk, finishReady, failStartup) {

--- a/test/ensure-sidecar-binaries.test.js
+++ b/test/ensure-sidecar-binaries.test.js
@@ -97,7 +97,7 @@ test("ensureCurrentPlatformSidecar reports fetch failures without throwing", asy
   assert.equal(result.command, "npm run fetch:sidecars -- --target darwin-arm64");
   assert.match(stderr.text(), /could not be fetched automatically/);
   assert.match(stderr.text(), /npm run fetch:sidecars -- --target darwin-arm64/);
-  assert.match(stderr.text(), /CLAWD_SKIP_SIDECAR_FETCH=1 npm start/);
+  assert.match(stderr.text(), /Set CLAWD_SKIP_SIDECAR_FETCH=1 before running npm start/);
 });
 
 test("ensureCurrentPlatformSidecar honors skip and valid override env vars", async () => {
@@ -147,6 +147,28 @@ test("ensureCurrentPlatformSidecar reports a missing override path without fetch
   assert.equal(result.reason, "override-path-missing");
   assert.match(result.path, /missing-sidecar/);
   assert.match(stderr.text(), /CLAWD_CC_CONNECT_CLAWD_PATH is set but no sidecar executable was found/);
+  assert.match(stderr.text(), /Clawd will still launch/);
+});
+
+test("ensureCurrentPlatformSidecar reports strict override failures accurately", async () => {
+  const stderr = makeStream();
+  const result = await ensure.ensureCurrentPlatformSidecar({
+    strict: true,
+    env: { CLAWD_CC_CONNECT_CLAWD_PATH: "/tmp/missing-sidecar" },
+    stderr,
+    fs: {
+      existsSync: () => false,
+      statSync: () => {
+        throw new Error("missing");
+      },
+    },
+    fetchSidecarBinaries: () => {
+      throw new Error("should not fetch");
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.match(stderr.text(), /Strict mode will stop launch/);
 });
 
 test("resolveOverridePath appends the runtime executable for directory-like values", () => {

--- a/test/ensure-sidecar-binaries.test.js
+++ b/test/ensure-sidecar-binaries.test.js
@@ -72,6 +72,7 @@ test("ensureCurrentPlatformSidecar fetches only the current platform target when
   assert.equal(fetchCalls.length, 1);
   assert.equal(fetchCalls[0].target, "windows-x64");
   assert.equal(fetchCalls[0].rootDir, "D:\\repo");
+  assert.equal(fetchCalls[0].requestTimeoutMs, ensure.DEFAULT_PREFLIGHT_REQUEST_TIMEOUT_MS);
   assert.match(stdout.text(), /fetching pinned binary/);
 });
 
@@ -96,9 +97,10 @@ test("ensureCurrentPlatformSidecar reports fetch failures without throwing", asy
   assert.equal(result.command, "npm run fetch:sidecars -- --target darwin-arm64");
   assert.match(stderr.text(), /could not be fetched automatically/);
   assert.match(stderr.text(), /npm run fetch:sidecars -- --target darwin-arm64/);
+  assert.match(stderr.text(), /CLAWD_SKIP_SIDECAR_FETCH=1 npm start/);
 });
 
-test("ensureCurrentPlatformSidecar honors skip and explicit override env vars", async () => {
+test("ensureCurrentPlatformSidecar honors skip and valid override env vars", async () => {
   const fetchSidecarBinaries = () => {
     throw new Error("should not fetch");
   };
@@ -106,10 +108,52 @@ test("ensureCurrentPlatformSidecar honors skip and explicit override env vars", 
     env: { CLAWD_SKIP_SIDECAR_FETCH: "1" },
     fetchSidecarBinaries,
   }), { ok: true, skipped: true, reason: "env-skip" });
-  assert.deepEqual(await ensure.ensureCurrentPlatformSidecar({
-    env: { CLAWD_CC_CONNECT_CLAWD_PATH: "/tmp/sidecar" },
+  const overrideDir = path.join("D:\\tools", "sidecar");
+  const overrideExe = path.join(overrideDir, "cc-connect-clawd.exe");
+  const result = await ensure.ensureCurrentPlatformSidecar({
+    platform: "win32",
+    env: { CLAWD_CC_CONNECT_CLAWD_PATH: overrideDir },
+    fs: {
+      existsSync: (filePath) => filePath === overrideExe,
+      statSync: (filePath) => {
+        if (filePath === overrideDir) return { isDirectory: () => true, isFile: () => false };
+        if (filePath === overrideExe) return { isDirectory: () => false, isFile: () => true };
+        throw new Error(`unexpected path: ${filePath}`);
+      },
+    },
     fetchSidecarBinaries,
-  }), { ok: true, skipped: true, reason: "override-path" });
+  });
+  assert.deepEqual(result, { ok: true, skipped: true, reason: "override-path", path: overrideExe });
+});
+
+test("ensureCurrentPlatformSidecar reports a missing override path without fetching", async () => {
+  const stderr = makeStream();
+  const result = await ensure.ensureCurrentPlatformSidecar({
+    env: { CLAWD_CC_CONNECT_CLAWD_PATH: "/tmp/missing-sidecar" },
+    stderr,
+    fs: {
+      existsSync: () => false,
+      statSync: () => {
+        throw new Error("missing");
+      },
+    },
+    fetchSidecarBinaries: () => {
+      throw new Error("should not fetch");
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.skipped, true);
+  assert.equal(result.reason, "override-path-missing");
+  assert.match(result.path, /missing-sidecar/);
+  assert.match(stderr.text(), /CLAWD_CC_CONNECT_CLAWD_PATH is set but no sidecar executable was found/);
+});
+
+test("resolveOverridePath appends the runtime executable for directory-like values", () => {
+  assert.equal(
+    ensure.resolveOverridePath("D:\\tools\\sidecar\\", { platform: "win32", fs: { statSync: () => { throw new Error("skip"); } } }),
+    path.join("D:\\tools\\sidecar\\", "cc-connect-clawd.exe")
+  );
 });
 
 test("sidecarFetchCommand gives the manual recovery command", () => {

--- a/test/ensure-sidecar-binaries.test.js
+++ b/test/ensure-sidecar-binaries.test.js
@@ -1,0 +1,120 @@
+"use strict";
+
+const assert = require("node:assert");
+const path = require("node:path");
+const test = require("node:test");
+
+const ensure = require("../scripts/ensure-sidecar-binaries");
+
+function makeStream() {
+  let text = "";
+  return {
+    write(chunk) {
+      text += String(chunk);
+    },
+    text() {
+      return text;
+    },
+  };
+}
+
+test("runtimeSidecarTarget maps supported runtime platforms to pinned sidecar targets", () => {
+  assert.equal(ensure.runtimeSidecarTarget({ platform: "win32", arch: "x64" }).dir, "windows-x64");
+  assert.equal(ensure.runtimeSidecarTarget({ platform: "darwin", arch: "arm64" }).dir, "darwin-arm64");
+  assert.equal(ensure.runtimeSidecarTarget({ platform: "linux", arch: "x64" }).dir, "linux-x64");
+  assert.equal(ensure.runtimeSidecarTarget({ platform: "linux", arch: "arm64" }), null);
+});
+
+test("ensureCurrentPlatformSidecar skips when the current binary already exists", async () => {
+  const calls = [];
+  const result = await ensure.ensureCurrentPlatformSidecar({
+    platform: "win32",
+    arch: "x64",
+    rootDir: "D:\\repo",
+    env: {},
+    fs: {
+      existsSync: () => true,
+      statSync: () => ({ isFile: () => true }),
+    },
+    fetchSidecarBinaries: () => {
+      calls.push("fetch");
+      throw new Error("should not fetch");
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.existing, true);
+  assert.equal(result.target, "windows-x64");
+  assert.deepEqual(calls, []);
+});
+
+test("ensureCurrentPlatformSidecar fetches only the current platform target when missing", async () => {
+  const fetchCalls = [];
+  const stdout = makeStream();
+  const result = await ensure.ensureCurrentPlatformSidecar({
+    platform: "win32",
+    arch: "x64",
+    rootDir: "D:\\repo",
+    env: {},
+    stdout,
+    fs: {
+      existsSync: () => false,
+    },
+    fetchSidecarBinaries: async (options) => {
+      fetchCalls.push(options);
+      return { ok: true, installed: [] };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.fetched, true);
+  assert.equal(result.target, "windows-x64");
+  assert.equal(fetchCalls.length, 1);
+  assert.equal(fetchCalls[0].target, "windows-x64");
+  assert.equal(fetchCalls[0].rootDir, "D:\\repo");
+  assert.match(stdout.text(), /fetching pinned binary/);
+});
+
+test("ensureCurrentPlatformSidecar reports fetch failures without throwing", async () => {
+  const stderr = makeStream();
+  const result = await ensure.ensureCurrentPlatformSidecar({
+    platform: "darwin",
+    arch: "arm64",
+    rootDir: "/repo",
+    env: {},
+    stdout: makeStream(),
+    stderr,
+    fs: {
+      existsSync: () => false,
+    },
+    fetchSidecarBinaries: async () => {
+      throw new Error("offline");
+    },
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.command, "npm run fetch:sidecars -- --target darwin-arm64");
+  assert.match(stderr.text(), /could not be fetched automatically/);
+  assert.match(stderr.text(), /npm run fetch:sidecars -- --target darwin-arm64/);
+});
+
+test("ensureCurrentPlatformSidecar honors skip and explicit override env vars", async () => {
+  const fetchSidecarBinaries = () => {
+    throw new Error("should not fetch");
+  };
+  assert.deepEqual(await ensure.ensureCurrentPlatformSidecar({
+    env: { CLAWD_SKIP_SIDECAR_FETCH: "1" },
+    fetchSidecarBinaries,
+  }), { ok: true, skipped: true, reason: "env-skip" });
+  assert.deepEqual(await ensure.ensureCurrentPlatformSidecar({
+    env: { CLAWD_CC_CONNECT_CLAWD_PATH: "/tmp/sidecar" },
+    fetchSidecarBinaries,
+  }), { ok: true, skipped: true, reason: "override-path" });
+});
+
+test("sidecarFetchCommand gives the manual recovery command", () => {
+  assert.equal(
+    ensure.sidecarFetchCommand("windows-x64"),
+    "npm run fetch:sidecars -- --target windows-x64"
+  );
+});

--- a/test/fetch-sidecar-binaries.test.js
+++ b/test/fetch-sidecar-binaries.test.js
@@ -10,10 +10,12 @@ const zlib = require("node:zlib");
 const {
   FETCH_COMMAND,
   DEFAULT_RELEASE,
+  PINNED_CHECKSUMS,
   archiveName,
   binaryChecksumName,
   releaseAssetUrl,
   targetBinaryPath,
+  checksumFor,
   selectTargets,
   buildReleaseManifest,
   parseChecksums,
@@ -30,8 +32,12 @@ test("release source is pinned to the public Clawd fork tag", () => {
     tag: "clawd-sidecar-v0.1.0",
   });
   assert.equal(
-    releaseAssetUrl("checksums.txt"),
-    "https://github.com/rullerzhou-afk/cc-connect-clawd/releases/download/clawd-sidecar-v0.1.0/checksums.txt"
+    checksumFor("cc-connect-clawd-windows-x64.zip"),
+    "70c7283f94dc55b974ca50a1ce2c564f0bf94092946f254d22bbe5e5f07fd4a7"
+  );
+  assert.equal(
+    releaseAssetUrl("cc-connect-clawd-windows-x64.zip"),
+    "https://github.com/rullerzhou-afk/cc-connect-clawd/releases/download/clawd-sidecar-v0.1.0/cc-connect-clawd-windows-x64.zip"
   );
 });
 
@@ -43,14 +49,24 @@ test("package exposes the sidecar fetch command", () => {
 test("manifest maps archives and install paths to Clawd sidecar layout", () => {
   const rootDir = "D:\\repo";
   const manifest = buildReleaseManifest({ rootDir, target: "windows-x64,linux-x64" });
-  assert.equal(manifest.checksums.name, "checksums.txt");
   assert.deepEqual(manifest.targets.map((target) => target.dir), ["windows-x64", "linux-x64"]);
   assert.equal(manifest.targets[0].archive, "cc-connect-clawd-windows-x64.zip");
+  assert.equal(manifest.targets[0].archiveSha256, PINNED_CHECKSUMS["cc-connect-clawd-windows-x64.zip"]);
   assert.equal(manifest.targets[0].binaryChecksumName, "windows-x64/cc-connect-clawd.exe");
+  assert.equal(manifest.targets[0].binarySha256, PINNED_CHECKSUMS["windows-x64/cc-connect-clawd.exe"]);
   assert.equal(
     manifest.targets[0].binaryPath,
     path.join(rootDir, "bin", "cc-connect-clawd", "windows-x64", "cc-connect-clawd.exe")
   );
+});
+
+test("pinned checksums cover every release target", () => {
+  const manifest = buildReleaseManifest();
+  assert.equal(manifest.targets.length, 5);
+  for (const target of manifest.targets) {
+    assert.match(target.archiveSha256, /^[a-f0-9]{64}$/);
+    assert.match(target.binarySha256, /^[a-f0-9]{64}$/);
+  }
 });
 
 test("selectTargets dedupes and rejects Go arch directory names", () => {
@@ -89,8 +105,8 @@ test("fetchSidecarBinaries downloads, verifies, extracts, and installs selected 
     `${sha256(binary)}  ${binaryChecksumName(target)}`,
     "",
   ].join("\n");
+  const pinnedChecksums = Object.fromEntries(parseChecksums(checksums));
   const downloads = new Map([
-    [releaseAssetUrl("checksums.txt", release), Buffer.from(checksums)],
     [releaseAssetUrl(archiveName(target), release), archive],
   ]);
 
@@ -98,6 +114,7 @@ test("fetchSidecarBinaries downloads, verifies, extracts, and installs selected 
     rootDir,
     release,
     target: "windows-x64",
+    checksums: pinnedChecksums,
     download: async (url) => {
       if (!downloads.has(url)) throw new Error(`unexpected download: ${url}`);
       return downloads.get(url);
@@ -120,14 +137,15 @@ test("fetchSidecarBinaries fails closed on checksum mismatch", async () => {
     `${sha256(binary)}  ${binaryChecksumName(target)}`,
     "",
   ].join("\n");
+  const pinnedChecksums = Object.fromEntries(parseChecksums(checksums));
 
   await assert.rejects(
     fetchSidecarBinaries({
       rootDir,
       release,
       target: "windows-x64",
+      checksums: pinnedChecksums,
       download: async (url) => {
-        if (url.endsWith("checksums.txt")) return Buffer.from(checksums);
         return archive;
       },
     }),

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -132,6 +132,10 @@ describe("package build config", () => {
   });
 
   describe("Telegram approval sidecar packaging", () => {
+    it("preflights sidecar binaries before source launches", () => {
+      assert.match(pkg.scripts.start, /node scripts\/ensure-sidecar-binaries\.js && node launch\.js/);
+    });
+
     it("copies cc-connect-clawd sidecars into packaged resources", () => {
       const extra = pkg.build.extraResources || [];
       const copied = extra.some(
@@ -176,7 +180,7 @@ describe("package build config", () => {
 
     it("publishes GitHub releases only for version tags", () => {
       const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
-      const releaseIndex = workflow.indexOf("\n  release:\n");
+      const releaseIndex = findWorkflowJobIndex(workflow, "release");
       assert.ok(releaseIndex >= 0, "workflow should define a release job");
       const releaseGateIndex = workflow.indexOf("if: startsWith(github.ref, 'refs/tags/v')", releaseIndex);
       const bodyPathIndex = workflow.indexOf("body_path: docs/releases/release-${{ github.ref_name }}.md", releaseIndex);
@@ -187,7 +191,7 @@ describe("package build config", () => {
 
     it("creates tag releases as drafts for final asset inspection", () => {
       const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
-      const releaseIndex = workflow.indexOf("\n  release:\n");
+      const releaseIndex = findWorkflowJobIndex(workflow, "release");
       assert.ok(releaseIndex >= 0, "workflow should define a release job");
       const actionIndex = workflow.indexOf("softprops/action-gh-release@v2", releaseIndex);
       const draftIndex = workflow.indexOf("draft: true", actionIndex);
@@ -198,6 +202,11 @@ describe("package build config", () => {
     });
   });
 });
+
+function findWorkflowJobIndex(workflow, jobName) {
+  const match = String(workflow || "").match(new RegExp(`(?:^|\\r?\\n)  ${jobName}:\\r?\\n`));
+  return match ? match.index : -1;
+}
 
 function assertWorkflowOrder(workflow, fetchCommand, verifyCommand, buildCommand) {
   const fetchIndex = workflow.indexOf(fetchCommand);

--- a/test/telegram-approval-sidecar.test.js
+++ b/test/telegram-approval-sidecar.test.js
@@ -15,6 +15,7 @@ const {
   sidecarExecutableName,
   sidecarPlatformArchDir,
   sidecarResourceRelativePath,
+  devSidecarFetchHint,
   defaultConfigPath,
   defaultTokenEnvFilePath,
   redactText,
@@ -22,6 +23,7 @@ const {
   SIDECAR_ENV_TOKEN_FILE,
   SIDECAR_PATH_ENV,
 } = require("../src/telegram-approval-sidecar");
+const { TARGETS: SIDECAR_FETCH_TARGETS } = require("../scripts/fetch-sidecar-binaries");
 
 class FakeStream extends EventEmitter {
   setEncoding(value) {
@@ -345,6 +347,14 @@ test("sidecar binary names are stable across packaged platforms", () => {
     sidecarResourceRelativePath({ platform: "linux", arch: "x64" }),
     path.join("sidecars", "cc-connect-clawd", "linux-x64", "cc-connect-clawd")
   );
+});
+
+test("source fetch hints cover every pinned fetch target", () => {
+  const platformMap = { windows: "win32", darwin: "darwin", linux: "linux" };
+  for (const target of SIDECAR_FETCH_TARGETS) {
+    const hint = devSidecarFetchHint({ platform: platformMap[target.platform], arch: target.arch });
+    assert.match(hint, new RegExp(`npm run fetch:sidecars -- --target ${target.dir}`));
+  }
 });
 
 test("sidecar manager reports a clear missing binary error for resolved paths", async () => {

--- a/test/telegram-approval-sidecar.test.js
+++ b/test/telegram-approval-sidecar.test.js
@@ -380,6 +380,24 @@ test("sidecar manager reports a clear missing binary error for source-mode fallb
   assert.match(sidecar.getStatus().message, /npm run fetch:sidecars -- --target linux-x64/);
 });
 
+test("sidecar manager does not suggest an unsupported source fetch target", async () => {
+  const sidecar = new TelegramApprovalSidecar({
+    env: {},
+    baseEnv: {},
+    platform: "linux",
+    arch: "arm64",
+    isPackaged: false,
+    fs: { existsSync: () => false },
+  });
+
+  await assert.rejects(sidecar.start(), /sidecar binary not found/);
+  assert.equal(sidecar.getStatus().status, "failed");
+  assert.equal(sidecar.getStatus().binaryPathSource, "dev");
+  assert.match(sidecar.getStatus().message, /No pinned Telegram approval sidecar is available for linux-arm64/);
+  assert.match(sidecar.getStatus().message, /CLAWD_CC_CONNECT_CLAWD_PATH/);
+  assert.doesNotMatch(sidecar.getStatus().message, /npm run fetch:sidecars -- --target linux-arm64/);
+});
+
 test("sidecar manager fails closed when binary availability cannot be checked", async () => {
   const sidecar = new TelegramApprovalSidecar({
     env: {},

--- a/test/telegram-approval-sidecar.test.js
+++ b/test/telegram-approval-sidecar.test.js
@@ -377,6 +377,7 @@ test("sidecar manager reports a clear missing binary error for source-mode fallb
   assert.equal(sidecar.getStatus().status, "failed");
   assert.equal(sidecar.getStatus().binaryPathSource, "dev");
   assert.match(sidecar.getStatus().message, /linux-x64/);
+  assert.match(sidecar.getStatus().message, /npm run fetch:sidecars -- --target linux-x64/);
 });
 
 test("sidecar manager fails closed when binary availability cannot be checked", async () => {


### PR DESCRIPTION
Summary: add a source-launch preflight that auto-fetches the pinned current-platform cc-connect-clawd sidecar when missing, improve the dev missing-binary error with a concrete fetch command, and document the behavior. Tests: node --test test/ensure-sidecar-binaries.test.js test/package-build-config.test.js test/telegram-approval-sidecar.test.js.