### PR TITLE
feat(openclaw-plugin): session_title 显示 OpenClaw agent 名（含 emoji）

### DIFF
--- a/hooks/openclaw-plugin/index.js
+++ b/hooks/openclaw-plugin/index.js
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync, statSync } from "fs";
 import { request } from "http";
 import { homedir } from "os";
 import { join } from "path";
@@ -9,6 +9,7 @@ export const STOP_DEBOUNCE_MS = 1500;
 
 const CLAWD_DIR = join(homedir(), ".clawd");
 const RUNTIME_CONFIG_PATH = join(CLAWD_DIR, "runtime.json");
+const OPENCLAW_CONFIG_PATH = join(homedir(), ".openclaw", "openclaw.json");
 const SERVER_PORTS = [23333, 23334, 23335, 23336, 23337];
 const POST_TIMEOUT_MS = 1000;
 
@@ -69,6 +70,50 @@ function firstNumber(...values) {
     if (Number.isFinite(value)) return value;
   }
   return null;
+}
+
+// OpenClaw `sessionKey` is structured like `agent:<agentId>:<channel>:...`.
+// Extract the agent id segment.
+function getAgentIdFromSession(event, ctx) {
+  const key = firstString(event && event.sessionKey, ctx && ctx.sessionKey);
+  if (!key) return "";
+  const match = /^agent:([^:]+)/.exec(key);
+  return match ? match[1] : "";
+}
+
+// Cached lookup of OpenClaw's agents.list → display name (with emoji),
+// refreshed when the config file mtime changes.
+let cachedAgentIndex = null;
+let cachedAgentIndexMtimeMs = 0;
+function loadAgentIndex() {
+  let mtimeMs;
+  try { mtimeMs = statSync(OPENCLAW_CONFIG_PATH).mtimeMs; } catch { return null; }
+  if (cachedAgentIndex && mtimeMs === cachedAgentIndexMtimeMs) return cachedAgentIndex;
+  let parsed;
+  try { parsed = JSON.parse(readFileSync(OPENCLAW_CONFIG_PATH, "utf8")); }
+  catch { return cachedAgentIndex; }
+  const list = parsed && parsed.agents && Array.isArray(parsed.agents.list)
+    ? parsed.agents.list : [];
+  const index = new Map();
+  for (const entry of list) {
+    if (!entry || typeof entry.id !== "string" || !entry.id) continue;
+    const identity = entry.identity && typeof entry.identity === "object" ? entry.identity : {};
+    const display = firstString(identity.name, entry.name) || entry.id;
+    const emoji = firstString(identity.emoji);
+    const title = emoji ? `${emoji} ${display}` : display;
+    index.set(entry.id, title);
+  }
+  cachedAgentIndex = index;
+  cachedAgentIndexMtimeMs = mtimeMs;
+  return index;
+}
+
+function getAgentDisplayName(event, ctx) {
+  const id = getAgentIdFromSession(event, ctx);
+  if (!id) return "";
+  const index = loadAgentIndex();
+  if (index && index.has(id)) return index.get(id);
+  return id;
 }
 
 function getSessionId(event, ctx) {
@@ -141,6 +186,7 @@ export function createOpenClawRuntime(options = {}) {
       state,
       event: eventName,
       session_id: getSessionId(nativeEvent, ctx),
+      session_title: getAgentDisplayName(nativeEvent, ctx),
       cwd: firstString(ctx.workspaceDir, nativeEvent.cwd, nativeEvent.workspaceDir),
       agent_pid: process.pid,
       source_pid: firstNumber(info.source_pid),


### PR DESCRIPTION
> Generated By [Claude](https://claude.ai)

## 概述

OpenClaw session 卡在 Clawd HUD / Dashboard 上原本只显示 cwd 目录名或截断的 session ID，无法区分同一目录下不同 agent（如 `vultr-ops`、`router-admin`）。本 PR 让 openclaw-plugin 上报 `session_title`，并按 OpenClaw 自己的 `agents.list[]` 反查 agent 的显示名（带 emoji），HUD 直接显示 `🖥️ Vultr 管理员` 这种人类可读标题。

## 改动点

1. **session_title 抽取**：`openclaw-plugin/index.js` 的 `buildPayload` 新增 `session_title`，从 OpenClaw 喂给插件的 `sessionKey`（格式 `agent:<id>:<channel>:...`）抠出 agent id 段。
2. **按 OpenClaw 配置反查显示名**：新增 `loadAgentIndex()`，按 `mtime` 缓存解析 `~/.openclaw/openclaw.json` 的 `agents.list[]`，每条按优先级 `identity.name` → `name` → `id` 取显示名；存在 `identity.emoji` 时拼成 `🖥️ Vultr 管理员` 形式。
3. **回退策略**：sessionKey 缺失或 id 不在 `agents.list` 时回退到原始 id；都没有则返回空串，由 `stripUndefined` 丢掉，不影响其他字段。
4. **零外部 IO 风险**：所有文件读取走 `try/catch`，配置缺失/损坏时静默回退，不抛错；mtime 缓存命中时不重复 JSON 解析。

## 服务端兼容性

服务端 `src/server-route-state.js` 已经在读取 `payload.session_title` 并写入 session 状态，本次无需任何服务端改动；同样的 `session_title` 字段在 `clawd-hook` / `copilot-hook` 中也是同一机制。

## 测试

- `node --test test/openclaw-plugin.test.js` 全部 9 项通过（runtime 无 child_process / 无 SDK 依赖、payload redaction、debounce、错误映射、SessionEnd 分支均未受影响）。
- `npm test` 中预存在的 install / kiro-install / updater 失败为本仓库 main 已有问题（`git stash` 改动后在 clean main 上复现），与本 PR 无关。

## 测试建议

1. 在 `~/.openclaw/openclaw.json` 的 `agents.list[]` 中任选两个 agent（一个带 `identity.emoji`、一个不带），分别启动 OpenClaw 会话。
2. 打开 Clawd Dashboard，确认两个 session 标题分别显示 `<emoji> <identity.name>` 与 `<identity.name 或 name>`。
3. 删除一条 agent 配置后再发事件，确认标题回退到原始 id，无报错。
4. 之前手动给某 session 设置过别名的，别名仍优先于 agent 显示名（这是 `sessionDisplayTitle` 的既有优先级，未改）。