### PR TITLE
fix(launch-claude): Windows new-session 0x800700c1 — resolve claude.cmd shim & route wt.exe via cmd.exe

### DIFF
--- a/src/launch-claude.js
+++ b/src/launch-claude.js
@@ -91,28 +91,51 @@ function tryLaunch(bin, args, opts) {
   });
 }
 
-function findClaudeCmd(plat = platform()) {
+function findClaudeCmd(plat = platform(), deps = {}) {
+  const _execFileSync = deps.execFileSync || execFileSync;
+  const _existsSync = deps.existsSync || fs.existsSync;
+
   // 1. Try system PATH lookup
   try {
     const cmd = plat === "win32" ? "where" : "which";
-    const out = execFileSync(cmd, ["claude"], {
+    const out = _execFileSync(cmd, ["claude"], {
       encoding: "utf8",
       timeout: 5000,
       windowsHide: true,
     });
-    const lines = out.trim().split(/\r?\n/);
-    for (const line of lines) {
-      const p = line.trim();
-      if (p && fs.existsSync(p)) return p;
+    const existing = out
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((p) => p && _existsSync(p));
+    if (plat === "win32") {
+      // npm installs `claude` as BOTH an extensionless POSIX shell script and a
+      // launchable shim (claude.cmd) in the same directory, and `where claude`
+      // can list the extensionless script first. Handing that script to a
+      // terminal raises ERROR_BAD_EXE_FORMAT (0x800700c1): it is not a PE/Win32
+      // image, and nothing in our launch path (wt/cmd/powershell) runs POSIX
+      // scripts. So prefer a Windows-launchable extension; if `where` surfaced
+      // only the extensionless script, probe for its launchable sibling. Only
+      // when neither exists do we fall through to the stage-2 npm locations
+      // rather than returning the unrunnable script.
+      const launchable = existing.find((p) => /\.(com|exe|bat|cmd)$/i.test(p));
+      if (launchable) return launchable;
+      for (const p of existing) {
+        for (const ext of [".cmd", ".exe", ".bat", ".com"]) {
+          if (_existsSync(p + ext)) return p + ext;
+        }
+      }
+    } else if (existing.length) {
+      return existing[0];
     }
   } catch {}
 
-  // 2. Check common npm global install locations
+  // 2. Check common npm global install locations. On Windows we only offer the
+  // launchable .cmd shim — never the extensionless POSIX script (see above).
   const candidates = [];
   if (plat === "win32") {
     candidates.push(
       path.join(process.env.APPDATA || "", "npm", "claude.cmd"),
-      path.join(process.env.APPDATA || "", "npm", "claude"),
       path.join(process.env.LOCALAPPDATA || "", "npm", "claude.cmd"),
     );
   } else {
@@ -123,10 +146,12 @@ function findClaudeCmd(plat = platform()) {
     );
   }
   for (const p of candidates) {
-    if (fs.existsSync(p)) return p;
+    if (_existsSync(p)) return p;
   }
 
-  // 3. Fallback: return "claude" and let the shell resolve it
+  // 3. Fallback: return "claude" and let the shell resolve it. cmd.exe (the
+  // wt/cmd launch layer) resolves a bare name through PATHEXT and so still
+  // picks the .cmd shim over the extensionless script.
   return "claude";
 }
 
@@ -157,8 +182,27 @@ function buildTerminalCandidates(claudePath, claudeArgs, plat = platform()) {
     const cmdLine = buildCmdLaunchCommand(claudePath, claudeArgs);
     // powershell.exe -Command: call operator `&` + single-quoted PS strings.
     const psCmd = "& " + [claudePath, ...claudeArgs].map(quoteForPowerShell).join(" ");
+    // wt.exe runs its commandline through CreateProcess (no shell), which cannot
+    // execute an npm .cmd/.bat shim or an extensionless POSIX script directly —
+    // that raises ERROR_BAD_EXE_FORMAT (0x800700c1). Route the tab through
+    // cmd.exe (a real PE), which resolves and runs the shim.
+    //
+    // Two quoting hazards, both neutralized by the `call "<path>"` prefix:
+    //  - Windows Terminal re-tokenizes the args after `--` and re-quotes only
+    //    those containing spaces, so we can't rely on our own quotes surviving
+    //    verbatim (windowsVerbatimArguments only protects the Node->wt hop).
+    //  - cmd.exe's /K strips a *leading* quote unless a narrow preserve rule
+    //    holds, which breaks paths like `C:\Program Files (x86)\...`.
+    // Prefixing `call` means the /K command never begins with a quote, so cmd
+    // keeps the quoted path intact whether wt forwarded it raw or re-quoted it.
+    // (We still avoid cmdLine's `/s ""..""` idiom: cmd.exe understands it but
+    // wt's tokenizer mangles it.) This path still needs real-Windows validation.
     return [
-      { bin: "wt.exe", args: ["--", claudePath, ...claudeArgs] },
+      {
+        bin: "wt.exe",
+        args: ["--", "cmd.exe", "/d", "/v:off", "/k", "call", quoteCmdExecutablePath(claudePath), ...claudeArgs],
+        extraOpts: { shell: false, windowsVerbatimArguments: true },
+      },
       {
         bin: "cmd.exe",
         args: ["/d", "/v:off", "/s", "/k", cmdLine],

--- a/test/launch-claude.test.js
+++ b/test/launch-claude.test.js
@@ -15,6 +15,7 @@ const {
   quoteCmdExecutablePath,
   quoteForPowerShell,
   launchClaudeSession,
+  findClaudeCmd,
 } = require("../src/launch-claude");
 
 const WIN_PATH = "C:\\Program Files\\nodejs\\node_modules\\@anthropic\\claude.cmd";
@@ -108,16 +109,96 @@ describe("cmd executable quoting", () => {
   });
 });
 
+describe("findClaudeCmd", () => {
+  const NPM_DIR = "C:\\Users\\Tester\\AppData\\Roaming\\npm";
+  // `where`/`which` stub: emits the given paths as newline output.
+  const fakeWhere = (...paths) => ({ execFileSync: () => paths.join("\r\n") + "\r\n" });
+  // filesystem stub: only the listed paths "exist" (case-insensitive on Windows).
+  const fakeFs = (existing) => {
+    const set = new Set(existing.map((p) => String(p).toLowerCase()));
+    return { existsSync: (p) => set.has(String(p).toLowerCase()) };
+  };
+
+  it("Windows: prefers claude.cmd when `where` lists the extensionless script first", () => {
+    const ext = `${NPM_DIR}\\claude`;
+    const cmd = `${NPM_DIR}\\claude.cmd`;
+    const out = findClaudeCmd("win32", { ...fakeWhere(ext, cmd), ...fakeFs([ext, cmd]) });
+    assert.strictEqual(out, cmd, "must not return the 0x800700c1 POSIX shim");
+  });
+
+  it("Windows: never returns the extensionless POSIX shim, probing for a sibling", () => {
+    // `where` surfaced only the unrunnable script; its launchable sibling is
+    // right next to it. Returning `ext` here is the exact #435 bug.
+    const ext = `${NPM_DIR}\\claude`;
+    const cmd = `${NPM_DIR}\\claude.cmd`;
+    const out = findClaudeCmd("win32", { ...fakeWhere(ext), ...fakeFs([ext, cmd]) });
+    assert.strictEqual(out, cmd);
+  });
+
+  it("Windows: prefers a real claude.exe over the .cmd shim", () => {
+    const exe = `${NPM_DIR}\\claude.exe`;
+    const cmd = `${NPM_DIR}\\claude.cmd`;
+    const out = findClaudeCmd("win32", { ...fakeWhere(exe, cmd), ...fakeFs([exe, cmd]) });
+    assert.strictEqual(out, exe);
+  });
+
+  it("Windows: falls back to %APPDATA%\\npm\\claude.cmd when PATH lookup misses", () => {
+    const prev = process.env.APPDATA;
+    process.env.APPDATA = "C:\\Users\\Tester\\AppData\\Roaming";
+    try {
+      const cmd = path.join(process.env.APPDATA, "npm", "claude.cmd");
+      const out = findClaudeCmd("win32", {
+        execFileSync: () => { throw new Error("where: not found"); },
+        ...fakeFs([cmd]),
+      });
+      assert.strictEqual(out, cmd);
+    } finally {
+      if (prev === undefined) delete process.env.APPDATA;
+      else process.env.APPDATA = prev;
+    }
+  });
+
+  it("Windows: returns bare \"claude\" when nothing is found", () => {
+    const out = findClaudeCmd("win32", { execFileSync: () => "", existsSync: () => false });
+    assert.strictEqual(out, "claude");
+  });
+
+  it("Windows: passes through to stage 3 when only an extensionless shim exists (no sibling)", () => {
+    // No launchable variant anywhere — must NOT return the unrunnable script;
+    // falls through to bare \"claude\" for cmd.exe/PATHEXT to resolve.
+    const ext = `${NPM_DIR}\\claude`;
+    const out = findClaudeCmd("win32", { ...fakeWhere(ext), ...fakeFs([ext]) });
+    assert.strictEqual(out, "claude");
+  });
+
+  it("Windows: matches launchable extensions case-insensitively", () => {
+    const cmd = `${NPM_DIR}\\CLAUDE.CMD`;
+    const out = findClaudeCmd("win32", { ...fakeWhere(cmd), ...fakeFs([cmd]) });
+    assert.strictEqual(out, cmd);
+  });
+
+  it("POSIX: returns the first existing `which` result", () => {
+    const p = "/usr/local/bin/claude";
+    const out = findClaudeCmd("linux", { ...fakeWhere(p), ...fakeFs([p]) });
+    assert.strictEqual(out, p);
+  });
+});
+
 describe("buildTerminalCandidates - Windows", () => {
   it("orders fallbacks wt -> cmd -> powershell", () => {
     const cands = buildTerminalCandidates("claude", [], "win32");
     assert.deepStrictEqual(cands.map((c) => c.bin), ["wt.exe", "cmd.exe", "powershell.exe"]);
   });
 
-  it("wt.exe uses an argv array, no shell quoting needed", () => {
+  it("wt.exe routes through cmd.exe so Windows Terminal never execs a .cmd shim directly", () => {
     const cands = buildTerminalCandidates(WIN_PATH, ["--resume", "sid"], "win32");
     const wt = cands.find((c) => c.bin === "wt.exe");
-    assert.deepStrictEqual(wt.args, ["--", WIN_PATH, "--resume", "sid"]);
+    assert.deepStrictEqual(wt.args, [
+      "--", "cmd.exe", "/d", "/v:off", "/k", "call", `"${WIN_PATH}"`, "--resume", "sid",
+    ]);
+    // `call` keeps cmd's /K from stripping the leading quote; verbatim keeps the
+    // Node->wt hop from re-quoting. WT's own re-tokenization needs real Windows.
+    assert.deepStrictEqual(wt.extraOpts, { shell: false, windowsVerbatimArguments: true });
   });
 
   it("cmd.exe quotes a claude path with spaces", () => {
@@ -210,6 +291,59 @@ describe("buildTerminalCandidates - Windows", () => {
       assert.strictEqual(result.status, 0, detail);
       assert.deepStrictEqual(JSON.parse(result.stdout.trim()), claudeArgs, detail);
       assert.throws(() => buildClaudeArgs("resume", 'a" & echo injected & "b'), /Invalid Claude session ID/);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("round-trips a spaced + parenthesized .cmd shim through wt's cmd.exe layer", { skip: process.platform !== "win32" }, () => {
+    // Dir name carries BOTH a space and cmd-special chars `()` — the exact shape
+    // (`Program Files (x86)`) that strips quotes under plain `/k "..."`. The
+    // `call` prefix is what keeps it intact.
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "launch (x86) claude wt shim-"));
+    try {
+      const shimPath = path.join(tmpDir, "claude.cmd");
+      const echoPath = path.join(tmpDir, "echo-argv.js");
+      fs.writeFileSync(echoPath, 'console.log(JSON.stringify(process.argv.slice(2)));\n', "utf8");
+      fs.writeFileSync(
+        shimPath,
+        [
+          "@ECHO off",
+          "GOTO start",
+          ":find_dp0",
+          "SET dp0=%~dp0",
+          "EXIT /b",
+          ":start",
+          "SETLOCAL",
+          "CALL :find_dp0",
+          'SET "_prog=node"',
+          'endLocal & goto #_undefined_# 2>NUL || "%_prog%"  "%dp0%echo-argv.js" %*',
+          "",
+        ].join("\r\n"),
+        "utf8",
+      );
+
+      const claudeArgs = buildClaudeArgs("resume", "safe_sid-123");
+      const cands = buildTerminalCandidates(shimPath, claudeArgs, "win32");
+      const wt = cands.find((c) => c.bin === "wt.exe");
+      // Covers the cmd.exe SIDE only: given the tokens delivered faithfully, does
+      // `cmd /c call "<path>" <args>` run the shim and forward argv? It does NOT
+      // exercise Windows Terminal's own commandline re-tokenization/re-quoting —
+      // that layer needs a real wt.exe launch on Windows. Here we drop "--", swap
+      // /k -> /c so cmd exits, and feed the tokens to cmd.exe verbatim.
+      const inner = wt.args.slice(1).map((a) => (a === "/k" ? "/c" : a));
+      const result = spawnSync(inner[0], inner.slice(1), {
+        encoding: "utf8",
+        windowsVerbatimArguments: true,
+      });
+      const detail = JSON.stringify({
+        status: result.status,
+        error: result.error && result.error.message,
+        stdout: result.stdout,
+        stderr: result.stderr,
+      });
+      assert.strictEqual(result.status, 0, detail);
+      assert.deepStrictEqual(JSON.parse(result.stdout.trim()), claudeArgs, detail);
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
@@ -327,7 +461,9 @@ describe("launchClaudeSession - terminal fallback", () => {
   it("passes the resolved claude path and quoted args through to the terminal", async () => {
     const { attempted, deps } = makeDeps({ plat: "win32", okBins: ["wt.exe"], findResult: WIN_PATH });
     await launchClaudeSession("resume", undefined, "sid_1", deps);
-    assert.deepStrictEqual(attempted[0].args, ["--", WIN_PATH, "--resume", "sid_1"]);
+    assert.deepStrictEqual(attempted[0].args, [
+      "--", "cmd.exe", "/d", "/v:off", "/k", "call", `"${WIN_PATH}"`, "--resume", "sid_1",
+    ]);
   });
 
   it("rejects unsafe resume IDs before trying any terminal", async () => {


### PR DESCRIPTION
## Summary
Fixes the Windows **New Session** failure in #435 (`0x800700c1` / `ERROR_BAD_EXE_FORMAT`).

## Root cause
- `findClaudeCmd()` runs `where claude` and returns the first existing path. npm installs **two** files in the same dir: an extensionless POSIX shell script `claude` and the Windows shim `claude.cmd`. `where` can list the extensionless one first, so we returned it.
- That path flows into the first launch candidate `wt.exe -- <path>`. Windows Terminal is asked to launch the extensionless POSIX script directly; that script is not a Windows PE/Win32 image, so it can fail with `0x800700c1` / `ERROR_BAD_EXE_FORMAT`.
- **Confirming evidence:** the error the reporter saw is Windows Terminal's *own* dialog, not our app's "Failed to launch Claude Code" dialog (`runLaunchClaudeSession` only shows that when `res.ok` is false). So `wt.exe` spawned fine (`tryLaunch` resolves on spawn) and the failure is inside WT's child command path — which also means the working `cmd.exe /k` fallback is never reached.

## Why not just "prefer .cmd" (the issue's suggested fix)
Necessary, but not the whole fix. Preferring `claude.cmd` fixes the root selection bug, but the launch layer still needs to be robust because `tryLaunch()` treats a successfully spawned `wt.exe` as success and cannot observe failures inside the new WT tab.

Local Windows validation showed current WT can launch a `.cmd` shim directly, so this PR no longer relies on the stronger claim that `wt.exe -- claude.cmd` necessarily fails. The safer launch contract is still to route WT through `cmd.exe`, which consistently resolves npm shims and preserves quoted paths with spaces/parentheses via `call "<path>"`.

## The fix (two layers)
1. **`findClaudeCmd`** — on Windows: prefer a launchable extension (`.com/.exe/.bat/.cmd`) from the PATH results; if `where` surfaces only the extensionless script, probe for its launchable sibling; never return the unrunnable script (also removed from the npm fallback list). Added a small `deps` seam so this selection logic is now unit-testable.
2. **`buildTerminalCandidates`** — the `wt.exe` candidate now launches `cmd.exe` (a real PE), which resolves & runs the shim:
   `wt.exe -- cmd.exe /d /v:off /k call "<path>" <args>`
   - `call` keeps cmd's `/K` from stripping the leading quote, so the quoted path survives **whether wt forwards the args raw or re-tokenizes/re-quotes them**.
   - Avoids the `/s ""..""` idiom (understood only by cmd.exe, mangled by wt's tokenizer).

## Tests
- New `findClaudeCmd` unit tests (it had **zero** coverage): `.cmd` preference, sibling probe, `.exe` preference, passthrough when only the script exists, case-insensitive match, `%APPDATA%` fallback, POSIX path.
- New Windows-only round-trip test for the `wt -> cmd.exe` path using a **spaced + parenthesized** shim dir (the `Program Files (x86)` shape).
- Windows targeted suite: `node --test test\launch-claude.test.js` -> **44 pass, 0 fail**.
- Windows full suite on the PR branch: **3657 tests, 3645 pass, 12 skipped, 0 fail**.
- Windows full suite on a local `main` + #438 merge result: **3714 tests, 3702 pass, 12 skipped, 0 fail**.

## Windows live verification
Using a temporary PATH entry containing both an extensionless `claude` script and a neighboring `claude.cmd` shim:

```bat
where claude
```

confirmed the risky ordering:

```text
...\claude
...\claude.cmd
...\claude.exe
```

Then:
- old shape `wt.exe -- <extensionless claude> --resume old_sid-456` did not execute the shim / write argv;
- new shape `wt.exe -- cmd.exe /d /v:off /c call "<claude.cmd>" --resume safe_sid-123` executed successfully and wrote `['--resume','safe_sid-123']`.

Fixes #435