### PR TITLE
fix(state): respect session timeout for remote completion sessions (#414)

### DIFF
--- a/src/dashboard.html
+++ b/src/dashboard.html
@@ -19,7 +19,7 @@
   --accent: #d97757;
   --accent-hover: #c4684a;
   --running: #16803c;
-  --done: #71717a;
+  --done: #2563eb;
   --interrupted: #b45309;
   --idle: #71717a;
   --scroll-thumb: rgba(0, 0, 0, 0.15);
@@ -37,7 +37,7 @@
     --border: rgba(255, 255, 255, 0.08);
     --row-border: rgba(255, 255, 255, 0.06);
     --running: #22c55e;
-    --done: #a1a1aa;
+    --done: #60a5fa;
     --interrupted: #f59e0b;
     --idle: #a1a1aa;
     --scroll-thumb: rgba(255, 255, 255, 0.1);

--- a/src/session-hud.html
+++ b/src/session-hud.html
@@ -14,7 +14,7 @@
   --text-muted: #6b6b70;
   --shadow: rgba(0, 0, 0, 0.16);
   --running: #16a34a;
-  --done: #71717a;
+  --done: #2563eb;
   --interrupted: #d97706;
   --idle: #9ca3af;
 }
@@ -26,6 +26,7 @@
     --text: #f4f4f5;
     --text-muted: #a1a1aa;
     --shadow: rgba(0, 0, 0, 0.34);
+    --done: #60a5fa;
     --idle: #71717a;
   }
 }

--- a/src/state-stale-cleanup.js
+++ b/src/state-stale-cleanup.js
@@ -5,11 +5,6 @@ const WORKING_STALE_MS = 300000;
 const DETACHED_IDLE_STALE_MS = 30000;
 const CODEX_LOCAL_WORKING_STALE_FLOOR_MS = 20 * 60 * 1000;
 
-// Hard ceiling for sessions held back by requiresCompletionAck — beyond this
-// we delete the session even if the user never clicked anything. Private
-// constant; tests inject `options.unackedMaxAgeMs` if they need to override.
-const UNACKED_SESSION_MAX_AGE_MS = 86_400_000;
-
 function isWorkingLikeState(state) {
   return state === "working" || state === "juggling" || state === "thinking";
 }
@@ -54,34 +49,24 @@ function getStaleSessionDecision(session, options = {}) {
     return { action: "delete", reason: "agent-exit" };
   }
 
-  // GLOBAL reference time hoisted to the top: ack-pending guard and stale
-  // branches both consume Math.max(updatedAt, ackedAt). Without this hoist,
-  // an ack-then-natural-stale path would revert to raw updatedAt the moment
-  // the flag clears, deleting on the next 10s tick.
+  // GLOBAL reference time: the stale branches consume Math.max(updatedAt,
+  // ackedAt) so a freshly-acked session restarts its idle countdown from the
+  // ack instant instead of its (possibly ancient) last updatedAt.
   const referenceTs = Math.max(
     Number(session.updatedAt) || 0,
     Number(session.ackedAt) || 0
   );
   const age = now - referenceTs;
 
-  // requiresCompletionAck holds the session out of stale cleanup until the
-  // user acknowledges, OR until the hard ceiling fires. Order matters:
-  // agent-exit above still wins (a dead process is dead). The ack-pending
-  // guard runs BEFORE the detached-cleanup branch — once a session has the
-  // flag set, the detached sweep cannot reach it either (the whole point of
-  // the flag is "hold this session until user sees it").
-  if (session.requiresCompletionAck === true) {
-    const cap = Number.isFinite(options.unackedMaxAgeMs)
-      ? options.unackedMaxAgeMs
-      : UNACKED_SESSION_MAX_AGE_MS;
-    if (age <= cap) {
-      return { action: null, reason: "ack-pending" };
-    }
-    // Explicit delete at the cap. With sessionStaleMs=0 the branch below is
-    // skipped, and a `done`-state session isn't working-like either, so
-    // without an explicit delete here the session would leak forever.
-    return { action: "delete", reason: "ack-expired" };
-  }
+  // NOTE: requiresCompletionAck does NOT hold a session out of stale cleanup.
+  // The completion notification (e.g. Telegram push) already fires once at the
+  // completion instant, so an unacknowledged remote session has already been
+  // surfaced — it does not need to linger past the user's configured session
+  // timeout to be "seen". The `done` badge (deriveSessionBadge) keeps the
+  // session visually distinct while it waits out the normal timeout, then it
+  // deletes like any other idle remote session. With sessionStaleMs=0 the
+  // session is kept forever, matching a normal idle session. agent-exit above
+  // still wins (a dead process is dead).
 
   const deriveSessionBadge = options.deriveSessionBadge;
   const shouldAutoClearDetachedSession = options.shouldAutoClearDetachedSession;

--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -36,7 +36,6 @@ function decision(target, overrides = {}) {
     deriveSessionBadge: overrides.deriveSessionBadge || (() => "idle"),
     shouldAutoClearDetachedSession: overrides.shouldAutoClearDetachedSession || (() => false),
     staleConfig: overrides.staleConfig,
-    unackedMaxAgeMs: overrides.unackedMaxAgeMs,
   });
   return { result, calls };
 }
@@ -278,7 +277,23 @@ describe("state stale cleanup decisions", () => {
     assert.deepStrictEqual(result, { action: null });
   });
 
-  it("requiresCompletionAck=true holds an otherwise-deletable remote session", () => {
+  it("requiresCompletionAck within the session timeout is kept (done badge stays visible)", () => {
+    // Completion already pushed a notification; the session lingers only long
+    // enough for the user to spot the `done` badge — bounded by sessionStaleMs.
+    const { result } = decision(session({
+      updatedAt: 1000000 - 3 * 60 * 1000,
+      pidReachable: false,
+      requiresCompletionAck: true,
+    }), {
+      staleConfig: { sessionStaleMs: 10 * 60 * 1000 },
+    });
+    assert.deepStrictEqual(result, { action: null });
+  });
+
+  it("requiresCompletionAck no longer holds a remote session past the session timeout", () => {
+    // The completion notification already fired once, so an unacknowledged
+    // remote session deletes at the user-configured timeout like any other
+    // idle one — it does not get the old 24h hold.
     const { result } = decision(session({
       updatedAt: 1000000 - 11 * 60 * 1000,
       pidReachable: false,
@@ -286,24 +301,10 @@ describe("state stale cleanup decisions", () => {
     }), {
       staleConfig: { sessionStaleMs: 10 * 60 * 1000 },
     });
-    assert.deepStrictEqual(result, { action: null, reason: "ack-pending" });
+    assert.deepStrictEqual(result, { action: "delete", reason: "unreachable" });
   });
 
-  it("requiresCompletionAck=true past 24h cap deletes with reason ack-expired", () => {
-    // Use a realistic now baseline so updatedAt stays positive — the
-    // global referenceTs hoist uses Math.max(updatedAt, ackedAt||0), so
-    // a negative updatedAt would silently fall back to 0 and break the
-    // age math.
-    const now = 2_000_000_000_000;
-    const { result } = decision(session({
-      updatedAt: now - 86_400_000 - 1,
-      pidReachable: false,
-      requiresCompletionAck: true,
-    }), { now });
-    assert.deepStrictEqual(result, { action: "delete", reason: "ack-expired" });
-  });
-
-  it("ack-expired still fires with sessionStaleMs=0 (explicit delete, not fall-through)", () => {
+  it("requiresCompletionAck with sessionStaleMs=0 is kept forever, like a normal idle session", () => {
     const now = 2_000_000_000_000;
     const { result } = decision(session({
       state: "idle",
@@ -314,7 +315,7 @@ describe("state stale cleanup decisions", () => {
       now,
       staleConfig: { sessionStaleMs: 0 },
     });
-    assert.deepStrictEqual(result, { action: "delete", reason: "ack-expired" });
+    assert.deepStrictEqual(result, { action: null });
   });
 
   it("agent-exit wins over requiresCompletionAck", () => {
@@ -326,16 +327,5 @@ describe("state stale cleanup decisions", () => {
       alivePids: new Set(),
     });
     assert.deepStrictEqual(result, { action: "delete", reason: "agent-exit" });
-  });
-
-  it("options.unackedMaxAgeMs overrides the 24h cap for tests", () => {
-    const { result } = decision(session({
-      updatedAt: 1000000 - 6 * 60 * 1000,
-      pidReachable: false,
-      requiresCompletionAck: true,
-    }), {
-      unackedMaxAgeMs: 5 * 60 * 1000,
-    });
-    assert.deepStrictEqual(result, { action: "delete", reason: "ack-expired" });
   });
 });

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -2308,6 +2308,39 @@ describe("requiresCompletionAck lifecycle", () => {
     assert.strictEqual(entry.requiresCompletionAck, true);
   });
 
+  it("#414: unacknowledged remote completion is deleted by the session timeout (no 24h hold)", () => {
+    // End-to-end: completion sets the flag, stale-cleanup keeps the `done`
+    // badge, but once the configured idle timeout elapses the session is
+    // removed like any other unreachable remote session — it is NOT held for
+    // 24h waiting on a manual ack.
+    update(api, { id: "s1", state: "attention", event: "event_msg:task_complete", agentId: "codex", host: "ssh:example.com" });
+    update(api, { id: "s1", state: "sleeping", event: "stale-cleanup", agentId: "codex", host: "ssh:example.com" });
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.requiresCompletionAck, true);
+    assert.strictEqual(api.buildSessionSnapshot().sessions.find((s) => s.id === "s1").badge, "done");
+
+    // Simulate the default sessionStaleMs (600000ms) elapsing since the last update.
+    session.updatedAt = Date.now() - 700000;
+    api.cleanStaleSessions();
+    assert.strictEqual(api.sessions.has("s1"), false);
+  });
+
+  it("#414: ack resets the idle window via ackedAt; deletion waits for a fresh timeout", () => {
+    update(api, { id: "s1", state: "attention", event: "event_msg:task_complete", agentId: "codex", host: "ssh:example.com" });
+    // Completion is already old, but the user acks now → ackedAt is fresh.
+    api.sessions.get("s1").updatedAt = Date.now() - 700000;
+    assert.strictEqual(api.ackSessionCompletion("s1"), true);
+
+    // referenceTs = max(updatedAt, ackedAt) = the fresh ack → still in window.
+    api.cleanStaleSessions();
+    assert.strictEqual(api.sessions.has("s1"), true);
+
+    // Advance past the window from the ack instant → now it deletes.
+    api.sessions.get("s1").ackedAt = Date.now() - 700000;
+    api.cleanStaleSessions();
+    assert.strictEqual(api.sessions.has("s1"), false);
+  });
+
   it("remote Codex stale-cleanup alone does not create an ack requirement", () => {
     update(api, { id: "s1", state: "sleeping", event: "stale-cleanup", agentId: "codex", host: "ssh:example.com" });
     assert.notStrictEqual(api.sessions.get("s1").requiresCompletionAck, true);


### PR DESCRIPTION
## What

Remote SSH Codex sessions that had finished were not being removed by the
configured **session timeout** — they lingered as `idle` in the list for up to
24 hours and had to be cleared by hand (#414).

## Root cause

A finished remote Codex session sets `requiresCompletionAck = true`. In
`getStaleSessionDecision` that flag short-circuited stale cleanup, holding the
session until the user manually acked it or a hard-coded 24h ceiling fired —
**silently overriding the user's `sessionStaleMs` setting**.

The intent was "keep the session around so the user sees it finished". But the
completion notification (Telegram push) already fires **once** at the
completion instant (`telegram-companion` dedupes by `id:rawEvent:at`), so the
user has already been notified. Keeping the list entry for 24h added nothing to
"did the user find out it finished" — it only defeated their timeout setting.

## Fix

- Drop the `ack-pending` / `ack-expired` short-circuit. `requiresCompletionAck`
  sessions now expire at `sessionStaleMs` like any other idle remote session.
  `sessionStaleMs = 0` keeps them forever, matching a normal idle session.
- The `done` badge stays visible during the timeout window, and now has a
  distinct color in the dashboard and HUD (it was previously identical to the
  `idle` color), so a freshly-completed session is visually distinguishable
  from a stale one.
- `ackedAt` window-reset logic is kept: acking restarts the idle countdown from
  the ack instant.

## Notes / scope

- `stale-cleanup` from the remote monitor fires **once** (guarded by
  `entry.stale`), so effective deletion is `sessionStaleMs + ~5min` after
  completion — a one-time offset, not an indefinite hold.
- `evictOldestSessionIfNeeded` still prefers to retain ack sessions on capacity
  pressure. That is a leftover of the old semantics, not the #414 bug, and only
  shows up at 20 sessions + multiple done + `sessionStaleMs=0`. Left as a small
  independent follow-up.

## Tests

- Reversed the stale-cleanup unit tests that locked the old 24h semantics; added
  "kept within timeout" and "deleted past timeout" cases.
- Added end-to-end `state.test.js` coverage: completion → stale-cleanup → `done`
  badge → timeout delete, and ack resetting the idle window via `ackedAt`.
- `node --test test/state-stale-cleanup.test.js test/state.test.js test/state-session-snapshot.test.js test/session-ipc.test.js test/session-hud-style.test.js test/telegram-companion.test.js test/codex-remote-monitor.test.js` → 267 pass.

Closes #414
