### PR TITLE
fix(hooks): use absolute node path in Windows hook commands (#317)

### DIFF
--- a/hooks/copilot-install.js
+++ b/hooks/copilot-install.js
@@ -17,6 +17,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const { writeJsonAtomic, asarUnpackedPath } = require("./json-utils");
+const { resolveNodeBin } = require("./server-config");
 
 const MARKER = "copilot-hook.js";
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".copilot");
@@ -113,7 +114,13 @@ function registerCopilotHooks(options = {}) {
   const hookScript = options.hookScript
     || asarUnpackedPath(path.resolve(__dirname, "copilot-hook.js").replace(/\\/g, "/"));
 
-  const nodeBin = options.nodeBin || (options.remote === true ? process.execPath : "node");
+  // Remote installs keep using this process' Node executable so the SSH host
+  // doesn't need a working PATH. Local installs go through the shared resolver
+  // so Windows users get an absolute path (issue #317) instead of bare "node".
+  const localResolved = options.remote === true ? null : resolveNodeBin(options);
+  const nodeBin = options.nodeBin
+    || (options.remote === true ? process.execPath : localResolved)
+    || "node";
 
   let settings = {};
   try {

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -8,7 +8,7 @@ const path = require("path");
 const os = require("os");
 const childProcess = require("child_process");
 const { buildPermissionUrl, DEFAULT_SERVER_PORT, PERMISSION_PATH, readRuntimePort, resolveNodeBin, resolveNodeBinAsync, SERVER_PORTS } = require("./server-config");
-const { writeJsonAtomic, writeJsonAtomicAsync, asarUnpackedPath } = require("./json-utils");
+const { writeJsonAtomic, writeJsonAtomicAsync, asarUnpackedPath, extractExistingNodeBin } = require("./json-utils");
 
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".claude");
 const DEFAULT_CONFIG_PATH = path.join(DEFAULT_PARENT_DIR, "settings.json");
@@ -435,42 +435,6 @@ const AUTO_START_MARKER = "auto-start.js";
 const LEGACY_AUTO_START_MARKER = "auto-start.sh";
 const HTTP_MARKER = PERMISSION_PATH;
 
-/**
- * Extract the node binary path from existing hook commands in settings.
- * Looks for the first quoted absolute path before `marker` in any hook command.
- * Returns the path (e.g. "/opt/homebrew/bin/node") or null.
- */
-function extractNodeBinFromSettings(settings, marker) {
-  if (!settings || !settings.hooks) return null;
-  for (const entries of Object.values(settings.hooks)) {
-    if (!Array.isArray(entries)) continue;
-    for (const entry of entries) {
-      if (!entry || typeof entry !== "object") continue;
-      const cmds = [];
-      if (typeof entry.command === "string") cmds.push(entry.command);
-      if (Array.isArray(entry.hooks)) {
-        for (const h of entry.hooks) {
-          if (h && typeof h.command === "string") cmds.push(h.command);
-        }
-      }
-      for (const cmd of cmds) {
-        if (!cmd.includes(marker)) continue;
-        // Find first quoted token: "something"
-        const qi = cmd.indexOf('"');
-        if (qi === -1) continue;
-        const qe = cmd.indexOf('"', qi + 1);
-        if (qe === -1) continue;
-        const firstQuoted = cmd.substring(qi + 1, qe);
-        // If first quoted token IS the hook script (old format), node was bare — nothing to preserve
-        if (firstQuoted.includes(marker)) continue;
-        // Only preserve absolute paths
-        if (firstQuoted.startsWith("/")) return firstQuoted;
-      }
-    }
-  }
-  return null;
-}
-
 function buildCommandHookSpec(nodeBin, scriptPath, args = "", options = {}) {
   const platform = options.platform || process.platform;
   const argSuffix = args ? ` ${args}` : "";
@@ -789,7 +753,7 @@ function registerHooks(options = {}) {
   // to avoid destructively overwriting a working config with bare "node".
   const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
   const nodeBin = resolved
-    || extractNodeBinFromSettings(settings, MARKER)
+    || extractExistingNodeBin(settings, MARKER, { nested: true })
     || "node";
 
   let added = 0;
@@ -1005,7 +969,7 @@ async function registerHooksAsync(options = {}) {
 
   const configuredNodeBin = options.nodeBin !== undefined
     ? options.nodeBin
-    : extractNodeBinFromSettings(settings, MARKER);
+    : extractExistingNodeBin(settings, MARKER, { nested: true });
   const nodeBin = configuredNodeBin
     || await resolveNodeBinAsync(options)
     || "node";

--- a/hooks/json-utils.js
+++ b/hooks/json-utils.js
@@ -82,6 +82,33 @@ function formatNodeHookCommand(nodeBin, scriptPath, options = {}) {
 }
 
 /**
+ * Extract the first absolute node binary path from a list of command strings.
+ * Scans each command for double-quoted tokens, ignores the hook script marker
+ * itself, and returns the first token that looks like an absolute path
+ * (POSIX `/`, Windows `C:\`, or UNC `\\server`).
+ *
+ * Used as a shared primitive so installers that don't share a settings.hooks
+ * shape (e.g. Kimi's TOML) can still preserve a user-repaired Node path.
+ *
+ * @param {string[]} commands - Raw command strings (already unescaped)
+ * @param {string}   marker   - Hook script filename to skip
+ * @returns {string|null}
+ */
+function extractExistingNodeBinFromCommands(commands, marker) {
+  if (!Array.isArray(commands) || typeof marker !== "string" || !marker) return null;
+  for (const cmd of commands) {
+    if (typeof cmd !== "string") continue;
+    const matches = cmd.matchAll(/"([^"]+)"/g);
+    for (const match of matches) {
+      const token = match && match[1];
+      if (!token || token.includes(marker)) continue;
+      if (isAbsoluteCommandToken(token)) return token;
+    }
+  }
+  return null;
+}
+
+/**
  * Extract the existing absolute node binary path from hook commands that
  * contain `marker` (e.g. "cursor-hook.js").  Scans settings.hooks for
  * matching commands, then returns the first quoted token that is an
@@ -95,16 +122,7 @@ function formatNodeHookCommand(nodeBin, scriptPath, options = {}) {
  * @returns {string|null}
  */
 function extractExistingNodeBin(settings, marker, options) {
-  const commands = findHookCommands(settings, marker, options);
-  for (const cmd of commands) {
-    const matches = cmd.matchAll(/"([^"]+)"/g);
-    for (const match of matches) {
-      const token = match && match[1];
-      if (!token || token.includes(marker)) continue;
-      if (isAbsoluteCommandToken(token)) return token;
-    }
-  }
-  return null;
+  return extractExistingNodeBinFromCommands(findHookCommands(settings, marker, options), marker);
 }
 
 /**
@@ -147,6 +165,7 @@ module.exports = {
   writeJsonAtomicAsync,
   asarUnpackedPath,
   extractExistingNodeBin,
+  extractExistingNodeBinFromCommands,
   findHookCommands,
   formatNodeHookCommand,
 };

--- a/hooks/kimi-install.js
+++ b/hooks/kimi-install.js
@@ -5,7 +5,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const { resolveNodeBin } = require("./server-config");
-const { asarUnpackedPath } = require("./json-utils");
+const { asarUnpackedPath, extractExistingNodeBinFromCommands } = require("./json-utils");
 const MARKER = "kimi-hook.js";
 const MODE_EXPLICIT = "explicit";
 const MODE_SUSPECT = "suspect";
@@ -144,8 +144,6 @@ function registerKimiHooks(options = {}) {
   }
 
   const hookScript = asarUnpackedPath(path.resolve(__dirname, "kimi-hook.js").replace(/\\/g, "/"));
-  const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
-  const nodeBin = resolved || "node";
 
   let content = "";
   try {
@@ -157,6 +155,15 @@ function registerKimiHooks(options = {}) {
     // Create a minimal config.toml if it doesn't exist
     content = 'default_model = "kimi-for-coding"\n';
   }
+
+  // Preserve a user-repaired absolute Node path baked into the existing TOML
+  // when fresh detection fails. Without this, startup auto-sync would overwrite
+  // a working `C:\Program Files\nodejs\node.exe` back to bare `"node"` — the
+  // same regression mode #317 reported for Claude's settings.json.
+  const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
+  const nodeBin = resolved
+    || extractExistingNodeBinFromCommands(findKimiHookCommands(content, MARKER), MARKER)
+    || "node";
 
   // Priority: explicit caller option → env var → mode already baked into the
   // existing config.toml hook command. The fallback is critical for the

--- a/hooks/server-config.js
+++ b/hooks/server-config.js
@@ -538,11 +538,166 @@ function extractAbsolutePathFromShellOutput(raw) {
   return null;
 }
 
+const WINDOWS_NODE_BASENAMES = new Set(["node.exe", "node"]);
+
+function isWindowsNodeBasename(value) {
+  return WINDOWS_NODE_BASENAMES.has(
+    path.basename(String(value || "")).toLowerCase()
+  );
+}
+
+function normalizeWindowsPathForMatch(value) {
+  return path.normalize(String(value || "")).replace(/\//g, "\\").toLowerCase();
+}
+
+function isScoopShimPath(value) {
+  if (typeof value !== "string" || !value) return false;
+  return normalizeWindowsPathForMatch(value).includes("\\scoop\\shims\\");
+}
+
+function isClawdOrElectronPath(value) {
+  const norm = normalizeWindowsPathForMatch(value);
+  if (!norm) return false;
+  // Reject the packaged Electron host. Match by basename so we don't false-flag
+  // a legitimate Node living under a parent folder whose name happens to
+  // contain "Clawd" or "Electron".
+  const base = path.basename(norm);
+  return base.includes("clawd on desk") || base === "electron.exe";
+}
+
+function validateWindowsNodeCandidate(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  // Accept drive letter (C:\...), UNC (\\server\share\...), and POSIX
+  // absolutes returned by mocks.
+  if (!path.isAbsolute(trimmed) && !/^[A-Za-z]:[\\/]/.test(trimmed) && !trimmed.startsWith("\\\\")) {
+    return null;
+  }
+  if (!isWindowsNodeBasename(trimmed)) return null;
+  if (isScoopShimPath(trimmed)) return null;
+  if (isClawdOrElectronPath(trimmed)) return null;
+  return trimmed;
+}
+
+function getWindowsCommonNodePaths(options = {}) {
+  const env = options.env || process.env;
+  const probes = [];
+  if (env.ProgramFiles) {
+    probes.push(path.join(env.ProgramFiles, "nodejs", "node.exe"));
+  }
+  if (env["ProgramFiles(x86)"]) {
+    probes.push(path.join(env["ProgramFiles(x86)"], "nodejs", "node.exe"));
+  }
+  if (env.LOCALAPPDATA) {
+    probes.push(path.join(env.LOCALAPPDATA, "Programs", "nodejs", "node.exe"));
+    probes.push(path.join(env.LOCALAPPDATA, "Volta", "bin", "node.exe"));
+  }
+  if (env.USERPROFILE) {
+    probes.push(path.join(env.USERPROFILE, "scoop", "apps", "nodejs", "current", "node.exe"));
+  }
+  return probes;
+}
+
+function windowsWhereExePath(options = {}) {
+  const systemRoot = (options.env || process.env).SystemRoot;
+  return systemRoot
+    ? path.join(systemRoot, "System32", "where.exe")
+    : "where.exe";
+}
+
+function resolveWindowsNodeBinSync(options = {}) {
+  const access = options.accessSync || fs.accessSync;
+  const checkAccess = (candidate) => {
+    if (!candidate) return null;
+    try {
+      access(candidate, fs.constants.F_OK);
+      return candidate;
+    } catch {
+      return null;
+    }
+  };
+
+  // 1. process.execPath / options.execPath when it's actually node[.exe].
+  //    In packaged Clawd builds this is `Clawd on Desk.exe`, so it falls
+  //    through; mostly useful for unit tests and non-Electron Node runs.
+  const execHit = checkAccess(validateWindowsNodeCandidate(options.execPath || process.execPath));
+  if (execHit) return execHit;
+
+  // 2. where.exe node — iterate every line; first line passing validation wins.
+  try {
+    const execFileSync = options.execFileSync || require("child_process").execFileSync;
+    const out = execFileSync(windowsWhereExePath(options), ["node"], {
+      encoding: "utf8",
+      timeout: 2000,
+      windowsHide: true,
+    });
+    for (const line of String(out || "").split(/\r?\n/)) {
+      const hit = checkAccess(validateWindowsNodeCandidate(line));
+      if (hit) return hit;
+    }
+  } catch {}
+
+  // 3. Common install locations.
+  for (const probe of getWindowsCommonNodePaths(options)) {
+    const hit = checkAccess(validateWindowsNodeCandidate(probe));
+    if (hit) return hit;
+  }
+
+  return null;
+}
+
+async function resolveWindowsNodeBinAsync(options = {}) {
+  const access = options.access || fs.promises.access.bind(fs.promises);
+  const checkAccess = async (candidate) => {
+    if (!candidate) return null;
+    try {
+      await access(candidate, fs.constants.F_OK);
+      return candidate;
+    } catch {
+      return null;
+    }
+  };
+
+  const execHit = await checkAccess(validateWindowsNodeCandidate(options.execPath || process.execPath));
+  if (execHit) return execHit;
+
+  try {
+    const execFile = options.execFile || ((command, args, execOptions) => new Promise((resolve, reject) => {
+      require("child_process").execFile(command, args, execOptions, (err, stdout, stderr) => {
+        if (err) reject(err);
+        else resolve({ stdout, stderr });
+      });
+    }));
+    const out = await execFile(windowsWhereExePath(options), ["node"], {
+      encoding: "utf8",
+      timeout: 2000,
+      windowsHide: true,
+    });
+    const raw = typeof out === "string"
+      ? out
+      : (out && typeof out.stdout === "string" ? out.stdout : "");
+    for (const line of raw.split(/\r?\n/)) {
+      const hit = await checkAccess(validateWindowsNodeCandidate(line));
+      if (hit) return hit;
+    }
+  } catch {}
+
+  for (const probe of getWindowsCommonNodePaths(options)) {
+    const hit = await checkAccess(validateWindowsNodeCandidate(probe));
+    if (hit) return hit;
+  }
+
+  return null;
+}
+
 /**
  * Resolve the absolute path to the Node.js binary for hook commands.
  * On macOS/Linux, Claude Code runs hooks with a minimal PATH (/usr/bin:/bin)
- * that excludes Homebrew, nvm, volta, fnm, etc.  We embed the full path in
- * hook commands so they work regardless of the hook runner's PATH.
+ * that excludes Homebrew, nvm, volta, fnm, etc.  On Windows, hook runners
+ * can execute under PowerShell whose PATH does not include the Node install
+ * directory (see issue #317).  We embed the full path in hook commands so
+ * they work regardless of the hook runner's PATH.
  *
  * @param {object} [options] — for testing
  * @param {string} [options.platform]
@@ -551,13 +706,13 @@ function extractAbsolutePathFromShellOutput(raw) {
  * @param {Function} [options.accessSync]
  * @param {string} [options.execPath]
  * @param {boolean} [options.isElectron]
- * @returns {string|null} absolute path, "node" (Windows), or null (detection failed)
+ * @param {object} [options.env]
+ * @returns {string|null} absolute path, or null when detection fails
  */
 function resolveNodeBin(options = {}) {
   const platform = options.platform || process.platform;
 
-  // Windows: bare `node` works fine (PATH is inherited properly)
-  if (platform === "win32") return "node";
+  if (platform === "win32") return resolveWindowsNodeBinSync(options);
 
   const isElectron = options.isElectron !== undefined
     ? options.isElectron
@@ -615,7 +770,7 @@ function resolveNodeBin(options = {}) {
 async function resolveNodeBinAsync(options = {}) {
   const platform = options.platform || process.platform;
 
-  if (platform === "win32") return "node";
+  if (platform === "win32") return await resolveWindowsNodeBinAsync(options);
 
   const isElectron = options.isElectron !== undefined
     ? options.isElectron
@@ -690,6 +845,9 @@ module.exports = {
   readRuntimePort,
   resolveNodeBin,
   resolveNodeBinAsync,
+  resolveWindowsNodeBinSync,
+  resolveWindowsNodeBinAsync,
+  validateWindowsNodeCandidate,
   splitPortCandidates,
   postStateToPort,
   writeRuntimeConfig,

--- a/hooks/server-config.js
+++ b/hooks/server-config.js
@@ -538,16 +538,21 @@ function extractAbsolutePathFromShellOutput(raw) {
   return null;
 }
 
+// Use path.win32.* explicitly throughout so resolveNodeBin behaves identically
+// when the test suite (or any caller) drives win32 logic from a Linux/macOS
+// host. The default `path` module follows the host platform, which on POSIX
+// treats `C:\Program Files\nodejs\node.exe` as a single filename — basename
+// returns the entire string and every Windows check silently misfires.
 const WINDOWS_NODE_BASENAMES = new Set(["node.exe", "node"]);
 
 function isWindowsNodeBasename(value) {
   return WINDOWS_NODE_BASENAMES.has(
-    path.basename(String(value || "")).toLowerCase()
+    path.win32.basename(String(value || "")).toLowerCase()
   );
 }
 
 function normalizeWindowsPathForMatch(value) {
-  return path.normalize(String(value || "")).replace(/\//g, "\\").toLowerCase();
+  return path.win32.normalize(String(value || "")).replace(/\//g, "\\").toLowerCase();
 }
 
 function isScoopShimPath(value) {
@@ -561,7 +566,7 @@ function isClawdOrElectronPath(value) {
   // Reject the packaged Electron host. Match by basename so we don't false-flag
   // a legitimate Node living under a parent folder whose name happens to
   // contain "Clawd" or "Electron".
-  const base = path.basename(norm);
+  const base = path.win32.basename(norm);
   return base.includes("clawd on desk") || base === "electron.exe";
 }
 
@@ -569,9 +574,10 @@ function validateWindowsNodeCandidate(value) {
   if (typeof value !== "string") return null;
   const trimmed = value.trim();
   if (!trimmed) return null;
-  // Accept drive letter (C:\...), UNC (\\server\share\...), and POSIX
-  // absolutes returned by mocks.
-  if (!path.isAbsolute(trimmed) && !/^[A-Za-z]:[\\/]/.test(trimmed) && !trimmed.startsWith("\\\\")) {
+  // Accept drive letter (C:\...), UNC (\\server\share\...). path.win32.isAbsolute
+  // already covers both; the regex fallback exists only as a belt-and-braces
+  // guard if a future caller hands in a hand-built path object.
+  if (!path.win32.isAbsolute(trimmed) && !/^[A-Za-z]:[\\/]/.test(trimmed) && !trimmed.startsWith("\\\\")) {
     return null;
   }
   if (!isWindowsNodeBasename(trimmed)) return null;
@@ -584,17 +590,17 @@ function getWindowsCommonNodePaths(options = {}) {
   const env = options.env || process.env;
   const probes = [];
   if (env.ProgramFiles) {
-    probes.push(path.join(env.ProgramFiles, "nodejs", "node.exe"));
+    probes.push(path.win32.join(env.ProgramFiles, "nodejs", "node.exe"));
   }
   if (env["ProgramFiles(x86)"]) {
-    probes.push(path.join(env["ProgramFiles(x86)"], "nodejs", "node.exe"));
+    probes.push(path.win32.join(env["ProgramFiles(x86)"], "nodejs", "node.exe"));
   }
   if (env.LOCALAPPDATA) {
-    probes.push(path.join(env.LOCALAPPDATA, "Programs", "nodejs", "node.exe"));
-    probes.push(path.join(env.LOCALAPPDATA, "Volta", "bin", "node.exe"));
+    probes.push(path.win32.join(env.LOCALAPPDATA, "Programs", "nodejs", "node.exe"));
+    probes.push(path.win32.join(env.LOCALAPPDATA, "Volta", "bin", "node.exe"));
   }
   if (env.USERPROFILE) {
-    probes.push(path.join(env.USERPROFILE, "scoop", "apps", "nodejs", "current", "node.exe"));
+    probes.push(path.win32.join(env.USERPROFILE, "scoop", "apps", "nodejs", "current", "node.exe"));
   }
   return probes;
 }
@@ -602,7 +608,7 @@ function getWindowsCommonNodePaths(options = {}) {
 function windowsWhereExePath(options = {}) {
   const systemRoot = (options.env || process.env).SystemRoot;
   return systemRoot
-    ? path.join(systemRoot, "System32", "where.exe")
+    ? path.win32.join(systemRoot, "System32", "where.exe")
     : "where.exe";
 }
 

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -832,6 +832,42 @@ describe("Hook installer version compatibility", () => {
     assert.ok(!commands[0].startsWith('"node"'), "should not downgrade to bare node");
   });
 
+  it("preserves an existing absolute Windows node path when detection fails", () => {
+    // Issue #317: startup auto-sync must not overwrite the user's manual
+    // `C:\Program Files\nodejs\node.exe` repair with bare `"node"`. install.js
+    // previously gated preservation on POSIX `/` prefixes, so Windows paths
+    // slipped through and got clobbered.
+    const existingWinPath = "C:\\Program Files\\nodejs\\node.exe";
+    const settingsPath = makeTempSettings({
+      hooks: {
+        Stop: [
+          {
+            matcher: "",
+            hooks: [{
+              type: "command",
+              shell: "powershell",
+              command: `& "${existingWinPath}" "C:/app/hooks/clawd-hook.js" Stop`,
+            }],
+          },
+        ],
+      },
+    });
+
+    registerHooks({
+      silent: true,
+      settingsPath,
+      platform: "win32",
+      nodeBin: null,
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    const commands = getClawdCommands(settings, "Stop");
+    assert.strictEqual(commands.length, 1);
+    assert.ok(commands[0].includes(existingWinPath), `expected ${existingWinPath} in: ${commands[0]}`);
+    assert.ok(!commands[0].includes('& "node"'), "should not downgrade to bare node");
+  });
+
   it("uses PowerShell-safe auto-start hooks on Windows", () => {
     const settingsPath = makeTempSettings({});
     registerHooks({

--- a/test/json-utils.test.js
+++ b/test/json-utils.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { extractExistingNodeBin, formatNodeHookCommand, writeJsonAtomicAsync } = require("../hooks/json-utils");
+const { extractExistingNodeBin, extractExistingNodeBinFromCommands, formatNodeHookCommand, writeJsonAtomicAsync } = require("../hooks/json-utils");
 
 describe("extractExistingNodeBin", () => {
   it("extracts node path from flat command format", () => {
@@ -108,6 +108,53 @@ describe("extractExistingNodeBin", () => {
       extractExistingNodeBin(settings, "cursor-hook.js"),
       "\\\\fileserver\\tools\\nodejs\\node.exe"
     );
+  });
+});
+
+describe("extractExistingNodeBinFromCommands", () => {
+  it("extracts the first absolute path that is not the hook script", () => {
+    const commands = ['"/usr/local/bin/node" "/path/to/kimi-hook.js"'];
+    assert.strictEqual(extractExistingNodeBinFromCommands(commands, "kimi-hook.js"), "/usr/local/bin/node");
+  });
+
+  it("returns Windows drive paths verbatim", () => {
+    const commands = ['"C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\u\\.kimi\\hooks\\kimi-hook.js"'];
+    assert.strictEqual(
+      extractExistingNodeBinFromCommands(commands, "kimi-hook.js"),
+      "C:\\Program Files\\nodejs\\node.exe"
+    );
+  });
+
+  it("returns UNC paths", () => {
+    const commands = ['"\\\\fileserver\\tools\\node.exe" "C:\\hooks\\kimi-hook.js"'];
+    assert.strictEqual(
+      extractExistingNodeBinFromCommands(commands, "kimi-hook.js"),
+      "\\\\fileserver\\tools\\node.exe"
+    );
+  });
+
+  it("skips bare 'node' and returns null when nothing absolute is found", () => {
+    const commands = ['"node" "/path/to/kimi-hook.js"'];
+    assert.strictEqual(extractExistingNodeBinFromCommands(commands, "kimi-hook.js"), null);
+  });
+
+  it("walks past commands that begin with the marker itself", () => {
+    const commands = [
+      '"/path/to/kimi-hook.js"',
+      '"/usr/bin/node" "/path/to/kimi-hook.js"',
+    ];
+    assert.strictEqual(extractExistingNodeBinFromCommands(commands, "kimi-hook.js"), "/usr/bin/node");
+  });
+
+  it("returns null for non-array or missing inputs", () => {
+    assert.strictEqual(extractExistingNodeBinFromCommands([], "kimi-hook.js"), null);
+    assert.strictEqual(extractExistingNodeBinFromCommands(null, "kimi-hook.js"), null);
+    assert.strictEqual(extractExistingNodeBinFromCommands(["something"], ""), null);
+  });
+
+  it("ignores non-string entries in the commands array", () => {
+    const commands = [null, 42, '"/usr/bin/node" "/hooks/kimi-hook.js"'];
+    assert.strictEqual(extractExistingNodeBinFromCommands(commands, "kimi-hook.js"), "/usr/bin/node");
   });
 });
 

--- a/test/kimi-install.test.js
+++ b/test/kimi-install.test.js
@@ -217,6 +217,31 @@ timeout = 30
     assert.strictEqual(markerLines.length, KIMI_HOOK_EVENTS.length);
   });
 
+  it("preserves an existing absolute Windows node path when detection fails", () => {
+    // Issue #317 follow-up: Kimi TOML used to lose the user's manual
+    // C:\Program Files\nodejs\node.exe repair on startup auto-sync because
+    // no preservation chain existed for the kimi-install path.
+    const { settingsPath } = makeTempKimiHome();
+    const existingWinPath = "C:\\Program Files\\nodejs\\node.exe";
+    const initial = [
+      'default_model = "kimi-for-coding"',
+      "",
+      "[[hooks]]",
+      'event = "PreToolUse"',
+      `command = '"${existingWinPath}" "/opt/clawd/hooks/kimi-hook.js"'`,
+      'matcher = ""',
+      "timeout = 30",
+      "",
+    ].join("\n");
+    fs.writeFileSync(settingsPath, initial, "utf8");
+
+    registerKimiHooks({ silent: true, settingsPath, nodeBin: null });
+
+    const after = fs.readFileSync(settingsPath, "utf8");
+    assert.ok(after.includes(existingWinPath), `expected ${existingWinPath} to be preserved`);
+    assert.ok(!/command\s*=\s*'"node"/.test(after), "should not downgrade to bare node");
+  });
+
   it("skips when ~/.kimi/ does not exist", () => {
     const { root } = makeTempKimiHome();
     const settingsPath = path.join(root, ".kimi-not-exist", "config.toml");

--- a/test/server-config.test.js
+++ b/test/server-config.test.js
@@ -213,6 +213,37 @@ describe("server-config helpers", () => {
       assert.strictEqual(v("C:\\bin\\python.exe"), null);
     });
 
+    it("validateWindowsNodeCandidate parses Windows paths regardless of host platform", () => {
+      // Regression: an earlier draft used the default `path` module, which on
+      // POSIX treats `C:\Program Files\nodejs\node.exe` as one big filename.
+      // path.basename returned the whole string, isWindowsNodeBasename failed,
+      // and every Windows resolver test silently passed only because it ran on
+      // a Windows host. Force the win32 path semantics by using path.win32.*
+      // everywhere — this assertion fails on Linux/macOS if anyone reverts.
+      const v = serverConfig.validateWindowsNodeCandidate;
+      assert.strictEqual(v("C:\\Program Files\\nodejs\\node.exe"), "C:\\Program Files\\nodejs\\node.exe");
+      assert.strictEqual(v("\\\\fileserver\\share\\node.exe"), "\\\\fileserver\\share\\node.exe");
+    });
+
+    it("getWindowsCommonNodePaths emits backslash-joined Windows paths on any host", () => {
+      // Same risk class as the validator regression: path.join on POSIX would
+      // splice the env var with forward slashes, producing paths that never
+      // exist on Windows and never match the scoop-shim/normalize checks.
+      const result = serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: { ProgramFiles: "C:\\Program Files" },
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        execFileSync() { throw new Error("where failed"); },
+        accessSync(candidate) {
+          assert.ok(candidate.includes("\\"), `expected backslash in ${candidate}`);
+          assert.ok(!candidate.includes("/"), `expected no forward slash in ${candidate}`);
+          if (candidate === "C:\\Program Files\\nodejs\\node.exe") return;
+          throw new Error("ENOENT");
+        },
+      });
+      assert.strictEqual(result, "C:\\Program Files\\nodejs\\node.exe");
+    });
+
     it("async resolver mirrors sync (execPath, where.exe, common paths, scoop shim skip)", async () => {
       const realNode = "C:\\Program Files\\nodejs\\node.exe";
       const shim = "C:\\Users\\tester\\scoop\\shims\\node.exe";

--- a/test/server-config.test.js
+++ b/test/server-config.test.js
@@ -72,9 +72,196 @@ describe("server-config helpers", () => {
     });
   });
 
-  it("resolveNodeBin returns bare node on Windows", () => {
-    const result = serverConfig.resolveNodeBin({ platform: "win32" });
-    assert.strictEqual(result, "node");
+  describe("resolveNodeBin on Windows", () => {
+    const WIN_ENV = {
+      SystemRoot: "C:\\Windows",
+      ProgramFiles: "C:\\Program Files",
+      "ProgramFiles(x86)": "C:\\Program Files (x86)",
+      LOCALAPPDATA: "C:\\Users\\tester\\AppData\\Local",
+      USERPROFILE: "C:\\Users\\tester",
+    };
+
+    it("returns options.execPath when it points at node.exe", () => {
+      const result = serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\nodejs\\node.exe",
+        accessSync(candidate) {
+          if (candidate === "C:\\Program Files\\nodejs\\node.exe") return;
+          throw new Error("ENOENT");
+        },
+        execFileSync() { throw new Error("where.exe should not run when execPath is node.exe"); },
+      });
+      assert.strictEqual(result, "C:\\Program Files\\nodejs\\node.exe");
+    });
+
+    it("rejects the packaged Clawd Electron host as execPath", () => {
+      const wherePath = "C:\\Program Files\\nodejs\\node.exe";
+      const result = serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        accessSync(candidate) {
+          if (candidate === wherePath) return;
+          throw new Error("ENOENT");
+        },
+        execFileSync() { return `${wherePath}\r\n`; },
+      });
+      assert.strictEqual(result, wherePath);
+    });
+
+    it("iterates every where.exe line and skips scoop shims", () => {
+      const realNode = "C:\\Program Files\\nodejs\\node.exe";
+      const shim = "C:\\Users\\tester\\scoop\\shims\\node.exe";
+      const result = serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        accessSync(candidate) {
+          if (candidate === realNode) return;
+          throw new Error("ENOENT");
+        },
+        execFileSync() { return `${shim}\r\n${realNode}\r\n`; },
+      });
+      assert.strictEqual(result, realNode);
+    });
+
+    it("falls back to common install paths when where.exe fails", () => {
+      const probed = [];
+      const result = serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        accessSync(candidate) {
+          probed.push(candidate);
+          if (candidate === "C:\\Program Files\\nodejs\\node.exe") return;
+          throw new Error("ENOENT");
+        },
+        execFileSync() { throw new Error("where.exe not found"); },
+      });
+      assert.strictEqual(result, "C:\\Program Files\\nodejs\\node.exe");
+      assert.ok(probed.includes("C:\\Program Files\\nodejs\\node.exe"));
+    });
+
+    it("resolves the Scoop real app path, not the shim path", () => {
+      const realScoop = "C:\\Users\\tester\\scoop\\apps\\nodejs\\current\\node.exe";
+      const result = serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        accessSync(candidate) {
+          if (candidate === realScoop) return;
+          throw new Error("ENOENT");
+        },
+        execFileSync() { throw new Error("where failed"); },
+      });
+      assert.strictEqual(result, realScoop);
+    });
+
+    it("rejects Clawd on Desk.exe even when accessSync says it exists", () => {
+      // accessSync only succeeds for the Clawd.exe path so validator rejection
+      // is the only thing standing between us and a wrong return value.
+      const clawdExe = "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe";
+      const result = serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: clawdExe,
+        accessSync(candidate) {
+          if (candidate === clawdExe) return;
+          throw new Error("ENOENT");
+        },
+        execFileSync() { return ""; },
+      });
+      assert.strictEqual(result, null);
+    });
+
+    it("does not spawn PowerShell as part of the default detection chain", () => {
+      const calls = [];
+      serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        accessSync() { throw new Error("ENOENT"); },
+        execFileSync(cmd, args) {
+          calls.push({ cmd, args });
+          throw new Error("not found");
+        },
+      });
+      const lowered = calls.map((c) => String(c.cmd).toLowerCase());
+      assert.ok(lowered.every((c) => !c.includes("powershell")), "PowerShell should not be spawned");
+    });
+
+    it("returns null when every detection step fails", () => {
+      const result = serverConfig.resolveNodeBin({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        accessSync() { throw new Error("ENOENT"); },
+        execFileSync() { throw new Error("where failed"); },
+      });
+      assert.strictEqual(result, null);
+    });
+
+    it("validateWindowsNodeCandidate rejects Clawd, Electron, scoop shims, and non-node basenames", () => {
+      const v = serverConfig.validateWindowsNodeCandidate;
+      assert.strictEqual(v("C:\\Program Files\\nodejs\\node.exe"), "C:\\Program Files\\nodejs\\node.exe");
+      assert.strictEqual(v("C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe"), null);
+      assert.strictEqual(v("C:\\Windows\\System32\\Electron.exe"), null);
+      assert.strictEqual(v("C:\\Users\\tester\\scoop\\shims\\node.exe"), null);
+      assert.strictEqual(v("C:\\Users\\TESTER\\Scoop\\Shims\\node.exe"), null);
+      assert.strictEqual(v("not absolute"), null);
+      assert.strictEqual(v("C:\\bin\\python.exe"), null);
+    });
+
+    it("async resolver mirrors sync (execPath, where.exe, common paths, scoop shim skip)", async () => {
+      const realNode = "C:\\Program Files\\nodejs\\node.exe";
+      const shim = "C:\\Users\\tester\\scoop\\shims\\node.exe";
+
+      const fromExecPath = await serverConfig.resolveNodeBinAsync({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: realNode,
+        async access(candidate) {
+          if (candidate === realNode) return;
+          throw new Error("ENOENT");
+        },
+        async execFile() { throw new Error("where should not run when execPath wins"); },
+      });
+      assert.strictEqual(fromExecPath, realNode);
+
+      const fromWhere = await serverConfig.resolveNodeBinAsync({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        async access(candidate) {
+          if (candidate === realNode) return;
+          throw new Error("ENOENT");
+        },
+        async execFile() { return { stdout: `${shim}\r\n${realNode}\r\n` }; },
+      });
+      assert.strictEqual(fromWhere, realNode);
+
+      const fromCommon = await serverConfig.resolveNodeBinAsync({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        async access(candidate) {
+          if (candidate === realNode) return;
+          throw new Error("ENOENT");
+        },
+        async execFile() { throw new Error("where failed"); },
+      });
+      assert.strictEqual(fromCommon, realNode);
+
+      const none = await serverConfig.resolveNodeBinAsync({
+        platform: "win32",
+        env: WIN_ENV,
+        execPath: "C:\\Program Files\\Clawd on Desk\\Clawd on Desk.exe",
+        async access() { throw new Error("ENOENT"); },
+        async execFile() { throw new Error("where failed"); },
+      });
+      assert.strictEqual(none, null);
+    });
   });
 
   it("resolveNodeBin returns process.execPath when not in Electron", () => {


### PR DESCRIPTION
## Summary

Closes #317. Windows hook runners can execute under PowerShell whose PATH does not include the Node install directory, so Clawd's generated `& "node" "..."` command fails with `The term 'node' is not recognized`. This PR embeds the absolute `node.exe` path in generated hook commands and adds a preservation path so existing manual repairs survive startup auto-sync.

### Changes

- **`hooks/server-config.js`**: replace the immediate `return "node"` on win32 with a real detection chain.
  - Order: `execPath` (if it's actually `node.exe`) → `where.exe node` (iterate every line) → common install paths (`%ProgramFiles%\nodejs`, `%ProgramFiles(x86)%\nodejs`, `%LOCALAPPDATA%\Programs\nodejs`, `%LOCALAPPDATA%\Volta\bin`, `%USERPROFILE%\scoop\apps\nodejs\current`) → `null`.
  - Validation: absolute path + basename `node.exe` (case-insensitive) + `F_OK` + rejects packaged Clawd / Electron host + rejects `\scoop\shims\` after `path.normalize` + lowercase.
  - PowerShell `Get-Command node` is intentionally **not** in the default sync path — it would add a `powershell.exe` cold spawn on every startup auto-sync while usually seeing the same PATH state as `where.exe`.
  - nvm-windows is **not** explicitly probed. NVM_SYMLINK defaults to `C:\Program Files\nodejs`, which is already covered by `where.exe` and the common-path probe. Explicit `%NVM_HOME%` enumeration is left for follow-up if real QA shows users who moved NVM_SYMLINK off the default *and* lost PATH at the same time.

- **`hooks/json-utils.js`**: extract a shared `extractExistingNodeBinFromCommands(commands, marker)` helper that already handles Windows drive paths, UNC paths, and the hook-script-as-first-token edge case. Refactor `extractExistingNodeBin(settings, marker, options)` to delegate to it so TOML-based installers (Kimi) can use the same primitive without duplicating regex.

- **`hooks/install.js`**: drop the local `extractNodeBinFromSettings()` — it only preserved paths beginning with `/`, so Windows users who manually repaired `settings.json` to use `C:\Program Files\nodejs\node.exe` had their fix silently overwritten on the next auto-sync. Both the sync `registerHooks` and async `registerHooksAsync` paths now go through `extractExistingNodeBin(..., { nested: true })`.

- **`hooks/kimi-install.js`**: add preservation chain `fresh resolver → extractExistingNodeBinFromCommands(findKimiHookCommands(content, MARKER), MARKER) → "node"`. This is mandatory, not optional — Kimi had the same overwrite-back-to-`"node"` failure mode as the Claude path that #317 reported.

- **`hooks/copilot-install.js`**: replace the local `"node"` default for non-remote installs with `resolveNodeBin(options)`. Remote installs continue to use `process.execPath` (the SSH host shouldn't need a working PATH).

### Out of scope / follow-ups

- **Antigravity (`hooks/antigravity-install.js::resolveWindowsNodeBin`)** still has its own local Windows resolver. Folding it into the shared resolver is planned (plan §5 P1b) but deferred because the file is not yet on main. Will be done as a follow-up once the antigravity feature lands.
- PowerShell `Get-Command node` probing.
- Explicit `%NVM_HOME%\v*\node.exe` enumeration with semver-max selection.
- Windows registry probing (`HKLM\SOFTWARE\Node.js\InstallPath`).

## Test plan

Automated:
- [x] `node --test test/*.test.js` — 2656 pass / 5 skipped (unrelated) / 0 fail
- [x] New `test/server-config.test.js` suite covers: execPath==node.exe, packaged Clawd rejection, `where.exe` per-line iteration, scoop-shim skip (case-insensitive, normalized), common-path fallback, no PowerShell spawn in default chain, `null` on total failure, async parity.
- [x] New `test/json-utils.test.js` cases cover `extractExistingNodeBinFromCommands` for POSIX / Windows drive / UNC / bare-`node` / marker-as-first-token / non-array inputs.
- [x] New `test/install.test.js` regression: preserves an existing absolute Windows path when `nodeBin: null`.
- [x] New `test/kimi-install.test.js` regression: preserves an existing absolute Windows path when `nodeBin: null`.

Manual QA (Windows, pending):
- [ ] Install Clawd on Windows with Node at `C:\Program Files\nodejs\node.exe`. Confirm `~/.claude/settings.json` writes the absolute Node path, not `"node"`.
- [ ] Run a real Claude Code session and verify hook events reach Clawd (synthetic `curl` is not enough).
- [ ] Run a Codex CLI session (`/hooks` activation) and verify Codex events arrive.
- [ ] Confirm a packaged Clawd build does **not** write `Clawd on Desk.exe` as the hook executable.
- [ ] Verify Cursor's generated `cmd /d /s /c` command on Windows with a Node path containing spaces actually executes (string-equality unit tests can't catch `cmd /s` quote handling).
- [ ] Edit `settings.json` to use `C:\Program Files\nodejs\node.exe`, restart Clawd, confirm the value is preserved across startup auto-sync.