### PR TITLE
Wire Telegram native migration and approval

### DIFF
--- a/docs/guides/telegram-approval.md
+++ b/docs/guides/telegram-approval.md
@@ -71,6 +71,37 @@ button stay disabled until token and recipient are in place.
 - Sidecar logs and Clawd logs redact Telegram tokens, chat ids, and token-like
   values.
 
+## Native Migration Dogfood
+
+Use this checklist before marking the v0.9.0 native Telegram migration as
+ready. Run it on Windows with a dedicated Telegram bot token, and capture the
+commit hash, Settings screenshots, Telegram test-card screenshots, and redacted
+Clawd logs as evidence.
+
+1. Back up the current user-data `clawd-prefs.json`,
+   `telegram-approval.env`, and sidecar bridge config. Stop any other
+   `getUpdates` owner or webhook for the test bot.
+2. Seed the legacy upgrade path with `tgApproval.enabled=true`, a stored token,
+   and a valid recipient. Start Clawd and verify Settings shows
+   `LEGACY_ACTIVE`, the sidecar owner is running, and the legacy Telegram test
+   still resolves a real approval card.
+3. Click **Test native and switch**. Verify the sidecar stops, Telegram receives
+   the nonce test card, tapping it from the allowed user moves Settings to
+   `NATIVE_ACTIVE`, and the owner line is `sidecar=stopped, native=polling`.
+   Restart Clawd and verify it returns to `NATIVE_ACTIVE`.
+4. Force failures separately: invalid token, missing/incorrect recipient, and a
+   competing `getUpdates` owner. The test should fail or time out without
+   auto-approving a real permission, and legacy users should return to
+   `LEGACY_ACTIVE`.
+5. Exercise disable, enable legacy, and rollback. **Disable Telegram approval**
+   must persist `IDLE` without restarting the sidecar. **Enable legacy sidecar**
+   must start the sidecar. **Roll back to legacy** from native must end in
+   `LEGACY_ACTIVE`.
+6. Confirm **Delete legacy token file** is wired to the main process. While
+   native still reads the shared `telegram-approval.env` token file, deletion
+   must be refused with `TOKEN_FILE_IN_USE`; only mark unconditional deletion
+   done after native has separate token storage.
+
 ## Release Notes
 
 Packaged builds ship the pinned `cc-connect-clawd` sidecar binary from

--- a/src/main.js
+++ b/src/main.js
@@ -989,6 +989,10 @@ const _permCtx = {
   onPermissionsChanged: () => {
     if (hardwareBuddyAdapter) hardwareBuddyAdapter.notifyPermissionsChanged();
   },
+  onPermissionResolved: (permEntry, options = {}) => {
+    if (!_state || typeof _state.clearPermissionNotification !== "function") return;
+    _state.clearPermissionNotification(permEntry && permEntry.sessionId, options);
+  },
 };
 const _perm = initPermission(_permCtx);
 const { showPermissionBubble, resolvePermissionEntry, sendPermissionResponse, repositionBubbles, permLog, PASSTHROUGH_TOOLS, addPendingPermission, removePendingPermission, maybeStartRemoteApproval, showCodexNotifyBubble, clearCodexNotifyBubbles, showKimiNotifyBubble, clearKimiNotifyBubbles, syncPermissionShortcuts, replyOpencodePermission } = _perm;

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ const initPermission = require("./permission");
 const { registerPermissionIpc } = initPermission;
 const { createTelegramApprovalSidecar } = require("./telegram-approval-sidecar");
 const telegramApprovalSettings = require("./telegram-approval-settings");
+const { createTelegramMigrationController } = require("./telegram-migration-controller");
 const initUpdateBubble = require("./update-bubble");
 const { registerUpdateBubbleIpc } = initUpdateBubble;
 const createSettingsAnimationOverridesMain = require("./settings-animation-overrides-main");
@@ -216,6 +217,8 @@ let telegramApprovalSidecar = null;
 let telegramApprovalSyncPromise = Promise.resolve();
 let telegramApprovalConfigSignature = "";
 let telegramApprovalTokenRevision = 0;
+let _telegramMigrationController = null;
+let suppressTelegramApprovalSidecarSync = 0;
 let hardwareBuddyAdapter = null;
 let hardwareBuddyStatus = null;
 let hardwareBuddyTestApprovalPromise = null;
@@ -259,6 +262,11 @@ const _settingsController = createSettingsController({
     getTelegramApprovalStatus: () => getTelegramApprovalStatus(),
     getTelegramApprovalTokenInfo: () => getTelegramApprovalTokenInfo(),
     sendTelegramApprovalTest: () => sendTelegramApprovalTest(),
+    // Lazy getter so settings-actions can use the controller even though it's
+    // instantiated below (forward-reference).
+    get telegramMigration() {
+      return _telegramMigrationController;
+    },
     // Theme runtime is wired after theme-loader.init(); keep these closures
     // lazy so settings actions never capture a pre-init runtime reference.
     activateTheme: (id, variantId, overrideMap) => themeRuntime.activateTheme(id, variantId, overrideMap),
@@ -1400,6 +1408,68 @@ function getTelegramApprovalPrefs() {
   return telegramApprovalSettings.normalizeTelegramApproval(_settingsController.get("tgApproval"));
 }
 
+function getTelegramMigrationPrefs() {
+  const raw = _settingsController.get("tgMigration");
+  return raw && typeof raw === "object" ? raw : {};
+}
+
+function readTelegramMigrationPrefsForController() {
+  const raw = { ...getTelegramMigrationPrefs() };
+  if (typeof raw.legacyEnabled !== "boolean") {
+    raw.legacyEnabled = getTelegramApprovalPrefs().enabled === true;
+  }
+  return raw;
+}
+
+function hasCompleteTelegramApprovalConfig(config, tokenInfo) {
+  return !!(
+    tokenInfo && tokenInfo.tokenStored === true
+    && config && config.allowedTgUserId
+    && config.targetSessionKey
+  );
+}
+
+function isTelegramLegacySidecarSyncAllowed() {
+  const migration = getTelegramMigrationPrefs();
+  if (migration.transport === "native" || migration.transport === "off") return false;
+  const controller = _telegramMigrationController;
+  if (controller && typeof controller.getSnapshot === "function") {
+    const snap = controller.getSnapshot() || {};
+    if (snap.state === "NATIVE_ACTIVE" || snap.state === "TESTING_NATIVE") return false;
+    if (snap.transport === "native" || snap.transport === "off") return false;
+  }
+  return true;
+}
+
+async function applySettingsUpdateOrThrow(key, value, label) {
+  const result = await Promise.resolve(_settingsController.applyUpdate(key, value));
+  if (!result || result.status !== "ok") {
+    throw new Error((result && result.message) || `${label || key} update failed`);
+  }
+  return result;
+}
+
+async function setTelegramApprovalEnabledForMigration(enabled) {
+  const current = getTelegramApprovalPrefs();
+  if (current.enabled === enabled) return;
+  suppressTelegramApprovalSidecarSync += 1;
+  try {
+    await applySettingsUpdateOrThrow("tgApproval", { ...current, enabled }, "tgApproval");
+  } finally {
+    suppressTelegramApprovalSidecarSync = Math.max(0, suppressTelegramApprovalSidecarSync - 1);
+  }
+}
+
+async function persistTelegramMigrationPatch(patch) {
+  const cur = getTelegramMigrationPrefs();
+  await applySettingsUpdateOrThrow("tgMigration", { ...cur, ...patch }, "tgMigration");
+  if (patch && patch.transport === "legacy") {
+    await setTelegramApprovalEnabledForMigration(true);
+  } else if (patch && (patch.transport === "native" || patch.transport === "off")) {
+    await setTelegramApprovalEnabledForMigration(false);
+  }
+}
+
 // Canonical paths only — no env-var override. The Settings "Save token" button,
 // the sidecar's bridge TOML, and tokenStatus all share this single location so
 // a malicious or accidental CLAWD_TG_BOT_TOKEN_FILE / CLAWD_BRIDGE_CONFIG can't
@@ -1557,6 +1627,110 @@ async function startTelegramApprovalSidecar() {
   return false;
 }
 
+async function initTelegramMigrationController() {
+  if (_telegramMigrationController) return _telegramMigrationController;
+  const paths = getTelegramApprovalPaths();
+
+  // Sidecar handle: forwards to the existing async start/stop functions so
+  // there is exactly one sidecar lifecycle in the process.
+  const sidecarHandle = {
+    isRunning: () => !!(telegramApprovalSidecar && telegramApprovalSidecar.isRunning && telegramApprovalSidecar.isRunning()),
+    start: async () => {
+      await setTelegramApprovalEnabledForMigration(true);
+      const started = await startTelegramApprovalSidecar();
+      if (!started) {
+        const err = new Error("Telegram approval sidecar did not start");
+        err.code = "SIDECAR_START_FAILED";
+        throw err;
+      }
+      return true;
+    },
+    stop: () => stopTelegramApprovalSidecar(),
+  };
+
+  // Native handle: spike-level real implementation. Token comes from the same
+  // env file the sidecar uses; production transport closes over the token.
+  const { envFileTokenStore } = require("./telegram-token-store");
+  const { createTelegramNativeRunner } = require("./telegram-native-runner");
+  const tokenStore = envFileTokenStore({ filePath: paths.tokenEnvFilePath });
+  const nativeRunner = createTelegramNativeRunner({
+    tokenStore,
+    transport: makeFetchTransport({ tokenStore }),
+    getDispatch: () => _telegramMigrationController && _telegramMigrationController.dispatch,
+    getChatId: () => {
+      const cfg = getTelegramApprovalPrefs();
+      const key = cfg && cfg.targetSessionKey;
+      // targetSessionKey is "telegram:<chat>:..." — extract chat id.
+      const m = typeof key === "string" ? key.match(/^telegram:(-?\d+)/) : null;
+      return m ? m[1] : "";
+    },
+    getAllowedUserId: () => {
+      const cfg = getTelegramApprovalPrefs();
+      return (cfg && cfg.allowedTgUserId) || "";
+    },
+    log: telegramApprovalLog,
+  });
+
+  _telegramMigrationController = createTelegramMigrationController({
+    sidecar: sidecarHandle,
+    native: nativeRunner,
+    readPrefs: () => readTelegramMigrationPrefsForController(),
+    writePrefs: (patch) => persistTelegramMigrationPatch(patch),
+    readFiles: () => {
+      const cfg = getTelegramApprovalPrefs();
+      const tokenInfo = getTelegramApprovalTokenStatus();
+      const hasTokenFile = !!(tokenInfo && tokenInfo.tokenStored);
+      const configComplete = hasCompleteTelegramApprovalConfig(cfg, tokenInfo);
+      return {
+        hasLegacyEnvFile: hasTokenFile,
+        legacyConfigComplete: configComplete,
+        nativeConfigComplete: configComplete,
+      };
+    },
+    log: telegramApprovalLog,
+  });
+
+  await _telegramMigrationController.init();
+  return _telegramMigrationController;
+}
+
+// Minimal fetch-based transport for the native client. Closes over the token
+// (no per-call token argument) so logging or debug serialization of request
+// args cannot leak the secret.
+function makeFetchTransport({ tokenStore }) {
+  return async ({ method, payload, signal }) => {
+    const token = await tokenStore.getToken();
+    if (!token) {
+      return { ok: false, status: null, error_code: "TOKEN_MISSING", description: "no token" };
+    }
+    const url = `https://api.telegram.org/bot${token}/${method}`;
+    let res;
+    try {
+      res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload || {}),
+        signal,
+      });
+    } catch (err) {
+      if (err && err.name === "AbortError") throw err;
+      throw Object.assign(new Error(err && err.message), { code: err && err.code });
+    }
+    const status = res.status;
+    let body;
+    try { body = await res.json(); } catch { body = null; }
+    if (!body) return { ok: false, status, error_code: status, description: res.statusText || "" };
+    if (body.ok) return { ok: true, result: body.result };
+    return {
+      ok: false,
+      status,
+      error_code: body.error_code || status,
+      description: body.description || "",
+      parameters: body.parameters || {},
+    };
+  };
+}
+
 function stopTelegramApprovalSidecar() {
   const sidecar = telegramApprovalSidecar;
   telegramApprovalSidecar = null;
@@ -1568,6 +1742,11 @@ function stopTelegramApprovalSidecar() {
 }
 
 async function syncTelegramApprovalSidecar(reason = "settings") {
+  if (!isTelegramLegacySidecarSyncAllowed()) {
+    if (telegramApprovalSidecar) await stopTelegramApprovalSidecar();
+    telegramApprovalLog("debug", `sync ${reason} skipped by migration transport`);
+    return false;
+  }
   const config = getTelegramApprovalPrefs();
   const paths = getTelegramApprovalPaths();
   const token = getTelegramApprovalTokenStatus();
@@ -2008,6 +2187,7 @@ const settingsEffectRouter = createSettingsEffectRouter({
 });
 settingsEffectRouter.start();
 _settingsController.subscribeKey("tgApproval", () => {
+  if (suppressTelegramApprovalSidecarSync > 0) return;
   queueTelegramApprovalSidecarSync("settings");
 });
 
@@ -2560,7 +2740,9 @@ if (!gotTheLock) {
     updateDebugLog = path.join(app.getPath("userData"), "update-debug.log");
     sessionDebugLog = path.join(app.getPath("userData"), "session-debug.log");
     focusDebugLog = path.join(app.getPath("userData"), "focus-debug.log");
-    queueTelegramApprovalSidecarSync("startup");
+    initTelegramMigrationController().catch((err) => {
+      console.warn("Clawd: migration controller init failed:", err && err.message);
+    });
     createWindow();
     if (shouldOpenSettingsWindowFromArgv(process.argv)) {
       settingsWindowRuntime.open();

--- a/src/main.js
+++ b/src/main.js
@@ -262,6 +262,7 @@ const _settingsController = createSettingsController({
     getTelegramApprovalStatus: () => getTelegramApprovalStatus(),
     getTelegramApprovalTokenInfo: () => getTelegramApprovalTokenInfo(),
     sendTelegramApprovalTest: () => sendTelegramApprovalTest(),
+    deleteTelegramApprovalTokenFile: () => deleteTelegramApprovalTokenFile(),
     // Lazy getter so settings-actions can use the controller even though it's
     // instantiated below (forward-reference).
     get telegramMigration() {
@@ -1552,6 +1553,47 @@ function writeTelegramApprovalToken(token) {
     queueTelegramApprovalSidecarSync("token");
   }
   return result;
+}
+
+function isTelegramTokenFileRequiredByNative() {
+  const migration = getTelegramMigrationPrefs();
+  if (migration.transport === "native") return true;
+  const controller = _telegramMigrationController;
+  if (!controller || typeof controller.getSnapshot !== "function") return false;
+  const snap = controller.getSnapshot() || {};
+  const owner = snap.ownerSnapshot || {};
+  return snap.state === "NATIVE_ACTIVE"
+    || snap.state === "TESTING_NATIVE"
+    || owner.nativePolling === true;
+}
+
+async function deleteTelegramApprovalTokenFile() {
+  if (isTelegramTokenFileRequiredByNative()) {
+    return {
+      status: "error",
+      code: "TOKEN_FILE_IN_USE",
+      message: "Native Telegram currently uses the shared token file. Keep it until native token storage is split.",
+    };
+  }
+  const paths = getTelegramApprovalPaths();
+  if (telegramApprovalSidecar) {
+    await stopTelegramApprovalSidecar();
+  }
+  try {
+    fs.unlinkSync(paths.tokenEnvFilePath);
+    telegramApprovalTokenRevision += 1;
+    queueTelegramApprovalSidecarSync("token-delete");
+    return { status: "ok", deleted: true };
+  } catch (err) {
+    if (err && err.code === "ENOENT") {
+      return { status: "ok", deleted: false, noop: true };
+    }
+    return {
+      status: "error",
+      code: err && err.code ? err.code : "DELETE_FAILED",
+      message: `Telegram token file delete failed: ${err && err.message ? err.message : err}`,
+    };
+  }
 }
 
 async function startTelegramApprovalSidecar() {

--- a/src/main.js
+++ b/src/main.js
@@ -218,6 +218,7 @@ let telegramApprovalSyncPromise = Promise.resolve();
 let telegramApprovalConfigSignature = "";
 let telegramApprovalTokenRevision = 0;
 let _telegramMigrationController = null;
+let telegramNativeRunner = null;
 let suppressTelegramApprovalSidecarSync = 0;
 let hardwareBuddyAdapter = null;
 let hardwareBuddyStatus = null;
@@ -1394,12 +1395,21 @@ function focusLog(msg) {
 }
 
 function getTelegramApprovalClient() {
+  const controller = _telegramMigrationController;
+  if (controller && typeof controller.getSnapshot === "function") {
+    const snap = controller.getSnapshot() || {};
+    if (snap.state === "NATIVE_ACTIVE"
+      && telegramNativeRunner
+      && typeof telegramNativeRunner.requestApproval === "function") {
+      return telegramNativeRunner;
+    }
+  }
   if (!telegramApprovalSidecar || typeof telegramApprovalSidecar.getClient !== "function") return null;
   return telegramApprovalSidecar.getClient();
 }
 
 function telegramApprovalLog(level, message, meta = {}) {
-  const parts = [`telegram approval sidecar ${level}: ${message}`];
+  const parts = [`telegram approval ${level}: ${message}`];
   if (meta && meta.text) parts.push(String(meta.text).trim());
   if (meta && meta.error) parts.push(String(meta.error).trim());
   permLog(parts.filter(Boolean).join(" | "));
@@ -1712,6 +1722,7 @@ async function initTelegramMigrationController() {
     },
     log: telegramApprovalLog,
   });
+  telegramNativeRunner = nativeRunner;
 
   _telegramMigrationController = createTelegramMigrationController({
     sidecar: sidecarHandle,

--- a/src/permission.js
+++ b/src/permission.js
@@ -659,6 +659,25 @@ function notifyPermissionsChanged(reason) {
   }
 }
 
+function notifyPermissionResolved(permEntry, reason) {
+  if (!permEntry || permEntry.isCodexNotify || permEntry.isKimiNotify) return;
+  if (typeof ctx.onPermissionResolved !== "function") return;
+  const hasPendingForSession = pendingPermissions.some((entry) =>
+    entry
+    && entry.sessionId === permEntry.sessionId
+    && !entry.isCodexNotify
+    && !entry.isKimiNotify
+  );
+  try {
+    ctx.onPermissionResolved(permEntry, {
+      reason: reason || "resolved",
+      hasPendingForSession,
+    });
+  } catch (err) {
+    permLog(`onPermissionResolved failed: ${err && err.message ? err.message : err}`);
+  }
+}
+
 function addPendingPermission(permEntry, reason = "added") {
   pendingPermissions.push(permEntry);
   notifyPermissionsChanged(reason);
@@ -824,6 +843,7 @@ function dismissPermissionForTerminal(perm) {
   if (idx !== -1) {
     pendingPermissions.splice(idx, 1);
     notifyPermissionsChanged("deny-and-focus");
+    notifyPermissionResolved(perm, "deny-and-focus");
   }
   if (perm.bubble && !perm.bubble.isDestroyed()) {
     perm.bubble.webContents.send("permission-hide");
@@ -905,6 +925,7 @@ function maybeStartRemoteApproval(permEntry) {
 
   pendingPermissions.splice(idx, 1);
   notifyPermissionsChanged("resolved");
+  notifyPermissionResolved(permEntry, "resolved");
 
   if (permEntry.autoCloseTimer) {
     clearTimeout(permEntry.autoCloseTimer);

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -222,6 +222,34 @@ const SCHEMA = {
     defaultFactory: () => cloneDefaultTelegramApproval(),
     normalize: normalizeTelegramApproval,
   },
+  // v0.9.0 migration state. transport defaults to null (undecided) so v0.8.x
+  // users upgrading without this key fall onto the "detect legacy artefacts"
+  // path inside the migration reducer.
+  tgMigration: {
+    type: "object",
+    defaultFactory: () => ({
+      transport: null,
+      nativeVerifiedAt: null,
+      legacyEnabled: null,
+      migration: { importedAt: null, importError: null },
+    }),
+    normalize: (value) => {
+      if (!value || typeof value !== "object") {
+        return { transport: null, nativeVerifiedAt: null, legacyEnabled: null, migration: { importedAt: null, importError: null } };
+      }
+      return {
+        transport: ["legacy", "native", "off"].includes(value.transport) ? value.transport : null,
+        nativeVerifiedAt: typeof value.nativeVerifiedAt === "number" ? value.nativeVerifiedAt : null,
+        legacyEnabled: typeof value.legacyEnabled === "boolean" ? value.legacyEnabled : null,
+        migration: value.migration && typeof value.migration === "object"
+          ? {
+              importedAt: typeof value.migration.importedAt === "number" ? value.migration.importedAt : null,
+              importError: typeof value.migration.importError === "string" ? value.migration.importError : null,
+            }
+          : { importedAt: null, importError: null },
+      };
+    },
+  },
   hardwareBuddy: {
     type: "object",
     defaultFactory: () => ({ ...DEFAULT_HARDWARE_BUDDY_SETTINGS }),

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -114,9 +114,17 @@ const {
   validateTelegramApproval,
   validateTelegramBotToken,
 } = require("./telegram-approval-settings");
+const { EVENTS: TELEGRAM_MIGRATION_EVENTS } = require("./telegram-migration-state");
 const {
   validateHardwareBuddySettings,
 } = require("./hardware-buddy-settings");
+
+const TELEGRAM_MIGRATION_RENDERER_EVENTS = new Set([
+  TELEGRAM_MIGRATION_EVENTS.USER_TEST_NATIVE,
+  TELEGRAM_MIGRATION_EVENTS.USER_ENABLE_LEGACY,
+  TELEGRAM_MIGRATION_EVENTS.USER_ROLLBACK_TO_LEGACY,
+  TELEGRAM_MIGRATION_EVENTS.USER_DISABLE,
+]);
 
 // ── updateRegistry ──
 // Maps prefs field name → validator. Controller looks up by key and runs.
@@ -346,6 +354,33 @@ const updateRegistry = {
   },
   tgApproval(value) {
     return validateTelegramApproval(value);
+  },
+
+  // v0.9.0 spike: persisted migration state across restarts. Shape:
+  //   { transport?: "legacy"|"native"|"off", nativeVerifiedAt?: number|null,
+  //     legacyEnabled?: boolean|null,
+  //     migration?: { importedAt: number|null, importError: string|null } }
+  tgMigration(value) {
+    if (value == null || typeof value !== "object") {
+      return { status: "error", message: "tgMigration must be a plain object" };
+    }
+    const allowed = new Set(["transport", "nativeVerifiedAt", "legacyEnabled", "migration"]);
+    for (const k of Object.keys(value)) {
+      if (!allowed.has(k)) return { status: "error", message: `tgMigration.${k} not supported` };
+    }
+    if (value.transport != null && !["legacy", "native", "off"].includes(value.transport)) {
+      return { status: "error", message: "tgMigration.transport must be legacy|native|off" };
+    }
+    if (value.nativeVerifiedAt != null && (typeof value.nativeVerifiedAt !== "number" || !Number.isFinite(value.nativeVerifiedAt))) {
+      return { status: "error", message: "tgMigration.nativeVerifiedAt must be a finite number" };
+    }
+    if (value.legacyEnabled != null && typeof value.legacyEnabled !== "boolean") {
+      return { status: "error", message: "tgMigration.legacyEnabled must be boolean" };
+    }
+    if (value.migration != null && typeof value.migration !== "object") {
+      return { status: "error", message: "tgMigration.migration must be an object" };
+    }
+    return { status: "ok" };
   },
 
   hardwareBuddy(value) {
@@ -934,6 +969,44 @@ function telegramApprovalTokenInfo(_payload, deps = {}) {
   };
 }
 
+// v0.9.0 migration: native-vs-sidecar transport controller.
+// All telegramMigration.* commands lock on the same `tgApproval` domain as the
+// legacy approval commands so they can't race against token writes.
+function telegramMigrationSnapshot(_payload, deps = {}) {
+  if (!deps || !deps.telegramMigration) {
+    return { status: "error", message: "telegramMigration.snapshot requires controller dep" };
+  }
+  return { status: "ok", snapshot: deps.telegramMigration.getSnapshot() };
+}
+
+async function telegramMigrationDispatch(payload, deps = {}) {
+  if (!deps || !deps.telegramMigration) {
+    return { status: "error", message: "telegramMigration.dispatch requires controller dep" };
+  }
+  if (!payload || typeof payload.type !== "string") {
+    return { status: "error", message: "telegramMigration.dispatch requires event.type" };
+  }
+  if (!TELEGRAM_MIGRATION_RENDERER_EVENTS.has(payload.type)) {
+    return {
+      status: "error",
+      errorCode: "EVENT_NOT_ALLOWED",
+      message: `telegramMigration.dispatch event ${payload.type} is not renderer-callable`,
+      snapshot: deps.telegramMigration.getSnapshot(),
+    };
+  }
+  const res = await deps.telegramMigration.dispatch(payload);
+  return res && res.ok
+    ? { status: "ok", state: res.state, snapshot: deps.telegramMigration.getSnapshot() }
+    : {
+        status: "error",
+        errorCode: res ? res.errorCode : "UNKNOWN",
+        message: res && res.message,
+        snapshot: deps.telegramMigration.getSnapshot(),
+      };
+}
+
+telegramMigrationDispatch.lockKey = "tgApproval";
+
 async function telegramApprovalSendTest(_payload, deps = {}) {
   if (!deps || typeof deps.sendTelegramApprovalTest !== "function") {
     return { status: "error", message: "telegramApproval.test requires sendTelegramApprovalTest dep" };
@@ -1001,6 +1074,8 @@ const commandRegistry = {
   "telegramApproval.status": telegramApprovalStatus,
   "telegramApproval.tokenInfo": telegramApprovalTokenInfo,
   "telegramApproval.test": telegramApprovalSendTest,
+  "telegramMigration.snapshot": telegramMigrationSnapshot,
+  "telegramMigration.dispatch": telegramMigrationDispatch,
 };
 
 module.exports = {

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -949,6 +949,14 @@ async function telegramApprovalSetToken(payload, deps = {}) {
   return { status: "ok", tokenStored: true };
 }
 
+async function telegramApprovalDeleteTokenFile(_payload, deps = {}) {
+  if (!deps || typeof deps.deleteTelegramApprovalTokenFile !== "function") {
+    return { status: "error", message: "telegramApproval.deleteTokenFile requires deleteTelegramApprovalTokenFile dep" };
+  }
+  const result = await deps.deleteTelegramApprovalTokenFile();
+  return result || { status: "error", message: "Telegram token file delete returned no result" };
+}
+
 function telegramApprovalStatus(_payload, deps = {}) {
   if (!deps || typeof deps.getTelegramApprovalStatus !== "function") {
     return { status: "error", message: "telegramApproval.status requires getTelegramApprovalStatus dep" };
@@ -1006,6 +1014,7 @@ async function telegramMigrationDispatch(payload, deps = {}) {
 }
 
 telegramMigrationDispatch.lockKey = "tgApproval";
+telegramApprovalDeleteTokenFile.lockKey = "tgApproval";
 
 async function telegramApprovalSendTest(_payload, deps = {}) {
   if (!deps || typeof deps.sendTelegramApprovalTest !== "function") {
@@ -1071,6 +1080,7 @@ const commandRegistry = {
   "remoteSsh.markDeployed": remoteSshMarkDeployed,
   "remoteSsh.markRemoteNode": remoteSshMarkRemoteNode,
   "telegramApproval.setToken": telegramApprovalSetToken,
+  "telegramApproval.deleteTokenFile": telegramApprovalDeleteTokenFile,
   "telegramApproval.status": telegramApprovalStatus,
   "telegramApproval.tokenInfo": telegramApprovalTokenInfo,
   "telegramApproval.test": telegramApprovalSendTest,

--- a/src/settings-ipc.js
+++ b/src/settings-ipc.js
@@ -164,6 +164,9 @@ function registerSettingsIpc(options = {}) {
     if (!payload || typeof payload !== "object") {
       return { status: "error", message: "settings:update payload must be { key, value }" };
     }
+    if (payload.key === "tgMigration") {
+      return { status: "error", message: "tgMigration is internal; use telegramMigration.dispatch" };
+    }
     return settingsController.applyUpdate(payload.key, payload.value);
   });
   handle("settings:begin-size-preview", () => settingsSizePreviewSession.begin());

--- a/src/settings-tab-telegram-approval.js
+++ b/src/settings-tab-telegram-approval.js
@@ -143,10 +143,173 @@
     subtitle.textContent = t("remoteApprovalSubtitle");
     parent.appendChild(subtitle);
 
+    // v0.9.0 migration: native vs sidecar transport selector. Lives ABOVE the
+    // legacy Telegram card so users see migration progress before the legacy
+    // setup steps.
+    parent.appendChild(buildTelegramMigrationCard());
+
     // Each remote approval channel renders as its own collapsible card so the
     // page can stay tidy as external approval channels grow.
     parent.appendChild(buildTelegramChannelCard());
     parent.appendChild(buildHardwareBuddyChannelCard());
+  }
+
+  // ── v0.9.0 migration card ──────────────────────────────────────────────────
+  let migrationSnapshot = null;
+  let migrationCardEl = null;
+  let migrationPending = false;
+  let migrationSnapshotSeq = 0;
+
+  function buildTelegramMigrationCard() {
+    migrationCardEl = document.createElement("div");
+    migrationCardEl.className = "tg-migration-card";
+    refreshMigrationSnapshot();
+    return migrationCardEl;
+  }
+
+  function refreshMigrationSnapshot() {
+    if (migrationPending) return;
+    const seq = ++migrationSnapshotSeq;
+    callCommand("telegramMigration.snapshot").then((res) => {
+      if (seq !== migrationSnapshotSeq || migrationPending) return;
+      if (res && res.status === "ok") {
+        migrationSnapshot = res.snapshot;
+        renderMigrationCard();
+      }
+    });
+  }
+
+  function migrationDispatch(eventType, extra = {}) {
+    if (migrationPending) return;
+    migrationPending = true;
+    renderMigrationCard();
+    callCommand("telegramMigration.dispatch", { type: eventType, ...extra }).then((res) => {
+      migrationPending = false;
+      if (res && res.snapshot) migrationSnapshot = res.snapshot;
+      if (res && res.status !== "ok" && res.errorCode) {
+        ops.showToast(`Telegram migration: ${res.errorCode}`, { error: true });
+      }
+      renderMigrationCard();
+      // Status of the legacy sidecar may change as a side-effect (start/stop).
+      refreshStatus({ forceRender: true });
+    });
+  }
+
+  function renderMigrationCard() {
+    if (!migrationCardEl) return;
+    migrationCardEl.innerHTML = "";
+    const snap = migrationSnapshot;
+    if (!snap) {
+      migrationCardEl.textContent = "Loading migration status…";
+      return;
+    }
+    const state = snap.state;
+    const title = document.createElement("h3");
+    title.textContent = "Telegram bot transport (v0.9.0 spike)";
+    migrationCardEl.appendChild(title);
+
+    const stateLine = document.createElement("p");
+    stateLine.className = "tg-migration-state";
+    stateLine.textContent = `State: ${state}` +
+      (snap.runtimeStatus && snap.runtimeStatus.status === "failed"
+        ? ` (runtime: failed — ${snap.runtimeStatus.reason || "unknown"})`
+        : "");
+    migrationCardEl.appendChild(stateLine);
+
+    const ownerLine = document.createElement("p");
+    ownerLine.className = "tg-migration-owner";
+    const o = snap.ownerSnapshot || {};
+    ownerLine.textContent = `Owner: sidecar=${o.sidecarRunning ? "running" : "stopped"}, native=${o.nativePolling ? "polling" : "stopped"}`;
+    migrationCardEl.appendChild(ownerLine);
+
+    const body = document.createElement("div");
+    body.className = "tg-migration-body";
+    migrationCardEl.appendChild(body);
+
+    const importErr = snap.migrationInfo && snap.migrationInfo.importError;
+    if (importErr && state === "LEGACY_ACTIVE") {
+      const banner = document.createElement("div");
+      banner.className = "tg-migration-banner";
+      banner.textContent = `Native config import failed: ${importErr}`;
+      body.appendChild(banner);
+      body.appendChild(migrationButton("Retry import", () =>
+        migrationDispatch("USER_TEST_NATIVE")));
+    }
+
+    switch (state) {
+      case "IDLE":
+      case "NEEDS_SETUP":
+        body.appendChild(migrationCopy(
+          "Configure the Telegram bot below, then choose how to run it:",
+        ));
+        body.appendChild(migrationButton("Test native bot and switch", () =>
+          migrationDispatch("USER_TEST_NATIVE")));
+        body.appendChild(migrationButton("Enable legacy sidecar", () =>
+          migrationDispatch("USER_ENABLE_LEGACY")));
+        break;
+      case "LEGACY_ACTIVE":
+        if (snap.runtimeStatus && snap.runtimeStatus.status === "failed") {
+          body.appendChild(migrationCopy("Legacy sidecar failed to start."));
+          body.appendChild(migrationButton("Retry legacy sidecar", () =>
+            migrationDispatch("USER_ENABLE_LEGACY")));
+        }
+        if (!snap.nativeVerifiedAt) {
+          body.appendChild(migrationCopy(
+            "Native Telegram bot is available. Test it to switch over — legacy stays as fallback.",
+          ));
+          body.appendChild(migrationButton("Test native and switch", () =>
+            migrationDispatch("USER_TEST_NATIVE")));
+        } else {
+          body.appendChild(migrationCopy("Legacy sidecar is active."));
+        }
+        body.appendChild(migrationButton("Disable Telegram approval", () =>
+          migrationDispatch("USER_DISABLE")));
+        break;
+      case "TESTING_NATIVE":
+        body.appendChild(migrationCopy("Waiting for your Telegram tap… (60s timeout)"));
+        break;
+      case "NATIVE_ACTIVE":
+        body.appendChild(migrationCopy(
+          "Native Telegram is active. Legacy files kept for rollback.",
+        ));
+        body.appendChild(migrationButton("Roll back to legacy", () =>
+          migrationDispatch("USER_ROLLBACK_TO_LEGACY")));
+        body.appendChild(migrationButton("Delete legacy token file", deleteLegacyTokenFile));
+        body.appendChild(migrationButton("Disable Telegram approval", () =>
+          migrationDispatch("USER_DISABLE")));
+        break;
+      case "SWITCHING_TO_LEGACY":
+        body.appendChild(migrationCopy("Switching to legacy approval…"));
+        break;
+    }
+    if (migrationPending) {
+      const pending = document.createElement("p");
+      pending.className = "tg-migration-pending";
+      pending.textContent = "Working…";
+      migrationCardEl.appendChild(pending);
+    }
+  }
+
+  function migrationCopy(text) {
+    const p = document.createElement("p");
+    p.className = "tg-migration-copy";
+    p.textContent = text;
+    return p;
+  }
+
+  function migrationButton(label, handler) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "tg-migration-btn";
+    btn.textContent = label;
+    btn.disabled = migrationPending;
+    btn.addEventListener("click", handler);
+    return btn;
+  }
+
+  function deleteLegacyTokenFile() {
+    // Reuse existing token clear command if available; spike just toasts.
+    ops.showToast("Delete legacy token: use Settings → Telegram approval → Token clear", { error: false });
   }
 
   function buildTelegramChannelCard() {

--- a/src/settings-tab-telegram-approval.js
+++ b/src/settings-tab-telegram-approval.js
@@ -163,6 +163,7 @@
   function buildTelegramMigrationCard() {
     migrationCardEl = document.createElement("div");
     migrationCardEl.className = "tg-migration-card";
+    renderMigrationCard();
     refreshMigrationSnapshot();
     return migrationCardEl;
   }
@@ -308,8 +309,25 @@
   }
 
   function deleteLegacyTokenFile() {
-    // Reuse existing token clear command if available; spike just toasts.
-    ops.showToast("Delete legacy token: use Settings → Telegram approval → Token clear", { error: false });
+    if (migrationPending) return;
+    migrationPending = true;
+    renderMigrationCard();
+    callCommand("telegramApproval.deleteTokenFile").then((res) => {
+      migrationPending = false;
+      if (res && res.status === "ok") {
+        ops.showToast(res.deleted === false
+          ? "Telegram token file was already removed."
+          : "Telegram token file deleted.");
+      } else {
+        ops.showToast((res && res.message) || "Telegram token file delete failed", { error: true });
+      }
+      view.tokenInfo = null;
+      view.status = null;
+      renderMigrationCard();
+      refreshTokenInfo({ forceRender: true });
+      refreshStatus({ forceRender: true });
+      refreshMigrationSnapshot();
+    });
   }
 
   function buildTelegramChannelCard() {

--- a/src/settings.css
+++ b/src/settings.css
@@ -3234,6 +3234,66 @@ html, body {
 .remote-approval-channel-card.collapsible-group {
   margin: 8px 0 14px;
 }
+
+/* v0.9.0 migration card — sits above the legacy Telegram setup card. */
+.tg-migration-card {
+  margin: 8px 0 14px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--card-bg, transparent);
+}
+.tg-migration-card h3 {
+  margin: 0 0 6px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.tg-migration-state,
+.tg-migration-owner {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-family: var(--mono-font, monospace);
+}
+.tg-migration-copy {
+  margin: 10px 0 6px;
+  font-size: 13px;
+  color: var(--text-primary);
+}
+.tg-migration-body {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 8px;
+}
+.tg-migration-banner {
+  padding: 8px 10px;
+  border-radius: 6px;
+  background: rgba(220, 53, 69, 0.12);
+  color: #b91c1c;
+  font-size: 12px;
+}
+.tg-migration-btn {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--btn-bg, transparent);
+  color: var(--text-primary);
+  font-size: 13px;
+  cursor: pointer;
+}
+.tg-migration-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.tg-migration-pending {
+  margin: 6px 0 0;
+  font-size: 12px;
+  font-style: italic;
+  color: var(--text-secondary);
+}
 .tg-approval-channel-header {
   display: flex;
   align-items: center;

--- a/src/state.js
+++ b/src/state.js
@@ -915,7 +915,12 @@ function updateSession(sessionId, state, event, opts = {}) {
       const srcCodexOriginator = codexOriginator || (existing && existing.codexOriginator) || null;
       const srcCodexSource = codexSource || (existing && existing.codexSource) || null;
       const srcSessionTitle = normalizeTitle(sessionTitle) || (existing && existing.sessionTitle) || null;
-      const storedState = existing && existing.state ? existing.state : "notification";
+      // PermissionRequest should flash the pet via setState("notification"),
+      // but a brand-new Codex permission session must not persist as
+      // notification. Otherwise, if the prompt is resolved remotely and no
+      // later hook arrives for that synthetic session, auto-return keeps
+      // resolving back to notification forever.
+      const storedState = existing && existing.state ? existing.state : "idle";
       const recentEvents = pushRecentEvent(existing, storedState, event);
       sessions.set(sessionId, {
         state: storedState,
@@ -1292,6 +1297,28 @@ function dismissSession(sessionId) {
   return true;
 }
 
+function clearPermissionNotification(sessionId, options = {}) {
+  const id = typeof sessionId === "string" ? sessionId : "";
+  if (!id || options.hasPendingForSession === true) return false;
+
+  let changed = false;
+  const session = sessions.get(id);
+  if (session && session.state === "notification") {
+    session.state = "idle";
+    session.updatedAt = Date.now();
+    session.displayHint = null;
+    session.resumeState = null;
+    changed = true;
+  }
+
+  // Leave the one-shot notification immediately after the permission channel
+  // resolves. If another session still deserves notification, resolveDisplayState
+  // will pick it again.
+  applyResolvedDisplayState();
+  if (changed) emitSessionSnapshot({ force: true });
+  return changed;
+}
+
 function clearSessionsByAgent(agentId) {
   if (!agentId) return 0;
   let removed = 0;
@@ -1635,6 +1662,7 @@ return {
   emitSessionSnapshot, broadcastSessionSnapshot, getLastSessionSnapshot,
   getActiveSessionAliasKeys,
   dismissSession,
+  clearPermissionNotification,
   ackSessionCompletion,
   clearSessionsByAgent,
   disposeAllKimiPermissionState,

--- a/src/telegram-migration-controller.js
+++ b/src/telegram-migration-controller.js
@@ -1,0 +1,190 @@
+"use strict";
+
+// Main-process controller that bolts the migration reducer + owner-manager
+// onto Clawd's existing sidecar lifecycle. The renderer never talks to the
+// reducer directly — it goes through this controller via IPC commands, so the
+// state machine has a single source of truth.
+
+const {
+  STATES,
+  EVENTS,
+  applyEvent,
+  computeInitial,
+  defaultPrefs,
+} = require("./telegram-migration-state");
+const { TelegramOwnerManager } = require("./telegram-owner-manager");
+
+function createTelegramMigrationController({
+  sidecar,
+  native,
+  readPrefs,
+  writePrefs,
+  readFiles,
+  settleMs,
+  stopGraceMs,
+  log = () => {},
+  setTimer = setTimeout,
+  clearTimer = clearTimeout,
+  testTimeoutMs = 60000,
+}) {
+  if (!sidecar || typeof sidecar.isRunning !== "function") {
+    throw new TypeError("migration-controller: sidecar handle required");
+  }
+  if (!native || typeof native.isPolling !== "function") {
+    throw new TypeError("migration-controller: native handle required");
+  }
+  if (typeof readPrefs !== "function" || typeof writePrefs !== "function") {
+    throw new TypeError("migration-controller: readPrefs/writePrefs required");
+  }
+  if (typeof readFiles !== "function") {
+    throw new TypeError("migration-controller: readFiles required");
+  }
+
+  let state = STATES.IDLE;
+  let prefs = defaultPrefs();
+  let runtimeStatus = { transport: "off", status: "stopped", reason: null };
+  let pendingTestTimer = null;
+  let lastError = null;
+
+  const manager = new TelegramOwnerManager({
+    sidecar,
+    native,
+    settleMs,
+    stopGraceMs,
+    onPersist: async (patch) => {
+      prefs = { ...prefs, ...patch };
+      await writePrefs(patch);
+    },
+    onRuntimeStatus: (s) => {
+      runtimeStatus = { ...runtimeStatus, ...s };
+    },
+    logger: { warn: (msg) => log("warn", String(msg)) },
+  });
+
+  function readPrefsNow() {
+    // Important: do NOT fill `transport` with defaultPrefs()'s "off". The
+    // reducer treats an explicit "off" as "user has disabled remote approval",
+    // which is a different signal from "v0.8 user upgrading and we have no
+    // pref yet". Only carry the field through when the caller actually set it.
+    const raw = readPrefs() || {};
+    prefs = {
+      nativeVerifiedAt: typeof raw.nativeVerifiedAt === "number" ? raw.nativeVerifiedAt : null,
+      legacyEnabled: typeof raw.legacyEnabled === "boolean" ? raw.legacyEnabled : null,
+      migration: raw.migration && typeof raw.migration === "object"
+        ? raw.migration
+        : { importedAt: null, importError: null },
+    };
+    if (Object.prototype.hasOwnProperty.call(raw, "transport")) {
+      prefs.transport = raw.transport;
+    }
+    return prefs;
+  }
+
+  function readFilesNow() {
+    return readFiles() || {};
+  }
+
+  function clearTestTimer() {
+    if (pendingTestTimer) {
+      clearTimer(pendingTestTimer);
+      pendingTestTimer = null;
+    }
+  }
+
+  function armTestTimer() {
+    clearTestTimer();
+    pendingTestTimer = setTimer(() => {
+      pendingTestTimer = null;
+      dispatch({ type: EVENTS.TEST_TIMEOUT }).catch(() => {});
+    }, testTimeoutMs);
+    if (pendingTestTimer && typeof pendingTestTimer.unref === "function") {
+      pendingTestTimer.unref();
+    }
+  }
+
+  async function dispatch(event) {
+    readPrefsNow();
+    const files = readFilesNow();
+    const result = applyEvent({ state, prefs, files }, event);
+
+    if (result.errorCode) {
+      lastError = { code: result.errorCode, eventType: event && event.type };
+      log("warn", `migration dispatch ${event && event.type} rejected`, {
+        code: result.errorCode,
+      });
+      return { ok: false, errorCode: result.errorCode, state };
+    }
+
+    try {
+      await manager.apply(result.sideEffects || []);
+    } catch (err) {
+      lastError = { code: err && err.code ? err.code : "APPLY_FAILED", message: err && err.message };
+      log("warn", "migration apply failed", { error: err && err.message });
+
+      if (event && event.type === EVENTS.USER_ROLLBACK_TO_LEGACY && result.state === STATES.SWITCHING_TO_LEGACY) {
+        state = STATES.SWITCHING_TO_LEGACY;
+        const failed = applyEvent(
+          { state, prefs, files: readFilesNow() },
+          { type: EVENTS.SIDECAR_START_FAILED, reason: lastError.code },
+        );
+        try {
+          await manager.apply(failed.sideEffects || []);
+          state = failed.state;
+          clearTestTimer();
+        } catch (fallbackErr) {
+          lastError = {
+            code: fallbackErr && fallbackErr.code ? fallbackErr.code : "APPLY_FAILED",
+            message: fallbackErr && fallbackErr.message,
+          };
+          state = result.state;
+        }
+      }
+      // Best-effort recover: re-read the world so state mirrors reality.
+      return { ok: false, errorCode: lastError.code, message: lastError.message, state };
+    }
+
+    state = result.state;
+    lastError = null;
+
+    // Arm/clear the 60s test timer alongside state transitions (per plan §148
+    // the Telegram tap deadline is owned by the driver, not the reducer).
+    if (state === STATES.TESTING_NATIVE) armTestTimer();
+    else clearTestTimer();
+
+    if (event && event.type === EVENTS.USER_ROLLBACK_TO_LEGACY && state === STATES.SWITCHING_TO_LEGACY) {
+      return dispatch({ type: EVENTS.SIDECAR_STARTED });
+    }
+
+    return { ok: true, state };
+  }
+
+  async function init() {
+    readPrefsNow();
+    const files = readFilesNow();
+    const result = computeInitial({ prefs, files });
+    try {
+      await manager.apply(result.sideEffects || []);
+    } catch (err) {
+      log("warn", "migration init apply failed", { error: err && err.message });
+    }
+    state = result.state;
+    return state;
+  }
+
+  function getSnapshot() {
+    return {
+      state,
+      transport: prefs.transport,
+      nativeVerifiedAt: prefs.nativeVerifiedAt,
+      legacyEnabled: prefs.legacyEnabled,
+      runtimeStatus,
+      ownerSnapshot: manager.snapshot(),
+      migrationInfo: prefs.migration || { importedAt: null, importError: null },
+      lastError,
+    };
+  }
+
+  return { init, dispatch, getSnapshot, _manager: manager };
+}
+
+module.exports = { createTelegramMigrationController };

--- a/src/telegram-migration-state.js
+++ b/src/telegram-migration-state.js
@@ -1,0 +1,334 @@
+"use strict";
+
+const STATES = Object.freeze({
+  IDLE: "IDLE",
+  LEGACY_ACTIVE: "LEGACY_ACTIVE",
+  TESTING_NATIVE: "TESTING_NATIVE",
+  NATIVE_ACTIVE: "NATIVE_ACTIVE",
+  SWITCHING_TO_LEGACY: "SWITCHING_TO_LEGACY",
+  NEEDS_SETUP: "NEEDS_SETUP",
+});
+
+const EVENTS = Object.freeze({
+  INIT: "INIT",
+  USER_TEST_NATIVE: "USER_TEST_NATIVE",
+  USER_ENABLE_LEGACY: "USER_ENABLE_LEGACY",
+  TEST_SUCCESS: "TEST_SUCCESS",
+  TEST_FAILED: "TEST_FAILED",
+  // 60s wall-clock timeout while waiting for the user's Telegram tap.
+  // The reducer treats it as a sub-case of TEST_FAILED, but having a distinct
+  // event type means the driver (owner-manager or the UI orchestrator) MUST
+  // own a wall-clock timer that dispatches this when no callback arrives,
+  // otherwise TESTING_NATIVE hangs indefinitely.
+  TEST_TIMEOUT: "TEST_TIMEOUT",
+  USER_ROLLBACK_TO_LEGACY: "USER_ROLLBACK_TO_LEGACY",
+  SIDECAR_STARTED: "SIDECAR_STARTED",
+  SIDECAR_START_FAILED: "SIDECAR_START_FAILED",
+  USER_DISABLE: "USER_DISABLE",
+});
+
+const SIDE_EFFECTS = Object.freeze({
+  START_SIDECAR: "START_SIDECAR",
+  STOP_SIDECAR: "STOP_SIDECAR",
+  START_NATIVE_POLLER: "START_NATIVE_POLLER",
+  STOP_NATIVE_POLLER: "STOP_NATIVE_POLLER",
+  SEND_TEST_CARD: "SEND_TEST_CARD",
+  PERSIST_PREFS: "PERSIST_PREFS",
+  // Runtime-status notifications for the UI. The reducer emits these when the
+  // state alone cannot express whether the transport is healthy (e.g. a
+  // sidecar start that failed still resolves to LEGACY_ACTIVE per plan §130,
+  // but the UI must surface "failed" so the user knows approval is broken).
+  EMIT_RUNTIME_STATUS: "EMIT_RUNTIME_STATUS",
+});
+
+const ERROR_CODES = Object.freeze({
+  ILLEGAL_TRANSITION: "ILLEGAL_TRANSITION",
+  TRANSPORT_NORMALIZED: "TRANSPORT_NORMALIZED",
+  // Rollback / re-enable refused because the on-disk legacy env file is gone.
+  LEGACY_ENV_MISSING: "LEGACY_ENV_MISSING",
+  // Rollback / re-enable refused because legacy env exists but other config
+  // (toml / user id / chat id) is incomplete — UI can offer "fix legacy
+  // setup" instead of an opaque illegal-transition toast.
+  LEGACY_CONFIG_INCOMPLETE: "LEGACY_CONFIG_INCOMPLETE",
+});
+
+const VALID_TRANSPORTS = new Set(["legacy", "native", "off"]);
+
+function defaultPrefs() {
+  return {
+    transport: "off",
+    nativeVerifiedAt: null,
+    migration: { importedAt: null, importError: null },
+    // legacyEnabled mirrors v0.8.x tgApproval.enabled. Tri-state:
+    //   true  = v0.8.x user had Telegram approval enabled
+    //   false = v0.8.x user had it explicitly disabled (must not auto-activate)
+    //   null  = unknown / fresh install
+    legacyEnabled: null,
+  };
+}
+
+function defaultFiles() {
+  return {
+    hasLegacyEnvFile: false,
+    legacyConfigComplete: false,
+    nativeConfigComplete: false,
+  };
+}
+
+function normalizePrefs(prefs) {
+  const base = defaultPrefs();
+  if (!prefs || typeof prefs !== "object") return { prefs: base, normalized: true };
+  const hasTransport = Object.prototype.hasOwnProperty.call(prefs, "transport");
+  const transportValid = hasTransport && VALID_TRANSPORTS.has(prefs.transport);
+  const out = {
+    transport: transportValid ? prefs.transport : "off",
+    nativeVerifiedAt: typeof prefs.nativeVerifiedAt === "number" ? prefs.nativeVerifiedAt : null,
+    legacyEnabled: typeof prefs.legacyEnabled === "boolean" ? prefs.legacyEnabled : null,
+    migration: {
+      importedAt:
+        prefs.migration && typeof prefs.migration.importedAt === "number"
+          ? prefs.migration.importedAt
+          : null,
+      importError:
+        prefs.migration && typeof prefs.migration.importError === "string"
+          ? prefs.migration.importError
+          : null,
+    },
+  };
+  // "normalized" = caller did not supply a valid transport value. Either the
+  // field was missing (legacy user upgrading from v0.8.x) or it held garbage.
+  // Per plan §99-101 this is not an error — the reducer falls back to file
+  // detection without raising errorCode.
+  const normalized = !transportValid;
+  return { prefs: out, normalized };
+}
+
+function normalizeFiles(files) {
+  const base = defaultFiles();
+  if (!files || typeof files !== "object") return base;
+  return {
+    hasLegacyEnvFile: !!files.hasLegacyEnvFile,
+    legacyConfigComplete: !!files.legacyConfigComplete,
+    nativeConfigComplete: !!files.nativeConfigComplete,
+  };
+}
+
+function effect(type, payload) {
+  return payload === undefined ? { type } : { type, payload };
+}
+
+function ok(state, sideEffects = [], prefsPatch = null, errorCode = null) {
+  const result = { state, sideEffects, errorCode };
+  if (prefsPatch) result.prefsPatch = prefsPatch;
+  return result;
+}
+
+function illegal(currentState, code = ERROR_CODES.ILLEGAL_TRANSITION) {
+  return { state: currentState, sideEffects: [], errorCode: code };
+}
+
+function computeInitial({ prefs, files }) {
+  const normalizedPrefs = normalizePrefs(prefs);
+  const f = normalizeFiles(files);
+  const p = normalizedPrefs.prefs;
+
+  // Explicit "off" → user disabled remote approval, regardless of file state.
+  if (p.transport === "off" && !normalizedPrefs.normalized) {
+    return ok(STATES.IDLE, []);
+  }
+
+  if (p.transport === "legacy") {
+    if (f.legacyConfigComplete) {
+      return ok(STATES.LEGACY_ACTIVE, [effect(SIDE_EFFECTS.START_SIDECAR)]);
+    }
+    return ok(STATES.NEEDS_SETUP, []);
+  }
+
+  if (p.transport === "native") {
+    if (f.nativeConfigComplete && p.nativeVerifiedAt) {
+      return ok(STATES.NATIVE_ACTIVE, [effect(SIDE_EFFECTS.START_NATIVE_POLLER)]);
+    }
+    return ok(STATES.NEEDS_SETUP, []);
+  }
+
+  // transport was missing or invalid → "undecided"; detect legacy artefacts.
+  // Plan §81 + safety: only auto-activate legacy if the v0.8.x user had
+  // tgApproval.enabled === true. If they had explicitly disabled remote
+  // approval (legacyEnabled === false), respect that and stay IDLE — otherwise
+  // upgrading to v0.9.0 would silently re-enable Telegram for them.
+  // legacyEnabled === null means "we don't know" — treat as enabled to keep
+  // backwards-compat for callers that don't supply the field yet.
+  const legacyOptedOut = p.legacyEnabled === false;
+  if (f.legacyConfigComplete && !legacyOptedOut) {
+    return ok(STATES.LEGACY_ACTIVE, [effect(SIDE_EFFECTS.START_SIDECAR)]);
+  }
+  if (f.hasLegacyEnvFile && !f.legacyConfigComplete && !legacyOptedOut) {
+    return ok(STATES.NEEDS_SETUP, []);
+  }
+  return ok(STATES.IDLE, []);
+}
+
+function applyEvent({ state, prefs, files }, event) {
+  if (!event || typeof event !== "object" || !event.type) {
+    return illegal(state);
+  }
+  if (event.type === EVENTS.INIT) {
+    return computeInitial({ prefs, files });
+  }
+
+  const f = normalizeFiles(files);
+  const p = normalizePrefs(prefs).prefs;
+
+  if (event.type === EVENTS.USER_DISABLE) {
+    const fx = [];
+    if (state === STATES.LEGACY_ACTIVE || state === STATES.SWITCHING_TO_LEGACY) {
+      fx.push(effect(SIDE_EFFECTS.STOP_SIDECAR));
+    }
+    if (state === STATES.NATIVE_ACTIVE || state === STATES.TESTING_NATIVE) {
+      fx.push(effect(SIDE_EFFECTS.STOP_NATIVE_POLLER));
+    }
+    fx.push(effect(SIDE_EFFECTS.PERSIST_PREFS, { transport: "off" }));
+    return ok(STATES.IDLE, fx);
+  }
+
+  if (event.type === EVENTS.USER_ENABLE_LEGACY) {
+    // Restore legacy mode (old user previously disabled, or new user picks
+    // legacy explicitly from Settings). Requires legacy env+config to be
+    // intact; otherwise illegal so the UI surfaces a setup card.
+    if (state !== STATES.IDLE && state !== STATES.NEEDS_SETUP && state !== STATES.LEGACY_ACTIVE) {
+      return illegal(state);
+    }
+    if (!f.legacyConfigComplete) {
+      return illegal(state, ERROR_CODES.LEGACY_CONFIG_INCOMPLETE);
+    }
+    return ok(
+      STATES.LEGACY_ACTIVE,
+      [
+        effect(SIDE_EFFECTS.START_SIDECAR),
+        effect(SIDE_EFFECTS.PERSIST_PREFS, { transport: "legacy", legacyEnabled: true }),
+      ],
+      { transport: "legacy", legacyEnabled: true },
+    );
+  }
+
+  if (event.type === EVENTS.USER_TEST_NATIVE) {
+    if (state === STATES.IDLE || state === STATES.NEEDS_SETUP) {
+      if (!f.nativeConfigComplete) return illegal(state);
+      return ok(STATES.TESTING_NATIVE, [
+        effect(SIDE_EFFECTS.START_NATIVE_POLLER),
+        effect(SIDE_EFFECTS.SEND_TEST_CARD),
+      ]);
+    }
+    if (state === STATES.LEGACY_ACTIVE) {
+      if (!f.nativeConfigComplete) return illegal(state);
+      return ok(STATES.TESTING_NATIVE, [
+        effect(SIDE_EFFECTS.STOP_SIDECAR),
+        effect(SIDE_EFFECTS.START_NATIVE_POLLER),
+        effect(SIDE_EFFECTS.SEND_TEST_CARD),
+      ]);
+    }
+    return illegal(state);
+  }
+
+  if (event.type === EVENTS.TEST_SUCCESS) {
+    if (state !== STATES.TESTING_NATIVE) return illegal(state);
+    const verifiedAt = typeof event.at === "number" ? event.at : Date.now();
+    return ok(
+      STATES.NATIVE_ACTIVE,
+      [effect(SIDE_EFFECTS.PERSIST_PREFS, { transport: "native", nativeVerifiedAt: verifiedAt })],
+      { transport: "native", nativeVerifiedAt: verifiedAt },
+    );
+  }
+
+  if (event.type === EVENTS.TEST_FAILED || event.type === EVENTS.TEST_TIMEOUT) {
+    if (state !== STATES.TESTING_NATIVE) return illegal(state);
+    // Stop native poller first regardless of fallback target.
+    const fx = [effect(SIDE_EFFECTS.STOP_NATIVE_POLLER)];
+    // legacyConfigComplete alone is not enough: we must also respect the
+    // v0.8.x opt-out signal. If the user had Telegram explicitly disabled in
+    // v0.8 (legacyEnabled === false) we do NOT auto-restart the sidecar.
+    const legacyAvailable = f.legacyConfigComplete && p.legacyEnabled !== false;
+    if (legacyAvailable) {
+      fx.push(effect(SIDE_EFFECTS.START_SIDECAR));
+      return ok(STATES.LEGACY_ACTIVE, fx);
+    }
+    if (f.nativeConfigComplete) {
+      // New user, native config there but test failed — stay at IDLE so they can retry.
+      return ok(STATES.IDLE, fx);
+    }
+    return ok(STATES.NEEDS_SETUP, fx);
+  }
+
+  if (event.type === EVENTS.USER_ROLLBACK_TO_LEGACY) {
+    if (state !== STATES.NATIVE_ACTIVE) return illegal(state);
+    if (!f.hasLegacyEnvFile) return illegal(state, ERROR_CODES.LEGACY_ENV_MISSING);
+    if (!f.legacyConfigComplete) return illegal(state, ERROR_CODES.LEGACY_CONFIG_INCOMPLETE);
+    return ok(STATES.SWITCHING_TO_LEGACY, [
+      effect(SIDE_EFFECTS.STOP_NATIVE_POLLER),
+      effect(SIDE_EFFECTS.START_SIDECAR),
+    ]);
+  }
+
+  if (event.type === EVENTS.SIDECAR_STARTED) {
+    if (state !== STATES.SWITCHING_TO_LEGACY) return illegal(state);
+    return ok(
+      STATES.LEGACY_ACTIVE,
+      [effect(SIDE_EFFECTS.PERSIST_PREFS, { transport: "legacy" })],
+      { transport: "legacy" },
+    );
+  }
+
+  if (event.type === EVENTS.SIDECAR_START_FAILED) {
+    if (state !== STATES.SWITCHING_TO_LEGACY) return illegal(state);
+    // Per plan §"切 native → legacy" rule 4: stay legacy-selected with failed
+    // status. State still resolves to LEGACY_ACTIVE (so the UI doesn't snap
+    // back to NATIVE_ACTIVE and confuse the user about which mode is
+    // "selected"), but we emit a runtime-status side-effect so the UI can
+    // render a failure banner / retry button.
+    return ok(
+      STATES.LEGACY_ACTIVE,
+      [
+        effect(SIDE_EFFECTS.PERSIST_PREFS, { transport: "legacy" }),
+        effect(SIDE_EFFECTS.EMIT_RUNTIME_STATUS, {
+          transport: "legacy",
+          status: "failed",
+          reason: (event && event.reason) || "sidecar_start_failed",
+        }),
+      ],
+      { transport: "legacy" },
+    );
+  }
+
+  return illegal(state);
+}
+
+function checkInvariants({ state, sideEffects }) {
+  const violations = [];
+  const fx = Array.isArray(sideEffects) ? sideEffects : [];
+  const starts = new Set(fx.filter((e) => e && typeof e.type === "string").map((e) => e.type));
+  if (starts.has(SIDE_EFFECTS.START_SIDECAR) && starts.has(SIDE_EFFECTS.START_NATIVE_POLLER)) {
+    violations.push("START_SIDECAR and START_NATIVE_POLLER in same transition");
+  }
+  // Mutual exclusion: stable states must not be "polling/running both" — encoded via state itself.
+  if (state === STATES.LEGACY_ACTIVE && starts.has(SIDE_EFFECTS.START_NATIVE_POLLER)) {
+    violations.push("LEGACY_ACTIVE side-effect started native poller");
+  }
+  if (state === STATES.NATIVE_ACTIVE && starts.has(SIDE_EFFECTS.START_SIDECAR)) {
+    violations.push("NATIVE_ACTIVE side-effect started sidecar");
+  }
+  return violations;
+}
+
+module.exports = {
+  STATES,
+  EVENTS,
+  SIDE_EFFECTS,
+  ERROR_CODES,
+  defaultPrefs,
+  defaultFiles,
+  normalizePrefs,
+  normalizeFiles,
+  computeInitial,
+  applyEvent,
+  checkInvariants,
+};

--- a/src/telegram-native-client.js
+++ b/src/telegram-native-client.js
@@ -1,0 +1,226 @@
+"use strict";
+
+// Telegram Bot API client used by the native owner. Spike scope: just the
+// primitives the migration test card and approval surface need:
+//
+//   getMe / sendMessage / getUpdates / answerCallbackQuery / editMessageReplyMarkup
+//
+// + offset progression on getUpdates and AbortController-driven cancellation.
+//
+// All HTTP I/O is delegated to an injected `transport({method, payload, token, signal})`
+// function so tests can replay scripted responses without spinning up a real
+// HTTP server. Token reads go through a TelegramTokenStore (see
+// telegram-token-store.js); the client never touches the env file directly.
+
+class TelegramApiError extends Error {
+  constructor({ status, code, description, parameters } = {}) {
+    super(description || `Telegram API HTTP ${status ?? "?"}`);
+    this.name = "TelegramApiError";
+    this.status = status ?? null;
+    this.code = code ?? null;
+    this.description = description || "";
+    this.parameters = parameters || {};
+  }
+}
+
+const ERROR_CLASSES = Object.freeze({
+  UNAUTHORIZED: "401",
+  FORBIDDEN: "403",
+  BAD_REQUEST: "400",
+  CONFLICT: "409_conflict",
+  WEBHOOK_CONFLICT: "409_webhook",
+  RATE_LIMITED: "429",
+  NETWORK: "network",
+  TIMEOUT: "timeout",
+  TOKEN_MISSING: "token_missing",
+  UNKNOWN: "unknown",
+});
+
+function classifyError(err) {
+  if (!err) return ERROR_CLASSES.UNKNOWN;
+  if (err.name === "AbortError") return ERROR_CLASSES.TIMEOUT;
+  if (err instanceof TelegramApiError) {
+    if (err.code === "TOKEN_MISSING") return ERROR_CLASSES.TOKEN_MISSING;
+    // Some fetch wrappers only populate `error_code` (mirroring the Bot API
+    // body) and leave `status` null. Fall back to `code` so classification
+    // still works.
+    const code = err.status ?? err.code ?? null;
+    if (code === 401) return ERROR_CLASSES.UNAUTHORIZED;
+    if (code === 403) return ERROR_CLASSES.FORBIDDEN;
+    if (code === 400) return ERROR_CLASSES.BAD_REQUEST;
+    if (code === 429) return ERROR_CLASSES.RATE_LIMITED;
+    if (code === 409) {
+      // Plan §168 TODO: regex on description is a UX hint only. The Telegram
+      // Bot API does not formally distinguish "another consumer" vs "webhook
+      // active" by error_code, so for production reliability we should call
+      // `getWebhookInfo` after a 409 and inspect `.url` to be sure. Spike
+      // keeps the regex as a fast hint.
+      return /webhook/i.test(err.description || "")
+        ? ERROR_CLASSES.WEBHOOK_CONFLICT
+        : ERROR_CLASSES.CONFLICT;
+    }
+    return ERROR_CLASSES.UNKNOWN;
+  }
+  if (err.code === "ENOTFOUND" || err.code === "ECONNREFUSED" || err.code === "ECONNRESET") {
+    return ERROR_CLASSES.NETWORK;
+  }
+  return ERROR_CLASSES.UNKNOWN;
+}
+
+class TelegramNativeClient {
+  constructor({ tokenStore, transport, logger = null } = {}) {
+    if (!tokenStore || typeof tokenStore.getToken !== "function") {
+      throw new TypeError("TelegramNativeClient: tokenStore.getToken is required");
+    }
+    if (typeof transport !== "function") {
+      throw new TypeError("TelegramNativeClient: transport function is required");
+    }
+    this.tokenStore = tokenStore;
+    this.transport = transport;
+    this.logger = logger;
+    this._offset = 0;
+  }
+
+  get offset() {
+    return this._offset;
+  }
+
+  resetOffset() {
+    this._offset = 0;
+  }
+
+  async _call(method, payload = {}, { signal } = {}) {
+    // Token availability is checked here, but the value is intentionally not
+    // forwarded to the transport call. Production transport implementations
+    // hold the token in a closure (or look it up via the tokenStore each
+    // call); the per-call API surface stays free of raw secrets so that any
+    // future logging / debug serialization of {method, payload, signal}
+    // cannot accidentally leak the token.
+    const hasToken = await this.tokenStore.hasToken();
+    if (!hasToken) {
+      throw new TelegramApiError({
+        status: null,
+        code: "TOKEN_MISSING",
+        description: "no Telegram bot token configured",
+      });
+    }
+    const response = await this.transport({ method, payload, signal });
+    if (response && response.ok === true) {
+      return response.result;
+    }
+    throw new TelegramApiError({
+      status: response && response.status,
+      code: response && response.error_code,
+      description: response && response.description,
+      parameters: response && response.parameters,
+    });
+  }
+
+  getMe(opts) {
+    return this._call("getMe", {}, opts);
+  }
+
+  sendMessage(payload, opts) {
+    return this._call("sendMessage", payload, opts);
+  }
+
+  answerCallbackQuery(payload, opts) {
+    return this._call("answerCallbackQuery", payload, opts);
+  }
+
+  editMessageReplyMarkup(payload, opts) {
+    return this._call("editMessageReplyMarkup", payload, opts);
+  }
+
+  // long-poll one batch. Caller is responsible for looping; this method only
+  // ever issues one HTTP call so tests stay deterministic.
+  async getUpdates({ timeout = 25, signal } = {}) {
+    const updates = await this._call(
+      "getUpdates",
+      { offset: this._offset, timeout },
+      { signal },
+    );
+    if (Array.isArray(updates) && updates.length > 0) {
+      const lastId = updates[updates.length - 1].update_id;
+      if (Number.isInteger(lastId)) {
+        this._offset = Math.max(this._offset, lastId + 1);
+      }
+    }
+    return updates || [];
+  }
+}
+
+// Plan §116: when starting the native poller right after stopping the sidecar
+// (or starting fresh while another consumer is still releasing its long-poll
+// session), Telegram returns 409 Conflict. Retry with exponential backoff:
+// 1s start, ×2, capped at 5s, total deadline 35s. While in conflict we MUST
+// NOT persist transport=native — that is the caller's responsibility; this
+// helper only governs the retry loop itself.
+const DEFAULT_RETRY_OPTS = Object.freeze({
+  initialDelayMs: 1000,
+  maxDelayMs: 5000,
+  totalDeadlineMs: 35000,
+  factor: 2,
+});
+
+async function pollWithConflictRetry(
+  doCall,
+  {
+    initialDelayMs = DEFAULT_RETRY_OPTS.initialDelayMs,
+    maxDelayMs = DEFAULT_RETRY_OPTS.maxDelayMs,
+    totalDeadlineMs = DEFAULT_RETRY_OPTS.totalDeadlineMs,
+    factor = DEFAULT_RETRY_OPTS.factor,
+    now = () => Date.now(),
+    sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+    signal,
+  } = {},
+) {
+  const startedAt = now();
+  let delay = initialDelayMs;
+  let attempts = 0;
+  let lastConflictErr = null;
+
+  while (true) {
+    if (signal && signal.aborted) {
+      const err = new Error("aborted");
+      err.name = "AbortError";
+      throw err;
+    }
+    attempts += 1;
+    try {
+      const result = await doCall();
+      return { result, attempts };
+    } catch (err) {
+      const cls = classifyError(err);
+      // Only loop on plain 409 conflict — webhook conflict is fatal because it
+      // requires user action (deleteWebhook), not waiting.
+      if (cls !== ERROR_CLASSES.CONFLICT) throw err;
+      lastConflictErr = err;
+      const elapsed = now() - startedAt;
+      const remaining = totalDeadlineMs - elapsed;
+      if (remaining <= 0) {
+        // Deadline hit — propagate the original conflict so caller can decide
+        // (UI prompts user to close other Clawd instances).
+        const wrapped = new TelegramApiError({
+          status: 409,
+          code: 409,
+          description: err.description || "Conflict (retry deadline exceeded)",
+          parameters: { attempts, elapsedMs: elapsed },
+        });
+        throw wrapped;
+      }
+      const waitMs = Math.min(delay, remaining);
+      await sleep(waitMs);
+      delay = Math.min(maxDelayMs, Math.floor(delay * factor));
+    }
+  }
+}
+
+module.exports = {
+  TelegramNativeClient,
+  TelegramApiError,
+  ERROR_CLASSES,
+  classifyError,
+  pollWithConflictRetry,
+  DEFAULT_RETRY_OPTS,
+};

--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -8,6 +8,9 @@
 //   - long-poll loop with 409 retry on first iteration
 //   - test-card lifecycle: build a nonce, sendMessage with inline keyboard,
 //     watch incoming callback_queries for matching nonce + allowed user
+//   - real approval lifecycle: requestApproval(payload, { signal }) Promise
+//     that resolves allow/deny on a matching Telegram callback, or null on
+//     abort/timeout/send failure
 //   - dispatch TEST_SUCCESS / TEST_FAILED back to the migration controller
 
 const {
@@ -19,6 +22,32 @@ const {
 
 const { EVENTS } = require("./telegram-migration-state");
 
+const APPROVAL_CALLBACK_RE = /^clawdperm:([a-z0-9]+):(allow|deny)$/;
+const MAX_MESSAGE_TEXT = 3800;
+const DEFAULT_APPROVAL_TIMEOUT_MS = 90000;
+
+function randomId() {
+  return Math.random().toString(36).slice(2, 12);
+}
+
+function compactMessageText(value, maxLen = MAX_MESSAGE_TEXT) {
+  let text = typeof value === "string" ? value : String(value == null ? "" : value);
+  text = text
+    .replace(/\r\n?/g, "\n")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]+/g, " ")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+  if (text.length > maxLen) text = `${text.slice(0, Math.max(0, maxLen - 3))}...`;
+  return text;
+}
+
+function buildApprovalText(payload) {
+  const title = compactMessageText(payload && payload.title, 240);
+  if (!title) return null;
+  const detail = compactMessageText(payload && payload.detail, MAX_MESSAGE_TEXT - title.length - 32);
+  return detail ? `${title}\n\n${detail}` : title;
+}
+
 function createTelegramNativeRunner({
   tokenStore,
   transport,
@@ -27,15 +56,21 @@ function createTelegramNativeRunner({
   getAllowedUserId,   // () => "<user id>"
   log = () => {},
   longPollTimeoutMs = 25, // Telegram seconds
+  approvalTimeoutMs = DEFAULT_APPROVAL_TIMEOUT_MS,
 }) {
   const client = new TelegramNativeClient({ tokenStore, transport });
 
   let abortController = null;
   let polling = false;
   let pendingTest = null; // { nonce, chatId, allowedUser, messageId }
+  const pendingApprovals = new Map(); // id -> { resolve, chatId, allowedUser, messageId, timer, signal, onAbort }
 
   function isPolling() {
     return polling;
+  }
+
+  function isEnabled() {
+    return polling && !!getChatId();
   }
 
   async function start() {
@@ -60,6 +95,7 @@ function createTelegramNativeRunner({
       try { abortController.abort(); } catch {}
       abortController = null;
     }
+    clearAllApprovals();
   }
 
   async function loopFirst(signal) {
@@ -97,16 +133,28 @@ function createTelegramNativeRunner({
   }
 
   async function handleUpdate(update) {
-    if (!update || !update.callback_query || !pendingTest) return;
+    if (!update || !update.callback_query) return;
     const cb = update.callback_query;
     const fromId = cb.from && String(cb.from.id);
     const chatId = cb.message && cb.message.chat && String(cb.message.chat.id);
+
+    if (pendingTest) {
+      const handledTest = await handleTestCallback(cb, { fromId, chatId });
+      if (handledTest) return;
+    }
+
+    const handledApproval = await handleApprovalCallback(cb, { fromId, chatId });
+    if (!handledApproval) return;
+  }
+
+  async function handleTestCallback(cb, { fromId, chatId }) {
     const isAllowedUser = !pendingTest.allowedUser || fromId === String(pendingTest.allowedUser);
     const isExpectedChat = !pendingTest.chatId || chatId === String(pendingTest.chatId);
     if (cb.data !== `clawd-test:${pendingTest.nonce}` || !isAllowedUser || !isExpectedChat) {
+      if (typeof cb.data !== "string" || !cb.data.startsWith("clawd-test:")) return false;
       // Acknowledge stray callbacks so the Telegram client closes its spinner.
       try { await client.answerCallbackQuery({ callback_query_id: cb.id }); } catch {}
-      return;
+      return true;
     }
     try { await client.answerCallbackQuery({ callback_query_id: cb.id, text: "OK" }); } catch {}
     try {
@@ -119,6 +167,41 @@ function createTelegramNativeRunner({
     pendingTest = null;
     const dispatch = getDispatch && getDispatch();
     if (dispatch) await dispatch({ type: EVENTS.TEST_SUCCESS, at: Date.now() });
+    return true;
+  }
+
+  async function handleApprovalCallback(cb, { fromId, chatId }) {
+    const data = typeof cb.data === "string" ? cb.data : "";
+    const match = data.match(APPROVAL_CALLBACK_RE);
+    if (!match) return false;
+    const entry = pendingApprovals.get(match[1]);
+    if (!entry) {
+      try { await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Expired" }); } catch {}
+      return true;
+    }
+    const isAllowedUser = !entry.allowedUser || fromId === String(entry.allowedUser);
+    const isExpectedChat = !entry.chatId || chatId === String(entry.chatId);
+    if (!isAllowedUser || !isExpectedChat) {
+      try { await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Not allowed" }); } catch {}
+      return true;
+    }
+
+    const decision = match[2];
+    try {
+      await client.answerCallbackQuery({
+        callback_query_id: cb.id,
+        text: decision === "allow" ? "Allowed" : "Denied",
+      });
+    } catch {}
+    try {
+      await client.editMessageReplyMarkup({
+        chat_id: chatId,
+        message_id: entry.messageId || (cb.message && cb.message.message_id),
+        reply_markup: { inline_keyboard: [] },
+      });
+    } catch {}
+    finishApproval(match[1], decision);
+    return true;
   }
 
   async function dispatchEvent(event) {
@@ -153,7 +236,7 @@ function createTelegramNativeRunner({
       dispatchEventSoon({ type: EVENTS.TEST_FAILED, errorClass: "no_chat" });
       return;
     }
-    const nonce = Math.random().toString(36).slice(2, 12);
+    const nonce = randomId();
     try {
       const msg = await client.sendMessage({
         chat_id: chatId,
@@ -173,7 +256,84 @@ function createTelegramNativeRunner({
     }
   }
 
-  return { isPolling, start, stop, sendTestCard, _client: client };
+  function finishApproval(id, decision) {
+    const entry = pendingApprovals.get(id);
+    if (!entry) return;
+    pendingApprovals.delete(id);
+    if (entry.timer) clearTimeout(entry.timer);
+    if (entry.signal && entry.onAbort) {
+      try { entry.signal.removeEventListener("abort", entry.onAbort); } catch {}
+    }
+    entry.resolve(decision === "allow" || decision === "deny" ? decision : null);
+  }
+
+  function clearAllApprovals() {
+    const ids = Array.from(pendingApprovals.keys());
+    for (const id of ids) finishApproval(id, null);
+  }
+
+  function requestApproval(payload, options = {}) {
+    const chatId = getChatId();
+    const allowedUser = getAllowedUserId();
+    const text = buildApprovalText(payload);
+    const signal = options && options.signal;
+    if (!polling || !chatId || !text || (signal && signal.aborted)) {
+      return Promise.resolve(null);
+    }
+    const id = randomId();
+    const callbackBase = `clawdperm:${id}`;
+    return new Promise((resolve) => {
+      const entry = {
+        resolve,
+        chatId,
+        allowedUser,
+        messageId: null,
+        timer: null,
+        signal,
+        onAbort: null,
+      };
+      pendingApprovals.set(id, entry);
+
+      entry.timer = setTimeout(() => finishApproval(id, null), Math.max(1, approvalTimeoutMs));
+      if (entry.timer && typeof entry.timer.unref === "function") entry.timer.unref();
+
+      if (signal) {
+        entry.onAbort = () => finishApproval(id, null);
+        signal.addEventListener("abort", entry.onAbort, { once: true });
+      }
+
+      client.sendMessage({
+        chat_id: chatId,
+        text,
+        reply_markup: {
+          inline_keyboard: [[
+            { text: "Allow", callback_data: `${callbackBase}:allow` },
+            { text: "Deny", callback_data: `${callbackBase}:deny` },
+          ]],
+        },
+      }).then((msg) => {
+        const current = pendingApprovals.get(id);
+        if (current) current.messageId = msg && msg.message_id;
+      }).catch((err) => {
+        log("warn", "native approval send failed", { error: err && err.message });
+        finishApproval(id, null);
+      });
+    });
+  }
+
+  return {
+    isEnabled,
+    isPolling,
+    start,
+    stop,
+    sendTestCard,
+    requestApproval,
+    _client: client,
+    _pendingApprovals: pendingApprovals,
+  };
 }
 
-module.exports = { createTelegramNativeRunner };
+module.exports = {
+  createTelegramNativeRunner,
+  buildApprovalText,
+};

--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -1,0 +1,179 @@
+"use strict";
+
+// Bridges TelegramNativeClient (raw API primitives) and the owner-manager's
+// expected handle shape:
+//   { isPolling(), start(), stop(), sendTestCard(payload) }
+//
+// Responsibilities the client itself does NOT handle:
+//   - long-poll loop with 409 retry on first iteration
+//   - test-card lifecycle: build a nonce, sendMessage with inline keyboard,
+//     watch incoming callback_queries for matching nonce + allowed user
+//   - dispatch TEST_SUCCESS / TEST_FAILED back to the migration controller
+
+const {
+  TelegramNativeClient,
+  pollWithConflictRetry,
+  classifyError,
+  ERROR_CLASSES,
+} = require("./telegram-native-client");
+
+const { EVENTS } = require("./telegram-migration-state");
+
+function createTelegramNativeRunner({
+  tokenStore,
+  transport,
+  getDispatch,        // () => migrationController.dispatch (lazy for cycle)
+  getChatId,          // () => "<chat id>" (number-string)
+  getAllowedUserId,   // () => "<user id>"
+  log = () => {},
+  longPollTimeoutMs = 25, // Telegram seconds
+}) {
+  const client = new TelegramNativeClient({ tokenStore, transport });
+
+  let abortController = null;
+  let polling = false;
+  let pendingTest = null; // { nonce, chatId, allowedUser, messageId }
+
+  function isPolling() {
+    return polling;
+  }
+
+  async function start() {
+    if (polling) return;
+    polling = true;
+    const controller = new AbortController();
+    abortController = controller;
+    // First poll uses retry to absorb 409 from a still-releasing sidecar.
+    loopFirst(controller.signal).catch((err) => {
+      log("warn", "native polling stopped", { error: err && err.message });
+    }).finally(() => {
+      if (abortController === controller) {
+        polling = false;
+        abortController = null;
+      }
+    });
+  }
+
+  async function stop() {
+    polling = false;
+    if (abortController) {
+      try { abortController.abort(); } catch {}
+      abortController = null;
+    }
+  }
+
+  async function loopFirst(signal) {
+    try {
+      await pollWithConflictRetry(() => client.getUpdates({ timeout: 0, signal }), { signal });
+    } catch (err) {
+      const cls = classifyError(err);
+      if (cls === ERROR_CLASSES.TIMEOUT) return; // aborted
+      if (cls === ERROR_CLASSES.CONFLICT || cls === ERROR_CLASSES.WEBHOOK_CONFLICT) {
+        await failTest(err, cls);
+        return;
+      }
+      // Any other class: pass through to normal loop so consistent classification.
+      await failTest(err, cls);
+      return;
+    }
+    return loop(signal);
+  }
+
+  async function loop(signal) {
+    while (polling && !signal.aborted) {
+      let updates;
+      try {
+        updates = await client.getUpdates({ timeout: longPollTimeoutMs, signal });
+      } catch (err) {
+        const cls = classifyError(err);
+        if (cls === ERROR_CLASSES.TIMEOUT) return; // aborted
+        await failTest(err, cls);
+        return;
+      }
+      for (const u of updates) {
+        await handleUpdate(u);
+      }
+    }
+  }
+
+  async function handleUpdate(update) {
+    if (!update || !update.callback_query || !pendingTest) return;
+    const cb = update.callback_query;
+    const fromId = cb.from && String(cb.from.id);
+    const chatId = cb.message && cb.message.chat && String(cb.message.chat.id);
+    const isAllowedUser = !pendingTest.allowedUser || fromId === String(pendingTest.allowedUser);
+    const isExpectedChat = !pendingTest.chatId || chatId === String(pendingTest.chatId);
+    if (cb.data !== `clawd-test:${pendingTest.nonce}` || !isAllowedUser || !isExpectedChat) {
+      // Acknowledge stray callbacks so the Telegram client closes its spinner.
+      try { await client.answerCallbackQuery({ callback_query_id: cb.id }); } catch {}
+      return;
+    }
+    try { await client.answerCallbackQuery({ callback_query_id: cb.id, text: "OK" }); } catch {}
+    try {
+      await client.editMessageReplyMarkup({
+        chat_id: chatId,
+        message_id: pendingTest.messageId,
+        reply_markup: { inline_keyboard: [] },
+      });
+    } catch {}
+    pendingTest = null;
+    const dispatch = getDispatch && getDispatch();
+    if (dispatch) await dispatch({ type: EVENTS.TEST_SUCCESS, at: Date.now() });
+  }
+
+  async function dispatchEvent(event) {
+    const dispatch = getDispatch && getDispatch();
+    if (dispatch) await dispatch(event);
+  }
+
+  function dispatchEventSoon(event) {
+    const timer = setTimeout(() => {
+      dispatchEvent(event).catch((err) => {
+        log("warn", "native dispatch failed", { error: err && err.message });
+      });
+    }, 0);
+    if (timer && typeof timer.unref === "function") timer.unref();
+  }
+
+  async function failTest(err, errorClass, { defer = false } = {}) {
+    pendingTest = null;
+    const event = {
+      type: EVENTS.TEST_FAILED,
+      errorClass,
+      description: err && err.description,
+    };
+    if (defer) dispatchEventSoon(event);
+    else await dispatchEvent(event);
+  }
+
+  async function sendTestCard() {
+    const chatId = getChatId();
+    const allowedUser = getAllowedUserId();
+    if (!chatId) {
+      dispatchEventSoon({ type: EVENTS.TEST_FAILED, errorClass: "no_chat" });
+      return;
+    }
+    const nonce = Math.random().toString(36).slice(2, 12);
+    try {
+      const msg = await client.sendMessage({
+        chat_id: chatId,
+        text: "Clawd: test native Telegram bot. Tap to confirm.",
+        reply_markup: {
+          inline_keyboard: [[{ text: "Confirm", callback_data: `clawd-test:${nonce}` }]],
+        },
+      });
+      pendingTest = {
+        nonce,
+        chatId,
+        allowedUser,
+        messageId: msg && msg.message_id,
+      };
+    } catch (err) {
+      await failTest(err, classifyError(err), { defer: true });
+    }
+  }
+
+  return { isPolling, start, stop, sendTestCard, _client: client };
+}
+
+module.exports = { createTelegramNativeRunner };

--- a/src/telegram-owner-manager.js
+++ b/src/telegram-owner-manager.js
@@ -1,0 +1,169 @@
+"use strict";
+
+// Owner manager: executes side-effects emitted by the migration reducer and
+// guarantees that at no point in time both the Go sidecar (`isRunning()`) and
+// the native poller (`isPolling()`) are active against the same Telegram bot
+// token. Mutual exclusion is enforced two ways:
+//
+//   1. Pre-condition checks before START_SIDECAR / START_NATIVE_POLLER.
+//   2. Post-condition assertion after every effect — if a fake / future code
+//      path silently violates the invariant, the manager throws InvariantError
+//      and the reducer driver can surface a fatal bug.
+//
+// All `apply()` calls are serialized through an internal queue so that
+// concurrent reducer dispatches cannot race.
+
+const { SIDE_EFFECTS } = require("./telegram-migration-state");
+
+const DEFAULT_SETTLE_MS = 500;
+const DEFAULT_STOP_GRACE_MS = 2000;
+
+class InvariantError extends Error {
+  constructor(code, message) {
+    super(message || code);
+    this.name = "InvariantError";
+    this.code = code;
+  }
+}
+
+function defaultSleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, Math.max(0, ms)));
+}
+
+class TelegramOwnerManager {
+  constructor({
+    sidecar,
+    native,
+    settleMs = DEFAULT_SETTLE_MS,
+    stopGraceMs = DEFAULT_STOP_GRACE_MS,
+    now = () => Date.now(),
+    sleep = defaultSleep,
+    onPersist = null,
+    onRuntimeStatus = null,
+    logger = null,
+  } = {}) {
+    if (!sidecar || typeof sidecar.start !== "function" || typeof sidecar.stop !== "function" || typeof sidecar.isRunning !== "function") {
+      throw new TypeError("owner-manager: sidecar handle must implement start/stop/isRunning");
+    }
+    if (!native || typeof native.start !== "function" || typeof native.stop !== "function" || typeof native.isPolling !== "function") {
+      throw new TypeError("owner-manager: native handle must implement start/stop/isPolling");
+    }
+    this.sidecar = sidecar;
+    this.native = native;
+    this.settleMs = settleMs;
+    this.stopGraceMs = stopGraceMs;
+    this.now = now;
+    this.sleep = sleep;
+    this.onPersist = onPersist;
+    this.onRuntimeStatus = onRuntimeStatus;
+    this.logger = logger;
+    this._lastSidecarStopAt = -Infinity;
+    this._queue = Promise.resolve();
+  }
+
+  snapshot() {
+    return {
+      sidecarRunning: !!this.sidecar.isRunning(),
+      nativePolling: !!this.native.isPolling(),
+    };
+  }
+
+  apply(sideEffects) {
+    const effects = Array.isArray(sideEffects) ? sideEffects : [];
+    const work = this._queue.then(() => this._applyNow(effects));
+    // Swallow rejection on the queue handle so that one failed apply() does
+    // not poison every subsequent dispatch. Callers still observe the error
+    // through the returned promise.
+    this._queue = work.catch(() => {});
+    return work;
+  }
+
+  async _applyNow(effects) {
+    this._assertMutex("pre-apply");
+    for (const fx of effects) {
+      if (!fx || typeof fx.type !== "string") continue;
+      await this._runOne(fx);
+      this._assertMutex(`post-${fx.type}`);
+    }
+  }
+
+  async _runOne(fx) {
+    switch (fx.type) {
+      case SIDE_EFFECTS.STOP_SIDECAR:
+        await this.sidecar.stop({ graceMs: this.stopGraceMs });
+        this._lastSidecarStopAt = this.now();
+        return;
+      case SIDE_EFFECTS.STOP_NATIVE_POLLER:
+        await this.native.stop();
+        return;
+      case SIDE_EFFECTS.START_SIDECAR:
+        if (this.native.isPolling()) {
+          throw new InvariantError(
+            "PRE_START_SIDECAR_BUT_NATIVE_POLLING",
+            "Refused to start sidecar while native poller is active",
+          );
+        }
+        {
+          const started = await this.sidecar.start();
+          if (started === false) {
+            throw new InvariantError(
+              "SIDECAR_START_FAILED",
+              "Sidecar handle reported startup failure",
+            );
+          }
+        }
+        return;
+      case SIDE_EFFECTS.START_NATIVE_POLLER:
+        if (this.sidecar.isRunning()) {
+          throw new InvariantError(
+            "PRE_START_NATIVE_BUT_SIDECAR_RUNNING",
+            "Refused to start native poller while sidecar is running",
+          );
+        }
+        await this._waitForSettle();
+        await this.native.start();
+        return;
+      case SIDE_EFFECTS.SEND_TEST_CARD:
+        if (typeof this.native.sendTestCard !== "function") {
+          throw new TypeError("native handle missing sendTestCard()");
+        }
+        await this.native.sendTestCard(fx.payload || {});
+        return;
+      case SIDE_EFFECTS.PERSIST_PREFS:
+        if (typeof this.onPersist === "function") {
+          await this.onPersist(fx.payload || {});
+        }
+        return;
+      case SIDE_EFFECTS.EMIT_RUNTIME_STATUS:
+        if (typeof this.onRuntimeStatus === "function") {
+          await this.onRuntimeStatus(fx.payload || {});
+        }
+        return;
+      default:
+        if (this.logger) this.logger.warn(`owner-manager: ignoring unknown effect ${fx.type}`);
+        return;
+    }
+  }
+
+  async _waitForSettle() {
+    const elapsed = this.now() - this._lastSidecarStopAt;
+    const remaining = this.settleMs - elapsed;
+    if (remaining > 0) await this.sleep(remaining);
+  }
+
+  _assertMutex(label) {
+    if (this.sidecar.isRunning() && this.native.isPolling()) {
+      throw new InvariantError(
+        "MUTUAL_EXCLUSION_VIOLATED",
+        `Both sidecar running and native polling at ${label}`,
+      );
+    }
+  }
+}
+
+module.exports = {
+  TelegramOwnerManager,
+  InvariantError,
+  DEFAULT_SETTLE_MS,
+  DEFAULT_STOP_GRACE_MS,
+};

--- a/src/telegram-token-store.js
+++ b/src/telegram-token-store.js
@@ -1,0 +1,112 @@
+"use strict";
+
+// Telegram bot token storage abstraction.
+//
+// Plan §298-304 invariant: the Clawd source must NEVER read the bot-token
+// environment variable from the host process. The token lives only at
+// `userData/telegram-approval.env` (the same file the Go sidecar reads through
+// CLAWD_TG_BOT_TOKEN_FILE). This module exposes a TelegramTokenStore interface
+// so that callers (native client, sidecar bootstrap) take the store as a
+// dependency rather than touching the env file directly.
+//
+// Spike scope: only `envFileTokenStore` is implemented. Tests can use any
+// object matching the interface.
+
+const fsDefault = require("fs");
+const pathDefault = require("path");
+const { writeTokenEnvFile } = require("./telegram-approval-settings");
+
+const TOKEN_LINE_RE = /^\s*CLAWD_TG_BOT_TOKEN\s*=\s*(.+?)\s*$/m;
+const BOT_TOKEN_RE = /^\d+:[A-Za-z0-9_-]{30,}$/;
+
+function isValidToken(value) {
+  return typeof value === "string" && BOT_TOKEN_RE.test(value);
+}
+
+function parseTokenFromEnvFileText(text) {
+  if (typeof text !== "string" || !text) return null;
+  const match = text.match(TOKEN_LINE_RE);
+  if (!match) return null;
+  const token = match[1].trim();
+  return isValidToken(token) ? token : null;
+}
+
+function buildEnvFileText(token) {
+  return `CLAWD_TG_BOT_TOKEN=${token}\n`;
+}
+
+// Factory: returns a store backed by the env file at `filePath`.
+// Caller (typically the Electron main process) passes the resolved absolute
+// path and may inject `fs` for testing.
+function envFileTokenStore({
+  filePath,
+  fs = fsDefault,
+  path: pathModule = pathDefault,
+  platform = process.platform,
+} = {}) {
+  if (typeof filePath !== "string" || !filePath) {
+    throw new TypeError("envFileTokenStore: filePath is required");
+  }
+  if (!fs || typeof fs.readFileSync !== "function") {
+    throw new TypeError("envFileTokenStore: fs must implement readFileSync");
+  }
+
+  function readText() {
+    try {
+      return String(fs.readFileSync(filePath, { encoding: "utf8" }) || "");
+    } catch {
+      return "";
+    }
+  }
+
+  return {
+    kind: "envFile",
+    filePath,
+
+    async getToken() {
+      return parseTokenFromEnvFileText(readText());
+    },
+
+    async hasToken() {
+      return parseTokenFromEnvFileText(readText()) !== null;
+    },
+
+    async writeToken(token) {
+      if (!isValidToken(token)) {
+        throw new Error("envFileTokenStore: refusing to write invalid bot token");
+      }
+      // Delegate to the existing temp+rename atomic writer in
+      // telegram-approval-settings — that path already covers Windows
+      // (mode is best-effort POSIX, ACL inherits from userData) and POSIX
+      // chmod 0600. Reusing it avoids a half-written env file on crash.
+      const result = writeTokenEnvFile({
+        fs,
+        path: pathModule,
+        filePath,
+        token,
+        platform,
+      });
+      if (!result || result.status !== "ok") {
+        throw new Error(
+          `envFileTokenStore: writeTokenEnvFile failed (${result && result.message ? result.message : "unknown"})`,
+        );
+      }
+    },
+
+    async deleteToken() {
+      if (typeof fs.unlinkSync !== "function") return;
+      try {
+        fs.unlinkSync(filePath);
+      } catch {
+        // missing file is fine; other errors silently ignored at spike scope.
+      }
+    },
+  };
+}
+
+module.exports = {
+  envFileTokenStore,
+  parseTokenFromEnvFileText,
+  buildEnvFileText,
+  isValidToken,
+};

--- a/test/fakes/migration-transitions.js
+++ b/test/fakes/migration-transitions.js
@@ -1,0 +1,539 @@
+"use strict";
+
+// Enumerated transition table for the Telegram migration state machine.
+// Each case is: { name, state, prefs, files, event, expect: { state, sideEffectTypes, errorCode?, prefsPatch? } }
+//
+// Conventions:
+//   - sideEffectTypes is an ordered array of side-effect `.type` strings; the
+//     test driver checks order and exact set.
+//   - When `errorCode` is omitted, the case is a "legal" transition; when
+//     present (and not null), the case is an "illegal event under this state"
+//     and the expected state MUST equal the input state.
+//   - prefsPatch is the persisted-fields diff produced by reducer; omitted
+//     means none.
+
+const {
+  STATES,
+  EVENTS,
+  SIDE_EFFECTS,
+  ERROR_CODES,
+} = require("../../src/telegram-migration-state");
+
+const fullLegacyFiles = {
+  hasLegacyEnvFile: true,
+  legacyConfigComplete: true,
+  nativeConfigComplete: false,
+};
+const fullNativeFiles = {
+  hasLegacyEnvFile: false,
+  legacyConfigComplete: false,
+  nativeConfigComplete: true,
+};
+const bothConfigsFiles = {
+  hasLegacyEnvFile: true,
+  legacyConfigComplete: true,
+  nativeConfigComplete: true,
+};
+const emptyFiles = {
+  hasLegacyEnvFile: false,
+  legacyConfigComplete: false,
+  nativeConfigComplete: false,
+};
+const partialLegacyFiles = {
+  hasLegacyEnvFile: true,
+  legacyConfigComplete: false,
+  nativeConfigComplete: false,
+};
+
+// Explicit "off" — user has previously disabled remote approval.
+const prefsOff = { transport: "off", nativeVerifiedAt: null, migration: { importedAt: null, importError: null } };
+// "Undecided" — v0.8.x user upgrading; prefs file has no `transport` key yet.
+const prefsUndecided = { nativeVerifiedAt: null, migration: { importedAt: null, importError: null } };
+// v0.8.x user who had Telegram explicitly disabled (tgApproval.enabled === false).
+const prefsUndecidedOptOut = { ...prefsUndecided, legacyEnabled: false };
+// v0.8.x user who had Telegram enabled — same as prefsUndecided semantically,
+// but pinned for clarity in the table.
+const prefsUndecidedOptIn = { ...prefsUndecided, legacyEnabled: true };
+const prefsLegacy = { ...prefsOff, transport: "legacy" };
+const prefsNativeVerified = { ...prefsOff, transport: "native", nativeVerifiedAt: 1700000000000 };
+const prefsNativeUnverified = { ...prefsOff, transport: "native", nativeVerifiedAt: null };
+
+// ============================================================================
+// INIT (startup normalization) — drives `computeInitial`.
+// ============================================================================
+const initCases = [
+  {
+    name: "INIT: fresh install (no prefs, no files) → IDLE",
+    state: STATES.IDLE,
+    prefs: prefsOff,
+    files: emptyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.IDLE, sideEffectTypes: [] },
+  },
+  {
+    name: "INIT: legacy v0.8.x user upgrading (no transport pref) + full env → LEGACY_ACTIVE",
+    state: STATES.IDLE,
+    prefs: prefsUndecided,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.LEGACY_ACTIVE, sideEffectTypes: [SIDE_EFFECTS.START_SIDECAR] },
+  },
+  {
+    name: "INIT: v0.8.x user upgrading with legacyEnabled=true + full env → LEGACY_ACTIVE",
+    state: STATES.IDLE,
+    prefs: prefsUndecidedOptIn,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.LEGACY_ACTIVE, sideEffectTypes: [SIDE_EFFECTS.START_SIDECAR] },
+  },
+  {
+    name: "INIT: v0.8.x user who had Telegram disabled (legacyEnabled=false) → IDLE, NOT re-enabled",
+    state: STATES.IDLE,
+    prefs: prefsUndecidedOptOut,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.IDLE, sideEffectTypes: [] },
+  },
+  {
+    name: "INIT: v0.8.x opt-out user with partial legacy files → IDLE (still respects opt-out)",
+    state: STATES.IDLE,
+    prefs: prefsUndecidedOptOut,
+    files: partialLegacyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.IDLE, sideEffectTypes: [] },
+  },
+  {
+    name: "INIT: user explicitly disabled (transport=off) ignores leftover legacy files",
+    state: STATES.IDLE,
+    prefs: prefsOff,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.IDLE, sideEffectTypes: [] },
+  },
+  {
+    name: "INIT: transport=legacy persisted + legacy files complete → LEGACY_ACTIVE",
+    state: STATES.IDLE,
+    prefs: prefsLegacy,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.LEGACY_ACTIVE, sideEffectTypes: [SIDE_EFFECTS.START_SIDECAR] },
+  },
+  {
+    name: "INIT: transport=native verified + native config complete → NATIVE_ACTIVE",
+    state: STATES.IDLE,
+    prefs: prefsNativeVerified,
+    files: fullNativeFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.NATIVE_ACTIVE, sideEffectTypes: [SIDE_EFFECTS.START_NATIVE_POLLER] },
+  },
+  {
+    name: "INIT: transport=native but nativeVerifiedAt null → NEEDS_SETUP",
+    state: STATES.IDLE,
+    prefs: prefsNativeUnverified,
+    files: fullNativeFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.NEEDS_SETUP, sideEffectTypes: [] },
+  },
+  {
+    name: "INIT: transport=legacy persisted but env partial → NEEDS_SETUP",
+    state: STATES.IDLE,
+    prefs: prefsLegacy,
+    files: partialLegacyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.NEEDS_SETUP, sideEffectTypes: [] },
+  },
+  {
+    name: "INIT: invalid transport value → normalized silently, falls back per files",
+    state: STATES.IDLE,
+    prefs: { transport: "garbage", nativeVerifiedAt: null, migration: {} },
+    files: emptyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.IDLE, sideEffectTypes: [] },
+  },
+  {
+    name: "INIT: invalid transport + legacy file residue → NEEDS_SETUP (normalized)",
+    state: STATES.IDLE,
+    prefs: { transport: "garbage", nativeVerifiedAt: null, migration: {} },
+    files: partialLegacyFiles,
+    event: { type: EVENTS.INIT },
+    expect: { state: STATES.NEEDS_SETUP, sideEffectTypes: [] },
+  },
+];
+
+// ============================================================================
+// USER_TEST_NATIVE
+// ============================================================================
+const userTestCases = [
+  {
+    name: "USER_TEST_NATIVE @ IDLE with native config → TESTING_NATIVE (no STOP_SIDECAR)",
+    state: STATES.IDLE,
+    prefs: prefsOff,
+    files: fullNativeFiles,
+    event: { type: EVENTS.USER_TEST_NATIVE },
+    expect: {
+      state: STATES.TESTING_NATIVE,
+      sideEffectTypes: [SIDE_EFFECTS.START_NATIVE_POLLER, SIDE_EFFECTS.SEND_TEST_CARD],
+    },
+  },
+  {
+    name: "USER_TEST_NATIVE @ LEGACY_ACTIVE with native config → TESTING_NATIVE (stops sidecar first)",
+    state: STATES.LEGACY_ACTIVE,
+    prefs: prefsLegacy,
+    files: bothConfigsFiles,
+    event: { type: EVENTS.USER_TEST_NATIVE },
+    expect: {
+      state: STATES.TESTING_NATIVE,
+      sideEffectTypes: [
+        SIDE_EFFECTS.STOP_SIDECAR,
+        SIDE_EFFECTS.START_NATIVE_POLLER,
+        SIDE_EFFECTS.SEND_TEST_CARD,
+      ],
+    },
+  },
+  {
+    name: "USER_TEST_NATIVE @ IDLE without native config → illegal",
+    state: STATES.IDLE,
+    prefs: prefsOff,
+    files: emptyFiles,
+    event: { type: EVENTS.USER_TEST_NATIVE },
+    expect: { state: STATES.IDLE, sideEffectTypes: [], errorCode: ERROR_CODES.ILLEGAL_TRANSITION },
+  },
+  {
+    name: "USER_TEST_NATIVE @ NATIVE_ACTIVE → illegal (already active)",
+    state: STATES.NATIVE_ACTIVE,
+    prefs: prefsNativeVerified,
+    files: fullNativeFiles,
+    event: { type: EVENTS.USER_TEST_NATIVE },
+    expect: {
+      state: STATES.NATIVE_ACTIVE,
+      sideEffectTypes: [],
+      errorCode: ERROR_CODES.ILLEGAL_TRANSITION,
+    },
+  },
+  {
+    name: "USER_TEST_NATIVE @ TESTING_NATIVE → illegal (already testing)",
+    state: STATES.TESTING_NATIVE,
+    prefs: prefsOff,
+    files: fullNativeFiles,
+    event: { type: EVENTS.USER_TEST_NATIVE },
+    expect: {
+      state: STATES.TESTING_NATIVE,
+      sideEffectTypes: [],
+      errorCode: ERROR_CODES.ILLEGAL_TRANSITION,
+    },
+  },
+];
+
+// ============================================================================
+// TEST_SUCCESS / TEST_FAILED
+// ============================================================================
+const testOutcomeCases = [
+  {
+    name: "TEST_SUCCESS @ TESTING_NATIVE → NATIVE_ACTIVE + persist transport=native",
+    state: STATES.TESTING_NATIVE,
+    prefs: prefsOff,
+    files: fullNativeFiles,
+    event: { type: EVENTS.TEST_SUCCESS, at: 1700000123456 },
+    expect: {
+      state: STATES.NATIVE_ACTIVE,
+      sideEffectTypes: [SIDE_EFFECTS.PERSIST_PREFS],
+      prefsPatch: { transport: "native", nativeVerifiedAt: 1700000123456 },
+    },
+  },
+  {
+    name: "TEST_SUCCESS @ LEGACY_ACTIVE → illegal",
+    state: STATES.LEGACY_ACTIVE,
+    prefs: prefsLegacy,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.TEST_SUCCESS, at: 1700000000000 },
+    expect: {
+      state: STATES.LEGACY_ACTIVE,
+      sideEffectTypes: [],
+      errorCode: ERROR_CODES.ILLEGAL_TRANSITION,
+    },
+  },
+  {
+    name: "TEST_FAILED @ TESTING_NATIVE with legacy files → LEGACY_ACTIVE (restart sidecar)",
+    state: STATES.TESTING_NATIVE,
+    prefs: prefsLegacy,
+    files: bothConfigsFiles,
+    event: { type: EVENTS.TEST_FAILED, errorClass: "timeout" },
+    expect: {
+      state: STATES.LEGACY_ACTIVE,
+      sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER, SIDE_EFFECTS.START_SIDECAR],
+    },
+  },
+  {
+    name: "TEST_FAILED @ TESTING_NATIVE new user with native config only → IDLE",
+    state: STATES.TESTING_NATIVE,
+    prefs: prefsOff,
+    files: fullNativeFiles,
+    event: { type: EVENTS.TEST_FAILED, errorClass: "401" },
+    expect: {
+      state: STATES.IDLE,
+      sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER],
+    },
+  },
+  {
+    name: "TEST_FAILED @ TESTING_NATIVE no fallback config → NEEDS_SETUP",
+    state: STATES.TESTING_NATIVE,
+    prefs: prefsOff,
+    files: emptyFiles,
+    event: { type: EVENTS.TEST_FAILED, errorClass: "401" },
+    expect: {
+      state: STATES.NEEDS_SETUP,
+      sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER],
+    },
+  },
+  {
+    name: "TEST_FAILED @ IDLE → illegal",
+    state: STATES.IDLE,
+    prefs: prefsOff,
+    files: emptyFiles,
+    event: { type: EVENTS.TEST_FAILED, errorClass: "timeout" },
+    expect: { state: STATES.IDLE, sideEffectTypes: [], errorCode: ERROR_CODES.ILLEGAL_TRANSITION },
+  },
+  {
+    name: "TEST_TIMEOUT @ TESTING_NATIVE with legacy files → LEGACY_ACTIVE",
+    state: STATES.TESTING_NATIVE,
+    prefs: prefsLegacy,
+    files: bothConfigsFiles,
+    event: { type: EVENTS.TEST_TIMEOUT },
+    expect: {
+      state: STATES.LEGACY_ACTIVE,
+      sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER, SIDE_EFFECTS.START_SIDECAR],
+    },
+  },
+  {
+    name: "TEST_TIMEOUT @ TESTING_NATIVE new user → IDLE",
+    state: STATES.TESTING_NATIVE,
+    prefs: prefsOff,
+    files: fullNativeFiles,
+    event: { type: EVENTS.TEST_TIMEOUT },
+    expect: { state: STATES.IDLE, sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER] },
+  },
+  {
+    name: "TEST_TIMEOUT @ LEGACY_ACTIVE → illegal",
+    state: STATES.LEGACY_ACTIVE,
+    prefs: prefsLegacy,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.TEST_TIMEOUT },
+    expect: { state: STATES.LEGACY_ACTIVE, sideEffectTypes: [], errorCode: ERROR_CODES.ILLEGAL_TRANSITION },
+  },
+  {
+    name: "TEST_FAILED @ TESTING_NATIVE legacyEnabled=false → NEEDS_SETUP (NOT auto-restart sidecar)",
+    state: STATES.TESTING_NATIVE,
+    prefs: { ...prefsLegacy, legacyEnabled: false },
+    files: bothConfigsFiles,
+    event: { type: EVENTS.TEST_FAILED, errorClass: "401" },
+    // legacyEnabled === false ⇒ skip the sidecar restart path. Native config
+    // is also present so the user can retry test; we fall to IDLE.
+    expect: { state: STATES.IDLE, sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER] },
+  },
+];
+
+// ============================================================================
+// Rollback / sidecar lifecycle
+// ============================================================================
+const rollbackCases = [
+  {
+    name: "USER_ROLLBACK_TO_LEGACY @ NATIVE_ACTIVE with legacy env → SWITCHING_TO_LEGACY",
+    state: STATES.NATIVE_ACTIVE,
+    prefs: prefsNativeVerified,
+    files: bothConfigsFiles,
+    event: { type: EVENTS.USER_ROLLBACK_TO_LEGACY },
+    expect: {
+      state: STATES.SWITCHING_TO_LEGACY,
+      sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER, SIDE_EFFECTS.START_SIDECAR],
+    },
+  },
+  {
+    name: "USER_ROLLBACK_TO_LEGACY @ NATIVE_ACTIVE without legacy env → LEGACY_ENV_MISSING",
+    state: STATES.NATIVE_ACTIVE,
+    prefs: prefsNativeVerified,
+    files: fullNativeFiles,
+    event: { type: EVENTS.USER_ROLLBACK_TO_LEGACY },
+    expect: {
+      state: STATES.NATIVE_ACTIVE,
+      sideEffectTypes: [],
+      errorCode: ERROR_CODES.LEGACY_ENV_MISSING,
+    },
+  },
+  {
+    name: "USER_ROLLBACK_TO_LEGACY with env present but config incomplete → LEGACY_CONFIG_INCOMPLETE",
+    state: STATES.NATIVE_ACTIVE,
+    prefs: prefsNativeVerified,
+    files: { hasLegacyEnvFile: true, legacyConfigComplete: false, nativeConfigComplete: true },
+    event: { type: EVENTS.USER_ROLLBACK_TO_LEGACY },
+    expect: {
+      state: STATES.NATIVE_ACTIVE,
+      sideEffectTypes: [],
+      errorCode: ERROR_CODES.LEGACY_CONFIG_INCOMPLETE,
+    },
+  },
+  {
+    name: "USER_ENABLE_LEGACY @ IDLE with legacy config → LEGACY_ACTIVE + persist legacyEnabled=true",
+    state: STATES.IDLE,
+    prefs: prefsOff,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.USER_ENABLE_LEGACY },
+    expect: {
+      state: STATES.LEGACY_ACTIVE,
+      sideEffectTypes: [SIDE_EFFECTS.START_SIDECAR, SIDE_EFFECTS.PERSIST_PREFS],
+      prefsPatch: { transport: "legacy", legacyEnabled: true },
+    },
+  },
+  {
+    name: "USER_ENABLE_LEGACY @ NEEDS_SETUP with legacy config → LEGACY_ACTIVE",
+    state: STATES.NEEDS_SETUP,
+    prefs: prefsOff,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.USER_ENABLE_LEGACY },
+    expect: {
+      state: STATES.LEGACY_ACTIVE,
+      sideEffectTypes: [SIDE_EFFECTS.START_SIDECAR, SIDE_EFFECTS.PERSIST_PREFS],
+      prefsPatch: { transport: "legacy", legacyEnabled: true },
+    },
+  },
+  {
+    name: "USER_ENABLE_LEGACY @ IDLE without legacy config → LEGACY_CONFIG_INCOMPLETE",
+    state: STATES.IDLE,
+    prefs: prefsOff,
+    files: emptyFiles,
+    event: { type: EVENTS.USER_ENABLE_LEGACY },
+    expect: {
+      state: STATES.IDLE,
+      sideEffectTypes: [],
+      errorCode: ERROR_CODES.LEGACY_CONFIG_INCOMPLETE,
+    },
+  },
+  {
+    name: "USER_ENABLE_LEGACY @ NATIVE_ACTIVE → illegal (must rollback explicitly)",
+    state: STATES.NATIVE_ACTIVE,
+    prefs: prefsNativeVerified,
+    files: bothConfigsFiles,
+    event: { type: EVENTS.USER_ENABLE_LEGACY },
+    expect: {
+      state: STATES.NATIVE_ACTIVE,
+      sideEffectTypes: [],
+      errorCode: ERROR_CODES.ILLEGAL_TRANSITION,
+    },
+  },
+  {
+    name: "SIDECAR_STARTED @ SWITCHING_TO_LEGACY → LEGACY_ACTIVE + persist transport=legacy",
+    state: STATES.SWITCHING_TO_LEGACY,
+    prefs: prefsNativeVerified,
+    files: bothConfigsFiles,
+    event: { type: EVENTS.SIDECAR_STARTED },
+    expect: {
+      state: STATES.LEGACY_ACTIVE,
+      sideEffectTypes: [SIDE_EFFECTS.PERSIST_PREFS],
+      prefsPatch: { transport: "legacy" },
+    },
+  },
+  {
+    name: "SIDECAR_START_FAILED @ SWITCHING_TO_LEGACY → LEGACY_ACTIVE + EMIT_RUNTIME_STATUS",
+    state: STATES.SWITCHING_TO_LEGACY,
+    prefs: prefsNativeVerified,
+    files: bothConfigsFiles,
+    event: { type: EVENTS.SIDECAR_START_FAILED, reason: "binary_missing" },
+    expect: {
+      state: STATES.LEGACY_ACTIVE,
+      sideEffectTypes: [SIDE_EFFECTS.PERSIST_PREFS, SIDE_EFFECTS.EMIT_RUNTIME_STATUS],
+      prefsPatch: { transport: "legacy" },
+    },
+  },
+  {
+    name: "SIDECAR_STARTED @ LEGACY_ACTIVE → illegal",
+    state: STATES.LEGACY_ACTIVE,
+    prefs: prefsLegacy,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.SIDECAR_STARTED },
+    expect: {
+      state: STATES.LEGACY_ACTIVE,
+      sideEffectTypes: [],
+      errorCode: ERROR_CODES.ILLEGAL_TRANSITION,
+    },
+  },
+];
+
+// ============================================================================
+// USER_DISABLE (any → IDLE)
+// ============================================================================
+const disableCases = [
+  {
+    name: "USER_DISABLE @ LEGACY_ACTIVE → IDLE + STOP_SIDECAR + persist transport=off",
+    state: STATES.LEGACY_ACTIVE,
+    prefs: prefsLegacy,
+    files: fullLegacyFiles,
+    event: { type: EVENTS.USER_DISABLE },
+    expect: {
+      state: STATES.IDLE,
+      sideEffectTypes: [SIDE_EFFECTS.STOP_SIDECAR, SIDE_EFFECTS.PERSIST_PREFS],
+    },
+  },
+  {
+    name: "USER_DISABLE @ NATIVE_ACTIVE → IDLE + STOP_NATIVE_POLLER + persist transport=off",
+    state: STATES.NATIVE_ACTIVE,
+    prefs: prefsNativeVerified,
+    files: fullNativeFiles,
+    event: { type: EVENTS.USER_DISABLE },
+    expect: {
+      state: STATES.IDLE,
+      sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER, SIDE_EFFECTS.PERSIST_PREFS],
+    },
+  },
+  {
+    name: "USER_DISABLE @ TESTING_NATIVE → IDLE + STOP_NATIVE_POLLER",
+    state: STATES.TESTING_NATIVE,
+    prefs: prefsOff,
+    files: fullNativeFiles,
+    event: { type: EVENTS.USER_DISABLE },
+    expect: {
+      state: STATES.IDLE,
+      sideEffectTypes: [SIDE_EFFECTS.STOP_NATIVE_POLLER, SIDE_EFFECTS.PERSIST_PREFS],
+    },
+  },
+  {
+    name: "USER_DISABLE @ IDLE → IDLE (no-op, still persists off)",
+    state: STATES.IDLE,
+    prefs: prefsOff,
+    files: emptyFiles,
+    event: { type: EVENTS.USER_DISABLE },
+    expect: {
+      state: STATES.IDLE,
+      sideEffectTypes: [SIDE_EFFECTS.PERSIST_PREFS],
+    },
+  },
+];
+
+const ALL_CASES = [
+  ...initCases,
+  ...userTestCases,
+  ...testOutcomeCases,
+  ...rollbackCases,
+  ...disableCases,
+];
+
+module.exports = {
+  ALL_CASES,
+  initCases,
+  userTestCases,
+  testOutcomeCases,
+  rollbackCases,
+  disableCases,
+  fixtures: {
+    fullLegacyFiles,
+    fullNativeFiles,
+    bothConfigsFiles,
+    emptyFiles,
+    partialLegacyFiles,
+    prefsOff,
+    prefsUndecided,
+    prefsUndecidedOptIn,
+    prefsUndecidedOptOut,
+    prefsLegacy,
+    prefsNativeVerified,
+    prefsNativeUnverified,
+  },
+};

--- a/test/fakes/telegram-server.js
+++ b/test/fakes/telegram-server.js
@@ -1,0 +1,108 @@
+"use strict";
+
+// In-memory fake of the Telegram Bot API surface that the native client
+// touches. Drives the client through a queue of scripted responses; tests push
+// scenarios onto the queue and the fake replays them in order.
+//
+// Response shape mirrors the Bot API contract: every reply is either
+//   { ok: true, result: <any> }           — success
+// or
+//   { ok: false, status: <int>, error_code?: int, description?: string, parameters?: { retry_after?: int } }
+//
+// Tests can supply a function instead of a static response when they need to
+// branch on the request payload (e.g. polling offset progression).
+
+function createFakeTelegramServer() {
+  const scripts = [];
+  const calls = [];
+
+  function enqueue(method, response) {
+    scripts.push({ method, response });
+  }
+
+  function enqueueOk(method, result) {
+    enqueue(method, { ok: true, result });
+  }
+
+  function enqueueError(method, { status, code, description, parameters } = {}) {
+    enqueue(method, {
+      ok: false,
+      status: status ?? 500,
+      error_code: code ?? status ?? 500,
+      description: description || "",
+      parameters: parameters || {},
+    });
+  }
+
+  async function transport({ method, payload, signal }) {
+    if (signal && signal.aborted) {
+      throw makeAbortError();
+    }
+    // Note: the production transport closes over the bot token; the fake
+    // intentionally records only {method, payload} to mirror that contract.
+    calls.push({ method, payload });
+
+    const next = scripts.shift();
+    if (!next) {
+      throw new Error(`fake-telegram: no scripted response queued for ${method}`);
+    }
+    if (next.method && next.method !== method) {
+      throw new Error(`fake-telegram: expected next call to be ${next.method}, got ${method}`);
+    }
+
+    // Race the scripted response against the abort signal so mid-flight
+    // cancellation surfaces as AbortError (matching real fetch semantics).
+    const responsePromise = Promise.resolve(
+      typeof next.response === "function" ? next.response(payload) : next.response,
+    );
+    if (!signal) return responsePromise;
+
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      const onAbort = () => {
+        if (settled) return;
+        settled = true;
+        signal.removeEventListener("abort", onAbort);
+        reject(makeAbortError());
+      };
+      signal.addEventListener("abort", onAbort);
+      responsePromise.then(
+        (value) => {
+          if (settled) return;
+          settled = true;
+          signal.removeEventListener("abort", onAbort);
+          resolve(value);
+        },
+        (err) => {
+          if (settled) return;
+          settled = true;
+          signal.removeEventListener("abort", onAbort);
+          reject(err);
+        },
+      );
+    });
+  }
+
+  function makeAbortError() {
+    const err = new Error("aborted");
+    err.name = "AbortError";
+    return err;
+  }
+
+  return {
+    transport,
+    enqueue,
+    enqueueOk,
+    enqueueError,
+    calls,
+    get pending() {
+      return scripts.length;
+    },
+    reset() {
+      scripts.length = 0;
+      calls.length = 0;
+    },
+  };
+}
+
+module.exports = { createFakeTelegramServer };

--- a/test/permission-autoclose-dismiss.test.js
+++ b/test/permission-autoclose-dismiss.test.js
@@ -125,8 +125,10 @@ describe("permission autoclose: no-decision dismiss semantics", () => {
 
   it("notifies when a resolved permission leaves the pending list", () => {
     const changes = [];
+    const resolved = [];
     const ctx = makeCtx({
       onPermissionsChanged: (reason) => changes.push(reason),
+      onPermissionResolved: (entry, meta) => resolved.push({ entry, meta }),
     });
     const { resolvePermissionEntry, pendingPermissions } = initPermission(ctx);
     const permEntry = makePermEntry();
@@ -135,7 +137,30 @@ describe("permission autoclose: no-decision dismiss semantics", () => {
     resolvePermissionEntry(permEntry, "allow");
 
     assert.deepEqual(changes, ["resolved"]);
+    assert.deepEqual(resolved, [{
+      entry: permEntry,
+      meta: { reason: "resolved", hasPendingForSession: false },
+    }]);
     assert.equal(pendingPermissions.indexOf(permEntry), -1);
+  });
+
+  it("reports when another permission for the same session is still pending", () => {
+    const resolved = [];
+    const ctx = makeCtx({
+      onPermissionResolved: (entry, meta) => resolved.push({ entry, meta }),
+    });
+    const { resolvePermissionEntry, pendingPermissions } = initPermission(ctx);
+    const first = makePermEntry({ sessionId: "same-session" });
+    const second = makePermEntry({ sessionId: "same-session" });
+    pendingPermissions.push(first, second);
+
+    resolvePermissionEntry(first, "allow");
+
+    assert.deepEqual(resolved, [{
+      entry: first,
+      meta: { reason: "resolved", hasPendingForSession: true },
+    }]);
+    assert.deepEqual(pendingPermissions, [second]);
   });
 
   it("notifies when a permission enters the pending list through the runtime helper", () => {

--- a/test/permission-telegram-approval.test.js
+++ b/test/permission-telegram-approval.test.js
@@ -102,6 +102,7 @@ describe("permission telegram remote approval", () => {
   it("sends a conservative payload and resolves allow without a message", async () => {
     let resolveApproval;
     const requests = [];
+    const resolved = [];
     const client = {
       isEnabled: () => true,
       requestApproval: (payload, options) => {
@@ -109,7 +110,10 @@ describe("permission telegram remote approval", () => {
         return new Promise((resolve) => { resolveApproval = resolve; });
       },
     };
-    const perm = initPermission(makeCtx({ getTelegramApprovalClient: () => client }));
+    const perm = initPermission(makeCtx({
+      getTelegramApprovalClient: () => client,
+      onPermissionResolved: (entry, meta) => resolved.push({ entry, meta }),
+    }));
     const entry = makePermEntry({
       toolInput: {
         command: "npm test -- --token sk-1234567890123456",
@@ -135,6 +139,12 @@ describe("permission telegram remote approval", () => {
     await flush();
 
     assert.equal(perm.pendingPermissions.length, 0);
+    assert.equal(resolved.length, 1);
+    assert.equal(resolved[0].entry, entry);
+    assert.deepEqual(resolved[0].meta, {
+      reason: "resolved",
+      hasPendingForSession: false,
+    });
     const body = JSON.parse(entry.res.captured.body);
     assert.deepEqual(body.hookSpecificOutput.decision, { behavior: "allow" });
   });

--- a/test/settings-actions.test.js
+++ b/test/settings-actions.test.js
@@ -488,6 +488,34 @@ describe("telegram approval commands", () => {
     const missing = await commandRegistry["telegramApproval.tokenInfo"](null, {});
     assert.equal(missing.status, "error");
   });
+
+  it("telegramMigration.dispatch only accepts renderer-callable user events", async () => {
+    const calls = [];
+    const deps = {
+      telegramMigration: {
+        getSnapshot: () => ({ state: "TESTING_NATIVE" }),
+        dispatch: async (event) => {
+          calls.push(event);
+          return { ok: true, state: "TESTING_NATIVE" };
+        },
+      },
+    };
+
+    const allowed = await commandRegistry["telegramMigration.dispatch"](
+      { type: "USER_TEST_NATIVE" },
+      deps,
+    );
+    assert.strictEqual(allowed.status, "ok");
+    assert.deepStrictEqual(calls, [{ type: "USER_TEST_NATIVE" }]);
+
+    const blocked = await commandRegistry["telegramMigration.dispatch"](
+      { type: "TEST_SUCCESS", at: 123 },
+      deps,
+    );
+    assert.strictEqual(blocked.status, "error");
+    assert.strictEqual(blocked.errorCode, "EVENT_NOT_ALLOWED");
+    assert.deepStrictEqual(calls, [{ type: "USER_TEST_NATIVE" }]);
+  });
 });
 
 describe("bubble policy commands", () => {

--- a/test/settings-actions.test.js
+++ b/test/settings-actions.test.js
@@ -489,6 +489,31 @@ describe("telegram approval commands", () => {
     assert.equal(missing.status, "error");
   });
 
+  it("telegramApproval.deleteTokenFile proxies the guarded main-process helper", async () => {
+    const calls = [];
+    const result = await commandRegistry["telegramApproval.deleteTokenFile"](null, {
+      deleteTelegramApprovalTokenFile: async () => {
+        calls.push(true);
+        return { status: "ok", deleted: true };
+      },
+    });
+    assert.deepStrictEqual(result, { status: "ok", deleted: true });
+    assert.deepStrictEqual(calls, [true]);
+
+    const guarded = await commandRegistry["telegramApproval.deleteTokenFile"](null, {
+      deleteTelegramApprovalTokenFile: async () => ({
+        status: "error",
+        code: "TOKEN_FILE_IN_USE",
+        message: "Native Telegram currently uses the shared token file.",
+      }),
+    });
+    assert.strictEqual(guarded.status, "error");
+    assert.strictEqual(guarded.code, "TOKEN_FILE_IN_USE");
+
+    const missing = await commandRegistry["telegramApproval.deleteTokenFile"](null, {});
+    assert.equal(missing.status, "error");
+  });
+
   it("telegramMigration.dispatch only accepts renderer-callable user events", async () => {
     const calls = [];
     const deps = {

--- a/test/settings-ipc.test.js
+++ b/test/settings-ipc.test.js
@@ -241,6 +241,10 @@ test("settings IPC delegates controller and size preview handlers", async () => 
     key: "size",
     value: "P:20",
   });
+  assert.deepStrictEqual(await ipcMain.invoke("settings:update", { key: "tgMigration", value: { transport: "native" } }), {
+    status: "error",
+    message: "tgMigration is internal; use telegramMigration.dispatch",
+  });
   assert.deepStrictEqual(await ipcMain.invoke("settings:command", { action: "resizePet", payload: "P:30" }), {
     status: "ok",
   });

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -1413,6 +1413,72 @@ describe("settings renderer browser environment", () => {
     assert.equal(harness.renderRequests.length, beforeStatusResolve + 2);
   });
 
+  it("wires the native migration delete-token button to a real command", async () => {
+    const commandCalls = [];
+    const toastMessages = [];
+    const harness = loadTelegramApprovalTabForTest({
+      snapshot: {
+        tgApproval: {
+          enabled: false,
+          allowedTgUserId: "123456789",
+          targetSessionKey: "telegram:123456789",
+        },
+      },
+      settingsAPI: {
+        command: (name, payload) => {
+          commandCalls.push({ name, payload });
+          if (name === "telegramMigration.snapshot") {
+            return Promise.resolve({
+              status: "ok",
+              snapshot: {
+                state: "NATIVE_ACTIVE",
+                runtimeStatus: { status: "running" },
+                ownerSnapshot: { sidecarRunning: false, nativePolling: true },
+                migrationInfo: {},
+                nativeVerifiedAt: 123,
+              },
+            });
+          }
+          if (name === "telegramApproval.status") {
+            return Promise.resolve({ status: "ok", state: { status: "stopped", tokenStored: true } });
+          }
+          if (name === "telegramApproval.tokenInfo") {
+            return Promise.resolve({ status: "ok", configured: true, masked: "1234……wXyZ" });
+          }
+          if (name === "telegramApproval.deleteTokenFile") {
+            return Promise.resolve({ status: "ok", deleted: true });
+          }
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+    });
+    harness.core.ops.showToast = (message, options = {}) => {
+      toastMessages.push({ message, options });
+    };
+
+    await Promise.resolve();
+    await Promise.resolve();
+    harness.render();
+
+    const deleteButton = harness.content
+      .querySelectorAll("button")
+      .find((button) => button.textContent === "Delete legacy token file");
+    assert.ok(deleteButton, "delete legacy token button should render for NATIVE_ACTIVE");
+
+    deleteButton.dispatchEvent({ type: "click" });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(
+      commandCalls.some((call) => call.name === "telegramApproval.deleteTokenFile"),
+      true,
+    );
+    assert.equal(
+      toastMessages.some((toast) => /deleted/i.test(toast.message)),
+      true,
+    );
+  });
+
   it("wires Clawd Doctor through Settings with Step 2 connection actions", () => {
     const html = fs.readFileSync(SETTINGS_HTML, "utf8");
     const css = fs.readFileSync(SETTINGS_CSS, "utf8");

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -937,6 +937,41 @@ describe("updateSession()", () => {
     assert.ok(!api.sessions.has("s0"));
   });
 
+  it("Codex PermissionRequest without an existing session does not persist notification", () => {
+    update(api, {
+      id: "codex:new-permission",
+      state: "notification",
+      event: "PermissionRequest",
+      agentId: "codex",
+      sourcePid: 456,
+      cwd: "/repo",
+    });
+
+    assert.strictEqual(api.getCurrentState(), "notification");
+    assert.strictEqual(api.sessions.get("codex:new-permission").state, "idle");
+    assert.strictEqual(api.resolveDisplayState(), "idle");
+
+    mock.timers.tick(5000);
+
+    assert.strictEqual(api.getCurrentState(), "idle");
+  });
+
+  it("clearPermissionNotification releases a persisted notification session immediately", () => {
+    api.sessions.set("codex:stale-permission", rawSession("notification", {
+      agentId: "codex",
+      sourcePid: 456,
+      pidReachable: true,
+    }));
+    api.setState("notification");
+
+    assert.strictEqual(api.getCurrentState(), "notification");
+
+    assert.strictEqual(api.clearPermissionNotification("codex:stale-permission"), true);
+
+    assert.strictEqual(api.sessions.get("codex:stale-permission").state, "idle");
+    assert.strictEqual(api.getCurrentState(), "idle");
+  });
+
   it("SessionEnd + sweeping → plays sweeping even with other active sessions", () => {
     // Insert sessions directly to avoid MIN_DISPLAY_MS cascade from setState
     api.sessions.set("s1", rawSession("working"));

--- a/test/telegram-approval-settings.test.js
+++ b/test/telegram-approval-settings.test.js
@@ -231,10 +231,17 @@ test("invariant: Clawd source never reads process.env.CLAWD_TG_BOT_TOKEN", () =>
   // content for the sidecar to read) and in src/telegram-approval-sidecar.js
   // (handshake constants and child env stripping). What's forbidden is
   // process.env access to that specific name in Clawd's own code.
+  const srcDir = path.join(__dirname, "..", "src");
+  // Cover main.js plus every src/telegram-*.js (sidecar, settings, the new
+  // native-client / owner-manager / migration-state / token-store added in
+  // the v0.9.0 spike) so future Telegram modules can't silently regress this
+  // invariant.
   const sourceFiles = [
-    path.join(__dirname, "..", "src", "main.js"),
-    path.join(__dirname, "..", "src", "telegram-approval-sidecar.js"),
-    path.join(__dirname, "..", "src", "telegram-approval-settings.js"),
+    path.join(srcDir, "main.js"),
+    ...fs
+      .readdirSync(srcDir)
+      .filter((name) => /^telegram-.*\.js$/.test(name))
+      .map((name) => path.join(srcDir, name)),
   ];
   const offenders = [];
   const needle = "process.env.CLAWD_TG_BOT_TOKEN";

--- a/test/telegram-migration-controller.test.js
+++ b/test/telegram-migration-controller.test.js
@@ -1,0 +1,199 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  createTelegramMigrationController,
+} = require("../src/telegram-migration-controller");
+const { STATES, EVENTS } = require("../src/telegram-migration-state");
+
+class FakeSidecar {
+  constructor() { this.running = false; this.stopCalls = []; }
+  isRunning() { return this.running; }
+  async start() { this.running = true; }
+  async stop() { this.stopCalls.push(true); this.running = false; }
+}
+
+class FakeNative {
+  constructor() { this.polling = false; this.cards = []; }
+  isPolling() { return this.polling; }
+  async start() { this.polling = true; }
+  async stop() { this.polling = false; }
+  async sendTestCard(payload) { this.cards.push(payload); }
+}
+
+function makeController(overrides = {}) {
+  const sidecar = new FakeSidecar();
+  const native = new FakeNative();
+  let prefsState = { ...overrides.initialPrefs };
+  let filesState = { ...overrides.initialFiles };
+  const persisted = [];
+  const timers = [];
+  const ctrl = createTelegramMigrationController({
+    sidecar,
+    native,
+    readPrefs: () => prefsState,
+    writePrefs: async (patch) => { prefsState = { ...prefsState, ...patch }; persisted.push(patch); },
+    readFiles: () => filesState,
+    settleMs: 0,
+    stopGraceMs: 0,
+    setTimer: (cb, ms) => { const t = { cb, ms, cancelled: false }; timers.push(t); return t; },
+    clearTimer: (t) => { if (t) t.cancelled = true; },
+    log: () => {},
+    ...overrides.opts,
+  });
+  return { ctrl, sidecar, native, persisted,
+    setFiles(f) { filesState = { ...filesState, ...f }; },
+    setPrefs(p) { prefsState = { ...prefsState, ...p }; },
+    getPrefs: () => prefsState,
+    fireTimer: async () => {
+      const t = timers.find((x) => !x.cancelled && !x.fired);
+      if (!t) throw new Error("no pending timer");
+      t.fired = true;
+      t.cb();
+      // Let async dispatch + manager.apply chain settle.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+    },
+    pendingTimer: () => timers.find((x) => !x.cancelled && !x.fired) || null,
+  };
+}
+
+test("init: legacy user with full env → LEGACY_ACTIVE + starts sidecar", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true },
+  });
+  const state = await env.ctrl.init();
+  assert.equal(state, STATES.LEGACY_ACTIVE);
+  assert.equal(env.sidecar.running, true);
+});
+
+test("init: fresh user → IDLE, nothing started", async () => {
+  const env = makeController({ initialFiles: {} });
+  const state = await env.ctrl.init();
+  assert.equal(state, STATES.IDLE);
+  assert.equal(env.sidecar.running, false);
+  assert.equal(env.native.polling, false);
+});
+
+test("init: v0.8 opt-out user (legacyEnabled=false) → IDLE NOT re-activated", async () => {
+  const env = makeController({
+    initialPrefs: { legacyEnabled: false },
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true },
+  });
+  const state = await env.ctrl.init();
+  assert.equal(state, STATES.IDLE);
+  assert.equal(env.sidecar.running, false);
+});
+
+test("dispatch USER_TEST_NATIVE from LEGACY_ACTIVE: stops sidecar, starts native, sends test card", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true },
+  });
+  await env.ctrl.init();
+  assert.equal(env.sidecar.running, true);
+
+  const res = await env.ctrl.dispatch({ type: EVENTS.USER_TEST_NATIVE });
+  assert.equal(res.ok, true);
+  assert.equal(res.state, STATES.TESTING_NATIVE);
+  assert.equal(env.sidecar.running, false);
+  assert.equal(env.native.polling, true);
+  assert.equal(env.native.cards.length, 1);
+});
+
+test("dispatch TEST_SUCCESS from TESTING_NATIVE: persists transport=native + clears test timer", async () => {
+  const env = makeController({
+    initialFiles: { nativeConfigComplete: true },
+  });
+  await env.ctrl.init();
+  await env.ctrl.dispatch({ type: EVENTS.USER_TEST_NATIVE });
+  const res = await env.ctrl.dispatch({ type: EVENTS.TEST_SUCCESS, at: 12345 });
+  assert.equal(res.ok, true);
+  assert.equal(res.state, STATES.NATIVE_ACTIVE);
+  const persistedPatches = env.persisted;
+  const lastPatch = persistedPatches[persistedPatches.length - 1];
+  assert.equal(lastPatch.transport, "native");
+  assert.equal(lastPatch.nativeVerifiedAt, 12345);
+});
+
+test("dispatch USER_ROLLBACK_TO_LEGACY auto-finalizes after sidecar start", async () => {
+  const env = makeController({
+    initialPrefs: { transport: "native", nativeVerifiedAt: 1 },
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true },
+  });
+  await env.ctrl.init();
+  assert.equal(env.native.polling, true);
+
+  const res = await env.ctrl.dispatch({ type: EVENTS.USER_ROLLBACK_TO_LEGACY });
+  assert.equal(res.ok, true);
+  assert.equal(res.state, STATES.LEGACY_ACTIVE);
+  assert.equal(env.native.polling, false);
+  assert.equal(env.sidecar.running, true);
+  assert.equal(env.persisted.at(-1).transport, "legacy");
+});
+
+test("dispatch USER_ROLLBACK_TO_LEGACY records failed legacy runtime when sidecar start returns false", async () => {
+  const env = makeController({
+    initialPrefs: { transport: "native", nativeVerifiedAt: 1 },
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true },
+  });
+  env.sidecar.start = async () => false;
+  await env.ctrl.init();
+
+  const res = await env.ctrl.dispatch({ type: EVENTS.USER_ROLLBACK_TO_LEGACY });
+  assert.equal(res.ok, false);
+  assert.equal(res.state, STATES.LEGACY_ACTIVE);
+  assert.equal(env.native.polling, false);
+  const snap = env.ctrl.getSnapshot();
+  assert.equal(snap.runtimeStatus.status, "failed");
+  assert.equal(env.persisted.at(-1).transport, "legacy");
+});
+
+test("dispatch: illegal event returns ok:false + errorCode + state unchanged", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true },
+  });
+  await env.ctrl.init();
+  const res = await env.ctrl.dispatch({ type: EVENTS.TEST_SUCCESS });
+  assert.equal(res.ok, false);
+  assert.equal(res.errorCode, "ILLEGAL_TRANSITION");
+  assert.equal(res.state, STATES.LEGACY_ACTIVE);
+});
+
+test("test timer is armed on entering TESTING_NATIVE and cancelled on success", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true },
+  });
+  await env.ctrl.init();
+  await env.ctrl.dispatch({ type: EVENTS.USER_TEST_NATIVE });
+  assert.ok(env.pendingTimer(), "timer should be armed in TESTING_NATIVE");
+
+  await env.ctrl.dispatch({ type: EVENTS.TEST_SUCCESS, at: 1 });
+  assert.equal(env.pendingTimer(), null, "successful test should cancel timer");
+});
+
+test("test timer firing dispatches TEST_TIMEOUT → falls back to LEGACY_ACTIVE", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true },
+  });
+  await env.ctrl.init();
+  await env.ctrl.dispatch({ type: EVENTS.USER_TEST_NATIVE });
+  await env.fireTimer();
+  const snap = env.ctrl.getSnapshot();
+  assert.equal(snap.state, STATES.LEGACY_ACTIVE);
+  assert.equal(env.sidecar.running, true);
+});
+
+test("getSnapshot exposes state + runtime status + owner snapshot", async () => {
+  const env = makeController({});
+  await env.ctrl.init();
+  const snap = env.ctrl.getSnapshot();
+  assert.equal(snap.state, STATES.IDLE);
+  assert.equal(typeof snap.ownerSnapshot.sidecarRunning, "boolean");
+  assert.equal(typeof snap.ownerSnapshot.nativePolling, "boolean");
+  // Undecided prefs surface as transport=undefined, not "off" (we distinguish
+  // "user explicitly disabled" from "v0.8 user with no transport key yet").
+  assert.equal(snap.transport, undefined);
+});

--- a/test/telegram-migration-state.test.js
+++ b/test/telegram-migration-state.test.js
@@ -1,0 +1,179 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  STATES,
+  EVENTS,
+  SIDE_EFFECTS,
+  ERROR_CODES,
+  defaultPrefs,
+  defaultFiles,
+  normalizePrefs,
+  normalizeFiles,
+  applyEvent,
+  computeInitial,
+  checkInvariants,
+} = require("../src/telegram-migration-state");
+
+const { ALL_CASES } = require("./fakes/migration-transitions");
+
+function effectTypes(fx) {
+  return (fx || []).map((e) => e && e.type).filter(Boolean);
+}
+
+test("normalizePrefs handles undefined/null/invalid transport", () => {
+  const out = normalizePrefs(undefined);
+  assert.equal(out.prefs.transport, "off");
+  assert.equal(out.normalized, true);
+
+  const out2 = normalizePrefs({ transport: "garbage" });
+  assert.equal(out2.prefs.transport, "off");
+  assert.equal(out2.normalized, true);
+
+  const out3 = normalizePrefs({ transport: "legacy" });
+  assert.equal(out3.prefs.transport, "legacy");
+  assert.equal(out3.normalized, false);
+});
+
+test("normalizeFiles tolerates missing input", () => {
+  assert.deepEqual(normalizeFiles(undefined), defaultFiles());
+  assert.deepEqual(normalizeFiles(null), defaultFiles());
+  assert.deepEqual(
+    normalizeFiles({ hasLegacyEnvFile: 1, legacyConfigComplete: "yes", nativeConfigComplete: 0 }),
+    { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: false },
+  );
+});
+
+test("defaultPrefs / defaultFiles are stable", () => {
+  assert.equal(defaultPrefs().transport, "off");
+  assert.equal(defaultPrefs().nativeVerifiedAt, null);
+  assert.deepEqual(defaultFiles(), {
+    hasLegacyEnvFile: false,
+    legacyConfigComplete: false,
+    nativeConfigComplete: false,
+  });
+});
+
+for (const c of ALL_CASES) {
+  test(c.name, () => {
+    const ctx = { state: c.state, prefs: c.prefs, files: c.files };
+    const result =
+      c.event.type === EVENTS.INIT
+        ? computeInitial({ prefs: c.prefs, files: c.files })
+        : applyEvent(ctx, c.event);
+
+    assert.equal(result.state, c.expect.state, `state mismatch for ${c.name}`);
+    assert.deepEqual(
+      effectTypes(result.sideEffects),
+      c.expect.sideEffectTypes,
+      `sideEffectTypes mismatch for ${c.name}`,
+    );
+
+    if (c.expect.errorCode !== undefined) {
+      assert.equal(result.errorCode, c.expect.errorCode, `errorCode mismatch for ${c.name}`);
+    } else {
+      assert.equal(result.errorCode, null, `unexpected errorCode for ${c.name}`);
+    }
+
+    if (c.expect.prefsPatch) {
+      assert.deepEqual(result.prefsPatch, c.expect.prefsPatch, `prefsPatch mismatch for ${c.name}`);
+    }
+
+    // Invariant: mutual exclusion must never be violated by emitted side effects.
+    const violations = checkInvariants(result);
+    assert.deepEqual(violations, [], `invariant violations: ${violations.join("; ")}`);
+
+    // Invariant: illegal transitions return the same state unchanged.
+    if (c.expect.errorCode === ERROR_CODES.ILLEGAL_TRANSITION) {
+      assert.equal(result.state, c.state, "illegal event must leave state unchanged");
+      assert.deepEqual(result.sideEffects, [], "illegal event must emit no side effects");
+    }
+  });
+}
+
+test("applyEvent: unknown event type → illegal, state unchanged", () => {
+  const result = applyEvent(
+    { state: STATES.LEGACY_ACTIVE, prefs: { transport: "legacy" }, files: { legacyConfigComplete: true } },
+    { type: "UNKNOWN_NOISE" },
+  );
+  assert.equal(result.state, STATES.LEGACY_ACTIVE);
+  assert.equal(result.errorCode, ERROR_CODES.ILLEGAL_TRANSITION);
+  assert.deepEqual(result.sideEffects, []);
+});
+
+test("applyEvent: missing event → illegal, state unchanged", () => {
+  const result = applyEvent({ state: STATES.NATIVE_ACTIVE, prefs: {}, files: {} }, null);
+  assert.equal(result.state, STATES.NATIVE_ACTIVE);
+  assert.equal(result.errorCode, ERROR_CODES.ILLEGAL_TRANSITION);
+});
+
+test("checkInvariants flags simultaneous START_SIDECAR + START_NATIVE_POLLER", () => {
+  const violations = checkInvariants({
+    state: STATES.TESTING_NATIVE,
+    sideEffects: [
+      { type: SIDE_EFFECTS.START_SIDECAR },
+      { type: SIDE_EFFECTS.START_NATIVE_POLLER },
+    ],
+  });
+  assert.equal(violations.length, 1);
+  assert.match(violations[0], /START_SIDECAR and START_NATIVE_POLLER/);
+});
+
+test("Full migration happy path: IDLE → TESTING_NATIVE → NATIVE_ACTIVE", () => {
+  let state = STATES.IDLE;
+  let prefs = defaultPrefs();
+  const files = { hasLegacyEnvFile: false, legacyConfigComplete: false, nativeConfigComplete: true };
+
+  const r1 = applyEvent({ state, prefs, files }, { type: EVENTS.USER_TEST_NATIVE });
+  assert.equal(r1.state, STATES.TESTING_NATIVE);
+  state = r1.state;
+
+  const r2 = applyEvent({ state, prefs, files }, { type: EVENTS.TEST_SUCCESS, at: 1234567890 });
+  assert.equal(r2.state, STATES.NATIVE_ACTIVE);
+  assert.deepEqual(r2.prefsPatch, { transport: "native", nativeVerifiedAt: 1234567890 });
+  prefs = { ...prefs, ...r2.prefsPatch };
+  state = r2.state;
+
+  // After restart: INIT should rehydrate to NATIVE_ACTIVE.
+  const r3 = computeInitial({ prefs, files });
+  assert.equal(r3.state, STATES.NATIVE_ACTIVE);
+  assert.deepEqual(effectTypes(r3.sideEffects), [SIDE_EFFECTS.START_NATIVE_POLLER]);
+});
+
+test("Legacy migration path: LEGACY_ACTIVE → TESTING_NATIVE → TEST_FAILED → LEGACY_ACTIVE", () => {
+  let state = STATES.LEGACY_ACTIVE;
+  const prefs = { transport: "legacy", nativeVerifiedAt: null, migration: {} };
+  const files = { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true };
+
+  const r1 = applyEvent({ state, prefs, files }, { type: EVENTS.USER_TEST_NATIVE });
+  assert.equal(r1.state, STATES.TESTING_NATIVE);
+  assert.deepEqual(effectTypes(r1.sideEffects), [
+    SIDE_EFFECTS.STOP_SIDECAR,
+    SIDE_EFFECTS.START_NATIVE_POLLER,
+    SIDE_EFFECTS.SEND_TEST_CARD,
+  ]);
+  state = r1.state;
+
+  const r2 = applyEvent({ state, prefs, files }, { type: EVENTS.TEST_FAILED, errorClass: "401" });
+  assert.equal(r2.state, STATES.LEGACY_ACTIVE);
+  assert.deepEqual(effectTypes(r2.sideEffects), [
+    SIDE_EFFECTS.STOP_NATIVE_POLLER,
+    SIDE_EFFECTS.START_SIDECAR,
+  ]);
+});
+
+test("Rollback path: NATIVE_ACTIVE → SWITCHING_TO_LEGACY → LEGACY_ACTIVE", () => {
+  let state = STATES.NATIVE_ACTIVE;
+  let prefs = { transport: "native", nativeVerifiedAt: 1, migration: {} };
+  const files = { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true };
+
+  const r1 = applyEvent({ state, prefs, files }, { type: EVENTS.USER_ROLLBACK_TO_LEGACY });
+  assert.equal(r1.state, STATES.SWITCHING_TO_LEGACY);
+  state = r1.state;
+
+  const r2 = applyEvent({ state, prefs, files }, { type: EVENTS.SIDECAR_STARTED });
+  assert.equal(r2.state, STATES.LEGACY_ACTIVE);
+  assert.deepEqual(r2.prefsPatch, { transport: "legacy" });
+});

--- a/test/telegram-native-client.test.js
+++ b/test/telegram-native-client.test.js
@@ -1,0 +1,360 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  TelegramNativeClient,
+  TelegramApiError,
+  ERROR_CLASSES,
+  classifyError,
+  pollWithConflictRetry,
+  DEFAULT_RETRY_OPTS,
+} = require("../src/telegram-native-client");
+const { createFakeTelegramServer } = require("./fakes/telegram-server");
+
+const VALID_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ-_0123456789";
+
+function fakeTokenStore(token = VALID_TOKEN) {
+  return {
+    async getToken() { return token; },
+    async hasToken() { return !!token; },
+  };
+}
+
+function makeClient({ token = VALID_TOKEN } = {}) {
+  const server = createFakeTelegramServer();
+  const client = new TelegramNativeClient({
+    tokenStore: fakeTokenStore(token),
+    transport: server.transport,
+  });
+  return { client, server };
+}
+
+test("constructor rejects missing tokenStore / transport", () => {
+  assert.throws(() => new TelegramNativeClient({}), /tokenStore.getToken is required/);
+  assert.throws(
+    () => new TelegramNativeClient({ tokenStore: fakeTokenStore() }),
+    /transport function is required/,
+  );
+});
+
+test("sendMessage: success returns result; token is NOT in transport args", async () => {
+  const { client, server } = makeClient();
+  server.enqueueOk("sendMessage", { message_id: 42, chat: { id: 1 } });
+  const result = await client.sendMessage({ chat_id: 1, text: "hi" });
+  assert.equal(result.message_id, 42);
+  assert.equal(server.calls.length, 1);
+  assert.equal(server.calls[0].token, undefined, "token must not be forwarded in per-call args");
+  assert.deepEqual(server.calls[0].payload, { chat_id: 1, text: "hi" });
+});
+
+test("getMe / answerCallbackQuery / editMessageReplyMarkup roundtrip", async () => {
+  const { client, server } = makeClient();
+  server.enqueueOk("getMe", { id: 9, username: "fake_bot" });
+  server.enqueueOk("answerCallbackQuery", true);
+  server.enqueueOk("editMessageReplyMarkup", { message_id: 11 });
+
+  assert.equal((await client.getMe()).username, "fake_bot");
+  assert.equal(await client.answerCallbackQuery({ callback_query_id: "x" }), true);
+  assert.equal((await client.editMessageReplyMarkup({ chat_id: 1, message_id: 11 })).message_id, 11);
+});
+
+test("getUpdates advances offset to lastUpdate.update_id + 1", async () => {
+  const { client, server } = makeClient();
+  server.enqueueOk("getUpdates", [
+    { update_id: 100 },
+    { update_id: 105 },
+  ]);
+  server.enqueueOk("getUpdates", []);
+  server.enqueueOk("getUpdates", [{ update_id: 200 }]);
+
+  assert.equal(client.offset, 0);
+  await client.getUpdates();
+  assert.equal(client.offset, 106);
+  await client.getUpdates();
+  assert.equal(client.offset, 106, "empty batch must not regress offset");
+  assert.equal(server.calls[1].payload.offset, 106);
+  await client.getUpdates();
+  assert.equal(client.offset, 201);
+});
+
+test("Missing token throws TOKEN_MISSING (does not call transport)", async () => {
+  const server = createFakeTelegramServer();
+  const client = new TelegramNativeClient({
+    tokenStore: { async getToken() { return null; }, async hasToken() { return false; } },
+    transport: server.transport,
+  });
+  await assert.rejects(
+    () => client.getMe(),
+    (err) => {
+      assert.ok(err instanceof TelegramApiError);
+      assert.equal(classifyError(err), ERROR_CLASSES.TOKEN_MISSING);
+      return true;
+    },
+  );
+  assert.equal(server.calls.length, 0);
+});
+
+test("Error classes: 401 unauthorized", async () => {
+  const { client, server } = makeClient();
+  server.enqueueError("sendMessage", { status: 401, description: "Unauthorized" });
+  const err = await client.sendMessage({ chat_id: 1, text: "x" }).catch((e) => e);
+  assert.equal(classifyError(err), ERROR_CLASSES.UNAUTHORIZED);
+});
+
+test("Error classes: 403 forbidden (bot blocked / not started)", async () => {
+  const { client, server } = makeClient();
+  server.enqueueError("sendMessage", {
+    status: 403,
+    description: "Forbidden: bot was blocked by the user",
+  });
+  const err = await client.sendMessage({ chat_id: 1, text: "x" }).catch((e) => e);
+  assert.equal(classifyError(err), ERROR_CLASSES.FORBIDDEN);
+});
+
+test("Error classes: 400 bad request", async () => {
+  const { client, server } = makeClient();
+  server.enqueueError("sendMessage", { status: 400, description: "Bad Request: chat not found" });
+  const err = await client.sendMessage({ chat_id: 999, text: "x" }).catch((e) => e);
+  assert.equal(classifyError(err), ERROR_CLASSES.BAD_REQUEST);
+});
+
+test("Error classes: 409 conflict (another consumer polling)", async () => {
+  const { client, server } = makeClient();
+  server.enqueueError("getUpdates", {
+    status: 409,
+    description: "Conflict: terminated by other getUpdates request",
+  });
+  const err = await client.getUpdates().catch((e) => e);
+  assert.equal(classifyError(err), ERROR_CLASSES.CONFLICT);
+});
+
+test("Error classes: 409 webhook conflict (distinct class)", async () => {
+  const { client, server } = makeClient();
+  server.enqueueError("getUpdates", {
+    status: 409,
+    description: "Conflict: can't use getUpdates method while webhook is active",
+  });
+  const err = await client.getUpdates().catch((e) => e);
+  assert.equal(classifyError(err), ERROR_CLASSES.WEBHOOK_CONFLICT);
+  assert.match(err.description, /webhook/);
+});
+
+test("Error classes: 429 rate limited exposes retry_after", async () => {
+  const { client, server } = makeClient();
+  server.enqueueError("sendMessage", {
+    status: 429,
+    description: "Too Many Requests",
+    parameters: { retry_after: 5 },
+  });
+  const err = await client.sendMessage({ chat_id: 1, text: "x" }).catch((e) => e);
+  assert.equal(classifyError(err), ERROR_CLASSES.RATE_LIMITED);
+  assert.equal(err.parameters.retry_after, 5);
+});
+
+test("Error classes: 429 with retry_after=60 (>30s, UI shows wait prompt)", async () => {
+  const { client, server } = makeClient();
+  server.enqueueError("sendMessage", {
+    status: 429,
+    description: "Too Many Requests",
+    parameters: { retry_after: 60 },
+  });
+  const err = await client.sendMessage({ chat_id: 1, text: "x" }).catch((e) => e);
+  assert.equal(classifyError(err), ERROR_CLASSES.RATE_LIMITED);
+  assert.equal(err.parameters.retry_after, 60);
+});
+
+test("Error classes: network error (ECONNREFUSED)", () => {
+  const err = Object.assign(new Error("connect ECONNREFUSED"), { code: "ECONNREFUSED" });
+  assert.equal(classifyError(err), ERROR_CLASSES.NETWORK);
+});
+
+test("Error classes: status=null but error_code=409 still classified as CONFLICT", () => {
+  const err = new TelegramApiError({ status: null, code: 409, description: "Conflict" });
+  assert.equal(classifyError(err), ERROR_CLASSES.CONFLICT);
+});
+
+test("Error classes: AbortError → TIMEOUT", () => {
+  const err = new Error("aborted");
+  err.name = "AbortError";
+  assert.equal(classifyError(err), ERROR_CLASSES.TIMEOUT);
+});
+
+test("AbortController cancels in-flight getUpdates with AbortError", async () => {
+  const { client, server } = makeClient();
+  // Long-running response that never settles unless aborted.
+  server.enqueue("getUpdates", () => new Promise(() => {}));
+  const ac = new AbortController();
+  setTimeout(() => ac.abort(), 5);
+  const err = await client.getUpdates({ signal: ac.signal }).catch((e) => e);
+  assert.ok(err instanceof Error, "expected an error");
+  assert.equal(err.name, "AbortError");
+  assert.equal(classifyError(err), ERROR_CLASSES.TIMEOUT);
+});
+
+test("Pre-aborted signal: transport refuses immediately, no call recorded", async () => {
+  const { client, server } = makeClient();
+  const ac = new AbortController();
+  ac.abort();
+  const err = await client.getUpdates({ signal: ac.signal }).catch((e) => e);
+  assert.equal(err.name, "AbortError");
+  assert.equal(server.calls.length, 0);
+});
+
+test("Wrong-user callback flow: client surfaces both updates; handler filters", async () => {
+  // The client itself does not filter by user — the spike treats that as
+  // handler-level concern (so a future approval module can choose to log
+  // wrong-user attempts). This test pins that contract.
+  const { client, server } = makeClient();
+  server.enqueueOk("getUpdates", [
+    { update_id: 1, callback_query: { id: "a", from: { id: 999 }, data: "test_ok" } },
+    { update_id: 2, callback_query: { id: "b", from: { id: 100 }, data: "test_ok" } },
+  ]);
+  const updates = await client.getUpdates();
+  assert.equal(updates.length, 2);
+
+  const allowed = 100;
+  const filtered = updates.filter((u) => u.callback_query.from.id === allowed);
+  assert.equal(filtered.length, 1);
+  assert.equal(filtered[0].callback_query.from.id, allowed);
+});
+
+// ============================================================================
+// pollWithConflictRetry — plan §116 (1s base / ×2 / cap 5s / 35s deadline)
+// ============================================================================
+
+function makeClock() {
+  let t = 0;
+  const slept = [];
+  return {
+    now: () => t,
+    sleep(ms) {
+      slept.push(ms);
+      t += ms;
+      return Promise.resolve();
+    },
+    advance(ms) { t += ms; },
+    slept,
+  };
+}
+
+test("pollWithConflictRetry: succeeds first try without sleeping", async () => {
+  const clock = makeClock();
+  const out = await pollWithConflictRetry(async () => "ok", { now: clock.now, sleep: clock.sleep });
+  assert.equal(out.result, "ok");
+  assert.equal(out.attempts, 1);
+  assert.deepEqual(clock.slept, []);
+});
+
+test("pollWithConflictRetry: retries through 409 conflicts, then succeeds", async () => {
+  const clock = makeClock();
+  let calls = 0;
+  const out = await pollWithConflictRetry(
+    async () => {
+      calls += 1;
+      if (calls <= 3) {
+        throw new TelegramApiError({
+          status: 409,
+          description: "Conflict: terminated by other getUpdates request",
+        });
+      }
+      return "released";
+    },
+    { now: clock.now, sleep: clock.sleep },
+  );
+  assert.equal(out.result, "released");
+  assert.equal(out.attempts, 4);
+  // 1s, 2s, 4s (exponential factor 2)
+  assert.deepEqual(clock.slept, [1000, 2000, 4000]);
+});
+
+test("pollWithConflictRetry: caps backoff at maxDelayMs", async () => {
+  const clock = makeClock();
+  let calls = 0;
+  await pollWithConflictRetry(
+    async () => {
+      calls += 1;
+      if (calls <= 5) {
+        throw new TelegramApiError({ status: 409, description: "Conflict" });
+      }
+      return "ok";
+    },
+    { now: clock.now, sleep: clock.sleep },
+  );
+  // 1, 2, 4, 5 (capped), 5
+  assert.deepEqual(clock.slept, [1000, 2000, 4000, 5000, 5000]);
+});
+
+test("pollWithConflictRetry: hits 35s deadline → throws 409 with attempts metadata", async () => {
+  const clock = makeClock();
+  const err = await pollWithConflictRetry(
+    async () => {
+      throw new TelegramApiError({ status: 409, description: "Conflict" });
+    },
+    { now: clock.now, sleep: clock.sleep },
+  ).catch((e) => e);
+  assert.ok(err instanceof TelegramApiError);
+  assert.equal(err.status, 409);
+  assert.ok(err.parameters.attempts >= 5, "should record attempt count");
+  assert.ok(err.parameters.elapsedMs >= DEFAULT_RETRY_OPTS.totalDeadlineMs);
+});
+
+test("pollWithConflictRetry: webhook conflict short-circuits (no retry)", async () => {
+  const clock = makeClock();
+  let calls = 0;
+  const err = await pollWithConflictRetry(
+    async () => {
+      calls += 1;
+      throw new TelegramApiError({
+        status: 409,
+        description: "Conflict: can't use getUpdates method while webhook is active",
+      });
+    },
+    { now: clock.now, sleep: clock.sleep },
+  ).catch((e) => e);
+  assert.equal(calls, 1, "webhook conflict must not retry");
+  assert.equal(classifyError(err), ERROR_CLASSES.WEBHOOK_CONFLICT);
+});
+
+test("pollWithConflictRetry: non-409 error rethrown immediately", async () => {
+  const clock = makeClock();
+  let calls = 0;
+  const err = await pollWithConflictRetry(
+    async () => {
+      calls += 1;
+      throw new TelegramApiError({ status: 401, description: "Unauthorized" });
+    },
+    { now: clock.now, sleep: clock.sleep },
+  ).catch((e) => e);
+  assert.equal(calls, 1);
+  assert.equal(classifyError(err), ERROR_CLASSES.UNAUTHORIZED);
+});
+
+test("pollWithConflictRetry: external abort signal cancels mid-retry", async () => {
+  const clock = makeClock();
+  const ac = new AbortController();
+  let calls = 0;
+  const err = await pollWithConflictRetry(
+    async () => {
+      calls += 1;
+      if (calls === 2) ac.abort();
+      throw new TelegramApiError({ status: 409, description: "Conflict" });
+    },
+    { now: clock.now, sleep: clock.sleep, signal: ac.signal },
+  ).catch((e) => e);
+  assert.equal(err.name, "AbortError");
+});
+
+test("60s timeout scenario: long poll returns empty batch (no tap)", async () => {
+  // The 60s timeout in the migration flow is enforced by the caller, not the
+  // client. From the client's perspective an empty getUpdates is the normal
+  // "no events" outcome — the migration manager interprets sustained empties
+  // plus a wall-clock deadline as "user did not tap".
+  const { client, server } = makeClient();
+  server.enqueueOk("getUpdates", []);
+  const updates = await client.getUpdates({ timeout: 60 });
+  assert.deepEqual(updates, []);
+  assert.equal(client.offset, 0, "empty batch does not change offset");
+  assert.equal(server.calls[0].payload.timeout, 60);
+});

--- a/test/telegram-native-runner.test.js
+++ b/test/telegram-native-runner.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { createTelegramNativeRunner } = require("../src/telegram-native-runner");
+const { EVENTS } = require("../src/telegram-migration-state");
+const { createFakeTelegramServer } = require("./fakes/telegram-server");
+
+const VALID_TOKEN = "123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi_jklmnop";
+
+function tokenStore(token = VALID_TOKEN) {
+  return {
+    async getToken() { return token; },
+    async hasToken() { return !!token; },
+  };
+}
+
+function tick() {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test("sendTestCard defers TEST_FAILED when Telegram sendMessage fails", async () => {
+  const server = createFakeTelegramServer();
+  const events = [];
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async (event) => { events.push(event); },
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+  server.enqueueError("sendMessage", { status: 401, description: "Unauthorized" });
+
+  await runner.sendTestCard();
+  assert.deepEqual(events, [], "failure is deferred until caller can enter TESTING_NATIVE");
+
+  await delay(5);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, EVENTS.TEST_FAILED);
+  assert.equal(events[0].errorClass, "401");
+});
+
+test("sendTestCard defers TEST_FAILED when chat id is missing", async () => {
+  const events = [];
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: createFakeTelegramServer().transport,
+    getDispatch: () => async (event) => { events.push(event); },
+    getChatId: () => "",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.sendTestCard();
+  assert.deepEqual(events, []);
+  await delay(5);
+  assert.deepEqual(events, [{ type: EVENTS.TEST_FAILED, errorClass: "no_chat" }]);
+});
+
+test("native runner sends nonce card and dispatches TEST_SUCCESS for matching callback", async () => {
+  const server = createFakeTelegramServer();
+  const events = [];
+  let runner;
+  let releaseFirstPoll;
+  let callbackData = "";
+
+  server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+  server.enqueue("sendMessage", (payload) => {
+    callbackData = payload.reply_markup.inline_keyboard[0][0].callback_data;
+    return { ok: true, result: { message_id: 42, chat: { id: 123 } } };
+  });
+  server.enqueue("getUpdates", () => ({
+    ok: true,
+    result: [{
+      update_id: 1,
+      callback_query: {
+        id: "cb-1",
+        from: { id: 777 },
+        message: { chat: { id: 123 } },
+        data: callbackData,
+      },
+    }],
+  }));
+  server.enqueueOk("answerCallbackQuery", true);
+  server.enqueueOk("editMessageReplyMarkup", { message_id: 42 });
+
+  runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async (event) => {
+      events.push(event);
+      await runner.stop();
+    },
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.start();
+  await tick();
+  assert.equal(server.calls[0].method, "getUpdates");
+
+  await runner.sendTestCard();
+  assert.match(callbackData, /^clawd-test:[a-z0-9]+$/);
+
+  releaseFirstPoll({ ok: true, result: [] });
+  await tick();
+  await tick();
+  await tick();
+
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, EVENTS.TEST_SUCCESS);
+  assert.equal(server.calls.some((call) => call.method === "answerCallbackQuery"), true);
+  assert.equal(server.calls.some((call) => call.method === "editMessageReplyMarkup"), true);
+  assert.equal(runner.isPolling(), false);
+});

--- a/test/telegram-native-runner.test.js
+++ b/test/telegram-native-runner.test.js
@@ -117,3 +117,183 @@ test("native runner sends nonce card and dispatches TEST_SUCCESS for matching ca
   assert.equal(server.calls.some((call) => call.method === "editMessageReplyMarkup"), true);
   assert.equal(runner.isPolling(), false);
 });
+
+test("native runner requestApproval resolves allow for matching callback", async () => {
+  const server = createFakeTelegramServer();
+  let releaseFirstPoll;
+  let allowData = "";
+  let denyData = "";
+
+  server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+  server.enqueue("sendMessage", (payload) => {
+    assert.match(payload.text, /claude-code requests Bash/);
+    assert.match(payload.text, /Summary: Run tests/);
+    allowData = payload.reply_markup.inline_keyboard[0][0].callback_data;
+    denyData = payload.reply_markup.inline_keyboard[0][1].callback_data;
+    return { ok: true, result: { message_id: 99, chat: { id: 123 } } };
+  });
+  server.enqueue("getUpdates", () => ({
+    ok: true,
+    result: [{
+      update_id: 1,
+      callback_query: {
+        id: "cb-allow",
+        from: { id: 777 },
+        message: { message_id: 99, chat: { id: 123 } },
+        data: allowData,
+      },
+    }],
+  }));
+  server.enqueueOk("answerCallbackQuery", true);
+  server.enqueueOk("editMessageReplyMarkup", { message_id: 99 });
+
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.start();
+  await tick();
+  const decisionPromise = runner.requestApproval({
+    title: "claude-code requests Bash",
+    detail: "Summary: Run tests",
+  });
+  await tick();
+  assert.match(allowData, /^clawdperm:[a-z0-9]+:allow$/);
+  assert.match(denyData, /^clawdperm:[a-z0-9]+:deny$/);
+
+  releaseFirstPoll({ ok: true, result: [] });
+  const decision = await decisionPromise;
+  assert.equal(decision, "allow");
+  assert.equal(server.calls.some((call) => call.method === "answerCallbackQuery"), true);
+  assert.equal(server.calls.some((call) => call.method === "editMessageReplyMarkup"), true);
+  await runner.stop();
+});
+
+test("native runner requestApproval ignores wrong user and resolves later callback", async () => {
+  const server = createFakeTelegramServer();
+  let releaseFirstPoll;
+  let denyData = "";
+
+  server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+  server.enqueue("sendMessage", (payload) => {
+    denyData = payload.reply_markup.inline_keyboard[0][1].callback_data;
+    return { ok: true, result: { message_id: 100, chat: { id: 123 } } };
+  });
+  server.enqueue("getUpdates", () => ({
+    ok: true,
+    result: [
+      {
+        update_id: 1,
+        callback_query: {
+          id: "cb-wrong-user",
+          from: { id: 999 },
+          message: { message_id: 100, chat: { id: 123 } },
+          data: denyData,
+        },
+      },
+      {
+        update_id: 2,
+        callback_query: {
+          id: "cb-deny",
+          from: { id: 777 },
+          message: { message_id: 100, chat: { id: 123 } },
+          data: denyData,
+        },
+      },
+    ],
+  }));
+  server.enqueueOk("answerCallbackQuery", true);
+  server.enqueueOk("answerCallbackQuery", true);
+  server.enqueueOk("editMessageReplyMarkup", { message_id: 100 });
+
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.start();
+  await tick();
+  const decisionPromise = runner.requestApproval({
+    title: "claude-code requests Bash",
+    detail: "Summary: Run tests",
+  });
+  await tick();
+  releaseFirstPoll({ ok: true, result: [] });
+
+  assert.equal(await decisionPromise, "deny");
+  assert.equal(
+    server.calls.filter((call) => call.method === "answerCallbackQuery").length,
+    2,
+  );
+  await runner.stop();
+});
+
+test("native runner requestApproval resolves null on abort and send failure", async () => {
+  {
+    const server = createFakeTelegramServer();
+    let releaseFirstPoll;
+    server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+    server.enqueueOk("sendMessage", { message_id: 1 });
+
+    const runner = createTelegramNativeRunner({
+      tokenStore: tokenStore(),
+      transport: server.transport,
+      getDispatch: () => async () => {},
+      getChatId: () => "123",
+      getAllowedUserId: () => "777",
+    });
+    await runner.start();
+    await tick();
+    const controller = new AbortController();
+    const promise = runner.requestApproval(
+      { title: "x", detail: "y" },
+      { signal: controller.signal },
+    );
+    controller.abort();
+    assert.equal(await promise, null);
+    releaseFirstPoll({ ok: true, result: [] });
+    await runner.stop();
+  }
+
+  {
+    const server = createFakeTelegramServer();
+    let releaseFirstPoll;
+    server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+    server.enqueueError("sendMessage", { status: 403, description: "Forbidden" });
+
+    const runner = createTelegramNativeRunner({
+      tokenStore: tokenStore(),
+      transport: server.transport,
+      getDispatch: () => async () => {},
+      getChatId: () => "123",
+      getAllowedUserId: () => "777",
+    });
+    await runner.start();
+    await tick();
+    const decision = await runner.requestApproval({ title: "x", detail: "y" });
+    assert.equal(decision, null);
+    releaseFirstPoll({ ok: true, result: [] });
+    await runner.stop();
+  }
+});
+
+test("native runner requestApproval is disabled until polling with a valid payload", async () => {
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: createFakeTelegramServer().transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  assert.equal(runner.isEnabled(), false);
+  assert.equal(await runner.requestApproval({ title: "x", detail: "y" }), null);
+  assert.equal(await runner.requestApproval({ title: "", detail: "y" }), null);
+});

--- a/test/telegram-owner-manager.test.js
+++ b/test/telegram-owner-manager.test.js
@@ -1,0 +1,293 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  TelegramOwnerManager,
+  InvariantError,
+  DEFAULT_SETTLE_MS,
+} = require("../src/telegram-owner-manager");
+const {
+  SIDE_EFFECTS,
+  applyEvent,
+  computeInitial,
+  EVENTS,
+  STATES,
+} = require("../src/telegram-migration-state");
+const { ALL_CASES } = require("./fakes/migration-transitions");
+
+class FakeSidecar {
+  constructor() {
+    this.running = false;
+    this.stopCalls = [];
+    this.startDelayMs = 0;
+  }
+  isRunning() {
+    return this.running;
+  }
+  async start() {
+    if (this.startDelayMs) await new Promise((r) => setTimeout(r, this.startDelayMs));
+    this.running = true;
+  }
+  async stop(opts = {}) {
+    this.stopCalls.push(opts);
+    this.running = false;
+  }
+}
+
+class FakeNative {
+  constructor() {
+    this.polling = false;
+    this.testCardCalls = [];
+  }
+  isPolling() {
+    return this.polling;
+  }
+  async start() {
+    this.polling = true;
+  }
+  async stop() {
+    this.polling = false;
+  }
+  async sendTestCard(payload) {
+    this.testCardCalls.push(payload);
+  }
+}
+
+function makeManager(overrides = {}) {
+  const sidecar = overrides.sidecar || new FakeSidecar();
+  const native = overrides.native || new FakeNative();
+  const slept = [];
+  const sleep = overrides.sleep || ((ms) => {
+    slept.push(ms);
+    return Promise.resolve();
+  });
+  let clock = 1_000_000;
+  const now = overrides.now || (() => clock);
+  const advance = (ms) => {
+    clock += ms;
+  };
+  const persistCalls = [];
+  const onPersist = overrides.onPersist || ((patch) => {
+    persistCalls.push(patch);
+  });
+  const mgr = new TelegramOwnerManager({
+    sidecar,
+    native,
+    sleep,
+    now,
+    onPersist,
+    ...overrides.opts,
+  });
+  return { mgr, sidecar, native, slept, advance, persistCalls };
+}
+
+test("constructor rejects handles missing required methods", () => {
+  assert.throws(
+    () => new TelegramOwnerManager({ sidecar: {}, native: new FakeNative() }),
+    /sidecar handle must implement/,
+  );
+  assert.throws(
+    () => new TelegramOwnerManager({ sidecar: new FakeSidecar(), native: {} }),
+    /native handle must implement/,
+  );
+});
+
+test("START_SIDECAR starts the sidecar; snapshot reflects state", async () => {
+  const { mgr, sidecar } = makeManager();
+  await mgr.apply([{ type: SIDE_EFFECTS.START_SIDECAR }]);
+  assert.equal(sidecar.running, true);
+  assert.deepEqual(mgr.snapshot(), { sidecarRunning: true, nativePolling: false });
+});
+
+test("START_SIDECAR treats explicit false return as startup failure", async () => {
+  const sidecar = new FakeSidecar();
+  sidecar.start = async () => false;
+  const { mgr } = makeManager({ sidecar });
+  await assert.rejects(
+    () => mgr.apply([{ type: SIDE_EFFECTS.START_SIDECAR }]),
+    (err) => {
+      assert.ok(err instanceof InvariantError);
+      assert.equal(err.code, "SIDECAR_START_FAILED");
+      return true;
+    },
+  );
+});
+
+test("STOP_SIDECAR passes graceMs=2000 by default", async () => {
+  const { mgr, sidecar } = makeManager();
+  sidecar.running = true;
+  await mgr.apply([{ type: SIDE_EFFECTS.STOP_SIDECAR }]);
+  assert.deepEqual(sidecar.stopCalls, [{ graceMs: 2000 }]);
+  assert.equal(sidecar.running, false);
+});
+
+test("START_NATIVE_POLLER waits settleMs after STOP_SIDECAR", async () => {
+  const { mgr, sidecar, native, slept } = makeManager();
+  sidecar.running = true;
+  await mgr.apply([
+    { type: SIDE_EFFECTS.STOP_SIDECAR },
+    { type: SIDE_EFFECTS.START_NATIVE_POLLER },
+  ]);
+  assert.equal(native.polling, true);
+  assert.equal(sidecar.running, false);
+  assert.deepEqual(slept, [DEFAULT_SETTLE_MS], "expected one settle wait");
+});
+
+test("START_NATIVE_POLLER skips settle wait if enough time already elapsed", async () => {
+  const { mgr, sidecar, native, slept, advance } = makeManager();
+  sidecar.running = true;
+  await mgr.apply([{ type: SIDE_EFFECTS.STOP_SIDECAR }]);
+  advance(DEFAULT_SETTLE_MS + 50);
+  await mgr.apply([{ type: SIDE_EFFECTS.START_NATIVE_POLLER }]);
+  assert.equal(native.polling, true);
+  assert.deepEqual(slept, [], "should not sleep when settle already satisfied");
+});
+
+test("Refuses START_NATIVE_POLLER while sidecar still running", async () => {
+  const { mgr, sidecar, native } = makeManager();
+  sidecar.running = true;
+  await assert.rejects(
+    () => mgr.apply([{ type: SIDE_EFFECTS.START_NATIVE_POLLER }]),
+    (err) => {
+      assert.ok(err instanceof InvariantError);
+      assert.equal(err.code, "PRE_START_NATIVE_BUT_SIDECAR_RUNNING");
+      return true;
+    },
+  );
+  assert.equal(native.polling, false, "native must not have started");
+});
+
+test("Refuses START_SIDECAR while native still polling", async () => {
+  const { mgr, sidecar, native } = makeManager();
+  native.polling = true;
+  await assert.rejects(
+    () => mgr.apply([{ type: SIDE_EFFECTS.START_SIDECAR }]),
+    (err) => {
+      assert.ok(err instanceof InvariantError);
+      assert.equal(err.code, "PRE_START_SIDECAR_BUT_NATIVE_POLLING");
+      return true;
+    },
+  );
+  assert.equal(sidecar.running, false);
+});
+
+test("Detects post-effect mutex violation (caller fake bug)", async () => {
+  const { mgr, sidecar, native } = makeManager();
+  sidecar.running = true;
+  // Hand-craft an effect that does not enforce pre-check: STOP_NATIVE_POLLER
+  // is fine, but the fake flips native.polling=true behind the manager's back
+  // to simulate a faulty handle.
+  native.polling = true;
+  // Native polling but sidecar also still running → invariant must trip even
+  // before any effects run.
+  await assert.rejects(
+    () => mgr.apply([{ type: SIDE_EFFECTS.STOP_NATIVE_POLLER }]),
+    (err) => err.code === "MUTUAL_EXCLUSION_VIOLATED",
+  );
+});
+
+test("apply() serializes concurrent calls", async () => {
+  const { mgr, sidecar, native } = makeManager();
+  sidecar.startDelayMs = 10;
+  // Fire two applies back-to-back; second must observe first's completion.
+  const p1 = mgr.apply([{ type: SIDE_EFFECTS.START_SIDECAR }]);
+  const p2 = mgr.apply([{ type: SIDE_EFFECTS.STOP_SIDECAR }]);
+  await Promise.all([p1, p2]);
+  assert.equal(sidecar.running, false, "stop should run after start completes");
+  assert.equal(native.polling, false);
+});
+
+test("apply() failure does not poison the queue", async () => {
+  const { mgr, sidecar } = makeManager();
+  sidecar.running = true;
+  // First apply violates invariant.
+  await assert.rejects(() => mgr.apply([{ type: SIDE_EFFECTS.START_NATIVE_POLLER }]));
+  // Recover: stop sidecar, then start native should succeed.
+  await mgr.apply([{ type: SIDE_EFFECTS.STOP_SIDECAR }]);
+  // bypass settle delay by advancing clock-free via real sleep skipping
+  await mgr.apply([{ type: SIDE_EFFECTS.START_NATIVE_POLLER }]);
+  assert.equal(sidecar.running, false);
+});
+
+test("SEND_TEST_CARD forwards payload to native.sendTestCard", async () => {
+  const { mgr, native } = makeManager();
+  native.polling = true;
+  await mgr.apply([{ type: SIDE_EFFECTS.SEND_TEST_CARD, payload: { nonce: "abc" } }]);
+  assert.deepEqual(native.testCardCalls, [{ nonce: "abc" }]);
+});
+
+test("PERSIST_PREFS forwards patch to onPersist callback", async () => {
+  const { mgr, persistCalls } = makeManager();
+  await mgr.apply([{ type: SIDE_EFFECTS.PERSIST_PREFS, payload: { transport: "native" } }]);
+  assert.deepEqual(persistCalls, [{ transport: "native" }]);
+});
+
+test("EMIT_RUNTIME_STATUS forwards payload to onRuntimeStatus callback", async () => {
+  const statuses = [];
+  const { mgr } = makeManager({
+    opts: { onRuntimeStatus: (s) => { statuses.push(s); } },
+  });
+  await mgr.apply([
+    { type: SIDE_EFFECTS.EMIT_RUNTIME_STATUS, payload: { transport: "legacy", status: "failed" } },
+  ]);
+  assert.deepEqual(statuses, [{ transport: "legacy", status: "failed" }]);
+});
+
+test("Unknown effect type is ignored", async () => {
+  const { mgr } = makeManager();
+  await mgr.apply([{ type: "MYSTERY_EFFECT" }]);
+});
+
+// ============================================================================
+// Mutex invariant under every reducer-emitted side-effect sequence
+// ============================================================================
+test("Every transition-table case runs through the manager without violating mutex", async () => {
+  // We start the manager in the same observable owner state implied by the
+  // pre-condition state in each fixture case.
+  for (const c of ALL_CASES) {
+    const { mgr, sidecar, native } = makeManager();
+    seedManager(sidecar, native, c.state);
+
+    const result =
+      c.event.type === EVENTS.INIT
+        ? computeInitial({ prefs: c.prefs, files: c.files })
+        : applyEvent({ state: c.state, prefs: c.prefs, files: c.files }, c.event);
+
+    // Illegal transitions emit no side effects, so nothing to apply.
+    if (!result.sideEffects || result.sideEffects.length === 0) continue;
+
+    try {
+      await mgr.apply(result.sideEffects);
+    } catch (err) {
+      if (err instanceof InvariantError) {
+        assert.fail(`mutex violation while replaying "${c.name}": ${err.message}`);
+      }
+      throw err;
+    }
+
+    const snap = mgr.snapshot();
+    assert.equal(
+      snap.sidecarRunning && snap.nativePolling,
+      false,
+      `after ${c.name}: both running and polling`,
+    );
+  }
+});
+
+function seedManager(sidecar, native, state) {
+  switch (state) {
+    case STATES.LEGACY_ACTIVE:
+    case STATES.SWITCHING_TO_LEGACY:
+      sidecar.running = true;
+      break;
+    case STATES.NATIVE_ACTIVE:
+    case STATES.TESTING_NATIVE:
+      native.polling = true;
+      break;
+    default:
+      // IDLE / NEEDS_SETUP — both off.
+      break;
+  }
+}

--- a/test/telegram-token-store.test.js
+++ b/test/telegram-token-store.test.js
@@ -1,0 +1,138 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  envFileTokenStore,
+  parseTokenFromEnvFileText,
+  buildEnvFileText,
+  isValidToken,
+} = require("../src/telegram-token-store");
+
+const VALID = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ-_0123456789";
+
+function tmpDir(label) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `clawd-tg-store-${label}-`));
+  return {
+    dir,
+    file: path.join(dir, "telegram-approval.env"),
+    cleanup() {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+    },
+  };
+}
+
+test("isValidToken matches Telegram bot token shape", () => {
+  assert.equal(isValidToken(VALID), true);
+  assert.equal(isValidToken("not-a-token"), false);
+  assert.equal(isValidToken(""), false);
+  assert.equal(isValidToken(null), false);
+});
+
+test("parseTokenFromEnvFileText accepts the standard CLAWD_TG_BOT_TOKEN line", () => {
+  assert.equal(parseTokenFromEnvFileText(`CLAWD_TG_BOT_TOKEN=${VALID}\n`), VALID);
+  assert.equal(parseTokenFromEnvFileText(`  CLAWD_TG_BOT_TOKEN = ${VALID}  \n`), VALID);
+});
+
+test("parseTokenFromEnvFileText rejects malformed contents", () => {
+  assert.equal(parseTokenFromEnvFileText(""), null);
+  assert.equal(parseTokenFromEnvFileText("OTHER_VAR=foo"), null);
+  assert.equal(parseTokenFromEnvFileText("CLAWD_TG_BOT_TOKEN=garbage"), null);
+});
+
+test("buildEnvFileText produces the line the sidecar expects", () => {
+  assert.equal(buildEnvFileText(VALID), `CLAWD_TG_BOT_TOKEN=${VALID}\n`);
+});
+
+test("envFileTokenStore requires filePath + fs.readFileSync", () => {
+  assert.throws(() => envFileTokenStore({ filePath: "" }), /filePath is required/);
+  assert.throws(
+    () => envFileTokenStore({ filePath: "x", fs: {} }),
+    /fs must implement readFileSync/,
+  );
+});
+
+test("envFileTokenStore.getToken reads the file and parses", async (t) => {
+  const tmp = tmpDir("get");
+  t.after(tmp.cleanup);
+  fs.writeFileSync(tmp.file, `CLAWD_TG_BOT_TOKEN=${VALID}\n`);
+  const store = envFileTokenStore({ filePath: tmp.file });
+  assert.equal(await store.getToken(), VALID);
+  assert.equal(await store.hasToken(), true);
+});
+
+test("envFileTokenStore.getToken returns null when file missing", async (t) => {
+  const tmp = tmpDir("missing");
+  t.after(tmp.cleanup);
+  const store = envFileTokenStore({ filePath: tmp.file });
+  assert.equal(await store.getToken(), null);
+  assert.equal(await store.hasToken(), false);
+});
+
+test("envFileTokenStore.writeToken refuses invalid tokens", async (t) => {
+  const tmp = tmpDir("invalid");
+  t.after(tmp.cleanup);
+  const store = envFileTokenStore({ filePath: tmp.file });
+  await assert.rejects(() => store.writeToken("nope"), /invalid bot token/);
+  assert.equal(fs.existsSync(tmp.file), false, "no file should be created on invalid input");
+});
+
+test("envFileTokenStore.writeToken atomically persists token (temp+rename)", async (t) => {
+  const tmp = tmpDir("write");
+  t.after(tmp.cleanup);
+  const store = envFileTokenStore({ filePath: tmp.file });
+  await store.writeToken(VALID);
+  const text = fs.readFileSync(tmp.file, "utf8");
+  assert.equal(text, buildEnvFileText(VALID));
+  // round-trip via store
+  assert.equal(await store.getToken(), VALID);
+  // No leftover .tmp files in the directory.
+  const leftovers = fs.readdirSync(tmp.dir).filter((n) => n.endsWith(".tmp"));
+  assert.deepEqual(leftovers, [], "atomic write must clean temp files");
+});
+
+test("envFileTokenStore.writeToken overwrites existing token safely", async (t) => {
+  const tmp = tmpDir("overwrite");
+  t.after(tmp.cleanup);
+  const store = envFileTokenStore({ filePath: tmp.file });
+  const OLD = "987654321:ZYXWVUTSRQPONMLKJIHGFEDCBA-_9876543210";
+  await store.writeToken(OLD);
+  assert.equal(await store.getToken(), OLD);
+  await store.writeToken(VALID);
+  assert.equal(await store.getToken(), VALID);
+});
+
+test("envFileTokenStore.deleteToken removes the file silently if missing", async (t) => {
+  const tmp = tmpDir("delete");
+  t.after(tmp.cleanup);
+  const store = envFileTokenStore({ filePath: tmp.file });
+  // First delete with no file present.
+  await store.deleteToken();
+  // Then create + delete.
+  fs.writeFileSync(tmp.file, `CLAWD_TG_BOT_TOKEN=${VALID}\n`);
+  await store.deleteToken();
+  assert.equal(fs.existsSync(tmp.file), false);
+});
+
+test("Source invariant: src/telegram-token-store.js never references process.env.CLAWD_TG_BOT_TOKEN", () => {
+  // Mirrors the existing invariant test for telegram-approval-settings.js.
+  const fs = require("node:fs");
+  const path = require("node:path");
+  const source = fs.readFileSync(
+    path.join(__dirname, "..", "src", "telegram-token-store.js"),
+    "utf8",
+  );
+  assert.equal(
+    source.includes("process.env.CLAWD_TG_BOT_TOKEN"),
+    false,
+    "token store must not read CLAWD_TG_BOT_TOKEN from process.env",
+  );
+  assert.equal(
+    /process\.env\s*\.\s*CLAWD_TG_BOT_TOKEN/.test(source),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary
- Adds the Telegram migration controller, owner-managed legacy/native transport switching, native long-poll runner, and Settings migration UI wiring.
- Bridges `tgMigration` and `tgApproval` so legacy sidecar and native poller remain mutually exclusive across startup, disable, rollback, and settings sync paths.
- Adds native Telegram approval callbacks for `NATIVE_ACTIVE`, so remote Allow/Deny approval no longer depends on the Go sidecar after migration.
- Fixes a dogfood-found permission notification loop: remote Telegram approval now releases the transient `PermissionRequest` notification instead of leaving an orphan `notification` session that can out-prioritize later hooks.

## Deliberate LOC Overruns
The implementation intentionally exceeds the original planning caps because four product modules, seven Settings UI states, and fixture-heavy coverage landed together:

| Cap | Actual |
|---|---:|
| plan §194 production 1200 | 1572 |
| plan §194 test 800 | 1769 |
| plan §326 Settings UI 200 | 411 |

## Tests
- `node --test test/state.test.js test/permission-telegram-approval.test.js test/permission-autoclose-dismiss.test.js test/telegram-native-runner.test.js test/server-route-permission.test.js` — 211 pass
- `npm test` — 3124 pass / 5 skipped / 0 fail

## Dogfood
- Real Telegram diagnostic callback passed with matching nonce/user/chat.
- Real migration happy path passed: `LEGACY_ACTIVE -> TESTING_NATIVE -> NATIVE_ACTIVE`.
- Cold start in `NATIVE_ACTIVE` verified with sidecar stopped.
- Rollback, disable, and enable-legacy paths passed.
- Negative cases passed: wrong target, missing recipient, competing owner 409, invalid token.
- Native approval dogfood after restarting the current branch:
  - direct `/permission` + Telegram Allow -> HTTP 200 `behavior=allow`
  - direct `/permission` + Telegram Deny -> HTTP 200 `behavior=deny`
  - `hooks/codex-hook.js` official `PermissionRequest` payload + Telegram Allow -> hook stdout `behavior=allow`
- Notification-loop regression dogfood after `3df1f93`:
  - restarted the current branch
  - triggered `hooks/codex-hook.js` official `PermissionRequest`
  - approved from Telegram on phone
  - waited past the notification auto-return window
  - verified no repeat notification loop and no orphan `notification` session
- Final verification state: `tgMigration.transport="native"`, `tgApproval.enabled=false`, and no legacy sidecar process running.

## Remaining Risk
- Settings card behavior is covered by manual dogfood rather than renderer/UI automation.
- Full reducer + owner + controller + runner collaboration is covered by focused unit tests plus real Telegram dogfood, not a single end-to-end test harness.
- The Settings migration card still has spike/debug copy (`v0.9.0 spike`, raw state/owner line). Keep it through review and alpha dogfood, then productize before v0.9.0 stable.