### PR TITLE
fix(kiro): build win32 CLI candidate paths with path.win32

### DIFF
--- a/hooks/kiro-install.js
+++ b/hooks/kiro-install.js
@@ -144,11 +144,11 @@ function formatHookCommand(nodeBin, scriptPath, platformOverride) {
 function getKiroCliCandidates(homeDir = os.homedir(), platformOverride, env = process.env) {
   const platform = platformOverride || process.platform;
   if (platform === "win32") {
-    const localAppData = env.LOCALAPPDATA || path.join(homeDir, "AppData", "Local");
+    const localAppData = env.LOCALAPPDATA || path.win32.join(homeDir, "AppData", "Local");
     const programFiles = env.ProgramFiles || "C:\\Program Files";
     return [
-      path.join(localAppData, "Kiro-Cli", "kiro-cli.exe"),
-      path.join(programFiles, "Kiro-Cli", "kiro-cli.exe"),
+      path.win32.join(localAppData, "Kiro-Cli", "kiro-cli.exe"),
+      path.win32.join(programFiles, "Kiro-Cli", "kiro-cli.exe"),
       "kiro-cli.exe",
       "kiro-cli",
     ];


### PR DESCRIPTION
## What

`getKiroCliCandidates()` builds its **win32** install-path candidates with the host-dependent `path.join`. On macOS/Linux that joins with `/`, producing mixed-separator strings like `C:\Users\test\AppData\Local/Kiro-Cli/kiro-cli.exe`. As a result the test `getKiroCliCandidates returns Windows install paths on win32` ([test/kiro-install.test.js](../blob/main/test/kiro-install.test.js)) fails whenever the suite runs off-Windows.

## Fix

Use `path.win32.join` in the `win32` branch so the candidate paths are correct regardless of host OS. The posix branch is left on `path.join`.

```
path.join       => C:\Users\test\AppData\Local/Kiro-Cli/kiro-cli.exe   (mixed, on macOS)
path.win32.join => C:\Users\test\AppData\Local\Kiro-Cli\kiro-cli.exe  (correct, any host)
```

## Safety

- On **Windows**, `path === path.win32`, so `path.win32.join` is byte-for-byte identical to the old `path.join` — **zero production behavior change** for real Windows users (the only place this branch runs in production).
- Off-Windows, the `win32` branch only runs when a platform override is passed (i.e. tests), so the only effect is correct paths there.

## Test

`node --test test/kiro-install.test.js` → **12/12** on macOS (was 11/12; the win32 path test now passes cross-platform).

Unrelated to #397; this is a pre-existing cross-platform test-portability issue.