### PR TITLE
[codex] Guard macOS dock icon override

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3012,7 +3012,7 @@ if (!gotTheLock) {
     // macOS: override the dock icon with a version that fills the canvas
     // (the build-time icon.png has transparent margins that make the icon
     // appear smaller than other apps in the dock).
-    if (isMac && app.dock) {
+    if (isMac && app.dock && _settingsController.get("showDock") !== false) {
       try {
         app.dock.setIcon(path.join(__dirname, "..", "assets", "dock-icon.png"));
       } catch (_) {

--- a/test/main-mac-dock-icon.test.js
+++ b/test/main-mac-dock-icon.test.js
@@ -1,0 +1,32 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = path.join(__dirname, "..");
+const MAIN = path.join(ROOT, "src", "main.js");
+const DOCK_ICON = path.join(ROOT, "assets", "dock-icon.png");
+const pkg = require("../package.json");
+
+test("macOS runtime dock icon asset is packaged", () => {
+  assert.ok(fs.existsSync(DOCK_ICON), "assets/dock-icon.png should exist");
+  assert.ok(
+    pkg.build.files.includes("assets/dock-icon.png"),
+    "build.files should include assets/dock-icon.png"
+  );
+});
+
+test("macOS runtime dock icon override respects hidden Dock preference", () => {
+  const source = fs.readFileSync(MAIN, "utf8");
+  const setIcon = 'app.dock.setIcon(path.join(__dirname, "..", "assets", "dock-icon.png"))';
+  const guard = 'if (isMac && app.dock && _settingsController.get("showDock") !== false)';
+  const setIconIndex = source.indexOf(setIcon);
+  const guardIndex = source.lastIndexOf(guard, setIconIndex);
+
+  assert.ok(setIconIndex >= 0, "main.js should set the runtime macOS dock icon");
+  assert.ok(guardIndex >= 0, "dock icon override should be guarded by showDock !== false");
+  assert.ok(
+    setIconIndex - guardIndex < 250,
+    "showDock guard should wrap the dock icon override"
+  );
+});


### PR DESCRIPTION
## Summary
- Skip the runtime macOS Dock icon override when the user has hidden the Dock icon via `showDock=false`.
- Add a small static regression test that the dock icon asset is packaged and the runtime override stays behind the hidden-Dock guard.

## Why
PR #396 safely fixed the small Dock icon, but its runtime `app.dock.setIcon()` call did not need to run for users who already hide Clawd from the Dock. This keeps that preference path quiet without changing the visible-Dock behavior.

## Validation
- `node --test test/main-mac-dock-icon.test.js`
- `npm test`
- `git diff --cached --check`