### PR TITLE
perf(mobile): event-driven push, smooth expand animation, live timers

### DIFF
--- a/pwa/app.js
+++ b/pwa/app.js
@@ -217,7 +217,7 @@
   // === SessionRenderer ===
 
   class SessionRenderer {
-    constructor(container) { this.container = container; this.sessions = new Map(); this.staleTimer = null; this.expandedSet = new Set(); }
+    constructor(container) { this.container = container; this.sessions = new Map(); this.staleTimer = null; this.expandedSet = new Set(); this._startTimerUpdater(); }
 
     updateFromSnapshot(sessions) {
       this.sessions.clear();
@@ -234,7 +234,12 @@
     }
 
     removeSession(sessionId) { this.sessions.delete(sessionId); this.expandedSet.delete(sessionId); this.render(); }
-    toggleExpand(sid) { if (this.expandedSet.has(sid)) this.expandedSet.delete(sid); else this.expandedSet.add(sid); this.render(); }
+    toggleExpand(sid) {
+      var wasExpanded = this.expandedSet.has(sid);
+      if (wasExpanded) this.expandedSet.delete(sid); else this.expandedSet.add(sid);
+      this._animatingSid = sid;
+      this.render();
+    }
 
     render() {
       var self = this;
@@ -259,6 +264,20 @@
       this.container.querySelectorAll(".card-footer").forEach(function(el) {
         el.addEventListener("click", function() { self.toggleExpand(this.getAttribute("data-sid")); });
       });
+      if (this._animatingSid) {
+        var animatingSid = this._animatingSid;
+        this._animatingSid = null;
+        if (this.expandedSet.has(animatingSid)) {
+          var cards = this.container.querySelectorAll('.session-card');
+          cards.forEach(function(card) {
+            var footer = card.querySelector('.card-footer');
+            if (footer && footer.getAttribute('data-sid') === animatingSid) {
+              var eh = card.querySelector('.event-history');
+              if (eh) requestAnimationFrame(function() { eh.classList.add('show'); });
+            }
+          });
+        }
+      }
     }
 
     _renderCard(sid, s) {
@@ -278,21 +297,34 @@
       html += '<div class="card-footer" data-sid="' + sid + '"><div class="footer-events">' + icon("activity") + '<span>最近事件</span>';
       if (events.length) html += '<span class="event-count">' + events.length + '</span>';
       html += '</div><span class="footer-chevron">' + (isExpanded ? icon("collapse") : icon("expand")) + '</span></div>';
-      if (isExpanded && events.length) html += this._renderEvents(events);
+      if (events.length) html += this._renderEvents(events, isExpanded, this._animatingSid === sid);
       html += '</div>';
       return html;
     }
 
-    _renderEvents(events) {
-      var html = '<div class="event-history">';
+    _renderEvents(events, expanded, animate) {
+      var showClass = (expanded && !animate) ? ' show' : '';
+      var html = '<div class="event-history' + showClass + '"><div class="event-timeline">';
       for (var i = 0; i < events.length; i++) {
         var ev = events[i]; var c = STATE_CONFIG[ev.state] || STATE_CONFIG.idle;
         html += '<div class="event-row"><div class="event-dot" style="background:' + c.color + '"></div>';
         html += '<div class="event-line" style="background:' + c.color + '"></div>';
         html += '<span class="event-label">' + esc(eventLabel(ev.event)) + '</span>';
-        html += '<span class="event-time">' + formatAgo(ev.at) + '</span></div>';
+        html += '<span class="event-time"' + (ev.at ? ' data-ts="' + ev.at + '"' : '') + '>' + formatAgo(ev.at) + '</span></div>';
       }
-      return html + '</div>';
+      return html + '</div></div>';
+    }
+
+    _startTimerUpdater() {
+      var self = this;
+      setInterval(function() {
+        if (document.visibilityState !== 'visible') return;
+        var els = self.container.querySelectorAll('.event-time[data-ts]');
+        for (var i = 0; i < els.length; i++) {
+          var ts = parseInt(els[i].getAttribute('data-ts'), 10);
+          if (!isNaN(ts)) els[i].textContent = formatAgo(ts);
+        }
+      }, 1000);
     }
 
     startStaleCleanup() {

--- a/pwa/style.css
+++ b/pwa/style.css
@@ -117,8 +117,10 @@ body { display: flex; flex-direction: column; height: 100%; }
 .footer-chevron svg { width: 14px; height: 14px; color: var(--faint); }
 
 /* === Event History === */
-.event-history { margin-top: 8px; padding-left: 4px; animation: slideDown 0.2s ease-out; }
-@keyframes slideDown { from { opacity: 0; max-height: 0; } to { opacity: 1; max-height: 500px; } }
+.event-history { display: grid; grid-template-rows: 0fr; transition: grid-template-rows 0.28s cubic-bezier(0.2, 0.9, 0.4, 1.1); }
+.event-history.show { grid-template-rows: 1fr; }
+.event-history > .event-timeline { overflow: hidden; min-height: 0; }
+.event-timeline { padding-left: 4px; }
 .event-row { display: flex; align-items: center; gap: 10px; padding: 5px 0; position: relative; }
 .event-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; position: relative; z-index: 1; }
 .event-line { position: absolute; left: 3.5px; top: 13px; bottom: -5px; width: 1px; opacity: 0.3; }

--- a/src/main.js
+++ b/src/main.js
@@ -1149,6 +1149,7 @@ const _stateCtx = {
     if (telegramCompanion) {
       try { telegramCompanion.onSnapshot(snapshot); } catch {}
     }
+    if (_lanWss) { try { _lanWss.onSnapshot(); } catch {} }
   },
   // Phase 3b: 读 prefs.themeOverrides 判断某个 oneshot state 是否被用户禁用。
   // state.js gate 调这个做 early-return。不做白名单校验——settings-actions

--- a/src/network/mobile-preview-server.js
+++ b/src/network/mobile-preview-server.js
@@ -19,7 +19,6 @@ const CLIENT_TIMEOUT_MS = 90000;
 const RATE_WINDOW_MS = 60000;
 const RATE_MAX = 60;
 const MAX_CLIENTS = 10;
-const SESSION_POLL_MS = 2000;
 
 const PWA_DIR = path.resolve(__dirname, "../../pwa");
 const TOKEN_PATH = path.join(os.homedir(), ".clawd", "mobile-token.json");
@@ -63,7 +62,6 @@ function initMobilePreviewServer(ctx) {
   let httpServer = null;
   let wss = null;
   let activePort = null;
-  let pollTimer = null;
   let heartbeatTimer = null;
   let closed = false;
 
@@ -295,14 +293,13 @@ function initMobilePreviewServer(ctx) {
     });
 
     httpServer.listen(ports[0], "0.0.0.0");
-    pollTimer = setInterval(pollSessions, SESSION_POLL_MS);
+    pollSessions(); // Prime cache from current state
     return ready;
   }
 
   function cleanup() {
     closed = true;
     sessionCache.clear();
-    if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
     stopHeartbeat();
     for (const c of clients) { try { c.close(1001, "Server shutting down"); } catch {} }
     clients.clear();
@@ -311,9 +308,15 @@ function initMobilePreviewServer(ctx) {
     if (httpServer) { try { httpServer.close(); } catch {} }
   }
 
+  function onSnapshot() {
+    if (closed) return;
+    pollSessions();
+  }
+
   return {
     start,
     cleanup,
+    onSnapshot,
     getPort: () => activePort,
     getToken: () => token,
     PROTOCOL_VERSION,

--- a/test/mobile-preview-server.test.js
+++ b/test/mobile-preview-server.test.js
@@ -150,8 +150,7 @@ describe("Mobile Preview Server", () => {
 
   it("connects with valid token and receives snapshot", async () => {
     createSession("s1", "working", "claude-code");
-    // Wait for poll cycle to pick up the session
-    await new Promise((r) => setTimeout(r, 2500));
+    server.onSnapshot(); // Prime cache before connecting
 
     const client = connectClient(port, token);
     await waitForOpen(client.ws);
@@ -176,6 +175,7 @@ describe("Mobile Preview Server", () => {
     // Change session state
     sessions.get("s1").state = "thinking";
     sessions.get("s1").updatedAt = Date.now();
+    server.onSnapshot();
 
     const stateMsg = await client.waitFor("state");
     assert.strictEqual(stateMsg.version, "v1");
@@ -192,6 +192,7 @@ describe("Mobile Preview Server", () => {
     await client.waitFor("snapshot");
 
     sessions.delete("s1");
+    server.onSnapshot();
 
     const delMsg = await client.waitFor("session_deleted");
     assert.strictEqual(delMsg.version, "v1");


### PR DESCRIPTION
Part of #411

## Overview

Three experience optimizations to the M1 LAN preview — pure frontend + lightweight backend changes, no protocol or security boundary changes.

## Changes

### 1. Event-driven push (replaces 2s polling)

- Removed `setInterval(pollSessions, 2000)` polling loop
- Wired into the existing `broadcastSessionSnapshot` callback chain — session changes now trigger `onSnapshot()` in real time
- Latency drops from ≤2s to milliseconds; eliminates the per-2s `JSON.stringify` full-comparison overhead

### 2. Smooth expand/collapse animation

- Replaced `@keyframes slideDown` with CSS `grid-template-rows: 0fr → 1fr` transition
- Event list is always rendered (visibility controlled by CSS), enabling bidirectional smooth animation
- Uses `requestAnimationFrame` to defer `.show` class on expand so the transition actually plays

### 3. Live relative timestamps

- Event timestamps get a `data-ts` attribute
- `setInterval` updates all visible `.event-time` elements every second ("3s ago" → "4s ago")
- Skips updates when page is hidden (`visibilityState` check)

## Files changed

| File | Change |
|------|--------|
| `src/network/mobile-preview-server.js` | Remove polling, add `onSnapshot()` |
| `src/main.js` | Wire `onSnapshot` into broadcast chain (+1 line) |
| `pwa/style.css` | Grid animation + `.event-timeline` wrapper |
| `pwa/app.js` | Event render refactor + timer + expand animation |
| `test/mobile-preview-server.test.js` | `setTimeout(2500)` → `server.onSnapshot()` |

## Testing

- All 8 mobile-preview-server tests pass
- Related settings-ipc and prefs tests pass
- Module load and syntax check pass

## Not in scope

- No protocol or DTO changes
- No security boundary changes
- No new dependencies
- No settings tab or IPC changes
