### PR TITLE
fix(state): stop replaying completion animation on duplicate Stop

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -213,6 +213,23 @@ function resolveAwaitingInputSinceStop(existing, event) {
   return false;
 }
 
+function hasCompletionTailWithoutProgress(session) {
+  const events = Array.isArray(session && session.recentEvents) ? session.recentEvents : [];
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i] && events[i].event;
+    if (POST_COMPLETION_EVENTS.has(event)) return true;
+    if (event === "Notification" || event === "stale-cleanup" || event == null) continue;
+    return false;
+  }
+  return false;
+}
+
+function shouldSuppressDuplicateCompletionVisual(existing, state, event) {
+  if (state !== "attention" || !POST_COMPLETION_EVENTS.has(event)) return false;
+  if (!existing || (existing.state !== "idle" && existing.state !== "sleeping")) return false;
+  return existing.awaitingInputSinceStop === true || hasCompletionTailWithoutProgress(existing);
+}
+
 function shouldMuteMiniPostCompletionNotification(state, event, session) {
   return !!ctx.miniMode
     && state === "notification"
@@ -1173,6 +1190,7 @@ function updateSession(sessionId, state, event, opts = {}) {
   const isSubagentStart = event === "SubagentStart" || event === "subagentStart";
   const isSubagentStop = event === "SubagentStop" || event === "subagentStop";
   const preservedState = preserveState && existing ? existing.state : null;
+  const duplicateCompletionVisualAtEntry = shouldSuppressDuplicateCompletionVisual(existing, state, event);
 
   // #406 Stop completion gate — Claude Code only; other agents keep their own
   // completion semantics (Codex task_complete + remote exit probes, etc.). A
@@ -1183,7 +1201,12 @@ function updateSession(sessionId, state, event, opts = {}) {
   // The first two are decidable now: hold "working" (badge stays "running", no
   // celebrate, no "done"). A plain Stop is debounced — held "working" until a
   // quiet window with no forward-progress event confirms the turn really ended.
-  if (event === "Stop" && state === "attention" && srcAgentId === "claude-code") {
+  if (
+    !duplicateCompletionVisualAtEntry
+    && event === "Stop"
+    && state === "attention"
+    && srcAgentId === "claude-code"
+  ) {
     cancelCompletionDebounce(sessionId, "stop-superseded");
     const liveWork =
       backgroundTasksCount > 0 || sessionCronsCount > 0 || stopHookActive === true;
@@ -1405,6 +1428,9 @@ function updateSession(sessionId, state, event, opts = {}) {
     schedulePermissionSuspect(sessionId);
   }
 
+  const suppressDuplicateCompletionVisual =
+    duplicateCompletionVisualAtEntry || shouldSuppressDuplicateCompletionVisual(existing, state, event);
+
   if (ONESHOT_STATES.has(state)) {
     // Permission animation lock: while any permission request is pending,
     // keep the pet on notification and block all other one-shot visuals.
@@ -1436,6 +1462,11 @@ function updateSession(sessionId, state, event, opts = {}) {
       && typeof ctx.isAgentNotificationHookEnabled === "function"
       && !ctx.isAgentNotificationHookEnabled(srcAgentId)
     ) {
+      const displayState = resolveDisplayState();
+      setState(displayState, getSvgOverride(displayState));
+      return;
+    }
+    if (suppressDuplicateCompletionVisual) {
       const displayState = resolveDisplayState();
       setState(displayState, getSvgOverride(displayState));
       return;

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1374,6 +1374,115 @@ describe("updateSession()", () => {
     assert.strictEqual(api.getCurrentState(), "attention");
   });
 
+  it("does not replay the completion animation for a duplicate Stop without progress", () => {
+    const soundsPlayed = [];
+    const stateChanges = [];
+    api.cleanup();
+    ctx = makeCtx({
+      processKill: () => true,
+      playSound: (name) => soundsPlayed.push(name),
+      sendToRenderer: (channel, state) => {
+        if (channel === "state-change") stateChanges.push(state);
+      },
+    });
+    api = require("../src/state")(ctx);
+
+    update(api, { id: "s1", state: "working" });
+    mock.timers.tick(1000);
+    stateChanges.length = 0;
+
+    update(api, { id: "s1", state: "attention", event: "Stop" });
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 1);
+    assert.deepStrictEqual(stateChanges, ["attention"]);
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+    mock.timers.tick(4000);
+    assert.strictEqual(api.getCurrentState(), "idle");
+
+    soundsPlayed.length = 0;
+    stateChanges.length = 0;
+    update(api, { id: "s1", state: "attention", event: "Stop" });
+
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 0);
+    assert.ok(!stateChanges.includes("attention"), "duplicate Stop must not re-send attention");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+    assert.strictEqual(api.getCurrentState(), "idle");
+  });
+
+  it("does not replay remote Codex task_complete after the completion animation returned to idle", () => {
+    const soundsPlayed = [];
+    const stateChanges = [];
+    api.cleanup();
+    ctx = makeCtx({
+      processKill: () => true,
+      playSound: (name) => soundsPlayed.push(name),
+      sendToRenderer: (channel, state) => {
+        if (channel === "state-change") stateChanges.push(state);
+      },
+    });
+    api = require("../src/state")(ctx);
+
+    update(api, {
+      id: "codex:remote",
+      state: "attention",
+      event: "event_msg:task_complete",
+      agentId: "codex",
+      host: "ssh:box",
+    });
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 1);
+    assert.deepStrictEqual(stateChanges, ["attention"]);
+    assert.strictEqual(api.sessions.get("codex:remote").requiresCompletionAck, true);
+    mock.timers.tick(4000);
+    assert.strictEqual(api.getCurrentState(), "idle");
+
+    soundsPlayed.length = 0;
+    stateChanges.length = 0;
+    update(api, {
+      id: "codex:remote",
+      state: "attention",
+      event: "event_msg:task_complete",
+      agentId: "codex",
+      host: "ssh:box",
+    });
+
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 0);
+    assert.ok(!stateChanges.includes("attention"), "duplicate task_complete must not re-send attention");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("codex:remote")), "done");
+    assert.strictEqual(api.sessions.get("codex:remote").requiresCompletionAck, true);
+  });
+
+  it("still plays completion after new progress follows a completed turn", () => {
+    const soundsPlayed = [];
+    const stateChanges = [];
+    api.cleanup();
+    ctx = makeCtx({
+      processKill: () => true,
+      playSound: (name) => soundsPlayed.push(name),
+      sendToRenderer: (channel, state) => {
+        if (channel === "state-change") stateChanges.push(state);
+      },
+    });
+    api = require("../src/state")(ctx);
+
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    mock.timers.tick(1000);
+    update(api, { id: "s1", state: "attention", event: "Stop" });
+    mock.timers.tick(4000);
+
+    soundsPlayed.length = 0;
+    stateChanges.length = 0;
+    update(api, { id: "s1", state: "thinking", event: "UserPromptSubmit" });
+    mock.timers.tick(1000);
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    mock.timers.tick(1000);
+    stateChanges.length = 0;
+
+    update(api, { id: "s1", state: "attention", event: "Stop" });
+
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 1);
+    assert.deepStrictEqual(stateChanges, ["attention"]);
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+  });
+
   it("SessionEnd + other non-headless sessions → resolves to highest", () => {
     update(api, { id: "s1", state: "working" });
     update(api, { id: "s2", state: "thinking" });
@@ -2198,6 +2307,27 @@ describe("Stop completion gate (#406)", () => {
     assert.strictEqual(api.getCurrentState(), "attention");
     assert.ok(soundsPlayed.includes("complete"), "a real completion celebrates");
     assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+  });
+
+  it("debounce: a duplicate Stop after auto-return does not replay completion", () => {
+    update(api, { id: "s1", state: "attention", event: "Stop" });
+    mock.timers.tick(1000);
+    assert.strictEqual(api.sessions.get("s1").state, "idle");
+    assert.strictEqual(api.getCurrentState(), "attention");
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 1);
+    mock.timers.tick(4000);
+    assert.strictEqual(api.getCurrentState(), "idle");
+
+    soundsPlayed.length = 0;
+    stateChanges.length = 0;
+    update(api, { id: "s1", state: "attention", event: "Stop" });
+
+    assert.strictEqual(api.sessions.get("s1").state, "idle");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+    mock.timers.tick(5000);
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 0);
+    assert.ok(!stateChanges.includes("working"), "duplicate Stop must not reopen a running state");
+    assert.ok(!stateChanges.includes("attention"), "duplicate Stop must not replay attention");
   });
 
   it("does not debounce non-Claude agents — a Codex Stop celebrates immediately", () => {


### PR DESCRIPTION
## Problem

After an agent turn finished, the desktop pet would **repeatedly replay the completion animation + sound** and could not settle. Root cause: once a session has completed and settled to `idle`/`sleeping`, a duplicate `Stop` (or remote Codex `event_msg:task_complete`) with no forward progress in between still re-fired `setState("attention")`. With the `#406` completion debounce enabled it was worse — the duplicate reopened the session as `working` and re-promoted it, so the animation looped.

## Fix (`src/state.js`)

- Add `hasCompletionTailWithoutProgress()` + `shouldSuppressDuplicateCompletionVisual()`: an attention-mapped completion event landing on an already-`idle`/`sleeping` session that is still `awaitingInputSinceStop` (or whose `recentEvents` tail is a completion with no progress since) resolves to the current display state instead of re-celebrating.
- Compute it once at entry (`duplicateCompletionVisualAtEntry`) **before** the Claude Stop debounce gate, and skip the gate for duplicates — otherwise the duplicate is re-held as `working` and re-promoted, replaying the animation.
- **Ledger is untouched**: `recentEvents`, the `done` badge, and remote Codex `requiresCompletionAck` still update. Only the redundant visual + sound is suppressed.

Preserved behaviors (all still celebrate exactly once): first completions, live `background_tasks`/`session_crons`/`stop_hook_active` holds, the debounce-delayed first Stop, and real new completions after genuine progress.

## Tests (`test/state.test.js`, +4)

- duplicate `Stop` after auto-return → no replay, badge stays `done`
- remote Codex `event_msg:task_complete` duplicate → no replay, `requiresCompletionAck`/badge preserved
- debounce path (`CLAWD_COMPLETION_DEBOUNCE_MS=1000`) duplicate → does **not** reopen as `working`, no delayed replay
- completion after **new progress** → still celebrates (no over-suppression)

Each was confirmed to fail if the guard / entry-gate is removed (mutation-checked). Full required suites green: `state` (203), `agent-runtime-main` (15), `server-route-state` (19), `state-session-snapshot` (18), `session-hud` (32), `state-notification-hook-gate` (22); `git diff --check` clean.

## Real-app smoke QA

Drove the running app over the `/state` HTTP route (Cloudling theme) and traced what the renderer was actually told:

| Step | Event | Renderer result |
|------|-------|-----------------|
| First `Stop` | completion | `play-sound complete` + `state-change attention` ✅ celebrates |
| Duplicate `Stop` (after auto-return, no progress) | completion | **no `attention`, no `complete`** ✅ suppressed |
| New `Stop` after `UserPromptSubmit`+`PreToolUse` | real completion | `play-sound complete` + `state-change attention` ✅ celebrates again |

session-debug.log confirmed the duplicate was genuinely delivered (`existing.state=idle`), not dropped at the route.