### PR TITLE
Fix Codex same-process session ghosts

### DIFF
--- a/src/state-priority.js
+++ b/src/state-priority.js
@@ -1,5 +1,10 @@
 "use strict";
 
+const {
+  buildLatestLocalCodexProcessIds,
+  isSupersededLocalCodexProcessSession,
+} = require("./state-session-dedupe");
+
 const SLEEP_SEQUENCE_STATES = ["yawning", "dozing", "collapsing", "sleeping", "waking"];
 
 const STATE_PRIORITY = Object.freeze({
@@ -44,10 +49,12 @@ function resolveDominantSessionState(sessions, options = {}) {
   let best = "sleeping";
   let hasSession = false;
   let hasNonHeadless = false;
+  const latestLocalCodexProcessIds = buildLatestLocalCodexProcessIds(sessions);
 
-  for (const [, session] of normalizeSessionsIterable(sessions)) {
+  for (const [id, session] of normalizeSessionsIterable(sessions)) {
     hasSession = true;
     if (session && session.headless) continue;
+    if (isSupersededLocalCodexProcessSession(id, session, latestLocalCodexProcessIds)) continue;
     hasNonHeadless = true;
     const state = session && session.state;
     if (getStatePriority(state, statePriority) > getStatePriority(best, statePriority)) best = state;

--- a/src/state-session-dedupe.js
+++ b/src/state-session-dedupe.js
@@ -1,0 +1,53 @@
+"use strict";
+
+function normalizeSessionsIterable(sessions) {
+  if (!sessions) return [];
+  if (sessions instanceof Map) return sessions.entries();
+  if (typeof sessions[Symbol.iterator] === "function") return sessions;
+  return [];
+}
+
+function normalizePositiveInteger(value) {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : null;
+}
+
+function getLocalCodexProcessKey(session) {
+  if (!session || session.agentId !== "codex" || session.host || session.headless) return null;
+  const agentPid = normalizePositiveInteger(session.agentPid);
+  return agentPid ? `codex-agent:${agentPid}` : null;
+}
+
+function sessionUpdatedAt(session) {
+  const n = Number(session && session.updatedAt);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function buildLatestLocalCodexProcessIds(sessions) {
+  const latestByKey = new Map();
+  for (const [id, session] of normalizeSessionsIterable(sessions)) {
+    const key = getLocalCodexProcessKey(session);
+    if (!key) continue;
+    const updatedAt = sessionUpdatedAt(session);
+    const current = latestByKey.get(key);
+    if (
+      !current
+      || updatedAt > current.updatedAt
+      || (updatedAt === current.updatedAt && String(id) > String(current.id))
+    ) {
+      latestByKey.set(key, { id, updatedAt });
+    }
+  }
+  return new Set(Array.from(latestByKey.values(), (entry) => entry.id));
+}
+
+function isSupersededLocalCodexProcessSession(id, session, latestIds) {
+  if (!getLocalCodexProcessKey(session)) return false;
+  return latestIds instanceof Set && !latestIds.has(id);
+}
+
+module.exports = {
+  buildLatestLocalCodexProcessIds,
+  getLocalCodexProcessKey,
+  isSupersededLocalCodexProcessSession,
+};

--- a/src/state-session-snapshot.js
+++ b/src/state-session-snapshot.js
@@ -3,6 +3,10 @@
 const path = require("path");
 const { sessionAliasKey } = require("./session-alias");
 const { getSessionFocusTarget } = require("./session-focus");
+const {
+  buildLatestLocalCodexProcessIds,
+  isSupersededLocalCodexProcessSession,
+} = require("./state-session-dedupe");
 const { readCodexThreadName } = require("../hooks/codex-session-index");
 
 const EVENT_LABEL_KEYS = {
@@ -170,7 +174,8 @@ function buildSessionSnapshotEntry(id, session, sessionAliases = {}, options = {
     ? options.getAgentIconUrl
     : () => null;
   const state = (session && session.state) || "idle";
-  const hiddenFromHud = shouldAutoClearDetachedSession(session, badge, options);
+  const hiddenFromHud = shouldAutoClearDetachedSession(session, badge, options)
+    || isSupersededLocalCodexProcessSession(id, session, options.latestLocalCodexProcessIds);
   const focusTarget = session && !session.headless && state !== "sleeping" && !hiddenFromHud
     ? getSessionFocusTarget({ ...(session || {}), id }, {
       osPlatform: options.focusHostPlatform || options.osPlatform,
@@ -227,8 +232,12 @@ function buildSessionSnapshot(sessions, options = {}) {
   const sessionAliases = options.sessionAliases && typeof options.sessionAliases === "object"
     ? options.sessionAliases
     : {};
+  const latestLocalCodexProcessIds = buildLatestLocalCodexProcessIds(sessions);
   for (const [id, session] of normalizeSessionsIterable(sessions)) {
-    entries.push(buildSessionSnapshotEntry(id, session, sessionAliases, options));
+    entries.push(buildSessionSnapshotEntry(id, session, sessionAliases, {
+      ...options,
+      latestLocalCodexProcessIds,
+    }));
   }
 
   const dashboardEntries = entries.slice().sort(sessionUpdatedAtComparator);

--- a/test/state-priority.test.js
+++ b/test/state-priority.test.js
@@ -73,6 +73,82 @@ describe("state-priority display selection", () => {
     ])), "carrying");
   });
 
+  it("ignores superseded local Codex sessions that share one agent process", () => {
+    assert.strictEqual(resolveDominantSessionState(new Map([
+      ["codex:old", session("working", {
+        agentId: "codex",
+        agentPid: 4242,
+        updatedAt: 1000,
+      })],
+      ["codex:new", session("idle", {
+        agentId: "codex",
+        agentPid: 4242,
+        updatedAt: 2000,
+      })],
+    ])), "idle");
+
+    assert.strictEqual(resolveDominantSessionState(new Map([
+      ["codex:a", session("working", {
+        agentId: "codex",
+        agentPid: 1111,
+        updatedAt: 1000,
+      })],
+      ["codex:b", session("idle", {
+        agentId: "codex",
+        agentPid: 2222,
+        updatedAt: 2000,
+      })],
+    ])), "working");
+  });
+
+  it("does not dedupe Codex sessions without a local agent pid", () => {
+    assert.strictEqual(resolveDominantSessionState(new Map([
+      ["codex:old", session("working", {
+        agentId: "codex",
+        agentPid: null,
+        updatedAt: 1000,
+      })],
+      ["codex:new", session("idle", {
+        agentId: "codex",
+        agentPid: null,
+        updatedAt: 2000,
+      })],
+    ])), "working");
+  });
+
+  it("does not dedupe remote Codex sessions that happen to share an agent pid", () => {
+    assert.strictEqual(resolveDominantSessionState(new Map([
+      ["codex:remote-old", session("working", {
+        agentId: "codex",
+        agentPid: 4242,
+        host: "remote-box",
+        updatedAt: 1000,
+      })],
+      ["codex:remote-new", session("idle", {
+        agentId: "codex",
+        agentPid: 4242,
+        host: "remote-box",
+        updatedAt: 2000,
+      })],
+    ])), "working");
+  });
+
+  it("does not let headless Codex sessions supersede an interactive root session", () => {
+    assert.strictEqual(resolveDominantSessionState(new Map([
+      ["codex:root", session("working", {
+        agentId: "codex",
+        agentPid: 4242,
+        updatedAt: 1000,
+      })],
+      ["codex:subagent", session("idle", {
+        agentId: "codex",
+        agentPid: 4242,
+        headless: true,
+        updatedAt: 2000,
+      })],
+    ])), "working");
+  });
+
   it("applies permission locks and update overlays with strict priority comparison", () => {
     const sessions = new Map([["s1", session("working")]]);
     assert.strictEqual(resolveDisplayStateFromSessions(sessions), "working");

--- a/test/state-session-snapshot.test.js
+++ b/test/state-session-snapshot.test.js
@@ -366,6 +366,34 @@ describe("state-session-snapshot builder", () => {
     assert.strictEqual(snapshot.hudLastSessionId, "idle-local");
   });
 
+  it("hides older local Codex sessions that share one agent process from HUD", () => {
+    const snapshot = buildSessionSnapshot(new Map([
+      ["codex:old", session("working", {
+        agentId: "codex",
+        agentPid: 4242,
+        updatedAt: 1000,
+        cwd: "/repo/old",
+      })],
+      ["codex:new", session("idle", {
+        agentId: "codex",
+        agentPid: 4242,
+        updatedAt: 2000,
+        cwd: "/repo/new",
+        recentEvents: [{ event: "Stop", state: "attention", at: 1900 }],
+      })],
+    ]), {
+      statePriority: STATE_PRIORITY,
+      getAgentIconUrl: () => null,
+    });
+
+    assert.strictEqual(snapshot.sessions.find((entry) => entry.id === "codex:old").hiddenFromHud, true);
+    assert.strictEqual(snapshot.sessions.find((entry) => entry.id === "codex:new").hiddenFromHud, false);
+    assert.strictEqual(snapshot.hudTotalNonIdle, 1);
+    assert.strictEqual(snapshot.hudLastSessionId, "codex:new");
+    assert.deepStrictEqual(snapshot.orderedIds, ["codex:new", "codex:old"]);
+    assert.deepStrictEqual(snapshot.groups, [{ host: "", ids: ["codex:new", "codex:old"] }]);
+  });
+
   it("snapshot signatures include visible fields but ignore icon URL churn", () => {
     const base = buildSessionSnapshot(new Map([
       ["s1", session("working", {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1721,6 +1721,34 @@ describe("buildSessionSnapshot", () => {
     assert.strictEqual(snapshot.hudLastTitle, "done-project");
   });
 
+  it("dedupes local Codex sessions that share one agent process across display and HUD", () => {
+    api.sessions.set("codex:old", rawSession("working", {
+      updatedAt: 1000,
+      sourcePid: pid,
+      agentPid: pid,
+      pidReachable: true,
+      cwd: "/tmp/current-project",
+      agentId: "codex",
+      recentEvents: [{ event: "PreToolUse", state: "working", at: 900 }],
+    }));
+    api.sessions.set("codex:new", rawSession("idle", {
+      updatedAt: 2000,
+      sourcePid: pid,
+      agentPid: pid,
+      pidReachable: true,
+      cwd: "/tmp/current-project",
+      agentId: "codex",
+      recentEvents: [{ event: "Stop", state: "attention", at: 1900 }],
+    }));
+
+    const snapshot = api.buildSessionSnapshot();
+    assert.strictEqual(api.resolveDisplayState(), "idle");
+    assert.strictEqual(snapshot.sessions.find((s) => s.id === "codex:old").hiddenFromHud, true);
+    assert.strictEqual(snapshot.sessions.find((s) => s.id === "codex:new").hiddenFromHud, false);
+    assert.strictEqual(snapshot.hudTotalNonIdle, 1);
+    assert.strictEqual(snapshot.hudLastSessionId, "codex:new");
+  });
+
   it("hides detached ended idle sessions from HUD aggregates when auto-clear is enabled and source is dead", () => {
     api.cleanup();
     api = require("../src/state")(makeCtx({


### PR DESCRIPTION
## Summary
- Hide superseded local Codex sessions that share one agentPid from HUD and display-state selection.
- Keep hidden sessions in snapshot/dashboard grouping so aliases and direct session lookups still work.
- Add regression coverage for missing pid, remote Codex sessions, and headless subagents.

## Tests
- node --test test\state-priority.test.js test\state-session-snapshot.test.js test\state.test.js
- git diff --cached --check