### PR TITLE
fix(telegram): strip approval keyboard when resolved on desktop

### DIFF
--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -506,6 +506,17 @@ function createTelegramNativeRunner({
     }
   }
 
+  // Best-effort: strip the inline keyboard off an approval card whose decision
+  // landed somewhere other than this Telegram chat. Never throws.
+  function clearApprovalKeyboard(entry) {
+    if (!entry || !entry.messageId || !entry.chatId) return;
+    client.editMessageReplyMarkup({
+      chat_id: entry.chatId,
+      message_id: entry.messageId,
+      reply_markup: { inline_keyboard: [] },
+    }).catch(() => {});
+  }
+
   function finishApproval(id, decision) {
     const entry = pendingApprovals.get(id);
     if (!entry) return;
@@ -514,7 +525,14 @@ function createTelegramNativeRunner({
     if (entry.signal && entry.onAbort) {
       try { entry.signal.removeEventListener("abort", entry.onAbort); } catch {}
     }
-    entry.resolve(normalizeApprovalDecision(decision));
+    const normalized = normalizeApprovalDecision(decision);
+    // A Telegram-side decision already strips the keyboard in
+    // handleApprovalCallback before we get here. A null decision means the
+    // approval was resolved elsewhere — answered on the desktop, timed out, or
+    // polling stopped — leaving a still-clickable card that would later answer
+    // "Expired". Pull its buttons so the stale prompt can't be tapped.
+    if (!normalized) clearApprovalKeyboard(entry);
+    entry.resolve(normalized);
   }
 
   function clearAllApprovals() {

--- a/test/telegram-native-runner.test.js
+++ b/test/telegram-native-runner.test.js
@@ -463,6 +463,49 @@ test("native runner aborts an in-flight approval send before a late Telegram suc
   await runner.stop();
 });
 
+test("native runner strips approval keyboard when resolved on desktop (abort)", async () => {
+  const server = createFakeTelegramServer();
+  let releaseFirstPoll;
+
+  server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+  server.enqueueOk("sendMessage", { message_id: 99, chat: { id: 123 } });
+  server.enqueueOk("editMessageReplyMarkup", { message_id: 99 });
+
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.start();
+  await tick();
+
+  const controller = new AbortController();
+  const decisionPromise = runner.requestApproval(
+    { title: "claude-code requests Bash", detail: "Summary: Run tests" },
+    { signal: controller.signal },
+  );
+  // Let the card send resolve so the entry records its message id.
+  await tick();
+  assert.equal(server.calls.filter((call) => call.method === "sendMessage").length, 1);
+
+  // Desktop answered the permission: the caller aborts the in-flight request.
+  controller.abort();
+  assert.equal(await decisionPromise, null);
+  await tick();
+
+  const editCalls = server.calls.filter((call) => call.method === "editMessageReplyMarkup");
+  assert.equal(editCalls.length, 1, "stale approval card must have its keyboard stripped");
+  assert.equal(editCalls[0].payload.chat_id, "123");
+  assert.equal(editCalls[0].payload.message_id, 99);
+  assert.deepEqual(editCalls[0].payload.reply_markup, { inline_keyboard: [] });
+
+  releaseFirstPoll({ ok: true, result: [] });
+  await runner.stop();
+});
+
 test("native runner requestApproval is disabled until polling with a valid payload", async () => {
   const runner = createTelegramNativeRunner({
     tokenStore: tokenStore(),


### PR DESCRIPTION
## Summary

When a permission is answered on the desktop, the in-flight Telegram approval request is aborted, but the card's inline keyboard was left intact. Tapping it later hit the no-pending-entry branch and answered **"Expired"**.

`finishApproval` now strips the keyboard via `editMessageReplyMarkup` whenever an approval ends **without** a Telegram-side decision (desktop answer, timeout, or polling stop), so the stale prompt can no longer be tapped.

Telegram-side taps are unaffected: `handleApprovalCallback` already clears the keyboard and passes a real (non-null) decision, so there's no double-edit. The abort-before-send case is also safe — `messageId` is still null then, so the helper is a no-op.

## Testing

- Added a regression test: `native runner strips approval keyboard when resolved on desktop (abort)` — asserts a single `editMessageReplyMarkup` with an empty `inline_keyboard` is sent for the card when the request is aborted after the card was delivered.
- `node --test test/telegram-native-runner.test.js` — all 28 pass.
- Manually verified in a local build: answering on the desktop removes the buttons from the Telegram card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)