### PR TITLE
Fix stuck local Codex turns with JSONL task_complete fallback

### DIFF
--- a/src/agent-runtime-main.js
+++ b/src/agent-runtime-main.js
@@ -20,6 +20,10 @@ const CODEX_LOG_EVENTS_COVERED_BY_OFFICIAL_HOOKS = new Set([
   "event_msg:task_complete",
 ]);
 
+// Local Codex turns that are still in flight sit in one of these states. Kept in
+// sync with isWorkingLikeState() in state-stale-cleanup.js.
+const CODEX_WORKING_LIKE_STATES = new Set(["working", "thinking", "juggling"]);
+
 function createAgentRuntimeMain(options = {}) {
   const now = typeof options.now === "function" ? options.now : Date.now;
   const logWarn = typeof options.logWarn === "function" ? options.logWarn : console.warn;
@@ -52,10 +56,33 @@ function createAgentRuntimeMain(options = {}) {
     return true;
   }
 
+  // JSONL fallback rescue. Official Codex hooks normally emit a Stop that closes
+  // the turn, so the matching JSONL event_msg:task_complete is suppressed as a
+  // duplicate. But when the official Stop never arrives, the session stays stuck
+  // working-like while the rollout JSONL still records task_complete. Let that one
+  // JSONL completion through to close the turn — only for a local (non-remote,
+  // non-headless) Codex session the state runtime still shows as working-like.
+  // Once Stop (or this very fallback) idles the session it is no longer
+  // working-like, so a later duplicate task_complete is suppressed again and we
+  // avoid double done/celebration.
+  function shouldAllowCodexJsonlCompletionFallback(sessionId, state, event) {
+    if (event !== "event_msg:task_complete") return false;
+    // codex-log-monitor only resolves task_complete to a completion state.
+    if (state !== "attention" && state !== "idle") return false;
+    const stateRuntime = getStateRuntime();
+    const sessions = stateRuntime && stateRuntime.sessions;
+    const session = sessions && typeof sessions.get === "function" ? sessions.get(sessionId) : null;
+    if (!session || session.agentId !== "codex") return false;
+    if (session.host || session.headless) return false;
+    return CODEX_WORKING_LIKE_STATES.has(session.state);
+  }
+
   function shouldSuppressCodexLogEvent(sessionId, state, event) {
     if (state === "codex-permission") return hasRecentCodexOfficialHookSession(sessionId);
     if (!CODEX_LOG_EVENTS_COVERED_BY_OFFICIAL_HOOKS.has(event)) return false;
-    return hasRecentCodexOfficialHookSession(sessionId);
+    if (!hasRecentCodexOfficialHookSession(sessionId)) return false;
+    if (shouldAllowCodexJsonlCompletionFallback(sessionId, state, event)) return false;
+    return true;
   }
 
   function updateSessionFromServer(sessionId, state, event, opts = {}) {

--- a/test/agent-runtime-main.test.js
+++ b/test/agent-runtime-main.test.js
@@ -237,4 +237,180 @@ describe("agent-runtime-main", () => {
       ["setState", "idle", "svg:idle"],
     ]);
   });
+
+  it("rescues a stuck local Codex turn with JSONL task_complete while suppressing other covered events", () => {
+    const sessions = new Map();
+    const runtime = createAgentRuntimeMain({
+      codexSubagentClassifier: {},
+      getStateRuntime: () => ({ sessions }),
+    });
+
+    // Official hooks were active this turn, but the official Stop never arrived,
+    // so the session is still shown as working-like.
+    runtime.markCodexOfficialHookSession("codex:s1");
+    sessions.set("codex:s1", { agentId: "codex", state: "working" });
+
+    // task_complete from JSONL is allowed through to close the turn (attention
+    // when the turn used tools, idle when it did not).
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "attention", "event_msg:task_complete"),
+      false
+    );
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "idle", "event_msg:task_complete"),
+      false
+    );
+
+    // Every other covered JSONL event stays suppressed under recent official hooks.
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "working", "event_msg:task_started"),
+      true
+    );
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "attention", "event_msg:exec_command_end"),
+      true
+    );
+  });
+
+  it("treats every working-like state as a rescuable local Codex turn", () => {
+    const sessions = new Map();
+    const runtime = createAgentRuntimeMain({
+      codexSubagentClassifier: {},
+      getStateRuntime: () => ({ sessions }),
+    });
+    runtime.markCodexOfficialHookSession("codex:s1");
+
+    for (const workingLike of ["working", "thinking", "juggling"]) {
+      sessions.set("codex:s1", { agentId: "codex", state: workingLike });
+      assert.equal(
+        runtime.shouldSuppressCodexLogEvent("codex:s1", "idle", "event_msg:task_complete"),
+        false,
+        `expected ${workingLike} session to allow the JSONL completion fallback`
+      );
+    }
+  });
+
+  it("keeps suppressing JSONL task_complete once the official Stop has idled the session", () => {
+    const sessions = new Map();
+    const runtime = createAgentRuntimeMain({
+      codexSubagentClassifier: {},
+      getStateRuntime: () => ({ sessions }),
+    });
+    runtime.markCodexOfficialHookSession("codex:s1");
+
+    // Official Stop already closed the turn → no longer working-like.
+    sessions.set("codex:s1", { agentId: "codex", state: "idle" });
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "attention", "event_msg:task_complete"),
+      true
+    );
+
+    // A session that has moved on to a fresh non-working state is not rescued either.
+    sessions.set("codex:s1", { agentId: "codex", state: "attention" });
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "idle", "event_msg:task_complete"),
+      true
+    );
+  });
+
+  it("does not apply the JSONL completion fallback to remote or headless Codex sessions", () => {
+    const sessions = new Map();
+    const runtime = createAgentRuntimeMain({
+      codexSubagentClassifier: {},
+      getStateRuntime: () => ({ sessions }),
+    });
+    runtime.markCodexOfficialHookSession("codex:remote");
+    runtime.markCodexOfficialHookSession("codex:headless");
+
+    sessions.set("codex:remote", { agentId: "codex", state: "working", host: "ssh:example" });
+    sessions.set("codex:headless", { agentId: "codex", state: "working", headless: true });
+
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:remote", "idle", "event_msg:task_complete"),
+      true
+    );
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:headless", "attention", "event_msg:task_complete"),
+      true
+    );
+  });
+
+  it("only rescues known local Codex sessions, and never suppresses without recent official hooks", () => {
+    const sessions = new Map();
+    const runtime = createAgentRuntimeMain({
+      codexSubagentClassifier: {},
+      getStateRuntime: () => ({ sessions }),
+    });
+    runtime.markCodexOfficialHookSession("codex:s1");
+
+    // Recent official hook, but the state runtime has no entry for the session.
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "idle", "event_msg:task_complete"),
+      true
+    );
+
+    // Recent official hook, but the session belongs to a different agent.
+    sessions.set("codex:s1", { agentId: "claude-code", state: "working" });
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "idle", "event_msg:task_complete"),
+      true
+    );
+
+    // No official hook seen for this session: JSONL is the only completion source,
+    // so it must not be suppressed regardless of working-like state.
+    sessions.set("codex:s2", { agentId: "codex", state: "working" });
+    assert.equal(
+      runtime.shouldSuppressCodexLogEvent("codex:s2", "idle", "event_msg:task_complete"),
+      false
+    );
+  });
+
+  it("lets the JSONL monitor close a stuck local Codex turn, then suppresses the duplicate", () => {
+    const instances = [];
+    const calls = [];
+    const sessions = new Map();
+    const FakeMonitor = makeFakeMonitorClass(instances);
+    const runtime = createAgentRuntimeMain({
+      loadCodexLogMonitor: () => FakeMonitor,
+      loadCodexAgent: () => ({ id: "codex" }),
+      codexSubagentClassifier: {},
+      isAgentEnabled: (agentId) => agentId === "codex",
+      getStateRuntime: () => ({ sessions }),
+      updateSession: (...args) => calls.push(["update", ...args]),
+      showCodexNotifyBubble: (...args) => calls.push(["notify", ...args]),
+      clearCodexNotifyBubbles: (...args) => calls.push(["clear", ...args]),
+    });
+
+    const monitor = runtime.startCodexLogMonitor();
+
+    // Recent official hook activity + a still-working local Codex session whose
+    // official Stop never arrived.
+    runtime.markCodexOfficialHookSession("codex:s1");
+    sessions.set("codex:s1", { agentId: "codex", state: "working" });
+
+    monitor.emit("codex:s1", "idle", "event_msg:task_complete", {
+      cwd: "D:\\repo",
+      sessionTitle: "Codex turn",
+    });
+
+    assert.deepStrictEqual(calls, [
+      ["clear", "codex:s1", "codex-state-transition:idle"],
+      ["update", "codex:s1", "idle", "event_msg:task_complete", {
+        cwd: "D:\\repo",
+        agentId: "codex",
+        sessionTitle: "Codex turn",
+        headless: false,
+      }],
+    ]);
+
+    // The fallback idled the turn; a duplicate JSONL task_complete is now dropped
+    // so there is no double done/celebration.
+    calls.length = 0;
+    sessions.set("codex:s1", { agentId: "codex", state: "idle" });
+    monitor.emit("codex:s1", "idle", "event_msg:task_complete", {
+      cwd: "D:\\repo",
+      sessionTitle: "Codex turn",
+    });
+    assert.deepStrictEqual(calls, []);
+  });
 });


### PR DESCRIPTION
## Summary
- Allow local non-headless Codex JSONL `event_msg:task_complete` to close a still working-like session when recent official hooks exist but official `Stop` never arrives.
- Keep suppressing duplicate JSONL completions after official Stop or fallback has already idled the session.
- Add regression coverage for working/thinking/juggling, remote/headless exclusion, duplicate suppression, and monitor integration.

## Testing
- `node --test test/agent-runtime-main.test.js test/codex-log-monitor.test.js test/state-stale-cleanup.test.js`
- Manual dogfood: independent `codex exec` turn produced `UserPromptSubmit -> PreToolUse -> PostToolUse -> Stop`, exited working normally.