### PR TITLE
feat(theme): support directional Codex Pet drag animations

### DIFF
--- a/scripts/validate-theme.js
+++ b/scripts/validate-theme.js
@@ -232,6 +232,8 @@ function collectFiles() {
     for (const [key, react] of Object.entries(raw.reactions)) {
       if (key.startsWith("_")) continue;
       if (react.file) files.add(react.file);
+      if (react.fileLeft) files.add(react.fileLeft);
+      if (react.fileRight) files.add(react.fileRight);
       if (react.files) react.files.forEach(f => files.add(f));
     }
   }

--- a/src/codex-pet-adapter.js
+++ b/src/codex-pet-adapter.js
@@ -6,7 +6,7 @@ const os = require("os");
 const path = require("path");
 const zlib = require("zlib");
 
-const ADAPTER_VERSION = 2;
+const ADAPTER_VERSION = 3;
 const MARKER_FILENAME = ".clawd-codex-pet.json";
 const THEME_ID_PREFIX = "codex-pet-";
 const PNG_ALPHA_VALIDATION_SCHEMA_VERSION = 1;
@@ -265,7 +265,11 @@ function syncCodexPetThemes(options = {}) {
     if (materialized.operation === "created") summary.imported += 1;
     else if (materialized.operation === "updated") summary.updated += 1;
     else if (materialized.operation === "unchanged") summary.unchanged += 1;
-    summary.themes.push({ packageDir: result.packageInfo.packageDir, themeId: materialized.themeId });
+    summary.themes.push({
+      packageDir: result.packageInfo.packageDir,
+      themeId: materialized.themeId,
+      operation: materialized.operation,
+    });
   }
 
   const gc = removeOrphanManagedThemes(userThemesDir, { activeThemeId: options.activeThemeId });
@@ -367,7 +371,11 @@ function buildThemeJson(packageInfo, themeId) {
       wide: { x: 0, y: 0, w: ATLAS.frameWidth, h: ATLAS.frameHeight },
     },
     reactions: {
-      drag: { file: "codex-pet-running-loop.svg" },
+      drag: {
+        file: "codex-pet-running-loop.svg",
+        fileLeft: "codex-pet-running-left-loop.svg",
+        fileRight: "codex-pet-running-right-loop.svg",
+      },
       clickLeft: { file: "codex-pet-jumping-once.svg", duration: 840 },
       clickRight: { file: "codex-pet-jumping-once.svg", duration: 840 },
       double: { files: ["codex-pet-waving-once.svg"], duration: 700 },

--- a/src/codex-pet-main.js
+++ b/src/codex-pet-main.js
@@ -159,6 +159,25 @@ function createCodexPetMain(options = {}) {
     lastSyncSummary = summary;
   }
 
+  function reloadActiveThemeIfUpdated(summary, activeThemeId) {
+    if (
+      !activeThemeId
+      || !summary
+      || !Array.isArray(summary.themes)
+      || typeof options.reloadActiveTheme !== "function"
+    ) {
+      return false;
+    }
+    const updatedActiveTheme = summary.themes.some((theme) => (
+      theme
+      && theme.themeId === activeThemeId
+      && theme.operation === "updated"
+    ));
+    if (!updatedActiveTheme) return false;
+    options.reloadActiveTheme();
+    return true;
+  }
+
   function getManagedThemeDir(themeId) {
     if (typeof themeId !== "string" || !themeId) return null;
     let userThemesDir;
@@ -235,6 +254,17 @@ function createCodexPetMain(options = {}) {
       if (cleanup.error) {
         return { status: "error", message: cleanup.error, summary, switchedToFallback };
       }
+    }
+
+    try {
+      reloadActiveThemeIfUpdated(summary, activeId);
+    } catch (err) {
+      return {
+        status: "error",
+        message: (err && err.message) || String(err),
+        summary,
+        switchedToFallback,
+      };
     }
 
     rebuildMenusBestEffort();
@@ -476,6 +506,7 @@ function createCodexPetMain(options = {}) {
     if (!result || result.status !== "ok") {
       throw new Error((result && result.message) || "failed to switch to imported theme");
     }
+    reloadActiveThemeIfUpdated(summary, activeId);
     rebuildMenusBestEffort({ logFailure: false });
     return { themeId: generated.themeId, summary };
   }

--- a/src/hit-renderer.js
+++ b/src/hit-renderer.js
@@ -39,6 +39,8 @@ window.hitAPI.onStateSync((data) => {
 let isDragging = false;
 let didDrag = false;
 let mouseDownX, mouseDownY;
+let lastDragClientX;
+let dragReactionDirection = null;
 let dragMoveRAF = null;
 const DRAG_THRESHOLD = 3;
 
@@ -51,6 +53,7 @@ window.hitAPI.onCancelReaction(() => {
   if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; clickCount = 0; firstClickDir = null; }
   isReacting = false;
   isDragReacting = false;
+  dragReactionDirection = null;
 });
 
 function queueDragMove() {
@@ -77,6 +80,8 @@ area.addEventListener("pointerdown", (e) => {
     didDrag = false;
     mouseDownX = e.clientX;
     mouseDownY = e.clientY;
+    lastDragClientX = e.clientX;
+    dragReactionDirection = null;
     window.hitAPI.dragLock(true);
     area.classList.add("dragging");
   }
@@ -89,9 +94,13 @@ document.addEventListener("pointermove", (e) => {
       const totalDy = e.clientY - mouseDownY;
       if (Math.abs(totalDx) > DRAG_THRESHOLD || Math.abs(totalDy) > DRAG_THRESHOLD) {
         didDrag = true;
-        startDragReaction();
+        startDragReaction(totalDx < 0 ? "left" : (totalDx > 0 ? "right" : null));
       }
+    } else {
+      const stepDx = e.clientX - lastDragClientX;
+      if (stepDx !== 0) startDragReaction(stepDx < 0 ? "left" : "right");
     }
+    lastDragClientX = e.clientX;
     queueDragMove();
   }
 });
@@ -222,21 +231,23 @@ function playReaction(svg, duration) {
 }
 
 // --- Drag reaction ---
-function startDragReaction() {
-  if (isDragReacting) return;
+function startDragReaction(direction) {
   if (dndEnabled) return;
+  if (isDragReacting && dragReactionDirection === direction) return;
 
   if (isReacting) {
     isReacting = false;
   }
 
   isDragReacting = true;
-  window.hitAPI.startDragReaction();
+  dragReactionDirection = direction;
+  window.hitAPI.startDragReaction(direction);
 }
 
 function endDragReaction() {
   if (!isDragReacting) return;
   isDragReacting = false;
+  dragReactionDirection = null;
   window.hitAPI.endDragReaction();
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -477,6 +477,7 @@ codexPetMain = createCodexPetMain({
   getMainWindow: () => win,
   getSettingsWindow,
   path,
+  reloadActiveTheme: () => themeRuntime.reloadActiveTheme(),
   rebuildAllMenus: () => rebuildAllMenus(),
   settingsController: _settingsController,
   shell,

--- a/src/pet-interaction-ipc.js
+++ b/src/pet-interaction-ipc.js
@@ -82,7 +82,9 @@ function registerPetInteractionIpc(options = {}) {
     }
   });
 
-  on("start-drag-reaction", () => sendToRenderer("start-drag-reaction"));
+  on("start-drag-reaction", (_event, direction) => {
+    sendToRenderer("start-drag-reaction", direction === "left" || direction === "right" ? direction : null);
+  });
   on("end-drag-reaction", () => sendToRenderer("end-drag-reaction"));
   on("play-click-reaction", (_event, svg, duration) => {
     sendToRenderer("play-click-reaction", svg, duration);

--- a/src/preload-hit.js
+++ b/src/preload-hit.js
@@ -28,7 +28,7 @@ contextBridge.exposeInMainWorld("hitAPI", {
   showDashboard: () => ipcRenderer.send("show-dashboard"),
   revealSessionHud: () => ipcRenderer.send("pet-interaction:reveal-session-hud"),
   // Reaction triggers → main → renderWin
-  startDragReaction: () => ipcRenderer.send("start-drag-reaction"),
+  startDragReaction: (direction) => ipcRenderer.send("start-drag-reaction", direction),
   endDragReaction: () => ipcRenderer.send("end-drag-reaction"),
   playClickReaction: (svg, duration) => ipcRenderer.send("play-click-reaction", svg, duration),
   // State sync ← main

--- a/src/preload.js
+++ b/src/preload.js
@@ -21,7 +21,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onMiniClip: (cb) => ipcRenderer.on("mini-clip", (_, info) => cb(info)),
   onLowPowerIdleModeChange: (cb) => ipcRenderer.on("low-power-idle-mode-change", (_, enabled) => cb(enabled)),
   // Reaction control (from main, relayed from hit window)
-  onStartDragReaction: (cb) => ipcRenderer.on("start-drag-reaction", () => cb()),
+  onStartDragReaction: (cb) => ipcRenderer.on("start-drag-reaction", (_, direction) => cb(direction)),
   onEndDragReaction: (cb) => ipcRenderer.on("end-drag-reaction", () => cb()),
   onPlayClickReaction: (cb) => ipcRenderer.on("play-click-reaction", (_, svg, duration) => cb(svg, duration)),
   // Sound playback (from main)

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -37,6 +37,7 @@ function initWithConfig(cfg) {
   _miniViewBox = tc.miniModeViewBox || null;
   _fileViewBoxes = tc.fileViewBoxes || {};
   _dragSvg = tc.dragSvg || null;
+  _dragSvgs = tc.dragSvgs || {};
   _idleFollowSvg = tc.idleFollowSvg || "clawd-idle-follow.svg";
   _glyphFlipDefs = tc.glyphFlips || { "pixel-z": 4, "pixel-z-small": 3 };
 
@@ -334,6 +335,8 @@ let _imgCacheBustSeq = 0;
 let _miniViewBox = null;
 let _fileViewBoxes = {};
 let _dragSvg;
+let _dragSvgs;
+let currentDragSvg = null;
 let _idleFollowSvg;
 let _glyphFlipDefs;
 let _objectScaleCSS;
@@ -599,7 +602,7 @@ function getAssetUrl(file) {
 }
 
 // --- IPC-triggered reactions (from hit window via main relay) ---
-window.electronAPI.onStartDragReaction(() => startDragReaction());
+window.electronAPI.onStartDragReaction((direction) => startDragReaction(direction));
 window.electronAPI.onEndDragReaction(() => endDragReaction());
 window.electronAPI.onPlayClickReaction((svg, duration) => playReaction(svg, duration));
 
@@ -634,26 +637,29 @@ function cancelReaction() {
 }
 
 // --- Drag reaction (loops while dragging) ---
-function startDragReaction() {
-  if (isDragReacting) return;
+function startDragReaction(direction) {
   if (dndEnabled) return;
-  if (!_dragSvg) return;
+  const dragSvg = (direction && _dragSvgs[direction]) || _dragSvg;
+  if (!dragSvg) return;
+  if (isDragReacting && currentDragSvg === dragSvg) return;
 
-  if (isReacting) {
+  if (!isDragReacting && isReacting) {
     if (reactTimer) { clearTimeout(reactTimer); reactTimer = null; }
     isReacting = false;
   }
 
   isDragReacting = true;
+  currentDragSvg = dragSvg;
   detachEyeTracking();
   resumeCurrentSvgForLowPower();
   window.electronAPI.pauseCursorPolling();
-  swapToFile(_dragSvg, null);
+  swapToFile(dragSvg, null);
 }
 
 function endDragReaction() {
   if (!isDragReacting) return;
   isDragReacting = false;
+  currentDragSvg = null;
   window.electronAPI.resumeFromReaction();
 }
 

--- a/src/theme-context.js
+++ b/src/theme-context.js
@@ -75,6 +75,10 @@ function createThemeContext(theme, options = {}) {
       glyphFlips: theme.miniMode ? theme.miniMode.glyphFlips : {},
       miniFlipAssets: theme.miniMode ? !!theme.miniMode.flipAssets : false,
       dragSvg: theme.reactions && theme.reactions.drag ? theme.reactions.drag.file : null,
+      dragSvgs: theme.reactions && theme.reactions.drag ? {
+        left: theme.reactions.drag.fileLeft || null,
+        right: theme.reactions.drag.fileRight || null,
+      } : null,
       idleFollowSvg: theme.states.idle[0],
       eyeTrackingStates: theme.eyeTracking.enabled ? theme.eyeTracking.states : [],
       trustedScriptedSvgFiles: [...trustedScriptedSvgFiles],

--- a/src/theme-runtime.js
+++ b/src/theme-runtime.js
@@ -127,6 +127,7 @@ function createThemeRuntime(options = {}) {
       throw new Error("theme switch requires ready windows");
     }
 
+    const activateOptions = arguments.length >= 4 ? arguments[3] : null;
     const currentVariantMap = settingsController.get("themeVariant") || {};
     const targetVariant = (typeof variantId === "string" && variantId)
       ? variantId
@@ -139,7 +140,8 @@ function createThemeRuntime(options = {}) {
       activeTheme &&
       activeTheme._id === themeId &&
       activeTheme._variantId === targetVariant &&
-      (activeTheme._overrideSignature || "{}") === targetOverrideSignature
+      (activeTheme._overrideSignature || "{}") === targetOverrideSignature &&
+      !(activateOptions && activateOptions.forceReload === true)
     ) {
       return { themeId, variantId: activeTheme._variantId };
     }
@@ -229,6 +231,17 @@ function createThemeRuntime(options = {}) {
     return { themeId, variantId: newTheme._variantId };
   }
 
+  function reloadActiveTheme() {
+    if (!activeTheme) throw new Error("active theme is not loaded");
+    const currentOverrides = settingsController.get("themeOverrides") || {};
+    return activateTheme(
+      activeTheme._id,
+      activeTheme._variantId || "default",
+      currentOverrides[activeTheme._id] || null,
+      { forceReload: true }
+    );
+  }
+
   function refreshActiveThemeHitboxOverrides(themeId, overrideMap) {
     if (!activeTheme || activeTheme._id !== themeId) {
       throw new Error("hitbox refresh requires the requested theme to already be active");
@@ -293,6 +306,7 @@ function createThemeRuntime(options = {}) {
   return {
     loadInitialTheme,
     activateTheme,
+    reloadActiveTheme,
     refreshActiveThemeHitboxOverrides,
     getActiveTheme,
     getActiveThemeContext,

--- a/src/theme-schema.js
+++ b/src/theme-schema.js
@@ -293,6 +293,8 @@ function hasReactionBindings(reactions) {
     isPlainObject(entry)
     && (
       (typeof entry.file === "string" && entry.file.length > 0)
+      || (typeof entry.fileLeft === "string" && entry.fileLeft.length > 0)
+      || (typeof entry.fileRight === "string" && entry.fileRight.length > 0)
       || (Array.isArray(entry.files) && entry.files.some((file) => typeof file === "string" && file.length > 0))
     )
   );
@@ -372,6 +374,8 @@ function collectRequiredAssetFiles(theme) {
     for (const entry of Object.values(theme.reactions)) {
       if (!entry || typeof entry !== "object") continue;
       if (typeof entry.file === "string") addThemeAssetFile(files, entry.file);
+      if (typeof entry.fileLeft === "string") addThemeAssetFile(files, entry.fileLeft);
+      if (typeof entry.fileRight === "string") addThemeAssetFile(files, entry.fileRight);
       if (Array.isArray(entry.files)) {
         for (const file of entry.files) addThemeAssetFile(files, file);
       }
@@ -661,6 +665,8 @@ function mergeDefaults(raw, themeId, isBuiltin) {
   if (theme.reactions) {
     for (const r of Object.values(theme.reactions)) {
       if (r && r.file) r.file = bn(r.file);
+      if (r && r.fileLeft) r.fileLeft = bn(r.fileLeft);
+      if (r && r.fileRight) r.fileRight = bn(r.fileRight);
       if (r && Array.isArray(r.files)) r.files = r.files.map(bn);
     }
   }

--- a/test/codex-pet-adapter.test.js
+++ b/test/codex-pet-adapter.test.js
@@ -377,6 +377,8 @@ describe("codex-pet-adapter wrapper generation and materialization", () => {
     assert.strictEqual(themeJson.states.error[0], "codex-pet-failed-loop.svg");
     assert.deepStrictEqual(themeJson.hitBoxes.default, { x: 0, y: 0, w: 192, h: 208 });
     assert.strictEqual(themeJson.reactions.drag.file, "codex-pet-running-loop.svg");
+    assert.strictEqual(themeJson.reactions.drag.fileLeft, "codex-pet-running-left-loop.svg");
+    assert.strictEqual(themeJson.reactions.drag.fileRight, "codex-pet-running-right-loop.svg");
     assert.strictEqual(Object.prototype.hasOwnProperty.call(themeJson, "objectScale"), false);
 
     const marker = readJson(path.join(materialized.themeDir, adapter.MARKER_FILENAME));

--- a/test/codex-pet-main.test.js
+++ b/test/codex-pet-main.test.js
@@ -156,6 +156,78 @@ test("Codex Pet main runtime records sync summaries and normalizes adapter failu
   assert.strictEqual(failingRuntime.getLastSyncSummary(), failed);
 });
 
+test("Codex Pet settings refresh hot reloads an updated active managed theme", async () => {
+  let reloadCalls = 0;
+  let syncCalls = 0;
+  const runtime = createCodexPetMain({
+    app: {
+      getPath: () => "user-data",
+      isReady: () => false,
+    },
+    dialog: {},
+    shell: {},
+    settingsController: {
+      get: () => "codex-pet-live",
+    },
+    themeLoader: {},
+    codexPetAdapter: {
+      syncCodexPetThemes() {
+        syncCalls += 1;
+        return {
+          updated: 1,
+          themes: [{ themeId: "codex-pet-live", operation: "updated" }],
+        };
+      },
+    },
+    codexPetImporter: {},
+    getActiveTheme: () => ({ _id: "codex-pet-live" }),
+    reloadActiveTheme: () => {
+      reloadCalls += 1;
+    },
+  });
+
+  assert.deepStrictEqual(await runtime.refreshFromSettings(), {
+    status: "ok",
+    summary: {
+      updated: 1,
+      themes: [{ themeId: "codex-pet-live", operation: "updated" }],
+    },
+    switchedToFallback: false,
+  });
+  assert.strictEqual(syncCalls, 1);
+  assert.strictEqual(reloadCalls, 1);
+});
+
+test("Codex Pet settings refresh leaves an unchanged active theme alone", async () => {
+  let reloadCalls = 0;
+  const runtime = createCodexPetMain({
+    app: {
+      getPath: () => "user-data",
+      isReady: () => false,
+    },
+    dialog: {},
+    shell: {},
+    settingsController: {
+      get: () => "codex-pet-live",
+    },
+    themeLoader: {},
+    codexPetAdapter: {
+      syncCodexPetThemes: () => ({
+        unchanged: 1,
+        themes: [{ themeId: "codex-pet-live", operation: "unchanged" }],
+      }),
+    },
+    codexPetImporter: {},
+    getActiveTheme: () => ({ _id: "codex-pet-live" }),
+    reloadActiveTheme: () => {
+      reloadCalls += 1;
+    },
+  });
+
+  assert.strictEqual((await runtime.refreshFromSettings()).status, "ok");
+  assert.strictEqual(reloadCalls, 0);
+});
+
 test("Codex Pet import URLs queued before app ready do not flush until explicitly drained", async () => {
   const originalSetImmediate = global.setImmediate;
   let immediateCalls = 0;

--- a/test/hit-renderer.test.js
+++ b/test/hit-renderer.test.js
@@ -63,7 +63,7 @@ function createHarness({ isMac = false, sendState = {} } = {}) {
         exitMiniMode: () => apiCalls.push(["exitMiniMode"]),
         showDashboard: () => apiCalls.push(["showDashboard"]),
         revealSessionHud: () => apiCalls.push(["revealSessionHud"]),
-        startDragReaction: () => apiCalls.push(["startDragReaction"]),
+        startDragReaction: (direction) => apiCalls.push(["startDragReaction", direction]),
         endDragReaction: () => apiCalls.push(["endDragReaction"]),
         playClickReaction: (svg, d) => apiCalls.push(["playClickReaction", svg, d]),
         onStateSync: (cb) => { apiHandlers.stateSync = cb; },
@@ -97,6 +97,15 @@ function createHarness({ isMac = false, sendState = {} } = {}) {
     fakeDocument._dispatch("pointerup", { button, ctrlKey, metaKey, clientX });
   }
 
+  function pointerdown({ button = 0, pointerId = 1, clientX = 100, clientY = 100 } = {}) {
+    const cb = area.listeners.get("pointerdown");
+    if (cb) cb({ button, pointerId, clientX, clientY });
+  }
+
+  function pointermove({ clientX = 100, clientY = 100 } = {}) {
+    fakeDocument._dispatch("pointermove", { clientX, clientY });
+  }
+
   function fireTimer(predicate) {
     const t = timers.find((x) => !x.cleared && predicate(x));
     if (!t) return false;
@@ -105,7 +114,7 @@ function createHarness({ isMac = false, sendState = {} } = {}) {
     return true;
   }
 
-  return { apiCalls, apiHandlers, pointerup, fireTimer, timers, area, context };
+  return { apiCalls, apiHandlers, pointerdown, pointermove, pointerup, fireTimer, timers, area, context };
 }
 
 describe("hit-renderer input layer", () => {
@@ -203,5 +212,21 @@ describe("hit-renderer input layer", () => {
     h.fireTimer((t) => t.ms === 400);
     assert.strictEqual(h.apiCalls.length, before,
       "after cancelReaction, no new reaction should fire");
+  });
+
+  it("updates the drag reaction when horizontal direction changes", () => {
+    const h = createHarness();
+    h.pointerdown({ clientX: 100, clientY: 100 });
+    h.pointermove({ clientX: 90, clientY: 100 });
+    h.pointermove({ clientX: 80, clientY: 100 });
+    h.pointermove({ clientX: 95, clientY: 100 });
+
+    assert.deepStrictEqual(
+      h.apiCalls.filter((call) => call[0] === "startDragReaction"),
+      [
+        ["startDragReaction", "left"],
+        ["startDragReaction", "right"],
+      ]
+    );
   });
 });

--- a/test/pet-interaction-ipc.test.js
+++ b/test/pet-interaction-ipc.test.js
@@ -138,9 +138,23 @@ test("pet interaction IPC delegates menu, drag move, reaction pause, and rendere
     ["setLowPowerIdlePaused", true],
     ["setLowPowerIdlePaused", false],
     ["setIdlePaused", false],
-    ["sendToRenderer", "start-drag-reaction"],
+    ["sendToRenderer", "start-drag-reaction", null],
     ["sendToRenderer", "end-drag-reaction"],
     ["sendToRenderer", "play-click-reaction", "click.svg", 900],
+  ]);
+});
+
+test("pet interaction IPC relays only supported drag directions", () => {
+  const { ipcMain, calls } = createHarness();
+
+  ipcMain.send("start-drag-reaction", "left");
+  ipcMain.send("start-drag-reaction", "right");
+  ipcMain.send("start-drag-reaction", "up");
+
+  assert.deepStrictEqual(calls, [
+    ["sendToRenderer", "start-drag-reaction", "left"],
+    ["sendToRenderer", "start-drag-reaction", "right"],
+    ["sendToRenderer", "start-drag-reaction", null],
   ]);
 });
 

--- a/test/renderer-low-power.test.js
+++ b/test/renderer-low-power.test.js
@@ -261,9 +261,9 @@ describe("renderer object-channel selection", () => {
     const source = readNormalized(RENDERER);
 
     assert.ok(source.includes("swapToFile(svgFile, null);"));
-    assert.ok(source.includes("swapToFile(_dragSvg, null);"));
+    assert.ok(source.includes("swapToFile(dragSvg, null);"));
     assert.ok(!source.includes("swapToFile(svgFile, null, false);"));
-    assert.ok(!source.includes("swapToFile(_dragSvg, null, false);"));
+    assert.ok(!source.includes("swapToFile(dragSvg, null, false);"));
   });
 
   it("uses a monotonic cache-bust counter for remaining img-channel SVG swaps", () => {

--- a/test/theme-runtime.test.js
+++ b/test/theme-runtime.test.js
@@ -220,6 +220,20 @@ describe("theme-runtime active ownership", () => {
     assert.deepStrictEqual(calls, []);
   });
 
+  it("explicitly reloads an already-active theme through the full reload protocol", () => {
+    makeFixture();
+    const { runtime, calls } = createRuntime();
+    runtime.loadInitialTheme("clawd");
+
+    const result = runtime.reloadActiveTheme();
+
+    assert.deepStrictEqual(result, { themeId: "clawd", variantId: "default" });
+    assert.ok(calls.includes("state.cleanup"));
+    assert.ok(calls.includes("state.refreshTheme"));
+    assert.ok(calls.includes("syncRendererState"));
+    assert.ok(calls.includes("flushPrefs"));
+  });
+
   it("returns the resolved variant id when activation falls back from an unknown variant", () => {
     makeFixture();
     const { runtime } = createRuntime();

--- a/test/theme-schema.test.js
+++ b/test/theme-schema.test.js
@@ -101,7 +101,7 @@ describe("theme schema defaults and normalization", () => {
       },
       sounds: { complete: "../complete.wav" },
       reactions: {
-        drag: { file: "../drag.svg" },
+        drag: { file: "../drag.svg", fileLeft: "../drag-left.svg", fileRight: "nested/drag-right.svg" },
         double: { files: ["nested/a.svg", "../b.svg"] },
       },
       workingTiers: [{ minSessions: 2, file: "../tier.svg" }],
@@ -117,6 +117,8 @@ describe("theme schema defaults and normalization", () => {
     assert.deepStrictEqual(theme._stateBindings.sleeping, { files: ["sleeping.svg"], fallbackTo: null });
     assert.strictEqual(theme.sounds.complete, "complete.wav");
     assert.strictEqual(theme.reactions.drag.file, "drag.svg");
+    assert.strictEqual(theme.reactions.drag.fileLeft, "drag-left.svg");
+    assert.strictEqual(theme.reactions.drag.fileRight, "drag-right.svg");
     assert.deepStrictEqual(theme.reactions.double.files, ["a.svg", "b.svg"]);
     assert.strictEqual(theme.workingTiers[0].file, "tier.svg");
     assert.strictEqual(theme.idleAnimations[0].file, "look.svg");
@@ -164,7 +166,10 @@ describe("theme schema defaults and normalization", () => {
       workingTiers: [{ file: "../tier.svg" }],
       jugglingTiers: [{ file: "juggling.svg" }],
       idleAnimations: [{ file: "idle-look.svg" }],
-      reactions: { drag: { file: "drag.svg" }, double: { files: ["drag.svg", "../double.svg"] } },
+      reactions: {
+        drag: { file: "drag.svg", fileLeft: "../drag-left.svg", fileRight: "nested/drag-right.svg" },
+        double: { files: ["drag.svg", "../double.svg"] },
+      },
       displayHintMap: { old: "../hint.svg" },
       updateVisuals: { checking: "../checking.svg" },
     });
@@ -172,6 +177,8 @@ describe("theme schema defaults and normalization", () => {
     assert.deepStrictEqual(files.sort(), [
       "checking.svg",
       "double.svg",
+      "drag-left.svg",
+      "drag-right.svg",
       "drag.svg",
       "hint.svg",
       "idle-look.svg",


### PR DESCRIPTION
## Summary

Add optional left/right drag reaction assets while preserving the existing drag fallback.
Map Codex Pet atlas running-left and running-right rows into generated Clawd themes.
Hot-reload an active managed Codex Pet theme after refresh or replacement.
Bump the Codex Pet adapter version so existing generated themes are rebuilt.

## Changes

- feat(theme): support directional Codex Pet drag animations (single commit)

## Testing

```bash
git diff --check upstream/main...HEAD
node --test test/codex-pet-adapter.test.js test/codex-pet-main.test.js test/theme-runtime.test.js test/theme-schema.test.js test/theme-context.test.js test/hit-renderer.test.js test/pet-interaction-ipc.test.js test/renderer-low-power.test.js
```

## Notes

This PR contains only the single commit for directional drag animations.