### PR TITLE
fix(gemini): use bash-compatible command format on Windows

### DIFF
--- a/hooks/gemini-install.js
+++ b/hooks/gemini-install.js
@@ -33,7 +33,8 @@ function buildGeminiHookEntry(command) {
 }
 
 function buildGeminiHookCommand(nodeBin, hookScript, event, options = {}) {
-  return formatNodeHookCommand(nodeBin, hookScript, { ...options, args: [event] });
+  const opts = options.windowsWrapper !== undefined ? options : { ...options, windowsWrapper: "none" };
+  return formatNodeHookCommand(nodeBin, hookScript, { ...opts, args: [event] });
 }
 
 function replaceEntry(target, source) {

--- a/test/gemini-install.test.js
+++ b/test/gemini-install.test.js
@@ -251,7 +251,7 @@ describe("Gemini hook installer", () => {
     assert.deepStrictEqual(settings.hooksConfig.disabled, ["other-hook", "clawd"]);
   });
 
-  it("builds Windows PowerShell commands with the Gemini event argv", () => {
+  it("builds bash-compatible bare commands with the Gemini event argv on Windows", () => {
     const command = __test.buildGeminiHookCommand(
       "node",
       "D:/clawd/hooks/gemini-hook.js",
@@ -259,7 +259,7 @@ describe("Gemini hook installer", () => {
       { platform: "win32" }
     );
 
-    assert.strictEqual(command, '& "node" "D:/clawd/hooks/gemini-hook.js" "BeforeTool"');
+    assert.strictEqual(command, '"node" "D:/clawd/hooks/gemini-hook.js" "BeforeTool"');
   });
 
   it("builds Windows cmd-wrapped commands with the Gemini event argv", () => {


### PR DESCRIPTION
## Summary

- Gemini hook commands on Windows used the default PowerShell `&` prefix, but Gemini CLI runs hooks with bash - the same bug fixed for Claude hooks in #372
- Changed `buildGeminiHookCommand` to default to `windowsWrapper: none` (bare command, no `&` prefix)
- Updated test to match the new expected output

## Test plan

- [x] All 13 Gemini install tests pass
- [x] Verified buildGeminiHookCommand produces bare command format on Windows by default
- [x] Verified explicit windowsWrapper: cmd override still works