### PR TITLE
Fix Claude cold-start hook blocking (#331)

### DIFF
--- a/hooks/install.js
+++ b/hooks/install.js
@@ -7,7 +7,7 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const childProcess = require("child_process");
-const { buildPermissionUrl, DEFAULT_SERVER_PORT, PERMISSION_PATH, readRuntimePort, resolveNodeBin, resolveNodeBinAsync, SERVER_PORTS } = require("./server-config");
+const { buildPermissionUrl, DEFAULT_SERVER_PORT, PERMISSION_PATH, readRuntimePort, REMOTE_HOOK_HTTP_TIMEOUT_MS, resolveNodeBin, resolveNodeBinAsync, SERVER_PORTS } = require("./server-config");
 const { writeJsonAtomic, writeJsonAtomicAsync, asarUnpackedPath, extractExistingNodeBin } = require("./json-utils");
 
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".claude");
@@ -434,34 +434,46 @@ const MARKER = "clawd-hook.js";
 const AUTO_START_MARKER = "auto-start.js";
 const LEGACY_AUTO_START_MARKER = "auto-start.sh";
 const HTTP_MARKER = PERMISSION_PATH;
+const STATE_HOOK_TIMEOUT_SECONDS = 5;
+const REMOTE_STATE_HOOK_TIMEOUT_SECONDS = Math.ceil(REMOTE_HOOK_HTTP_TIMEOUT_MS / 1000) + 5;
+const AUTO_START_HOOK_TIMEOUT_SECONDS = 15;
 
 function buildCommandHookSpec(nodeBin, scriptPath, args = "", options = {}) {
   const platform = options.platform || process.platform;
   const argSuffix = args ? ` ${args}` : "";
   const quotedCommand = `"${nodeBin}" "${scriptPath}"${argSuffix}`;
+  const withHookOptions = (hook) => {
+    if (Object.prototype.hasOwnProperty.call(options, "async")) {
+      hook.async = options.async === true;
+    }
+    if (Number.isFinite(options.timeout)) {
+      hook.timeout = options.timeout;
+    }
+    return hook;
+  };
 
   // Remote hook deployment targets POSIX shells over SSH and relies on bash-style
   // env-prefix syntax (`CLAWD_REMOTE=1 cmd`). Keep that legacy form even if tests
   // force win32 here; Windows + remote is not a supported deployment target.
   if (options.remote) {
-    return {
+    return withHookOptions({
       type: "command",
       command: `CLAWD_REMOTE=1 ${quotedCommand}`,
-    };
+    });
   }
 
   if (platform === "win32") {
-    return {
+    return withHookOptions({
       type: "command",
       shell: "powershell",
       command: `& ${quotedCommand}`,
-    };
+    });
   }
 
-  return {
+  return withHookOptions({
     type: "command",
     command: quotedCommand,
-  };
+  });
 }
 
 function forEachCommandHook(entries, visitor) {
@@ -483,21 +495,31 @@ function forEachCommandHook(entries, visitor) {
 function syncCommandHook(entries, marker, expectedHook) {
   let found = false;
   let changed = false;
-  const expectedShell = typeof expectedHook.shell === "string" ? expectedHook.shell : undefined;
+  const syncField = (hook, field) => {
+    const hasExpected = Object.prototype.hasOwnProperty.call(expectedHook, field);
+    const hasCurrent = Object.prototype.hasOwnProperty.call(hook, field);
+    if (!hasExpected) {
+      if (!hasCurrent) return;
+      delete hook[field];
+      changed = true;
+      return;
+    }
+    if (hook[field] === expectedHook[field]) return;
+    hook[field] = expectedHook[field];
+    changed = true;
+  };
 
   forEachCommandHook(entries, (hook) => {
     if (!hook.command.includes(marker)) return;
     found = true;
+    syncField(hook, "type");
     if (hook.command !== expectedHook.command) {
       hook.command = expectedHook.command;
       changed = true;
     }
-
-    const currentShell = typeof hook.shell === "string" ? hook.shell : undefined;
-    if (currentShell === expectedShell) return;
-    if (expectedShell === undefined) delete hook.shell;
-    else hook.shell = expectedShell;
-    changed = true;
+    syncField(hook, "shell");
+    syncField(hook, "async");
+    syncField(hook, "timeout");
   });
   return { found, changed };
 }
@@ -809,6 +831,8 @@ function registerHooks(options = {}) {
     const desiredHook = buildCommandHookSpec(nodeBin, hookScript, event, {
       platform,
       remote: options.remote,
+      async: true,
+      timeout: options.remote ? REMOTE_STATE_HOOK_TIMEOUT_SECONDS : STATE_HOOK_TIMEOUT_SECONDS,
     });
     const commandSync = syncCommandHook(settings.hooks[event], MARKER, desiredHook);
     if (commandSync.found) {
@@ -838,10 +862,15 @@ function registerHooks(options = {}) {
       changed = true;
     }
 
-    const autoStartHook = buildCommandHookSpec(nodeBin, autoStartScript, "", { platform });
+    const autoStartHook = buildCommandHookSpec(nodeBin, autoStartScript, "", {
+      platform,
+      async: true,
+      timeout: AUTO_START_HOOK_TIMEOUT_SECONDS,
+    });
     const autoStartSync = syncCommandHook(settings.hooks.SessionStart, AUTO_START_MARKER, autoStartHook);
     if (!autoStartSync.found) {
-      // Insert at index 0 — must run BEFORE clawd-hook.js so the app is starting
+      // Keep auto-start visible before the state hook in settings. Claude Code
+      // runs matching hooks in parallel, so correctness must not depend on order.
       settings.hooks.SessionStart.unshift({
         matcher: "",
         hooks: [autoStartHook],
@@ -1019,6 +1048,8 @@ async function registerHooksAsync(options = {}) {
     const desiredHook = buildCommandHookSpec(nodeBin, hookScript, event, {
       platform,
       remote: options.remote,
+      async: true,
+      timeout: options.remote ? REMOTE_STATE_HOOK_TIMEOUT_SECONDS : STATE_HOOK_TIMEOUT_SECONDS,
     });
     const commandSync = syncCommandHook(settings.hooks[event], MARKER, desiredHook);
     if (commandSync.found) {
@@ -1046,7 +1077,11 @@ async function registerHooksAsync(options = {}) {
       changed = true;
     }
 
-    const autoStartHook = buildCommandHookSpec(nodeBin, autoStartScript, "", { platform });
+    const autoStartHook = buildCommandHookSpec(nodeBin, autoStartScript, "", {
+      platform,
+      async: true,
+      timeout: AUTO_START_HOOK_TIMEOUT_SECONDS,
+    });
     const autoStartSync = syncCommandHook(settings.hooks.SessionStart, AUTO_START_MARKER, autoStartHook);
     if (!autoStartSync.found) {
       settings.hooks.SessionStart.unshift({

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -58,22 +58,26 @@ function getClawdCommands(settings, event) {
 }
 
 function getHttpUrls(settings, event) {
+  return getHttpHookEntries(settings, event).map((hook) => hook.url);
+}
+
+function getHttpHookEntries(settings, event) {
   const entries = settings.hooks?.[event];
   if (!Array.isArray(entries)) return [];
-  const urls = [];
+  const hooks = [];
   for (const entry of entries) {
     if (!entry || typeof entry !== "object") continue;
     if (entry.type === "http" && typeof entry.url === "string") {
-      urls.push(entry.url);
+      hooks.push(entry);
     }
     if (!Array.isArray(entry.hooks)) continue;
     for (const hook of entry.hooks) {
       if (hook && typeof hook === "object" && hook.type === "http" && typeof hook.url === "string") {
-        urls.push(hook.url);
+        hooks.push(hook);
       }
     }
   }
-  return urls;
+  return hooks;
 }
 
 afterEach(() => {
@@ -536,6 +540,8 @@ describe("Hook installer version compatibility", () => {
     const stopHooks = getCommandHookEntries(settings, "Stop", "clawd-hook.js");
     assert.strictEqual(stopHooks.length, 1);
     assert.strictEqual(stopHooks[0].shell, "powershell");
+    assert.strictEqual(stopHooks[0].async, true);
+    assert.strictEqual(stopHooks[0].timeout, 5);
     assert.ok(stopHooks[0].command.startsWith('& "node" "'), stopHooks[0].command);
     assert.ok(stopHooks[0].command.endsWith('" Stop'), stopHooks[0].command);
   });
@@ -552,6 +558,25 @@ describe("Hook installer version compatibility", () => {
     });
   });
 
+  it("registers remote hooks as async with reverse-tunnel headroom", () => {
+    const settingsPath = makeTempSettings({});
+    registerHooks({
+      silent: true,
+      settingsPath,
+      remote: true,
+      nodeBin: "/usr/bin/node",
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    const stopHooks = getCommandHookEntries(settings, "Stop", "clawd-hook.js");
+    assert.strictEqual(stopHooks.length, 1);
+    assert.ok(stopHooks[0].command.startsWith('CLAWD_REMOTE=1 "/usr/bin/node" "'), stopHooks[0].command);
+    assert.strictEqual(stopHooks[0].async, true);
+    assert.strictEqual(stopHooks[0].timeout, 10);
+    assert.ok(!Object.prototype.hasOwnProperty.call(stopHooks[0], "shell"));
+  });
+
   it("does not add a shell field for non-Windows hook registration", () => {
     const settingsPath = makeTempSettings({});
     registerHooks({
@@ -566,6 +591,8 @@ describe("Hook installer version compatibility", () => {
     const stopHooks = getCommandHookEntries(settings, "Stop", "clawd-hook.js");
     assert.strictEqual(stopHooks.length, 1);
     assert.ok(!Object.prototype.hasOwnProperty.call(stopHooks[0], "shell"));
+    assert.strictEqual(stopHooks[0].async, true);
+    assert.strictEqual(stopHooks[0].timeout, 5);
     assert.ok(stopHooks[0].command.startsWith('"/usr/bin/node" "'), stopHooks[0].command);
   });
 
@@ -883,7 +910,29 @@ describe("Hook installer version compatibility", () => {
     const autoStartHooks = getCommandHookEntries(settings, "SessionStart", "auto-start.js");
     assert.strictEqual(autoStartHooks.length, 1);
     assert.strictEqual(autoStartHooks[0].shell, "powershell");
+    assert.strictEqual(autoStartHooks[0].async, true);
+    assert.strictEqual(autoStartHooks[0].timeout, 15);
     assert.ok(autoStartHooks[0].command.startsWith('& "node" "'), autoStartHooks[0].command);
+  });
+
+  it("uses async auto-start hooks on non-Windows", () => {
+    const settingsPath = makeTempSettings({});
+    registerHooks({
+      silent: true,
+      settingsPath,
+      autoStart: true,
+      platform: "darwin",
+      nodeBin: "/usr/local/bin/node",
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    const autoStartHooks = getCommandHookEntries(settings, "SessionStart", "auto-start.js");
+    assert.strictEqual(autoStartHooks.length, 1);
+    assert.ok(!Object.prototype.hasOwnProperty.call(autoStartHooks[0], "shell"));
+    assert.strictEqual(autoStartHooks[0].async, true);
+    assert.strictEqual(autoStartHooks[0].timeout, 15);
+    assert.ok(autoStartHooks[0].command.startsWith('"/usr/local/bin/node" "'), autoStartHooks[0].command);
   });
 
   it("updates stale Windows auto-start hooks to PowerShell format", () => {
@@ -912,8 +961,40 @@ describe("Hook installer version compatibility", () => {
     assert.ok(result.updated >= 1);
     assert.strictEqual(autoStartHooks.length, 1);
     assert.strictEqual(autoStartHooks[0].shell, "powershell");
+    assert.strictEqual(autoStartHooks[0].async, true);
+    assert.strictEqual(autoStartHooks[0].timeout, 15);
     assert.ok(autoStartHooks[0].command.startsWith("& "), autoStartHooks[0].command);
     assert.ok(!autoStartHooks[0].command.includes("/old/path/"));
+  });
+
+  it("upgrades existing command hooks with async metadata without losing the Node path", () => {
+    const existingAbsPath = "/Users/tester/.nvm/versions/node/v20.11.0/bin/node";
+    const settingsPath = makeTempSettings({
+      hooks: {
+        Stop: [
+          {
+            matcher: "",
+            hooks: [{ command: `"${existingAbsPath}" "/app/hooks/clawd-hook.js" Stop` }],
+          },
+        ],
+      },
+    });
+
+    const result = registerHooks({
+      silent: true,
+      settingsPath,
+      nodeBin: null,
+      claudeVersionInfo: { version: "2.1.78", source: "test", status: "known" },
+    });
+
+    const settings = readSettings(settingsPath);
+    const stopHooks = getCommandHookEntries(settings, "Stop", "clawd-hook.js");
+    assert.ok(result.updated >= 1);
+    assert.strictEqual(stopHooks.length, 1);
+    assert.strictEqual(stopHooks[0].type, "command");
+    assert.ok(stopHooks[0].command.includes(existingAbsPath), stopHooks[0].command);
+    assert.strictEqual(stopHooks[0].async, true);
+    assert.strictEqual(stopHooks[0].timeout, 5);
   });
 
   it("checks macOS absolute Claude paths before PATH fallback", () => {
@@ -1112,7 +1193,10 @@ describe("Claude permission hook ownership", () => {
 
     const settings = readSettings(settingsPath);
     assert.ok(result.updated >= 1);
-    assert.deepStrictEqual(getHttpUrls(settings, "PermissionRequest"), [expectedUrl]);
+    const permissionHooks = getHttpHookEntries(settings, "PermissionRequest");
+    assert.deepStrictEqual(permissionHooks.map((hook) => hook.url), [expectedUrl]);
+    assert.strictEqual(permissionHooks[0].timeout, 600);
+    assert.ok(!Object.prototype.hasOwnProperty.call(permissionHooks[0], "async"));
   });
 });
 


### PR DESCRIPTION
## Summary

- Fix #331: Claude Code stalls on first launch when Clawd's SessionStart hook spawns the Electron app and Claude waits for the hook to return.
- Mark all Clawd-registered hooks (`clawd-hook.js` state events + `auto-start.js` SessionStart) as `async: true` so Claude Code no longer waits for them, and give each an explicit `timeout`:
  - state hooks: 5s local, `REMOTE_HOOK_HTTP_TIMEOUT_MS + 5s` remote
  - auto-start: 15s (cold start of Electron can be slow on Windows)
- Extend `syncCommandHook` to maintain `async` / `timeout` / `type` fields so existing installs are migrated next time the installer runs.
- Drop the stale "must run BEFORE clawd-hook.js" comment on the SessionStart insertion — Claude Code runs matching hooks in parallel, so correctness no longer depends on order.

## Test plan

- [x] `node --test test/install.test.js` — 54/54 green, including the new `upgrades existing command hooks with async metadata without losing the Node path` regression covering the migration path.
- [x] Manual dogfood on Windows 11 + Claude Code `2.1.152`: wrote the new hook shape into the real `~/.claude/settings.json` (auto-start `async:true timeout:15`, state hooks `async:true timeout:5`, `PermissionRequest` HTTP still `timeout:600`), quit Clawd, opened a fresh Claude Code session and sent the first prompt. Claude replied normally and Clawd auto-started and entered `thinking` — the #331 freeze no longer reproduces.

## Follow-ups (not in this PR)

- Pending-event queue / retry for early state events if `POST /state` lands before the server is ready.
- Defer Clawd's startup integration sync so it does not block the HTTP event loop on first paint.
- PowerShell `Add-Type` warm-up cost in `clawd-hook.js`'s Windows process snapshot path.
