### PR TITLE
fix(opencode-plugin): single default export so opencode loads the plugin

### DIFF
--- a/hooks/opencode-plugin/index.mjs
+++ b/hooks/opencode-plugin/index.mjs
@@ -704,6 +704,7 @@ const plugin = async (ctx) => {
 // separate named export — see the note on __testInternals and issue #413.
 // Object.values(mod) must contain only functions, or opencode's legacy plugin
 // loader throws "Plugin export is not a function" and the plugin never registers.
-plugin.__test = __testInternals;
+// Non-enumerable: it's a private test backdoor, never part of the plugin surface.
+Object.defineProperty(plugin, "__test", { value: __testInternals });
 
 export default plugin;

--- a/hooks/opencode-plugin/index.mjs
+++ b/hooks/opencode-plugin/index.mjs
@@ -453,7 +453,12 @@ function translateEvent(event) {
   }
 }
 
-export const __test = {
+// Test-only internals. Attached to the default export at the bottom of this
+// file — NOT a named export. opencode's plugin loader runs getLegacyPlugins()
+// over Object.values(mod) and throws "Plugin export is not a function" on ANY
+// non-function module export, which silently kills the whole plugin. The module
+// must therefore expose exactly one export: the default function. See #413.
+const __testInternals = {
   buildStateBody,
   translateEvent,
   get _sessionParentById() { return _sessionParentById; },
@@ -603,7 +608,7 @@ function startBridge() {
 }
 
 // Plugin entrypoint (opencode loads this via default export).
-export default async (ctx) => {
+const plugin = async (ctx) => {
   resetDebugLog();
   _serverUrl = normalizeServerUrl(ctx && ctx.serverUrl);
   _ctxClient = ctx && ctx.client ? ctx.client : null;
@@ -694,3 +699,11 @@ export default async (ctx) => {
     },
   };
 };
+
+// Expose test internals on the default-exported function rather than as a
+// separate named export — see the note on __testInternals and issue #413.
+// Object.values(mod) must contain only functions, or opencode's legacy plugin
+// loader throws "Plugin export is not a function" and the plugin never registers.
+plugin.__test = __testInternals;
+
+export default plugin;

--- a/src/doctor-detectors/agent-integrations.js
+++ b/src/doctor-detectors/agent-integrations.js
@@ -1243,6 +1243,25 @@ function findOpenClawPluginEntry(pluginPaths, marker) {
   return null;
 }
 
+function describeOpencodeEntryIssue(reason) {
+  switch (reason) {
+    case "not-absolute":
+      return "the plugin path is not absolute";
+    case "directory-missing":
+      return "the plugin directory does not exist";
+    case "not-a-directory":
+      return "the plugin entry is not a directory";
+    case "index-mjs-missing":
+      return "the plugin directory has no index.mjs";
+    case "index-mjs-unreadable":
+      return "the plugin index.mjs could not be read";
+    case "extra-module-exports":
+      return "the module exports more than the default function, so opencode rejects it and loads nothing (#413)";
+    default:
+      return reason;
+  }
+}
+
 function checkOpencodeSettings(descriptor, settings, options) {
   const entry = findOpencodePluginEntry(settings && settings.plugin, descriptor.marker);
   if (!entry) {
@@ -1262,7 +1281,7 @@ function checkOpencodeSettings(descriptor, settings, options) {
       parentDirExists: true,
       configFileExists: true,
       configPath: descriptor.configPath,
-      detail: `opencode plugin entry is invalid: ${validation.reason}`,
+      detail: `opencode plugin entry is invalid: ${describeOpencodeEntryIssue(validation.reason)}`,
       opencodeEntryIssue: validation.reason,
       opencodeEntry: entry,
     });

--- a/src/doctor-detectors/opencode-entry-validator.js
+++ b/src/doctor-detectors/opencode-entry-validator.js
@@ -24,10 +24,42 @@ function validateOpencodeEntry(entry, options = {}) {
   if (!stat || typeof stat.isDirectory !== "function" || !stat.isDirectory()) {
     return { ok: false, reason: "not-a-directory" };
   }
-  if (!fsImpl.existsSync(path.join(entry, "index.mjs"))) {
+  const indexPath = path.join(entry, "index.mjs");
+  if (!fsImpl.existsSync(indexPath)) {
     return { ok: false, reason: "index-mjs-missing" };
   }
+
+  // #413: opencode's plugin loader (getLegacyPlugins) iterates Object.values(mod)
+  // and throws "Plugin export is not a function" on any export beyond the default
+  // function, then swallows the error -- silently dropping the whole plugin. The
+  // path/file checks above can't see that, so they reported a false "ok". Guard
+  // the single-default-export invariant by scanning the module source. Skipped
+  // when the fs impl has no readFileSync (keeps older static-only callers working).
+  if (typeof fsImpl.readFileSync === "function") {
+    let source;
+    try {
+      source = fsImpl.readFileSync(indexPath, "utf8");
+    } catch {
+      return { ok: false, reason: "index-mjs-unreadable" };
+    }
+    if (hasNamedExport(source)) {
+      return { ok: false, reason: "extra-module-exports" };
+    }
+  }
+
   return { ok: true };
+}
+
+// opencode requires the plugin module to expose exactly ONE export: the default
+// function. Any named export breaks loading -- a non-function export throws
+// outright, and even a named function would be invoked as a second plugin. Match
+// a line-leading `export` that isn't `export default`, after stripping block
+// comments so commented-out examples don't trip it. (Line comments start with
+// `//`, so a leading `export` keyword can never sit inside one.)
+function hasNamedExport(source) {
+  if (typeof source !== "string" || !source) return false;
+  const stripped = source.replace(/\/\*[\s\S]*?\*\//g, "");
+  return /^[ \t]*export\s+(?!default\b)(?:const|let|var|function|class|async|\{|\*)/m.test(stripped);
 }
 
 module.exports = { validateOpencodeEntry };

--- a/src/doctor-detectors/opencode-entry-validator.js
+++ b/src/doctor-detectors/opencode-entry-validator.js
@@ -56,6 +56,11 @@ function validateOpencodeEntry(entry, options = {}) {
 // a line-leading `export` that isn't `export default`, after stripping block
 // comments so commented-out examples don't trip it. (Line comments start with
 // `//`, so a leading `export` keyword can never sit inside one.)
+//
+// Known limitation: a backtick template literal whose own line begins with
+// `export` would false-positive. That is safe by direction -- it produces an
+// extra warning, never a missed failure -- and does not occur in the plugin
+// entry. Fully fixing it would require a JS parser, which isn't worth it here.
 function hasNamedExport(source) {
   if (typeof source !== "string" || !source) return false;
   const stripped = source.replace(/\/\*[\s\S]*?\*\//g, "");

--- a/test/doctor-opencode-entry.test.js
+++ b/test/doctor-opencode-entry.test.js
@@ -3,10 +3,10 @@ const assert = require("node:assert");
 const path = require("path");
 const { validateOpencodeEntry } = require("../src/doctor-detectors/opencode-entry-validator");
 
-function fakeFs({ dirs = [], files = [] } = {}) {
+function fakeFs({ dirs = [], files = [], contents = null } = {}) {
   const dirSet = new Set(dirs);
   const fileSet = new Set(files);
-  return {
+  const impl = {
     statSync: (entry) => {
       if (!dirSet.has(entry) && !fileSet.has(entry)) {
         const err = new Error("missing");
@@ -17,6 +17,18 @@ function fakeFs({ dirs = [], files = [] } = {}) {
     },
     existsSync: (entry) => fileSet.has(entry) || dirSet.has(entry),
   };
+  // Only expose readFileSync when contents are supplied, so the existing
+  // static-only cases keep exercising the path/file checks — validateOpencodeEntry
+  // skips the source scan when readFileSync is absent.
+  if (contents) {
+    impl.readFileSync = (entry) => {
+      if (Object.prototype.hasOwnProperty.call(contents, entry)) return contents[entry];
+      const err = new Error("missing");
+      err.code = "ENOENT";
+      throw err;
+    };
+  }
+  return impl;
 }
 
 describe("validateOpencodeEntry", () => {
@@ -74,5 +86,46 @@ describe("validateOpencodeEntry", () => {
       }),
       { ok: true }
     );
+  });
+
+  it("rejects a module with an extra named export (#413 false-green guard)", () => {
+    const entry = "/opt/clawd/hooks/opencode-plugin";
+    const indexPath = path.join(entry, "index.mjs");
+    assert.deepStrictEqual(
+      validateOpencodeEntry(entry, {
+        fs: fakeFs({
+          dirs: [entry],
+          files: [indexPath],
+          contents: {
+            [indexPath]:
+              "export const __test = {};\nexport default async () => ({ event: async () => {} });\n",
+          },
+        }),
+      }),
+      { ok: false, reason: "extra-module-exports" }
+    );
+  });
+
+  it("accepts a module that only default-exports a function", () => {
+    const entry = "/opt/clawd/hooks/opencode-plugin";
+    const indexPath = path.join(entry, "index.mjs");
+    assert.deepStrictEqual(
+      validateOpencodeEntry(entry, {
+        fs: fakeFs({
+          dirs: [entry],
+          files: [indexPath],
+          contents: {
+            [indexPath]:
+              'const plugin = async () => ({ event: async () => {} });\nObject.defineProperty(plugin, "__test", { value: {} });\nexport default plugin;\n',
+          },
+        }),
+      }),
+      { ok: true }
+    );
+  });
+
+  it("accepts the real opencode plugin module (single default export)", () => {
+    const entry = path.join(__dirname, "..", "hooks", "opencode-plugin");
+    assert.deepStrictEqual(validateOpencodeEntry(entry), { ok: true });
   });
 });

--- a/test/opencode-plugin-session.test.js
+++ b/test/opencode-plugin-session.test.js
@@ -84,6 +84,20 @@ describe("opencode plugin session ids", () => {
   });
 });
 
+describe("opencode plugin module shape (#413 regression guard)", () => {
+  it("exposes exactly one export: the default plugin function", async () => {
+    const mod = await loadPluginModule();
+    // opencode's getLegacyPlugins() iterates Object.values(mod) and throws
+    // "Plugin export is not a function" on any non-function export. Any extra
+    // named export (a test helper, a constant, anything) silently kills the
+    // whole plugin — that was #413. Test internals must ride on the default
+    // function (mod.default.__test), never as a separate module export.
+    assert.deepStrictEqual(Object.keys(mod), ["default"]);
+    assert.strictEqual(typeof mod.default, "function");
+    assert.deepStrictEqual(Object.values(mod).map((v) => typeof v), ["function"]);
+  });
+});
+
 describe("opencode plugin headless (parentID-based child detection)", () => {
   let pluginMod;
 

--- a/test/opencode-plugin-session.test.js
+++ b/test/opencode-plugin-session.test.js
@@ -72,10 +72,10 @@ describe("opencode plugin session ids", () => {
     const start = { type: "session.created", properties: { sessionID: "ses_same" } };
     const end = { type: "session.deleted", properties: { sessionID: "ses_same" } };
 
-    const startMapped = mod.__test.translateEvent(start);
-    const endMapped = mod.__test.translateEvent(end);
-    const startBody = mod.__test.buildStateBody(startMapped.state, startMapped.event, "ses_same");
-    const endBody = mod.__test.buildStateBody(endMapped.state, endMapped.event, "ses_same");
+    const startMapped = mod.default.__test.translateEvent(start);
+    const endMapped = mod.default.__test.translateEvent(end);
+    const startBody = mod.default.__test.buildStateBody(startMapped.state, startMapped.event, "ses_same");
+    const endBody = mod.default.__test.buildStateBody(endMapped.state, endMapped.event, "ses_same");
 
     assert.strictEqual(startBody.session_id, "opencode:ses_same");
     assert.strictEqual(endBody.session_id, "opencode:ses_same");
@@ -89,8 +89,8 @@ describe("opencode plugin headless (parentID-based child detection)", () => {
 
   beforeEach(async () => {
     pluginMod = await loadPluginModule();
-    pluginMod.__test._sessionParentById.clear();
-    pluginMod.__test._rootSessionId = null;
+    pluginMod.default.__test._sessionParentById.clear();
+    pluginMod.default.__test._rootSessionId = null;
   });
 
   // Use case 1: getEventParentSessionId extracts parentID from event.properties.info
@@ -172,22 +172,22 @@ describe("opencode plugin headless (parentID-based child detection)", () => {
   // (both raw and prefixed sessionId forms)
   it("buildStateBody adds headless: true for child sessions (raw and prefixed id)", async () => {
     // Simulate what the event handler does: store normalized keys
-    pluginMod.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
+    pluginMod.default.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
 
     // Raw id passed to buildStateBody → isChildSessionId normalizes → match
-    const bodyRaw = pluginMod.__test.buildStateBody("working", "PreToolUse", "ses_child");
+    const bodyRaw = pluginMod.default.__test.buildStateBody("working", "PreToolUse", "ses_child");
     assert.strictEqual(bodyRaw.headless, true);
     assert.strictEqual(bodyRaw.session_id, "opencode:ses_child");
 
     // Prefixed id passed to buildStateBody → isChildSessionId normalizes → match
-    const bodyPrefixed = pluginMod.__test.buildStateBody("working", "PreToolUse", "opencode:ses_child");
+    const bodyPrefixed = pluginMod.default.__test.buildStateBody("working", "PreToolUse", "opencode:ses_child");
     assert.strictEqual(bodyPrefixed.headless, true);
     assert.strictEqual(bodyPrefixed.session_id, "opencode:ses_child");
   });
 
   // Use case 4: buildStateBody does NOT add headless for root sessions
   it("buildStateBody does not add headless for root sessions", async () => {
-    const body = pluginMod.__test.buildStateBody("working", "PreToolUse", "ses_root");
+    const body = pluginMod.default.__test.buildStateBody("working", "PreToolUse", "ses_root");
     assert.strictEqual(body.headless, undefined);
     assert.strictEqual(body.session_id, "opencode:ses_root");
   });
@@ -195,19 +195,19 @@ describe("opencode plugin headless (parentID-based child detection)", () => {
   // Use case 5: standalone session (not in _sessionParentById, not root)
   // must NOT be marked headless — no heuristic fallback
   it("buildStateBody does not add headless for standalone sessions without parentID", async () => {
-    pluginMod.__test._rootSessionId = "opencode:ses_root";
+    pluginMod.default.__test._rootSessionId = "opencode:ses_root";
 
     // ses_other is not in _sessionParentById → NOT headless (no heuristic)
-    const body = pluginMod.__test.buildStateBody("working", "PreToolUse", "ses_other");
+    const body = pluginMod.default.__test.buildStateBody("working", "PreToolUse", "ses_other");
     assert.strictEqual(body.headless, undefined);
     assert.strictEqual(body.session_id, "opencode:ses_other");
   });
 
   // Use case 6: translateEvent maps child session.idle → SessionEnd
   it("translateEvent maps child session.idle to SessionEnd when in _sessionParentById", async () => {
-    pluginMod.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
+    pluginMod.default.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
 
-    const result = pluginMod.__test.translateEvent({
+    const result = pluginMod.default.__test.translateEvent({
       type: "session.idle",
       properties: { sessionID: "ses_child" },
     });
@@ -217,7 +217,7 @@ describe("opencode plugin headless (parentID-based child detection)", () => {
 
   // Use case 7: translateEvent maps root session.idle → Stop (attention)
   it("translateEvent maps root session.idle to Stop (attention)", async () => {
-    const result = pluginMod.__test.translateEvent({
+    const result = pluginMod.default.__test.translateEvent({
       type: "session.idle",
       properties: { sessionID: "ses_root" },
     });
@@ -227,10 +227,10 @@ describe("opencode plugin headless (parentID-based child detection)", () => {
 
   // Use case 8: standalone session.idle (not in map) → Stop, NOT SessionEnd
   it("translateEvent maps standalone session.idle to Stop (no heuristic fallback)", async () => {
-    pluginMod.__test._rootSessionId = "opencode:ses_root";
+    pluginMod.default.__test._rootSessionId = "opencode:ses_root";
 
     // ses_other is not in _sessionParentById → Stop (not SessionEnd)
-    const result = pluginMod.__test.translateEvent({
+    const result = pluginMod.default.__test.translateEvent({
       type: "session.idle",
       properties: { sessionID: "ses_other" },
     });
@@ -312,15 +312,15 @@ describe("opencode plugin headless (parentID-based child detection)", () => {
 
   // Use case 13: full flow — session.created with parentID → headless body + SessionEnd idle
   it("full flow: session.created with parentID produces headless body and SessionEnd idle", async () => {
-    pluginMod.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
+    pluginMod.default.__test._sessionParentById.set("opencode:ses_child", "opencode:ses_root");
 
     // buildStateBody for child → headless
-    const body = pluginMod.__test.buildStateBody("working", "PreToolUse", "ses_child");
+    const body = pluginMod.default.__test.buildStateBody("working", "PreToolUse", "ses_child");
     assert.strictEqual(body.headless, true);
     assert.strictEqual(body.session_id, "opencode:ses_child");
 
     // translateEvent for child session.idle → SessionEnd
-    const idleResult = pluginMod.__test.translateEvent({
+    const idleResult = pluginMod.default.__test.translateEvent({
       type: "session.idle",
       properties: { sessionID: "ses_child" },
     });
@@ -328,7 +328,7 @@ describe("opencode plugin headless (parentID-based child detection)", () => {
     assert.strictEqual(idleResult.event, "SessionEnd");
 
     // translateEvent for root session.idle → Stop
-    const rootIdleResult = pluginMod.__test.translateEvent({
+    const rootIdleResult = pluginMod.default.__test.translateEvent({
       type: "session.idle",
       properties: { sessionID: "ses_root" },
     });


### PR DESCRIPTION
## Summary

The `opencode` CLI stopped loading the Clawd plugin entirely — no hooks, no events, no session capture (#413). The root cause is on our side: the plugin module exposed a second named export, which opencode's plugin loader rejects.

## Root cause

opencode loads a plugin via `applyPlugin` → `readV1Plugin(..., "detect")` (our default export is a function, not a `{ id, server() }` object, so this returns `undefined`) → `getLegacyPlugins`, which iterates **every** export:

```ts
for (const entry of Object.values(mod)) {
  const plugin = getServerPlugin(entry)
  if (!plugin) throw new TypeError("Plugin export is not a function")
}
```

`hooks/opencode-plugin/index.mjs` had both `export default <fn>` **and** `export const __test = {…}`. `Object.values(mod)` hits `__test` (an object with no `server` field) and throws. opencode swallows the error, so the whole plugin is silently dropped.

`__test` was introduced in 672e151 (2026-05-31) to lock unit-test invariants. This is **not an opencode regression**: the legacy-plugin walk is present unchanged from `v1.3.15` through `v1.15.13` (verified against the `v1.3.15`, `v1.14.48`, `v1.15.13` tags). The integration has simply been dead on every opencode since that commit.

## Fix

Attach the test internals to the default-exported function so the module has exactly one export, and it is a function:

```js
const plugin = async (ctx) => { /* ... */ }
Object.defineProperty(plugin, "__test", { value: __testInternals }) // non-enumerable
export default plugin
```

Tests now read `mod.default.__test`. A new regression test asserts the module exposes exactly one (function) export, so re-introducing a named export fails the suite instead of silently killing the plugin (the old tests imported `__test` directly, so they could not catch this).

## Doctor: stop the false green

`validateOpencodeEntry` only did static path / `index.mjs` checks, so the doctor reported `OpenCode … ok` even though the runtime load had failed (the report's connection test said `NO-ACTIVITY` at the same time). It now scans the module source and returns `extra-module-exports` when the plugin has any export beyond the default function, surfaced as a readable detail. The scan is skipped when the fs impl has no `readFileSync`, so the existing static-only callers and tests are unchanged.

## Verification

- Load simulation mirroring opencode's `getLegacyPlugins` / `readV1Plugin`: `Object.keys(mod) === ["default"]`, no throw.
- Full suite green (`node test/run-tests.js`): 3482 tests, 0 fail — includes the new module-shape regression test and doctor tests for `extra-module-exports` (the real plugin module passes).
- Real opencode 1.14.48 + OpenRouter session: fresh `INIT` + 3× `POST status=200` in `~/.clawd/opencode-plugin.log`, pet reacts. (The log had been frozen since 05-29 — right before `__test` landed.)

Fixes #413
