### PR TITLE
Fix duplicated v prefix in update labels

### DIFF
--- a/src/settings-tab-about.js
+++ b/src/settings-tab-about.js
@@ -10,6 +10,10 @@
     return helpers.t(key);
   }
 
+  function formatVersionForMessage(version) {
+    return String(version || "").replace(/^v/i, "");
+  }
+
   // #329: getAboutInfo() now returns dynamic fields (pendingUpdateVersion,
   // autoUpdateCheck) alongside the static identity fields. The static
   // parts (heroSvgContent, license, copyright, etc.) are still safe to
@@ -245,7 +249,10 @@
       if (safe.pendingUpdateVersion) {
         const hint = document.createElement("span");
         hint.className = "about-update-hint";
-        hint.textContent = "· " + t("aboutUpdateAvailableHint").replace("{version}", safe.pendingUpdateVersion);
+        hint.textContent = "· " + t("aboutUpdateAvailableHint").replace(
+          "{version}",
+          formatVersionForMessage(safe.pendingUpdateVersion)
+        );
         hint.style.cursor = "pointer";
         hint.addEventListener("click", () => {
           if (!window.settingsAPI || typeof window.settingsAPI.checkForUpdates !== "function") return;

--- a/src/updater.js
+++ b/src/updater.js
@@ -4,7 +4,6 @@ const path = require("path");
 const fs = require("fs");
 const electron = require("electron");
 
-const isMac = process.platform === "darwin";
 const RELEASES_LATEST_URL = "https://github.com/rullerzhou-afk/clawd-on-desk/releases/latest";
 
 function makeTranslate(ctx) {
@@ -97,6 +96,7 @@ function initUpdater(ctx, deps = {}) {
   const t = makeTranslate(ctx);
   const runtimePlatform = deps.platform || process.platform;
   const runtimeArch = deps.arch || process.arch;
+  const isMac = runtimePlatform === "darwin";
 
   let updateStatus = "idle";
   // activeCheck carries the current in-flight check context. trigger:
@@ -375,11 +375,12 @@ function initUpdater(ctx, deps = {}) {
   }
 
   async function showUpToDateBubble(version) {
+    const displayVersion = formatVersionForMessage(version);
     clearOverlay();
     return showInfoBubble(
       "up-to-date",
       t("updateNotAvailable", "You're Up to Date"),
-      t("updateNotAvailableMsg", "Clawd v{version} is the latest version.").replace("{version}", version),
+      t("updateNotAvailableMsg", "Clawd v{version} is the latest version.").replace("{version}", displayVersion),
       {
         version,
         actions: [{ id: "dismiss", label: t("dismiss", "Dismiss"), variant: "secondary" }],
@@ -617,6 +618,7 @@ function initUpdater(ctx, deps = {}) {
   //          user never made.
   async function handlePendingVersion(version, release, promptCtx = { trigger: "scheduled" }) {
     if (!version) return;
+    const displayVersion = formatVersionForMessage(version);
 
     // Always record the pending version so the tray label / About hint
     // reflect reality, even if we end up not showing the bubble.
@@ -634,16 +636,15 @@ function initUpdater(ctx, deps = {}) {
     // pet does not get stuck masking working/thinking.
     pulseState("notification");
 
-    const isMacUi = process.platform === "darwin";
-    const primaryLabel = isMacUi ? t("download", "Download") : t("updateNow", "Update Now");
-    const messageKey = isMacUi
+    const primaryLabel = isMac ? t("download", "Download") : t("updateNow", "Update Now");
+    const messageKey = isMac
       ? t("updateAvailableMacMsg", "v{version} is available. Open the download page?")
       : t("updateAvailableMsg", "v{version} is available. Download and install now?");
 
     const result = await awaitBubbleResult(showBubble({
       mode: "available",
       title: t("updateAvailable", "Update Available"),
-      message: messageKey.replace("{version}", version),
+      message: messageKey.replace("{version}", displayVersion),
       version,
       actions: [
         { id: "primary", label: primaryLabel, variant: "primary" },
@@ -702,6 +703,7 @@ function initUpdater(ctx, deps = {}) {
   }
 
   async function promptAvailableUpdate({ mode, version, onPrimary }) {
+    const displayVersion = formatVersionForMessage(version);
     const primaryLabel = mode === "git"
       ? t("updateNow", "Update Now")
       : t("download", "Download");
@@ -711,7 +713,7 @@ function initUpdater(ctx, deps = {}) {
       message: (mode === "mac"
         ? t("updateAvailableMacMsg", "v{version} is available. Open the download page?")
         : t("updateAvailableMsg", "v{version} is available. Download and install now?"))
-        .replace("{version}", version),
+        .replace("{version}", displayVersion),
       version,
       actions: [
         { id: "primary", label: primaryLabel, variant: "primary" },
@@ -732,11 +734,12 @@ function initUpdater(ctx, deps = {}) {
   }
 
   async function promptReadyUpdate(version, onPrimary) {
+    const displayVersion = formatVersionForMessage(version);
     pulseSuccessState();
     const action = await awaitBubbleAction(showBubble({
       mode: "ready",
       title: t("updateReady", "Update Ready"),
-      message: t("updateReadyMsg", "v{version} has been downloaded. Restart now to update?").replace("{version}", version),
+      message: t("updateReadyMsg", "v{version} has been downloaded. Restart now to update?").replace("{version}", displayVersion),
       version,
       actions: [
         { id: "primary", label: t("restartNow", "Restart Now"), variant: "primary" },
@@ -845,7 +848,7 @@ function initUpdater(ctx, deps = {}) {
           execFileFn("npm", ["install", "--no-fund", "--no-audit"], {
             cwd: repoRoot,
             timeout: 120000,
-            shell: process.platform === "win32",
+            shell: runtimePlatform === "win32",
           }, (err) => (err ? reject(err) : resolve()));
         });
       } catch (err) {
@@ -1309,7 +1312,7 @@ function initUpdater(ctx, deps = {}) {
       default:
         if (pendingUpdateVersion) {
           return t("checkForUpdatesPending", "Update available · v{version}")
-            .replace("{version}", pendingUpdateVersion);
+            .replace("{version}", formatVersionForMessage(pendingUpdateVersion));
         }
         return t("checkForUpdates", "Check for Updates");
     }

--- a/test/updater.test.js
+++ b/test/updater.test.js
@@ -542,6 +542,7 @@ describe("updater visual flow", () => {
       },
     });
     const updater = initUpdater(ctx, makeDeps({
+      platform: "win32",
       autoUpdaterFactory: () => ({
         autoDownload: false,
         autoInstallOnAppQuit: true,
@@ -1352,6 +1353,29 @@ describe("updater #329 background scheduler", () => {
     assert.deepStrictEqual(prefs.snapshot().dismissedUpdateVersions, {});
     // Pending version is still recorded so the menu badge can show.
     assert.strictEqual(prefs.snapshot().pendingUpdateVersion, "v0.9.0");
+  });
+
+  it("formats pending update menu labels without duplicating the release tag v prefix", async () => {
+    const prefs = makePrefs();
+    const bubbles = [];
+    const ctx = makeCtxWithPrefs(prefs, {
+      t: (key) => key === "checkForUpdatesPending" ? "有新版本 · v{version}" : key,
+      showUpdateBubble: (payload) => {
+        bubbles.push(payload);
+        return Promise.resolve({ action: "later", source: "autoClose" });
+      },
+    });
+    const updater = initUpdater(ctx, makeDeps({
+      app: { isPackaged: true, getVersion: () => "0.5.0", relaunch() {}, exit() {} },
+    }));
+
+    await updater.handlePendingVersion("v0.9.0", { tag_name: "v0.9.0" }, { trigger: "scheduled" });
+
+    assert.strictEqual(prefs.snapshot().pendingUpdateVersion, "v0.9.0");
+    assert.strictEqual(updater.getUpdateMenuLabel(), "有新版本 · v0.9.0");
+    assert.doesNotMatch(updater.getUpdateMenuLabel(), /vv0\.9\.0/);
+    assert.strictEqual(bubbles[0].version, "v0.9.0");
+    assert.doesNotMatch(bubbles[0].message, /vv0\.9\.0/);
   });
 
   it("handlePendingVersion: source=policy later → NO dedupe entry", async () => {


### PR DESCRIPTION
## Summary

- Normalize release tags only for update UI copy so v0.9.0 displays as v0.9.0, not vv0.9.0.
- Keep the internal pending update version stored as the original release tag for compare, dismiss, and persistence behavior.
- Apply the same display formatting to the About pending update hint.

Fixes #429.

## Checks

- node --test test/updater.test.js
- node --check src/updater.js
- node --check src/settings-tab-about.js
- git diff --check