### PR TITLE
fix(codex): deterministic subagent headless gate + doc/comment cleanups (#448 follow-up)

### DIFF
--- a/docs/investigations/codex-subagent-session-meta.md
+++ b/docs/investigations/codex-subagent-session-meta.md
@@ -57,4 +57,10 @@ The subagent sample was `rollout-2026-05-01T12-16-50-019de1c0-ed8e-73b0-992d-109
 
 - Treat unknown fields as `unknown` and fail open as root/interactive behavior.
 - Do not infer subagents from cwd or timing.
-- Do not classify `/permission` requests; subagent PermissionRequest still needs a user decision.
+- ~~Do not classify `/permission` requests; subagent PermissionRequest still needs a user decision.~~
+  **Superseded by PR #448 (2026-06-10).** The auto-pilot work made the `/permission` route gate
+  headless requests before the bubble/auto-approve chokepoint, and codex subagent requests are
+  deliberately treated as headless (no-decision → native fallback) rather than shown as bubbles
+  (`isHeadlessPermissionRequest`, `src/server-route-permission.js`). To make that gate
+  deterministic, `buildPermissionBody` now carries `codex_session_role` on PermissionRequest
+  payloads too (`hooks/codex-hook.js`, #448 follow-up). The state-path guidance above is unchanged.

--- a/hooks/codex-hook.js
+++ b/hooks/codex-hook.js
@@ -292,6 +292,12 @@ function buildPermissionBody(payload, resolve) {
     body.transcript_path = payload.transcript_path;
   }
   if (typeof payload.model === "string" && payload.model) body.model = payload.model;
+  // Carry the session role so the /permission route's headless gate
+  // (isHeadlessPermissionRequest) can identify subagent requests even when
+  // no state event has populated the sessions map yet. Before PR #448
+  // subagent permissions deliberately bubbled, so the role was state-only.
+  const codexRole = resolveCodexSessionRole(payload, sessionMeta);
+  if (codexRole !== ROLE_UNKNOWN) body.codex_session_role = codexRole;
   applyCodexSessionMetaFields(body, payload, sessionMeta);
 
   const toolUseId = normalizeToolUseId(payload.tool_use_id ?? payload.toolUseId ?? payload.toolUseID);

--- a/test/codex-hook.test.js
+++ b/test/codex-hook.test.js
@@ -426,7 +426,7 @@ describe("Codex official hook", () => {
     });
   });
 
-  it("does not classify PermissionRequest payloads even when the transcript is subagent", () => {
+  it("classifies subagent PermissionRequest payloads so the headless gate fires without a state event", () => {
     withTempTranscript([
       JSON.stringify({
         type: "session_meta",
@@ -445,7 +445,7 @@ describe("Codex official hook", () => {
       }, mockResolve);
 
       assert.strictEqual(body.agent_id, "codex");
-      assert.strictEqual(Object.prototype.hasOwnProperty.call(body, "codex_session_role"), false);
+      assert.strictEqual(body.codex_session_role, "subagent");
     });
   });
 

--- a/test/permission-auto-approve.test.js
+++ b/test/permission-auto-approve.test.js
@@ -2,6 +2,7 @@
 //
 // When the toggle is on, showPermissionBubble must resolve the entry as
 // "allow" and return BEFORE constructing a BrowserWindow — that early return
+// is also what lets this test run without a real Electron window.
 // The DND / per-agent / headless gates live earlier in the route (server-
 // route-permission.js), so they still win: by the time showPermissionBubble
 // runs, a gated request never reaches it. Headless fallback is deliberately


### PR DESCRIPTION
Follow-up to #448 (auto-pilot toggle), as promised in the merge review — nothing here changes runtime behavior for root sessions; it makes the codex headless gate deterministic and fixes two docs/comment slips.

## What

1. **`buildPermissionBody` now carries `codex_session_role`** (`hooks/codex-hook.js`). The `/permission` route's `isHeadlessPermissionRequest` sniffs this field to catch codex subagent requests before any state event populates the sessions map — but the real permission payload never carried it (only the state body did), so the payload prong only fired for synthetic payloads and the gate depended on the SessionStart-state race. The role resolves from the same `sessionMeta` the function already reads (zero extra I/O). The old test pin asserting non-classification served the pre-#448 "subagent permissions must bubble" design and is flipped accordingly.
2. **Restored a half-deleted sentence** in the `test/permission-auto-approve.test.js` header comment.
3. **Marked the stale conclusion** in `docs/investigations/codex-subagent-session-meta.md` ("do not classify /permission…") as superseded by #448, keeping the original line as a struck-through historical record.

## Review chain

- Authored and self-reviewed here; all five A–E verification points (misclassification surface, downstream field consumers, old-invariant counterexample search, fail-open behavior, test coverage) were independently cross-checked by an external Codex review (云宝) — verdict: no runtime findings, one P3 doc drift (fixed as item 3). The official codex `permission-request` input schema (`additionalProperties: false`, no `source`/`agent_role`/`parent_*`) bounds the misclassification surface; revisit if Codex ever expresses root custom agents via subagent-like `agent_type` values.

## Tests

`codex-hook`, `permission-auto-approve`, `server-codex-permission`, `server-route-permission`, `codex-subagent-fields`, `server-hook-management`, `server-qwen-permission`: **136/136**; plus `codex-subagent-classifier`, `server-route-state`, `server-state-title`: **35/35**.
