### PR TITLE
fix(state): default Stop completion debounce for headless sessions (#449)

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -94,16 +94,23 @@ const COMPLETION_CANCEL_EVENTS = new Set([
   "SubagentStart", "SubagentStop", "PreCompact", "PostCompact",
   "PermissionRequest", "Elicitation", "StopFailure", "ApiError", "SessionEnd",
 ]);
-function getCompletionDebounceMs() {
+// #449: headless sessions (claude -p / Agent SDK hosts such as Obsidian-
+// Claudian) end every intermediate orchestrator step with a REAL Stop and
+// submit the next step right after, so each step celebrated. The follow-up
+// UserPromptSubmit lands within hook-spawn latency (~0.3s) of the Stop, so a
+// 2s quiet window absorbs it; a genuinely final Stop just celebrates 2s late.
+const HEADLESS_COMPLETION_DEBOUNCE_MS = 2000;
+function getCompletionDebounceMs(headless) {
   const raw = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
   const n = Number.parseInt(raw, 10);
-  // Opt-in, default 0 = celebrate immediately on Stop. The field gates
-  // (PostCompact / background_tasks / session_crons / stop_hook_active) already
-  // suppress the common false completions with zero delay; the debounce only
-  // adds value for the rare third-party Stop-hook veto, so it is off by default
-  // and users who actually hit that can set CLAWD_COMPLETION_DEBOUNCE_MS > 0.
+  // Explicit env override wins for every session kind (0 = fully off).
   if (Number.isFinite(n) && n >= 0 && n <= 10000) return n;
-  return 0;
+  // Interactive default stays 0 = celebrate immediately on Stop. The field
+  // gates (PostCompact / background_tasks / session_crons / stop_hook_active)
+  // already suppress the common false completions with zero delay; a terminal
+  // user otherwise wants the celebration the instant the turn ends. Headless
+  // sessions default to the #449 window above.
+  return headless ? HEADLESS_COMPLETION_DEBOUNCE_MS : 0;
 }
 let lastSessionSnapshotSignature = null;
 let lastSessionSnapshot = null;
@@ -995,8 +1002,7 @@ function updateSessionFocusMetadata(sessionId, opts = {}) {
 // "working" and only celebrate if no forward-progress event for the session
 // arrives within the window — this catches a third-party Stop hook that vetoes
 // the stop (Claude keeps going) without us ever seeing the veto.
-function scheduleCompletionDebounce(sessionId) {
-  const debounceMs = getCompletionDebounceMs();
+function scheduleCompletionDebounce(sessionId, debounceMs) {
   const existing = pendingCompletionTimers.get(sessionId);
   if (existing) clearTimeout(existing);
   const timer = setTimeout(() => {
@@ -1223,7 +1229,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     cancelCompletionDebounce(sessionId, "stop-superseded");
     const liveWork =
       backgroundTasksCount > 0 || sessionCronsCount > 0 || stopHookActive === true;
-    const debounceMs = getCompletionDebounceMs();
+    const debounceMs = getCompletionDebounceMs(srcHeadless);
     if (liveWork || debounceMs > 0) {
       // Hold the Stop as "working" and DROP the event to null so recentEvents
       // keeps NO "Stop" tail while held. Why null and not "Stop": deriveSessionBadge
@@ -1241,7 +1247,7 @@ function updateSession(sessionId, state, event, opts = {}) {
         );
         // liveWork never auto-promotes; a later plain Stop (no bg work) will.
       } else {
-        scheduleCompletionDebounce(sessionId);
+        scheduleCompletionDebounce(sessionId, debounceMs);
       }
     }
     // debounceMs <= 0 && !liveWork → keep "attention" (immediate celebration).

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -2461,6 +2461,82 @@ describe("Stop completion gate (#406)", () => {
   });
 });
 
+describe("Headless Stop debounce default (#449)", () => {
+  let api, ctx, soundsPlayed, savedDebounceEnv;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    // This group exercises the built-in defaults — make sure no env override
+    // from the host shell leaks in.
+    savedDebounceEnv = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    delete process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    soundsPlayed = [];
+    ctx = makeCtx({
+      processKill: () => true,
+      playSound: (name) => soundsPlayed.push(name),
+    });
+    api = require("../src/state")(ctx);
+  });
+  afterEach(() => {
+    api.cleanup();
+    mock.timers.reset();
+    if (savedDebounceEnv === undefined) delete process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    else process.env.CLAWD_COMPLETION_DEBOUNCE_MS = savedDebounceEnv;
+  });
+
+  it("headless Stop is held; the orchestrator's next prompt suppresses the celebration", () => {
+    update(api, { id: "h1", state: "attention", event: "Stop", headless: true });
+    assert.strictEqual(api.sessions.get("h1").state, "working", "held during the window");
+    assert.deepStrictEqual(soundsPlayed, [], "no celebration on the mid-task Stop");
+    mock.timers.tick(500); // Claudian-style continuation lands inside the window
+    update(api, { id: "h1", state: "thinking", event: "UserPromptSubmit", headless: true });
+    mock.timers.tick(5000); // well past the original window
+    assert.strictEqual(api.sessions.get("h1").state, "thinking");
+    assert.ok(!soundsPlayed.includes("complete"), "a continued Stop must not celebrate");
+  });
+
+  it("headless Stop with a quiet window celebrates after the 2s default", () => {
+    update(api, { id: "h1", state: "attention", event: "Stop", headless: true });
+    mock.timers.tick(1999);
+    assert.deepStrictEqual(soundsPlayed, [], "still inside the default window");
+    mock.timers.tick(1); // 2000ms — the turn really ended
+    assert.strictEqual(api.sessions.get("h1").state, "idle");
+    assert.strictEqual(api.getCurrentState(), "attention");
+    assert.ok(soundsPlayed.includes("complete"), "a real headless completion celebrates");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("h1")), "done");
+  });
+
+  it("interactive (non-headless) Stop still celebrates immediately by default", () => {
+    update(api, { id: "i1", state: "attention", event: "Stop" });
+    assert.strictEqual(api.getCurrentState(), "attention");
+    assert.ok(soundsPlayed.includes("complete"));
+  });
+
+  it("the headless flag persists — a later Stop without the flag still debounces", () => {
+    update(api, { id: "h1", state: "thinking", event: "UserPromptSubmit", headless: true });
+    update(api, { id: "h1", state: "attention", event: "Stop" }); // flag omitted on this event
+    assert.strictEqual(api.sessions.get("h1").state, "working", "held via persisted headless flag");
+    mock.timers.tick(2000);
+    assert.ok(soundsPlayed.includes("complete"), "quiet window still promotes");
+  });
+
+  it("CLAWD_COMPLETION_DEBOUNCE_MS=0 disables the headless default too", () => {
+    process.env.CLAWD_COMPLETION_DEBOUNCE_MS = "0";
+    update(api, { id: "h1", state: "attention", event: "Stop", headless: true });
+    assert.strictEqual(api.getCurrentState(), "attention");
+    assert.ok(soundsPlayed.includes("complete"), "explicit 0 keeps the old immediate behavior");
+  });
+
+  it("an explicit CLAWD_COMPLETION_DEBOUNCE_MS overrides the headless default window", () => {
+    process.env.CLAWD_COMPLETION_DEBOUNCE_MS = "100";
+    update(api, { id: "h1", state: "attention", event: "Stop", headless: true });
+    mock.timers.tick(99);
+    assert.deepStrictEqual(soundsPlayed, [], "inside the overridden window");
+    mock.timers.tick(1);
+    assert.ok(soundsPlayed.includes("complete"), "overridden window promotes, not the 2s default");
+  });
+});
+
 describe("deriveSessionBadge", () => {
   let api;
   beforeEach(() => { api = require("../src/state")(makeCtx()); });


### PR DESCRIPTION
## Problem

Issue #449: with Obsidian's embedded **Claudian**, the pet plays the completion celebration right after Claudian merely finishes reading a file, then drops back to working as Claudian continues — effectively one celebration **per orchestrator step**, reliably reproducible on v0.9.0 with no compaction involved.

## Root cause — every intermediate step ends with a REAL Stop

Reproduced locally against a live dev instance with a faithful simulation of an Agent-SDK host: `claude -p --input-format stream-json --output-format stream-json`, one persistent session, submitting step N+1 the moment step N's `result` arrives (react-on-result — the shape SDK hosts use). Old behavior, from `session-debug.log`:

```
22:47:04.858 event sid=… headless=1 -> incoming=attention/Stop      ← celebrates mid-task
22:47:10.182 event sid=… headless=1 -> incoming=thinking/UserPromptSubmit  ← back to work
```

Why none of the existing guards cover this:

- **#447** only suppresses a duplicate Stop tail **without progress**. Here there IS progress (PreToolUse / UserPromptSubmit) between Stops, so every step's Stop re-celebrates.
- **#406 field gates** (`background_tasks` / `session_crons` / `stop_hook_active`) stay empty — the continuation is the orchestrator's own loop, not a Stop-hook veto.
- The **#406 debounce** was built for exactly this shape, but it is opt-in via `CLAWD_COMPLETION_DEBOUNCE_MS` (default 0) — an env var on the Electron process, effectively unreachable for app users.

Two additional measurements that pin the design:

- Queue-piped continuations (next message already buffered at turn end) produce **no intermediate Stop at all** — so real-world hosts that show this bug are react-on-result, where the follow-up `UserPromptSubmit` lands ~**5 ms** after the Stop.
- Headless `SessionEnd` / final-turn Stop frequently never arrive (async hook loses the race against process exit); the session is reaped by the `agent-exit` stale sweep instead.

## What changed (`src/state.js`)

- `getCompletionDebounceMs(headless)`: an explicit `CLAWD_COMPLETION_DEBOUNCE_MS` still wins for every session kind (`0` = fully off, unchanged semantics). With no override, **headless sessions now default to a 2000 ms quiet window** (`HEADLESS_COMPLETION_DEBOUNCE_MS`); **interactive sessions stay at 0** — a terminal user keeps the instant celebration.
- The #406 Stop gate passes `srcHeadless`; `scheduleCompletionDebounce(sessionId, debounceMs)` takes the window as a parameter instead of re-reading the env.
- Headless detection is the **existing** clawd-hook command-line check (`-p|--print`) — no hook changes, the flag already persists on the session.

## Live verification (fixed build, same react-on-result repro)

```
22:58:43.794 event sid=… headless=1 -> incoming=working/-           ← Stop held, no celebration
22:58:43.799 stop-debounce cancel sid=… by=UserPromptSubmit         ← next step cancels it (5 ms)
22:58:49.552 event sid=… headless=1 -> incoming=working/-           ← final Stop held
             (2 s quiet window elapses → promoted: idle + one celebration)
22:58:55.555 event sid=… -> incoming=sleeping/SessionEnd            ← clean teardown
```

Mid-task Stops: suppressed. Final Stop: celebrates exactly once, 2 s late. Interactive terminal sessions: byte-for-byte unchanged behavior.

## Known limits (status quo, not regressions)

- If the next step's `UserPromptSubmit` races **ahead** of the Stop hook (async hooks; the two land ~5 ms apart), the held Stop can still promote mid-thinking — same false celebration as today, no worse.
- Whether Claudian's spawn matches the `-p|--print` headless heuristic is unverified — the reporter's log attachment was lost in a GitHub email reply. Asked the reporter to verify on this build / upload the log via web; if Claudian spawns differently, `headless` never sets and behavior is exactly today's.
- One-shot `claude -p` celebrations now additionally depend on 2 s of quiet before the agent-exit stale sweep; they were already racy today (the final Stop is frequently lost to process exit, observed in repro).

## Tests

- New group `Headless Stop debounce default (#449)` in `test/state.test.js` (6 cases): held + canceled by the next prompt, quiet-window promote (1999 ms boundary), interactive default unchanged, persisted `headless` flag on a later unflagged Stop, `env=0` kill switch, explicit env override window.

```
node --test test/state.test.js
#   -> 211 pass, 0 fail
```

Full `npm test`: 3766 tests, 8 failures — the **identical set fails on main** (Claude version detection helpers; pre-existing, unrelated to this change).

Fixes #449.
