### PR TITLE
fix(codex): relabel MCP tool calls instead of "Permission Request" (#445)

### DIFF
--- a/src/bubble-format.js
+++ b/src/bubble-format.js
@@ -81,7 +81,30 @@
     return truncate(JSON.stringify(input), 100);
   }
 
-  const api = { formatDetail, formatAntigravityDetail, truncate, firstStringValue };
+  // Issue #445: MCP tool names arrive as opaque, scary-looking identifiers
+  // (e.g. "MCP__CODEX_APPS__VERCEL__LIST_PROJECTS"). Parse them into a friendly
+  // "server · tool" label for display ONLY. Naming differs across agents —
+  // Codex uses upper-case 4-segment names, Claude Code uses lower-case 3-segment
+  // ("mcp__github__list_issues") — so we are case-insensitive and key off the
+  // last two segments. Returns null for anything that is not MCP-shaped, so the
+  // caller falls back to the raw name. This must never throw and must never
+  // decide safety/approval behavior.
+  function parseMcpToolName(toolName) {
+    if (typeof toolName !== "string" || !toolName) return null;
+    const segs = toolName.split("__");
+    if (segs.length < 2 || segs[0].toLowerCase() !== "mcp") return null;
+    const rest = segs.slice(1);
+    // Any empty segment (leading / middle / trailing "__") means a malformed
+    // name: fall back to the raw display rather than a misleading partial label
+    // (e.g. "MCP__CODEX_APPS__VERCEL__" must NOT render as "codex_apps · vercel").
+    if (rest.some((seg) => seg === "")) return null;
+    const tool = rest[rest.length - 1].toLowerCase();
+    const server = rest.length >= 2 ? rest[rest.length - 2].toLowerCase() : null;
+    const display = server ? `${server} · ${tool}` : tool;
+    return { server, tool, display };
+  }
+
+  const api = { formatDetail, formatAntigravityDetail, truncate, firstStringValue, parseMcpToolName };
 
   if (typeof module === "object" && module.exports) {
     module.exports = api;

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -1,4 +1,4 @@
-const { formatDetail, truncate } = window.ClawdBubbleFormat;
+const { formatDetail, truncate, parseMcpToolName } = window.ClawdBubbleFormat;
 const card = document.getElementById("card");
 const toolPill = document.getElementById("toolPill");
 const toolPillText = document.getElementById("toolPillText");
@@ -76,6 +76,7 @@ const BUBBLE_STRINGS = {
     other: "Other",
     otherPlaceholder: "Type your answer…",
     codexPermission: "Codex Permission",
+    codexToolApproval: "Codex Tool Approval",
     kimiPermission: "Kimi Permission",
     checkKimiTerminal: "Approve or reject this request in the Kimi terminal.",
     gotIt: "Got it",
@@ -110,6 +111,7 @@ const BUBBLE_STRINGS = {
     other: "\u5176\u4ED6",
     otherPlaceholder: "\u8F93\u5165\u4F60\u7684\u56DE\u7B54\u2026",
     codexPermission: "Codex \u6743\u9650\u8BF7\u6C42",
+    codexToolApproval: "Codex \u5DE5\u5177\u8C03\u7528\u5BA1\u6279",
     kimiPermission: "Kimi \u6743\u9650\u8BF7\u6C42",
     checkKimiTerminal: "\u8BF7\u5728 Kimi \u7EC8\u7AEF\u4E2D\u6279\u51C6\u6216\u62D2\u7EDD\u8BE5\u8BF7\u6C42\u3002",
     gotIt: "\u77E5\u9053\u4E86",
@@ -144,6 +146,7 @@ const BUBBLE_STRINGS = {
     other: "其他",
     otherPlaceholder: "輸入你的回答…",
     codexPermission: "Codex 權限請求",
+    codexToolApproval: "Codex 工具呼叫審批",
     kimiPermission: "Kimi 權限請求",
     checkKimiTerminal: "請在 Kimi 終端機中允許或拒絕此請求。",
     gotIt: "了解",
@@ -178,6 +181,7 @@ const BUBBLE_STRINGS = {
     other: "\uAE30\uD0C0",
     otherPlaceholder: "\uC9C1\uC811 \uC785\uB825\u2026",
     codexPermission: "Codex \uAD8C\uD55C \uC694\uCCAD",
+    codexToolApproval: "Codex \uB3C4\uAD6C \uD638\uCD9C \uC2B9\uC778",
     kimiPermission: "Kimi \uAD8C\uD55C \uC694\uCCAD",
     checkKimiTerminal: "Kimi \uD130\uBBF8\uB110\uC5D0\uC11C \uC774 \uC694\uCCAD\uC744 \uD5C8\uC6A9\uD558\uAC70\uB098 \uAC70\uBD80\uD558\uC138\uC694.",
     gotIt: "\uD655\uC778",
@@ -212,6 +216,7 @@ const BUBBLE_STRINGS = {
     other: "その他",
     otherPlaceholder: "回答を入力…",
     codexPermission: "Codex 権限リクエスト",
+    codexToolApproval: "Codex ツール呼び出しの承認",
     kimiPermission: "Kimi 権限リクエスト",
     checkKimiTerminal: "Kimi ターミナルでこのリクエストを許可または拒否してください。",
     gotIt: "了解",
@@ -813,16 +818,23 @@ function show(data) {
   }
 
   const isPlanReview = data.toolName === "ExitPlanMode";
+  // Issue #445: an MCP tool call (e.g. Codex + Vercel MCP) is not an OS
+  // permission. For Codex MCP approvals, relabel the title and show a friendly
+  // "server · tool" pill so "MCP__CODEX_APPS__VERCEL__LIST_PROJECTS" reads as
+  // "vercel · list_projects". Parsing is display-only — Allow/Deny semantics and
+  // the no-decision fallback are untouched.
+  const mcp = parseMcpToolName(data.toolName);
 
   // Header
-  headerTitle.textContent = isPlanReview
-    ? bubbleText(data.lang, "planReview")
-    : bubbleText(data.lang, "permissionRequest");
+  let titleKey = "permissionRequest";
+  if (isPlanReview) titleKey = "planReview";
+  else if (mcp && data.isCodex) titleKey = "codexToolApproval";
+  headerTitle.textContent = bubbleText(data.lang, titleKey);
   toolPill.style.display = isPlanReview ? "none" : "";
   btnDeny.style.display = isPlanReview ? "none" : "";
 
-  // Tool pill
-  toolPillText.textContent = data.toolName || "Unknown";
+  // Tool pill — friendly "server · tool" for MCP, raw tool name otherwise
+  toolPillText.textContent = mcp ? mcp.display : (data.toolName || "Unknown");
   toolPill.setAttribute("data-tool", data.toolName || "");
 
   // Command block (textContent only — never innerHTML)

--- a/src/permission.js
+++ b/src/permission.js
@@ -753,6 +753,9 @@ function buildPermissionBubblePayload(permEntry) {
     isElicitation: permEntry.isElicitation || false,
     isOpencode: permEntry.isOpencode || false,
     isAntigravity: permEntry.isAntigravity || false,
+    // Provenance for the renderer: lets the bubble relabel Codex MCP tool calls
+    // (issue #445) without touching approval semantics. Mirrors the flags above.
+    isCodex: permEntry.isCodex || false,
     opencodeAlways: permEntry.opencodeAlwaysCandidates || [],
     opencodePatterns: permEntry.opencodePatterns || [],
     sessionFolder,

--- a/test/bubble-format.test.js
+++ b/test/bubble-format.test.js
@@ -3,7 +3,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 
-const { formatDetail, formatAntigravityDetail, truncate, firstStringValue } = require("../src/bubble-format");
+const { formatDetail, formatAntigravityDetail, truncate, firstStringValue, parseMcpToolName } = require("../src/bubble-format");
 
 describe("bubble-format truncate", () => {
   it("returns input unchanged when within max", () => {
@@ -123,5 +123,63 @@ describe("bubble-format formatAntigravityDetail tool coverage", () => {
   it("returns empty string for empty / unknown tool name", () => {
     assert.strictEqual(formatAntigravityDetail("", {}), "");
     assert.strictEqual(formatAntigravityDetail("unknown_tool_x", {}), "");
+  });
+});
+
+describe("bubble-format parseMcpToolName (issue #445)", () => {
+  it("parses the reported Codex Vercel MCP names to server · tool", () => {
+    assert.deepStrictEqual(
+      parseMcpToolName("MCP__CODEX_APPS__VERCEL__LIST_PROJECTS"),
+      { server: "vercel", tool: "list_projects", display: "vercel · list_projects" }
+    );
+    assert.strictEqual(
+      parseMcpToolName("MCP__CODEX_APPS__VERCEL__LIST_TOOLBAR_THREADS").display,
+      "vercel · list_toolbar_threads"
+    );
+  });
+
+  it("handles Claude Code lower-case 3-segment names too", () => {
+    assert.strictEqual(parseMcpToolName("mcp__github__list_issues").display, "github · list_issues");
+    assert.strictEqual(parseMcpToolName("mcp__server__tool").display, "server · tool");
+  });
+
+  it("uses the last two segments regardless of namespace depth", () => {
+    // server is always second-to-last, tool is last — robust to extra prefixes.
+    assert.deepStrictEqual(
+      parseMcpToolName("MCP__NS__SUB__SERVER__DO_THING"),
+      { server: "server", tool: "do_thing", display: "server · do_thing" }
+    );
+  });
+
+  it("returns tool-only display when there is no server segment", () => {
+    assert.deepStrictEqual(
+      parseMcpToolName("mcp__solo"),
+      { server: null, tool: "solo", display: "solo" }
+    );
+  });
+
+  it("returns null for non-MCP tool names (raw fallback path)", () => {
+    for (const name of ["Bash", "Edit", "CodexExec", "KimiPermission", "ExitPlanMode", "AskUserQuestion"]) {
+      assert.strictEqual(parseMcpToolName(name), null, `${name} must not be treated as MCP`);
+    }
+  });
+
+  it("never throws and falls back to null for malformed / empty input", () => {
+    for (const bad of ["", "MCP__", "mcp__", "MCP", "mcp", "__", "MCP____", null, undefined, 42, {}]) {
+      assert.strictEqual(parseMcpToolName(bad), null, `${JSON.stringify(bad)} must return null`);
+    }
+  });
+
+  it("returns null for trailing / middle empty segments (raw fallback, not partial label)", () => {
+    // Regression for the lenient-parse concern: a stray "__" must not drop the
+    // real tool segment and show a misleading "server · server" style label.
+    for (const bad of [
+      "MCP__CODEX_APPS__VERCEL__", // trailing "__" — would have shown "codex_apps · vercel"
+      "mcp__github__",            // trailing "__" — would have shown "github"
+      "MCP__CODEX_APPS____VERCEL", // empty middle segment
+      "mcp____tool",              // empty middle segment
+    ]) {
+      assert.strictEqual(parseMcpToolName(bad), null, `${JSON.stringify(bad)} must be raw fallback (null)`);
+    }
   });
 });

--- a/test/bubble-mcp-labeling.test.js
+++ b/test/bubble-mcp-labeling.test.js
@@ -1,0 +1,76 @@
+"use strict";
+
+// Issue #445 — Codex MCP tool calls were rendered as generic "Permission
+// Request" bubbles, which read like an OS permission prompt. bubble-renderer.js
+// pulls in DOM globals at load time, so (per this repo's convention) we assert
+// the relevant logic against the source string instead of instantiating it.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const RENDERER_SRC = fs.readFileSync(
+  path.join(__dirname, "..", "src", "bubble-renderer.js"),
+  "utf8"
+);
+const PERMISSION_SRC = fs.readFileSync(
+  path.join(__dirname, "..", "src", "permission.js"),
+  "utf8"
+);
+
+describe("bubble-renderer MCP labeling (issue #445)", () => {
+  it("imports the display-only MCP parser from bubble-format", () => {
+    assert.match(
+      RENDERER_SRC,
+      /const \{[^}]*\bparseMcpToolName\b[^}]*\} = window\.ClawdBubbleFormat;/
+    );
+  });
+
+  it("relabels the title only for Codex MCP approvals", () => {
+    // Title is gated on BOTH an MCP-shaped name AND Codex provenance, so a
+    // non-Codex MCP tool keeps the generic title and non-MCP Codex tools are
+    // untouched.
+    assert.match(
+      RENDERER_SRC,
+      /else if \(mcp && data\.isCodex\) titleKey = "codexToolApproval";/
+    );
+    // Default remains the generic permission title; plan review still wins.
+    assert.match(RENDERER_SRC, /let titleKey = "permissionRequest";/);
+    assert.match(RENDERER_SRC, /if \(isPlanReview\) titleKey = "planReview";/);
+  });
+
+  it("shows the friendly server · tool pill for MCP, raw name otherwise", () => {
+    assert.match(
+      RENDERER_SRC,
+      /toolPillText\.textContent = mcp \? mcp\.display : \(data\.toolName \|\| "Unknown"\);/
+    );
+  });
+
+  it("keeps Allow/Deny decision semantics (no auto-resolve added)", () => {
+    // The generic approval branch must still label the two real buttons; the
+    // MCP change is presentation-only.
+    assert.match(RENDERER_SRC, /bubbleText\(data\.lang, "allow"\)/);
+    assert.match(RENDERER_SRC, /bubbleText\(data\.lang, "deny"\)/);
+  });
+
+  it("does not reuse the OS-permission wording for the new Codex title", () => {
+    assert.match(RENDERER_SRC, /codexToolApproval: "Codex Tool Approval",/);
+    // The new English title must not fall back to the loaded word "Permission".
+    assert.doesNotMatch(RENDERER_SRC, /codexToolApproval: "[^"]*Permission/);
+  });
+
+  it("defines the new title key in every supported language", () => {
+    // Mirrors test/i18n.test.js parity, scoped to the key this change adds.
+    const count = (RENDERER_SRC.match(/codexToolApproval:/g) || []).length;
+    assert.strictEqual(count, 5, "expected codexToolApproval in all 5 locales");
+  });
+});
+
+describe("permission payload carries Codex provenance (issue #445)", () => {
+  it("buildPermissionBubblePayload forwards isCodex to the renderer", () => {
+    // Without this field the renderer cannot tell a Codex approval apart, so the
+    // §4.4 label fix would silently no-op.
+    assert.match(PERMISSION_SRC, /isCodex: permEntry\.isCodex \|\| false,/);
+  });
+});


### PR DESCRIPTION
## Problem

Issue #445: with Codex + the Vercel MCP integration, Clawd shows a **"Permission Request" / "权限请求"** bubble for ordinary read-only MCP tool calls such as `MCP__CODEX_APPS__VERCEL__LIST_PROJECTS` / `MCP__CODEX_APPS__VERCEL__LIST_TOOLBAR_THREADS`. The generic title + raw tool name read like an **OS permission prompt** (camera / mic / screen recording), which is misleading.

## Root cause — labeling, not misclassification

Codex sends a **real `PermissionRequest`** for these tools; Clawd doesn't invent them. And in this codebase returning `no-decision` doesn't silence the prompt — it just **relocates it to Codex's native approval UI** (see the comment in `server-route-permission.js`: "Codex will then continue to its native approval prompt"). So the correct first fix is **presentation only**: describe the approval truthfully without touching Codex's security gate.

## What changed (Phase 1 — label only)

- **`src/bubble-format.js`** — new display-only parser `parseMcpToolName()`: `MCP__CODEX_APPS__VERCEL__LIST_PROJECTS` → `vercel · list_projects`. Case-insensitive, keys off the last two `__` segments, also handles Claude Code's lower-case `mcp__server__tool`. Malformed names (empty segments) fall back to the **raw** name — never throws, never shows a misleading partial label.
- **`src/bubble-renderer.js`** — new `codexToolApproval` title ("Codex Tool Approval / Codex 工具调用审批", all 5 locales), gated on `mcp && data.isCodex`; pill shows the friendly `server · tool`. **Buttons stay Allow / Deny.**
- **`src/permission.js`** — `buildPermissionBubblePayload` now forwards `isCodex` to the renderer (provenance only; mirrors the existing `isOpencode` / `isAntigravity` flags).

## Not changed — security red-lines

- **No diff to `src/server-route-permission.js` or `hooks/codex-hook.js`.** Allow / deny / no-decision behavior is unchanged.
- No auto-allow, no verb-based "read-only" classification, no new settings.

## Tests

- `parseMcpToolName` unit coverage: 4-seg Codex, 3-seg Claude Code, multi-segment, no-server, non-MCP, and **malformed / empty → raw fallback**.
- Source-string regression for the renderer branch + the `isCodex` payload field (the renderer pulls in DOM globals at load, so there is no jsdom harness — this matches the repo's existing convention).
- i18n parity for the new key (enforced by `test/i18n.test.js`).

```
node --test test/bubble-format.test.js test/bubble-mcp-labeling.test.js test/i18n.test.js
#   -> 39 pass, 0 fail

node --test test/server-codex-permission.test.js test/permission-auto-approve.test.js \
            test/permission-codex-response.test.js test/bubble-html-assets.test.js \
            test/bubble-policy.test.js
#   -> 28 pass, 0 fail
```

Full `npm test` was not run in this environment.

## Review

Adversarial review (external reviewer "云宝"): **no approval-semantics blocker; direction correct; MERGE-READY.** Both findings handled in this branch — the untracked regression test is now included, and malformed-name parsing was tightened to a raw fallback (with trailing/middle empty-segment regression tests).

## Verification note

Implemented and unit-tested in a headless environment where the bubble can't be rendered visually. **Recommend a quick real-app check** on a live Codex + Vercel MCP session before merge: confirm the bubble now reads "Codex 工具调用审批" with a `vercel · list_projects` pill, and that Allow / Deny still resolve correctly.

## Follow-up (not in this PR)

Phase 2 — optionally letting Codex natively handle read-only MCP calls — is **deferred and gated** on capturing a real Codex MCP `PermissionRequest` payload to check for reliable `readOnlyHint` / annotation fields. No verb-based safety classification.

Closes #445
