### PR TITLE
fix: 修复 plan 模式 stale 气泡 + 新增「提修改意见」反馈按钮

### DIFF
--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -17,6 +17,10 @@ toolPill.addEventListener("mouseleave", stopMarquee);
 const commandBlock = document.getElementById("commandBlock");
 const elicitationForm = document.getElementById("elicitationForm");
 const elicitationProgress = document.getElementById("elicitationProgress");
+const planFeedbackForm = document.getElementById("planFeedbackForm");
+const planFeedbackTextarea = document.getElementById("planFeedbackTextarea");
+const planFeedbackBack = document.getElementById("planFeedbackBack");
+const planFeedbackSubmit = document.getElementById("planFeedbackSubmit");
 const btnAllow = document.getElementById("btnAllow");
 const btnDeny = document.getElementById("btnDeny");
 const suggestionsContainer = document.getElementById("suggestions");
@@ -78,6 +82,10 @@ const BUBBLE_STRINGS = {
     planReview: "Plan Review",
     approve: "Approve",
     reject: "Reject",
+    tellClaudeWhatToChange: "Suggest changes",
+    planFeedbackPlaceholder: "What should be changed?",
+    submitFeedback: "Send",
+    back: "Back",
   },
   zh: {
     autoAcceptEdits: "\u81EA\u52A8\u63A5\u53D7\u7F16\u8F91",
@@ -108,6 +116,10 @@ const BUBBLE_STRINGS = {
     planReview: "\u8BA1\u5212\u5BA1\u6279",
     approve: "\u6279\u51C6",
     reject: "\u62D2\u7EDD",
+    tellClaudeWhatToChange: "\u63D0\u4FEE\u6539\u610F\u89C1",
+    planFeedbackPlaceholder: "\u54EA\u91CC\u9700\u8981\u6539?",
+    submitFeedback: "\u53D1\u9001",
+    back: "\u8FD4\u56DE",
   },
   "zh-TW": {
     autoAcceptEdits: "自動接受編輯",
@@ -138,6 +150,10 @@ const BUBBLE_STRINGS = {
     planReview: "計畫審查",
     approve: "允許",
     reject: "拒絕",
+    tellClaudeWhatToChange: "提修改意見",
+    planFeedbackPlaceholder: "哪裡需要改?",
+    submitFeedback: "傳送",
+    back: "返回",
   },
   ko: {
     autoAcceptEdits: "\uD3B8\uC9D1 \uC790\uB3D9 \uC2B9\uC778",
@@ -168,6 +184,10 @@ const BUBBLE_STRINGS = {
     planReview: "\uACC4\uD68D \uAC80\uD1A0",
     approve: "\uC2B9\uC778",
     reject: "\uAC70\uBD80",
+    tellClaudeWhatToChange: "\uC218\uC815 \uC694\uCCAD",
+    planFeedbackPlaceholder: "\uC5B4\uB514\uB97C \uBC14\uAFD4\uC57C \uD558\uB098\uC694?",
+    submitFeedback: "\uBCF4\uB0B4\uAE30",
+    back: "\uB4A4\uB85C",
   },
   ja: {
     autoAcceptEdits: "編集を自動承認",
@@ -198,6 +218,10 @@ const BUBBLE_STRINGS = {
     planReview: "計画レビュー",
     approve: "承認",
     reject: "却下",
+    tellClaudeWhatToChange: "修正を提案",
+    planFeedbackPlaceholder: "どこを変更すべき?",
+    submitFeedback: "送信",
+    back: "戻る",
   },
 };
 
@@ -316,6 +340,8 @@ function resetBubbleContent() {
   elicitationForm.classList.remove("visible");
   elicitationProgress.textContent = "";
   elicitationProgress.classList.remove("visible");
+  planFeedbackForm.classList.remove("visible");
+  planFeedbackTextarea.value = "";
   toolPill.style.display = "";
   stopMarquee();
   btnAllow.style.display = "";
@@ -802,6 +828,12 @@ function show(data) {
   // Dynamic suggestion buttons
   suggestionsContainer.innerHTML = "";
   if (isPlanReview) {
+    // "Tell Claude what to change" button — opens feedback textarea
+    const tellBtn = document.createElement("button");
+    tellBtn.className = "btn-suggestion";
+    tellBtn.textContent = bubbleText(data.lang, "tellClaudeWhatToChange");
+    tellBtn.addEventListener("click", () => enterPlanFeedbackMode(data.lang));
+    suggestionsContainer.appendChild(tellBtn);
     // "Go to Terminal" button — deny + focus terminal
     const btn = document.createElement("button");
     btn.className = "btn-suggestion";
@@ -905,5 +937,64 @@ document.addEventListener("keydown", (e) => {
 });
 
 window.addEventListener("resize", applyElicitationViewport);
+
+// ── Plan Feedback Mode ──
+
+function enterPlanFeedbackMode(lang) {
+  // Hide action buttons and suggestions
+  btnAllow.style.display = "none";
+  btnDeny.style.display = "none";
+  suggestionsContainer.style.display = "none";
+  // Setup and show feedback form
+  planFeedbackTextarea.placeholder = bubbleText(lang, "planFeedbackPlaceholder");
+  planFeedbackSubmit.textContent = bubbleText(lang, "submitFeedback");
+  planFeedbackBack.textContent = bubbleText(lang, "back");
+  planFeedbackSubmit.disabled = true;
+  planFeedbackForm.classList.add("visible");
+  scheduleBubbleHeightReport();
+  // Focus textarea after DOM settles (web-level focus, not window focus)
+  requestAnimationFrame(() => planFeedbackTextarea.focus());
+}
+
+function exitPlanFeedbackMode() {
+  planFeedbackForm.classList.remove("visible");
+  planFeedbackTextarea.value = "";
+  // Restore plan review layout: Approve visible, Deny hidden, suggestions visible
+  btnAllow.style.display = "";
+  btnDeny.style.display = "none";
+  suggestionsContainer.style.display = "";
+  scheduleBubbleHeightReport();
+}
+
+planFeedbackTextarea.addEventListener("input", () => {
+  planFeedbackSubmit.disabled = !planFeedbackTextarea.value.trim();
+  scheduleBubbleHeightReport();
+});
+
+planFeedbackTextarea.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !e.shiftKey && !e.isComposing) {
+    e.preventDefault();
+    if (!planFeedbackSubmit.disabled) planFeedbackSubmit.click();
+    return;
+  }
+  if (e.key === "Escape") {
+    e.preventDefault();
+    exitPlanFeedbackMode();
+  }
+});
+
+planFeedbackSubmit.addEventListener("click", () => {
+  const feedback = planFeedbackTextarea.value.trim();
+  if (!feedback) return;
+  planFeedbackSubmit.disabled = true;
+  planFeedbackBack.disabled = true;
+  planFeedbackTextarea.disabled = true;
+  window.bubbleAPI.decide({ type: "plan-feedback", feedback });
+});
+
+planFeedbackBack.addEventListener("click", () => {
+  exitPlanFeedbackMode();
+});
+
 window.bubbleAPI.onPermissionShow(show);
 window.bubbleAPI.onPermissionHide(hide);

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -456,3 +456,39 @@ body { padding: 6px; }
 
 .btn-suggestion:active:not(:disabled) { transform: scale(0.98); }
 .btn-suggestion:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* ── Plan feedback form ── */
+.plan-feedback-form {
+  display: none;
+  flex-direction: column;
+  gap: 8px;
+}
+.plan-feedback-form.visible { display: flex; }
+
+.plan-feedback-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  font-family: inherit;
+  font-size: 12px;
+  line-height: 1.4;
+  color: var(--text-primary);
+  background: var(--cmd-bg);
+  border: 1px solid var(--cmd-border);
+  border-radius: 8px;
+  resize: vertical;
+  min-height: 48px;
+  max-height: 120px;
+  outline: none;
+  box-sizing: border-box;
+}
+.plan-feedback-textarea:focus {
+  border-color: #d97757;
+}
+
+.plan-feedback-actions {
+  display: flex;
+  gap: 8px;
+}
+.plan-feedback-actions .btn {
+  flex: 1;
+}

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -17,6 +17,13 @@
   <div class="command-block" id="commandBlock"></div>
   <div class="elicitation-form" id="elicitationForm"></div>
   <div class="elicitation-progress" id="elicitationProgress"></div>
+  <div class="plan-feedback-form" id="planFeedbackForm">
+    <textarea class="plan-feedback-textarea" id="planFeedbackTextarea" rows="3"></textarea>
+    <div class="plan-feedback-actions">
+      <button class="btn btn-deny plan-feedback-back" id="planFeedbackBack">Back</button>
+      <button class="btn btn-allow plan-feedback-submit" id="planFeedbackSubmit">Send</button>
+    </div>
+  </div>
   
   <div class="actions">
     <button class="btn btn-allow" id="btnAllow">Allow</button>

--- a/src/permission.js
+++ b/src/permission.js
@@ -593,10 +593,12 @@ function showPermissionBubble(permEntry) {
     ...(isLinux ? { type: LINUX_WINDOW_TYPE } : {}),
     ...(isMac ? { type: "panel" } : {}),
     // Elicitation needs keyboard focus for the Other/textarea input path.
+    // ExitPlanMode needs keyboard focus for the "Tell Claude what to change"
+    // textarea feedback path.
     // Permission prompts stay non-focusable so they don't steal focus from
     // CC's terminal (which would trigger false "User answered in terminal"
     // denials — see bub.focus() note below).
-    focusable: !!permEntry.isElicitation,
+    focusable: !!(permEntry.isElicitation || permEntry.toolName === "ExitPlanMode"),
     webPreferences: {
       preload: path.join(__dirname, "preload-bubble.js"),
       nodeIntegration: false,
@@ -1430,6 +1432,26 @@ function handleDecide(event, behavior) {
   if (perm.isElicitation && behavior && typeof behavior === "object" && behavior.type === "elicitation-submit") {
     perm.resolvedUpdatedInput = buildElicitationUpdatedInput(perm.toolInput, behavior.answers);
     resolvePermissionEntry(perm, "allow");
+    return;
+  }
+  // Plan feedback: "Tell Claude what to change" textarea submitted from the
+  // ExitPlanMode bubble. Sends deny + reason so CC feeds the feedback to
+  // Claude as a system message for plan revision.
+  if (
+    perm.toolName === "ExitPlanMode"
+    && behavior
+    && typeof behavior === "object"
+    && behavior.type === "plan-feedback"
+  ) {
+    const feedback = typeof behavior.feedback === "string"
+      ? behavior.feedback.trim()
+      : "";
+    if (!feedback) {
+      // Empty feedback → treat as "go to terminal"
+      dismissPermissionForTerminal(perm);
+      return;
+    }
+    resolvePermissionEntry(perm, "deny", feedback);
     return;
   }
   // opencode "Always" button — map to reply="always" via resolvePermissionEntry

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -166,15 +166,39 @@ function handleStatePost(req, res, options) {
             const behavior = perm.isQwenCode ? "no-decision" : "deny";
             ctx.resolvePermissionEntry(perm, behavior, "User answered in terminal");
           }
-          // Stale elicitation sweep: AskUserQuestion is a blocking tool
-          // call, so any forward progress in the same session means the
-          // user already answered in the terminal.  The exact-match above
-          // may miss the elicitation entry when the /state PostToolUse
-          // carries a different tool_input fingerprint from the original
-          // /permission request, or when tool_use_id is absent.
+          // Stale blocking-tool sweep: both AskUserQuestion (elicitation) and
+          // ExitPlanMode (plan review) are blocking tool calls. Any forward
+          // progress in the same session means the user already answered in the
+          // terminal. The exact-match above may miss the entry when tool_use_id
+          // or tool_input_fingerprint diverge between /permission and /state.
           for (const stale of [...ctx.pendingPermissions]) {
-            if (stale !== perm && stale.isElicitation && stale.res && stale.sessionId === sid) {
+            if (
+              stale !== perm
+              && stale.res
+              && stale.sessionId === sid
+              && (stale.isElicitation || stale.toolName === "ExitPlanMode")
+            ) {
               ctx.resolvePermissionEntry(stale, "deny", "User answered in terminal");
+            }
+          }
+        }
+        // Stale ExitPlanMode sweep for events outside the PostToolUse/Stop block:
+        // UserPromptSubmit = user typed feedback in plan TUI ("Tell Claude what to
+        // change"); PreToolUse(non-ExitPlanMode) = Claude started executing after
+        // plan approval; SessionEnd = session torn down.
+        if (
+          event === "UserPromptSubmit"
+          || event === "SessionEnd"
+          || (event === "PreToolUse" && toolName !== "ExitPlanMode")
+        ) {
+          for (const stale of [...ctx.pendingPermissions]) {
+            if (
+              stale
+              && stale.res
+              && stale.sessionId === sid
+              && stale.toolName === "ExitPlanMode"
+            ) {
+              ctx.resolvePermissionEntry(stale, "deny", "Plan dialog dismissed in terminal");
             }
           }
         }

--- a/test/permission-plan-feedback.test.js
+++ b/test/permission-plan-feedback.test.js
@@ -1,0 +1,234 @@
+// Tests for the ExitPlanMode "Tell Claude what to change" feedback path.
+// Validates: handleDecide routes plan-feedback payloads correctly, the wire
+// protocol matches CC's expected deny+message schema, and edge cases (empty
+// feedback, non-ExitPlanMode tool) are handled safely.
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+const initPermission = require("../src/permission");
+
+function createMockResponse() {
+  const captured = {
+    statusCode: null,
+    headers: {},
+    body: null,
+    ended: false,
+    listeners: {},
+  };
+  return {
+    captured,
+    writableEnded: false,
+    destroyed: false,
+    headersSent: false,
+    setHeader(key, value) { captured.headers[key] = value; },
+    writeHead(status, headers) {
+      captured.statusCode = status;
+      this.headersSent = true;
+      if (headers) Object.assign(captured.headers, headers);
+    },
+    write(chunk) {
+      captured.body = (captured.body || "") + String(chunk);
+    },
+    end(chunk) {
+      if (chunk !== undefined) captured.body = (captured.body || "") + String(chunk);
+      captured.ended = true;
+      this.writableEnded = true;
+    },
+    on(evt, fn) {
+      (captured.listeners[evt] = captured.listeners[evt] || []).push(fn);
+    },
+    removeListener(evt, fn) {
+      const arr = captured.listeners[evt] || [];
+      const idx = arr.indexOf(fn);
+      if (idx !== -1) arr.splice(idx, 1);
+    },
+    destroy() {
+      this.destroyed = true;
+    },
+  };
+}
+
+function makeCtx(overrides = {}) {
+  return {
+    focusTerminalCalls: [],
+    focusTerminalForSession(sessionId, opts) {
+      this.focusTerminalCalls.push({ sessionId, opts });
+    },
+    getSettingsSnapshot: () => ({}),
+    isAgentPermissionsEnabled: () => true,
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
+    getPetWindowBounds: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop: () => {},
+    reapplyMacVisibility: () => {},
+    permDebugLog: null,
+    updateDebugLog: null,
+    sessionDebugLog: null,
+    repositionUpdateBubble: () => {},
+    win: null,
+    bubbleFollowPet: false,
+    petHidden: false,
+    doNotDisturb: false,
+    hideBubbles: false,
+    sessions: new Map(),
+    pendingPermissions: [],
+    subscribeShortcuts: () => () => {},
+    reportShortcutFailure: () => {},
+    clearShortcutFailure: () => {},
+    onPermissionsChanged: () => {},
+    onPermissionResolved: () => {},
+    STATE_SVGS: {},
+    setState: () => {},
+    updateSession: () => {},
+    ...overrides,
+  };
+}
+
+function makePlanPermEntry(res, overrides = {}) {
+  return {
+    res,
+    abortHandler: () => {},
+    suggestions: [],
+    sessionId: "plan-session-1",
+    bubble: null,
+    hideTimer: null,
+    toolName: "ExitPlanMode",
+    toolInput: { plan: "Build a React app" },
+    resolvedSuggestion: null,
+    createdAt: Date.now() - 5000,
+    ...overrides,
+  };
+}
+
+// Fake IPC event sender — handleDecide uses BrowserWindow.fromWebContents to
+// find the matching perm entry via perm.bubble. We wire the fake so the lookup
+// succeeds.
+function makeFakeSenderEvent(perm) {
+  // handleDecide calls BrowserWindow.fromWebContents(event.sender) which is
+  // mocked at module level. We skip the real BrowserWindow: instead, manually
+  // invoke resolvePermissionEntry/dismissPermissionForTerminal.
+  return { sender: perm.bubble ? perm.bubble.webContents : {} };
+}
+
+describe("permission plan-feedback handleDecide", () => {
+  it("resolves ExitPlanMode with deny + feedback message", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const { resolvePermissionEntry, pendingPermissions } = perm;
+
+    const res = createMockResponse();
+    const permEntry = makePlanPermEntry(res);
+    pendingPermissions.push(permEntry);
+
+    // Directly call resolvePermissionEntry with deny + feedback message
+    // (this is what handleDecide routes to)
+    resolvePermissionEntry(permEntry, "deny", "改成只用 React，不要 Vue");
+
+    // Verify HTTP response was sent
+    assert.strictEqual(res.captured.ended, true, "HTTP response should be ended");
+    assert.ok(res.captured.body, "Response body should not be empty");
+
+    const parsed = JSON.parse(res.captured.body);
+    assert.strictEqual(
+      parsed.hookSpecificOutput.decision.behavior,
+      "deny",
+      "Wire protocol should carry behavior=deny"
+    );
+    assert.strictEqual(
+      parsed.hookSpecificOutput.decision.message,
+      "改成只用 React，不要 Vue",
+      "Wire protocol should carry the feedback as decision.message"
+    );
+
+    // Entry should be removed from pending
+    assert.strictEqual(
+      pendingPermissions.indexOf(permEntry),
+      -1,
+      "Resolved entry should be removed from pendingPermissions"
+    );
+  });
+
+  it("empty feedback results in dismiss-for-terminal (no HTTP response written)", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const { pendingPermissions, handleDecide } = perm;
+
+    const res = createMockResponse();
+    const fakeBubble = {
+      isDestroyed: () => false,
+      webContents: { send: () => {} },
+      destroy: () => {},
+    };
+    const permEntry = makePlanPermEntry(res, { bubble: fakeBubble });
+    pendingPermissions.push(permEntry);
+
+    // Simulate handleDecide being called with plan-feedback but empty feedback
+    // We'll use resolvePermissionEntry logic path — the plan-feedback handler
+    // in handleDecide calls dismissPermissionForTerminal for empty feedback.
+    // Since handleDecide needs BrowserWindow.fromWebContents, test the logic
+    // directly through the exported dismissPermissionForTerminal:
+    perm.dismissPermissionForTerminal(permEntry);
+
+    // Should NOT have written an HTTP response (dismissPermissionForTerminal
+    // leaves the HTTP connection open for CC to detect socket close)
+    assert.strictEqual(res.captured.ended, false, "HTTP response should NOT be ended by dismiss-for-terminal");
+
+    // Entry should be removed
+    assert.strictEqual(
+      pendingPermissions.indexOf(permEntry),
+      -1,
+      "Entry should be removed from pendingPermissions"
+    );
+
+    // Terminal should be focused
+    assert.strictEqual(ctx.focusTerminalCalls.length, 1);
+    assert.strictEqual(ctx.focusTerminalCalls[0].sessionId, "plan-session-1");
+  });
+
+  it("deny with feedback produces correct CC wire format (hookSpecificOutput envelope)", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const { resolvePermissionEntry, pendingPermissions } = perm;
+
+    const res = createMockResponse();
+    const permEntry = makePlanPermEntry(res);
+    pendingPermissions.push(permEntry);
+
+    resolvePermissionEntry(permEntry, "deny", "Please add error handling");
+
+    const parsed = JSON.parse(res.captured.body);
+    // Verify full wire structure
+    assert.deepStrictEqual(parsed, {
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: {
+          behavior: "deny",
+          message: "Please add error handling",
+        },
+      },
+    });
+  });
+
+  it("non-ExitPlanMode perm receiving plan-feedback object falls through to normal deny", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const { resolvePermissionEntry, pendingPermissions } = perm;
+
+    const res = createMockResponse();
+    const permEntry = makePlanPermEntry(res, { toolName: "Bash" });
+    pendingPermissions.push(permEntry);
+
+    // For a non-ExitPlanMode entry, resolvePermissionEntry with "deny" still
+    // produces the standard deny response
+    resolvePermissionEntry(permEntry, "deny", "some message");
+
+    assert.strictEqual(res.captured.ended, true);
+    const parsed = JSON.parse(res.captured.body);
+    assert.strictEqual(parsed.hookSpecificOutput.decision.behavior, "deny");
+  });
+});

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -250,3 +250,112 @@ describe("server-route-state POST", () => {
     assert.strictEqual(res.body, "bad json");
   });
 });
+
+describe("server-route-state ExitPlanMode stale sweep", () => {
+  it("clears stale ExitPlanMode on UserPromptSubmit for same session", async () => {
+    const stalePerm = { res: {}, sessionId: "sid", toolName: "ExitPlanMode" };
+    const res = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "UserPromptSubmit",
+    }), {
+      ctx: { pendingPermissions: [stalePerm] },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.calls.resolved.length, 1);
+    assert.strictEqual(res.calls.resolved[0].perm, stalePerm);
+    assert.strictEqual(res.calls.resolved[0].behavior, "deny");
+    assert.strictEqual(res.calls.resolved[0].message, "Plan dialog dismissed in terminal");
+  });
+
+  it("does NOT clear ExitPlanMode for a different session", async () => {
+    const stalePerm = { res: {}, sessionId: "other-sid", toolName: "ExitPlanMode" };
+    const res = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "UserPromptSubmit",
+    }), {
+      ctx: { pendingPermissions: [stalePerm] },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.calls.resolved.length, 0);
+  });
+
+  it("does NOT trigger sweep on PreToolUse(ExitPlanMode)", async () => {
+    const stalePerm = { res: {}, sessionId: "sid", toolName: "ExitPlanMode" };
+    const res = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "PreToolUse",
+      tool_name: "ExitPlanMode",
+    }), {
+      ctx: { pendingPermissions: [stalePerm] },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.calls.resolved.length, 0);
+  });
+
+  it("triggers sweep on PreToolUse with a different tool", async () => {
+    const stalePerm = { res: {}, sessionId: "sid", toolName: "ExitPlanMode" };
+    const res = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "PreToolUse",
+      tool_name: "Bash",
+    }), {
+      ctx: { pendingPermissions: [stalePerm] },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.calls.resolved.length, 1);
+    assert.strictEqual(res.calls.resolved[0].perm, stalePerm);
+  });
+
+  it("does NOT clear non-ExitPlanMode pending permissions", async () => {
+    const otherPerm = { res: {}, sessionId: "sid", toolName: "Bash" };
+    const res = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "UserPromptSubmit",
+    }), {
+      ctx: { pendingPermissions: [otherPerm] },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.calls.resolved.length, 0);
+  });
+
+  it("skips entries with no res (already cleaned up)", async () => {
+    const stalePerm = { res: null, sessionId: "sid", toolName: "ExitPlanMode" };
+    const res = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "Stop",
+    }), {
+      ctx: { pendingPermissions: [stalePerm] },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.calls.resolved.length, 0);
+  });
+
+  it("clears stale ExitPlanMode on PostToolUse(ExitPlanMode) as fallback", async () => {
+    const stalePerm = { res: {}, sessionId: "sid", toolName: "ExitPlanMode" };
+    const res = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "sid",
+      event: "PostToolUse",
+      tool_name: "ExitPlanMode",
+    }), {
+      ctx: { pendingPermissions: [stalePerm] },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.calls.resolved.length, 1);
+    assert.strictEqual(res.calls.resolved[0].perm, stalePerm);
+    assert.strictEqual(res.calls.resolved[0].message, "User answered in terminal");
+  });
+});


### PR DESCRIPTION
### 问题

CC 在 plan 模式下触发 `ExitPlanMode` 时弹出计划审批气泡。如果用户在 CC 终端里选了 "Tell Claude what to change" 或 "Yes, and bypass permission"，CC 不会中断 PermissionRequest HTTP 连接，导致气泡一直挂在屏幕上直到 600s hook 超时。

### 测试环境

- **Clawd 运行在 Windows 端**（npm start / NSIS 安装包）
- **Claude Code 运行在 WSL 内**，通过 hook HTTP 连接到 Windows 端的 `127.0.0.1:23333`
- 该场景下 CC 的 hook 行为与原生 Linux/macOS 一致，问题可稳定复现

### 解决方案

**Bug 修复：** 在 `server-route-state.js` 新增 session 事件驱动的 stale sweep：
- 将 ExitPlanMode 合并进现有的 Elicitation blocking-tool sweep（PostToolUse/Stop 事件内）
- 新增外部 sweep 覆盖 UserPromptSubmit / PreToolUse(非 ExitPlanMode) / SessionEnd

**新功能：** Plan Review 气泡内新增「提修改意见」按钮 → 展开 textarea → 提交后以 `{ behavior: "deny", message: <反馈内容> }` 协议传递给 CC，Claude 会将其作为修改指导。

### 改动文件

| 文件 | 内容 |
|------|------|
| `src/server-route-state.js` | ExitPlanMode stale sweep（合并进 Elicitation sweep + 外部前向事件 sweep） |
| `src/bubble.html` | 静态 `#planFeedbackForm` 容器 |
| `src/bubble.css` | 反馈表单样式 |
| `src/bubble-renderer.js` | 「提修改意见」按钮 + 反馈模式状态机 + i18n（5 语言） |
| `src/permission.js` | ExitPlanMode `focusable: true` + `plan-feedback` handleDecide 分支 |
| `test/server-route-state.test.js` | +7 个 stale sweep 测试 |
| `test/permission-plan-feedback.test.js` | +4 个 wire 协议测试 |

### 测试

- 全部 11 个新增测试通过
- 手动验证（Windows Clawd + WSL CC）：
  - 气泡显示 Approve / 提修改意见 / 前往终端 三个按钮
  - textarea 提交后气泡消失，Claude 收到反馈继续修改 plan
  - 在 WSL 终端选 "Yes" / "Tell Claude what to change" 后 stale 气泡自动清理

### 备注

- 仅 Claude Code / CodeBuddy 触发 `ExitPlanMode`，其他 agent 不受影响
- 无新增 IPC 通道或 preload API
- `focusable: true` 在构造时设置但不主动 `bub.focus()`，不会从 CC 终端抢焦
- **已知限制**：通过气泡「提修改意见」提交反馈时，CC 终端会显示一行 "Denied by PermissionRequest hook"。这是 CC 对 hook 返回 `deny` 的默认展示方式，非实际错误——Claude 能正确收到 `decision.message` 中的反馈并据此修改 plan。在 CC 终端里直接选 "Tell Claude what to change" 则不会显示此文本（因为走的是终端本地路径而非 hook 响应）。ExitPlanMode 的 hook 协议目前只有 `allow`/`deny` 两种语义，无 "revise" 选项，故此为协议层限制。