### PR TITLE
Fix Codex working state during long silent permission turns

### DIFF
--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -425,6 +425,7 @@ function handlePermissionPost(req, res, options) {
           if (shouldMuteCodexNativeNotificationSound(ctx)) {
             nativeSessionOptions.muteNotificationSound = true;
           }
+          nativeSessionOptions.transientPermissionEvent = true;
           ctx.updateSession(sessionId, "notification", "PermissionRequest", nativeSessionOptions);
           ctx.permLog(`codex native permission mode -> no decision, native prompt fallback (tool=${toolName})`);
           recordRequestHookEvent.accepted();

--- a/src/state-stale-cleanup.js
+++ b/src/state-stale-cleanup.js
@@ -3,6 +3,7 @@
 const SESSION_STALE_MS = 600000;
 const WORKING_STALE_MS = 300000;
 const DETACHED_IDLE_STALE_MS = 30000;
+const CODEX_LOCAL_WORKING_STALE_FLOOR_MS = 20 * 60 * 1000;
 
 // Hard ceiling for sessions held back by requiresCompletionAck — beyond this
 // we delete the session even if the user never clicked anything. Private
@@ -13,18 +14,39 @@ function isWorkingLikeState(state) {
   return state === "working" || state === "juggling" || state === "thinking";
 }
 
+function isLocalCodexWorkingLikeSession(session) {
+  return !!session
+    && session.agentId === "codex"
+    && !session.host
+    && isWorkingLikeState(session.state);
+}
+
 function getStaleSessionDecision(session, options = {}) {
   const now = options.now;
   const config = options.staleConfig || {};
-  const sessionStaleMs = Number.isFinite(config.sessionStaleMs)
+  let sessionStaleMs = Number.isFinite(config.sessionStaleMs)
     ? config.sessionStaleMs
     : SESSION_STALE_MS;
-  const workingStaleMs = Number.isFinite(config.workingStaleMs)
+  let workingStaleMs = Number.isFinite(config.workingStaleMs)
     ? config.workingStaleMs
     : WORKING_STALE_MS;
   const detachedIdleStaleMs = Number.isFinite(config.detachedIdleStaleMs)
     ? config.detachedIdleStaleMs
     : DETACHED_IDLE_STALE_MS;
+
+  if (isLocalCodexWorkingLikeSession(session)) {
+    // Codex can spend many minutes in one silent model/command segment. Keep
+    // the stuck-session guard, but do not let the generic 5/10 minute defaults
+    // make an active local Codex turn look idle.
+    const floor = (
+      Number.isFinite(config.codexLocalWorkingStaleFloorMs)
+      && config.codexLocalWorkingStaleFloorMs > 0
+    )
+      ? config.codexLocalWorkingStaleFloorMs
+      : CODEX_LOCAL_WORKING_STALE_FLOOR_MS;
+    workingStaleMs = Math.max(workingStaleMs, floor);
+    if (sessionStaleMs > 0) sessionStaleMs = Math.max(sessionStaleMs, floor);
+  }
 
   const isProcessAlive = options.isProcessAlive;
 
@@ -104,6 +126,8 @@ module.exports = {
   SESSION_STALE_MS,
   WORKING_STALE_MS,
   DETACHED_IDLE_STALE_MS,
+  CODEX_LOCAL_WORKING_STALE_FLOOR_MS,
   isWorkingLikeState,
+  isLocalCodexWorkingLikeSession,
   getStaleSessionDecision,
 };

--- a/src/state.js
+++ b/src/state.js
@@ -16,6 +16,7 @@ const {
 } = require("./state-visual-resolver");
 const {
   getStaleSessionDecision,
+  isWorkingLikeState,
 } = require("./state-stale-cleanup");
 const {
   createHitboxRuntime,
@@ -898,6 +899,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     hookSource = null,
     agentIdDefaulted = false,
     muteNotificationSound = false,
+    transientPermissionEvent = false,
   } = opts;
   if (startupRecoveryActive) {
     startupRecoveryActive = false;
@@ -948,7 +950,9 @@ function updateSession(sessionId, state, event, opts = {}) {
       // later hook arrives for that synthetic session, auto-return keeps
       // resolving back to notification forever.
       const storedState = existing && existing.state ? existing.state : "idle";
-      const recentEvents = pushRecentEvent(existing, storedState, event);
+      const recentEvents = transientPermissionEvent === true
+        ? (Array.isArray(existing && existing.recentEvents) ? existing.recentEvents.slice() : [])
+        : pushRecentEvent(existing, storedState, event);
       sessions.set(sessionId, {
         state: storedState,
         updatedAt: Date.now(),
@@ -1326,18 +1330,47 @@ function dismissSession(sessionId) {
   return true;
 }
 
+function takeTrailingPermissionRequest(session) {
+  const events = Array.isArray(session && session.recentEvents)
+    ? session.recentEvents
+    : null;
+  if (!events || events.length === 0) return null;
+  const last = events[events.length - 1];
+  if (!last || last.event !== "PermissionRequest") return null;
+  session.recentEvents = events.slice(0, -1);
+  return last;
+}
+
 function clearPermissionNotification(sessionId, options = {}) {
   const id = typeof sessionId === "string" ? sessionId : "";
   if (!id || options.hasPendingForSession === true) return false;
 
   let changed = false;
   const session = sessions.get(id);
-  if (session && session.state === "notification") {
-    session.state = "idle";
-    session.updatedAt = Date.now();
-    session.displayHint = null;
-    session.resumeState = null;
-    changed = true;
+  if (session) {
+    const trailingPermission = takeTrailingPermissionRequest(session);
+    if (session.state === "notification") {
+      session.state = "idle";
+      session.displayHint = null;
+      session.resumeState = null;
+      changed = true;
+    } else if (
+      session.state === "idle"
+      && trailingPermission
+      && isWorkingLikeState(trailingPermission.state)
+    ) {
+      // A stale sweep may downgrade a Codex session while the approval is
+      // still pending. Once the permission resolves, restore the work state
+      // recorded at request time so long commands do not stay visually idle.
+      session.state = trailingPermission.state;
+      changed = true;
+    }
+    if (trailingPermission) {
+      session.updatedAt = Date.now();
+      changed = true;
+    } else if (changed) {
+      session.updatedAt = Date.now();
+    }
   }
 
   // Leave the one-shot notification immediately after the permission channel

--- a/test/server-codex-permission.test.js
+++ b/test/server-codex-permission.test.js
@@ -206,6 +206,7 @@ describe("Codex official /permission path", () => {
         model: "gpt-5.4",
         codexOriginator: "Codex Desktop",
         codexSource: "vscode",
+        transientPermissionEvent: true,
       },
     ]);
   });

--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -7,7 +7,9 @@ const {
   SESSION_STALE_MS,
   WORKING_STALE_MS,
   DETACHED_IDLE_STALE_MS,
+  CODEX_LOCAL_WORKING_STALE_FLOOR_MS,
   isWorkingLikeState,
+  isLocalCodexWorkingLikeSession,
   getStaleSessionDecision,
 } = require("../src/state-stale-cleanup");
 
@@ -131,6 +133,15 @@ describe("state stale cleanup decisions", () => {
     assert.strictEqual(isWorkingLikeState("thinking"), true);
     assert.strictEqual(isWorkingLikeState("juggling"), true);
     assert.strictEqual(isWorkingLikeState("idle"), false);
+    assert.strictEqual(isLocalCodexWorkingLikeSession(session({
+      state: "working",
+      agentId: "codex",
+    })), true);
+    assert.strictEqual(isLocalCodexWorkingLikeSession(session({
+      state: "working",
+      agentId: "codex",
+      host: "ssh:example.com",
+    })), false);
   });
 
   it("falls back to module defaults when no staleConfig provided", () => {
@@ -175,6 +186,44 @@ describe("state stale cleanup decisions", () => {
       staleConfig: { workingStaleMs: 600_000 },
     });
     assert.deepStrictEqual(result, { action: null });
+  });
+
+  it("keeps local Codex working through the default short stale windows", () => {
+    const { result } = decision(session({
+      state: "working",
+      agentId: "codex",
+      updatedAt: 1000000 - 11 * 60 * 1000,
+      agentPid: 10,
+      sourcePid: 20,
+    }), {
+      alivePids: new Set([10, 20]),
+    });
+    assert.deepStrictEqual(result, { action: null });
+  });
+
+  it("still downgrades local Codex working after the Codex floor expires", () => {
+    const { result } = decision(session({
+      state: "thinking",
+      agentId: "codex",
+      updatedAt: 2000000 - CODEX_LOCAL_WORKING_STALE_FLOOR_MS - 1,
+      agentPid: 10,
+      sourcePid: 20,
+    }), {
+      now: 2000000,
+      alivePids: new Set([10, 20]),
+    });
+    assert.deepStrictEqual(result, { action: "idle", reason: "session-timeout", updateTimestamp: false });
+  });
+
+  it("does not extend remote Codex working sessions", () => {
+    const { result } = decision(session({
+      state: "working",
+      agentId: "codex",
+      host: "ssh:example.com",
+      updatedAt: 1000000 - WORKING_STALE_MS - 1,
+      sourcePid: null,
+    }));
+    assert.deepStrictEqual(result, { action: "idle", reason: "working-timeout", updateTimestamp: true });
   });
 
   it("honors a configured detachedIdleStaleMs cutoff", () => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1037,6 +1037,22 @@ describe("updateSession()", () => {
     assert.strictEqual(api.getCurrentState(), "idle");
   });
 
+  it("Codex transient PermissionRequest preserves focus without keeping a waiting tail", () => {
+    update(api, { id: "codex:native", state: "working", event: "PreToolUse", agentId: "codex" });
+
+    api.updateSession("codex:native", "notification", "PermissionRequest", {
+      agentId: "codex",
+      sourcePid: 456,
+      transientPermissionEvent: true,
+    });
+
+    const session = api.sessions.get("codex:native");
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.sourcePid, 456);
+    assert.strictEqual(session.recentEvents.at(-1).event, "PreToolUse");
+    assert.ok(!session.recentEvents.some((entry) => entry.event === "PermissionRequest"));
+  });
+
   it("stores one-shot visuals as idle while permission prompts preserve active work", () => {
     update(api, { id: "notify", state: "notification", event: "Notification", agentId: "claude-code" });
     assert.strictEqual(api.sessions.get("notify").state, "idle");
@@ -1070,6 +1086,83 @@ describe("updateSession()", () => {
 
     assert.strictEqual(api.sessions.get("codex:stale-permission").state, "idle");
     assert.strictEqual(api.getCurrentState(), "idle");
+  });
+
+  it("clearPermissionNotification removes a resolved PermissionRequest tail event", () => {
+    update(api, { id: "perm-active", state: "working", event: "PreToolUse", agentId: "codex" });
+    update(api, {
+      id: "perm-active",
+      state: "notification",
+      event: "PermissionRequest",
+      agentId: "codex",
+      sourcePid: 456,
+    });
+
+    assert.strictEqual(api.sessions.get("perm-active").recentEvents.at(-1).event, "PermissionRequest");
+
+    assert.strictEqual(api.clearPermissionNotification("perm-active"), true);
+
+    const session = api.sessions.get("perm-active");
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.recentEvents.at(-1).event, "PreToolUse");
+    assert.strictEqual(api.resolveDisplayState(), "working");
+  });
+
+  it("clearPermissionNotification restores Codex work state after stale idle downgrade", () => {
+    api.sessions.set("codex:stale-approved", rawSession("idle", {
+      agentId: "codex",
+      sourcePid: 456,
+      pidReachable: true,
+      recentEvents: [
+        { event: "PreToolUse", state: "working", at: Date.now() - 360000 },
+        { event: "PermissionRequest", state: "working", at: Date.now() - 350000 },
+      ],
+    }));
+
+    assert.strictEqual(api.clearPermissionNotification("codex:stale-approved"), true);
+
+    const session = api.sessions.get("codex:stale-approved");
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.recentEvents.at(-1).event, "PreToolUse");
+    assert.strictEqual(api.getCurrentState(), "working");
+  });
+
+  it("clearPermissionNotification keeps the tail while another permission is pending", () => {
+    api.sessions.set("codex:stacked", rawSession("working", {
+      agentId: "codex",
+      sourcePid: 456,
+      pidReachable: true,
+      recentEvents: [
+        { event: "PreToolUse", state: "working", at: Date.now() - 2000 },
+        { event: "PermissionRequest", state: "working", at: Date.now() - 1000 },
+      ],
+    }));
+
+    assert.strictEqual(
+      api.clearPermissionNotification("codex:stacked", { hasPendingForSession: true }),
+      false,
+    );
+
+    const session = api.sessions.get("codex:stacked");
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.recentEvents.at(-1).event, "PermissionRequest");
+  });
+
+  it("clearPermissionNotification also strips a resolved remote Codex tail", () => {
+    api.sessions.set("codex:remote-approved", rawSession("idle", {
+      agentId: "codex",
+      host: "ssh://devbox",
+      recentEvents: [
+        { event: "PreToolUse", state: "working", at: Date.now() - 360000 },
+        { event: "PermissionRequest", state: "working", at: Date.now() - 350000 },
+      ],
+    }));
+
+    assert.strictEqual(api.clearPermissionNotification("codex:remote-approved"), true);
+
+    const session = api.sessions.get("codex:remote-approved");
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.recentEvents.at(-1).event, "PreToolUse");
   });
 
   it("SessionEnd + sweeping → plays sweeping even with other active sessions", () => {


### PR DESCRIPTION
## Summary

Fixes #382.

Codex can remain silent for several minutes while running a long command or model segment after a permission request. The generic stale-session guard could downgrade that local Codex session to idle, while a trailing `PermissionRequest` recent event kept the HUD showing a stale waiting chip.

This PR:
- gives local Codex working/thinking/juggling sessions a 20 minute stale floor, covering both working and session timeouts
- clears a resolved trailing `PermissionRequest` event and restores the recorded working-like state after stale idle downgrade
- marks native Codex permission prompts as transient so they flash notification state without leaving a persistent waiting tail
- adds regression coverage for local/remote Codex stale behavior, pending permission guard behavior, and native permission mode

## Validation

- `node --test test\state-stale-cleanup.test.js test\state.test.js test\server-codex-permission.test.js`
- `npm test`