### PR TITLE
fix(mobile): visibility reconnect + remove retry cap

### DIFF
--- a/pwa/app.js
+++ b/pwa/app.js
@@ -67,6 +67,20 @@
     return EVENT_LABELS_CN[eventName] || (typeof EVENT_LABELS !== "undefined" && EVENT_LABELS[eventName]) || eventName || "";
   }
 
+  var EVENT_ICONS = {
+    UserPromptSubmit: "💬", PreToolUse: "⚙️", PostToolUse: "✅",
+    PostToolUseFailure: "❌", Stop: "🏁", StopFailure: "❌",
+    SessionStart: "▶️", SessionEnd: "⏹️",
+    PermissionRequest: "🔒", Notification: "🔔",
+    SubagentStart: "🔀", SubagentStop: "🔀",
+    AfterAgent: "✅", ApiError: "❌",
+    Elicitation: "❓", WorktreeCreate: "🌿",
+  };
+
+  function eventIcon(eventName) {
+    return EVENT_ICONS[eventName] || "●";
+  }
+
   function log(msg) {
     var now = new Date();
     var ts = [now.getHours(), now.getMinutes(), now.getSeconds()]
@@ -326,13 +340,16 @@
       var isExpanded = this.expandedSet.has(sid);
       var events = s.recentEvents || [];
       var stateKey = s.state || "idle";
+      var agentLabel = (s.agentId || "agent").toUpperCase();
+      var sessionTitle = s.title || "";
       var html = '<div class="session-card">';
       html += '<div class="card-header"><div class="card-agent"><div class="agent-dot"></div>';
-      html += '<span class="agent-name">' + esc((s.title || "agent").toUpperCase()) + '</span></div>';
+      html += '<span class="agent-name">' + esc(agentLabel) + '</span></div>';
       html += '<span class="state-badge ' + stateKey + '">' + config.label + '</span></div>';
-      html += '<div class="card-title">' + esc(s.title || "") + '</div>';
+      if (sessionTitle) html += '<div class="card-title">' + esc(sessionTitle) + '</div>';
       html += '<div class="card-meta">';
       if (s.basename) { html += '<span class="meta-item mono">' + icon("folder") + '<span>' + esc(s.basename) + '</span></span>'; }
+      if (s.updatedAt) { html += '<span class="meta-sep">&middot;</span><span class="meta-item">' + formatAgo(s.updatedAt) + '</span>'; }
       html += '</div>';
       html += '<div class="card-divider"></div>';
       html += '<div class="card-footer" data-sid="' + sid + '"><div class="footer-events">' + icon("activity") + '<span>最近事件</span>';
@@ -350,6 +367,7 @@
         var ev = events[i]; var c = STATE_CONFIG[ev.state] || STATE_CONFIG.idle;
         html += '<div class="event-row"><div class="event-dot" style="background:' + c.color + '"></div>';
         html += '<div class="event-line" style="background:' + c.color + '"></div>';
+        html += '<span class="event-icon">' + eventIcon(ev.event) + '</span>';
         html += '<span class="event-label">' + esc(eventLabel(ev.event)) + '</span>';
         html += '<span class="event-time"' + (ev.at ? ' data-ts="' + ev.at + '"' : '') + '>' + formatAgo(ev.at) + '</span></div>';
       }

--- a/pwa/app.js
+++ b/pwa/app.js
@@ -83,18 +83,27 @@
     }
   }
 
-  function showToast(message, type) {
+  function showToast(message, type, persist) {
     type = type || "info";
     var container = document.getElementById("toast-container");
     var toast = document.createElement("div");
-    toast.className = "toast " + type;
+    toast.className = "toast " + type + (persist ? " toast-persist" : "");
     toast.textContent = message;
+    if (persist) {
+      var close = document.createElement("span");
+      close.className = "toast-close";
+      close.textContent = "✕";
+      close.onclick = function() { toast.remove(); };
+      toast.appendChild(close);
+    }
     container.appendChild(toast);
-    setTimeout(function() {
-      toast.style.opacity = "0";
-      toast.style.transition = "opacity 0.3s";
-      setTimeout(function() { toast.remove(); }, 300);
-    }, 3000);
+    if (!persist) {
+      setTimeout(function() {
+        toast.style.opacity = "0";
+        toast.style.transition = "opacity 0.3s";
+        setTimeout(function() { toast.remove(); }, 300);
+      }, 3000);
+    }
   }
 
   // === NotificationManager ===
@@ -146,9 +155,10 @@
       this.ws = null; this.config = null;
       this.reconnectDelay = 1000; this.maxReconnectDelay = 30000;
       this.reconnectTimer = null; this.state = "disconnected";
-      this.retryCount = 0; this.maxRetries = 10;
-      this._closingIntentionally = false;
+      this.retryCount = 0;
       this.onStateChange = null; this.onMessage = null; this.onDisconnected = null;
+      this._hiddenAt = 0;
+      this._bindVisibility();
     }
 
     connect(config) {
@@ -162,26 +172,40 @@
 
     _doConnect() {
       if (!this.config) return;
-      if (this.ws) {
-        this._closingIntentionally = true;
-        try { this.ws.close(); } catch {}
+      // Tear down old socket — clear callbacks first to prevent stale events
+      var old = this.ws;
+      if (old) {
+        old.onopen = old.onmessage = old.onclose = old.onerror = null;
+        try { old.close(); } catch {}
       }
       var url = "ws://" + this.config.host + ":" + this.config.port + "/ws?token=" + this.config.token;
       this._setState("connecting");
       log("Connecting to " + this.config.host + ":" + this.config.port + "...");
-      try { this.ws = new WebSocket(url); } catch (err) { this._closingIntentionally = false; log("WS create failed: " + err.message); this._scheduleReconnect(); return; }
+      var socket;
+      try { socket = new WebSocket(url); } catch (err) { log("WS create failed: " + err.message); this._scheduleReconnect(); return; }
+      this.ws = socket;
       var self = this;
       var connected = false;
-      this.ws.onopen = function() { self._closingIntentionally = false; connected = true; self.retryCount = 0; self.reconnectDelay = 1000; self._setState("connected"); log("Connected"); showToast("已连接到桌面端", "success"); };
-      this.ws.onmessage = function(event) { try { var msg = JSON.parse(event.data); if (self.onMessage) self.onMessage(msg); } catch {} };
-      this.ws.onclose = function(event) {
-        if (self._closingIntentionally) return;
-        if (event.code === 1008) { self._setState("auth_failed"); log("Auth failed"); showToast("认证失败", "error"); return; }
+      socket.onopen = function() {
+        if (socket !== self.ws) return; // stale socket — ignore
+        connected = true; self.retryCount = 0; self.reconnectDelay = 1000;
+        self._setState("connected"); log("Connected"); showToast("已连接到桌面端", "success");
+        // Dismiss any persistent toasts (e.g. retry hint)
+        var persisted = document.querySelectorAll(".toast-persist");
+        for (var i = 0; i < persisted.length; i++) { persisted[i].remove(); }
+      };
+      socket.onmessage = function(event) {
+        if (socket !== self.ws) return;
+        try { var msg = JSON.parse(event.data); if (self.onMessage) self.onMessage(msg); } catch {}
+      };
+      socket.onclose = function(event) {
+        if (socket !== self.ws) return; // stale socket — ignore
+        if (event.code === 1008) { self._setState("auth_failed"); log("Auth failed"); showToast("Token 已过期，请重新连接", "error"); return; }
         if (connected) log("Disconnected (code: " + event.code + ")");
         if (self.onDisconnected) self.onDisconnected();
         self._scheduleReconnect();
       };
-      this.ws.onerror = function() {};
+      socket.onerror = function() {};
     }
 
     send(data) { if (this.ws && this.ws.readyState === WebSocket.OPEN) this.ws.send(typeof data === "string" ? data : JSON.stringify(data)); }
@@ -189,13 +213,11 @@
     _scheduleReconnect() {
       if (!this.config) return;
       this.retryCount++;
-      if (this.retryCount > this.maxRetries) {
-        this._setState("disconnected");
-        log("Max retries (" + this.maxRetries + ") reached, stopping");
-        showToast("连接失败，请检查地址和 Token", "error");
-        return;
-      }
       this._setState("reconnecting");
+      // After several retries, give actionable feedback (don't stop — just inform)
+      if (this.retryCount === 5) {
+        showToast("仍在重连…请检查地址、端口或桌面端是否已开启", "info", true);
+      }
       var self = this;
       this.reconnectTimer = setTimeout(function() { self.reconnectDelay = Math.min(self.reconnectDelay * 2, self.maxReconnectDelay); self._doConnect(); }, this.reconnectDelay);
     }
@@ -212,6 +234,25 @@
 
     getHistory() { try { return JSON.parse(localStorage.getItem("clawd-history") || "[]"); } catch { return []; } }
     deleteHistory(index) { var h = this.getHistory(); h.splice(index, 1); localStorage.setItem("clawd-history", JSON.stringify(h)); }
+
+    _bindVisibility() {
+      var self = this;
+      document.addEventListener("visibilitychange", function() {
+        if (document.visibilityState !== "visible") {
+          self._hiddenAt = Date.now();
+          return;
+        }
+        if (!self.config) return;
+        var hiddenFor = self._hiddenAt ? Date.now() - self._hiddenAt : 0;
+        // Short tab switch: trust OPEN. Background > 30s: force reconnect (zombie guard)
+        if (hiddenFor < 30000 && self.ws && self.ws.readyState === WebSocket.OPEN) return;
+        log("Page visible after " + Math.round(hiddenFor / 1000) + "s, reconnecting...");
+        self.retryCount = 0;
+        self.reconnectDelay = 1000;
+        clearTimeout(self.reconnectTimer);
+        self._doConnect();
+      });
+    }
   }
 
   // === SessionRenderer ===

--- a/pwa/style.css
+++ b/pwa/style.css
@@ -106,6 +106,7 @@ body { display: flex; flex-direction: column; height: 100%; }
 .meta-item { display: flex; align-items: center; gap: 3px; font-size: 11px; color: var(--faint); }
 .meta-item svg { width: 11px; height: 11px; flex-shrink: 0; }
 .meta-item.mono { font-family: ui-monospace, Menlo, Consolas, monospace; }
+.meta-sep { color: var(--faint); font-size: 11px; flex-shrink: 0; }
 .meta-divider { width: 1px; height: 10px; background: var(--divider); flex-shrink: 0; }
 .card-output { font-size: 12px; color: var(--subtle); line-height: 16px; margin-top: 8px; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
 .card-divider { height: 0.5px; background: var(--card-border); margin-top: 10px; }
@@ -124,6 +125,7 @@ body { display: flex; flex-direction: column; height: 100%; }
 .event-row { display: flex; align-items: center; gap: 10px; padding: 5px 0; position: relative; }
 .event-dot { width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0; position: relative; z-index: 1; }
 .event-line { position: absolute; left: 3.5px; top: 13px; bottom: -5px; width: 1px; opacity: 0.3; }
+.event-icon { font-size: 12px; flex-shrink: 0; width: 16px; text-align: center; }
 .event-row:last-child .event-line { display: none; }
 .event-label { font-size: 12px; color: var(--faint); flex: 1; }
 .event-time { font-size: 11px; color: var(--subtle); font-variant-numeric: tabular-nums; flex-shrink: 0; }

--- a/pwa/style.css
+++ b/pwa/style.css
@@ -207,6 +207,9 @@ body { display: flex; flex-direction: column; height: 100%; }
 .toast { background: var(--card); color: var(--text); padding: 12px 20px; border-radius: 8px; font-size: 14px; box-shadow: 0 4px 12px rgba(0,0,0,0.3); border: 1px solid var(--card-border); animation: toast-in 0.3s ease-out; pointer-events: auto; }
 .toast.success { border-left: 3px solid var(--green); }
 .toast.error { border-left: 3px solid var(--red); }
+.toast-persist { display: flex; align-items: center; gap: 12px; }
+.toast-close { cursor: pointer; opacity: 0.5; font-size: 12px; padding: 2px 4px; flex-shrink: 0; }
+.toast-close:hover { opacity: 1; }
 @keyframes toast-in { from { opacity: 0; transform: translateY(-10px); } to { opacity: 1; transform: translateY(0); } }
 
 /* === Scrollbar === */

--- a/src/network/mobile-preview-server.js
+++ b/src/network/mobile-preview-server.js
@@ -216,9 +216,11 @@ function initMobilePreviewServer(ctx) {
     const recentEvents = Array.isArray(session.recentEvents) ? session.recentEvents.slice(-10) : [];
     return {
       sessionId: sid,
-      title: session.sessionTitle || session.agentId || null,
+      agentId: session.agentId || null,
+      title: session.sessionTitle || null,
       basename: session.cwd ? path.basename(session.cwd) : null,
       state: session.state || "idle",
+      updatedAt: session.updatedAt || null,
       recentEvents,
     };
   }


### PR DESCRIPTION
PR 0 #411 

## Problem

The PWA connection silently dies after being backgrounded on iOS/Android for ~5 minutes, requiring a manual refresh. Root cause: `maxRetries=10` caps retries, and there's no mechanism to detect a dead socket on return to foreground.

## Changes

-  **visibilitychange handler**: on return to foreground, check WS readyState and force reconnect if not OPEN

- **Remove maxRetries cap**: retry indefinitely with exponential backoff (1s → 30s). Previously gave up after ~5 minutes, permanently killing the connection

## Testing

- Background the PWA for 5+ minutes, return → should auto-reconnect

- Kill server, wait for retries, restart server → should reconnect within one backoff cycle

- Normal foreground usage → no behavior change

---
 
## 问题

PWA连接在iOS/Android上后台接地约5分钟后静默死亡，需要手动刷新。根本原因：“maxRetries=10”会限制重试次数，并且没有机制在返回前台时检测到死套接字

## 变化

- **可见性更改处理程序**：返回前台时，检查WS readyState并在未打开时强制重新连接

- **删除maxRetries上限**：无限期重试，指数退避（1s→30s）。之前在~5分钟后放弃，永久断连

## 测试

- PWA后台5分钟以上，返回 → 自动重新连接

- 关闭服务器，等待重试，重新启动服务器 → 在一个退避周期内重新连接

- 正常前台使用 → 无行为变化
