### PR TITLE
[codex] Harden Antigravity hook fail-open

### DIFF
--- a/hooks/antigravity-hook.js
+++ b/hooks/antigravity-hook.js
@@ -7,6 +7,7 @@ const os = require("os");
 const path = require("path");
 const { postPermissionToRunningServer, postStateToRunningServer, readHostPrefix } = require("./server-config");
 const { createPidResolver, readStdinJson, getPlatformConfig } = require("./shared-process");
+const { stdoutForAntigravityEvent } = require("./antigravity-stdout");
 
 const ANTIGRAVITY_PERMISSION_TIMEOUT_MS = 590000;
 const TOOL_INPUT_STRING_MAX = 2000;
@@ -131,9 +132,7 @@ function buildAntigravityNoDecisionOutput(reason) {
 }
 
 function stdoutForEvent(hookName) {
-  if (hookName === "PreToolUse") return buildAntigravityNoDecisionOutput();
-  if (hookName === "Stop") return JSON.stringify({ decision: "allow" });
-  return "{}";
+  return stdoutForAntigravityEvent(hookName);
 }
 
 function resolveHookName(payload, argvEvent) {

--- a/hooks/antigravity-install.js
+++ b/hooks/antigravity-install.js
@@ -5,13 +5,13 @@ const fs = require("fs");
 const path = require("path");
 const os = require("os");
 const { resolveNodeBin } = require("./server-config");
+const { stdoutForAntigravityEvent } = require("./antigravity-stdout");
 const {
   readJsonFile,
   writeJsonAtomic,
   writeJsonAtomicWithBackup,
   asarUnpackedPath,
   formatNodeHookCommand,
-  buildWindowsEncodedNodeHookCommand,
   decodeWindowsEncodedCommand,
   extractFirstQuotedToken,
   windowsPowerShellBin,
@@ -36,24 +36,82 @@ const ANTIGRAVITY_HOOK_EVENTS = [
 ];
 const DEFAULT_HOOK_TIMEOUT_SECONDS = 10;
 
+function fallbackStdoutForEvent(event) {
+  return stdoutForAntigravityEvent(event);
+}
+
+function quoteShellSingleArg(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function quotePowerShellSingleArg(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+function withFailOpenShellFallback(command, event) {
+  const fallback = quoteShellSingleArg(fallbackStdoutForEvent(event));
+  return `out=$(${command} 2>/dev/null); status=$?; if [ "$status" -eq 0 ] && [ -n "$out" ]; then printf '%s\\n' "$out"; else printf '%s\\n' ${fallback}; fi; exit 0`;
+}
+
+function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, options = {}) {
+  const fallback = fallbackStdoutForEvent(event);
+  const psCommand = [
+    "$ErrorActionPreference='SilentlyContinue'",
+    ";",
+    "$text=''",
+    ";",
+    "try {",
+    "$out = &",
+    quotePowerShellSingleArg(nodeBin),
+    quotePowerShellSingleArg(hookScript),
+    quotePowerShellSingleArg(event),
+    "2>$null",
+    ";",
+    "if (($LASTEXITCODE -eq 0) -and ($null -ne $out)) { $text=($out -join [Environment]::NewLine) }",
+    "} catch { $text='' }",
+    ";",
+    "if ($text.Length -gt 0) { [Console]::Out.WriteLine($text) } else { [Console]::Out.WriteLine(",
+    quotePowerShellSingleArg(fallback),
+    ") }",
+    ";",
+    "exit 0",
+  ].join(" ");
+  const encodedCommand = Buffer.from(psCommand, "utf16le").toString("base64");
+  return `${windowsPowerShellBin(options)} -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedCommand}`;
+}
+
 function buildAntigravityHookCommand(nodeBin, hookScript, event, options = {}) {
   const platform = options.platform || process.platform;
   if (platform === "win32") {
     return buildWindowsAntigravityHookCommand(nodeBin, hookScript, event, options);
   }
-  return formatNodeHookCommand(nodeBin, hookScript, {
+  const command = formatNodeHookCommand(nodeBin, hookScript, {
     ...options,
     args: [event],
   });
+  return withFailOpenShellFallback(command, event);
 }
 
 function buildWindowsAntigravityHookCommand(nodeBin, hookScript, event, options = {}) {
-  return buildWindowsEncodedNodeHookCommand(nodeBin, hookScript, [event], options);
+  return buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, options);
 }
 
 function extractNodeBinFromCommand(command) {
   const decoded = decodeWindowsEncodedCommand(command);
-  const token = extractFirstQuotedToken(decoded || command);
+  const text = decoded || command;
+  const quotedTokens = [];
+  const quotedRe = /'((?:''|[^'])*)'|"((?:\\"|[^"])*)"/g;
+  let match;
+  while ((match = quotedRe.exec(text))) {
+    if (match[1] !== undefined) quotedTokens.push(match[1].replace(/''/g, "'"));
+    else quotedTokens.push(match[2].replace(/\\"/g, "\"").replace(/\\\\/g, "\\"));
+  }
+  for (let i = 1; i < quotedTokens.length; i++) {
+    if (quotedTokens[i].includes(MARKER) && !quotedTokens[i - 1].includes(MARKER)) {
+      return quotedTokens[i - 1];
+    }
+  }
+  const token = extractFirstQuotedToken(text);
   if (!token || token.includes(MARKER)) return null;
   return token;
 }
@@ -222,14 +280,17 @@ module.exports = {
   __test: {
     buildAntigravityHookCommand,
     buildAntigravityHooks,
+    buildWindowsEncodedFailOpenNodeHookCommand,
     buildWindowsAntigravityHookCommand,
     decodeWindowsEncodedCommand,
     extractExistingAntigravityNodeBin,
     extractNodeBinFromCommand,
+    fallbackStdoutForEvent,
     groupHasClawdMarker,
     hasAntigravityConfig,
     normalizeSettings,
     resolveAntigravityNodeBin,
+    withFailOpenShellFallback,
   },
 };
 

--- a/hooks/antigravity-install.js
+++ b/hooks/antigravity-install.js
@@ -11,7 +11,6 @@ const {
   writeJsonAtomic,
   writeJsonAtomicWithBackup,
   asarUnpackedPath,
-  formatNodeHookCommand,
   decodeWindowsEncodedCommand,
   extractFirstQuotedToken,
   windowsPowerShellBin,
@@ -35,6 +34,7 @@ const ANTIGRAVITY_HOOK_EVENTS = [
   "Stop",
 ];
 const DEFAULT_HOOK_TIMEOUT_SECONDS = 10;
+const FAIL_OPEN_CHILD_TIMEOUT_SECONDS = 8;
 
 function fallbackStdoutForEvent(event) {
   return stdoutForAntigravityEvent(event);
@@ -48,27 +48,144 @@ function quotePowerShellSingleArg(value) {
   return `'${String(value).replace(/'/g, "''")}'`;
 }
 
-function withFailOpenShellFallback(command, event) {
+function normalizeFailOpenTimeoutSeconds(options = {}) {
+  const raw = Number(options.failOpenTimeoutSeconds);
+  if (Number.isFinite(raw) && raw > 0) return Math.max(1, Math.floor(raw));
+  return FAIL_OPEN_CHILD_TIMEOUT_SECONDS;
+}
+
+function quoteWindowsProcessArg(value) {
+  const text = String(value);
+  if (text && !/[\s"]/u.test(text)) return text;
+  let out = '"';
+  let backslashes = 0;
+  for (const ch of text) {
+    if (ch === "\\") {
+      backslashes++;
+      continue;
+    }
+    if (ch === '"') {
+      out += "\\".repeat((backslashes * 2) + 1);
+      out += '"';
+      backslashes = 0;
+      continue;
+    }
+    out += "\\".repeat(backslashes);
+    backslashes = 0;
+    out += ch;
+  }
+  out += "\\".repeat(backslashes * 2);
+  out += '"';
+  return out;
+}
+
+function withFailOpenShellFallback(command, event, nodeBin, options = {}) {
   const fallback = quoteShellSingleArg(fallbackStdoutForEvent(event));
-  return `out=$(${command} 2>/dev/null); status=$?; if [ "$status" -eq 0 ] && [ -n "$out" ]; then printf '%s\\n' "$out"; else printf '%s\\n' ${fallback}; fi; exit 0`;
+  const timeoutSeconds = normalizeFailOpenTimeoutSeconds(options);
+  const validatorScript = [
+    "let s='';",
+    "process.stdin.setEncoding('utf8');",
+    "process.stdin.on('data',c=>s+=c);",
+    "process.stdin.on('end',()=>{",
+    "try{const v=JSON.parse(s);if(!v||typeof v!=='object'||Array.isArray(v))process.exit(1);}",
+    "catch{process.exit(1);}",
+    "});",
+  ].join("");
+  const validatorCommand = [
+    nodeBin,
+    "-e",
+    validatorScript,
+  ].map(quoteShellSingleArg).join(" ");
+  return [
+    "tmp_dir=${TMPDIR:-/tmp}",
+    "in_file=$(mktemp \"$tmp_dir/clawd-agy-in.XXXXXX\" 2>/dev/null || printf '%s/clawd-agy-in-%s' \"$tmp_dir\" \"$$\")",
+    "out_file=$(mktemp \"$tmp_dir/clawd-agy-out.XXXXXX\" 2>/dev/null || printf '%s/clawd-agy-out-%s' \"$tmp_dir\" \"$$\")",
+    "pid=",
+    "watchdog=",
+    "cleanup(){ [ -n \"$watchdog\" ] && kill \"$watchdog\" 2>/dev/null; [ -n \"$pid\" ] && kill \"$pid\" 2>/dev/null; rm -f \"$in_file\" \"$out_file\"; }",
+    "trap cleanup EXIT HUP INT TERM",
+    "cat > \"$in_file\" 2>/dev/null || :",
+    `${command} < "$in_file" > "$out_file" 2>/dev/null & pid=$!`,
+    `( sleep ${timeoutSeconds}; kill "$pid" 2>/dev/null ) & watchdog=$!`,
+    "wait \"$pid\" 2>/dev/null",
+    "status=$?",
+    "kill \"$watchdog\" 2>/dev/null",
+    "wait \"$watchdog\" 2>/dev/null",
+    "pid=",
+    "watchdog=",
+    "out=$(cat \"$out_file\" 2>/dev/null)",
+    `if [ "$status" -eq 0 ] && [ -n "$out" ] && printf '%s' "$out" | ${validatorCommand} 2>/dev/null; then printf '%s\\n' "$out"; else printf '%s\\n' ${fallback}; fi`,
+    "exit 0",
+  ].join("; ");
 }
 
 function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, options = {}) {
   const fallback = fallbackStdoutForEvent(event);
+  const timeoutMs = normalizeFailOpenTimeoutSeconds(options) * 1000;
+  const childArgs = [
+    quoteWindowsProcessArg(hookScript),
+    quoteWindowsProcessArg(event),
+  ].join(" ");
   const psCommand = [
     "$ErrorActionPreference='SilentlyContinue'",
+    ";",
+    "$ProgressPreference='SilentlyContinue'",
     ";",
     "$text=''",
     ";",
     "try {",
-    "$out = &",
-    quotePowerShellSingleArg(nodeBin),
-    quotePowerShellSingleArg(hookScript),
-    quotePowerShellSingleArg(event),
-    "2>$null",
+    "$psi = New-Object System.Diagnostics.ProcessStartInfo",
     ";",
-    "if (($LASTEXITCODE -eq 0) -and ($null -ne $out)) { $text=($out -join [Environment]::NewLine) }",
+    "$psi.FileName =",
+    quotePowerShellSingleArg(nodeBin),
+    ";",
+    "$psi.Arguments =",
+    quotePowerShellSingleArg(childArgs),
+    ";",
+    "$psi.UseShellExecute = $false",
+    ";",
+    "$psi.RedirectStandardInput = $true",
+    ";",
+    "$psi.RedirectStandardOutput = $true",
+    ";",
+    "$psi.RedirectStandardError = $true",
+    ";",
+    "$psi.CreateNoWindow = $true",
+    ";",
+    "$proc = New-Object System.Diagnostics.Process",
+    ";",
+    "$proc.StartInfo = $psi",
+    ";",
+    "[void]$proc.Start()",
+    ";",
+    "$stdoutTask = $proc.StandardOutput.ReadToEndAsync()",
+    ";",
+    "$stderrTask = $proc.StandardError.ReadToEndAsync()",
+    ";",
+    "$stdinText = [Console]::In.ReadToEnd()",
+    ";",
+    "$proc.StandardInput.Write($stdinText)",
+    ";",
+    "$proc.StandardInput.Close()",
+    ";",
+    `if ($proc.WaitForExit(${timeoutMs})) {`,
+    "$proc.WaitForExit()",
+    ";",
+    "$out = $stdoutTask.Result",
+    ";",
+    "[void]$stderrTask.Result",
+    ";",
+    "if (($proc.ExitCode -eq 0) -and ($null -ne $out)) { $text=$out.TrimEnd(\"`r\", \"`n\") }",
+    "} else {",
+    "try { $proc.Kill() } catch {}",
+    ";",
+    "try { [void]$proc.WaitForExit(1000) } catch {}",
+    ";",
+    "$text=''",
+    "}",
     "} catch { $text='' }",
+    ";",
+    "if ($text.Length -gt 0) { $trimmed=$text.Trim(); if (($trimmed.Length -lt 2) -or ($trimmed[0] -ne '{') -or ($trimmed[$trimmed.Length - 1] -ne '}')) { $text='' } else { try { $null = ($text | ConvertFrom-Json -ErrorAction Stop) } catch { $text='' } } }",
     ";",
     "if ($text.Length -gt 0) { [Console]::Out.WriteLine($text) } else { [Console]::Out.WriteLine(",
     quotePowerShellSingleArg(fallback),
@@ -85,11 +202,11 @@ function buildAntigravityHookCommand(nodeBin, hookScript, event, options = {}) {
   if (platform === "win32") {
     return buildWindowsAntigravityHookCommand(nodeBin, hookScript, event, options);
   }
-  const command = formatNodeHookCommand(nodeBin, hookScript, {
-    ...options,
-    args: [event],
-  });
-  return withFailOpenShellFallback(command, event);
+  // Single-quote each argv at the shell level so a node/hook/event path that
+  // contains $ or backticks is never expanded by /bin/sh inside the $(...)
+  // capture. (formatNodeHookCommand double-quotes, which leaks expansion.)
+  const command = [nodeBin, hookScript, event].map(quoteShellSingleArg).join(" ");
+  return withFailOpenShellFallback(command, event, nodeBin, options);
 }
 
 function buildWindowsAntigravityHookCommand(nodeBin, hookScript, event, options = {}) {
@@ -286,6 +403,8 @@ module.exports = {
     extractExistingAntigravityNodeBin,
     extractNodeBinFromCommand,
     fallbackStdoutForEvent,
+    normalizeFailOpenTimeoutSeconds,
+    quoteWindowsProcessArg,
     groupHasClawdMarker,
     hasAntigravityConfig,
     normalizeSettings,

--- a/hooks/antigravity-stdout.js
+++ b/hooks/antigravity-stdout.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function stdoutForAntigravityEvent(hookName) {
+  if (hookName === "PreToolUse") return JSON.stringify({ decision: "ask" });
+  if (hookName === "Stop") return JSON.stringify({ decision: "allow" });
+  return "{}";
+}
+
+module.exports = {
+  stdoutForAntigravityEvent,
+};

--- a/src/doctor-detectors/agent-node-bin-parser.js
+++ b/src/doctor-detectors/agent-node-bin-parser.js
@@ -91,6 +91,61 @@ function tokenizeCommand(command) {
   return tokens;
 }
 
+function looksLikeNodeCandidate(value) {
+  const text = String(value || "");
+  const base = path.basename(text.replace(/\\/g, "/")).toLowerCase();
+  return base === "node" || base === "node.exe";
+}
+
+function looksLikeHookScriptToken(value) {
+  return typeof value === "string" && /\.js$/i.test(value);
+}
+
+function looksLikePrimaryHookScriptToken(value) {
+  return typeof value === "string" && /(?:^|[\\/])[^\\/]*hook\.js$/i.test(value);
+}
+
+function extractQuotedTokens(command) {
+  const tokens = [];
+  const quotedRe = /'((?:''|[^'])*)'|"((?:\\"|[^"])*)"/g;
+  let match;
+  while ((match = quotedRe.exec(String(command || "")))) {
+    if (match[1] !== undefined) tokens.push(match[1].replace(/''/g, "'"));
+    else tokens.push(match[2].replace(/\\"/g, "\"").replace(/\\\\/g, "\\"));
+  }
+  return tokens;
+}
+
+function parseNodeScriptPairFromTokens(tokens) {
+  if (!Array.isArray(tokens)) return null;
+  const skip = new Set(["&", "=", "try", "{", "}", ";"]);
+  const scriptIndexes = tokens
+    .map((token, index) => ({ token, index }))
+    .filter(({ token }) => looksLikePrimaryHookScriptToken(token));
+  if (!scriptIndexes.length) {
+    scriptIndexes.push(...tokens
+      .map((token, index) => ({ token, index }))
+      .filter(({ token }) => looksLikeHookScriptToken(token)));
+  }
+  for (const { index: i } of scriptIndexes) {
+    for (let j = i - 1; j >= 0; j--) {
+      const candidate = tokens[j];
+      if (!candidate || skip.has(candidate) || candidate.startsWith("$")) continue;
+      if (!looksLikeNodeCandidate(candidate)) continue;
+      return {
+        ok: true,
+        nodeBin: candidate,
+        scriptPath: tokens[i],
+      };
+    }
+  }
+  return null;
+}
+
+function parseNodeScriptPairFromQuotedText(command) {
+  return parseNodeScriptPairFromTokens(extractQuotedTokens(command));
+}
+
 function decodePowerShellEncodedCommand(command) {
   const withoutCmd = stripCmdWrapper(command);
   const withoutPsEnv = stripPowerShellEnvPrefix(withoutCmd);
@@ -117,6 +172,7 @@ function commandContainsFragment(command, fragment) {
 function parseHookCommand(command, depth = 0) {
   const withoutCmd = stripCmdWrapper(command);
   const withoutPsEnv = stripPowerShellEnvPrefix(withoutCmd);
+  const quotedSource = stripPowerShellCallOperator(withoutPsEnv).trim();
   const withoutPosixEnv = stripPosixEnvPrefix(withoutPsEnv);
   const normalized = stripPowerShellCallOperator(withoutPosixEnv).trim();
   const tokens = tokenizeCommand(normalized);
@@ -125,6 +181,21 @@ function parseHookCommand(command, depth = 0) {
       ok: false,
       issue: "parse-failed",
       fragment: String(command || "").slice(0, HOOK_COMMAND_FRAGMENT_MAX),
+    };
+  }
+
+  const quotedPair = parseNodeScriptPairFromQuotedText(quotedSource);
+  if (quotedPair) {
+    return {
+      ...quotedPair,
+      normalizedCommand: normalized,
+    };
+  }
+  const parsedPair = parseNodeScriptPairFromTokens(tokens);
+  if (parsedPair) {
+    return {
+      ...parsedPair,
+      normalizedCommand: normalized,
     };
   }
 

--- a/src/doctor-detectors/agent-node-bin-parser.js
+++ b/src/doctor-detectors/agent-node-bin-parser.js
@@ -119,15 +119,22 @@ function extractQuotedTokens(command) {
 function parseNodeScriptPairFromTokens(tokens) {
   if (!Array.isArray(tokens)) return null;
   const skip = new Set(["&", "=", "try", "{", "}", ";"]);
-  const scriptIndexes = tokens
-    .map((token, index) => ({ token, index }))
-    .filter(({ token }) => looksLikePrimaryHookScriptToken(token));
-  if (!scriptIndexes.length) {
-    scriptIndexes.push(...tokens
-      .map((token, index) => ({ token, index }))
-      .filter(({ token }) => looksLikeHookScriptToken(token)));
+  // A token consumed by a preload flag (--require/--import/--loader X) is NOT
+  // the hook script even when it ends in hook.js (e.g. a "pre-hook.js" preload).
+  const preloadFlags = new Set(["-r", "--require", "--import", "--loader", "--experimental-loader"]);
+  const consumed = new Set();
+  for (let k = 0; k < tokens.length - 1; k++) {
+    if (preloadFlags.has(tokens[k])) consumed.add(k + 1);
   }
-  for (const { index: i } of scriptIndexes) {
+  const pick = (pred) => tokens
+    .map((token, index) => ({ token, index }))
+    .filter(({ token, index }) => !consumed.has(index) && pred(token));
+  let scriptIndexes = pick(looksLikePrimaryHookScriptToken);
+  if (!scriptIndexes.length) scriptIndexes = pick(looksLikeHookScriptToken);
+  // Prefer the LAST matching script: the real hook script is the final
+  // positional argument, after any preload modules.
+  for (let s = scriptIndexes.length - 1; s >= 0; s--) {
+    const i = scriptIndexes[s].index;
     for (let j = i - 1; j >= 0; j--) {
       const candidate = tokens[j];
       if (!candidate || skip.has(candidate) || candidate.startsWith("$")) continue;
@@ -144,6 +151,27 @@ function parseNodeScriptPairFromTokens(tokens) {
 
 function parseNodeScriptPairFromQuotedText(command) {
   return parseNodeScriptPairFromTokens(extractQuotedTokens(command));
+}
+
+function extractPowerShellSingleQuotedAssignment(command, name) {
+  const pattern = new RegExp(`\\$psi\\.${name}\\s*=\\s*'((?:''|[^'])*)'`, "i");
+  const match = String(command || "").match(pattern);
+  return match ? match[1].replace(/''/g, "'") : null;
+}
+
+function parseProcessStartInfoNodePair(command) {
+  const nodeBin = extractPowerShellSingleQuotedAssignment(command, "FileName");
+  const args = extractPowerShellSingleQuotedAssignment(command, "Arguments");
+  if (!looksLikeNodeCandidate(nodeBin) || !args) return null;
+  const argTokens = tokenizeCommand(args);
+  if (!argTokens) return null;
+  const scriptToken = argTokens.find((token) => looksLikeHookScriptToken(token));
+  if (!scriptToken) return null;
+  return {
+    ok: true,
+    nodeBin,
+    scriptPath: scriptToken,
+  };
 }
 
 function decodePowerShellEncodedCommand(command) {
@@ -184,6 +212,13 @@ function parseHookCommand(command, depth = 0) {
     };
   }
 
+  const processStartInfoPair = parseProcessStartInfoNodePair(quotedSource);
+  if (processStartInfoPair) {
+    return {
+      ...processStartInfoPair,
+      normalizedCommand: normalized,
+    };
+  }
   const quotedPair = parseNodeScriptPairFromQuotedText(quotedSource);
   if (quotedPair) {
     return {

--- a/src/state.js
+++ b/src/state.js
@@ -222,6 +222,15 @@ function shouldMuteMiniPostCompletionNotification(state, event, session) {
     && !hasPermissionAnimationLock();
 }
 
+function shouldDropAntigravityPostStopToolUse(existing, state, event, agentId) {
+  return agentId === "antigravity-cli"
+    && event === "PostToolUse"
+    && state === "working"
+    && existing
+    && existing.awaitingInputSinceStop === true
+    && Number.isFinite(existing.lastStopAt);
+}
+
 // ── Qwen Code self-submit filter ──
 // qwen 0.16.1 fires a synthetic UserPromptSubmit ~900-1000ms after
 // PostToolUse to feed the tool result back to the model. Without filtering,
@@ -1205,6 +1214,14 @@ function updateSession(sessionId, state, event, opts = {}) {
     && isQwenSelfSubmitFilterEnabled()
   ) {
     debugSession(`qwen self-submit drop sid=${sessionId} elapsed=${Date.now() - existing.lastToolBoundaryAt}ms`);
+    return;
+  }
+
+  // Antigravity 1.0.6 can emit a trailing PostToolUse about a second after a
+  // fully-idle Stop for the same conversation. Treat it as stale so it does not
+  // resurrect the completed session into a permanent typing/working state.
+  if (shouldDropAntigravityPostStopToolUse(existing, state, event, srcAgentId)) {
+    debugSession(`antigravity trailing PostToolUse drop sid=${sessionId}`);
     return;
   }
 

--- a/test/antigravity-install.test.js
+++ b/test/antigravity-install.test.js
@@ -3,6 +3,7 @@ const assert = require("node:assert");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { spawnSync } = require("child_process");
 const {
   HOOK_GROUP_ID,
   MARKER,
@@ -70,6 +71,7 @@ describe("Antigravity hook installer", () => {
         : commands[0];
       assert.ok(commandText.includes(MARKER));
       assert.ok(commandText.includes(event));
+      assert.ok(commandText.includes("printf") || commandText.includes("[Console]::Out.WriteLine"));
     }
     // D2: PreToolUse intentionally NOT registered.
     assert.strictEqual(hooks[HOOK_GROUP_ID].PreToolUse, undefined);
@@ -197,7 +199,113 @@ describe("Antigravity hook installer", () => {
     assert.ok(Array.isArray(group.Stop));
   });
 
-  it("builds Windows PowerShell bridge commands with the event argv", () => {
+  it("fail-opens POSIX hook commands when Node cannot start", () => {
+    const command = __test.buildAntigravityHookCommand(
+      "/definitely/missing/node",
+      "/definitely/missing/antigravity-hook.js",
+      "PreInvocation",
+      { platform: "linux" }
+    );
+
+    const result = spawnSync("/bin/sh", ["-c", command], {
+      input: JSON.stringify({ conversationId: "c1" }),
+      encoding: "utf8",
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout.trim(), "{}");
+    assert.strictEqual(result.stderr, "");
+  });
+
+  it("fail-opens POSIX Stop hooks with an allow-shaped fallback", () => {
+    const command = __test.buildAntigravityHookCommand(
+      "/definitely/missing/node",
+      "/definitely/missing/antigravity-hook.js",
+      "Stop",
+      { platform: "linux" }
+    );
+
+    const result = spawnSync("/bin/sh", ["-c", command], {
+      input: JSON.stringify({ conversationId: "c1", fullyIdle: true }),
+      encoding: "utf8",
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: "allow" });
+    assert.strictEqual(result.stderr, "");
+  });
+
+  it("overrides partial POSIX hook stdout when Node exits nonzero", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-partial-"));
+    tempDirs.push(tmpDir);
+    const scriptPath = path.join(tmpDir, "partial-hook.js");
+    fs.writeFileSync(scriptPath, "process.stdout.write('{}\\n'); process.exit(1);\n", "utf8");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "linux" }
+    );
+
+    const result = spawnSync("/bin/sh", ["-c", command], {
+      input: JSON.stringify({ conversationId: "c1" }),
+      encoding: "utf8",
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout, "{}\n");
+    assert.strictEqual(result.stderr, "");
+  });
+
+  it("falls back when a POSIX hook exits successfully with empty stdout", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-empty-"));
+    tempDirs.push(tmpDir);
+    const scriptPath = path.join(tmpDir, "empty-hook.js");
+    fs.writeFileSync(scriptPath, "process.exit(0);\n", "utf8");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "linux" }
+    );
+
+    const result = spawnSync("/bin/sh", ["-c", command], {
+      input: JSON.stringify({ conversationId: "c1" }),
+      encoding: "utf8",
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout, "{}\n");
+    assert.strictEqual(result.stderr, "");
+  });
+
+  it("preserves successful POSIX multiline stdout and suppresses stderr", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-multiline-"));
+    tempDirs.push(tmpDir);
+    const scriptPath = path.join(tmpDir, "multiline-hook.js");
+    fs.writeFileSync(
+      scriptPath,
+      "process.stderr.write('noise\\n'); process.stdout.write('{\\n  \"ok\": true\\n}\\n');\n",
+      "utf8"
+    );
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "linux" }
+    );
+
+    const result = spawnSync("/bin/sh", ["-c", command], {
+      input: JSON.stringify({ conversationId: "c1" }),
+      encoding: "utf8",
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout, "{\n  \"ok\": true\n}\n");
+    assert.strictEqual(result.stderr, "");
+  });
+
+  it("builds Windows PowerShell bridge commands with fail-open fallback", () => {
     const command = __test.buildAntigravityHookCommand(
       "C:\\Program Files\\nodejs\\node.exe",
       "D:/clawd/hooks/antigravity-hook.js",
@@ -206,10 +314,12 @@ describe("Antigravity hook installer", () => {
     );
 
     assert.ok(command.startsWith("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand "));
-    assert.strictEqual(
-      decodeEncodedCommand(command),
-      "& 'C:\\Program Files\\nodejs\\node.exe' 'D:/clawd/hooks/antigravity-hook.js' 'PreToolUse'"
-    );
+    const decoded = decodeEncodedCommand(command);
+    assert.ok(decoded.includes("$ErrorActionPreference='SilentlyContinue'"));
+    assert.ok(decoded.includes("$out = & 'C:\\Program Files\\nodejs\\node.exe' 'D:/clawd/hooks/antigravity-hook.js' 'PreToolUse' 2>$null"));
+    assert.ok(decoded.includes("if (($LASTEXITCODE -eq 0) -and ($null -ne $out))"));
+    assert.ok(decoded.includes("[Console]::Out.WriteLine( '{\"decision\":\"ask\"}' )"));
+    assert.ok(decoded.endsWith("exit 0"));
   });
 
   it("uses an absolute node.exe for Windows Antigravity hooks", () => {
@@ -228,10 +338,9 @@ describe("Antigravity hook installer", () => {
     });
 
     const hooks = readJson(path.join(homeDir, ".gemini", "config", "hooks.json"));
-    assert.strictEqual(
-      decodeEncodedCommand(hooks[HOOK_GROUP_ID].PreInvocation[0].command),
-      `& '${nodeBin}' '${path.resolve(__dirname, "..", "hooks", "antigravity-hook.js").replace(/\\/g, "/")}' 'PreInvocation'`
-    );
+    const decoded = decodeEncodedCommand(hooks[HOOK_GROUP_ID].PreInvocation[0].command);
+    assert.ok(decoded.includes(`$out = & '${nodeBin}' '${path.resolve(__dirname, "..", "hooks", "antigravity-hook.js").replace(/\\/g, "/")}' 'PreInvocation' 2>$null`));
+    assert.ok(decoded.includes("[Console]::Out.WriteLine( '{}' )"));
   });
 
   it("finds node.exe with where.exe when the installer runs from Electron", () => {

--- a/test/antigravity-install.test.js
+++ b/test/antigravity-install.test.js
@@ -15,6 +15,11 @@ const {
 
 const tempDirs = [];
 
+// POSIX tests exec a real shell via /bin/sh (absent on Windows); Windows tests
+// spawn powershell.exe. Each is skipped on the platform where it cannot run.
+const posixOnly = { skip: process.platform === "win32" ? "requires POSIX /bin/sh" : false };
+const windowsOnly = { skip: process.platform !== "win32" ? "requires Windows PowerShell" : false };
+
 function makeTempHome({ withConfig = true } = {}) {
   const home = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-home-"));
   tempDirs.push(home);
@@ -35,6 +40,16 @@ function listCleanupBackups(filePath) {
 function decodeEncodedCommand(command) {
   const encoded = command.split(/\s+/).at(-1);
   return Buffer.from(encoded, "base64").toString("utf16le");
+}
+
+function runWindowsHookCommand(command, options = {}) {
+  const idx = command.indexOf(" -NoProfile");
+  assert.notStrictEqual(idx, -1, "expected PowerShell command");
+  return spawnSync(command.slice(0, idx), command.slice(idx + 1).split(/\s+/), {
+    input: options.input || JSON.stringify({ conversationId: "c1" }),
+    encoding: "utf8",
+    timeout: options.timeout,
+  });
 }
 
 afterEach(() => {
@@ -71,7 +86,7 @@ describe("Antigravity hook installer", () => {
         : commands[0];
       assert.ok(commandText.includes(MARKER));
       assert.ok(commandText.includes(event));
-      assert.ok(commandText.includes("printf") || commandText.includes("[Console]::Out.WriteLine"));
+      assert.ok(commandText.includes("printf") || commandText.includes("ProcessStartInfo"));
     }
     // D2: PreToolUse intentionally NOT registered.
     assert.strictEqual(hooks[HOOK_GROUP_ID].PreToolUse, undefined);
@@ -199,7 +214,7 @@ describe("Antigravity hook installer", () => {
     assert.ok(Array.isArray(group.Stop));
   });
 
-  it("fail-opens POSIX hook commands when Node cannot start", () => {
+  it("fail-opens POSIX hook commands when Node cannot start", posixOnly, () => {
     const command = __test.buildAntigravityHookCommand(
       "/definitely/missing/node",
       "/definitely/missing/antigravity-hook.js",
@@ -217,7 +232,7 @@ describe("Antigravity hook installer", () => {
     assert.strictEqual(result.stderr, "");
   });
 
-  it("fail-opens POSIX Stop hooks with an allow-shaped fallback", () => {
+  it("fail-opens POSIX Stop hooks with an allow-shaped fallback", posixOnly, () => {
     const command = __test.buildAntigravityHookCommand(
       "/definitely/missing/node",
       "/definitely/missing/antigravity-hook.js",
@@ -235,11 +250,11 @@ describe("Antigravity hook installer", () => {
     assert.strictEqual(result.stderr, "");
   });
 
-  it("overrides partial POSIX hook stdout when Node exits nonzero", () => {
+  it("overrides partial POSIX hook stdout when Node exits nonzero", posixOnly, () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-partial-"));
     tempDirs.push(tmpDir);
     const scriptPath = path.join(tmpDir, "partial-hook.js");
-    fs.writeFileSync(scriptPath, "process.stdout.write('{}\\n'); process.exit(1);\n", "utf8");
+    fs.writeFileSync(scriptPath, "process.stdout.write('PARTIAL-NOT-JSON'); process.exit(1);", "utf8");
     const command = __test.buildAntigravityHookCommand(
       process.execPath,
       scriptPath,
@@ -257,7 +272,7 @@ describe("Antigravity hook installer", () => {
     assert.strictEqual(result.stderr, "");
   });
 
-  it("falls back when a POSIX hook exits successfully with empty stdout", () => {
+  it("falls back when a POSIX hook exits successfully with empty stdout", posixOnly, () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-empty-"));
     tempDirs.push(tmpDir);
     const scriptPath = path.join(tmpDir, "empty-hook.js");
@@ -279,7 +294,7 @@ describe("Antigravity hook installer", () => {
     assert.strictEqual(result.stderr, "");
   });
 
-  it("preserves successful POSIX multiline stdout and suppresses stderr", () => {
+  it("preserves successful POSIX multiline stdout and suppresses stderr", posixOnly, () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-multiline-"));
     tempDirs.push(tmpDir);
     const scriptPath = path.join(tmpDir, "multiline-hook.js");
@@ -305,6 +320,125 @@ describe("Antigravity hook installer", () => {
     assert.strictEqual(result.stderr, "");
   });
 
+  it("falls back when a POSIX hook prints non-JSON on a zero exit", posixOnly, () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-nonjson-"));
+    tempDirs.push(tmpDir);
+    const scriptPath = path.join(tmpDir, "nonjson-hook.js");
+    fs.writeFileSync(scriptPath, "process.stdout.write('{bad}'); process.exit(0);", "utf8");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "linux" }
+    );
+
+    const result = spawnSync("/bin/sh", ["-c", command], {
+      input: JSON.stringify({ conversationId: "c1" }),
+      encoding: "utf8",
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout.trim(), "{}");
+    assert.strictEqual(result.stderr, "");
+  });
+
+  it("fails open when a POSIX hook exceeds the internal timeout", posixOnly, () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-timeout-"));
+    tempDirs.push(tmpDir);
+    const scriptPath = path.join(tmpDir, "timeout-hook.js");
+    fs.writeFileSync(scriptPath, "setTimeout(() => process.stdout.write('{}'), 5000);", "utf8");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "linux", failOpenTimeoutSeconds: 1 }
+    );
+
+    const started = Date.now();
+    const result = spawnSync("/bin/sh", ["-c", command], {
+      input: JSON.stringify({ conversationId: "c1" }),
+      encoding: "utf8",
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout.trim(), "{}");
+    assert.strictEqual(result.stderr, "");
+    assert.ok(Date.now() - started < 4000, "wrapper should not wait for the child timer");
+  });
+
+  it("fail-opens Windows hook commands when Node cannot start", windowsOnly, () => {
+    const command = __test.buildAntigravityHookCommand(
+      "C:/definitely/missing/node.exe",
+      "C:/definitely/missing/antigravity-hook.js",
+      "PreInvocation",
+      { platform: "win32" }
+    );
+    const result = runWindowsHookCommand(command);
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout.trim(), "{}");
+  });
+
+  it("falls back on Windows when the hook prints non-JSON on a zero exit", windowsOnly, () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-winjson-"));
+    tempDirs.push(tmpDir);
+    const scriptPath = path.join(tmpDir, "antigravity-hook.js");
+    fs.writeFileSync(scriptPath, "process.stdout.write('{bad}'); process.exit(0);", "utf8");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "win32" }
+    );
+    const result = runWindowsHookCommand(command);
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout.trim(), "{}");
+  });
+
+  it("preserves successful Windows hook stdout and suppresses stderr", windowsOnly, () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-winok-"));
+    tempDirs.push(tmpDir);
+    const scriptPath = path.join(tmpDir, "antigravity-hook.js");
+    fs.writeFileSync(
+      scriptPath,
+      "process.stderr.write('noise\\n'); process.stdout.write('{\\n  \"ok\": true\\n}\\n');",
+      "utf8"
+    );
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "win32" }
+    );
+
+    const result = runWindowsHookCommand(command);
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout.trim().replace(/\r\n/g, "\n"), "{\n  \"ok\": true\n}");
+    assert.strictEqual(result.stderr, "");
+  });
+
+  it("fails open when a Windows hook exceeds the internal timeout", windowsOnly, () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-wintimeout-"));
+    tempDirs.push(tmpDir);
+    const scriptPath = path.join(tmpDir, "antigravity-hook.js");
+    fs.writeFileSync(scriptPath, "setTimeout(() => process.stdout.write('{}'), 5000);", "utf8");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "win32", failOpenTimeoutSeconds: 1 }
+    );
+
+    const started = Date.now();
+    const result = runWindowsHookCommand(command, { timeout: 4000 });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout.trim(), "{}");
+    assert.ok(Date.now() - started < 4000, "wrapper should not wait for the child timer");
+  });
+
   it("builds Windows PowerShell bridge commands with fail-open fallback", () => {
     const command = __test.buildAntigravityHookCommand(
       "C:\\Program Files\\nodejs\\node.exe",
@@ -316,8 +450,11 @@ describe("Antigravity hook installer", () => {
     assert.ok(command.startsWith("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand "));
     const decoded = decodeEncodedCommand(command);
     assert.ok(decoded.includes("$ErrorActionPreference='SilentlyContinue'"));
-    assert.ok(decoded.includes("$out = & 'C:\\Program Files\\nodejs\\node.exe' 'D:/clawd/hooks/antigravity-hook.js' 'PreToolUse' 2>$null"));
-    assert.ok(decoded.includes("if (($LASTEXITCODE -eq 0) -and ($null -ne $out))"));
+    assert.ok(decoded.includes("$psi = New-Object System.Diagnostics.ProcessStartInfo"));
+    assert.ok(decoded.includes("$psi.FileName = 'C:\\Program Files\\nodejs\\node.exe'"));
+    assert.ok(decoded.includes("$psi.Arguments = 'D:/clawd/hooks/antigravity-hook.js PreToolUse'"));
+    assert.ok(decoded.includes("if ($proc.WaitForExit(8000))"));
+    assert.ok(decoded.includes("ConvertFrom-Json -ErrorAction Stop"));
     assert.ok(decoded.includes("[Console]::Out.WriteLine( '{\"decision\":\"ask\"}' )"));
     assert.ok(decoded.endsWith("exit 0"));
   });
@@ -339,7 +476,8 @@ describe("Antigravity hook installer", () => {
 
     const hooks = readJson(path.join(homeDir, ".gemini", "config", "hooks.json"));
     const decoded = decodeEncodedCommand(hooks[HOOK_GROUP_ID].PreInvocation[0].command);
-    assert.ok(decoded.includes(`$out = & '${nodeBin}' '${path.resolve(__dirname, "..", "hooks", "antigravity-hook.js").replace(/\\/g, "/")}' 'PreInvocation' 2>$null`));
+    assert.ok(decoded.includes(`$psi.FileName = '${nodeBin}'`));
+    assert.ok(decoded.includes(`$psi.Arguments = '${path.resolve(__dirname, "..", "hooks", "antigravity-hook.js").replace(/\\/g, "/")} PreInvocation'`));
     assert.ok(decoded.includes("[Console]::Out.WriteLine( '{}' )"));
   });
 

--- a/test/doctor-node-bin-parser.test.js
+++ b/test/doctor-node-bin-parser.test.js
@@ -82,6 +82,39 @@ describe("doctor hook command parser", () => {
     );
   });
 
+  it("validates POSIX Antigravity fail-open capture commands", () => {
+    const nodeBin = "/usr/local/bin/node";
+    const scriptPath = "/opt/clawd/hooks/antigravity-hook.js";
+    const command = antigravityInstallTest.buildAntigravityHookCommand(
+      nodeBin,
+      scriptPath,
+      "PreInvocation",
+      { platform: "linux" }
+    );
+
+    assert.deepStrictEqual(
+      validateHookCommand(command, {
+        platform: "linux",
+        fs: fakeFs([nodeBin, scriptPath]),
+      }),
+      { ok: true, nodeBin, scriptPath }
+    );
+  });
+
+  it("does not mistake preload scripts for the hook script", () => {
+    const nodeBin = "/usr/local/bin/node";
+    const scriptPath = "/opt/clawd/hooks/antigravity-hook.js";
+    const command = `"${nodeBin}" "--require" "./pre.js" "${scriptPath}"`;
+
+    assert.deepStrictEqual(
+      validateHookCommand(command, {
+        platform: "linux",
+        fs: fakeFs([nodeBin, scriptPath]),
+      }),
+      { ok: true, nodeBin, scriptPath }
+    );
+  });
+
   it("unwraps Windows cmd /d /s /c commands", () => {
     const nodeBin = "C:\\Program Files\\nodejs\\node.exe";
     const scriptPath = "D:/animation/hooks/codex-debug-hook.js";

--- a/test/doctor-node-bin-parser.test.js
+++ b/test/doctor-node-bin-parser.test.js
@@ -82,6 +82,28 @@ describe("doctor hook command parser", () => {
     );
   });
 
+  it("validates EncodedCommand ProcessStartInfo args when the hook path has spaces", () => {
+    const nodeBin = "C:\\Program Files\\nodejs\\node.exe";
+    const scriptPath = "D:/Program Files/Clawd/hooks/antigravity-hook.js";
+    const command = antigravityInstallTest.buildWindowsAntigravityHookCommand(
+      nodeBin,
+      scriptPath,
+      "PreInvocation",
+      {
+        platform: "win32",
+        powerShellBin: "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe",
+      }
+    );
+
+    assert.deepStrictEqual(
+      validateHookCommand(command, {
+        platform: "win32",
+        fs: fakeFs([nodeBin, scriptPath]),
+      }),
+      { ok: true, nodeBin, scriptPath }
+    );
+  });
+
   it("validates POSIX Antigravity fail-open capture commands", () => {
     const nodeBin = "/usr/local/bin/node";
     const scriptPath = "/opt/clawd/hooks/antigravity-hook.js";

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -2888,3 +2888,74 @@ describe("qwen-code self-submit filter", () => {
     assert.strictEqual(after.state, "thinking", "out-of-range env must fall back to default 2000ms (not honored)");
   });
 });
+
+// ═════════════════════════════════════════════════════════════════════════════
+// Antigravity 1.0.6 can emit a trailing PostToolUse after Stop. Once Stop has
+// marked the session awaiting input, that stale tool boundary must not resurrect
+// the mascot into a stuck typing/working state.
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("antigravity trailing PostToolUse filter", () => {
+  let api, ctx;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx();
+    api = require("../src/state")(ctx);
+  });
+  afterEach(() => {
+    api.cleanup();
+    mock.timers.reset();
+  });
+
+  function finishAntigravityTurn() {
+    update(api, { id: "agid", state: "thinking", event: "UserPromptSubmit", agentId: "antigravity-cli" });
+    mock.timers.tick(100);
+    update(api, { id: "agid", state: "working", event: "PostToolUse", agentId: "antigravity-cli" });
+    mock.timers.tick(100);
+    update(api, { id: "agid", state: "idle", event: "AfterAgent", agentId: "antigravity-cli" });
+    mock.timers.tick(100);
+    update(api, { id: "agid", state: "attention", event: "Stop", agentId: "antigravity-cli" });
+    const afterStop = api.sessions.get("agid");
+    assert.ok(afterStop, "Antigravity session should exist after Stop");
+    assert.strictEqual(afterStop.state, "idle");
+    assert.strictEqual(afterStop.awaitingInputSinceStop, true);
+    assert.ok(Number.isFinite(afterStop.lastStopAt), "Stop should bump lastStopAt");
+    return afterStop;
+  }
+
+  it("drops PostToolUse that arrives after a fully-idle Stop", () => {
+    const before = finishAntigravityTurn();
+    const snapshot = {
+      state: before.state,
+      updatedAt: before.updatedAt,
+      recentEvents: [...(before.recentEvents || [])],
+      lastToolBoundaryAt: before.lastToolBoundaryAt,
+      lastStopAt: before.lastStopAt,
+    };
+
+    mock.timers.tick(1200);
+    update(api, { id: "agid", state: "working", event: "PostToolUse", agentId: "antigravity-cli" });
+
+    const after = api.sessions.get("agid");
+    assert.strictEqual(after.state, "idle", "stale PostToolUse must not resurrect working");
+    assert.strictEqual(after.updatedAt, snapshot.updatedAt, "dropped event must not bump updatedAt");
+    assert.deepStrictEqual(after.recentEvents, snapshot.recentEvents, "dropped event must not append history");
+    assert.strictEqual(after.lastToolBoundaryAt, snapshot.lastToolBoundaryAt, "dropped event must not refresh tool boundary");
+    assert.strictEqual(after.lastStopAt, snapshot.lastStopAt, "dropped event must preserve Stop timestamp");
+  });
+
+  it("allows PostToolUse after a new user prompt starts the next turn", () => {
+    finishAntigravityTurn();
+
+    mock.timers.tick(500);
+    update(api, { id: "agid", state: "thinking", event: "UserPromptSubmit", agentId: "antigravity-cli" });
+    mock.timers.tick(100);
+    update(api, { id: "agid", state: "working", event: "PostToolUse", agentId: "antigravity-cli" });
+
+    const after = api.sessions.get("agid");
+    assert.strictEqual(after.state, "working");
+    assert.strictEqual(after.awaitingInputSinceStop, false);
+    assert.ok(after.lastToolBoundaryAt > after.lastStopAt, "new turn should refresh tool boundary after Stop");
+  });
+});


### PR DESCRIPTION
## Summary

This PR hardens the Antigravity CLI hook registration so Clawd-managed hooks fail open instead of letting agy retry forever when the launcher command fails before the hook script can run.

## What changed

- Wrap POSIX Antigravity hook commands with stdout capture, stderr suppression, and an explicit fallback JSON output before `exit 0`.
- Wrap Windows Antigravity hooks inside an encoded PowerShell bridge that falls back based on `$LASTEXITCODE` and captured stdout.
- Share Antigravity fallback stdout through `hooks/antigravity-stdout.js` so installer fallback output and hook-script output stay aligned.
- Harden doctor hook-command parsing so fail-open wrappers still resolve the real Node binary and hook script, without mistaking preload scripts for hook scripts.
- Expand installer and doctor tests around missing Node, empty stdout, partial stdout with nonzero exit, multiline stdout, Windows EncodedCommand output, and parser round-trips.

## Why

A reported Antigravity failure showed `jsonhook__clawd_PreInvocation_0_0` exiting with status 1 and empty stderr before the agent could proceed. The hook script itself already fails open once it starts, so this covers the earlier launcher layer as well.

## Validation

- `node --test test/antigravity-install.test.js test/antigravity-hook.test.js test/doctor-node-bin-parser.test.js test/doctor-agent-integrations.test.js`
- `git diff --check`

## Follow-up verification

Windows PowerShell 5.1 / 7 behavior and a real Antigravity repro-machine pull still need manual confirmation before merging.