### PR TITLE
Fix Remote SSH Authenticate password prompt suppressed by BatchMode (#348)

### DIFF
--- a/src/remote-ssh-ipc.js
+++ b/src/remote-ssh-ipc.js
@@ -232,9 +232,12 @@ function registerRemoteSshIpc(options = {}) {
   // Open Terminal is the same command path with a "general use" framing.
 
   function buildInteractiveSshArgs(profile) {
-    // interactive: true drops -T so the remote shell gets a proper pty.
-    // BatchMode=no overrides the BatchMode=yes from base opts via ssh's
-    // last-wins semantics, allowing host key prompts / passphrase entry.
+    // interactive: true uses SSH_INTERACTIVE_BASE_OPTS (empty) so there's no
+    // BatchMode=yes / ConnectTimeout / -T in the base. The explicit
+    // `-o BatchMode=no` here is the FIRST BatchMode token ssh sees and wins
+    // (ssh -o is first-wins; see buildSshArgs comment). That also beats a
+    // `BatchMode yes` in the user's ~/.ssh/config, since command-line -o
+    // precedes config file entries in the resolution order.
     return buildSshArgs(profile, {
       extraOpts: ["-o", "BatchMode=no"],
       interactive: true,

--- a/src/remote-ssh-runtime.js
+++ b/src/remote-ssh-runtime.js
@@ -41,6 +41,12 @@ const { decodeShellBytes } = require("./remote-ssh-decode");
 
 const SSH_BASE_OPTS = ["-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15"];
 const SCP_BASE_OPTS = ["-q", "-o", "BatchMode=yes", "-o", "ConnectTimeout=15"];
+// Interactive base intentionally empty: no -T (pty needed), no BatchMode=yes
+// (must allow password / passphrase / host-key prompts), no ConnectTimeout=15
+// (user-initiated; they can wait). Callers add `-o BatchMode=no` via extraOpts
+// to also beat any `BatchMode yes` in the user's ~/.ssh/config — command-line
+// -o wins because it's the FIRST BatchMode token ssh sees.
+const SSH_INTERACTIVE_BASE_OPTS = [];
 
 // "cmd is not recognized" — emitted by Windows OpenSSH when the remote
 // default shell is cmd.exe and our `sh -c <script>` probe lands on it.
@@ -135,12 +141,22 @@ function detectSsh({ spawnSync = childProcess.spawnSync } = {}) {
 // authenticate, and open-terminal paths MUST go through these. They guarantee:
 //
 //   1. Non-interactive defaults (-T, BatchMode=yes, ConnectTimeout=15) so
-//      the spawned process never wedges on a prompt.
+//      backgrounded tunnels / probes / deploys never wedge on a prompt.
 //   2. Profile's `-i identityFile` / `-p port` (scp: `-P port`) are always
 //      injected, so non-default-port / specified-key profiles work for
 //      Deploy, Codex monitor, Authenticate — not just Connect.
-//   3. extraOpts append AFTER profile defaults so `-o BatchMode=no` and
-//      `-o ConnectTimeout=2` overrides can win via ssh's last-wins semantics.
+//   3. Interactive callers (`interactive: true`) get an empty base via
+//      `SSH_INTERACTIVE_BASE_OPTS`, since `-T` breaks remote pty, and
+//      `BatchMode=yes` would suppress the very prompts (password,
+//      passphrase, host-key confirm) the user opened the terminal to answer.
+//
+// FIRST-WINS, NOT LAST-WINS. ssh_config(5): "For each parameter, the first
+// obtained value will be used." This applies to command-line `-o` too:
+// `-o BatchMode=yes -o BatchMode=no` resolves to BatchMode=yes, not no
+// (verified with `ssh -G` on OpenSSH 9.5p2 / 10.0p2). Consequence: a future
+// `extraOpts` `-o Foo=bar` only wins if Foo is NOT already in the base opt
+// list. If you need to override a base opt, change the base or add a
+// separate base array — appending in extraOpts is a no-op.
 //
 // Host is appended last for ssh; scp callers add `host:path` themselves.
 function buildSshArgs(profile, { extraOpts = [], interactive = false } = {}) {
@@ -150,15 +166,9 @@ function buildSshArgs(profile, { extraOpts = [], interactive = false } = {}) {
   if (!Array.isArray(extraOpts)) {
     throw new TypeError("buildSshArgs: extraOpts must be an array");
   }
-  // `-T` (no pseudo-tty) is correct for backgrounded tunnels, deploys, and
-  // probes — but **wrong** for Authenticate / Open Terminal: those land the
-  // user in an interactive shell, where -T breaks vim/less/bash readline.
-  // Caller passes interactive: true to drop -T, letting ssh negotiate a pty
-  // by default (terminal emulator already provides a local tty).
-  const baseOpts = interactive
-    ? SSH_BASE_OPTS.filter((opt) => opt !== "-T")
+  const args = interactive
+    ? SSH_INTERACTIVE_BASE_OPTS.slice()
     : SSH_BASE_OPTS.slice();
-  const args = baseOpts;
   if (profile.identityFile) args.push("-i", profile.identityFile);
   if (profile.port && profile.port !== 22) args.push("-p", String(profile.port));
   args.push(...extraOpts);
@@ -840,9 +850,10 @@ function createRemoteSshRuntime(deps = {}) {
       return;
     }
     const probeCmd = buildProbeCommand(profile.remoteForwardPort, nodeBin);
-    const probeArgs = buildSshArgs(profile, {
-      extraOpts: ["-o", "ConnectTimeout=2"],
-    }).concat([probeCmd]);
+    // No extraOpts override for ConnectTimeout: ssh -o is first-wins, so the
+    // base's ConnectTimeout=15 would always win anyway. PROBE_CHILD_TIMEOUT_MS
+    // (5s) is the real upper bound on each probe attempt.
+    const probeArgs = buildSshArgs(profile).concat([probeCmd]);
 
     let probe;
     try {

--- a/test/remote-ssh-ipc.test.js
+++ b/test/remote-ssh-ipc.test.js
@@ -468,7 +468,7 @@ test("remoteSsh:deploy on unknown profile id → error, no stamp", async () => {
 
 // ── Authenticate / Open Terminal ──
 
-test("remoteSsh:authenticate spawns interactive ssh args (no -T, BatchMode=no override)", async () => {
+test("remoteSsh:authenticate spawns interactive ssh args (no -T, only BatchMode=no, no ConnectTimeout)", async () => {
   const ipcMain = mockIpcMain();
   const { BrowserWindow } = mockBrowserWindow();
   const calls = [];
@@ -493,11 +493,53 @@ test("remoteSsh:authenticate spawns interactive ssh args (no -T, BatchMode=no ov
   assert.equal(calls[0].args[1], "ssh");
   // Interactive ssh args MUST NOT include -T (would break remote pty).
   assert.equal(calls[0].args.includes("-T"), false, "Authenticate must drop -T");
-  // BatchMode=no must override BatchMode=yes (extraOpts after defaults).
-  const bmIndices = [];
-  calls[0].args.forEach((v, i) => { if (v && v.startsWith && v.startsWith("BatchMode=")) bmIndices.push(i); });
-  assert.equal(bmIndices.length, 2);
-  assert.equal(calls[0].args[bmIndices[bmIndices.length - 1]], "BatchMode=no");
+  // ssh -o is first-wins (see remote-ssh-runtime.js for the long comment).
+  // Interactive base is empty, so BatchMode=no from extraOpts is the ONLY
+  // BatchMode token AND the first one ssh sees → effective config allows
+  // password / passphrase / host-key prompts. This is the #348 fix.
+  const bmTokens = calls[0].args.filter((v) => typeof v === "string" && v.startsWith("BatchMode="));
+  assert.equal(bmTokens.length, 1, "interactive must carry only the explicit BatchMode=no");
+  assert.equal(bmTokens[0], "BatchMode=no");
+  // ConnectTimeout must NOT be in the interactive base — user controls the
+  // pace, and we don't want a 15s ssh-level timeout fighting their typing.
+  assert.equal(
+    calls[0].args.some((v) => typeof v === "string" && v.startsWith("ConnectTimeout=")),
+    false,
+    "interactive must not carry ConnectTimeout"
+  );
+  ipc.dispose();
+});
+
+test("remoteSsh:open-terminal uses the same interactive ssh args contract as Authenticate", async () => {
+  // open-terminal and authenticate share spawnSystemTerminalWithSsh, but pin
+  // the contract on the open-terminal IPC entry so a future split can't
+  // silently regress one without the other.
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  const calls = [];
+  const spawn = (cmd, args, opts) => {
+    calls.push({ cmd, args, opts });
+    return makeFakeSpawnChild();
+  };
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController: mockSettingsController([baseProfile]),
+    remoteSshRuntime: mockRuntime(),
+    BrowserWindow,
+    platform: "win32",
+    spawn,
+  });
+  const r = await ipcMain.invoke("remoteSsh:open-terminal", "p1");
+  assert.equal(r.status, "ok");
+  assert.equal(calls[0].cmd, "wt.exe");
+  assert.equal(calls[0].args.includes("-T"), false);
+  const bmTokens = calls[0].args.filter((v) => typeof v === "string" && v.startsWith("BatchMode="));
+  assert.equal(bmTokens.length, 1);
+  assert.equal(bmTokens[0], "BatchMode=no");
+  assert.equal(
+    calls[0].args.some((v) => typeof v === "string" && v.startsWith("ConnectTimeout=")),
+    false
+  );
   ipc.dispose();
 });
 

--- a/test/remote-ssh-runtime.test.js
+++ b/test/remote-ssh-runtime.test.js
@@ -119,20 +119,24 @@ test("buildSshArgs places extraOpts after profile defaults, before host", () => 
   assert.ok(nIdx < hostIdx, "extraOpts must appear before host");
 });
 
-test("buildSshArgs extraOpts can override default via ssh last-wins (e.g. ConnectTimeout=2)", () => {
+// NOTE: ssh -o is FIRST-WINS, not last-wins (ssh_config(5): "the first
+// obtained value will be used"). Asserting `args[lastIndex] === "Foo=bar"`
+// does NOT prove ssh ends up with Foo=bar — it only proves where the token
+// sits in the array. These tests assert effective config by counting tokens
+// and checking the FIRST one, which is what ssh actually honors.
+
+test("buildSshArgs extraOpts cannot override base BatchMode (ssh first-wins)", () => {
+  // Even though BatchMode=no is appended after BatchMode=yes, ssh resolves
+  // the first occurrence — so non-interactive callers can NOT flip BatchMode
+  // by appending. This test pins that contract so a future "just add it to
+  // extraOpts" attempt fails loudly here instead of silently in production.
   const args = buildSshArgs(
     { host: "pi" },
-    { extraOpts: ["-o", "ConnectTimeout=2", "-o", "BatchMode=no"] }
+    { extraOpts: ["-o", "BatchMode=no"] }
   );
-  // The defaults come first, the overrides come second; ssh resolves last-wins.
-  const ctIndices = [];
-  args.forEach((v, i) => { if (v.startsWith("ConnectTimeout=")) ctIndices.push(i); });
-  assert.equal(ctIndices.length, 2);
-  assert.equal(args[ctIndices[ctIndices.length - 1]], "ConnectTimeout=2");
-  const bmIndices = [];
-  args.forEach((v, i) => { if (v.startsWith("BatchMode=")) bmIndices.push(i); });
-  assert.equal(bmIndices.length, 2);
-  assert.equal(args[bmIndices[bmIndices.length - 1]], "BatchMode=no");
+  const bmTokens = args.filter((v) => typeof v === "string" && v.startsWith("BatchMode="));
+  assert.equal(bmTokens.length, 2, "both tokens present in argv");
+  assert.equal(bmTokens[0], "BatchMode=yes", "first BatchMode wins; base must come first");
 });
 
 test("buildSshArgs validates extraOpts is an array", () => {
@@ -144,24 +148,35 @@ test("buildSshArgs default keeps -T (correct for backgrounded tunnels)", () => {
   assert.ok(args.includes("-T"), "non-interactive must include -T");
 });
 
-test("buildSshArgs interactive: true drops -T (Authenticate / Open Terminal path)", () => {
+test("buildSshArgs interactive: true uses empty base (no -T, BatchMode, ConnectTimeout)", () => {
   const args = buildSshArgs({ host: "pi" }, { interactive: true });
   assert.equal(args.includes("-T"), false, "interactive must drop -T to let pty negotiate");
-  // BatchMode + ConnectTimeout still present — only -T is dropped.
-  assert.ok(args.some((v) => v && v.startsWith && v.startsWith("BatchMode=")));
-  // Order check: identityFile / extraOpts / host still in correct slots.
+  assert.equal(
+    args.some((v) => typeof v === "string" && v.startsWith("BatchMode=")),
+    false,
+    "interactive base must not carry BatchMode (would block password / passphrase / host-key prompts)"
+  );
+  assert.equal(
+    args.some((v) => typeof v === "string" && v.startsWith("ConnectTimeout=")),
+    false,
+    "interactive base must not carry ConnectTimeout (user-initiated, they can wait)"
+  );
+  // Order check: host still last.
   assert.equal(args[args.length - 1], "pi");
 });
 
-test("buildSshArgs interactive + BatchMode=no override applies last-wins", () => {
+test("buildSshArgs interactive + BatchMode=no extraOpt: BatchMode=no is the only and first token", () => {
+  // With SSH_INTERACTIVE_BASE_OPTS empty, BatchMode=no from extraOpts is the
+  // FIRST and ONLY BatchMode ssh sees → effective config is BatchMode=no, so
+  // password / passphrase / host-key prompts can fire. This is the fix for
+  // issue #348 (Authenticate / Open Terminal path).
   const args = buildSshArgs(
     { host: "pi" },
     { interactive: true, extraOpts: ["-o", "BatchMode=no"] }
   );
-  const bmIdxs = [];
-  args.forEach((v, i) => { if (v && v.startsWith && v.startsWith("BatchMode=")) bmIdxs.push(i); });
-  assert.equal(bmIdxs.length, 2, "should have 2 BatchMode entries (default + override)");
-  assert.equal(args[bmIdxs[bmIdxs.length - 1]], "BatchMode=no");
+  const bmTokens = args.filter((v) => typeof v === "string" && v.startsWith("BatchMode="));
+  assert.equal(bmTokens.length, 1, "interactive base is empty; only the extraOpt BatchMode survives");
+  assert.equal(bmTokens[0], "BatchMode=no");
 });
 
 // ── buildScpArgs ──


### PR DESCRIPTION
## Summary

- Fix #348: Remote SSH Authenticate / Open Terminal exits 255 with `Permission denied (publickey,password)` before the user can type a password. Root cause: ssh `-o BatchMode=no` does not override `-o BatchMode=yes` — OpenSSH `-o` is **first-wins**, not last-wins (`ssh_config(5)`: "the first obtained value will be used", verified on OpenSSH 9.5p2 and 10.0p2). The interactive ssh args path was inheriting `-o BatchMode=yes` from the non-interactive base, and the appended `-o BatchMode=no` was a no-op.
- Add `SSH_INTERACTIVE_BASE_OPTS = []` and route `buildSshArgs({ interactive: true })` through it. Interactive callers no longer carry `-T`, `BatchMode=yes`, or `ConnectTimeout=15` in the base. `buildInteractiveSshArgs` still appends `-o BatchMode=no` via extraOpts — now the first (and only) `BatchMode` token, which both lets ssh prompt and beats `BatchMode yes` in the user's `~/.ssh/config` (command-line `-o` precedes config in OpenSSH resolution order).
- Drive-by: drop the dead `-o ConnectTimeout=2` extraOpt from `runProbe`. It was never effective (first-wins kept `ConnectTimeout=15`); the real upper bound on each probe is `PROBE_CHILD_TIMEOUT_MS=5000`. No behavior change.
- Rewrite misleading "last-wins" comments in `remote-ssh-runtime.js` and `remote-ssh-ipc.js`, with a warning that future `-o` "overrides" via `extraOpts` are no-ops.
- Rewrite three false-positive tests that asserted positional order (`args[lastIndex] === "BatchMode=no"`) instead of effective config. New assertions count tokens and check the first, which is what ssh actually honors. Pin the same contract for both Authenticate and Open Terminal IPC handlers.

## Test plan

- [x] `node --test test/*.test.js` — 2987 pass / 0 fail / 5 skipped (no skipped tests are in the remote-ssh layer).
- [x] Manual on Windows 11 + Clawd dev build: created a test profile pointing at a real reachable host with a deliberately non-existent user (`testxyz@<reachable-ip>`) so key auth could not silently succeed. Pre-fix behavior reproduced (`wt.exe` spawned, printed `Permission denied (publickey,password)`, exited 255). Post-fix confirmed: `wt.exe` spawns and the password prompt (`testxyz@<host>'s password:`) appears as expected. Open Terminal IPC handler covered by the new unit test.

## Out of scope / follow-up

- Password-only servers still cannot sustain the background reverse tunnel after Authenticate completes — `startConnect` is non-interactive by design and stays on `BatchMode=yes`. So Authenticate now correctly lets the user complete a one-shot interactive ssh session (host-key accept, passphrase prompt, etc.), but a user whose remote has no key auth and no `ssh-agent` caching will still see the background tunnel fail when Clawd tries to bring it up. A doc note in `guide-remote-ssh.md` or a guided `ssh-copy-id` flow are tracked as follow-ups, not in this PR.
