### PR TITLE
[codex] Fix Windows Codex Desktop focus fallback

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1273,7 +1273,7 @@ const { initFocusHelper, killFocusHelper, focusTerminalWindow, clearMacFocusCool
 
 function getFocusableLocalHudSessionIds() {
   if (!_state || typeof _state.buildSessionSnapshot !== "function") return [];
-  return selectFocusableLocalHudSessionIds(_state.buildSessionSnapshot());
+  return selectFocusableLocalHudSessionIds(_state.buildSessionSnapshot(), { osPlatform: process.platform });
 }
 
 function focusTerminalSession(session, sessionId, requestSource) {
@@ -1305,7 +1305,7 @@ function focusDashboardSession(sessionId, options = {}) {
   }
 
   const focusEntry = { ...(session || {}), ...(fallbackEntry || {}), id };
-  const focusTarget = getSessionFocusTarget(focusEntry);
+  const focusTarget = getSessionFocusTarget(focusEntry, { osPlatform: process.platform });
   if (focusTarget.type === "codex-thread" && focusTarget.url) {
     focusCodexThreadTarget({
       shell,

--- a/src/session-focus.js
+++ b/src/session-focus.js
@@ -6,6 +6,11 @@ function normalizeString(value) {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function normalizeOsPlatform(options) {
+  if (!options || typeof options !== "object") return "";
+  return normalizeString(options.osPlatform || options.focusHostPlatform).toLowerCase();
+}
+
 function getCodexThreadId(entry) {
   if (!entry || entry.agentId !== "codex") return null;
   const originator = normalizeString(entry.codexOriginator || entry.originator).toLowerCase();
@@ -19,12 +24,17 @@ function getCodexThreadUrl(entry) {
   return threadId ? `codex://threads/${threadId}` : null;
 }
 
-function getSessionFocusTarget(entry) {
+function getSessionFocusTarget(entry, options = {}) {
   if (!entry || !entry.id) return { canFocus: false, type: null, url: null };
   if (entry.host || entry.platform === "webui") return { canFocus: false, type: null, url: null };
 
   const codexThreadUrl = getCodexThreadUrl(entry);
   if (codexThreadUrl) {
+    if (normalizeOsPlatform(options) === "win32") {
+      return entry.sourcePid
+        ? { canFocus: true, type: "terminal", url: null }
+        : { canFocus: false, type: null, url: null };
+    }
     return { canFocus: true, type: "codex-thread", url: codexThreadUrl };
   }
 
@@ -35,19 +45,19 @@ function getSessionFocusTarget(entry) {
   return { canFocus: false, type: null, url: null };
 }
 
-function isFocusableLocalHudSession(entry) {
+function isFocusableLocalHudSession(entry, options = {}) {
   return !!entry
-    && getSessionFocusTarget(entry).canFocus
+    && getSessionFocusTarget(entry, options).canFocus
     && !entry.headless
     && entry.state !== "sleeping"
     && !entry.hiddenFromHud
     && !entry.host;
 }
 
-function getFocusableLocalHudSessionIds(snapshot) {
+function getFocusableLocalHudSessionIds(snapshot, options = {}) {
   const sessions = Array.isArray(snapshot && snapshot.sessions) ? snapshot.sessions : [];
   return sessions
-    .filter(isFocusableLocalHudSession)
+    .filter((entry) => isFocusableLocalHudSession(entry, options))
     .map((entry) => entry.id);
 }
 

--- a/src/state-session-snapshot.js
+++ b/src/state-session-snapshot.js
@@ -170,7 +170,9 @@ function buildSessionSnapshotEntry(id, session, sessionAliases = {}, options = {
   const state = (session && session.state) || "idle";
   const hiddenFromHud = shouldAutoClearDetachedSession(session, badge, options);
   const focusTarget = session && !session.headless && state !== "sleeping" && !hiddenFromHud
-    ? getSessionFocusTarget({ ...(session || {}), id })
+    ? getSessionFocusTarget({ ...(session || {}), id }, {
+      osPlatform: options.focusHostPlatform || options.osPlatform,
+    })
     : { canFocus: false, type: null, url: null };
   return {
     id,

--- a/src/state.js
+++ b/src/state.js
@@ -720,6 +720,7 @@ function buildSessionSnapshot() {
     getAgentIconUrl,
     statePriority: STATE_PRIORITY,
     sessionHudCleanupDetached: ctx.sessionHudCleanupDetached === true,
+    focusHostPlatform: ctx.focusHostPlatform || process.platform,
     isProcessAlive,
   });
 }

--- a/test/session-focus.test.js
+++ b/test/session-focus.test.js
@@ -68,6 +68,44 @@ describe("session focus helpers", () => {
     });
   });
 
+  it("downgrades Codex Desktop thread focus targets on Windows", () => {
+    const entry = {
+      id: "codex:019e115a-4df2-7ed0-b90e-8e6345aca777",
+      agentId: "codex",
+      codexOriginator: "Codex Desktop",
+      sourcePid: 123,
+      state: "working",
+    };
+    const noTerminalEntry = {
+      id: "codex:019e115b-4df2-7ed0-b90e-8e6345aca777",
+      agentId: "codex",
+      codexOriginator: "Codex Desktop",
+      state: "working",
+    };
+
+    assert.deepStrictEqual(getSessionFocusTarget(entry, { osPlatform: "win32" }), {
+      canFocus: true,
+      type: "terminal",
+      url: null,
+    });
+    assert.deepStrictEqual(getSessionFocusTarget(noTerminalEntry, { osPlatform: "win32" }), {
+      canFocus: false,
+      type: null,
+      url: null,
+    });
+    assert.deepStrictEqual(getSessionFocusTarget(noTerminalEntry, { osPlatform: "darwin" }), {
+      canFocus: true,
+      type: "codex-thread",
+      url: "codex://threads/019e115b-4df2-7ed0-b90e-8e6345aca777",
+    });
+    assert.deepStrictEqual(getFocusableLocalHudSessionIds({
+      sessions: [entry, noTerminalEntry],
+    }, { osPlatform: "win32" }), [
+      "codex:019e115a-4df2-7ed0-b90e-8e6345aca777",
+    ]);
+    assert.strictEqual(isFocusableLocalHudSession(noTerminalEntry, { osPlatform: "win32" }), false);
+  });
+
   it("rejects malformed entries defensively", () => {
     assert.strictEqual(isFocusableLocalHudSession(null), false);
     assert.strictEqual(isFocusableLocalHudSession({ sourcePid: 1 }), false);

--- a/test/state-session-snapshot.test.js
+++ b/test/state-session-snapshot.test.js
@@ -213,6 +213,40 @@ describe("state-session-snapshot builder", () => {
     assert.strictEqual(byId.get("codex:019e115a-4df2-7ed0-b90e-8e6345aca777").codexSource, "vscode");
   });
 
+  it("downgrades Codex Desktop focus targets on Windows snapshots", () => {
+    const snapshot = buildSessionSnapshot(new Map([
+      ["codex:019e115a-4df2-7ed0-b90e-8e6345aca777", session("working", {
+        agentId: "codex",
+        codexOriginator: "Codex Desktop",
+        sourcePid: 123,
+      })],
+      ["codex:019e115b-4df2-7ed0-b90e-8e6345aca777", session("working", {
+        agentId: "codex",
+        codexOriginator: "Codex Desktop",
+      })],
+    ]), { focusHostPlatform: "win32" });
+
+    const byId = new Map(snapshot.sessions.map((entry) => [entry.id, entry]));
+    assert.strictEqual(byId.get("codex:019e115a-4df2-7ed0-b90e-8e6345aca777").canFocus, true);
+    assert.deepStrictEqual(byId.get("codex:019e115a-4df2-7ed0-b90e-8e6345aca777").focusTarget, {
+      type: "terminal",
+      url: null,
+    });
+    assert.strictEqual(byId.get("codex:019e115b-4df2-7ed0-b90e-8e6345aca777").canFocus, false);
+    assert.strictEqual(byId.get("codex:019e115b-4df2-7ed0-b90e-8e6345aca777").focusTarget, null);
+
+    const nonWindowsSnapshot = buildSessionSnapshot(new Map([
+      ["codex:019e115b-4df2-7ed0-b90e-8e6345aca777", session("working", {
+        agentId: "codex",
+        codexOriginator: "Codex Desktop",
+      })],
+    ]), { focusHostPlatform: "darwin" });
+    assert.deepStrictEqual(nonWindowsSnapshot.sessions[0].focusTarget, {
+      type: "codex-thread",
+      url: "codex://threads/019e115b-4df2-7ed0-b90e-8e6345aca777",
+    });
+  });
+
   it("exposes assistant last output for completion companion consumers", () => {
     const snapshot = buildSessionSnapshot(new Map([
       ["done", session("idle", {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -39,6 +39,7 @@ function makeCtx(overrides = {}) {
     resolvePermissionEntry: () => {},
     dismissPermissionsForDnd: () => {},
     focusTerminalWindow: () => {},
+    focusHostPlatform: "darwin",
     // Default: all pids dead
     processKill: () => { const e = new Error("ESRCH"); e.code = "ESRCH"; throw e; },
     getCursorScreenPoint: () => ({ x: 100, y: 100 }),
@@ -943,6 +944,36 @@ describe("updateSession()", () => {
       type: "codex-thread",
       url: "codex://threads/019e115a-4df2-7ed0-b90e-8e6345aca777",
     });
+  });
+
+  it("Codex Desktop focus metadata downgrades on Windows", () => {
+    api = require("../src/state")(makeCtx({ focusHostPlatform: "win32" }));
+
+    update(api, {
+      id: "codex:019e115a-4df2-7ed0-b90e-8e6345aca777",
+      state: "notification",
+      event: "PermissionRequest",
+      agentId: "codex",
+      sourcePid: 456,
+      agentPid: 456,
+      codexOriginator: "Codex Desktop",
+    });
+    update(api, {
+      id: "codex:019e115b-4df2-7ed0-b90e-8e6345aca777",
+      state: "working",
+      event: "PreToolUse",
+      agentId: "codex",
+      codexOriginator: "Codex Desktop",
+    });
+
+    const byId = new Map(api.getLastSessionSnapshot().sessions.map((entry) => [entry.id, entry]));
+    assert.strictEqual(byId.get("codex:019e115a-4df2-7ed0-b90e-8e6345aca777").canFocus, true);
+    assert.deepStrictEqual(byId.get("codex:019e115a-4df2-7ed0-b90e-8e6345aca777").focusTarget, {
+      type: "terminal",
+      url: null,
+    });
+    assert.strictEqual(byId.get("codex:019e115b-4df2-7ed0-b90e-8e6345aca777").canFocus, false);
+    assert.strictEqual(byId.get("codex:019e115b-4df2-7ed0-b90e-8e6345aca777").focusTarget, null);
   });
 
   it("keeps wtHwnd sticky when later events do not provide one", () => {


### PR DESCRIPTION
## Summary

- route Windows Codex Desktop focus attempts through the terminal/window focus path when a `sourcePid` is available
- mark Windows Codex Desktop sessions without a `sourcePid` as not focusable instead of launching the broken `codex://threads/<uuid>` AppX handoff
- keep non-Windows Codex Desktop deep links unchanged and add deterministic coverage for Windows and non-Windows focus metadata

## Root Cause

On Windows, `shell.openExternal("codex://threads/<uuid>")` can resolve successfully while Codex Desktop/Electron later shows an error dialog from the AppX protocol activation path. Because Clawd only fell back when `openExternal` rejected, HUD/Dashboard clicks could still trigger the broken deep link from #378.

Fixes #378.

## Validation

- `node --test test\session-focus.test.js`
- `node --test test\state-session-snapshot.test.js`
- `node --test test\state.test.js`
- `npm test` (`3343 pass / 0 fail / 5 skipped`)