### PR TITLE
fix(telegram): honor system proxy for native bot via Electron session.fetch (#359)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1907,6 +1907,7 @@ async function initTelegramMigrationController() {
     createWindowsPasteOnlyDeliveryAdapter,
   } = require("./telegram-direct-send");
   const { createTelegramNativeRunner } = require("./telegram-native-runner");
+  const { createTelegramFetchTransport } = require("./telegram-fetch-transport");
   const tokenStore = envFileTokenStore({ filePath: paths.tokenEnvFilePath });
   telegramDirectSend = createTelegramDirectSend({
     getSessionSnapshot: () => _state && typeof _state.buildSessionSnapshot === "function"
@@ -1931,7 +1932,14 @@ async function initTelegramMigrationController() {
   });
   const nativeRunner = createTelegramNativeRunner({
     tokenStore,
-    transport: makeFetchTransport({ tokenStore }),
+    // issue #359: route the bot's HTTP through Electron's Chromium net stack so
+    // it follows the OS system proxy (and PAC/SOCKS), instead of Node's global
+    // fetch which ignores system/env proxy. Dedicated in-memory session.
+    transport: createTelegramFetchTransport({
+      tokenStore,
+      sessionFactory: () => require("electron").session.fromPartition("clawd-telegram", { cache: false }),
+      log: telegramApprovalLog,
+    }),
     getDispatch: () => _telegramMigrationController && _telegramMigrationController.dispatch,
     getChatId: () => {
       const cfg = getTelegramApprovalPrefs();
@@ -2008,46 +2016,6 @@ async function initTelegramMigrationController() {
 
   await _telegramMigrationController.init();
   return _telegramMigrationController;
-}
-
-// Minimal fetch-based transport for the native client. Closes over the token
-// (no per-call token argument) so logging or debug serialization of request
-// args cannot leak the secret.
-function makeFetchTransport({ tokenStore }) {
-  return async ({ method, payload, signal }) => {
-    const token = await tokenStore.getToken();
-    if (!token) {
-      return { ok: false, status: null, error_code: "TOKEN_MISSING", description: "no token" };
-    }
-    const url = `https://api.telegram.org/bot${token}/${method}`;
-    let res;
-    try {
-      res = await fetch(url, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload || {}),
-        signal,
-      });
-    } catch (err) {
-      if (err && err.name === "AbortError") throw err;
-      throw Object.assign(new Error(err && err.message ? err.message : String(err)), {
-        code: (err && (err.code || (err.cause && err.cause.code))) || undefined,
-        causeCode: err && err.cause && err.cause.code,
-      });
-    }
-    const status = res.status;
-    let body;
-    try { body = await res.json(); } catch { body = null; }
-    if (!body) return { ok: false, status, error_code: status, description: res.statusText || "" };
-    if (body.ok) return { ok: true, result: body.result };
-    return {
-      ok: false,
-      status,
-      error_code: body.error_code || status,
-      description: body.description || "",
-      parameters: body.parameters || {},
-    };
-  };
 }
 
 function stopTelegramApprovalSidecar() {

--- a/src/telegram-fetch-transport.js
+++ b/src/telegram-fetch-transport.js
@@ -1,0 +1,173 @@
+"use strict";
+
+// Fetch transport for the native Telegram client (issue #359).
+//
+// Why this exists: in the Electron MAIN process, the global `fetch` is Node's
+// (undici) fetch, which ignores the OS system-proxy settings and (by default)
+// the HTTP(S)_PROXY env vars. That breaks Telegram remote approval whenever the
+// user runs in "system proxy" mode (ClashX / Surge / Clash) instead of TUN mode:
+// the bot's direct requests never traverse the proxy. TUN mode works only because
+// it captures traffic at the routing layer.
+//
+// Fix: route the bot's HTTP through Electron's Chromium network stack via a
+// dedicated in-memory `session.fetch`, with `setProxy({ mode: "system" })` so it
+// follows the OS proxy (and PAC / SOCKS). The session is injected as a
+// `sessionFactory` so this module stays unit-testable without a live Electron app;
+// when no factory is supplied (tests / non-Electron) it falls back to plain fetch.
+//
+// Phase 1 scope (this file): system proxy + a CLAWD_TG_PROXY escape hatch
+// (direct | system | <url>). Environment-variable proxy parsing (ALL_PROXY /
+// HTTPS_PROXY) and NO_PROXY translation are Phase 2 and intentionally NOT here.
+
+const TELEGRAM_API_BASE = "https://api.telegram.org";
+// Probe URL for resolveProxy diagnostics — deliberately tokenless.
+const PROXY_PROBE_URL = "https://api.telegram.org/";
+const DEFAULT_RESOLVE_TIMEOUT_MS = 2000;
+
+// Phase 1 proxy selection: CLAWD_TG_PROXY escape hatch, else follow the OS
+// system proxy. Phase 2 will extend this with ALL_PROXY / HTTPS_PROXY +
+// NO_PROXY → proxyBypassRules translation.
+function resolveProxyConfig(env = {}) {
+  const override = String((env && env.CLAWD_TG_PROXY) || "").trim();
+  if (override === "direct") return { mode: "direct" };
+  if (override === "system") return { mode: "system" };
+  // Escape hatch: a raw proxy URL the user is responsible for formatting in
+  // Chromium's proxyRules syntax (e.g. "socks5://127.0.0.1:7890").
+  if (override) return { mode: "fixed_servers", proxyRules: override };
+  return { mode: "system" };
+}
+
+// Log only the proxy TYPE tokens (PROXY / SOCKS5 / DIRECT), never host:port.
+// resolveProxy() returns strings like "PROXY 127.0.0.1:7890; DIRECT".
+function sanitizeProxy(resolved) {
+  if (typeof resolved !== "string" || !resolved.trim()) return "unknown";
+  const types = [];
+  for (const part of resolved.split(/[;,]/)) {
+    const token = part.trim().split(/\s+/)[0];
+    if (token) types.push(token.toUpperCase());
+  }
+  return types.length ? Array.from(new Set(types)).join("+") : "unknown";
+}
+
+// resolveProxy has no AbortSignal; race a timeout so a hung lookup can't park the
+// apply-chain (Codex review D). Returns the sanitized type string, or null.
+function probeProxyType(ses, resolveTimeoutMs) {
+  const probe = Promise.resolve()
+    .then(() => ses.resolveProxy(PROXY_PROBE_URL))
+    .then((resolved) => sanitizeProxy(resolved))
+    .catch(() => null);
+  const timeout = new Promise((resolve) => {
+    const t = setTimeout(() => resolve(null), Math.max(1, resolveTimeoutMs));
+    if (t && typeof t.unref === "function") t.unref();
+  });
+  return Promise.race([probe, timeout]);
+}
+
+// Returns a transport `async ({ method, payload, signal }) => response` matching
+// the shape TelegramNativeClient expects.
+function createTelegramFetchTransport({
+  tokenStore,
+  sessionFactory = null,
+  env = process.env,
+  fetchImpl = null,
+  log = () => {},
+  resolveTimeoutMs = DEFAULT_RESOLVE_TIMEOUT_MS,
+} = {}) {
+  if (!tokenStore || typeof tokenStore.getToken !== "function") {
+    throw new TypeError("createTelegramFetchTransport: tokenStore.getToken is required");
+  }
+
+  // Per-transport state (NOT module-level — module singletons would leak across
+  // transports and tests). Codex review [P1].
+  let session = null;
+  let appliedKey = "";
+  let applyChain = null;
+
+  // Lazily create the proxied session and apply the proxy config. Serialized via
+  // an apply-promise chain so concurrent callers (long-poll, fire-and-forget
+  // notifications, test card, approval cards) don't double-init or interleave
+  // setProxy. The chain's .catch keeps it alive so one failed apply doesn't
+  // permanently wedge later calls.
+  function ensureSession() {
+    const run = (applyChain || Promise.resolve()).catch(() => {}).then(async () => {
+      const ses = session || (session = sessionFactory());
+      const cfg = resolveProxyConfig(env);
+      const key = JSON.stringify(cfg);
+      if (key !== appliedKey) {
+        await ses.setProxy(cfg);                          // 1) apply NEW proxy first
+        if (appliedKey && typeof ses.closeAllConnections === "function") {
+          // 2) only after setProxy succeeds, drop sockets pooled on the old proxy
+          try { await ses.closeAllConnections(); } catch {}
+        }
+        appliedKey = key;                                 // 3) commit key last
+        if (typeof ses.resolveProxy === "function") {
+          const type = await probeProxyType(ses, resolveTimeoutMs);
+          if (type) log("debug", "telegram proxy resolved", { mode: cfg.mode, proxy: type });
+        }
+      }
+      return ses;
+    });
+    applyChain = run.catch(() => {});                     // stored chain swallows errors…
+    return run;                                           // …but caller still sees the real error
+  }
+
+  return async ({ method, payload, signal }) => {
+    const token = await tokenStore.getToken();
+    if (!token) {
+      return { ok: false, status: null, error_code: "TOKEN_MISSING", description: "no token" };
+    }
+    const url = `${TELEGRAM_API_BASE}/bot${token}/${method}`;
+    let res;
+    try {
+      // ensureSession() (proxy resolve + setProxy + closeAllConnections) lives
+      // INSIDE this try so a setProxy/close failure flows through the same error
+      // normalization as fetch, instead of escaping as a raw error.
+      let doFetch;
+      if (sessionFactory) {
+        const ses = await ensureSession();
+        doFetch = (u, init) => ses.fetch(u, init);        // do not destructure (needs `this`)
+      } else {
+        doFetch = fetchImpl || globalThis.fetch;          // non-Electron / test fallback
+      }
+      res = await doFetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload || {}),
+        signal,
+      });
+    } catch (err) {
+      // Genuine abort: the signal fired, or the impl threw an AbortError.
+      // Don't only trust err.name — Chromium abort can surface as net::ERR_ABORTED
+      // with the signal already aborted. Normalize to name="AbortError" so
+      // classifyError → TIMEOUT and the poll loop exits cleanly.
+      if ((signal && signal.aborted) || (err && err.name === "AbortError")) {
+        if (err && err.name === "AbortError") throw err;
+        const aborted = new Error("aborted");
+        aborted.name = "AbortError";
+        throw aborted;
+      }
+      throw Object.assign(new Error(err && err.message ? err.message : String(err)), {
+        code: (err && (err.code || (err.cause && err.cause.code))) || undefined,
+        causeCode: err && err.cause && err.cause.code,
+      });
+    }
+    const status = res.status;
+    let body;
+    try { body = await res.json(); } catch { body = null; }
+    if (!body) return { ok: false, status, error_code: status, description: res.statusText || "" };
+    if (body.ok) return { ok: true, result: body.result };
+    return {
+      ok: false,
+      status,
+      error_code: body.error_code || status,
+      description: body.description || "",
+      parameters: body.parameters || {},
+    };
+  };
+}
+
+module.exports = {
+  createTelegramFetchTransport,
+  resolveProxyConfig,
+  sanitizeProxy,
+};

--- a/src/telegram-fetch-transport.js
+++ b/src/telegram-fetch-transport.js
@@ -102,7 +102,14 @@ function createTelegramFetchTransport({
         appliedKey = key;                                 // 3) commit key last
         if (typeof ses.resolveProxy === "function") {
           const type = await probeProxyType(ses, resolveTimeoutMs);
-          if (type) log("debug", "telegram proxy resolved", { mode: cfg.mode, proxy: type });
+          // The injected logger ultimately does a synchronous file write
+          // (telegramApprovalLog → permLog → rotatedAppend) that can throw on a
+          // bad path / EACCES. A best-effort diagnostic must never fail a request
+          // whose proxy is already applied (Codex review [P2]; same rationale as
+          // telegram-native-runner's safeLog).
+          if (type) {
+            try { log("debug", "telegram proxy resolved", { mode: cfg.mode, proxy: type }); } catch {}
+          }
         }
       }
       return ses;

--- a/src/telegram-native-client.js
+++ b/src/telegram-native-client.js
@@ -74,6 +74,16 @@ function classifyError(err) {
     return ERROR_CLASSES.NETWORK;
   }
   const message = String(err.message || "");
+  // Electron/Chromium net stack surfaces failures as "net::ERR_*" in the message
+  // with no Node-style err.code (issue #359). Allowlist the connection/proxy/DNS/
+  // transport failures as retryable NETWORK — NOT a catch-all, so ERR_CERT_* /
+  // ERR_BLOCKED_BY_* still fall through to UNKNOWN. ERR_ABORTED maps to NETWORK,
+  // not TIMEOUT: the poll loop treats TIMEOUT as user-stop and exits, while a
+  // genuine user abort is already handled above (err.name === "AbortError").
+  // PROXY_CONNECTION_FAILED is narrowed so proxy cert/auth errors aren't mislabeled.
+  if (/net::ERR_(PROXY_CONNECTION_FAILED|TUNNEL_|SOCKS_|CONNECTION_|NAME_NOT_RESOLVED|TIMED_OUT|NETWORK_CHANGED|INTERNET_DISCONNECTED|ADDRESS_UNREACHABLE|EMPTY_RESPONSE|ABORTED)/i.test(message)) {
+    return ERROR_CLASSES.NETWORK;
+  }
   if (/fetch failed|network|socket|timeout/i.test(message)) return ERROR_CLASSES.NETWORK;
   return ERROR_CLASSES.UNKNOWN;
 }

--- a/test/telegram-fetch-transport.test.js
+++ b/test/telegram-fetch-transport.test.js
@@ -1,0 +1,229 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  createTelegramFetchTransport,
+  resolveProxyConfig,
+  sanitizeProxy,
+} = require("../src/telegram-fetch-transport");
+
+const VALID_TOKEN = "123456789:ABCDEFGHIJKLMNOPQRSTUVWXYZ-_0123456789";
+
+function fakeTokenStore(token = VALID_TOKEN) {
+  return { async getToken() { return token; }, async hasToken() { return !!token; } };
+}
+
+function mkResponse(body = { ok: true, result: { message_id: 1 } }, status = 200, statusText = "OK") {
+  return { status, statusText, async json() { return body; } };
+}
+
+// Fake Electron Session: spies for fetch / setProxy / resolveProxy / closeAllConnections.
+function makeFakeSession({ resolveProxyResult = "PROXY 127.0.0.1:7890", fetchImpl } = {}) {
+  const order = [];
+  const calls = { setProxy: [], close: 0, resolveProxy: [], fetch: [] };
+  let setProxyError = null;
+  const ses = {
+    async setProxy(cfg) {
+      order.push("setProxy");
+      calls.setProxy.push(cfg);
+      if (setProxyError) throw setProxyError;
+    },
+    async closeAllConnections() { order.push("close"); calls.close += 1; },
+    async resolveProxy(url) { calls.resolveProxy.push(url); return resolveProxyResult; },
+    async fetch(url, init) {
+      calls.fetch.push({ url, init });
+      return fetchImpl ? fetchImpl(url, init) : mkResponse();
+    },
+  };
+  return { ses, calls, order, setSetProxyError(e) { setProxyError = e; } };
+}
+
+function makeLog() {
+  const entries = [];
+  return { log: (level, message, meta) => entries.push({ level, message, meta }), entries };
+}
+
+// ---- pure helpers ----
+
+test("resolveProxyConfig: CLAWD_TG_PROXY precedence, default system", () => {
+  assert.deepEqual(resolveProxyConfig({}), { mode: "system" });
+  assert.deepEqual(resolveProxyConfig({ CLAWD_TG_PROXY: "   " }), { mode: "system" });
+  assert.deepEqual(resolveProxyConfig({ CLAWD_TG_PROXY: "direct" }), { mode: "direct" });
+  assert.deepEqual(resolveProxyConfig({ CLAWD_TG_PROXY: "system" }), { mode: "system" });
+  assert.deepEqual(
+    resolveProxyConfig({ CLAWD_TG_PROXY: "http://127.0.0.1:8080" }),
+    { mode: "fixed_servers", proxyRules: "http://127.0.0.1:8080" },
+  );
+});
+
+test("sanitizeProxy: keeps type token, drops host:port", () => {
+  assert.equal(sanitizeProxy("DIRECT"), "DIRECT");
+  assert.equal(sanitizeProxy("PROXY 127.0.0.1:7890"), "PROXY");
+  assert.equal(sanitizeProxy("PROXY 1.2.3.4:8080; DIRECT"), "PROXY+DIRECT");
+  assert.equal(sanitizeProxy("SOCKS5 10.0.0.1:1080"), "SOCKS5");
+  assert.equal(sanitizeProxy(""), "unknown");
+  assert.equal(sanitizeProxy(null), "unknown");
+});
+
+// ---- transport behavior ----
+
+test("missing token short-circuits before session/proxy/fetch", async () => {
+  const { ses, calls } = makeFakeSession();
+  let created = 0;
+  const transport = createTelegramFetchTransport({
+    tokenStore: { async getToken() { return null; } },
+    sessionFactory: () => { created += 1; return ses; },
+    env: {},
+  });
+  const r = await transport({ method: "getMe", payload: {} });
+  assert.equal(r.ok, false);
+  assert.equal(r.error_code, "TOKEN_MISSING");
+  assert.equal(created, 0);
+  assert.equal(calls.setProxy.length, 0);
+  assert.equal(calls.fetch.length, 0);
+});
+
+test("default applies mode:system; fetch carries token; probe is tokenless; log sanitized", async () => {
+  const { ses, calls } = makeFakeSession();
+  const { log, entries } = makeLog();
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), sessionFactory: () => ses, env: {}, log,
+  });
+  const r = await transport({ method: "getMe", payload: { a: 1 } });
+  assert.equal(r.ok, true);
+  assert.deepEqual(calls.setProxy, [{ mode: "system" }]);
+  assert.equal(calls.fetch.length, 1);
+  assert.match(calls.fetch[0].url, /\/bot123456789:.*\/getMe$/);
+  // resolveProxy probe carries NO token
+  assert.deepEqual(calls.resolveProxy, ["https://api.telegram.org/"]);
+  assert.ok(!calls.resolveProxy[0].includes("bot"));
+  // diagnostic log is type-only, never host:port
+  const proxyLog = entries.find((e) => e.message === "telegram proxy resolved");
+  assert.ok(proxyLog, "expected a proxy-resolved log line");
+  assert.equal(proxyLog.meta.proxy, "PROXY");
+  assert.ok(!JSON.stringify(proxyLog).includes("127.0.0.1"));
+});
+
+test("CLAWD_TG_PROXY escape hatch: direct / system / url", async () => {
+  const cases = [
+    ["direct", { mode: "direct" }],
+    ["system", { mode: "system" }],
+    ["socks5://127.0.0.1:7890", { mode: "fixed_servers", proxyRules: "socks5://127.0.0.1:7890" }],
+  ];
+  for (const [val, expected] of cases) {
+    const { ses, calls } = makeFakeSession();
+    const transport = createTelegramFetchTransport({
+      tokenStore: fakeTokenStore(), sessionFactory: () => ses, env: { CLAWD_TG_PROXY: val },
+    });
+    await transport({ method: "getMe", payload: {} });
+    assert.deepEqual(calls.setProxy, [expected]);
+  }
+});
+
+test("setProxy applied once across repeated requests (same config)", async () => {
+  const { ses, calls } = makeFakeSession();
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), sessionFactory: () => ses, env: {},
+  });
+  await transport({ method: "getMe", payload: {} });
+  await transport({ method: "getMe", payload: {} });
+  await transport({ method: "getUpdates", payload: {} });
+  assert.equal(calls.setProxy.length, 1);
+  assert.equal(calls.fetch.length, 3);
+});
+
+test("concurrent calls init session and setProxy exactly once (apply-lock)", async () => {
+  const { ses, calls } = makeFakeSession();
+  let created = 0;
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), sessionFactory: () => { created += 1; return ses; }, env: {},
+  });
+  await Promise.all([
+    transport({ method: "getMe", payload: {} }),
+    transport({ method: "getMe", payload: {} }),
+    transport({ method: "getMe", payload: {} }),
+  ]);
+  assert.equal(created, 1);
+  assert.equal(calls.setProxy.length, 1);
+  assert.equal(calls.fetch.length, 3);
+});
+
+test("setProxy failure is normalized and retryable (chain not wedged)", async () => {
+  const fake = makeFakeSession();
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), sessionFactory: () => fake.ses, env: {},
+  });
+  fake.setSetProxyError(new Error("net::ERR_PROXY_CONNECTION_FAILED"));
+  await assert.rejects(
+    () => transport({ method: "getMe", payload: {} }),
+    /ERR_PROXY_CONNECTION_FAILED/,
+  );
+  assert.equal(fake.calls.fetch.length, 0, "fetch must not run when setProxy fails");
+  assert.equal(fake.calls.close, 0, "no closeAllConnections on a failed first apply");
+  // recover: the chain is not permanently wedged
+  fake.setSetProxyError(null);
+  const r = await transport({ method: "getMe", payload: {} });
+  assert.equal(r.ok, true);
+  assert.equal(fake.calls.setProxy.length, 2, "setProxy retried (key never committed on failure)");
+});
+
+test("config change: setProxy precedes closeAllConnections; first apply does not close", async () => {
+  const fake = makeFakeSession();
+  const env = {};
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), sessionFactory: () => fake.ses, env,
+  });
+  await transport({ method: "getMe", payload: {} });          // first apply: system
+  assert.equal(fake.calls.close, 0);
+  assert.deepEqual(fake.calls.setProxy, [{ mode: "system" }]);
+
+  env.CLAWD_TG_PROXY = "direct";                              // change config
+  await transport({ method: "getMe", payload: {} });
+  assert.equal(fake.calls.setProxy.length, 2);
+  assert.deepEqual(fake.calls.setProxy[1], { mode: "direct" });
+  assert.equal(fake.calls.close, 1);
+  const lastSetProxy = fake.order.lastIndexOf("setProxy");
+  const lastClose = fake.order.lastIndexOf("close");
+  assert.ok(lastSetProxy < lastClose, "setProxy must run before closeAllConnections");
+});
+
+test("aborted signal yields AbortError even if impl throws net::ERR_ABORTED", async () => {
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), env: {},
+    fetchImpl: async () => { throw new Error("net::ERR_ABORTED"); }, // not name === AbortError
+  });
+  const c = new AbortController();
+  c.abort();
+  await assert.rejects(
+    () => transport({ method: "getMe", payload: {}, signal: c.signal }),
+    (e) => e.name === "AbortError",
+  );
+});
+
+test("no sessionFactory falls back to injected fetchImpl", async () => {
+  let used = 0;
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), env: {},
+    fetchImpl: async (url) => { used += 1; assert.match(url, /\/getMe$/); return mkResponse(); },
+  });
+  const r = await transport({ method: "getMe", payload: {} });
+  assert.equal(r.ok, true);
+  assert.equal(used, 1);
+});
+
+test("non-ok Telegram body maps to error_code/description/parameters", async () => {
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), env: {},
+    fetchImpl: async () => mkResponse(
+      { ok: false, error_code: 403, description: "Forbidden", parameters: { migrate_to_chat_id: 7 } },
+      403, "Forbidden",
+    ),
+  });
+  const r = await transport({ method: "sendMessage", payload: {} });
+  assert.equal(r.ok, false);
+  assert.equal(r.error_code, 403);
+  assert.equal(r.description, "Forbidden");
+  assert.deepEqual(r.parameters, { migrate_to_chat_id: 7 });
+});

--- a/test/telegram-fetch-transport.test.js
+++ b/test/telegram-fetch-transport.test.js
@@ -227,3 +227,29 @@ test("non-ok Telegram body maps to error_code/description/parameters", async () 
   assert.equal(r.description, "Forbidden");
   assert.deepEqual(r.parameters, { migrate_to_chat_id: 7 });
 });
+
+test("a throwing diagnostic log does not fail the fetch (best-effort)", async () => {
+  const { ses, calls } = makeFakeSession();
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), sessionFactory: () => ses, env: {},
+    log: () => { throw new Error("EACCES permLog"); }, // mirrors telegramApprovalLog's sync file write
+  });
+  const r = await transport({ method: "getMe", payload: {} });
+  assert.equal(r.ok, true, "proxy is applied; a failing log must not fail the request");
+  assert.equal(calls.setProxy.length, 1);
+  assert.equal(calls.fetch.length, 1);
+});
+
+test("resolveProxy timeout: fetch still proceeds, no proxy log emitted", async () => {
+  const { ses, calls } = makeFakeSession();
+  ses.resolveProxy = () => new Promise(() => {}); // never settles → probe loses the race
+  const { log, entries } = makeLog();
+  const transport = createTelegramFetchTransport({
+    tokenStore: fakeTokenStore(), sessionFactory: () => ses, env: {}, log, resolveTimeoutMs: 5,
+  });
+  const r = await transport({ method: "getMe", payload: {} });
+  assert.equal(r.ok, true);
+  assert.equal(calls.setProxy.length, 1);
+  assert.equal(calls.fetch.length, 1);
+  assert.ok(!entries.some((e) => e.message === "telegram proxy resolved"), "no proxy log on resolve timeout");
+});

--- a/test/telegram-native-client.test.js
+++ b/test/telegram-native-client.test.js
@@ -177,6 +177,33 @@ test("Error classes: undici fetch cause codes are network errors", () => {
   assert.equal(classifyError(err), ERROR_CLASSES.NETWORK);
 });
 
+test("Error classes: Chromium net::ERR_* connection failures are NETWORK (issue #359)", () => {
+  for (const message of [
+    "net::ERR_PROXY_CONNECTION_FAILED",
+    "net::ERR_TUNNEL_CONNECTION_FAILED",
+    "net::ERR_SOCKS_CONNECTION_FAILED",
+    "net::ERR_NAME_NOT_RESOLVED",
+    "net::ERR_CONNECTION_REFUSED",
+    "net::ERR_CONNECTION_RESET",
+    "net::ERR_TIMED_OUT",
+    "net::ERR_INTERNET_DISCONNECTED",
+  ]) {
+    assert.equal(classifyError(new Error(message)), ERROR_CLASSES.NETWORK, message);
+  }
+});
+
+test("Error classes: net::ERR_ABORTED is NETWORK, not TIMEOUT (must not exit poll loop)", () => {
+  // A genuine user abort arrives as name === "AbortError" and is handled earlier.
+  // An involuntary Chromium abort must be retried, so it must NOT map to TIMEOUT —
+  // the poll loop exits on TIMEOUT (telegram-native-runner.js loop/loopFirst).
+  assert.equal(classifyError(new Error("net::ERR_ABORTED")), ERROR_CLASSES.NETWORK);
+});
+
+test("Error classes: non-retryable net::ERR_* (cert / blocked) fall through to UNKNOWN", () => {
+  assert.equal(classifyError(new Error("net::ERR_CERT_AUTHORITY_INVALID")), ERROR_CLASSES.UNKNOWN);
+  assert.equal(classifyError(new Error("net::ERR_BLOCKED_BY_CLIENT")), ERROR_CLASSES.UNKNOWN);
+});
+
 test("Error classes: status=null but error_code=409 still classified as CONFLICT", () => {
   const err = new TelegramApiError({ status: null, code: 409, description: "Conflict" });
   assert.equal(classifyError(err), ERROR_CLASSES.CONFLICT);


### PR DESCRIPTION
## Problem
Closes #359. With the OS in **system-proxy** mode (ClashX / Surge / Clash), the embedded Telegram remote-approval bot can't reach Telegram — approval messages are neither sent nor received. Only **TUN mode** works, which needs elevated permissions and captures all traffic.

## Root cause
The native bot's only outbound call was Node's global `fetch()`. In the Electron **main process** that's Node's (undici) fetch, which ignores OS system-proxy settings and (by default) `HTTP(S)_PROXY` env vars. TUN works only because it captures traffic at the routing/IP layer.

## Fix (Phase 1 — system proxy)
Route the bot's HTTP through Electron's Chromium network stack via a dedicated in-memory `session.fetch` with `setProxy({ mode: 'system' })`, so it follows the OS system proxy (and PAC / SOCKS). Extracted into `src/telegram-fetch-transport.js` (injectable `session` / `fetch` / `env`) so it's unit-testable without a live Electron app.

Highlights:
- **apply-chain** serializes proxy setup across concurrent callers (long-poll, fire-and-forget notifications, test card, approval cards); `setProxy` runs **before** `closeAllConnections`; one failed apply doesn't wedge later calls.
- `resolveProxy` diagnostic raced against a timeout and logged **sanitized** (type only, no host:port; tokenless probe URL).
- `classifyError`: allowlist Chromium `net::ERR_*` connection/proxy/DNS failures as `NETWORK`; **`ERR_ABORTED → NETWORK`** (not `TIMEOUT`, which the poll loop treats as user-stop and exits). Genuine aborts still flow through `signal.aborted → AbortError`.
- `CLAWD_TG_PROXY=direct|system|<url>` escape hatch.

## Changes
- **new** `src/telegram-fetch-transport.js` — the transport
- `src/main.js` — drop inline `makeFetchTransport`, inject `sessionFactory` (dedicated `clawd-telegram` in-memory session)
- `src/telegram-native-client.js` — `classifyError` net allowlist
- **new** `test/telegram-fetch-transport.test.js` (12) + extended `test/telegram-native-client.test.js`

## Tests
- Telegram suite **265/265 green** (`node --test test/telegram-*.test.js`).
- Full suite: only pre-existing macOS-environment failures in `install`/`kiro-install` (Windows path / Claude-version probes), unrelated to this change.

## Scope / follow-up
Phase 1 fixes the reported system-proxy case. **Phase 2** (env-var proxies `ALL_PROXY`/`HTTPS_PROXY` + `NO_PROXY`→Chromium bypass translation, credentialed-proxy handling, legacy-sidecar env allowlist) is planned separately.

## Manual verification (before release)
macOS ClashX/Surge system proxy on → `resolveProxy('https://api.telegram.org/')` shows PROXY/SOCKS not DIRECT; test card + approval round-trip succeed; stop/restart polling not wedged.

Reviewed across 3 Codex (云宝) rounds: root cause + approach, implementation-detail fixes, then a final "Phase 1 可开工" sign-off.