### PR TITLE
Fix Windows event sound warmup

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -629,6 +629,20 @@ function sendToHitWin(channel, ...args) {
   if (hitWin && !hitWin.isDestroyed()) hitWin.webContents.send(channel, ...args);
 }
 
+function getThemeSoundPreloadUrls() {
+  const urls = [];
+  for (const name of ["complete", "confirm"]) {
+    const url = themeRuntime.getSoundUrl(name);
+    if (url && !urls.includes(url)) urls.push(url);
+  }
+  return urls;
+}
+
+function syncSoundPreloads() {
+  const urls = getThemeSoundPreloadUrls();
+  if (urls.length) sendToRenderer("preload-sounds", { urls });
+}
+
 function setViewportOffsetY(offsetY) { return petWindowRuntime.setViewportOffsetY(offsetY); }
 function getPetWindowBounds() { return petWindowRuntime.getPetWindowBounds(); }
 function applyPetWindowBounds(bounds) { return petWindowRuntime.applyPetWindowBounds(bounds); }
@@ -644,6 +658,7 @@ function syncHitStateAfterLoad() {
 }
 
 function syncRendererStateAfterLoad({ includeStartupRecovery = true } = {}) {
+  syncSoundPreloads();
   sendToRenderer("low-power-idle-mode-change", lowPowerIdleMode);
   if (_mini.getMiniMode()) {
     sendToRenderer("mini-mode-change", true, _mini.getMiniEdge());
@@ -1207,6 +1222,16 @@ function sessionLog(msg) {
   const { rotatedAppend } = require("./log-rotate");
   rotatedAppend(sessionDebugLog, `[${new Date().toISOString()}] ${msg}\n`);
 }
+
+ipcMain.on("sound-playback-error", (_event, payload) => {
+  const phase = payload && typeof payload.phase === "string"
+    ? payload.phase.replace(/[^a-z0-9_-]/gi, "").slice(0, 32)
+    : "unknown";
+  const message = payload && typeof payload.message === "string"
+    ? payload.message.replace(/\s+/g, " ").slice(0, 240)
+    : "unknown";
+  sessionLog(`sound playback error phase=${phase || "unknown"} message=${message || "unknown"}`);
+});
 
 function focusLog(msg) {
   if (!focusDebugLog) return;

--- a/src/preload.js
+++ b/src/preload.js
@@ -25,8 +25,10 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onEndDragReaction: (cb) => ipcRenderer.on("end-drag-reaction", () => cb()),
   onPlayClickReaction: (cb) => ipcRenderer.on("play-click-reaction", (_, svg, duration) => cb(svg, duration)),
   // Sound playback (from main)
+  onPreloadSounds: (cb) => ipcRenderer.on("preload-sounds", (_, payload) => cb(payload)),
   onPlaySound: (cb) => ipcRenderer.on("play-sound", (_, payload) => cb(payload)),
   onInvalidateSoundCache: (cb) => ipcRenderer.on("invalidate-sound-cache", (_, url) => cb(url)),
+  reportSoundPlaybackError: (payload) => ipcRenderer.send("sound-playback-error", payload),
   // Render window → main (cursor polling control during reactions)
   pauseCursorPolling: () => ipcRenderer.send("pause-cursor-polling"),
   resumeFromReaction: () => ipcRenderer.send("resume-from-reaction"),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1274,6 +1274,72 @@ if (window.electronAPI && typeof window.electronAPI.onCloudlingPointer === "func
 
 // --- Sound playback (IPC from main, receives { url, volume } from theme) ---
 const _audioCache = {};
+const AUDIO_WARMUP_STALE_MS = 10000;
+const AUDIO_WARMUP_DELAY_MS = 50;
+const AUDIO_WARMUP_VOLUME = 0.001;
+let _lastAudioWarmupAt = 0;
+
+function reportSoundPlaybackError(phase, err) {
+  const message = err && err.message ? err.message : String(err || "unknown");
+  if (window.electronAPI && typeof window.electronAPI.reportSoundPlaybackError === "function") {
+    window.electronAPI.reportSoundPlaybackError({ phase, message });
+    return;
+  }
+  try { console.warn(`Clawd sound ${phase} failed:`, message); } catch {}
+}
+
+function cacheAudio(url) {
+  if (typeof url !== "string" || !url) return null;
+  let audio = _audioCache[url];
+  const created = !audio;
+  if (!audio) {
+    audio = new Audio(url);
+    audio.preload = "auto";
+    _audioCache[url] = audio;
+  }
+  if (created) {
+    try { audio.load(); } catch {}
+  }
+  return audio;
+}
+
+function normalizeSoundUrls(payload) {
+  const raw = Array.isArray(payload)
+    ? payload
+    : (payload && Array.isArray(payload.urls) ? payload.urls : []);
+  return raw.filter((url) => typeof url === "string" && url);
+}
+
+function warmAudioOutput(url, { force = false } = {}) {
+  const now = Date.now();
+  if (!force && now - _lastAudioWarmupAt < AUDIO_WARMUP_STALE_MS) {
+    return Promise.resolve();
+  }
+  if (!url) return Promise.resolve();
+  _lastAudioWarmupAt = now;
+
+  const primer = new Audio(url);
+  primer.preload = "auto";
+  primer.volume = AUDIO_WARMUP_VOLUME;
+  return primer.play()
+    .then(() => new Promise((resolve) => {
+      setTimeout(() => {
+        try { primer.pause(); } catch {}
+        resolve();
+      }, AUDIO_WARMUP_DELAY_MS);
+    }))
+    .catch((err) => {
+      reportSoundPlaybackError("warmup", err);
+    });
+}
+
+if (window.electronAPI && typeof window.electronAPI.onPreloadSounds === "function") {
+  window.electronAPI.onPreloadSounds((payload) => {
+    const urls = normalizeSoundUrls(payload);
+    urls.forEach((url) => cacheAudio(url));
+  });
+}
+
 window.electronAPI.onPlaySound((payload) => {
   const url = typeof payload === "string" ? payload : payload && payload.url;
   const volume = typeof payload === "object" && payload && typeof payload.volume === "number"
@@ -1285,14 +1351,14 @@ window.electronAPI.onPlaySound((payload) => {
   // for no benefit since the URL will never be requested again. Only cache
   // real playback URLs.
   const isPreview = url.includes("_t=");
-  let audio = !isPreview ? _audioCache[url] : null;
-  if (!audio) {
-    audio = new Audio(url);
-    if (!isPreview) _audioCache[url] = audio;
-  }
-  audio.volume = volume;
-  audio.currentTime = 0;
-  audio.play().catch(() => {});
+  const audio = isPreview ? new Audio(url) : cacheAudio(url);
+  if (!audio) return;
+  if (isPreview) audio.preload = "auto";
+  warmAudioOutput(url).then(() => {
+    audio.volume = volume;
+    audio.currentTime = 0;
+    audio.play().catch((err) => reportSoundPlaybackError("play", err));
+  });
 });
 // Same-extension override replacement overwrites the file on disk without
 // changing the URL, so the cached Audio object keeps its old buffered data.

--- a/src/settings-ipc.js
+++ b/src/settings-ipc.js
@@ -240,7 +240,10 @@ function registerSettingsIpc(options = {}) {
     }
     rememberRuntimeSoundOverrideFile({ getActiveTheme }, themeId, soundName, destPath);
     const newUrl = themeLoader.getSoundUrl(soundName);
-    if (newUrl) sendToRenderer("invalidate-sound-cache", newUrl);
+    if (newUrl) {
+      sendToRenderer("invalidate-sound-cache", newUrl);
+      sendToRenderer("preload-sounds", { urls: [newUrl] });
+    }
     return { status: "ok", file: destFilename };
   });
 

--- a/test/renderer-low-power.test.js
+++ b/test/renderer-low-power.test.js
@@ -82,6 +82,8 @@ class FakeElement {
 
 function createRendererHarness() {
   const timers = [];
+  const audioInstances = [];
+  const electronHandlers = {};
   const container = new FakeElement("div");
   container.id = "pet-container";
   container.isConnected = true;
@@ -102,7 +104,11 @@ function createRendererHarness() {
     },
   };
   const electronAPI = new Proxy({}, {
-    get() {
+    get(_target, prop) {
+      const name = String(prop);
+      if (name.startsWith("on")) {
+        return (callback) => { electronHandlers[name] = callback; };
+      }
       return () => {};
     },
   });
@@ -131,8 +137,17 @@ function createRendererHarness() {
     cancelAnimationFrame(timer) {
       context.clearTimeout(timer);
     },
-    Audio: function FakeAudio() {
-      return { play: () => Promise.resolve(), volume: 1, currentTime: 0 };
+    Audio: function FakeAudio(url) {
+      this.url = url;
+      this.volume = 1;
+      this.currentTime = 0;
+      this.loadCalls = 0;
+      this.playCalls = 0;
+      this.pauseCalls = 0;
+      this.load = () => { this.loadCalls++; };
+      this.play = () => { this.playCalls++; return Promise.resolve(); };
+      this.pause = () => { this.pauseCalls++; };
+      audioInstances.push(this);
     },
   };
   context.globalThis = context;
@@ -153,6 +168,8 @@ globalThis.__rendererTest = {
     container,
     clawd,
     timers,
+    audioInstances,
+    electronHandlers,
     api: context.__rendererTest,
     activeTimers: () => timers.filter((timer) => !timer.cleared),
   };
@@ -318,6 +335,36 @@ describe("renderer Cloudling pointer bridge", () => {
     assert.ok(source.includes('svgWindow.__cloudlingSetPointer(payload);'));
     assert.ok(source.includes('window.electronAPI.onCloudlingPointer((payload) => {'));
     assert.ok(preload.includes('onCloudlingPointer: (callback) => ipcRenderer.on("cloudling-pointer", (_, payload) => callback(payload))'));
+  });
+});
+
+describe("renderer sound preload and warmup", () => {
+  it("preloads sound files without playing a primer", () => {
+    const harness = createRendererHarness();
+    const preload = harness.electronHandlers.onPreloadSounds;
+
+    assert.strictEqual(typeof preload, "function");
+    preload({ urls: ["file:///complete.mp3"] });
+
+    assert.strictEqual(harness.audioInstances.length, 1);
+    assert.strictEqual(harness.audioInstances[0].url, "file:///complete.mp3");
+    assert.strictEqual(harness.audioInstances[0].loadCalls, 1);
+    assert.strictEqual(harness.audioInstances[0].playCalls, 0);
+  });
+
+  it("does not reload a cached sound object on playback", () => {
+    const harness = createRendererHarness();
+    const preload = harness.electronHandlers.onPreloadSounds;
+    const playSound = harness.electronHandlers.onPlaySound;
+
+    preload({ urls: ["file:///complete.mp3"] });
+    const cached = harness.audioInstances[0];
+    playSound({ url: "file:///complete.mp3", volume: 1 });
+
+    assert.strictEqual(cached.loadCalls, 1);
+    assert.strictEqual(harness.audioInstances.length, 2);
+    assert.strictEqual(harness.audioInstances[1].url, "file:///complete.mp3");
+    assert.strictEqual(harness.audioInstances[1].playCalls, 1);
   });
 });
 

--- a/test/settings-ipc.test.js
+++ b/test/settings-ipc.test.js
@@ -502,6 +502,7 @@ test("settings IPC copies sound overrides, removes stale siblings, and invalidat
         originalName: "picked.wav",
       }],
       ["sendToRenderer", "invalidate-sound-cache", "file:///complete.wav"],
+      ["sendToRenderer", "preload-sounds", { urls: ["file:///complete.wav"] }],
     ]);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- preload theme event sounds in the renderer without playing audio during preload
- add low-volume warmup before stale event playback to reduce Windows cold-start clipping
- report renderer audio playback failures to the session debug log
- refresh/preload replaced sound overrides and cover renderer audio behavior in tests

## Tests
- node --test test\\renderer-low-power.test.js
- node --test test\\settings-ipc.test.js
- npm test

Addresses #304