### PR TITLE
fix(telegram): surface legacy sidecar runtime failures in migration state (#430)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,6 +27,7 @@ const {
   formatTelegramStatusDiagnostic,
 } = require("./telegram-approval-runtime-status");
 const { createTelegramMigrationController } = require("./telegram-migration-controller");
+const { createTelegramSidecarStatusBridge } = require("./telegram-sidecar-status-bridge");
 const initUpdateBubble = require("./update-bubble");
 const { registerUpdateBubbleIpc } = initUpdateBubble;
 const createSettingsAnimationOverridesMain = require("./settings-animation-overrides-main");
@@ -1804,6 +1805,26 @@ async function deleteTelegramApprovalTokenFile() {
   }
 }
 
+// Bridge a freshly-created legacy sidecar's status-changed stream into the
+// migration controller. A new bridge per instance keeps everReady/dedupe state
+// scoped to that process; the controller is referenced lazily because it may be
+// created after the first sidecar (init drives the first start).
+function attachTelegramSidecarStatusBridge(sidecar) {
+  if (!sidecar || typeof sidecar.on !== "function") return;
+  const bridge = createTelegramSidecarStatusBridge({
+    getSnapshot: () => (_telegramMigrationController
+      && typeof _telegramMigrationController.getSnapshot === "function"
+      ? _telegramMigrationController.getSnapshot()
+      : null),
+    dispatch: (event) => (_telegramMigrationController
+      && typeof _telegramMigrationController.dispatch === "function"
+      ? _telegramMigrationController.dispatch(event)
+      : Promise.resolve()),
+    log: telegramApprovalLog,
+  });
+  sidecar.on("status-changed", (status) => bridge.onStatusChanged(status));
+}
+
 async function startTelegramApprovalSidecar() {
   const config = getTelegramApprovalPrefs();
   const paths = getTelegramApprovalPaths();
@@ -1861,6 +1882,7 @@ async function startTelegramApprovalSidecar() {
     redactionSecrets: telegramApprovalSettings.redactionSecretsForTelegramApproval(config),
     log: telegramApprovalLog,
   });
+  attachTelegramSidecarStatusBridge(telegramApprovalSidecar);
   telegramApprovalConfigSignature = signature;
   const sidecar = telegramApprovalSidecar;
   try {

--- a/src/settings-tab-telegram-approval.js
+++ b/src/settings-tab-telegram-approval.js
@@ -314,7 +314,7 @@
         break;
       case "LEGACY_ACTIVE":
         if (snap.runtimeStatus && snap.runtimeStatus.status === "failed") {
-          body.appendChild(migrationCopy("Legacy sidecar failed to start."));
+          body.appendChild(migrationCopy("Legacy sidecar is not running."));
           body.appendChild(migrationButton("Retry legacy sidecar", () =>
             migrationDispatch("USER_ENABLE_LEGACY")));
         }

--- a/src/telegram-approval-runtime-status.js
+++ b/src/telegram-approval-runtime-status.js
@@ -387,6 +387,28 @@ function buildTelegramApprovalStatus({
 
   const ready = telegramApprovalSettings.readiness(config, token);
   const legacyStatus = sidecarStatus || { status: "stopped" };
+  // Reverse-divergence guard: once the controller knows the legacy sidecar
+  // failed, keep the badge "failed" even if the live sidecar handle has since
+  // gone "stopped" or been torn down (which would otherwise read as "ready").
+  // Only the failure overlay is honoured — "running" must still come from the
+  // live sidecar status, never from a stale runtime-status snapshot.
+  const runtimeStatus = migrationSnapshot && migrationSnapshot.runtimeStatus;
+  // Only overlay while legacy is the *current* owner. A stale legacy failure
+  // (e.g. user disabled or switched after a failure) must not keep the badge
+  // red; the controller also reconciles runtimeStatus on those transitions.
+  if (migrationSnapshot && migrationSnapshot.state === "LEGACY_ACTIVE"
+    && runtimeStatus && runtimeStatus.transport === "legacy" && runtimeStatus.status === "failed") {
+    return {
+      ...legacyStatus,
+      status: "failed",
+      transport: "legacy",
+      enabled: config && config.enabled === true,
+      configured: ready.ready === true,
+      reason: runtimeStatus.reason || legacyStatus.reason || "failed",
+      message: runtimeStatus.message || legacyStatus.message || ready.message || "",
+      tokenStored: token && token.tokenStored === true,
+    };
+  }
   return {
     ...legacyStatus,
     transport: "legacy",

--- a/src/telegram-migration-controller.js
+++ b/src/telegram-migration-controller.js
@@ -8,6 +8,7 @@
 const {
   STATES,
   EVENTS,
+  SIDE_EFFECTS,
   applyEvent,
   computeInitial,
   defaultPrefs,
@@ -42,7 +43,7 @@ function createTelegramMigrationController({
 
   let state = STATES.IDLE;
   let prefs = defaultPrefs();
-  let runtimeStatus = { transport: "off", status: "stopped", reason: null };
+  let runtimeStatus = { transport: "off", status: "stopped", reason: null, message: "" };
   let pendingTestTimer = null;
   let lastError = null;
 
@@ -125,7 +126,7 @@ function createTelegramMigrationController({
         state = STATES.SWITCHING_TO_LEGACY;
         const failed = applyEvent(
           { state, prefs, files: readFilesNow() },
-          { type: EVENTS.SIDECAR_START_FAILED, reason: lastError.code },
+          { type: EVENTS.SIDECAR_START_FAILED, reason: lastError.code, message: lastError.message || "" },
         );
         try {
           await manager.apply(failed.sideEffects || []);
@@ -145,6 +146,7 @@ function createTelegramMigrationController({
 
     state = result.state;
     lastError = null;
+    reconcileRuntimeStatusAfterStateChange();
 
     // Arm/clear the 60s test timer alongside state transitions (per plan §148
     // the Telegram tap deadline is owned by the driver, not the reducer).
@@ -158,6 +160,36 @@ function createTelegramMigrationController({
     return { ok: true, state };
   }
 
+  function hasEffect(sideEffects, type) {
+    return Array.isArray(sideEffects) && sideEffects.some((e) => e && e.type === type);
+  }
+
+  // Record a legacy runtime failure as runtime-status without changing the
+  // lifecycle state. Caller must have already settled `state` to LEGACY_ACTIVE;
+  // the reducer rejects this event in any other state, so a guard miss is a
+  // safe no-op rather than a bad transition.
+  async function applyRuntimeFailure({ reason, message, files }) {
+    const failed = applyEvent(
+      { state, prefs, files: files || readFilesNow() },
+      { type: EVENTS.SIDECAR_RUNTIME_FAILED, reason, message },
+    );
+    if (failed.errorCode) return;
+    await manager.apply(failed.sideEffects || []);
+    state = failed.state;
+  }
+
+  // Reconcile runtime-status when a successful dispatch lands outside legacy
+  // ownership. A stale legacy "failed" must not survive USER_DISABLE / switch to
+  // native — otherwise it leaks into the badge overlay and the Telegram /status
+  // diagnostic. Recovery while still LEGACY_ACTIVE is owned by
+  // SIDECAR_RUNTIME_RECOVERED, so this never clears in legacy/switching states.
+  function reconcileRuntimeStatusAfterStateChange() {
+    if (state === STATES.LEGACY_ACTIVE || state === STATES.SWITCHING_TO_LEGACY) return;
+    if (runtimeStatus && runtimeStatus.transport === "legacy" && runtimeStatus.status === "failed") {
+      runtimeStatus = { transport: "off", status: "stopped", reason: null, message: "" };
+    }
+  }
+
   async function init() {
     readPrefsNow();
     const files = readFilesNow();
@@ -165,7 +197,22 @@ function createTelegramMigrationController({
     try {
       await manager.apply(result.sideEffects || []);
     } catch (err) {
+      lastError = { code: err && err.code ? err.code : "APPLY_FAILED", message: err && err.message };
       log("warn", "migration init apply failed", { error: err && err.message });
+      // computeInitial only emits START_SIDECAR alongside LEGACY_ACTIVE, so the
+      // selected transport stays legacy; surface the failure through
+      // runtime-status so the migration card matches the Telegram badge.
+      state = result.state;
+      if (hasEffect(result.sideEffects, SIDE_EFFECTS.START_SIDECAR)) {
+        try {
+          await applyRuntimeFailure({
+            reason: lastError.code || "sidecar_start_failed",
+            message: lastError.message || "",
+            files,
+          });
+        } catch {}
+      }
+      return state;
     }
     state = result.state;
     return state;

--- a/src/telegram-migration-controller.js
+++ b/src/telegram-migration-controller.js
@@ -139,6 +139,18 @@ function createTelegramMigrationController({
           };
           state = result.state;
         }
+      } else if (state === STATES.LEGACY_ACTIVE
+        && hasEffect(result.sideEffects, SIDE_EFFECTS.START_SIDECAR)) {
+        // "Retry legacy sidecar" (USER_ENABLE_LEGACY while already LEGACY_ACTIVE)
+        // failed again: refresh runtime-status so the badge failure detail isn't
+        // stale. A fresh enable from IDLE is intentionally left un-promoted —
+        // state stays IDLE and no runtime failure is recorded.
+        try {
+          await applyRuntimeFailure({
+            reason: lastError.code || "sidecar_start_failed",
+            message: lastError.message || "",
+          });
+        } catch {}
       }
       // Best-effort recover: re-read the world so state mirrors reality.
       return { ok: false, errorCode: lastError.code, message: lastError.message, state };

--- a/src/telegram-migration-state.js
+++ b/src/telegram-migration-state.js
@@ -24,6 +24,14 @@ const EVENTS = Object.freeze({
   USER_ROLLBACK_TO_LEGACY: "USER_ROLLBACK_TO_LEGACY",
   SIDECAR_STARTED: "SIDECAR_STARTED",
   SIDECAR_START_FAILED: "SIDECAR_START_FAILED",
+  // Runtime health of an already-selected legacy sidecar. Distinct from
+  // SIDECAR_START_FAILED (which is owned by the native→legacy switch path):
+  // these fire while LEGACY_ACTIVE is the steady state, carry no lifecycle
+  // transition, and only update runtime-status so the migration card and the
+  // Telegram badge agree. The main-process bridge maps sidecar status-changed
+  // → these. See plan-issue-430.
+  SIDECAR_RUNTIME_FAILED: "SIDECAR_RUNTIME_FAILED",
+  SIDECAR_RUNTIME_RECOVERED: "SIDECAR_RUNTIME_RECOVERED",
   USER_DISABLE: "USER_DISABLE",
 });
 
@@ -293,10 +301,44 @@ function applyEvent({ state, prefs, files }, event) {
           transport: "legacy",
           status: "failed",
           reason: (event && event.reason) || "sidecar_start_failed",
+          message: (event && event.message) || "",
         }),
       ],
       { transport: "legacy" },
     );
+  }
+
+  // Runtime health of the live legacy sidecar. Legal ONLY in LEGACY_ACTIVE:
+  // these events must never drive a lifecycle transition (e.g. they must not
+  // pull SWITCHING_TO_LEGACY forward to LEGACY_ACTIVE, which would skip the
+  // PERSIST_PREFS that SIDECAR_STARTED owns). The main-process bridge holds any
+  // SWITCHING_TO_LEGACY-window failure until the state settles to LEGACY_ACTIVE
+  // before dispatching. They only emit runtime-status; they carry no
+  // PERSIST_PREFS and resolve to the same state.
+  if (event.type === EVENTS.SIDECAR_RUNTIME_FAILED) {
+    if (state !== STATES.LEGACY_ACTIVE) return illegal(state);
+    return ok(STATES.LEGACY_ACTIVE, [
+      effect(SIDE_EFFECTS.EMIT_RUNTIME_STATUS, {
+        transport: "legacy",
+        status: "failed",
+        reason: (event && event.reason) || "sidecar_runtime_failed",
+        message: (event && event.message) || "",
+      }),
+    ]);
+  }
+
+  if (event.type === EVENTS.SIDECAR_RUNTIME_RECOVERED) {
+    if (state !== STATES.LEGACY_ACTIVE) return illegal(state);
+    // Explicitly clear message: onRuntimeStatus merges shallowly, so a stale
+    // failure message would otherwise survive the recovery.
+    return ok(STATES.LEGACY_ACTIVE, [
+      effect(SIDE_EFFECTS.EMIT_RUNTIME_STATUS, {
+        transport: "legacy",
+        status: "running",
+        reason: null,
+        message: "",
+      }),
+    ]);
   }
 
   return illegal(state);

--- a/src/telegram-sidecar-status-bridge.js
+++ b/src/telegram-sidecar-status-bridge.js
@@ -1,0 +1,126 @@
+"use strict";
+
+// Bridge: maps the legacy Telegram approval sidecar's `status-changed` events
+// onto migration-controller runtime events, so a runtime sidecar death (or
+// recovery) becomes visible in the migration state model instead of only in
+// the live sidecar handle. See plan-issue-430.
+//
+// Design constraints (verified against the reducer + controller):
+//   - Runtime health must NOT drive a lifecycle transition. The reducer only
+//     accepts SIDECAR_RUNTIME_FAILED/RECOVERED in LEGACY_ACTIVE.
+//   - During the narrow USER_ROLLBACK_TO_LEGACY window the sidecar can be ready
+//     (`running` already emitted) while the controller is still
+//     SWITCHING_TO_LEGACY and has not yet re-dispatched SIDECAR_STARTED. A
+//     failure there is NOT covered by the rollback catch (which only fires when
+//     manager.apply throws). So we hold the event and retry until the state
+//     settles to LEGACY_ACTIVE rather than dropping it or forcing a transition.
+//   - `everReady` separates startup failures (owned by start() rejection +
+//     controller init/rollback handling) from genuine runtime deaths.
+//   - Failures are deduped by reason+message so a later, more specific failure
+//     (e.g. "sidecar restart rate limit reached") still updates runtime status.
+//   - Dispatch is deferred off the emit call stack (status-changed fires from
+//     inside manager.apply) so we never re-enter the serialized apply queue and
+//     read a settled snapshot for the guards.
+
+const { EVENTS } = require("./telegram-migration-state");
+
+const DEFAULT_SETTLE_DELAY_MS = 25;
+const DEFAULT_SETTLE_RETRY_LIMIT = 8;
+const RATE_LIMIT_MESSAGE = "sidecar restart rate limit reached";
+
+function emptyMemory() {
+  return { everReady: false, lastFailureKey: "" };
+}
+
+// Pure decision. Given the per-instance bridge memory and a sidecar status
+// object, return the next memory and the runtime event to (eventually)
+// dispatch, or null. Never dispatches — kept side-effect free for unit tests.
+function decideSidecarRuntimeEvent(prev, status) {
+  const memory = prev || emptyMemory();
+  const s = status && status.status;
+
+  if (s === "running") {
+    // Reset failure dedupe and request a recovery. `onlyIfRuntimeFailed` makes
+    // this a no-op unless the controller currently shows failed, so a fresh
+    // instance reaching running also clears an init-failure recorded earlier.
+    return {
+      memory: { everReady: true, lastFailureKey: "" },
+      event: { type: EVENTS.SIDECAR_RUNTIME_RECOVERED, onlyIfRuntimeFailed: true },
+    };
+  }
+
+  if (s === "failed" && memory.everReady) {
+    const message = status && status.message ? String(status.message) : "";
+    const reason = message === RATE_LIMIT_MESSAGE
+      ? "sidecar_restart_rate_limit"
+      : "sidecar_runtime_failed";
+    const key = `${reason}\n${message}`;
+    if (key === memory.lastFailureKey) return { memory, event: null };
+    return {
+      memory: { everReady: true, lastFailureKey: key },
+      event: { type: EVENTS.SIDECAR_RUNTIME_FAILED, reason, message },
+    };
+  }
+
+  // starting / stopped / failed-before-ready / unknown: no runtime event.
+  return { memory, event: null };
+}
+
+// Stateful bridge bound to one sidecar instance. main.js calls onStatusChanged
+// from sidecar.on("status-changed"); deps are injected so it is fully testable.
+function createTelegramSidecarStatusBridge({
+  getSnapshot,
+  dispatch,
+  setTimer = setTimeout,
+  log = () => {},
+  settleDelayMs = DEFAULT_SETTLE_DELAY_MS,
+  settleRetryLimit = DEFAULT_SETTLE_RETRY_LIMIT,
+} = {}) {
+  let memory = emptyMemory();
+
+  function defer(event, attempt) {
+    const timer = setTimer(() => {
+      const snap = (typeof getSnapshot === "function" && getSnapshot()) || {};
+      // Hold during the rollback window: ready-but-not-yet-LEGACY_ACTIVE.
+      if (snap.state === "SWITCHING_TO_LEGACY" && attempt < settleRetryLimit) {
+        defer(event, attempt + 1);
+        return;
+      }
+      if (snap.state !== "LEGACY_ACTIVE") return;
+      if (event.onlyIfRuntimeFailed
+        && !(snap.runtimeStatus && snap.runtimeStatus.status === "failed")) {
+        return;
+      }
+      const { onlyIfRuntimeFailed, ...dispatchEvent } = event;
+      try {
+        Promise.resolve(dispatch(dispatchEvent)).catch((err) => {
+          log("warn", "telegram runtime status dispatch failed", {
+            error: err && err.message ? err.message : String(err),
+          });
+        });
+      } catch (err) {
+        log("warn", "telegram runtime status dispatch threw", {
+          error: err && err.message ? err.message : String(err),
+        });
+      }
+    }, settleDelayMs);
+    if (timer && typeof timer.unref === "function") timer.unref();
+    return timer;
+  }
+
+  return {
+    onStatusChanged(status) {
+      const decision = decideSidecarRuntimeEvent(memory, status);
+      memory = decision.memory;
+      if (decision.event) defer(decision.event, 0);
+    },
+  };
+}
+
+module.exports = {
+  createTelegramSidecarStatusBridge,
+  decideSidecarRuntimeEvent,
+  DEFAULT_SETTLE_DELAY_MS,
+  DEFAULT_SETTLE_RETRY_LIMIT,
+  RATE_LIMIT_MESSAGE,
+};

--- a/test/telegram-approval-runtime-status.test.js
+++ b/test/telegram-approval-runtime-status.test.js
@@ -129,6 +129,68 @@ test("off transport keeps the legacy disabled reason after USER_DISABLE", () => 
   assert.equal(status.message, "");
 });
 
+test("legacy runtime-failure overlay keeps the badge failed even if live sidecar is stopped", () => {
+  const status = buildTelegramApprovalStatus({
+    config: COMPLETE_CONFIG_ENABLED,
+    token: TOKEN_STORED,
+    // Live handle already torn down / cleared — without the overlay this would
+    // read back as "ready" and contradict the migration card (issue #430).
+    sidecarStatus: { status: "stopped" },
+    migrationSnapshot: {
+      state: "LEGACY_ACTIVE",
+      transport: "legacy",
+      runtimeStatus: {
+        transport: "legacy",
+        status: "failed",
+        reason: "sidecar_runtime_failed",
+        message: "sidecar exited (signal SIGTERM)",
+      },
+    },
+    nativePolling: false,
+  });
+
+  assert.equal(status.transport, "legacy");
+  assert.equal(status.status, "failed");
+  assert.equal(status.reason, "sidecar_runtime_failed");
+  assert.equal(status.message, "sidecar exited (signal SIGTERM)");
+});
+
+test("legacy runtime overlay never forges running from a stale runtime-status", () => {
+  const status = buildTelegramApprovalStatus({
+    config: COMPLETE_CONFIG_ENABLED,
+    token: TOKEN_STORED,
+    sidecarStatus: { status: "stopped" },
+    migrationSnapshot: {
+      state: "LEGACY_ACTIVE",
+      transport: "legacy",
+      runtimeStatus: { transport: "legacy", status: "running", reason: null, message: "" },
+    },
+    nativePolling: false,
+  });
+
+  // Overlay only honours "failed"; "running" must come from the live sidecar.
+  assert.equal(status.status, "stopped");
+});
+
+test("legacy runtime overlay is dropped once the owner left legacy (stale failed after disable)", () => {
+  const status = buildTelegramApprovalStatus({
+    config: COMPLETE_CONFIG_DISABLED,
+    token: TOKEN_STORED,
+    sidecarStatus: { status: "stopped" },
+    migrationSnapshot: {
+      // User disabled after a failure: state moved to IDLE/off, but a stale
+      // legacy failed runtimeStatus lingers. It must NOT keep the badge red.
+      state: "IDLE",
+      transport: "off",
+      runtimeStatus: { transport: "legacy", status: "failed", reason: "sidecar_runtime_failed", message: "boom" },
+    },
+    nativePolling: false,
+  });
+
+  assert.equal(status.status, "stopped");
+  assert.notEqual(status.status, "failed");
+});
+
 test("native selection includes persisted native transport while excluding off", () => {
   assert.equal(isNativeTelegramApprovalSelected({ state: "NATIVE_ACTIVE" }), true);
   assert.equal(isNativeTelegramApprovalSelected({ state: "TESTING_NATIVE" }), true);

--- a/test/telegram-migration-controller.test.js
+++ b/test/telegram-migration-controller.test.js
@@ -9,9 +9,16 @@ const {
 const { STATES, EVENTS } = require("../src/telegram-migration-state");
 
 class FakeSidecar {
-  constructor() { this.running = false; this.stopCalls = []; }
+  constructor() { this.running = false; this.stopCalls = []; this.failStart = false; }
   isRunning() { return this.running; }
-  async start() { this.running = true; }
+  async start() {
+    if (this.failStart) {
+      const err = new Error("fake sidecar start failed");
+      err.code = "SIDECAR_START_FAILED";
+      throw err;
+    }
+    this.running = true;
+  }
   async stop() { this.stopCalls.push(true); this.running = false; }
 }
 
@@ -196,4 +203,93 @@ test("getSnapshot exposes state + runtime status + owner snapshot", async () => 
   // Undecided prefs surface as transport=undefined, not "off" (we distinguish
   // "user explicitly disabled" from "v0.8 user with no transport key yet").
   assert.equal(snap.transport, undefined);
+});
+
+test("init: legacy sidecar start failure → LEGACY_ACTIVE but runtimeStatus failed", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true },
+  });
+  env.sidecar.failStart = true;
+  const state = await env.ctrl.init();
+  // Selected transport stays legacy; the failure must surface as runtime status,
+  // not by snapping the state away (issue #430).
+  assert.equal(state, STATES.LEGACY_ACTIVE);
+  const snap = env.ctrl.getSnapshot();
+  assert.equal(snap.ownerSnapshot.sidecarRunning, false);
+  assert.equal(snap.runtimeStatus.transport, "legacy");
+  assert.equal(snap.runtimeStatus.status, "failed");
+});
+
+test("dispatch SIDECAR_RUNTIME_FAILED @ LEGACY_ACTIVE records failure without lifecycle change", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true },
+  });
+  await env.ctrl.init();
+  assert.equal(env.sidecar.running, true);
+  const res = await env.ctrl.dispatch({
+    type: EVENTS.SIDECAR_RUNTIME_FAILED,
+    reason: "died",
+    message: "sidecar exited (signal SIGTERM)",
+  });
+  assert.equal(res.ok, true);
+  assert.equal(res.state, STATES.LEGACY_ACTIVE);
+  const snap = env.ctrl.getSnapshot();
+  assert.equal(snap.runtimeStatus.status, "failed");
+  assert.equal(snap.runtimeStatus.message, "sidecar exited (signal SIGTERM)");
+});
+
+test("dispatch SIDECAR_RUNTIME_RECOVERED clears a prior failure incl. message", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true },
+  });
+  env.sidecar.failStart = true;
+  await env.ctrl.init();
+  assert.equal(env.ctrl.getSnapshot().runtimeStatus.status, "failed");
+  // Manual retry / auto-restart reaching "running" → bridge dispatches recovered.
+  const res = await env.ctrl.dispatch({ type: EVENTS.SIDECAR_RUNTIME_RECOVERED });
+  assert.equal(res.ok, true);
+  const snap = env.ctrl.getSnapshot();
+  assert.equal(snap.runtimeStatus.status, "running");
+  assert.equal(snap.runtimeStatus.message, "");
+});
+
+test("SIDECAR_RUNTIME_FAILED is rejected outside LEGACY_ACTIVE", async () => {
+  const env = makeController({ initialFiles: {} });
+  await env.ctrl.init(); // IDLE
+  const res = await env.ctrl.dispatch({ type: EVENTS.SIDECAR_RUNTIME_FAILED, reason: "x" });
+  assert.equal(res.ok, false);
+  assert.equal(env.ctrl.getSnapshot().runtimeStatus.status, "stopped");
+});
+
+test("USER_DISABLE clears a stale legacy runtime failure (no leak after disable)", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true },
+  });
+  await env.ctrl.init(); // LEGACY_ACTIVE, sidecar running
+  await env.ctrl.dispatch({ type: EVENTS.SIDECAR_RUNTIME_FAILED, reason: "died", message: "boom" });
+  assert.equal(env.ctrl.getSnapshot().runtimeStatus.status, "failed");
+
+  const res = await env.ctrl.dispatch({ type: EVENTS.USER_DISABLE });
+  assert.equal(res.ok, true);
+  assert.equal(res.state, STATES.IDLE);
+  const rs = env.ctrl.getSnapshot().runtimeStatus;
+  assert.equal(rs.status, "stopped");
+  assert.equal(rs.transport, "off");
+  assert.equal(rs.message, "");
+});
+
+test("switching legacy→native clears stale legacy runtime failure (no /status leak)", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true },
+  });
+  await env.ctrl.init(); // LEGACY_ACTIVE
+  await env.ctrl.dispatch({ type: EVENTS.SIDECAR_RUNTIME_FAILED, reason: "died", message: "boom" });
+  assert.equal(env.ctrl.getSnapshot().runtimeStatus.status, "failed");
+
+  await env.ctrl.dispatch({ type: EVENTS.USER_TEST_NATIVE }); // → TESTING_NATIVE
+  await env.ctrl.dispatch({ type: EVENTS.TEST_SUCCESS, at: 1 }); // → NATIVE_ACTIVE
+  assert.equal(env.ctrl.getSnapshot().state, STATES.NATIVE_ACTIVE);
+  const rs = env.ctrl.getSnapshot().runtimeStatus;
+  assert.equal(rs.status, "stopped");
+  assert.equal(rs.transport, "off");
 });

--- a/test/telegram-migration-controller.test.js
+++ b/test/telegram-migration-controller.test.js
@@ -7,6 +7,7 @@ const {
   createTelegramMigrationController,
 } = require("../src/telegram-migration-controller");
 const { STATES, EVENTS } = require("../src/telegram-migration-state");
+const { buildTelegramStatusDiagnostic } = require("../src/telegram-approval-runtime-status");
 
 class FakeSidecar {
   constructor() { this.running = false; this.stopCalls = []; this.failStart = false; }
@@ -292,4 +293,45 @@ test("switching legacy→native clears stale legacy runtime failure (no /status 
   const rs = env.ctrl.getSnapshot().runtimeStatus;
   assert.equal(rs.status, "stopped");
   assert.equal(rs.transport, "off");
+});
+
+test("/status diagnostic does not leak a stale legacy failure after switching to native", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true, nativeConfigComplete: true },
+  });
+  await env.ctrl.init();
+  await env.ctrl.dispatch({ type: EVENTS.SIDECAR_RUNTIME_FAILED, reason: "died", message: "boom" });
+  await env.ctrl.dispatch({ type: EVENTS.USER_TEST_NATIVE });
+  await env.ctrl.dispatch({ type: EVENTS.TEST_SUCCESS, at: 1 });
+
+  // Feed the real post-flow snapshot into the Telegram /status builder.
+  const diagnostic = buildTelegramStatusDiagnostic({
+    config: { enabled: true, allowedTgUserId: "1", targetSessionKey: "telegram:1" },
+    token: { tokenConfigured: true, tokenStored: true },
+    approvalStatus: { status: "stopped", transport: "native" },
+    migrationSnapshot: env.ctrl.getSnapshot(),
+    nativeRunnerStatus: { polling: true },
+    pendingApprovalCount: 0,
+    sessionSnapshot: { sessions: [] },
+    now: 1000,
+  });
+  assert.equal(diagnostic.lastError, null);
+});
+
+test("Retry legacy (USER_ENABLE_LEGACY) failing again refreshes the stale runtime message", async () => {
+  const env = makeController({
+    initialFiles: { hasLegacyEnvFile: true, legacyConfigComplete: true },
+  });
+  await env.ctrl.init(); // LEGACY_ACTIVE, sidecar running
+  await env.ctrl.dispatch({ type: EVENTS.SIDECAR_RUNTIME_FAILED, reason: "old", message: "old failure" });
+  assert.equal(env.ctrl.getSnapshot().runtimeStatus.message, "old failure");
+
+  env.sidecar.failStart = true; // retry will fail again
+  const res = await env.ctrl.dispatch({ type: EVENTS.USER_ENABLE_LEGACY });
+  assert.equal(res.ok, false);
+  assert.equal(res.state, STATES.LEGACY_ACTIVE); // stays legacy-selected
+  const rs = env.ctrl.getSnapshot().runtimeStatus;
+  assert.equal(rs.status, "failed");
+  assert.equal(rs.reason, "SIDECAR_START_FAILED");
+  assert.notEqual(rs.message, "old failure"); // refreshed, not stale
 });

--- a/test/telegram-migration-state.test.js
+++ b/test/telegram-migration-state.test.js
@@ -177,3 +177,76 @@ test("Rollback path: NATIVE_ACTIVE → SWITCHING_TO_LEGACY → LEGACY_ACTIVE", (
   assert.equal(r2.state, STATES.LEGACY_ACTIVE);
   assert.deepEqual(r2.prefsPatch, { transport: "legacy" });
 });
+
+test("SIDECAR_RUNTIME_FAILED @ LEGACY_ACTIVE → LEGACY_ACTIVE + only EMIT_RUNTIME_STATUS", () => {
+  const r = applyEvent(
+    { state: STATES.LEGACY_ACTIVE, prefs: { transport: "legacy" }, files: {} },
+    { type: EVENTS.SIDECAR_RUNTIME_FAILED, reason: "boom", message: "sidecar exited (signal SIGTERM)" },
+  );
+  assert.equal(r.errorCode, null);
+  assert.equal(r.state, STATES.LEGACY_ACTIVE);
+  assert.deepEqual(effectTypes(r.sideEffects), [SIDE_EFFECTS.EMIT_RUNTIME_STATUS]);
+  const payload = r.sideEffects[0].payload;
+  assert.equal(payload.transport, "legacy");
+  assert.equal(payload.status, "failed");
+  assert.equal(payload.reason, "boom");
+  assert.equal(payload.message, "sidecar exited (signal SIGTERM)");
+  // Runtime health never persists prefs nor transitions state.
+  assert.equal(r.prefsPatch, undefined);
+});
+
+test("SIDECAR_RUNTIME_FAILED is illegal outside LEGACY_ACTIVE (incl. SWITCHING_TO_LEGACY)", () => {
+  for (const state of [
+    STATES.IDLE,
+    STATES.NATIVE_ACTIVE,
+    STATES.TESTING_NATIVE,
+    STATES.SWITCHING_TO_LEGACY,
+    STATES.NEEDS_SETUP,
+  ]) {
+    const r = applyEvent({ state, prefs: {}, files: {} }, { type: EVENTS.SIDECAR_RUNTIME_FAILED, reason: "x" });
+    assert.equal(r.errorCode, ERROR_CODES.ILLEGAL_TRANSITION, `state=${state}`);
+    assert.equal(r.state, state);
+    assert.deepEqual(r.sideEffects, []);
+  }
+});
+
+test("SIDECAR_RUNTIME_RECOVERED @ LEGACY_ACTIVE clears message (shallow-merge safe)", () => {
+  const r = applyEvent(
+    { state: STATES.LEGACY_ACTIVE, prefs: { transport: "legacy" }, files: {} },
+    { type: EVENTS.SIDECAR_RUNTIME_RECOVERED },
+  );
+  assert.equal(r.state, STATES.LEGACY_ACTIVE);
+  assert.deepEqual(effectTypes(r.sideEffects), [SIDE_EFFECTS.EMIT_RUNTIME_STATUS]);
+  const payload = r.sideEffects[0].payload;
+  assert.equal(payload.status, "running");
+  assert.equal(payload.reason, null);
+  assert.equal(payload.message, "");
+});
+
+test("SIDECAR_RUNTIME_RECOVERED is illegal outside LEGACY_ACTIVE", () => {
+  const r = applyEvent(
+    { state: STATES.SWITCHING_TO_LEGACY, prefs: {}, files: {} },
+    { type: EVENTS.SIDECAR_RUNTIME_RECOVERED },
+  );
+  assert.equal(r.errorCode, ERROR_CODES.ILLEGAL_TRANSITION);
+  assert.deepEqual(r.sideEffects, []);
+});
+
+test("SIDECAR_START_FAILED carries message through runtime-status", () => {
+  const r = applyEvent(
+    { state: STATES.SWITCHING_TO_LEGACY, prefs: {}, files: {} },
+    { type: EVENTS.SIDECAR_START_FAILED, reason: "RB", message: "boom detail" },
+  );
+  assert.equal(r.state, STATES.LEGACY_ACTIVE);
+  const emit = r.sideEffects.find((e) => e.type === SIDE_EFFECTS.EMIT_RUNTIME_STATUS);
+  assert.ok(emit, "expected EMIT_RUNTIME_STATUS");
+  assert.equal(emit.payload.message, "boom detail");
+});
+
+test("checkInvariants: runtime failure event emits no start side-effects", () => {
+  const r = applyEvent(
+    { state: STATES.LEGACY_ACTIVE, prefs: { transport: "legacy" }, files: {} },
+    { type: EVENTS.SIDECAR_RUNTIME_FAILED, reason: "x" },
+  );
+  assert.deepEqual(checkInvariants(r), []);
+});

--- a/test/telegram-sidecar-status-bridge.test.js
+++ b/test/telegram-sidecar-status-bridge.test.js
@@ -1,0 +1,167 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  createTelegramSidecarStatusBridge,
+  decideSidecarRuntimeEvent,
+} = require("../src/telegram-sidecar-status-bridge");
+const { EVENTS } = require("../src/telegram-migration-state");
+
+// ── Pure decision ──────────────────────────────────────────────────────────
+
+test("decide: running resets dedupe + requests recovery (onlyIfRuntimeFailed)", () => {
+  const out = decideSidecarRuntimeEvent({ everReady: false, lastFailureKey: "stale" }, { status: "running" });
+  assert.equal(out.memory.everReady, true);
+  assert.equal(out.memory.lastFailureKey, "");
+  assert.equal(out.event.type, EVENTS.SIDECAR_RUNTIME_RECOVERED);
+  assert.equal(out.event.onlyIfRuntimeFailed, true);
+});
+
+test("decide: failed before ever-ready → no event (startup failure, owned elsewhere)", () => {
+  const out = decideSidecarRuntimeEvent({ everReady: false, lastFailureKey: "" }, { status: "failed", message: "startup timed out" });
+  assert.equal(out.event, null);
+  assert.equal(out.memory.everReady, false);
+});
+
+test("decide: failed after ready → RUNTIME_FAILED with reason + message", () => {
+  const out = decideSidecarRuntimeEvent(
+    { everReady: true, lastFailureKey: "" },
+    { status: "failed", message: "sidecar exited (signal SIGTERM)" },
+  );
+  assert.equal(out.event.type, EVENTS.SIDECAR_RUNTIME_FAILED);
+  assert.equal(out.event.reason, "sidecar_runtime_failed");
+  assert.equal(out.event.message, "sidecar exited (signal SIGTERM)");
+});
+
+test("decide: rate-limit message maps to its own reason key", () => {
+  const out = decideSidecarRuntimeEvent(
+    { everReady: true, lastFailureKey: "" },
+    { status: "failed", message: "sidecar restart rate limit reached" },
+  );
+  assert.equal(out.event.reason, "sidecar_restart_rate_limit");
+});
+
+test("decide: identical failure key dedupes to null", () => {
+  const key = "sidecar_runtime_failed\nboom";
+  const out = decideSidecarRuntimeEvent({ everReady: true, lastFailureKey: key }, { status: "failed", message: "boom" });
+  assert.equal(out.event, null);
+  assert.equal(out.memory.lastFailureKey, key);
+});
+
+// ── Stateful bridge (fake timers + injected controller) ──────────────────────
+
+function makeHarness({ state = "LEGACY_ACTIVE", runtimeStatus = null } = {}) {
+  const timers = [];
+  const dispatched = [];
+  let snap = { state, runtimeStatus };
+  const bridge = createTelegramSidecarStatusBridge({
+    getSnapshot: () => snap,
+    dispatch: (event) => { dispatched.push(event); return Promise.resolve({ ok: true }); },
+    setTimer: (cb) => { const t = { cb, fired: false }; timers.push(t); return t; },
+    settleDelayMs: 0,
+    settleRetryLimit: 5,
+  });
+  return {
+    bridge,
+    dispatched,
+    setSnap: (patch) => { snap = { ...snap, ...patch }; },
+    flushAll: () => {
+      let guard = 0;
+      while (timers.some((t) => !t.fired) && guard < 100) {
+        const t = timers.find((x) => !x.fired);
+        t.fired = true;
+        t.cb();
+        guard += 1;
+      }
+    },
+    flushOnce: () => {
+      const pending = timers.filter((t) => !t.fired);
+      for (const t of pending) { t.fired = true; t.cb(); }
+    },
+    failedEvents: () => dispatched.filter((e) => e.type === EVENTS.SIDECAR_RUNTIME_FAILED),
+    recoveredEvents: () => dispatched.filter((e) => e.type === EVENTS.SIDECAR_RUNTIME_RECOVERED),
+  };
+}
+
+test("bridge: running→failed (after ready) dispatches RUNTIME_FAILED once in LEGACY_ACTIVE", () => {
+  const h = makeHarness({ state: "LEGACY_ACTIVE" });
+  h.bridge.onStatusChanged({ status: "running" });
+  h.flushAll();
+  // recovery is a no-op (controller not failed)
+  assert.equal(h.recoveredEvents().length, 0);
+
+  h.bridge.onStatusChanged({ status: "failed", message: "sidecar exited (signal SIGTERM)" });
+  h.flushAll();
+  const failed = h.failedEvents();
+  assert.equal(failed.length, 1);
+  assert.equal(failed[0].message, "sidecar exited (signal SIGTERM)");
+  assert.equal(failed[0].reason, "sidecar_runtime_failed");
+  // control flag must be stripped before dispatch
+  assert.equal("onlyIfRuntimeFailed" in failed[0], false);
+});
+
+test("bridge: repeated identical failed is deduped to a single dispatch", () => {
+  const h = makeHarness();
+  h.bridge.onStatusChanged({ status: "running" }); h.flushAll();
+  h.bridge.onStatusChanged({ status: "failed", message: "boom" }); h.flushAll();
+  h.bridge.onStatusChanged({ status: "failed", message: "boom" }); h.flushAll();
+  assert.equal(h.failedEvents().length, 1);
+});
+
+test("bridge: a later, more specific failure (rate limit) dispatches again", () => {
+  const h = makeHarness();
+  h.bridge.onStatusChanged({ status: "running" }); h.flushAll();
+  h.bridge.onStatusChanged({ status: "failed", message: "sidecar exited (signal SIGTERM)" }); h.flushAll();
+  h.bridge.onStatusChanged({ status: "failed", message: "sidecar restart rate limit reached" }); h.flushAll();
+  const failed = h.failedEvents();
+  assert.equal(failed.length, 2);
+  assert.equal(failed[1].reason, "sidecar_restart_rate_limit");
+});
+
+test("bridge: a startup failure before ever running never dispatches", () => {
+  const h = makeHarness();
+  h.bridge.onStatusChanged({ status: "starting" }); h.flushAll();
+  h.bridge.onStatusChanged({ status: "failed", message: "startup timed out" }); h.flushAll();
+  assert.equal(h.dispatched.length, 0);
+});
+
+test("bridge: recovery dispatches RUNTIME_RECOVERED only when controller shows failed", () => {
+  const failedSnap = makeHarness({ state: "LEGACY_ACTIVE", runtimeStatus: { status: "failed" } });
+  failedSnap.bridge.onStatusChanged({ status: "running" });
+  failedSnap.flushAll();
+  assert.equal(failedSnap.recoveredEvents().length, 1);
+  assert.equal("onlyIfRuntimeFailed" in failedSnap.recoveredEvents()[0], false);
+
+  const healthySnap = makeHarness({ state: "LEGACY_ACTIVE", runtimeStatus: null });
+  healthySnap.bridge.onStatusChanged({ status: "running" });
+  healthySnap.flushAll();
+  assert.equal(healthySnap.recoveredEvents().length, 0);
+});
+
+test("bridge: SWITCHING_TO_LEGACY window holds the failure until state settles", () => {
+  // Reproduces the narrow rollback window: sidecar ready (running emitted) then
+  // crashes before SIDECAR_STARTED settles the state to LEGACY_ACTIVE.
+  const h = makeHarness({ state: "SWITCHING_TO_LEGACY" });
+  h.bridge.onStatusChanged({ status: "running" });
+  h.bridge.onStatusChanged({ status: "failed", message: "sidecar exited (signal SIGTERM)" });
+
+  // While SWITCHING, nothing is dispatched — the events reschedule themselves.
+  h.flushOnce();
+  assert.equal(h.dispatched.length, 0);
+
+  // State settles to LEGACY_ACTIVE; the held failure is now delivered.
+  h.setSnap({ state: "LEGACY_ACTIVE" });
+  h.flushAll();
+  assert.equal(h.failedEvents().length, 1);
+  assert.equal(h.failedEvents()[0].message, "sidecar exited (signal SIGTERM)");
+});
+
+test("bridge: never dispatches while state is non-legacy (e.g. user switched to native)", () => {
+  const h = makeHarness({ state: "NATIVE_ACTIVE" });
+  h.bridge.onStatusChanged({ status: "running" });
+  h.bridge.onStatusChanged({ status: "failed", message: "late failure from a dying legacy instance" });
+  h.flushAll();
+  assert.equal(h.dispatched.length, 0);
+});


### PR DESCRIPTION
## What & why
#430: remote approval showed a contradictory state — the migration card stayed `LEGACY_ACTIVE` (looking healthy) while the Telegram badge showed `sidecar exited (signal SIGTERM)` with no recovery. The migration state machine never learned about runtime sidecar death: nothing subscribed to the sidecar `status-changed` event, and the reducer had no event for a legacy sidecar dying while active.

This makes legacy sidecar failures visible and consistent across the migration card, the Telegram badge, and the `/status` diagnostic, and auto-recovers when the sidecar returns. It does **not** silently switch transport.

## Changes
- **reducer**: `SIDECAR_RUNTIME_FAILED`/`RECOVERED` (legal only in `LEGACY_ACTIVE`, emit runtime-status, no lifecycle transition); `SIDECAR_START_FAILED` carries message.
- **controller**: record `init()` START_SIDECAR failures as runtime-status instead of a healthy-looking `LEGACY_ACTIVE`; reconcile stale legacy failure when a dispatch leaves legacy ownership (no leak into badge / `/status`); a failed "Retry legacy sidecar" refreshes the failure detail.
- **main**: status bridge maps sidecar `status-changed` -> controller, deferred off the apply stack, deduped by reason+message, holding a failure through the `SWITCHING_TO_LEGACY` rollback window until state settles.
- **runtime-status**: overlay the Telegram badge as failed from the controller runtime-status (guarded to `LEGACY_ACTIVE`).

## Tests / verification
New reducer/controller/runtime-status coverage + a dedicated bridge unit (incl. the `SWITCHING_TO_LEGACY` window and the `/status` no-leak path). Full telegram `node --test` suite green (168). Also ran the real modules end-to-end through death -> recovery -> disable to confirm the three UI surfaces stay consistent.

## Out of scope / follow-ups
- Root cause of the SIGTERM (why the reporter's `cc-connect-clawd` is terminated) is environmental — tracked via the reporter's logs on #430, not this PR.
- The `sidecar exited (signal SIGTERM)` text can itself be a clobbered startup error; un-clobbering it + richer exit diagnostics are a separate follow-up.

Refs #430
