### PR TITLE
[codex] Fix mini post-completion notification alert

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -66,6 +66,7 @@ const sessions = new Map();
 const MAX_SESSIONS = 20;
 const ASSISTANT_OUTPUT_MAX = 2400;
 const CODEX_EXIT_PROBE_DELAYS_MS = [1000, 3000, 8000, 15000];
+const POST_COMPLETION_EVENTS = new Set(["Stop", "PostCompact", "event_msg:task_complete"]);
 let lastSessionSnapshotSignature = null;
 let lastSessionSnapshot = null;
 let startupRecoveryActive = false;
@@ -167,6 +168,22 @@ function parseSuspectDelay() {
 function hasPermissionAnimationLock() {
   // Kimi-only lock: do not alter Claude/Codex/opencode permission behavior.
   return kimiPermissionHolds.size > 0;
+}
+
+function resolveAwaitingInputSinceStop(existing, event) {
+  if (POST_COMPLETION_EVENTS.has(event)) return true;
+  if (event === "Notification") return !!(existing && existing.awaitingInputSinceStop === true);
+  if (!event || event === "stale-cleanup") return !!(existing && existing.awaitingInputSinceStop === true);
+  return false;
+}
+
+function shouldMuteMiniPostCompletionNotification(state, event, session) {
+  return !!ctx.miniMode
+    && state === "notification"
+    && event === "Notification"
+    && session
+    && session.awaitingInputSinceStop === true
+    && !hasPermissionAnimationLock();
 }
 
 // ── Qwen Code self-submit filter ──
@@ -1057,7 +1074,7 @@ function updateSession(sessionId, state, event, opts = {}) {
   const srcLastStopAt = isStopBoundary
     ? Date.now()
     : (existing && Number.isFinite(existing.lastStopAt) ? existing.lastStopAt : null);
-  const base = { sourcePid: srcPid, wtHwnd: srcWtHwnd, cwd: srcCwd, editor: srcEditor, pidChain: srcPidChain, agentPid: srcAgentPid, agentId: srcAgentId, host: srcHost, headless: srcHeadless, platform: srcPlatform, model: srcModel, provider: srcProvider, codexOriginator: srcCodexOriginator, codexSource: srcCodexSource, sessionTitle: srcSessionTitle, assistantLastOutput: srcAssistantLastOutput, assistantLastOutputTruncated: srcAssistantLastOutputTruncated, recentEvents, pidReachable, lastToolBoundaryAt: srcLastToolBoundaryAt, lastStopAt: srcLastStopAt, muteNotificationSound: state === "notification" && muteNotificationSound === true };
+  const base = { sourcePid: srcPid, wtHwnd: srcWtHwnd, cwd: srcCwd, editor: srcEditor, pidChain: srcPidChain, agentPid: srcAgentPid, agentId: srcAgentId, host: srcHost, headless: srcHeadless, platform: srcPlatform, model: srcModel, provider: srcProvider, codexOriginator: srcCodexOriginator, codexSource: srcCodexSource, sessionTitle: srcSessionTitle, assistantLastOutput: srcAssistantLastOutput, assistantLastOutputTruncated: srcAssistantLastOutputTruncated, recentEvents, pidReachable, lastToolBoundaryAt: srcLastToolBoundaryAt, lastStopAt: srcLastStopAt, awaitingInputSinceStop: resolveAwaitingInputSinceStop(existing, event), muteNotificationSound: state === "notification" && muteNotificationSound === true };
   if (preserveCompletionAck) base.requiresCompletionAck = true;
 
   // Evict oldest session if at capacity and this is a new session.
@@ -1199,6 +1216,18 @@ function updateSession(sessionId, state, event, opts = {}) {
     // keep the pet on notification and block all other one-shot visuals.
     // (One-shot branch normally bypasses resolveDisplayState()).
     if (hasPermissionAnimationLock() && state !== "notification") {
+      return;
+    }
+    // Mini mode already celebrated completion with mini-happy. Keep the idle
+    // wait-for-input event in session history, but do not make the tucked-away
+    // pet pop a second strong alert for the same completed turn.
+    if (
+      event === "Notification"
+      && state === "notification"
+      && shouldMuteMiniPostCompletionNotification(state, event, sessions.get(sessionId))
+    ) {
+      const displayState = resolveDisplayState();
+      setState(displayState, getSvgOverride(displayState));
       return;
     }
     // Per-agent Notification-hook mute: presentation-layer only. By this

--- a/test/state-notification-hook-gate.test.js
+++ b/test/state-notification-hook-gate.test.js
@@ -89,6 +89,92 @@ describe("updateSession: Notification hook gate", () => {
     assert.deepStrictEqual(ctx._soundsPlayed, ["confirm"], "confirm sound must play");
   });
 
+  it("mutes mini alert for post-completion idle Notification while keeping bookkeeping", () => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx({ notificationHookEnabled: true });
+    ctx.miniMode = true;
+    api = require("../src/state")(ctx);
+
+    api.updateSession("cc-1", "attention", "Stop", { agentId: "claude-code" });
+    assert.strictEqual(api.getCurrentState(), "mini-happy", "completion should still show mini-happy");
+
+    mock.timers.tick(defaultTheme.timings.autoReturn["mini-happy"] + 1);
+    assert.strictEqual(api.getCurrentState(), "mini-idle", "mini-happy should settle before the idle ping");
+    ctx._rendererEvents.length = 0;
+    ctx._soundsPlayed.length = 0;
+
+    api.updateSession("cc-1", "notification", "Notification", { agentId: "claude-code" });
+
+    const stateChanges = ctx._rendererEvents.filter(([ch]) => ch === "state-change");
+    assert.ok(stateChanges.every(([, s]) => s !== "mini-alert"), "post-completion idle ping must not show mini-alert");
+    assert.deepStrictEqual(ctx._soundsPlayed, [], "post-completion idle ping must not play confirm");
+    assert.deepStrictEqual(
+      api.sessions.get("cc-1").recentEvents.map((entry) => entry.event),
+      ["Stop", "Notification"],
+      "Notification event should still be recorded"
+    );
+  });
+
+  it("keeps standalone mini Notification alerts enabled", () => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx({ notificationHookEnabled: true });
+    ctx.miniMode = true;
+    api = require("../src/state")(ctx);
+
+    api.updateSession("cc-1", "notification", "Notification", { agentId: "claude-code" });
+
+    const stateChanges = ctx._rendererEvents.filter(([ch]) => ch === "state-change");
+    assert.ok(stateChanges.length >= 1, "standalone mini notification should still broadcast");
+    assert.strictEqual(stateChanges[0][1], "mini-alert");
+    assert.deepStrictEqual(ctx._soundsPlayed, ["confirm"], "standalone mini notification should still chime");
+  });
+
+  it("restores mini Notification alerts after user activity follows completion", () => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx({ notificationHookEnabled: true });
+    ctx.miniMode = true;
+    api = require("../src/state")(ctx);
+
+    api.updateSession("cc-1", "attention", "Stop", { agentId: "claude-code" });
+    mock.timers.tick(defaultTheme.timings.autoReturn["mini-happy"] + 1);
+    ctx._rendererEvents.length = 0;
+    ctx._soundsPlayed.length = 0;
+
+    api.updateSession("cc-1", "thinking", "UserPromptSubmit", { agentId: "claude-code" });
+    assert.strictEqual(
+      api.sessions.get("cc-1").awaitingInputSinceStop,
+      false,
+      "new user activity should clear the post-completion idle tail"
+    );
+    ctx._rendererEvents.length = 0;
+    ctx._soundsPlayed.length = 0;
+
+    api.updateSession("cc-1", "notification", "Notification", { agentId: "claude-code" });
+
+    const stateChanges = ctx._rendererEvents.filter(([ch]) => ch === "state-change");
+    assert.ok(stateChanges.length >= 1, "notification after user activity should broadcast");
+    assert.strictEqual(stateChanges[0][1], "mini-alert");
+    assert.deepStrictEqual(ctx._soundsPlayed, ["confirm"], "notification after user activity should chime");
+  });
+
+  it("keeps post-completion Notification alerts enabled outside mini mode", () => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx({ notificationHookEnabled: true });
+    api = require("../src/state")(ctx);
+
+    api.updateSession("cc-1", "attention", "Stop", { agentId: "claude-code" });
+    mock.timers.tick(defaultTheme.timings.autoReturn.attention + 1);
+    ctx._rendererEvents.length = 0;
+    ctx._soundsPlayed.length = 0;
+
+    api.updateSession("cc-1", "notification", "Notification", { agentId: "claude-code" });
+
+    const stateChanges = ctx._rendererEvents.filter(([ch]) => ch === "state-change");
+    assert.ok(stateChanges.length >= 1, "normal-mode wait-for-input alert should still broadcast");
+    assert.strictEqual(stateChanges[0][1], "notification");
+    assert.deepStrictEqual(ctx._soundsPlayed, ["confirm"], "normal-mode wait-for-input alert should still chime");
+  });
+
   it("mutes Gemini Notification bell + animation when the per-agent flag is off", () => {
     mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
     ctx = makeCtx({ notificationHookEnabled: false });


### PR DESCRIPTION
## Summary
- Track each session's post-completion idle tail after `Stop` / completion events.
- Suppress the extra mini-mode post-completion `Notification` visual and sound after `mini-happy`, while keeping the event in session bookkeeping.
- Cover the suppression, standalone mini notifications, normal-mode wait-for-input alerts, and user re-entry reset with tests.

## Root Cause
Claude Code can emit an idle / wait-for-input `Notification` after a completed turn. In mini mode, `notification` remaps to `mini-alert`, so the pet could show a second exclamation after the completion animation.

## Validation
- `node --test test\state-notification-hook-gate.test.js`
- `node --test test\state.test.js`
- `npm test` (3425 pass, 5 skipped, 0 fail)
- Human smoke: mini-mode completed-task flow no longer produced the extra mini-alert / confirm sound after the idle ping on Lulu's machine.