### PR TITLE
feat: wire Hermes Agent into permission bubble and elicitation system

### DIFF
--- a/agents/hermes.js
+++ b/agents/hermes.js
@@ -18,8 +18,8 @@ module.exports = {
   },
   capabilities: {
     httpHook: false,
-    permissionApproval: false,
-    interactiveBubble: false,
+    permissionApproval: true,
+    interactiveBubble: true,
     sessionEnd: true,
     subagent: false,
   },

--- a/hooks/hermes-install.js
+++ b/hooks/hermes-install.js
@@ -55,6 +55,41 @@ function pathExists(filePath) {
   }
 }
 
+function discoverHermesProfileHomes(hermesHome) {
+  const profilesDir = path.join(hermesHome, "profiles");
+  let entries = [];
+  try {
+    entries = fs.readdirSync(profilesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const homes = [];
+  for (const entry of entries) {
+    if (!entry || !entry.isDirectory()) continue;
+    const profileHome = path.join(profilesDir, entry.name);
+    if (!pathExists(path.join(profileHome, "config.yaml"))) continue;
+    homes.push(profileHome);
+  }
+  homes.sort((a, b) => a.localeCompare(b));
+  return homes;
+}
+
+function hermesHomesForSync(options = {}) {
+  const hermesHome = resolveHermesHome(options);
+  const homes = [hermesHome];
+  if (options.syncProfiles === false) return homes;
+
+  const seen = new Set(homes.map((home) => path.resolve(home)));
+  for (const profileHome of discoverHermesProfileHomes(hermesHome)) {
+    const resolved = path.resolve(profileHome);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    homes.push(resolved);
+  }
+  return homes;
+}
+
 function hermesCommandCandidates(options = {}, hermesHome = resolveHermesHome(options)) {
   const env = options.env || process.env;
   const platform = options.platform || process.platform;
@@ -216,51 +251,101 @@ function runHermesCli(args, options = {}) {
 
 function registerHermesPlugin(options = {}) {
   const hermesHome = resolveHermesHome(options);
-  const pluginDir = options.pluginDir || path.join(hermesHome, "plugins", PLUGIN_ID);
-  const copied = copyManagedPluginFiles({
-    baseDir: options.baseDir,
-    sourcePluginDir: options.sourcePluginDir,
-    pluginDir,
-  });
+  const syncHomes = options.pluginDir ? [hermesHome] : hermesHomesForSync({ ...options, hermesHome });
+  const primaryCommand = resolveHermesCommand({ ...options, hermesHome });
+  const results = [];
+  let firstError = null;
+  let installed = 0;
+  let updated = 0;
+  let skipped = 0;
+  let primaryResult = null;
 
-  const enableResult = runHermesCli(["plugins", "enable", PLUGIN_ID], {
-    ...options,
-    hermesHome,
-  });
-  const enableCommand = enableResult.displayCommand
-    || formatHermesCommand(resolveHermesCommand({ ...options, hermesHome }) || "hermes", ["plugins", "enable", PLUGIN_ID]);
+  for (const targetHome of syncHomes) {
+    const pluginDir = options.pluginDir && targetHome === hermesHome
+      ? options.pluginDir
+      : path.join(targetHome, "plugins", PLUGIN_ID);
+    const copied = copyManagedPluginFiles({
+      baseDir: options.baseDir,
+      sourcePluginDir: options.sourcePluginDir,
+      pluginDir,
+    });
+    installed += copied.installed;
+    updated += copied.updated;
+    skipped += copied.skipped;
+
+    const enableResult = runHermesCli(["plugins", "enable", PLUGIN_ID], {
+      ...options,
+      hermesHome: targetHome,
+      // Profile homes do not contain their own Hermes venv. Reuse the root
+      // CLI command and only swap HERMES_HOME so Hermes writes that profile's
+      // plugins.enabled allow-list.
+      hermesCommand: options.hermesCommand || primaryCommand,
+    });
+    const enableCommand = enableResult.displayCommand
+      || formatHermesCommand(resolveHermesCommand({ ...options, hermesHome: targetHome }) || "hermes", ["plugins", "enable", PLUGIN_ID]);
+
+    const base = {
+      ...copied,
+      pluginDir,
+      hermesHome: targetHome,
+      enableCommand,
+      reason: null,
+      skipped: copied.skipped,
+    };
+
+    let entry;
+    if (!enableResult.ok) {
+      const reason = enableResult.unavailable ? "hermes-cli-unavailable" : "hermes-cli-enable-failed";
+      entry = {
+        ...base,
+        status: "error",
+        reason,
+        message: enableResult.unavailable
+          ? `Hermes plugin files were installed, but Hermes CLI was not found. Run: ${enableCommand}`
+          : `Hermes plugin files were installed, but enabling failed: ${enableResult.message}`,
+      };
+      if (!firstError) firstError = entry;
+    } else {
+      entry = {
+        ...base,
+        status: "ok",
+        message: copied.installed || copied.updated ? "Hermes plugin installed" : "Hermes plugin already installed",
+      };
+    }
+    results.push(entry);
+    if (targetHome === hermesHome) primaryResult = entry;
+  }
 
   const base = {
-    ...copied,
-    pluginDir,
+    ...(primaryResult || {}),
+    installed,
+    updated,
+    skipped,
     hermesHome,
-    enableCommand,
-    reason: null,
-    skipped: copied.skipped,
+    pluginDir: options.pluginDir || path.join(hermesHome, "plugins", PLUGIN_ID),
+    profileResults: results,
   };
 
-  if (!enableResult.ok) {
-    const reason = enableResult.unavailable ? "hermes-cli-unavailable" : "hermes-cli-enable-failed";
+  if (firstError) {
     return {
       ...base,
       status: "error",
-      reason,
-      message: enableResult.unavailable
-        ? `Hermes plugin files were installed, but Hermes CLI was not found. Run: ${enableCommand}`
-        : `Hermes plugin files were installed, but enabling failed: ${enableResult.message}`,
+      reason: firstError.reason,
+      message: firstError.message,
     };
   }
 
   if (!options.silent) {
-    console.log(`Clawd Hermes plugin -> ${pluginDir}`);
-    console.log(`  Installed: ${copied.installed}, updated: ${copied.updated}, skipped: ${copied.skipped}`);
+    console.log(`Clawd Hermes plugin -> ${base.pluginDir}`);
+    console.log(`  Installed: ${installed}, updated: ${updated}, skipped: ${skipped}`);
+    if (results.length > 1) console.log(`  Profiles synced: ${results.length - 1}`);
     console.log("  Enabled: clawd-on-desk");
   }
 
   return {
     ...base,
     status: "ok",
-    message: copied.installed || copied.updated ? "Hermes plugin installed" : "Hermes plugin already installed",
+    message: installed || updated ? "Hermes plugin installed" : "Hermes plugin already installed",
   };
 }
 
@@ -325,7 +410,9 @@ module.exports = {
   MANAGED_PLUGIN_FILES,
   PLUGIN_ID,
   copyManagedPluginFiles,
+  discoverHermesProfileHomes,
   formatHermesCommand,
+  hermesHomesForSync,
   isHermesInstalled,
   registerHermesPlugin,
   resolveHermesCommand,

--- a/hooks/hermes-plugin/__init__.py
+++ b/hooks/hermes-plugin/__init__.py
@@ -25,6 +25,7 @@ CLAWD_SERVER_HEADER = "x-clawd-server"
 CLAWD_SERVER_ID = "clawd-on-desk"
 SERVER_PORTS = (23333, 23334, 23335, 23336, 23337)
 POST_TIMEOUT_SECONDS = 0.25
+PERMISSION_POST_TIMEOUT_SECONDS = 600.0
 NO_SERVER_COOLDOWN_SECONDS = 2.0
 TASK_SESSION_TTL_SECONDS = 10 * 60
 MAX_TASK_SESSION_IDS = 256
@@ -258,6 +259,100 @@ def _post_state(body: Dict[str, Any]) -> None:
             continue
     _cached_port = None
     _no_server_until = time.monotonic() + NO_SERVER_COOLDOWN_SECONDS
+
+
+def _post_permission(tool_name: str, tool_input: dict, session_id: str) -> Optional[dict]:
+    """POST to Clawd's /permission endpoint and block until user decides.
+
+    Returns the JSON response body as a dict, or None if Clawd is unreachable,
+    returns 204 (no-decision), or the request fails.
+
+    Respects the no-server cooldown to avoid blocking Hermes tool calls when
+    Clawd is known to be absent.  Before the long blocking POST, issues a short
+    header probe so a non-Clawd service on a candidate port cannot block a
+    Hermes tool call for up to PERMISSION_POST_TIMEOUT_SECONDS.
+    """
+    global _cached_port, _no_server_until
+    now = time.monotonic()
+    if _cached_port is None and _no_server_until > now:
+        _append_log({
+            "ts": _utc_now(),
+            "event": "post_permission_skipped_no_server",
+            "cooldown_ms": int((_no_server_until - now) * 1000),
+        })
+        return None
+
+    payload_dict: Dict[str, Any] = {
+        "agent_id": AGENT_ID,
+        "tool_name": tool_name,
+        "tool_input": tool_input,
+        "session_id": session_id,
+        "cwd": _runtime_cwd(),
+        "agent_pid": os.getpid(),
+    }
+    _add_process_meta(payload_dict)
+    payload = json.dumps(payload_dict).encode("utf-8")
+    headers = {
+        "Content-Type": "application/json",
+        "Content-Length": str(len(payload)),
+    }
+    for port in _port_candidates():
+        # ── Short probe — verify Clawd is on this port before the long POST ──
+        # Reuse the existing GET /state health route instead of inventing a
+        # plugin-only /probe endpoint.  The server includes CLAWD_SERVER_HEADER
+        # on /state responses; non-Clawd services or stale candidate ports fail
+        # here with a short timeout and never reach the 600s permission POST.
+        probe_req = request.Request(
+            f"http://127.0.0.1:{port}/state",
+            method="GET",
+        )
+        try:
+            with request.urlopen(probe_req, timeout=POST_TIMEOUT_SECONDS) as probe_resp:
+                if probe_resp.headers.get(CLAWD_SERVER_HEADER) != CLAWD_SERVER_ID:
+                    continue
+        except Exception:
+            continue
+
+        # ── Blocking permission POST ──
+        req = request.Request(
+            f"http://127.0.0.1:{port}/permission",
+            data=payload,
+            headers=headers,
+            method="POST",
+        )
+        try:
+            with request.urlopen(req, timeout=PERMISSION_POST_TIMEOUT_SECONDS) as response:
+                if response.status == 204:
+                    _cached_port = port
+                    return None
+                if response.headers.get(CLAWD_SERVER_HEADER) == CLAWD_SERVER_ID:
+                    _cached_port = port
+                    body = json.loads(response.read().decode("utf-8"))
+                    return body
+                _append_log({
+                    "ts": _utc_now(),
+                    "event": "post_permission_header_mismatch",
+                    "port": port,
+                })
+        except (OSError, URLError) as exc:
+            _append_log({
+                "ts": _utc_now(),
+                "event": "post_permission_failed",
+                "port": port,
+                "error": str(exc),
+            })
+            continue
+        except Exception as exc:
+            _append_log({
+                "ts": _utc_now(),
+                "event": "post_permission_error",
+                "port": port,
+                "error": str(exc),
+            })
+            continue
+    _cached_port = None
+    _no_server_until = time.monotonic() + NO_SERVER_COOLDOWN_SECONDS
+    return None
 
 
 def _platform_key() -> str:
@@ -885,13 +980,147 @@ def _handle_hook(event_name: str, **kwargs: Any) -> None:
             _append_log({"ts": _utc_now(), "event": event_name, "slow_ms": elapsed_ms})
 
 
+# Tools that require user approval via permission bubble.
+# Configure via CLAWD_HERMES_PERMISSION_TOOLS env var (comma-separated tool names).
+_PERMISSION_TOOLS_ENV = os.environ.get("CLAWD_HERMES_PERMISSION_TOOLS", "").strip()
+_PERMISSION_TOOLS: set = set()
+if _PERMISSION_TOOLS_ENV:
+    _PERMISSION_TOOLS = {t.strip() for t in _PERMISSION_TOOLS_ENV.split(",") if t.strip()}
+
+
 def _make_callback(event_name: str):
+    if event_name == "pre_tool_call":
+        def callback(**kwargs: Any):
+            tool_name = kwargs.get("tool_name", "")
+            if tool_name == "clarify":
+                return _handle_clarify_tool(**kwargs)
+            if _PERMISSION_TOOLS and tool_name in _PERMISSION_TOOLS:
+                return _handle_permission_request(tool_name, **kwargs)
+            _handle_hook(event_name, **kwargs)
+            return None
+        callback.__name__ = "clawd_pre_tool_call"
+        return callback
+
     def callback(**kwargs: Any) -> None:
         _handle_hook(event_name, **kwargs)
         return None
 
     callback.__name__ = f"clawd_{event_name}"
     return callback
+
+
+def _handle_clarify_tool(**kwargs: Any):
+    """Intercept clarify tool and show elicitation bubble via /permission.
+
+    COMPROMISE — error-channel result injection:
+    When the user answers via the Clawd permission bubble, we return
+    ``{"action": "block", "message": "User selected: <answer>"}`` from
+    ``pre_tool_call``.  Hermes' plugin contract translates this into a tool
+    result of ``{"error": "User selected: <answer>"}`` (see
+    ``tool_executor.py:220`` in hermes-agent).  The model receives this as
+    the clarify tool's output — semantically an error shape, but the
+    answer text is plain enough that models parse it reliably.
+
+    When Hermes adds a result-injection hook (inject a result without
+    blocking the tool), this interception should be migrated to that
+    cleaner path.
+
+    Falls back to Hermes' native clarify dialog when:
+    - Clawd is unreachable (None result)
+    - Clawd returns 204 / no-decision
+    - The permission bubble fails to create
+    """
+    args = kwargs.get("args", {})
+    question = str(args.get("question") or "").strip()
+    choices_raw = args.get("choices")
+    choices: list[str] = []
+    if isinstance(choices_raw, list):
+        choices = [str(c).strip() for c in choices_raw if str(c).strip()]
+
+    if not question:
+        _handle_hook("pre_tool_call", **kwargs)
+        return None
+
+    options = [{"label": c} for c in choices] if choices else []
+    tool_input = {"questions": [{"question": question, "options": options}]}
+    session_id = _session_id("pre_tool_call", kwargs)
+
+    try:
+        result = _post_permission("clarify", tool_input, session_id)
+    except Exception:
+        _append_log({
+            "ts": _utc_now(),
+            "event": "clarify_intercept_error",
+            "error": traceback.format_exc(),
+        }, force=True)
+        result = None
+
+    if result is None:
+        _handle_hook("pre_tool_call", **kwargs)
+        return None
+
+    decision = result.get("decision", "")
+    if decision == "allow":
+        answers = result.get("answers", {})
+        answer = answers.get(question, "")
+        if not answer:
+            for a in answers.values():
+                if a:
+                    answer = a
+                    break
+        if answer:
+            _append_log({
+                "ts": _utc_now(),
+                "event": "clarify_intercepted",
+                "question": question,
+                "choices": choices,
+                "answer": answer,
+            })
+            return {"action": "block", "message": f"User selected: {answer}"}
+
+    if decision == "deny":
+        return {"action": "block", "message": "User cancelled the clarification"}
+
+    _handle_hook("pre_tool_call", **kwargs)
+    return None
+
+
+def _handle_permission_request(tool_name: str, **kwargs: Any):
+    """Show permission bubble for tools that require user approval."""
+    args = kwargs.get("args", {})
+    tool_input = _safe_value(args) if args else {}
+    session_id = _session_id("pre_tool_call", kwargs)
+
+    try:
+        result = _post_permission(tool_name, tool_input, session_id)
+    except Exception:
+        _append_log({
+            "ts": _utc_now(),
+            "event": "permission_intercept_error",
+            "tool_name": tool_name,
+            "error": traceback.format_exc(),
+        }, force=True)
+        result = None
+
+    if result is None:
+        _handle_hook("pre_tool_call", **kwargs)
+        return None
+
+    decision = result.get("decision", "")
+    if decision == "allow":
+        _handle_hook("pre_tool_call", **kwargs)
+        return None
+    if decision == "deny":
+        message = result.get("message", "User denied this tool execution")
+        _append_log({
+            "ts": _utc_now(),
+            "event": "permission_denied",
+            "tool_name": tool_name,
+        })
+        return {"action": "block", "message": message}
+
+    _handle_hook("pre_tool_call", **kwargs)
+    return None
 
 
 def register(ctx) -> None:

--- a/hooks/hermes-plugin/plugin.yaml
+++ b/hooks/hermes-plugin/plugin.yaml
@@ -1,7 +1,8 @@
 name: clawd-on-desk
-version: 0.1.0
+version: "0.2.0"
 description: "Forward Hermes Agent lifecycle and tool state events to Clawd."
 author: "Clawd on Desk"
+
 hooks:
   - on_session_start
   - pre_llm_call

--- a/src/permission.js
+++ b/src/permission.js
@@ -636,11 +636,11 @@ function showPermissionBubble(permEntry) {
   bub.on("closed", () => {
     const idx = pendingPermissions.indexOf(permEntry);
     if (idx !== -1) {
-      // Qwen + Copilot are fail-open agents: a closed bubble means "no
+      // Qwen + Copilot + Hermes are fail-open agents: a closed bubble means "no
       // decision, let the native flow run" so the user isn't forced into a
       // deny they didn't pick. CC/CodeBuddy still get an explicit deny so
       // the hook unblocks instead of waiting for the long timeout.
-      const behavior = (permEntry.isQwenCode || permEntry.isCopilotCli) ? "no-decision" : "deny";
+      const behavior = (permEntry.isQwenCode || permEntry.isCopilotCli || permEntry.isHermes) ? "no-decision" : "deny";
       resolvePermissionEntry(permEntry, behavior, "Bubble window closed by user");
     }
   });
@@ -1148,6 +1148,23 @@ function applyPermissionSuggestion(perm, index, options = {}) {
     return;
   }
 
+  if (permEntry.isHermes) {
+    if (behavior === "no-decision") {
+      sendHermesNoDecisionResponse(res, message || "fallback");
+    } else if (permEntry.isElicitation && behavior === "allow" && permEntry.resolvedUpdatedInput) {
+      sendHermesPermissionResponse(res, {
+        decision: "allow",
+        answers: permEntry.resolvedUpdatedInput.answers || {},
+      });
+    } else {
+      sendHermesPermissionResponse(res, {
+        decision: behavior === "deny" ? "deny" : "allow",
+        message: message || undefined,
+      });
+    }
+    return;
+  }
+
   if (permEntry.isElicitation) {
     if (behavior === "no-decision") {
       // Autoclose: drop the socket so CC stops waiting, then refocus the
@@ -1359,6 +1376,22 @@ function sendAntigravityPermissionResponse(res, decisionOrBehavior, message) {
   return true;
 }
 
+function sendHermesNoDecisionResponse(res, reason = "") {
+  return sendNoDecisionResponse(res, reason, "hermes");
+}
+
+function sendHermesPermissionResponse(res, responseObj) {
+  if (!res || res.writableEnded || res.destroyed || res.headersSent) return false;
+  const responseBody = JSON.stringify(responseObj);
+  permLog(`hermes response: ${responseBody}`);
+  res.writeHead(200, {
+    "Content-Type": "application/json",
+    [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID,
+  });
+  res.end(responseBody);
+  return true;
+}
+
 function handleBubbleHeight(event, height) {
   const senderWin = BrowserWindow.fromWebContents(event.sender);
   const perm = pendingPermissions.find(p => p.bubble === senderWin);
@@ -1422,6 +1455,22 @@ function handleDecide(event, behavior) {
   }
   if (perm.isAntigravity && behavior !== "allow" && behavior !== "deny") {
     resolvePermissionEntry(perm, "no-decision", `Unsupported Antigravity bubble action: ${String(behavior)}`);
+    if (behavior === "deny-and-focus") {
+      ctx.focusTerminalForSession(perm.sessionId, { fallbackEntry: buildPermissionFocusEntry(perm) });
+    }
+    return;
+  }
+  if (perm.isHermes) {
+    if (behavior === "allow" || behavior === "deny") {
+      resolvePermissionEntry(perm, behavior);
+      return;
+    }
+    if (perm.isElicitation && behavior && typeof behavior === "object" && behavior.type === "elicitation-submit") {
+      perm.resolvedUpdatedInput = buildElicitationUpdatedInput(perm.toolInput, behavior.answers);
+      resolvePermissionEntry(perm, "allow");
+      return;
+    }
+    resolvePermissionEntry(perm, "no-decision", `Unsupported Hermes bubble action: ${String(behavior)}`);
     if (behavior === "deny-and-focus") {
       ctx.focusTerminalForSession(perm.sessionId, { fallbackEntry: buildPermissionFocusEntry(perm) });
     }
@@ -1603,6 +1652,8 @@ function dismissInteractivePermissionWithoutDecision(perm, reason) {
     sendCopilotNoDecisionResponse(perm.res, reason || "permission-dismissed");
   } else if (perm.isAntigravity) {
     sendAntigravityNoDecisionResponse(perm.res, reason || "permission-dismissed");
+  } else if (perm.isHermes) {
+    sendHermesNoDecisionResponse(perm.res, reason || "permission-dismissed");
   } else if (!perm.isOpencode && perm.res && !perm.res.destroyed) {
     try { perm.res.destroy(); } catch {}
   }
@@ -1693,7 +1744,7 @@ function cleanup() {
   for (const perm of [...pendingPermissions]) {
     if (perm._delayTimer) clearTimeout(perm._delayTimer);
     if (perm.autoExpireTimer) clearTimeout(perm.autoExpireTimer);
-    if (perm.isCodex || perm.isQwenCode || perm.isCopilotCli || perm.isAntigravity) resolvePermissionEntry(perm, "no-decision", "Clawd is quitting");
+    if (perm.isCodex || perm.isQwenCode || perm.isCopilotCli || perm.isAntigravity || perm.isHermes) resolvePermissionEntry(perm, "no-decision", "Clawd is quitting");
     else resolvePermissionEntry(perm, "deny", "Clawd is quitting");
   }
 }

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -190,7 +190,7 @@ const SCHEMA = {
       "opencode": { enabled: true, permissionsEnabled: true, notificationHookEnabled: true },
       "pi": { enabled: true, permissionsEnabled: false, notificationHookEnabled: true },
       "openclaw": { enabled: true, permissionsEnabled: false, notificationHookEnabled: true },
-      "hermes": { enabled: true },
+      "hermes": { enabled: true, permissionsEnabled: true, notificationHookEnabled: true },
     }),
     normalize: normalizeAgents,
   },

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -57,6 +57,12 @@ function shouldBypassCopilotBubble(ctx) {
   return !ctx.isAgentPermissionsEnabled("copilot-cli");
 }
 
+function shouldBypassHermesBubble(ctx) {
+  if (!arePermissionBubblesEnabled(ctx)) return true;
+  if (typeof ctx.isAgentPermissionsEnabled !== "function") return false;
+  return !ctx.isAgentPermissionsEnabled("hermes");
+}
+
 function shouldInterceptCodexPermission(ctx) {
   if (typeof ctx.isCodexPermissionInterceptEnabled !== "function") return true;
   return ctx.isCodexPermissionInterceptEnabled();
@@ -156,6 +162,24 @@ function buildCopilotPermissionSessionOptions(data) {
   return options;
 }
 
+function buildHermesPermissionSessionOptions(data) {
+  const sourcePid = normalizePositiveInteger(data.source_pid);
+  const agentPid = normalizePositiveInteger(data.agent_pid);
+  const pidChain = Array.isArray(data.pid_chain)
+    ? data.pid_chain.filter((n) => Number.isFinite(n) && n > 0).map((n) => Math.floor(n))
+    : null;
+  const options = { agentId: "hermes" };
+
+  if (sourcePid) options.sourcePid = sourcePid;
+  if (agentPid) options.agentPid = agentPid;
+  if (pidChain && pidChain.length) options.pidChain = pidChain;
+  const cwd = normalizeString(data.cwd);
+  if (cwd) options.cwd = cwd;
+  const editor = normalizeString(data.editor);
+  if (editor) options.editor = editor;
+  return options;
+}
+
 function sendCodexPermissionNoDecision(res) {
   res.writeHead(204, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
   res.end();
@@ -186,6 +210,11 @@ function sendPiPermissionAllow(res) {
 }
 
 function sendAntigravityPermissionNoDecision(res) {
+  res.writeHead(204, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
+  res.end();
+}
+
+function sendHermesPermissionNoDecision(res) {
   res.writeHead(204, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
   res.end();
 }
@@ -705,6 +734,151 @@ function handlePermissionPost(req, res, options) {
         return;
       }
 
+      // ── Hermes Agent branch ──
+      // Blocking HTTP. Fallback is 204 (no-decision) so the Hermes plugin
+      // returns None and the tool executes via Hermes's native flow.
+      if (data.agent_id === "hermes") {
+        const toolName = typeof data.tool_name === "string" && data.tool_name ? data.tool_name : "Unknown";
+        const rawInput = data.tool_input && typeof data.tool_input === "object" ? data.tool_input : {};
+        const toolInput = truncateDeep(rawInput);
+        const sessionId = typeof data.session_id === "string" && data.session_id ? data.session_id : "hermes:default";
+        const toolUseId = normalizeHookToolUseId(
+          data.tool_use_id ?? data.toolUseId ?? data.toolUseID
+        );
+        const toolInputFingerprint = buildToolInputFingerprint(rawInput);
+
+        if (ctx.doNotDisturb) {
+          recordRequestHookEvent.droppedByDnd();
+          ctx.permLog(`hermes DND -> no decision, native fallback (tool=${toolName})`);
+          sendHermesPermissionNoDecision(res);
+          return;
+        }
+
+        if (typeof ctx.isAgentEnabled === "function" && !ctx.isAgentEnabled("hermes")) {
+          recordRequestHookEvent.droppedByDisabled();
+          ctx.permLog(`hermes disabled -> no decision, native fallback (tool=${toolName})`);
+          sendHermesPermissionNoDecision(res);
+          return;
+        }
+
+        if (shouldBypassHermesBubble(ctx)) {
+          recordRequestHookEvent.accepted();
+          const reason = !arePermissionBubblesEnabled(ctx)
+            ? "permission bubbles disabled"
+            : "hermes bubbles disabled";
+          ctx.permLog(`${reason} -> no decision, native fallback (tool=${toolName})`);
+          sendHermesPermissionNoDecision(res);
+          return;
+        }
+
+        const isElicitation = toolName === "clarify" || toolName === "AskUserQuestion";
+
+        if (isElicitation) {
+          const elicitationInput = normalizeElicitationToolInput(toolInput);
+          const hermesSessionOptions = buildHermesPermissionSessionOptions(data);
+          ctx.permLog(`HERMES ELICITATION: tool=${toolName} session=${sessionId}`);
+          ctx.updateSession(sessionId, "notification", "Elicitation", hermesSessionOptions);
+
+          const permEntry = {
+            res,
+            abortHandler: null,
+            suggestions: [],
+            sessionId,
+            bubble: null,
+            hideTimer: null,
+            toolName,
+            toolInput: elicitationInput,
+            toolUseId,
+            toolInputFingerprint,
+            resolvedSuggestion: null,
+            createdAt: Date.now(),
+            isElicitation: true,
+            isHermes: true,
+            agentId: "hermes",
+            cwd: hermesSessionOptions.cwd || "",
+            agentPid: hermesSessionOptions.agentPid || null,
+            sourcePid: hermesSessionOptions.sourcePid || null,
+            pidChain: hermesSessionOptions.pidChain || null,
+            editor: hermesSessionOptions.editor || null,
+          };
+          const abortHandler = () => {
+            if (res.writableFinished) return;
+            ctx.permLog("hermes abortHandler fired (elicitation)");
+            ctx.resolvePermissionEntry(permEntry, "no-decision", "Client disconnected");
+          };
+          permEntry.abortHandler = abortHandler;
+          res.on("close", abortHandler);
+          addPendingPermission(ctx, permEntry);
+          recordRequestHookEvent.accepted();
+          try {
+            ctx.showPermissionBubble(permEntry);
+          } catch (bubbleErr) {
+            ctx.permLog(`hermes elicitation bubble failed: ${bubbleErr && bubbleErr.message} -> no decision`);
+            removePendingPermission(ctx, permEntry, "hermes-elicitation-bubble-failed");
+            if (permEntry.abortHandler) res.removeListener("close", permEntry.abortHandler);
+            if (permEntry.autoCloseTimer) { clearTimeout(permEntry.autoCloseTimer); permEntry.autoCloseTimer = null; }
+            if (permEntry.hideTimer) { clearTimeout(permEntry.hideTimer); permEntry.hideTimer = null; }
+            if (permEntry.bubble && !permEntry.bubble.isDestroyed()) {
+              try { permEntry.bubble.destroy(); } catch {}
+            }
+            permEntry.bubble = null;
+            sendHermesPermissionNoDecision(res);
+          }
+          return;
+        }
+
+        // General permission request
+        const hermesSessionOptions = buildHermesPermissionSessionOptions(data);
+        ctx.permLog(`HERMES PERMISSION: tool=${toolName} session=${sessionId}`);
+        ctx.updateSession(sessionId, "notification", "PermissionRequest", hermesSessionOptions);
+
+        const permEntry = {
+          res,
+          abortHandler: null,
+          suggestions: [],
+          sessionId,
+          bubble: null,
+          hideTimer: null,
+          toolName,
+          toolInput,
+          toolUseId,
+          toolInputFingerprint,
+          resolvedSuggestion: null,
+          createdAt: Date.now(),
+          isHermes: true,
+          agentId: "hermes",
+          cwd: hermesSessionOptions.cwd || "",
+          agentPid: hermesSessionOptions.agentPid || null,
+          sourcePid: hermesSessionOptions.sourcePid || null,
+          pidChain: hermesSessionOptions.pidChain || null,
+          editor: hermesSessionOptions.editor || null,
+        };
+        const abortHandler = () => {
+          if (res.writableFinished) return;
+          ctx.permLog("hermes abortHandler fired");
+          ctx.resolvePermissionEntry(permEntry, "no-decision", "Client disconnected");
+        };
+        permEntry.abortHandler = abortHandler;
+        res.on("close", abortHandler);
+        addPendingPermission(ctx, permEntry);
+        recordRequestHookEvent.accepted();
+        try {
+          ctx.showPermissionBubble(permEntry);
+        } catch (bubbleErr) {
+          ctx.permLog(`hermes bubble failed: ${bubbleErr && bubbleErr.message} -> no decision`);
+          removePendingPermission(ctx, permEntry, "hermes-bubble-failed");
+          if (permEntry.abortHandler) res.removeListener("close", permEntry.abortHandler);
+          if (permEntry.autoCloseTimer) { clearTimeout(permEntry.autoCloseTimer); permEntry.autoCloseTimer = null; }
+          if (permEntry.hideTimer) { clearTimeout(permEntry.hideTimer); permEntry.hideTimer = null; }
+          if (permEntry.bubble && !permEntry.bubble.isDestroyed()) {
+            try { permEntry.bubble.destroy(); } catch {}
+          }
+          permEntry.bubble = null;
+          sendHermesPermissionNoDecision(res);
+        }
+        return;
+      }
+
       // ── Claude Code branch ──
       // DND: destroy connection — do NOT send deny on the user's behalf.
       // CC falls back to its built-in chat permission prompt so the user
@@ -907,5 +1081,7 @@ module.exports = {
   sendCopilotPermissionNoDecision,
   sendPiPermissionAllow,
   sendAntigravityPermissionNoDecision,
+  sendHermesPermissionNoDecision,
+  shouldBypassHermesBubble,
   handlePermissionPost,
 };

--- a/test/hermes-install.test.js
+++ b/test/hermes-install.test.js
@@ -7,6 +7,7 @@ const os = require("os");
 const {
   PLUGIN_ID,
   MANAGED_PLUGIN_FILES,
+  hermesHomesForSync,
   isHermesInstalled,
   registerHermesPlugin,
   resolveHermesHome,
@@ -76,6 +77,69 @@ describe("Hermes plugin installer", () => {
       fs.readFileSync(path.join(result.pluginDir, "plugin.yaml"), "utf8"),
       "name: clawd-on-desk\n"
     );
+  });
+
+  it("enables Clawd in every Hermes profile config", () => {
+    const sourcePluginDir = makeSourcePlugin();
+    const hermesHome = makeTempDir();
+    const opsHome = path.join(hermesHome, "profiles", "ops");
+    const browserHome = path.join(hermesHome, "profiles", "browser");
+    const ignoredHome = path.join(hermesHome, "profiles", "scratch");
+    fs.mkdirSync(opsHome, { recursive: true });
+    fs.mkdirSync(browserHome, { recursive: true });
+    fs.mkdirSync(ignoredHome, { recursive: true });
+    fs.writeFileSync(path.join(opsHome, "config.yaml"), "plugins:\n  desktop_notify:\n    bell: true\n", "utf8");
+    fs.writeFileSync(path.join(browserHome, "config.yaml"), "plugins:\n  enabled:\n  - other\n", "utf8");
+    const spawnSync = makeSpawn();
+
+    const result = registerHermesPlugin({
+      silent: true,
+      hermesHome,
+      sourcePluginDir,
+      hermesCommand: "hermes",
+      spawnSync,
+      env: {},
+    });
+
+    assert.strictEqual(result.status, "ok");
+    assert.deepStrictEqual(hermesHomesForSync({ hermesHome }), [hermesHome, browserHome, opsHome]);
+    assert.deepStrictEqual(
+      spawnSync.calls.map((call) => ({ args: call.args, hermesHome: call.options.env.HERMES_HOME })),
+      [hermesHome, browserHome, opsHome].map((home) => ({
+        args: ["plugins", "enable", PLUGIN_ID],
+        hermesHome: home,
+      }))
+    );
+    assert.deepStrictEqual(
+      result.profileResults.map((entry) => entry.hermesHome),
+      [hermesHome, browserHome, opsHome]
+    );
+    assert.ok(fs.existsSync(path.join(opsHome, "plugins", PLUGIN_ID, "__init__.py")));
+    assert.ok(fs.existsSync(path.join(browserHome, "plugins", PLUGIN_ID, "__init__.py")));
+    assert.ok(!fs.existsSync(path.join(ignoredHome, "plugins", PLUGIN_ID)));
+  });
+
+  it("can skip Hermes profile sync when requested", () => {
+    const sourcePluginDir = makeSourcePlugin();
+    const hermesHome = makeTempDir();
+    const opsHome = path.join(hermesHome, "profiles", "ops");
+    fs.mkdirSync(opsHome, { recursive: true });
+    fs.writeFileSync(path.join(opsHome, "config.yaml"), "plugins: {}\n", "utf8");
+    const spawnSync = makeSpawn();
+
+    const result = registerHermesPlugin({
+      silent: true,
+      hermesHome,
+      sourcePluginDir,
+      hermesCommand: "hermes",
+      spawnSync,
+      syncProfiles: false,
+      env: {},
+    });
+
+    assert.strictEqual(result.status, "ok");
+    assert.deepStrictEqual(spawnSync.calls.map((call) => call.options.env.HERMES_HOME), [hermesHome]);
+    assert.strictEqual(fs.existsSync(path.join(opsHome, "plugins", PLUGIN_ID)), false);
   });
 
   it("is idempotent when managed files already match", () => {

--- a/test/hermes-plugin.test.js
+++ b/test/hermes-plugin.test.js
@@ -468,4 +468,149 @@ print(json.dumps({
       },
     ]);
   });
+
+  it("probes existing /state health route before the long blocking permission POST", () => {
+    const output = runPluginPython(String.raw`
+import importlib.util
+import json
+import sys
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location("hermes_plugin", r"hooks/hermes-plugin/__init__.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+calls = []
+class FakeHeaders(dict):
+    def get(self, key, default=None):
+        return super().get(key, default)
+
+class FakeResponse:
+    def __init__(self, status=200, headers=None, body=b""):
+        self.status = status
+        self.headers = FakeHeaders(headers or {})
+        self._body = body
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+    def read(self):
+        return self._body
+
+def fake_urlopen(req, timeout=None):
+    calls.append({"url": req.full_url, "method": req.get_method(), "timeout": timeout})
+    if req.full_url.endswith("/state"):
+        return FakeResponse(headers={mod.CLAWD_SERVER_HEADER: mod.CLAWD_SERVER_ID})
+    if req.full_url.endswith("/permission"):
+        return FakeResponse(
+            headers={mod.CLAWD_SERVER_HEADER: mod.CLAWD_SERVER_ID},
+            body=json.dumps({"decision": "allow"}).encode("utf-8"),
+        )
+    raise AssertionError(req.full_url)
+
+mod.request.urlopen = fake_urlopen
+mod._port_candidates = lambda: [23333]
+mod._add_process_meta = lambda payload: None
+mod._runtime_cwd = lambda: "/repo"
+mod._append_log = lambda *args, **kwargs: None
+mod._cached_port = None
+mod._no_server_until = 0.0
+
+result = mod._post_permission("execute_bash", {"command": "echo hi"}, "hermes:s1")
+print(json.dumps({"result": result, "calls": calls, "cached_port": mod._cached_port}, sort_keys=True))
+`);
+    const result = JSON.parse(output);
+    assert.deepStrictEqual(result.result, { decision: "allow" });
+    assert.strictEqual(result.cached_port, 23333);
+    assert.deepStrictEqual(result.calls.map((call) => [call.method, call.url, call.timeout]), [
+      ["GET", "http://127.0.0.1:23333/state", 0.25],
+      ["POST", "http://127.0.0.1:23333/permission", 600],
+    ]);
+  });
+
+  it("skips Hermes permission POST during no-server cooldown", () => {
+    const output = runPluginPython(String.raw`
+import importlib.util
+import json
+import sys
+import time
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location("hermes_plugin", r"hooks/hermes-plugin/__init__.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+calls = []
+logs = []
+def fake_urlopen(*args, **kwargs):
+    calls.append([str(args), kwargs])
+    raise AssertionError("urlopen should not run during cooldown")
+
+mod.request.urlopen = fake_urlopen
+mod._append_log = lambda payload, **kwargs: logs.append(payload)
+mod._cached_port = None
+mod._no_server_until = time.monotonic() + 10
+
+result = mod._post_permission("execute_bash", {}, "hermes:s1")
+print(json.dumps({"result": result, "calls": calls, "logs": logs}, sort_keys=True))
+`);
+    const result = JSON.parse(output);
+    assert.strictEqual(result.result, null);
+    assert.deepStrictEqual(result.calls, []);
+    assert.strictEqual(result.logs[0].event, "post_permission_skipped_no_server");
+  });
+
+  it("does not issue the long permission POST when the short probe is not Clawd", () => {
+    const output = runPluginPython(String.raw`
+import importlib.util
+import json
+import sys
+import time
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location("hermes_plugin", r"hooks/hermes-plugin/__init__.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+calls = []
+class FakeHeaders(dict):
+    def get(self, key, default=None):
+        return super().get(key, default)
+class FakeResponse:
+    status = 200
+    headers = FakeHeaders({})
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+    def read(self):
+        return b""
+
+def fake_urlopen(req, timeout=None):
+    calls.append({"url": req.full_url, "method": req.get_method(), "timeout": timeout})
+    assert req.full_url.endswith("/state"), "permission POST should not be attempted after probe mismatch"
+    return FakeResponse()
+
+mod.request.urlopen = fake_urlopen
+mod._port_candidates = lambda: [23333]
+mod._append_log = lambda *args, **kwargs: None
+mod._cached_port = None
+mod._no_server_until = 0.0
+
+result = mod._post_permission("execute_bash", {}, "hermes:s1")
+print(json.dumps({
+    "result": result,
+    "calls": calls,
+    "cached_port": mod._cached_port,
+    "cooldown_set": mod._no_server_until > time.monotonic(),
+}, sort_keys=True))
+`);
+    const result = JSON.parse(output);
+    assert.strictEqual(result.result, null);
+    assert.deepStrictEqual(result.calls.map((call) => [call.method, call.url, call.timeout]), [
+      ["GET", "http://127.0.0.1:23333/state", 0.25],
+    ]);
+    assert.strictEqual(result.cached_port, null);
+    assert.strictEqual(result.cooldown_set, true);
+  });
 });

--- a/test/permission-autoclose-dismiss.test.js
+++ b/test/permission-autoclose-dismiss.test.js
@@ -123,6 +123,46 @@ describe("permission autoclose: no-decision dismiss semantics", () => {
     assert.equal(pendingPermissions.indexOf(permEntry), -1, "pending entry should be spliced");
   });
 
+  it("Hermes allow/deny resolutions return the documented JSON response shape", () => {
+    for (const behavior of ["allow", "deny"]) {
+      const ctx = makeCtx();
+      const { resolvePermissionEntry, pendingPermissions } = initPermission(ctx);
+      const permEntry = makePermEntry({ isHermes: true, agentId: "hermes" });
+      pendingPermissions.push(permEntry);
+
+      resolvePermissionEntry(permEntry, behavior);
+
+      assert.equal(permEntry.res.captured.statusCode, 200);
+      assert.equal(permEntry.res.captured.headers["Content-Type"], "application/json");
+      assert.deepEqual(JSON.parse(permEntry.res.captured.body), { decision: behavior });
+      assert.equal(permEntry.res.captured.destroyCalls, 0);
+      assert.equal(pendingPermissions.indexOf(permEntry), -1);
+    }
+  });
+
+  it("Hermes elicitation allow returns answers in the documented JSON response shape", () => {
+    const ctx = makeCtx();
+    const { resolvePermissionEntry, pendingPermissions } = initPermission(ctx);
+    const permEntry = makePermEntry({
+      isHermes: true,
+      isElicitation: true,
+      agentId: "hermes",
+      resolvedUpdatedInput: { answers: { "Which approach?": "A" } },
+    });
+    pendingPermissions.push(permEntry);
+
+    resolvePermissionEntry(permEntry, "allow");
+
+    assert.equal(permEntry.res.captured.statusCode, 200);
+    assert.equal(permEntry.res.captured.headers["Content-Type"], "application/json");
+    assert.deepEqual(JSON.parse(permEntry.res.captured.body), {
+      decision: "allow",
+      answers: { "Which approach?": "A" },
+    });
+    assert.equal(permEntry.res.captured.destroyCalls, 0);
+    assert.equal(pendingPermissions.indexOf(permEntry), -1);
+  });
+
   it("notifies when a resolved permission leaves the pending list", () => {
     const changes = [];
     const resolved = [];

--- a/test/prefs.test.js
+++ b/test/prefs.test.js
@@ -80,7 +80,7 @@ describe("prefs.getDefaults", () => {
   it("seeds permission-capable agents with permissionsEnabled=true", () => {
     const d = prefs.getDefaults();
     // State-only integrations intentionally excluded — no bubble.
-    for (const id of ["claude-code", "codex", "copilot-cli", "cursor-agent", "gemini-cli", "codebuddy", "kiro-cli", "kimi-cli", "qwen-code", "opencode"]) {
+    for (const id of ["claude-code", "codex", "copilot-cli", "cursor-agent", "gemini-cli", "codebuddy", "kiro-cli", "kimi-cli", "qwen-code", "opencode", "hermes"]) {
       assert.strictEqual(
         d.agents[id].permissionsEnabled,
         true,
@@ -94,11 +94,6 @@ describe("prefs.getDefaults", () => {
         `${id} is state-only, permissionsEnabled must default to false`
       );
     }
-    assert.strictEqual(
-      Object.prototype.hasOwnProperty.call(d.agents.hermes, "permissionsEnabled"),
-      false,
-      "hermes should not expose a dead permissionsEnabled switch"
-    );
   });
 
   it("defaults OpenClaw permission bubbles off", () => {
@@ -363,13 +358,13 @@ describe("prefs.validate", () => {
     assert.strictEqual(v.agents["claude-code"].permissionsEnabled, true);
   });
 
-  it("normalizes agents: strips Hermes permission/notification flags until implemented", () => {
+  it("normalizes agents: preserves Hermes permission/notification flags", () => {
     const v = prefs.validate({
       agents: {
         hermes: { enabled: true, permissionsEnabled: true, notificationHookEnabled: true },
       },
     });
-    assert.deepStrictEqual(v.agents.hermes, { enabled: true });
+    assert.deepStrictEqual(v.agents.hermes, { enabled: true, permissionsEnabled: true, notificationHookEnabled: true });
   });
 
   it("normalizes agents: preserves Antigravity permission flag but strips notification flag", () => {
@@ -434,18 +429,13 @@ describe("prefs.validate", () => {
 
   it("seeds all known agents with notificationHookEnabled=true", () => {
     const d = prefs.getDefaults();
-    for (const id of ["claude-code", "codex", "copilot-cli", "cursor-agent", "gemini-cli", "codebuddy", "kiro-cli", "kimi-cli", "qwen-code", "opencode", "pi", "openclaw"]) {
+    for (const id of ["claude-code", "codex", "copilot-cli", "cursor-agent", "gemini-cli", "codebuddy", "kiro-cli", "kimi-cli", "qwen-code", "opencode", "pi", "openclaw", "hermes"]) {
       assert.strictEqual(
         d.agents[id].notificationHookEnabled,
         true,
         `${id} should default notificationHookEnabled`
       );
     }
-    assert.strictEqual(
-      Object.prototype.hasOwnProperty.call(d.agents.hermes, "notificationHookEnabled"),
-      false,
-      "hermes should not expose a dead notificationHookEnabled switch"
-    );
     assert.strictEqual(
       Object.prototype.hasOwnProperty.call(d.agents["antigravity-cli"], "notificationHookEnabled"),
       false,

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -200,8 +200,8 @@ describe("Agent Registry", () => {
 
     const hermes = registry.getAgent("hermes");
     assert.strictEqual(hermes.capabilities.httpHook, false);
-    assert.strictEqual(hermes.capabilities.permissionApproval, false);
-    assert.strictEqual(hermes.capabilities.interactiveBubble, false);
+    assert.strictEqual(hermes.capabilities.permissionApproval, true);
+    assert.strictEqual(hermes.capabilities.interactiveBubble, true);
     assert.strictEqual(hermes.capabilities.sessionEnd, true);
     assert.strictEqual(hermes.capabilities.subagent, false);
 

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -768,4 +768,197 @@ describe("server-route-permission POST", () => {
     assert.strictEqual(entry.isCopilotCli, true);
     assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, []);
   });
+
+  // ── Hermes Agent branch ──
+  // Hermes permissions behave like Copilot: every Clawd fallback (DND /
+  // disabled / subgate / bubble failure / abort) emits 204 so the Hermes
+  // plugin falls back to its native clarify or terminal-based approval.
+
+  it("returns no-decision for Hermes DND fallback", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "hermes",
+      session_id: "hermes:s1",
+      tool_name: "execute_bash",
+      tool_input: { command: "rm -rf /tmp/test" },
+    }), {
+      ctx: { doNotDisturb: true },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+    assert.deepStrictEqual(res.recorder.map((entry) => entry.outcome).filter(Boolean), ["dnd"]);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+    assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, []);
+  });
+
+  it("returns no-decision when the Hermes agent master switch is off", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "hermes",
+      session_id: "hermes:s1",
+      tool_name: "execute_bash",
+      tool_input: { command: "rm -rf /tmp/test" },
+    }), {
+      ctx: {
+        isAgentEnabled: (agentId) => agentId !== "hermes",
+      },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+    assert.deepStrictEqual(res.recorder.map((entry) => entry.outcome).filter(Boolean), ["disabled"]);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+  });
+
+  it("returns no-decision when the global permission bubble gate is off (Hermes)", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "hermes",
+      session_id: "hermes:s1",
+      tool_name: "execute_bash",
+      tool_input: { command: "rm -rf /tmp/test" },
+    }), {
+      ctx: { hideBubbles: true },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+    assert.deepStrictEqual(res.recorder.map((entry) => entry.outcome).filter(Boolean), ["accepted"]);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+  });
+
+  it("returns no-decision when the per-agent Hermes permission subgate is off", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "hermes",
+      session_id: "hermes:s1",
+      tool_name: "execute_bash",
+      tool_input: { command: "rm -rf /tmp/test" },
+    }), {
+      ctx: {
+        isAgentPermissionsEnabled: (agentId) => agentId !== "hermes",
+      },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+  });
+
+  it("pushes a Hermes permission entry with isHermes=true and full metadata", async () => {
+    const sessionId = "hermes:01HQABCD";
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "hermes",
+      session_id: sessionId,
+      tool_name: "execute_bash",
+      tool_input: { command: "rm -rf /tmp/test" },
+      tool_use_id: "tool-1",
+      source_pid: 1234,
+      agent_pid: 1234,
+      pid_chain: [9999, 1234, -1],
+      cwd: "/home/user/repo",
+      editor: "cursor",
+    }));
+
+    assert.strictEqual(res.statusCode, null);
+    assert.strictEqual(res.ctx.pendingPermissions.length, 1);
+    const entry = res.ctx.pendingPermissions[0];
+    assert.strictEqual(entry.res, res);
+    assert.strictEqual(entry.sessionId, sessionId);
+    assert.strictEqual(entry.agentId, "hermes");
+    assert.strictEqual(entry.isHermes, true);
+    assert.strictEqual(entry.toolName, "execute_bash");
+    assert.strictEqual(entry.toolUseId, "tool-1");
+    assert.strictEqual(entry.sourcePid, 1234);
+    assert.strictEqual(entry.agentPid, 1234);
+    assert.deepStrictEqual(entry.pidChain, [9999, 1234]);
+    assert.strictEqual(entry.cwd, "/home/user/repo");
+    assert.strictEqual(entry.editor, "cursor");
+    assert.deepStrictEqual(res.ctx.calls.updateSession, [[
+      sessionId,
+      "notification",
+      "PermissionRequest",
+      {
+        agentId: "hermes",
+        sourcePid: 1234,
+        agentPid: 1234,
+        pidChain: [9999, 1234],
+        cwd: "/home/user/repo",
+        editor: "cursor",
+      },
+    ]]);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, [entry]);
+    assert.deepStrictEqual(res.ctx.calls.addPendingPermission, [entry]);
+    assert.deepStrictEqual(res.recorder.map((item) => item.outcome).filter(Boolean), ["accepted"]);
+  });
+
+  it("handles Hermes clarify tool as an elicitation entry", async () => {
+    const sessionId = "hermes:clarify-s1";
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "hermes",
+      session_id: sessionId,
+      tool_name: "clarify",
+      tool_input: { questions: [{ question: "Which approach?", options: [{ label: "A" }, { label: "B" }] }] },
+      cwd: "/home/user/repo",
+      agent_pid: 5678,
+    }));
+
+    assert.strictEqual(res.statusCode, null);
+    assert.strictEqual(res.ctx.pendingPermissions.length, 1);
+    const entry = res.ctx.pendingPermissions[0];
+    assert.strictEqual(entry.agentId, "hermes");
+    assert.strictEqual(entry.isHermes, true);
+    assert.strictEqual(entry.isElicitation, true);
+    assert.strictEqual(entry.toolName, "clarify");
+    // updateSession should be called with "Elicitation" kind, not "PermissionRequest"
+    assert.deepStrictEqual(res.ctx.calls.updateSession, [[
+      sessionId,
+      "notification",
+      "Elicitation",
+      {
+        agentId: "hermes",
+        cwd: "/home/user/repo",
+        agentPid: 5678,
+      },
+    ]]);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, [entry]);
+    assert.deepStrictEqual(res.ctx.calls.addPendingPermission, [entry]);
+  });
+
+  it("recovers via 204 when the Hermes bubble fails to construct", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "hermes",
+      session_id: "hermes:s1",
+      tool_name: "execute_bash",
+      tool_input: { command: "rm -rf /tmp/test" },
+    }), {
+      ctx: {
+        showPermissionBubble: () => {
+          throw new Error("no window");
+        },
+      },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+    assert.deepStrictEqual(res.ctx.calls.removePendingPermission.map((item) => item.reason), ["hermes-bubble-failed"]);
+    assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, []);
+  });
+
+  it("resolves Hermes abort as no-decision when the connection closes", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "hermes",
+      session_id: "hermes:s1",
+      tool_name: "execute_bash",
+      tool_input: { command: "rm -rf /tmp/test" },
+    }));
+
+    assert.strictEqual(res.ctx.pendingPermissions.length, 1);
+    const entry = res.ctx.pendingPermissions[0];
+    res.emit("close");
+
+    assert.strictEqual(res.ctx.calls.resolved.length, 1);
+    assert.strictEqual(res.ctx.calls.resolved[0].entry, entry);
+    assert.strictEqual(res.ctx.calls.resolved[0].behavior, "no-decision");
+  });
 });


### PR DESCRIPTION
## Summary
- Hermes Agent now uses the unified `/permission` route and bubble UI for clarify (elicitation) and general tool permission approval, replacing the legacy `/clarify` native dialog
- Plugin `pre_tool_call` hook intercepts clarify tool → converts to elicitation format → POSTs to `/permission` → Clawd shows the same bubble UI as Claude Code's AskUserQuestion
- General tool permission approval supported via `CLAWD_HERMES_PERMISSION_TOOLS` env var
- All fallback paths return 204 (no-decision) so Hermes falls through to its native flow when Clawd is unavailable, DND, or agent is disabled
- Fixed `plugin.yaml` missing `hermes_version` field which prevented Hermes from loading the plugin

## Changed files
- `agents/hermes.js` — enable `permissionApproval` and `interactiveBubble` capabilities
- `hooks/hermes-plugin/__init__.py` — replace `_post_clarify` with `_post_permission`, add `_handle_clarify_tool` (elicitation), `_handle_permission_request` (general approval)
- `hooks/hermes-plugin/plugin.yaml` — add `hermes_version`, bump to 0.2.0
- `src/server-route-permission.js` — add Hermes agent branch (DND/disabled/bypass → 204, elicitation + permission → bubble)
- `src/permission.js` — add `isHermes` resolution (elicitation returns answers, permission returns allow/deny), bubble close → no-decision
- `test/registry.test.js` — update Hermes capabilities assertions

## Test plan
- [x] `npm test` — all existing tests pass (10 pre-existing failures unrelated)
- [x] curl simulation: `POST /permission` with `agent_id: "hermes"` shows elicitation bubble, returns `{decision, answers}`
- [x] Real Hermes Agent: clarify tool triggers Clawd bubble, user selection returned correctly