### PR TITLE
fix: avoid crisp mini enter rendering

### DIFF
--- a/assets/svg/clawd-mini-enter-sleep.svg
+++ b/assets/svg/clawd-mini-enter-sleep.svg
@@ -1,5 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="-15 -25 45 45"
-  shape-rendering="crispEdges">
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="-15 -25 45 45">
     <style>
       #body-js {
         animation: bodyEnter 3.2s cubic-bezier(0.22, 1, 0.36, 1) 1 forwards;

--- a/assets/svg/clawd-mini-enter.svg
+++ b/assets/svg/clawd-mini-enter.svg
@@ -1,5 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="-15 -25 45 45"
-  shape-rendering="crispEdges">
+<svg xmlns="http://www.w3.org/2000/svg" width="500" height="500" viewBox="-15 -25 45 45">
     <style>
       #body-js {
         animation: bodyEnter 3.2s cubic-bezier(0.22, 1, 0.36, 1) 1 forwards;

--- a/test/clawd-mini-enter-rendering.test.js
+++ b/test/clawd-mini-enter-rendering.test.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO_ROOT = path.join(__dirname, "..");
+const CLAWD_THEME_PATH = path.join(REPO_ROOT, "themes", "clawd", "theme.json");
+const CLAWD_SVG_DIR = path.join(REPO_ROOT, "assets", "svg");
+const MINI_ENTER_STATES = ["mini-enter", "mini-enter-sleep"];
+
+function readRootSvgTag(filePath) {
+  const content = fs.readFileSync(filePath, "utf8");
+  const root = content.match(/<svg\b[^>]*>/i);
+  return root ? root[0] : null;
+}
+
+function miniStateSvg(theme, state) {
+  const files = theme && theme.miniMode && theme.miniMode.states && theme.miniMode.states[state];
+  assert.ok(Array.isArray(files), `Clawd ${state} should map to a file list`);
+  assert.strictEqual(files.length, 1, `Clawd ${state} should map to one SVG file`);
+  assert.match(files[0], /\.svg$/i, `Clawd ${state} should use an SVG asset`);
+  assert.ok(!files[0].includes("/") && !files[0].includes("\\"), `${state} asset should stay in assets/svg`);
+  return files[0];
+}
+
+describe("Clawd mini enter SVG rendering", () => {
+  it("does not force crisp root rendering on rotated mini enter assets", () => {
+    const theme = JSON.parse(fs.readFileSync(CLAWD_THEME_PATH, "utf8"));
+
+    for (const state of MINI_ENTER_STATES) {
+      const file = miniStateSvg(theme, state);
+      const root = readRootSvgTag(path.join(CLAWD_SVG_DIR, file));
+
+      assert.ok(root, `${file} should have a root <svg> tag`);
+      assert.doesNotMatch(
+        root,
+        /\bshape-rendering\s*=\s*["']crispEdges["']/i,
+        `${file} should not force crispEdges at the root SVG`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- remove root `shape-rendering="crispEdges"` from the two Clawd mini enter SVG assets
- keep the rest of the Clawd runtime SVG rendering policy unchanged
- add focused regression coverage so the rotated mini enter assets do not force crisp root rendering again

## Context
This is the narrower follow-up to #305. The visible jaggedness comes from the mini enter animations specifically: both assets rotate the character and move it through sub-pixel positions while forcing root crisp edge rendering.

## Validation
- `node --test test\clawd-mini-enter-rendering.test.js test\theme-schema.test.js test\theme-loader.test.js`