### PR TITLE
fix(hooks): use bash-compatible command format on Windows

### DIFF
--- a/hooks/install.js
+++ b/hooks/install.js
@@ -824,8 +824,8 @@ function registerHooks(options = {}) {
       changed = true;  // format was normalized, need to persist
     }
 
-    // Local Windows hooks must use explicit PowerShell invocation because Claude
-    // Code defaults command hooks to bash on Windows. Remote hooks stay on the
+    // Local Windows hooks use bare commands (no shell wrapper) because Claude
+    // Code runs command hooks with bash on Windows. Remote hooks stay on the
     // legacy POSIX/bash-compatible form; see buildCommandHookSpec().
     const desiredHook = buildCommandHookSpec(nodeBin, hookScript, event, {
       platform,

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -465,8 +465,7 @@ function buildCommandHookSpec(nodeBin, scriptPath, args = "", options = {}) {
   if (platform === "win32") {
     return withHookOptions({
       type: "command",
-      shell: "powershell",
-      command: `& ${quotedCommand}`,
+      command: quotedCommand,
     });
   }
 

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -526,7 +526,7 @@ describe("Claude version detection helpers", () => {
 });
 
 describe("Hook installer version compatibility", () => {
-  it("uses PowerShell-safe command hooks on Windows", () => {
+  it("uses bash-compatible command hooks on Windows", () => {
     const settingsPath = makeTempSettings({});
     registerHooks({
       silent: true,
@@ -539,10 +539,10 @@ describe("Hook installer version compatibility", () => {
     const settings = readSettings(settingsPath);
     const stopHooks = getCommandHookEntries(settings, "Stop", "clawd-hook.js");
     assert.strictEqual(stopHooks.length, 1);
-    assert.strictEqual(stopHooks[0].shell, "powershell");
+    assert.ok(!Object.prototype.hasOwnProperty.call(stopHooks[0], "shell"));
     assert.strictEqual(stopHooks[0].async, true);
     assert.strictEqual(stopHooks[0].timeout, 5);
-    assert.ok(stopHooks[0].command.startsWith('& "node" "'), stopHooks[0].command);
+    assert.ok(stopHooks[0].command.startsWith('"node" "'), stopHooks[0].command);
     assert.ok(stopHooks[0].command.endsWith('" Stop'), stopHooks[0].command);
   });
 
@@ -747,8 +747,8 @@ describe("Hook installer version compatibility", () => {
     const stopHooks = getCommandHookEntries(settings, "Stop", "clawd-hook.js");
     assert.strictEqual(result.updated, 1);
     assert.strictEqual(stopHooks.length, 1);
-    assert.strictEqual(stopHooks[0].shell, "powershell");
-    assert.ok(stopHooks[0].command.startsWith("& "), stopHooks[0].command);
+    assert.ok(!Object.prototype.hasOwnProperty.call(stopHooks[0], "shell"));
+    assert.ok(stopHooks[0].command.startsWith('"node"'), stopHooks[0].command);
     assert.ok(!stopHooks[0].command.includes("/old/path/"));
   });
 
@@ -826,8 +826,8 @@ describe("Hook installer version compatibility", () => {
     const settings = readSettings(settingsPath);
     const stopHooks = getCommandHookEntries(settings, "Stop", "clawd-hook.js");
     assert.strictEqual(stopHooks.length, 1);
-    assert.strictEqual(stopHooks[0].shell, "powershell");
-    assert.ok(stopHooks[0].command.startsWith("& "), stopHooks[0].command);
+    assert.ok(!Object.prototype.hasOwnProperty.call(stopHooks[0], "shell"));
+    assert.ok(stopHooks[0].command.startsWith('"node"'), stopHooks[0].command);
   });
 
   it("preserves existing absolute node path when detection fails", () => {
@@ -909,10 +909,10 @@ describe("Hook installer version compatibility", () => {
     const settings = readSettings(settingsPath);
     const autoStartHooks = getCommandHookEntries(settings, "SessionStart", "auto-start.js");
     assert.strictEqual(autoStartHooks.length, 1);
-    assert.strictEqual(autoStartHooks[0].shell, "powershell");
+    assert.ok(!Object.prototype.hasOwnProperty.call(autoStartHooks[0], "shell"));
     assert.strictEqual(autoStartHooks[0].async, true);
     assert.strictEqual(autoStartHooks[0].timeout, 15);
-    assert.ok(autoStartHooks[0].command.startsWith('& "node" "'), autoStartHooks[0].command);
+    assert.ok(autoStartHooks[0].command.startsWith('"node" "'), autoStartHooks[0].command);
   });
 
   it("uses async auto-start hooks on non-Windows", () => {
@@ -960,10 +960,10 @@ describe("Hook installer version compatibility", () => {
     const autoStartHooks = getCommandHookEntries(settings, "SessionStart", "auto-start.js");
     assert.ok(result.updated >= 1);
     assert.strictEqual(autoStartHooks.length, 1);
-    assert.strictEqual(autoStartHooks[0].shell, "powershell");
+    assert.ok(!Object.prototype.hasOwnProperty.call(autoStartHooks[0], "shell"));
     assert.strictEqual(autoStartHooks[0].async, true);
     assert.strictEqual(autoStartHooks[0].timeout, 15);
-    assert.ok(autoStartHooks[0].command.startsWith("& "), autoStartHooks[0].command);
+    assert.ok(autoStartHooks[0].command.startsWith('"node"'), autoStartHooks[0].command);
     assert.ok(!autoStartHooks[0].command.includes("/old/path/"));
   });
 
@@ -1279,11 +1279,11 @@ describe("Hook installer unregisterHooks", () => {
         SessionStart: [
           {
             matcher: "",
-            hooks: [{ type: "command", shell: "powershell", command: '& "node" "/tmp/auto-start.js"' }],
+            hooks: [{ type: "command", command: '"node" "/tmp/auto-start.js"' }],
           },
           {
             matcher: "",
-            hooks: [{ type: "command", shell: "powershell", command: '& "node" "/tmp/clawd-hook.js" SessionStart' }],
+            hooks: [{ type: "command", command: '"node" "/tmp/clawd-hook.js" SessionStart' }],
           },
           {
             matcher: "",
@@ -1293,7 +1293,7 @@ describe("Hook installer unregisterHooks", () => {
         Stop: [
           {
             matcher: "",
-            hooks: [{ type: "command", shell: "powershell", command: '& "node" "/tmp/clawd-hook.js" Stop' }],
+            hooks: [{ type: "command", command: '"node" "/tmp/clawd-hook.js" Stop' }],
           },
         ],
         PermissionRequest: [


### PR DESCRIPTION
## Summary

- Remove `shell: "powershell"` and `&` call-operator prefix from Windows hook commands
- Claude Code runs hooks with bash on Windows, so PowerShell syntax causes execution failures
- Use the same quoted command format as macOS/Linux

## Problem

On Windows, `buildCommandHookSpec` generated:
```json
{
  "shell": "powershell",
  "command": "& \"node\" \"script\" args"
}
```

But Claude Code runs hooks with bash, so the `&` (PowerShell call operator) fails in bash.

## Fix

Generate the same format as other platforms:
```json
{
  "command": "\"node\" \"script\" args"
}
```

No `shell` field, no `&` prefix. The `syncCommandHook` function automatically removes stale `shell` metadata from existing hooks on re-registration.

Fixes hook errors and `$`-in-path issues on Windows.