### PR TITLE
fix(eye-tracking): clamp horizontal pupil offset to keep eyes near face (#327)

### DIFF
--- a/src/tick.js
+++ b/src/tick.js
@@ -339,6 +339,8 @@ function runMainTickOnce() {
     eyeDx = Math.round(eyeDx * 2) / 2;
     eyeDy = Math.round(eyeDy * 2) / 2;
     const yClamp = MAX_OFFSET * 0.5;
+    const xClamp = MAX_OFFSET * 0.85;
+    eyeDx = Math.max(-xClamp, Math.min(xClamp, eyeDx));
     eyeDy = Math.max(-yClamp, Math.min(yClamp, eyeDy));
 
     if (skipDedup || eyeDx !== lastEyeDx || eyeDy !== lastEyeDy) {


### PR DESCRIPTION
## Summary

Addresses the second half of #327: on the default clawd theme, when the pet sits near a screen edge (especially the right edge), the pupils swing so far horizontally that they leave the torso silhouette entirely and become hard to see against the desktop background.

Root cause was in `src/tick.js`: vertical eye offset was already clamped to `0.5 × MAX_OFFSET`, but horizontal offset had no clamp at all, so it could run to the full `MAX_OFFSET` (3 viewBox units on the clawd theme). With the pupil sitting at viewBox x=4–5 inside a torso spanning x=2–13, a full 3-unit leftward swing pushed the left pupil out to x=1 — fully clear of the body.

## Change

One spot in `src/tick.js`:

```js
const yClamp = MAX_OFFSET * 0.5;
const xClamp = MAX_OFFSET * 0.85;
eyeDx = Math.max(-xClamp, Math.min(xClamp, eyeDx));
eyeDy = Math.max(-yClamp, Math.min(yClamp, eyeDy));
```

`0.85` is intentional rather than matching the vertical `0.5`: it caps the pupil exactly at the face edge so the eye sits half-in / half-out at maximum swing. This keeps the "locked-on stare" personality (the eye visibly *reaches* toward you when you're far away) while preventing the pupil from leaving the body silhouette entirely.

Geometry on clawd-idle-follow.svg:

| Clamp coef | Max offset (units) | Left pupil at max swing | Visible state |
| --- | --- | --- | --- |
| (none, prior) | 3.0 | x=1.0 | fully outside torso (x=2) |
| 0.5 (matches y) | 1.5 | x=2.5 | fully inside, no stretch |
| **0.85 (this PR)** | **2.55** | **x=1.45–2.45** | **half on face, half off** |

Vertical clamp is unchanged — verified empirically that the existing `0.5` ceiling already keeps vertical motion inside the face.

Layered tracking themes (calico) go through `_calcLayerOffset` in `renderer.js` for per-layer scaling and weren't affected by the unclamped axis in the same way, but they still pull from the same `eyeDx`/`eyeDy` IPC payload so this clamp applies uniformly. With calico's higher `maxOffset` values (12–20), the practical effect there is also a tighter horizontal swing, which matches the design intent.

## Test plan

- [x] `node --test test/tick.test.js` — all 19 tick tests pass
- [x] Manual: place pet at right edge of screen, sweep cursor to the left side of the monitor — pupils now stop at the face edge instead of disappearing past the torso outline
- [x] Manual: place pet at left edge — symmetric behavior on the right pupil
- [x] Vertical motion (up/down cursor sweeps) visually identical to before
