### PR TITLE
[codex] Fix updater GitHub API fallback

### DIFF
--- a/src/updater.js
+++ b/src/updater.js
@@ -436,7 +436,78 @@ function initUpdater(ctx, deps = {}) {
   let lastReleaseEtag = "";
   let lastReleaseJson = null;
 
-  function fetchLatestRelease() {
+  function buildGitHubApiStatusError(res, body) {
+    const statusCode = res && res.statusCode;
+    const headers = (res && res.headers) || {};
+    const parts = [`GitHub API returned ${statusCode}`];
+    const remaining = headers["x-ratelimit-remaining"];
+    const limit = headers["x-ratelimit-limit"];
+    const reset = headers["x-ratelimit-reset"];
+    if (remaining != null || limit != null) {
+      parts.push(`rate limit ${remaining != null ? remaining : "?"}/${limit != null ? limit : "?"}`);
+    }
+    if (reset != null) parts.push(`reset ${reset}`);
+    const trimmedBody = String(body || "").trim();
+    if (trimmedBody) {
+      try {
+        const parsed = JSON.parse(trimmedBody);
+        if (parsed && parsed.message) parts.push(String(parsed.message));
+      } catch {
+        parts.push(trimmedBody.slice(0, 160));
+      }
+    }
+    const err = new Error(parts.join("; "));
+    err.statusCode = statusCode;
+    return err;
+  }
+
+  function extractLatestRedirectTag(location) {
+    if (!location) return "";
+    try {
+      const url = new URL(String(location), RELEASES_LATEST_URL);
+      const match = /\/releases\/tag\/([^/?#]+)\/?$/.exec(url.pathname);
+      return match ? decodeURIComponent(match[1]) : "";
+    } catch {
+      return "";
+    }
+  }
+
+  function fetchLatestReleaseViaRedirect() {
+    return new Promise((resolve, reject) => {
+      const req = httpsGet({
+        hostname: "github.com",
+        path: "/rullerzhou-afk/clawd-on-desk/releases/latest",
+        headers: {
+          "User-Agent": "Clawd-on-Desk",
+          Accept: "text/html,*/*",
+        },
+      }, (res) => {
+        const tag = extractLatestRedirectTag(res.headers && res.headers.location);
+        let data = "";
+        res.on("data", (chunk) => { data += chunk; });
+        res.on("end", () => {
+          if (res.statusCode >= 300 && res.statusCode < 400 && tag) {
+            // The redirect fallback only exposes the tag, not release assets.
+            // Windows-on-ARM64 native-installer prompts therefore fall back to
+            // the normal updater path while the GitHub API is unavailable.
+            return resolve({ tag_name: tag, assets: [] });
+          }
+          reject(new Error(`GitHub releases redirect returned ${res.statusCode}${data ? `: ${data.slice(0, 160)}` : ""}`));
+        });
+        res.on("error", reject);
+      });
+
+      if (req && typeof req.on === "function") req.on("error", reject);
+      if (req && typeof req.setTimeout === "function") {
+        req.setTimeout(10000, () => {
+          if (typeof req.destroy === "function") req.destroy();
+          reject(new Error("GitHub releases redirect request timed out (10s)"));
+        });
+      }
+    });
+  }
+
+  function fetchLatestReleaseFromApi() {
     return new Promise((resolve, reject) => {
       const headers = { "User-Agent": "Clawd-on-Desk" };
       if (lastReleaseEtag) headers["If-None-Match"] = lastReleaseEtag;
@@ -460,7 +531,7 @@ function initUpdater(ctx, deps = {}) {
         res.on("end", () => {
           if (res.statusCode !== 200) {
             if (res.statusCode === 404) return reject(new Error("No releases found"));
-            return reject(new Error(`GitHub API returned ${res.statusCode}`));
+            return reject(buildGitHubApiStatusError(res, data));
           }
           try {
             const release = JSON.parse(data);
@@ -485,10 +556,23 @@ function initUpdater(ctx, deps = {}) {
     });
   }
 
-  // Scheduler-only discovery path. Hits GitHub API, compares against the
-  // running app version, and returns a structured result. Strictly no UI
-  // side effects: no setOverlay, no showInfoBubble, no showUpdateBubble,
-  // no applyState. Errors are logged + returned, never bubbled.
+  async function fetchLatestRelease() {
+    try {
+      return await fetchLatestReleaseFromApi();
+    } catch (err) {
+      if (err && err.message === "No releases found") throw err;
+      if (!err || err.statusCode == null) throw err;
+      const reason = getErrorMessage(err);
+      log(`GitHub API latest release lookup failed (${err.statusCode}): ${reason}; trying releases/latest redirect`);
+      return fetchLatestReleaseViaRedirect();
+    }
+  }
+
+  // Scheduler-only discovery path. Looks up the latest release, compares
+  // against the running app version, and returns a structured result.
+  // Strictly no UI side effects: no setOverlay, no showInfoBubble, no
+  // showUpdateBubble, no applyState. Errors are logged + returned, never
+  // bubbled.
   // electron-updater is intentionally bypassed here — see plan
   // "Architectural Boundary" section. If the caller wants to actually
   // download what this returns, route through checkForUpdates({ trigger:

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -85,6 +85,40 @@ function makePendingReleaseResponse(queue) {
   };
 }
 
+function makeHttpResponse({ statusCode, headers = {}, body = "" }) {
+  return {
+    statusCode,
+    headers,
+    on(event, handler) {
+      if (event === "data" && body) {
+        process.nextTick(() => handler(Buffer.from(body)));
+      }
+      if (event === "end") process.nextTick(() => handler());
+      return this;
+    },
+    resume() {},
+  };
+}
+
+function makeSequencedHttpsGet(responses, requests = []) {
+  const queue = [...responses];
+  return (options, cb) => {
+    requests.push(`${options.hostname}${options.path}`);
+    const next = queue.shift();
+    if (next instanceof Error) {
+      return {
+        on(event, handler) {
+          if (event === "error") process.nextTick(() => handler(next));
+          return this;
+        },
+        setTimeout() {},
+      };
+    }
+    cb(makeHttpResponse(next));
+    return { on() { return this; }, setTimeout() {} };
+  };
+}
+
 describe("updater visual flow", () => {
   beforeEach(() => {
     mock.restoreAll();
@@ -336,34 +370,164 @@ describe("updater visual flow", () => {
     const visualStates = [];
     const appliedStates = [];
     const bubbles = [];
+    const requests = [];
     const ctx = makeCtx({
       setUpdateVisualState: (state) => visualStates.push(state),
       applyState: (state) => appliedStates.push(state),
       showUpdateBubble: (payload) => bubbles.push(payload),
     });
     const updater = initUpdater(ctx, makeDeps({
-      httpsGetImpl: () => {
-        const req = {
-          on(event, handler) {
-            if (event === "error") {
-              process.nextTick(() => handler(new Error("network down")));
-            }
-            return this;
-          },
-          setTimeout() {},
-        };
-        return req;
-      },
+      httpsGetImpl: makeSequencedHttpsGet([new Error("network down")], requests),
     }));
 
     await updater.checkForUpdates(true);
 
     assert.deepStrictEqual(visualStates, ["checking", null]);
     assert.ok(appliedStates.includes("error"));
+    assert.deepStrictEqual(requests, [
+      "api.github.com/repos/rullerzhou-afk/clawd-on-desk/releases/latest",
+    ]);
     assert.deepStrictEqual(bubbles.map((bubble) => bubble.mode), ["checking", "error"]);
     assert.match(bubbles[1].detail, /Operation: Check for Updates/);
     assert.match(bubbles[1].detail, /Reason: network down/);
     assert.match(bubbles[1].detail, /network down/);
+  });
+
+  it("falls back to releases/latest redirect when GitHub API is rate-limited", async () => {
+    const bubbles = [];
+    const requests = [];
+    const ctx = makeCtx({
+      showUpdateBubble: (payload) => bubbles.push(payload),
+    });
+    const updater = initUpdater(ctx, makeDeps({
+      httpsGetImpl: makeSequencedHttpsGet([
+        {
+          statusCode: 403,
+          headers: {
+            "x-ratelimit-remaining": "0",
+            "x-ratelimit-limit": "60",
+          },
+          body: JSON.stringify({ message: "API rate limit exceeded" }),
+        },
+        {
+          statusCode: 302,
+          headers: {
+            location: "https://github.com/rullerzhou-afk/clawd-on-desk/releases/tag/v0.5.10",
+          },
+        },
+      ], requests),
+    }));
+
+    await updater.checkForUpdates(true);
+
+    assert.deepStrictEqual(requests, [
+      "api.github.com/repos/rullerzhou-afk/clawd-on-desk/releases/latest",
+      "github.com/rullerzhou-afk/clawd-on-desk/releases/latest",
+    ]);
+    assert.deepStrictEqual(bubbles.map((bubble) => bubble.mode), ["checking", "up-to-date"]);
+  });
+
+  it("continues into electron-updater when redirect fallback finds a newer version", async () => {
+    const bubbles = [];
+    const requests = [];
+    const handlers = {};
+    let updateChecks = 0;
+    const ctx = makeCtx({
+      showUpdateBubble: async (payload) => {
+        bubbles.push(payload);
+        if (payload.mode === "available") return "later";
+        return payload.defaultAction || null;
+      },
+    });
+    const updater = initUpdater(ctx, makeDeps({
+      autoUpdaterFactory: () => ({
+        autoDownload: false,
+        autoInstallOnAppQuit: true,
+        on(event, handler) { handlers[event] = handler; },
+        checkForUpdates: async () => {
+          updateChecks += 1;
+          return { updateInfo: { version: "0.5.11" } };
+        },
+        quitAndInstall() {},
+        downloadUpdate() {},
+      }),
+      httpsGetImpl: makeSequencedHttpsGet([
+        {
+          statusCode: 403,
+          headers: { "x-ratelimit-remaining": "0", "x-ratelimit-limit": "60" },
+          body: JSON.stringify({ message: "API rate limit exceeded" }),
+        },
+        {
+          statusCode: 302,
+          headers: {
+            location: "https://github.com/rullerzhou-afk/clawd-on-desk/releases/tag/v0.5.11",
+          },
+        },
+      ], requests),
+    }));
+
+    updater.setupAutoUpdater();
+    await updater.checkForUpdates(true);
+    await handlers["update-available"]({ version: "0.5.11" });
+
+    assert.strictEqual(updateChecks, 1);
+    assert.deepStrictEqual(requests, [
+      "api.github.com/repos/rullerzhou-afk/clawd-on-desk/releases/latest",
+      "github.com/rullerzhou-afk/clawd-on-desk/releases/latest",
+    ]);
+    assert.deepStrictEqual(bubbles.map((bubble) => bubble.mode), ["checking", "available"]);
+  });
+
+  it("shows an error when the GitHub API and redirect fallback both fail", async () => {
+    const bubbles = [];
+    const requests = [];
+    const ctx = makeCtx({
+      showUpdateBubble: (payload) => bubbles.push(payload),
+    });
+    const updater = initUpdater(ctx, makeDeps({
+      httpsGetImpl: makeSequencedHttpsGet([
+        {
+          statusCode: 403,
+          headers: { "x-ratelimit-remaining": "0", "x-ratelimit-limit": "60" },
+          body: JSON.stringify({ message: "API rate limit exceeded" }),
+        },
+        {
+          statusCode: 200,
+          headers: {},
+          body: "<html>no redirect</html>",
+        },
+      ], requests),
+    }));
+
+    await updater.checkForUpdates(true);
+
+    assert.deepStrictEqual(requests, [
+      "api.github.com/repos/rullerzhou-afk/clawd-on-desk/releases/latest",
+      "github.com/rullerzhou-afk/clawd-on-desk/releases/latest",
+    ]);
+    assert.deepStrictEqual(bubbles.map((bubble) => bubble.mode), ["checking", "error"]);
+    assert.match(bubbles[1].detail, /GitHub releases redirect returned 200/);
+  });
+
+  it("does not fallback when GitHub reports that no releases exist", async () => {
+    const bubbles = [];
+    const requests = [];
+    const ctx = makeCtx({
+      showUpdateBubble: (payload) => bubbles.push(payload),
+    });
+    const updater = initUpdater(ctx, makeDeps({
+      httpsGetImpl: makeSequencedHttpsGet([
+        { statusCode: 404, headers: {} },
+      ], requests),
+    }));
+
+    await updater.checkForUpdates(true);
+
+    assert.deepStrictEqual(requests, [
+      "api.github.com/repos/rullerzhou-afk/clawd-on-desk/releases/latest",
+    ]);
+    assert.deepStrictEqual(bubbles.map((bubble) => bubble.mode), ["checking", "error"]);
+    assert.match(bubbles[1].detail, /Reason: No releases found/);
   });
 
   it("shows a real error bubble when packaged download fails after user starts it", async () => {
@@ -508,6 +672,119 @@ describe("updater visual flow", () => {
     await updater.checkForUpdates(true);
 
     assert.deepStrictEqual(bubbles.map((bubble) => bubble.mode), ["checking", "up-to-date"]);
+  });
+
+  it("lets Windows-on-ARM64 fall back to the normal updater when redirect fallback has no asset metadata", async () => {
+    const bubbles = [];
+    const requests = [];
+    const openedUrls = [];
+    const ctx = makeCtx({
+      showUpdateBubble: async (payload) => {
+        bubbles.push(payload);
+        return payload.defaultAction || null;
+      },
+    });
+    const updater = initUpdater(ctx, makeDeps({
+      platform: "win32",
+      arch: "x64",
+      app: {
+        isPackaged: true,
+        runningUnderARM64Translation: true,
+        getVersion: () => "0.6.1",
+        relaunch() {},
+        exit() {},
+      },
+      shell: {
+        openExternal(url) {
+          openedUrls.push(url);
+        },
+      },
+      httpsGetImpl: makeSequencedHttpsGet([
+        {
+          statusCode: 403,
+          headers: { "x-ratelimit-remaining": "0", "x-ratelimit-limit": "60" },
+          body: JSON.stringify({ message: "API rate limit exceeded" }),
+        },
+        {
+          statusCode: 302,
+          headers: {
+            location: "https://github.com/rullerzhou-afk/clawd-on-desk/releases/tag/v0.6.1",
+          },
+        },
+      ], requests),
+    }));
+
+    await updater.checkForUpdates(true);
+
+    assert.deepStrictEqual(requests, [
+      "api.github.com/repos/rullerzhou-afk/clawd-on-desk/releases/latest",
+      "github.com/rullerzhou-afk/clawd-on-desk/releases/latest",
+    ]);
+    assert.deepStrictEqual(openedUrls, []);
+    assert.deepStrictEqual(bubbles.map((bubble) => bubble.mode), ["checking", "up-to-date"]);
+  });
+
+  it("lets Windows-on-ARM64 use the normal updater for newer redirect fallback releases without asset metadata", async () => {
+    const bubbles = [];
+    const requests = [];
+    const openedUrls = [];
+    let updateChecks = 0;
+    const ctx = makeCtx({
+      showUpdateBubble: async (payload) => {
+        bubbles.push(payload);
+        return payload.defaultAction || null;
+      },
+    });
+    const updater = initUpdater(ctx, makeDeps({
+      platform: "win32",
+      arch: "x64",
+      app: {
+        isPackaged: true,
+        runningUnderARM64Translation: true,
+        getVersion: () => "0.6.0",
+        relaunch() {},
+        exit() {},
+      },
+      shell: {
+        openExternal(url) {
+          openedUrls.push(url);
+        },
+      },
+      autoUpdaterFactory: () => ({
+        autoDownload: false,
+        autoInstallOnAppQuit: true,
+        on() {},
+        checkForUpdates: async () => {
+          updateChecks += 1;
+          return { updateInfo: { version: "0.6.1" } };
+        },
+        quitAndInstall() {},
+        downloadUpdate() {},
+      }),
+      httpsGetImpl: makeSequencedHttpsGet([
+        {
+          statusCode: 403,
+          headers: { "x-ratelimit-remaining": "0", "x-ratelimit-limit": "60" },
+          body: JSON.stringify({ message: "API rate limit exceeded" }),
+        },
+        {
+          statusCode: 302,
+          headers: {
+            location: "https://github.com/rullerzhou-afk/clawd-on-desk/releases/tag/v0.6.1",
+          },
+        },
+      ], requests),
+    }));
+
+    await updater.checkForUpdates(true);
+
+    assert.strictEqual(updateChecks, 1);
+    assert.deepStrictEqual(requests, [
+      "api.github.com/repos/rullerzhou-afk/clawd-on-desk/releases/latest",
+      "github.com/rullerzhou-afk/clawd-on-desk/releases/latest",
+    ]);
+    assert.deepStrictEqual(openedUrls, []);
+    assert.deepStrictEqual(bubbles.map((bubble) => bubble.mode), ["checking"]);
   });
 
   it("auto-prompts translated x64 Windows-on-ARM users during updater setup", async () => {


### PR DESCRIPTION
## Summary

- Adds an HTTP-level fallback for the updater's GitHub release preflight when `api.github.com` returns an error such as 403/rate limit.
- Falls back to `github.com/rullerzhou-afk/clawd-on-desk/releases/latest` and parses the redirected release tag so manual update checks can continue into the normal updater path.
- Keeps connection-layer failures, timeouts, and `No releases found` from using the fallback so offline users do not wait for a second doomed request.
- Documents and tests the Windows-on-ARM64 boundary: the redirect fallback has only tag metadata, so native ARM64 installer prompts degrade to the normal updater path while the GitHub API is unavailable.

## Root Cause

Issue #383 is triggered before `electron-updater` gets to run. Our own release preflight calls the unauthenticated GitHub REST API (`api.github.com/repos/.../releases/latest`), which can return 403 under shared proxy/TUN/rate-limit conditions. For public GitHub repos, `electron-updater` itself avoids that REST API path and uses GitHub release feed / update metadata instead.

Fixes #383.

## Validation

- `node --test test\updater.test.js` passes: 42 pass
- `npm test` passes: 3357 pass / 0 fail / 5 skipped
- `git diff --check` passes, with only LF/CRLF warnings