### PR TITLE
fix(antigravity): share Windows node resolver

### DIFF
--- a/hooks/antigravity-install.js
+++ b/hooks/antigravity-install.js
@@ -4,7 +4,6 @@
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { execFileSync: defaultExecFileSync } = require("child_process");
 const { resolveNodeBin } = require("./server-config");
 const { writeJsonAtomic, asarUnpackedPath, formatNodeHookCommand } = require("./json-utils");
 
@@ -121,44 +120,8 @@ function extractExistingAntigravityNodeBin(existingGroup) {
   return null;
 }
 
-function isNodeExecutablePath(value) {
-  return /(?:^|[\\/])node(?:\.exe)?$/i.test(String(value || ""));
-}
-
-function firstNonEmptyLine(value) {
-  return String(value || "")
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .find(Boolean) || null;
-}
-
-function resolveWindowsNodeBin(options = {}) {
-  const execPath = options.execPath || process.execPath;
-  if (isNodeExecutablePath(execPath)) return execPath;
-
-  const execFileSync = options.execFileSync || defaultExecFileSync;
-  try {
-    const whereExe = process.env.SystemRoot
-      ? path.join(process.env.SystemRoot, "System32", "where.exe")
-      : "where.exe";
-    const output = execFileSync(whereExe, ["node"], {
-      encoding: "utf8",
-      timeout: 2000,
-      windowsHide: true,
-    });
-    const resolved = firstNonEmptyLine(output);
-    if (resolved) return resolved;
-  } catch {}
-
-  return null;
-}
-
 function resolveAntigravityNodeBin(options = {}) {
   if (options.nodeBin !== undefined) return options.nodeBin;
-  const platform = options.platform || process.platform;
-  if (platform === "win32") {
-    return resolveWindowsNodeBin(options);
-  }
   return resolveNodeBin(options);
 }
 
@@ -268,7 +231,6 @@ module.exports = {
     hasAntigravityConfig,
     normalizeSettings,
     resolveAntigravityNodeBin,
-    resolveWindowsNodeBin,
   },
 };
 

--- a/test/antigravity-install.test.js
+++ b/test/antigravity-install.test.js
@@ -214,6 +214,9 @@ describe("Antigravity hook installer", () => {
       homeDir,
       platform: "win32",
       execPath: nodeBin,
+      accessSync: (candidate) => {
+        if (candidate !== nodeBin) throw new Error(`unexpected access: ${candidate}`);
+      },
       powerShellBin: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
     });
 
@@ -230,9 +233,26 @@ describe("Antigravity hook installer", () => {
       platform: "win32",
       execPath: "C:\\Program Files\\Clawd\\Clawd.exe",
       execFileSync: () => `${nodeBin}\r\n`,
+      accessSync: (candidate) => {
+        if (candidate !== nodeBin) throw new Error(`unexpected access: ${candidate}`);
+      },
     });
 
     assert.strictEqual(resolved, nodeBin);
+  });
+
+  it("ignores Windows scoop shims through the shared node resolver", () => {
+    const resolved = __test.resolveAntigravityNodeBin({
+      platform: "win32",
+      execPath: "C:\\Program Files\\Clawd\\Clawd.exe",
+      execFileSync: () => "C:\\Users\\me\\scoop\\shims\\node.exe\r\n",
+      accessSync: () => {},
+      env: {
+        SystemRoot: "C:\\Windows",
+      },
+    });
+
+    assert.strictEqual(resolved, null);
   });
 
   it("preserves an existing Windows node.exe path when detection fails later", () => {
@@ -253,6 +273,7 @@ describe("Antigravity hook installer", () => {
       platform: "win32",
       execPath: "C:\\Program Files\\Clawd\\Clawd.exe",
       execFileSync: () => { throw new Error("where failed"); },
+      accessSync: () => { throw new Error("missing"); },
       powerShellBin: options.powerShellBin,
     });
 


### PR DESCRIPTION
## Summary
- routes Antigravity hook Node resolution through the shared resolver added in #319
- removes the Antigravity-only Windows where.exe parser
- covers shared Windows resolver behavior in Antigravity installer tests, including scoop shim rejection and existing-path preservation

## Tests
- node --test test\\antigravity-install.test.js
- node --test test\\server-config.test.js
- git diff --check
- npm test