### PR TITLE
fix: smooth Clawd SVG diagonal rendering

### DIFF
--- a/assets/svg/clawd-collapse-sleep.svg
+++ b/assets/svg/clawd-collapse-sleep.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* Collapse (0-1s) → Sleep breathing + Zzz (1s onwards, infinite) */

--- a/assets/svg/clawd-error.svg
+++ b/assets/svg/clawd-error.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .body-exhausted {

--- a/assets/svg/clawd-happy.svg
+++ b/assets/svg/clawd-happy.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* Bouncing Character Body */

--- a/assets/svg/clawd-headphones-groove.svg
+++ b/assets/svg/clawd-headphones-groove.svg
@@ -4,7 +4,7 @@
   1. 眼睛 V 字 y +0.5 (顶 8->8.5 底 9->9.5) — v5 位置偏高
   2. 耳罩压缩 0.78 -> 0.85 (缩量 22%->15%), 过冲 1.04 -> 1.02 一起收 — v5 压太多
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .shadow-sway {

--- a/assets/svg/clawd-idle-bubble.svg
+++ b/assets/svg/clawd-idle-bubble.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <!-- 吹泡泡 v8
        v7 反馈: 整体 ok, 但眼睛回到正中后再眨一次眼更好
        v8 修正: eyes-anim 加一个 96% 眨眼帧 (在 (0, 0) 正中位置) -->

--- a/assets/svg/clawd-idle-doze.svg
+++ b/assets/svg/clawd-idle-doze.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* Dozing — looping gentle breathing in yawn-end squashed pose, eyes shut */

--- a/assets/svg/clawd-idle-follow.svg
+++ b/assets/svg/clawd-idle-follow.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .breathe-anim {

--- a/assets/svg/clawd-idle-look.svg
+++ b/assets/svg/clawd-idle-look.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* 10-Second Idle Loop — Looking Around + Scratching (no yawn) */

--- a/assets/svg/clawd-idle-reading.svg
+++ b/assets/svg/clawd-idle-reading.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* ═══ 14s story: idle 挥手 → 抓书 + 戴眼镜 → 读 (眼镜下滑+推回) → 书+眼镜同步退场

--- a/assets/svg/clawd-idle-yawn.svg
+++ b/assets/svg/clawd-idle-yawn.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* 5-Second Yawn — One-shot, ends in squashed/eyes-closed pose */

--- a/assets/svg/clawd-mini-alert.svg
+++ b/assets/svg/clawd-mini-alert.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .breathe-anim {

--- a/assets/svg/clawd-mini-crabwalk.svg
+++ b/assets/svg/clawd-mini-crabwalk.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .body-hunch {

--- a/assets/svg/clawd-mini-enter-sleep.svg
+++ b/assets/svg/clawd-mini-enter-sleep.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="-15 -25 45 45"
-  shape-rendering="crispEdges">
+  shape-rendering="geometricPrecision">
     <style>
       #body-js {
         animation: bodyEnter 3.2s cubic-bezier(0.22, 1, 0.36, 1) 1 forwards;

--- a/assets/svg/clawd-mini-enter.svg
+++ b/assets/svg/clawd-mini-enter.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="-15 -25 45 45"
-  shape-rendering="crispEdges">
+  shape-rendering="geometricPrecision">
     <style>
       #body-js {
         animation: bodyEnter 3.2s cubic-bezier(0.22, 1, 0.36, 1) 1 forwards;

--- a/assets/svg/clawd-mini-happy.svg
+++ b/assets/svg/clawd-mini-happy.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .breathe-anim {

--- a/assets/svg/clawd-mini-idle.svg
+++ b/assets/svg/clawd-mini-idle.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .breathe-anim {

--- a/assets/svg/clawd-mini-peek.svg
+++ b/assets/svg/clawd-mini-peek.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .breathe-anim {

--- a/assets/svg/clawd-mini-sleep.svg
+++ b/assets/svg/clawd-mini-sleep.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500"
-  shape-rendering="crispEdges">
+  shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* Slower breathing for sleepy feel */

--- a/assets/svg/clawd-mini-typing.svg
+++ b/assets/svg/clawd-mini-typing.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .breathe-anim {

--- a/assets/svg/clawd-notification.svg
+++ b/assets/svg/clawd-notification.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <!-- PoC v8: v7 左右翻转版
        唯一改动: master-group 加 transform="translate(15, 0) scale(-1, 1)"
                 围绕 viewBox 中心 X=7.5 镜像翻转

--- a/assets/svg/clawd-react-annoyed.svg
+++ b/assets/svg/clawd-react-annoyed.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* ===== 6s one-shot: annoyed, pause, resigned sigh, slow return =====

--- a/assets/svg/clawd-react-double-jump.svg
+++ b/assets/svg/clawd-react-double-jump.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* ===== 3.5s one-shot: startled jump, pat chest, settle =====

--- a/assets/svg/clawd-react-double.svg
+++ b/assets/svg/clawd-react-double.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .body-react {

--- a/assets/svg/clawd-react-drag.svg
+++ b/assets/svg/clawd-react-drag.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* Body sways side to side (held from above) */

--- a/assets/svg/clawd-react-left.svg
+++ b/assets/svg/clawd-react-left.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .body-react {

--- a/assets/svg/clawd-react-right.svg
+++ b/assets/svg/clawd-react-right.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .body-react {

--- a/assets/svg/clawd-sleeping.svg
+++ b/assets/svg/clawd-sleeping.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* Slow, rhythmic deep breathing animation */

--- a/assets/svg/clawd-wake.svg
+++ b/assets/svg/clawd-wake.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .once {

--- a/assets/svg/clawd-working-building.svg
+++ b/assets/svg/clawd-working-building.svg
@@ -4,7 +4,7 @@
   改动 = 把原黄色安全帽 (#FBC02D/#F9A825) 换成 helmet-tryon-v1 的三色橙帽 (#EFA74A/#B7782E/#FAB253)
   帽子仍放在 body-squash 组内, 跟随锤击 squash; z-order: torso → helmet → eyes (helmet 不遮眼, 无视觉冲突)
 -->
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="crispEdges">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* ===== Independent sub-animations ===== */

--- a/assets/svg/clawd-working-carrying.svg
+++ b/assets/svg/clawd-working-carrying.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       .body-walk {

--- a/assets/svg/clawd-working-debugger.svg
+++ b/assets/svg/clawd-working-debugger.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* ═══ Independent animations (always running) ═══ */

--- a/assets/svg/clawd-working-juggling.svg
+++ b/assets/svg/clawd-working-juggling.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* ===== Independent sub-animations ===== */

--- a/assets/svg/clawd-working-sweeping.svg
+++ b/assets/svg/clawd-working-sweeping.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* ===== Independent sub-animations ===== */

--- a/assets/svg/clawd-working-thinking.svg
+++ b/assets/svg/clawd-working-thinking.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <!-- clawd thinking bubble v25 (2026-05-15)
 
        v25 = v24 + dreamy edge-flow rewrite.

--- a/assets/svg/clawd-working-typing.svg
+++ b/assets/svg/clawd-working-typing.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-15 -25 45 45" width="500" height="500" shape-rendering="geometricPrecision">
   <defs>
     <style>
       /* ===== Body (KEEP) ===== */

--- a/test/clawd-svg-rendering.test.js
+++ b/test/clawd-svg-rendering.test.js
@@ -1,0 +1,72 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("fs");
+const path = require("path");
+
+const REPO_ROOT = path.join(__dirname, "..");
+const CLAWD_THEME_PATH = path.join(REPO_ROOT, "themes", "clawd", "theme.json");
+const CLAWD_SVG_DIR = path.join(REPO_ROOT, "assets", "svg");
+
+function addSvgFile(out, file) {
+  if (typeof file === "string" && file.endsWith(".svg")) out.add(file);
+}
+
+function addStateEntry(out, entry) {
+  if (Array.isArray(entry)) {
+    for (const file of entry) addSvgFile(out, file);
+    return;
+  }
+  if (entry && typeof entry === "object" && Array.isArray(entry.files)) {
+    for (const file of entry.files) addSvgFile(out, file);
+  }
+}
+
+function collectClawdRuntimeSvgFiles(theme) {
+  const files = new Set();
+
+  for (const entry of Object.values(theme.states || {})) addStateEntry(files, entry);
+  for (const entry of Object.values((theme.miniMode && theme.miniMode.states) || {})) {
+    addStateEntry(files, entry);
+  }
+  for (const groupName of ["workingTiers", "jugglingTiers", "idleAnimations"]) {
+    for (const entry of theme[groupName] || []) addSvgFile(files, entry && entry.file);
+  }
+  for (const entry of Object.values(theme.reactions || {})) {
+    addSvgFile(files, entry && entry.file);
+    for (const file of (entry && entry.files) || []) addSvgFile(files, file);
+  }
+  for (const file of Object.values(theme.displayHintMap || {})) addSvgFile(files, file);
+  addSvgFile(files, theme.updateVisuals && theme.updateVisuals.checking);
+
+  return [...files].sort();
+}
+
+function readRootSvgTag(file) {
+  const content = fs.readFileSync(file, "utf8");
+  const root = content.match(/<svg\b[^>]*>/i);
+  return root ? root[0] : null;
+}
+
+describe("Clawd SVG rendering", () => {
+  it("keeps runtime Clawd SVG roots in geometric rendering mode", () => {
+    const theme = JSON.parse(fs.readFileSync(CLAWD_THEME_PATH, "utf8"));
+    const files = collectClawdRuntimeSvgFiles(theme);
+
+    assert.strictEqual(files.length, 35);
+    assert.ok(!files.includes("clawd-about-hero.svg"));
+    assert.ok(!files.some((file) => file.includes("/") || file.includes("\\")));
+
+    for (const file of files) {
+      const filePath = path.join(CLAWD_SVG_DIR, file);
+      const root = readRootSvgTag(filePath);
+      assert.ok(root, `${file} should have a root <svg> tag`);
+      assert.match(
+        root,
+        /\bshape-rendering\s*=\s*["']geometricPrecision["']/i,
+        `${file} should use geometricPrecision at the root SVG`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Smooths diagonal and rotated edges in the default Clawd SVG animations by switching root SVG rendering hints to `geometricPrecision`.
- Applies the change only to runtime SVG files referenced by `themes/clawd/theme.json`.
- Preserves theme state mappings, animation timing, renderer logic, and non-Clawd themes.

## Problem context
- The previous crisp pixel rendering pass used `shape-rendering="crispEdges"`, which keeps hard pixel stair-steps on rotated or diagonal shapes.
- Clawd has many animated SVGs with rotated limbs, tools, sparks, and mini-mode poses, so root-level hard-edge rendering makes diagonal edges visibly jagged.
- The desired behavior is smoother diagonal rendering for default Clawd without changing the broader theme runtime.

## What changed
- Updated every runtime Clawd SVG referenced by the built-in Clawd theme to use `shape-rendering="geometricPrecision"` on the root `<svg>`.
- Added a focused Node test that derives the runtime SVG set from `themes/clawd/theme.json` and asserts all 35 referenced SVG roots use `geometricPrecision`.
- Kept local per-element rendering overrides intact and did not modify Cloudling, Calico, template, source, old, dist, or About hero assets.

## Behavior after this PR
- Default Clawd SVG animations ask Chromium's SVG renderer to prioritize geometric precision, improving diagonal and rotated edge smoothing.
- Existing animation playback, theme loading, mini mode, hitboxes, sounds, and state selection behavior remain unchanged.
- Non-Clawd themes continue to use their existing asset rendering behavior.

## Validation
- `node --test test\clawd-svg-rendering.test.js test\theme-loader.test.js test\theme-schema.test.js`
- `pwsh -NoLogo -NoProfile -Command "git diff --check"`
- `pwsh -NoLogo -NoProfile -Command "git diff --cached --check"`

## Platform note
- Automated validation ran on Windows in the local Electron project checkout.
- Manual Electron UI QA is still recommended for visually checking diagonal edges in Clawd working, reaction, mini-mode, and idle animations.
