### PR TITLE
fix: 基于 parentID 标记 opencode 子会话为 headless

### DIFF
--- a/hooks/opencode-plugin/index.mjs
+++ b/hooks/opencode-plugin/index.mjs
@@ -29,6 +29,9 @@ import { execFileSync, execSync } from "child_process";
 import {
   DEFAULT_SESSION_ID,
   getEventSessionId,
+  getEventParentSessionId,
+  isChildSessionId,
+  cleanupSessionParentMap,
   normalizeOpencodeSessionId,
   resolveOpencodeSessionId,
   shouldDropMappedEventWithoutSessionId,
@@ -92,9 +95,16 @@ let _reqCounter = 0;
 // and agent="explore"/other. Clawd's multi-session fanout already handles this
 // visually (1→typing, 2→juggling, 3+→building). The only fix needed is to
 // prevent subtask `session.idle` from firing the happy animation — only the
-// ROOT session (first seen) should do that. _rootSessionId captures the first
-// sessionID in the plugin's lifetime; all others are treated as subtasks.
+// Root session fallback used for legacy idle/permission association.
+// Child/headless detection is explicit: _sessionParentById is populated
+// from event.properties.info.parentID on session.created.
 let _rootSessionId = null;
+// Phase 3 headless: maps child sessionID → parentID. Populated on
+// session.created (from event.properties.info.parentID), cleaned on
+// session.deleted / server.instance.disposed. Used by buildStateBody()
+// to set headless: true for child sessions and by translateEvent() to
+// map child session.idle → SessionEnd instead of Stop.
+const _sessionParentById = new Map();
 // Process tree walk results — populated once by getStablePid() at init, then
 // read by every POST to /state and /permission. null until first resolution.
 let _stablePid = null;
@@ -339,13 +349,20 @@ function postPermissionToClawd(body) {
 function buildStateBody(state, eventName, sessionId) {
   if (!state || !eventName) return null;
   const clawdSessionId = normalizeOpencodeSessionId(sessionId) || DEFAULT_SESSION_ID;
-  return {
+  const body = {
     state,
     session_id: clawdSessionId,
     event: eventName,
     agent_id: AGENT_ID,
     hook_source: HOOK_SOURCE,
   };
+  // Phase 3 headless: child sessions (identified by parentID in
+  // _sessionParentById) get headless: true so downstream session
+  // handling can distinguish child sessions.
+  if (isChildSessionId(clawdSessionId, _sessionParentById)) {
+    body.headless = true;
+  }
+  return body;
 }
 
 // Clawd uses PascalCase event names matching Claude Code's hook vocabulary so
@@ -416,12 +433,10 @@ function translateEvent(event) {
       return { state: "sweeping", event: "PreCompact" };
 
     case "session.idle": {
-      // Phase 3 (plan A): only the root session's idle fires the happy
-      // animation. Subtask sessions (spawned by the `task` tool) end with
-      // SessionEnd so Clawd removes them from its tracking map — no happy
-      // flash, no menu pollution. If _rootSessionId is null (no session
-      // seen yet, should never happen), fall through to old behavior.
-      if (_rootSessionId && sessionId && sessionId !== _rootSessionId) {
+      // Phase 3 headless: child sessions (identified by parentID in
+      // _sessionParentById) end with SessionEnd so Clawd removes them
+      // from its tracking map — no happy flash, no menu pollution.
+      if (isChildSessionId(sessionId, _sessionParentById)) {
         return { state: "sleeping", event: "SessionEnd" };
       }
       return { state: "attention", event: "Stop" };
@@ -442,6 +457,9 @@ function translateEvent(event) {
 export const __test = {
   buildStateBody,
   translateEvent,
+  get _sessionParentById() { return _sessionParentById; },
+  get _rootSessionId() { return _rootSessionId; },
+  set _rootSessionId(v) { _rootSessionId = v; },
 };
 
 // Normalize ctx.serverUrl into a string with a trailing slash. opencode passes
@@ -613,6 +631,25 @@ export default async (ctx) => {
         }
         if (sid) _lastSeenSessionId = sid;
 
+        // Phase 3 headless: on session.created, read parentID from
+        // event.properties.info.parentID (opencode SDK ≥1.15.13) and store
+        // in _sessionParentById. Child sessions get headless: true in
+        // buildStateBody().
+        if (event.type === "session.created" && sid) {
+          const parentID = getEventParentSessionId(event);
+          if (parentID) {
+            // Store with normalized keys so lookups from buildStateBody()
+            // (which uses clawdSessionId = normalizeOpencodeSessionId(sessionId))
+            // match consistently regardless of raw vs prefixed form.
+            const normChild = normalizeOpencodeSessionId(sid);
+            const normParent = normalizeOpencodeSessionId(parentID);
+            if (normChild && normParent) {
+              _sessionParentById.set(normChild, normParent);
+              debugLog(`CHILD session id=${normChild} parentId=${normParent}`);
+            }
+          }
+        }
+
         // Phase 2: permission.asked rides a parallel channel — forward to Clawd
         // and skip state translation. Clawd replies directly to opencode's own
         // REST API, so we don't need to watch permission.replied here.
@@ -620,6 +657,13 @@ export default async (ctx) => {
           handlePermissionAsked(event);
           return;
         }
+
+        // Phase 3 headless: clean up _sessionParentById on session end
+        // events so the Map doesn't grow unboundedly across sessions.
+        // Must run BEFORE shouldDropMappedEventWithoutSessionId() because
+        // server.instance.disposed may lack a sessionID (causing the drop
+        // check to early-return) but still needs to clear the entire map.
+        cleanupSessionParentMap(event, _sessionParentById);
 
         const mapped = translateEvent(event);
         if (!mapped) {
@@ -637,10 +681,12 @@ export default async (ctx) => {
           debugLog(`DROP ${event.type} event=${mapped.event} reason=no-session-id`);
           return;
         }
+
         const sessionId = resolveOpencodeSessionId(
           getEventSessionId(event),
           _lastSeenSessionId || _rootSessionId
         );
+
         debugLog(`MAP ${event.type} → state=${mapped.state} event=${mapped.event}`);
         sendState(mapped.state, mapped.event, sessionId);
       } catch (err) {

--- a/hooks/opencode-plugin/session-ids.mjs
+++ b/hooks/opencode-plugin/session-ids.mjs
@@ -31,3 +31,55 @@ export function shouldDropMappedEventWithoutSessionId(event, mapped) {
     && mapped.event === "SessionEnd"
     && !getEventSessionId(event);
 }
+
+// Extract the parent session ID from a session.created event.
+// opencode SDK ≥1.15.13: event.properties.info.parentID (Session.parentID).
+// Returns null if absent (root session or older SDK).
+export function getEventParentSessionId(event) {
+  if (!event || typeof event !== "object") return null;
+  const props = event.properties && typeof event.properties === "object"
+    ? event.properties
+    : {};
+  const info = props.info && typeof props.info === "object" ? props.info : {};
+  const parentID = info.parentID;
+  return typeof parentID === "string" && parentID.trim() ? parentID.trim() : null;
+}
+
+// Check whether a session ID is a child session by looking up the
+// session→parentId map. The map is maintained by the plugin's event handler
+// (populated on session.created, cleaned on session.deleted/disposed).
+// Both the map keys and the lookup sessionId are normalized via
+// normalizeOpencodeSessionId() so raw ("ses_child") and prefixed
+// ("opencode:ses_child") forms match consistently.
+export function isChildSessionId(sessionId, sessionParentById) {
+  if (!sessionId || !sessionParentById || typeof sessionParentById.has !== "function") {
+    return false;
+  }
+  const normalized = normalizeOpencodeSessionId(sessionId);
+  if (!normalized) return false;
+  return sessionParentById.has(normalized);
+}
+
+// Clean up _sessionParentById on session end events so the Map doesn't grow
+// unboundedly across sessions. Must be called BEFORE shouldDropMappedEventWithoutSessionId()
+// because server.instance.disposed may lack a sessionID (causing early return) but
+// still needs to clear the entire map — all sessions are gone.
+//   - session.deleted: removes the single entry for that session (if present).
+//   - server.instance.disposed: clears the entire map.
+export function cleanupSessionParentMap(event, map) {
+  if (!event || typeof event.type !== "string") return;
+  if (!map || typeof map.clear !== "function") return;
+
+  if (event.type === "server.instance.disposed") {
+    map.clear();
+    return;
+  }
+
+  if (event.type === "session.deleted") {
+    const rawSid = getEventSessionId(event);
+    const normSid = normalizeOpencodeSessionId(rawSid);
+    if (normSid && map.has(normSid)) {
+      map.delete(normSid);
+    }
+  }
+}

--- a/test/opencode-plugin-session.test.js
+++ b/test/opencode-plugin-session.test.js
@@ -1,6 +1,6 @@
-const { describe, it } = require("node:test");
+const { describe, it, beforeEach } = require("node:test");
 const assert = require("node:assert");
-const path = require("node:path");
+const path = require("path");
 const { pathToFileURL } = require("node:url");
 
 async function loadSessionIdModule() {
@@ -81,5 +81,258 @@ describe("opencode plugin session ids", () => {
     assert.strictEqual(endBody.session_id, "opencode:ses_same");
     assert.strictEqual(startBody.event, "SessionStart");
     assert.strictEqual(endBody.event, "SessionEnd");
+  });
+});
+
+describe("opencode plugin headless (parentID-based child detection)", () => {
+  let pluginMod;
+
+  beforeEach(async () => {
+    pluginMod = await loadPluginModule();
+    pluginMod.__test._sessionParentById.clear();
+    pluginMod.__test._rootSessionId = null;
+  });
+
+  // Use case 1: getEventParentSessionId extracts parentID from event.properties.info
+  it("extracts parentID from event.properties.info.parentID", async () => {
+    const mod = await loadSessionIdModule();
+
+    // Child session with parentID
+    assert.strictEqual(
+      mod.getEventParentSessionId({
+        type: "session.created",
+        properties: { sessionID: "ses_child", info: { parentID: "ses_root" } },
+      }),
+      "ses_root"
+    );
+
+    // Root session — no parentID
+    assert.strictEqual(
+      mod.getEventParentSessionId({
+        type: "session.created",
+        properties: { sessionID: "ses_root", info: {} },
+      }),
+      null
+    );
+
+    // Missing info entirely
+    assert.strictEqual(
+      mod.getEventParentSessionId({
+        type: "session.created",
+        properties: { sessionID: "ses_root" },
+      }),
+      null
+    );
+
+    // Empty string parentID
+    assert.strictEqual(
+      mod.getEventParentSessionId({
+        type: "session.created",
+        properties: { sessionID: "ses_root", info: { parentID: "" } },
+      }),
+      null
+    );
+
+    // Whitespace-only parentID
+    assert.strictEqual(
+      mod.getEventParentSessionId({
+        type: "session.created",
+        properties: { sessionID: "ses_root", info: { parentID: "  " } },
+      }),
+      null
+    );
+
+    // null event
+    assert.strictEqual(mod.getEventParentSessionId(null), null);
+  });
+
+  // Use case 2: isChildSessionId normalizes sessionId before lookup
+  it("isChildSessionId normalizes sessionId before checking the parent map", async () => {
+    const mod = await loadSessionIdModule();
+    // Map stores normalized keys (as the event handler does)
+    const parentMap = new Map();
+    parentMap.set("opencode:ses_child", "opencode:ses_root");
+
+    // Raw id is normalized internally → matches
+    assert.strictEqual(mod.isChildSessionId("ses_child", parentMap), true);
+    // Already-prefixed id is also normalized → matches
+    assert.strictEqual(mod.isChildSessionId("opencode:ses_child", parentMap), true);
+    // Root session is not in the map
+    assert.strictEqual(mod.isChildSessionId("ses_root", parentMap), false);
+    assert.strictEqual(mod.isChildSessionId("opencode:ses_root", parentMap), false);
+    // Unknown session
+    assert.strictEqual(mod.isChildSessionId("ses_other", parentMap), false);
+    // Edge cases
+    assert.strictEqual(mod.isChildSessionId(null, parentMap), false);
+    assert.strictEqual(mod.isChildSessionId("ses_child", null), false);
+    assert.strictEqual(mod.isChildSessionId("ses_child", new Map()), false);
+  });
+
+  // Use case 3: buildStateBody adds headless: true for child sessions
+  // (both raw and prefixed sessionId forms)
+  it("buildStateBody adds headless: true for child sessions (raw and prefixed id)", async () => {
+    // Simulate what the event handler does: store normalized keys
+    pluginMod.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
+
+    // Raw id passed to buildStateBody → isChildSessionId normalizes → match
+    const bodyRaw = pluginMod.__test.buildStateBody("working", "PreToolUse", "ses_child");
+    assert.strictEqual(bodyRaw.headless, true);
+    assert.strictEqual(bodyRaw.session_id, "opencode:ses_child");
+
+    // Prefixed id passed to buildStateBody → isChildSessionId normalizes → match
+    const bodyPrefixed = pluginMod.__test.buildStateBody("working", "PreToolUse", "opencode:ses_child");
+    assert.strictEqual(bodyPrefixed.headless, true);
+    assert.strictEqual(bodyPrefixed.session_id, "opencode:ses_child");
+  });
+
+  // Use case 4: buildStateBody does NOT add headless for root sessions
+  it("buildStateBody does not add headless for root sessions", async () => {
+    const body = pluginMod.__test.buildStateBody("working", "PreToolUse", "ses_root");
+    assert.strictEqual(body.headless, undefined);
+    assert.strictEqual(body.session_id, "opencode:ses_root");
+  });
+
+  // Use case 5: standalone session (not in _sessionParentById, not root)
+  // must NOT be marked headless — no heuristic fallback
+  it("buildStateBody does not add headless for standalone sessions without parentID", async () => {
+    pluginMod.__test._rootSessionId = "opencode:ses_root";
+
+    // ses_other is not in _sessionParentById → NOT headless (no heuristic)
+    const body = pluginMod.__test.buildStateBody("working", "PreToolUse", "ses_other");
+    assert.strictEqual(body.headless, undefined);
+    assert.strictEqual(body.session_id, "opencode:ses_other");
+  });
+
+  // Use case 6: translateEvent maps child session.idle → SessionEnd
+  it("translateEvent maps child session.idle to SessionEnd when in _sessionParentById", async () => {
+    pluginMod.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
+
+    const result = pluginMod.__test.translateEvent({
+      type: "session.idle",
+      properties: { sessionID: "ses_child" },
+    });
+    assert.strictEqual(result.state, "sleeping");
+    assert.strictEqual(result.event, "SessionEnd");
+  });
+
+  // Use case 7: translateEvent maps root session.idle → Stop (attention)
+  it("translateEvent maps root session.idle to Stop (attention)", async () => {
+    const result = pluginMod.__test.translateEvent({
+      type: "session.idle",
+      properties: { sessionID: "ses_root" },
+    });
+    assert.strictEqual(result.state, "attention");
+    assert.strictEqual(result.event, "Stop");
+  });
+
+  // Use case 8: standalone session.idle (not in map) → Stop, NOT SessionEnd
+  it("translateEvent maps standalone session.idle to Stop (no heuristic fallback)", async () => {
+    pluginMod.__test._rootSessionId = "opencode:ses_root";
+
+    // ses_other is not in _sessionParentById → Stop (not SessionEnd)
+    const result = pluginMod.__test.translateEvent({
+      type: "session.idle",
+      properties: { sessionID: "ses_other" },
+    });
+    assert.strictEqual(result.state, "attention");
+    assert.strictEqual(result.event, "Stop");
+  });
+
+  // Use case 9: cleanupSessionParentMap clears entire map on server.instance.disposed
+  // even when the event has no sessionID
+  it("cleanupSessionParentMap clears entire map on server.instance.disposed (no sessionID)", async () => {
+    const mod = await loadSessionIdModule();
+    const parentMap = new Map();
+    parentMap.set("opencode:ses_child1", "opencode:ses_root");
+    parentMap.set("opencode:ses_child2", "opencode:ses_root");
+
+    // server.instance.disposed with no sessionID — must still clear the map
+    mod.cleanupSessionParentMap(
+      { type: "server.instance.disposed", properties: {} },
+      parentMap
+    );
+    assert.strictEqual(parentMap.size, 0);
+  });
+
+  // Use case 10: cleanupSessionParentMap removes single entry on session.deleted
+  it("cleanupSessionParentMap removes single entry on session.deleted", async () => {
+    const mod = await loadSessionIdModule();
+    const parentMap = new Map();
+    parentMap.set("opencode:ses_child1", "opencode:ses_root");
+    parentMap.set("opencode:ses_child2", "opencode:ses_root");
+
+    mod.cleanupSessionParentMap(
+      { type: "session.deleted", properties: { sessionID: "ses_child1" } },
+      parentMap
+    );
+    assert.strictEqual(parentMap.has("opencode:ses_child1"), false);
+    assert.strictEqual(parentMap.has("opencode:ses_child2"), true);
+    assert.strictEqual(parentMap.size, 1);
+  });
+
+  // Use case 11: cleanupSessionParentMap is a no-op for non-cleanup events
+  it("cleanupSessionParentMap is a no-op for non-cleanup events", async () => {
+    const mod = await loadSessionIdModule();
+    const parentMap = new Map();
+    parentMap.set("opencode:ses_child", "opencode:ses_root");
+
+    mod.cleanupSessionParentMap(
+      { type: "session.created", properties: { sessionID: "ses_child" } },
+      parentMap
+    );
+    assert.strictEqual(parentMap.size, 1);
+
+    mod.cleanupSessionParentMap(
+      { type: "message.part.updated", properties: {} },
+      parentMap
+    );
+    assert.strictEqual(parentMap.size, 1);
+  });
+
+  // Use case 12: cleanupSessionParentMap handles null/missing inputs gracefully
+  it("cleanupSessionParentMap handles null/missing inputs gracefully", async () => {
+    const mod = await loadSessionIdModule();
+    const parentMap = new Map();
+    parentMap.set("opencode:ses_child", "opencode:ses_root");
+
+    // null event
+    mod.cleanupSessionParentMap(null, parentMap);
+    assert.strictEqual(parentMap.size, 1);
+
+    // null map
+    mod.cleanupSessionParentMap(
+      { type: "server.instance.disposed", properties: {} },
+      null
+    );
+
+    // event without type
+    mod.cleanupSessionParentMap({}, parentMap);
+    assert.strictEqual(parentMap.size, 1);
+  });
+
+  // Use case 13: full flow — session.created with parentID → headless body + SessionEnd idle
+  it("full flow: session.created with parentID produces headless body and SessionEnd idle", async () => {
+    pluginMod.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
+
+    // buildStateBody for child → headless
+    const body = pluginMod.__test.buildStateBody("working", "PreToolUse", "ses_child");
+    assert.strictEqual(body.headless, true);
+    assert.strictEqual(body.session_id, "opencode:ses_child");
+
+    // translateEvent for child session.idle → SessionEnd
+    const idleResult = pluginMod.__test.translateEvent({
+      type: "session.idle",
+      properties: { sessionID: "ses_child" },
+    });
+    assert.strictEqual(idleResult.state, "sleeping");
+    assert.strictEqual(idleResult.event, "SessionEnd");
+
+    // translateEvent for root session.idle → Stop
+    const rootIdleResult = pluginMod.__test.translateEvent({
+      type: "session.idle",
+      properties: { sessionID: "ses_root" },
+    });
+    assert.strictEqual(rootIdleResult.state, "attention");
+    assert.strictEqual(rootIdleResult.event, "Stop");
   });
 });


### PR DESCRIPTION
## Summary

这个 PR 是继 #366 之后，单独拆出的 opencode child/subtask session 处理改动。

本 PR 不做全局 server-side guess，也不使用“第一个 session 是 root、后续 session 都是 child”的启发式。child/headless 判定只基于 opencode `session.created` 事件中的显式 parent 信息：

```txt
event.properties.info.parentID
```

该字段来自 opencode SDK 的 `Session.parentID`。

本 PR 只修改 opencode plugin 和对应测试，不包含：

- CodeFree-O 独立 agent 集成
- 通知接管 / `disabled_hooks`
- Dashboard / HUD 聚合 UI
- `state.js` / `state-priority` / `state-visual-resolver` 变更
- README / docs / package metadata 变更

## Changes

- 从 `event.properties.info.parentID` 提取 parent session id。
- 在 opencode plugin 内维护 child session 到 parent session 的显式映射。
- 对已确认的 child session，在 `/state` body 中上报 `headless: true`。
- child session 的 `session.idle` 继续映射为 `SessionEnd`，避免子任务结束时触发 root session 的 attention/happy 行为。
- 在 `session.deleted` / `server.instance.disposed` 时清理 child session 映射。
- 统一 raw / `opencode:`-prefixed session id 的匹配，避免生产路径漏标 headless。
- 增加 opencode plugin session 测试，覆盖 parentID 提取、child/root/standalone session 行为、cleanup 以及 no-heuristic fallback。

## Test Plan

- `node --test test/opencode-plugin-session.test.js`
  - 18 pass
  - 0 fail

- `npm test`
  - 3394 pass
  - 0 fail
  - 5 skipped
