### PR TITLE
fix(focus): resolve terminal PID and switch tmux pane for tmux users

### DIFF
--- a/hooks/antigravity-hook.js
+++ b/hooks/antigravity-hook.js
@@ -269,6 +269,7 @@ function buildStateBody(hookName, payload, options = {}) {
   if (pidMeta.detectedEditor) body.editor = pidMeta.detectedEditor;
   if (Number.isFinite(pidMeta.agentPid) && pidMeta.agentPid > 0) body.agent_pid = Math.floor(pidMeta.agentPid);
   if (Array.isArray(pidMeta.pidChain) && pidMeta.pidChain.length) body.pid_chain = pidMeta.pidChain;
+  if (pidMeta.tmuxSocket) body.tmux_socket = pidMeta.tmuxSocket;
   return body;
 }
 
@@ -304,6 +305,7 @@ function buildPermissionBody(hookName, payload, options = {}) {
   if (pidMeta.detectedEditor) body.editor = pidMeta.detectedEditor;
   if (Number.isFinite(pidMeta.agentPid) && pidMeta.agentPid > 0) body.agent_pid = Math.floor(pidMeta.agentPid);
   if (Array.isArray(pidMeta.pidChain) && pidMeta.pidChain.length) body.pid_chain = pidMeta.pidChain;
+  if (pidMeta.tmuxSocket) body.tmux_socket = pidMeta.tmuxSocket;
   return body;
 }
 

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -421,7 +421,7 @@ function buildStateBody(event, payload, resolve) {
   if (process.env.CLAWD_REMOTE) {
     body.host = readHostPrefix();
   } else {
-    const { stablePid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd } = resolve();
+    const { stablePid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket } = resolve();
     body.source_pid = stablePid;
     if (detectedEditor) body.editor = detectedEditor;
     if (agentPid) {
@@ -432,6 +432,7 @@ function buildStateBody(event, payload, resolve) {
       }
     }
     if (pidChain.length) body.pid_chain = pidChain;
+    if (tmuxSocket) body.tmux_socket = tmuxSocket;
     if (shouldReportForegroundWtHwnd(event) && foregroundWtHwnd) {
       body.wt_hwnd = String(foregroundWtHwnd);
     }

--- a/hooks/codebuddy-hook.js
+++ b/hooks/codebuddy-hook.js
@@ -83,7 +83,7 @@ readStdinJson()
     const sessionId = (payload && payload.session_id) || "default";
     const cwd = (payload && payload.cwd) || "";
 
-    const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket } = resolve();
 
     const body = { state, session_id: sessionId, event };
     body.agent_id = "codebuddy";
@@ -95,6 +95,7 @@ readStdinJson()
       if (detectedEditor) body.editor = detectedEditor;
       if (agentPid) body.agent_pid = agentPid;
       if (pidChain.length) body.pid_chain = pidChain;
+      if (tmuxSocket) body.tmux_socket = tmuxSocket;
     }
 
     // Answer CodeBuddy immediately so it never sees empty stdout, but don't

--- a/hooks/codex-hook.js
+++ b/hooks/codex-hook.js
@@ -196,12 +196,13 @@ function shouldReportForegroundWtHwnd(event) {
 }
 
 function applyLocalProcessFields(body, resolve, options = {}) {
-  const { stablePid, agentPid, detectedEditor, pidChain, foregroundWtHwnd } = resolve();
+  const { stablePid, agentPid, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket } = resolve();
   const sourcePid = options.preferAgentPid && agentPid ? agentPid : stablePid;
   body.source_pid = sourcePid;
   if (detectedEditor) body.editor = detectedEditor;
   if (agentPid) body.agent_pid = agentPid;
   if (pidChain.length) body.pid_chain = pidChain;
+  if (tmuxSocket) body.tmux_socket = tmuxSocket;
   if (shouldReportForegroundWtHwnd(options.event, foregroundWtHwnd) && foregroundWtHwnd) {
     body.wt_hwnd = String(foregroundWtHwnd);
   }

--- a/hooks/copilot-hook.js
+++ b/hooks/copilot-hook.js
@@ -286,10 +286,11 @@ function buildPermissionBody(payload, resolve, options = {}) {
     const readHost = options.readHostPrefix || readHostPrefix;
     body.host = readHost();
   } else if (typeof resolve === "function") {
-    const { stablePid, agentPid, pidChain } = resolve();
+    const { stablePid, agentPid, pidChain, tmuxSocket } = resolve();
     if (stablePid) body.source_pid = stablePid;
     if (agentPid) body.agent_pid = agentPid;
     if (Array.isArray(pidChain) && pidChain.length) body.pid_chain = pidChain;
+    if (tmuxSocket) body.tmux_socket = tmuxSocket;
   }
 
   return body;
@@ -370,11 +371,12 @@ function buildStateBody(event, payload, resolve, options = {}) {
     const readHost = options.readHostPrefix || readHostPrefix;
     body.host = readHost();
   } else {
-    const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket } = resolve();
     body.source_pid = stablePid;
     if (detectedEditor) body.editor = detectedEditor;
     if (agentPid) body.agent_pid = agentPid;
     if (pidChain.length) body.pid_chain = pidChain;
+    if (tmuxSocket) body.tmux_socket = tmuxSocket;
   }
 
   return body;

--- a/hooks/cursor-hook.js
+++ b/hooks/cursor-hook.js
@@ -101,7 +101,7 @@ readStdinJson()
       cwd = payload.workspace_roots[0];
     }
 
-    const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket } = resolve();
 
     const body = { state, session_id: sessionId, event };
     body.agent_id = "cursor-agent";
@@ -118,6 +118,7 @@ readStdinJson()
         body.cursor_pid = agentPid;
       }
       if (pidChain.length) body.pid_chain = pidChain;
+      if (tmuxSocket) body.tmux_socket = tmuxSocket;
     }
 
     // Answer Cursor immediately so it never sees empty/malformed stdout, but

--- a/hooks/gemini-hook.js
+++ b/hooks/gemini-hook.js
@@ -105,6 +105,7 @@ function buildStateBody(hookName, payload, options = {}) {
   if (pidMeta.detectedEditor) body.editor = pidMeta.detectedEditor;
   if (Number.isFinite(pidMeta.agentPid) && pidMeta.agentPid > 0) body.agent_pid = Math.floor(pidMeta.agentPid);
   if (Array.isArray(pidMeta.pidChain) && pidMeta.pidChain.length) body.pid_chain = pidMeta.pidChain;
+  if (pidMeta.tmuxSocket) body.tmux_socket = pidMeta.tmuxSocket;
   return body;
 }
 

--- a/hooks/hermes-plugin/__init__.py
+++ b/hooks/hermes-plugin/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import subprocess
 import sys
 import threading
@@ -611,6 +612,13 @@ def _resolve_process_metadata(start_pid: Optional[int] = None) -> Dict[str, Any]
         meta["pid_chain"] = pid_chain
     if detected_editor:
         meta["editor"] = detected_editor
+    tmux_env = os.environ.get("TMUX")
+    if tmux_env:
+        socket_path = tmux_env.split(",")[0]
+        if socket_path:
+            name = os.path.basename(socket_path)
+            if name and name != "default" and re.fullmatch(r"[\w.-]{1,64}", name):
+                meta["tmux_socket"] = name
     return meta
 
 
@@ -663,6 +671,9 @@ def _add_process_meta(payload: Dict[str, Any]) -> None:
     editor = meta.get("editor")
     if editor in ("code", "cursor"):
         payload["editor"] = editor
+    tmux_socket = meta.get("tmux_socket")
+    if isinstance(tmux_socket, str) and tmux_socket:
+        payload["tmux_socket"] = tmux_socket
 
 
 def _first_string(*values: Any) -> str:

--- a/hooks/kimi-hook.js
+++ b/hooks/kimi-hook.js
@@ -274,7 +274,7 @@ function buildStateBody(event, payload, resolve) {
   if (process.env.CLAWD_REMOTE) {
     body.host = readHostPrefix();
   } else {
-    const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket } = resolve();
     body.source_pid = stablePid;
     if (detectedEditor) body.editor = detectedEditor;
     if (agentPid) {
@@ -282,6 +282,7 @@ function buildStateBody(event, payload, resolve) {
       body.kimi_pid = agentPid;
     }
     if (pidChain.length) body.pid_chain = pidChain;
+    if (tmuxSocket) body.tmux_socket = tmuxSocket;
   }
 
   return body;

--- a/hooks/kiro-hook.js
+++ b/hooks/kiro-hook.js
@@ -36,7 +36,7 @@ readStdinJson()
     const sessionId = "default";
     const cwd = (payload && payload.cwd) || "";
 
-    const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket } = resolve();
 
     const body = { state, session_id: sessionId, event };
     body.agent_id = "kiro-cli";
@@ -48,6 +48,7 @@ readStdinJson()
       if (detectedEditor) body.editor = detectedEditor;
       if (agentPid) body.agent_pid = agentPid;
       if (pidChain.length) body.pid_chain = pidChain;
+      if (tmuxSocket) body.tmux_socket = tmuxSocket;
     }
 
     postStateToRunningServer(JSON.stringify(body), { timeoutMs: 100 }, () => {

--- a/hooks/opencode-plugin/index.mjs
+++ b/hooks/opencode-plugin/index.mjs
@@ -23,7 +23,7 @@
 
 import { readFileSync, writeFileSync, mkdirSync, promises as fsp } from "fs";
 import { homedir, platform } from "os";
-import { join } from "path";
+import { join, basename } from "path";
 import { randomBytes, timingSafeEqual } from "crypto";
 import { execFileSync, execSync } from "child_process";
 import {
@@ -109,6 +109,7 @@ const _sessionParentById = new Map();
 let _stablePid = null;
 let _pidChain = [];
 let _detectedEditor = null;
+let _tmuxSocket = null;
 // Project directory — captured from ctx.directory at init, sent with every
 // POST so state.js can display path.basename(cwd) as the session menu label
 // (otherwise it falls back to the session_id prefix, e.g. "ses 2a..").
@@ -273,6 +274,16 @@ function getStablePid() {
   }
 
   _stablePid = terminalPid || lastGoodPid;
+
+  _tmuxSocket = null;
+  if (process.env.TMUX) {
+    const socketPath = process.env.TMUX.split(",")[0];
+    if (socketPath) {
+      const name = basename(socketPath);
+      if (name && name !== "default" && /^[\w.-]{1,64}$/.test(name)) _tmuxSocket = name;
+    }
+  }
+
   debugLog(`PID resolved stable=${_stablePid} editor=${_detectedEditor || "none"} chain=[${_pidChain.join(",")}]`);
   return _stablePid;
 }
@@ -288,6 +299,7 @@ function postToClawd(urlPath, body, logTag) {
     body.source_pid = _stablePid;
     if (_pidChain.length) body.pid_chain = _pidChain;
     if (_detectedEditor) body.editor = _detectedEditor;
+    if (_tmuxSocket) body.tmux_socket = _tmuxSocket;
   }
   if (_cwd) body.cwd = _cwd;
   body.agent_pid = process.pid;

--- a/hooks/pi-extension-core.js
+++ b/hooks/pi-extension-core.js
@@ -108,6 +108,10 @@ function buildPayload(options = {}) {
     : [];
   if (pidChain.length > 0) payload.pid_chain = pidChain;
 
+  const tmuxSocket = typeof metadata.tmuxSocket === "string" && /^[\w.-]{1,64}$/.test(metadata.tmuxSocket)
+    ? metadata.tmuxSocket : null;
+  if (tmuxSocket) payload.tmux_socket = tmuxSocket;
+
   if (metadata.editor === "code" || metadata.editor === "cursor") {
     payload.editor = metadata.editor;
   }

--- a/hooks/pi-extension.ts
+++ b/hooks/pi-extension.ts
@@ -22,6 +22,7 @@ type ProcessMetadata = {
   sourcePid?: number;
   pidChain?: number[];
   editor?: "code" | "cursor";
+  tmuxSocket?: string;
 };
 
 type ProcessInfo = {
@@ -281,11 +282,21 @@ function getProcessMetadata(): ProcessMetadata {
     pid = info.ppid;
   }
 
+  let tmuxSocket: string | undefined;
+  if (process.env.TMUX) {
+    const socketPath = process.env.TMUX.split(",")[0];
+    if (socketPath) {
+      const name = require("path").basename(socketPath);
+      if (name && name !== "default" && /^[\w.-]{1,64}$/.test(name)) tmuxSocket = name;
+    }
+  }
+
   const value: ProcessMetadata = {
     cwd: process.cwd(),
     sourcePid: sourcePid || undefined,
     pidChain: pidChain.length > 0 ? pidChain : [process.pid],
     editor,
+    tmuxSocket,
   };
   processMetadataCache = { at: now, value };
   return value;

--- a/hooks/qoder-hook.js
+++ b/hooks/qoder-hook.js
@@ -125,6 +125,7 @@ function applyLocalProcessFields(body, pidMeta) {
   if (pidMeta.detectedEditor) body.editor = pidMeta.detectedEditor;
   if (Number.isFinite(pidMeta.agentPid) && pidMeta.agentPid > 0) body.agent_pid = Math.floor(pidMeta.agentPid);
   if (Array.isArray(pidMeta.pidChain) && pidMeta.pidChain.length) body.pid_chain = pidMeta.pidChain;
+  if (pidMeta.tmuxSocket) body.tmux_socket = pidMeta.tmuxSocket;
 }
 
 const TOOL_METADATA_EVENTS = new Set([

--- a/hooks/qwen-code-hook.js
+++ b/hooks/qwen-code-hook.js
@@ -124,11 +124,12 @@ function isQwenAgentCommandLine(cmd) {
 }
 
 function applyLocalProcessFields(body, resolve) {
-  const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
+  const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket } = resolve();
   if (Number.isFinite(stablePid) && stablePid > 0) body.source_pid = Math.floor(stablePid);
   if (detectedEditor) body.editor = detectedEditor;
   if (Number.isFinite(agentPid) && agentPid > 0) body.agent_pid = Math.floor(agentPid);
   if (Array.isArray(pidChain) && pidChain.length) body.pid_chain = pidChain;
+  if (tmuxSocket) body.tmux_socket = tmuxSocket;
 }
 
 function maybeAddToolMetadata(body, payload) {

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -271,42 +271,56 @@ function createPidResolver(options) {
       pid = parentPid;
     }
 
-    if (!isWin && !terminalPid && process.env.TMUX) {
+    if (!isWin && !terminalPid && process.env.TMUX && process.env.TMUX_PANE) {
       const tmuxParts = process.env.TMUX.split(",");
       const tmuxServerPid = tmuxParts.length >= 2 ? parseInt(tmuxParts[1], 10) : 0;
       const walkReachedTmux = tmuxServerPid > 1 && pidChain.includes(tmuxServerPid);
-      if (walkReachedTmux) try {
-        const clientPidStr = execFileSync(
-          "tmux", ["display-message", "-p", "#{client_pid}"],
-          { encoding: "utf8", timeout: 500 }
-        ).trim();
-        const clientPid = parseInt(clientPidStr, 10);
-        if (clientPid > 1) {
-          let walkPid = clientPid;
-          for (let t = 0; t < 4; t++) {
-            let tName, tParent;
-            try {
-              const tComm = execFileSync("ps", ["-o", "comm=", "-p", String(walkPid)],
-                { encoding: "utf8", timeout: 500 }).trim();
-              tName = require("path").basename(tComm).toLowerCase();
-              tParent = parseInt(
-                execFileSync("ps", ["-o", "ppid=", "-p", String(walkPid)],
-                  { encoding: "utf8", timeout: 500 }).trim(), 10);
-            } catch { break; }
-            if (terminalNames.has(tName)) {
-              terminalPid = walkPid;
-              pidChain.push(walkPid);
-              break;
+      if (walkReachedTmux) {
+        try {
+          const raw = execFileSync(
+            "tmux", ["list-clients", "-t", process.env.TMUX_PANE, "-F", "#{client_pid}"],
+            { encoding: "utf8", timeout: 500 }
+          );
+          const clientPids = raw.split("\n")
+            .map(s => parseInt(s.trim(), 10))
+            .filter(p => Number.isFinite(p) && p > 1);
+          outer: for (const clientPid of clientPids) {
+            let walkPid = clientPid;
+            const localAdds = [];
+            for (let t = 0; t < 4; t++) {
+              let tName, tParent;
+              try {
+                const tComm = execFileSync("ps", ["-o", "comm=", "-p", String(walkPid)],
+                  { encoding: "utf8", timeout: 500 }).trim();
+                tName = require("path").basename(tComm).toLowerCase();
+                tParent = parseInt(
+                  execFileSync("ps", ["-o", "ppid=", "-p", String(walkPid)],
+                    { encoding: "utf8", timeout: 500 }).trim(), 10);
+              } catch { break; }
+              if (terminalNames.has(tName)) {
+                terminalPid = walkPid;
+                pidChain.push(...localAdds, walkPid);
+                break outer;
+              }
+              if (!tParent || tParent <= 1 || tParent === walkPid) break;
+              localAdds.push(walkPid);
+              walkPid = tParent;
             }
-            if (!tParent || tParent <= 1 || tParent === walkPid) break;
-            pidChain.push(walkPid);
-            walkPid = tParent;
           }
-        }
-      } catch {}
+        } catch {}
+      }
     }
 
-    _cached = { stablePid: terminalPid || lastGoodPid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd };
+    let tmuxSocket = null;
+    if (process.env.TMUX) {
+      const socketPath = process.env.TMUX.split(",")[0];
+      if (socketPath) {
+        const name = require("path").basename(socketPath);
+        if (name && name !== "default") tmuxSocket = name;
+      }
+    }
+
+    _cached = { stablePid: terminalPid || lastGoodPid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket };
     return _cached;
   };
 }

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -271,6 +271,41 @@ function createPidResolver(options) {
       pid = parentPid;
     }
 
+    if (!isWin && !terminalPid && process.env.TMUX) {
+      const tmuxParts = process.env.TMUX.split(",");
+      const tmuxServerPid = tmuxParts.length >= 2 ? parseInt(tmuxParts[1], 10) : 0;
+      const walkReachedTmux = tmuxServerPid > 1 && pidChain.includes(tmuxServerPid);
+      if (walkReachedTmux) try {
+        const clientPidStr = execFileSync(
+          "tmux", ["display-message", "-p", "#{client_pid}"],
+          { encoding: "utf8", timeout: 500 }
+        ).trim();
+        const clientPid = parseInt(clientPidStr, 10);
+        if (clientPid > 1) {
+          let walkPid = clientPid;
+          for (let t = 0; t < 4; t++) {
+            let tName, tParent;
+            try {
+              const tComm = execFileSync("ps", ["-o", "comm=", "-p", String(walkPid)],
+                { encoding: "utf8", timeout: 500 }).trim();
+              tName = require("path").basename(tComm).toLowerCase();
+              tParent = parseInt(
+                execFileSync("ps", ["-o", "ppid=", "-p", String(walkPid)],
+                  { encoding: "utf8", timeout: 500 }).trim(), 10);
+            } catch { break; }
+            if (terminalNames.has(tName)) {
+              terminalPid = walkPid;
+              pidChain.push(walkPid);
+              break;
+            }
+            if (!tParent || tParent <= 1 || tParent === walkPid) break;
+            pidChain.push(walkPid);
+            walkPid = tParent;
+          }
+        }
+      } catch {}
+    }
+
     _cached = { stablePid: terminalPid || lastGoodPid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd };
     return _cached;
   };

--- a/src/focus.js
+++ b/src/focus.js
@@ -545,6 +545,13 @@ function normalizeGhosttyTerminalId(value) {
   return text;
 }
 
+function normalizeTmuxSocket(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed === "default") return null;
+  return /^[\w.-]{1,64}$/.test(trimmed) ? trimmed : null;
+}
+
 function normalizeFocusRequest(sourcePidOrRequest, cwd, editor, pidChain, meta = {}) {
   if (sourcePidOrRequest && typeof sourcePidOrRequest === "object" && !Array.isArray(sourcePidOrRequest)) {
     const request = sourcePidOrRequest;
@@ -558,6 +565,7 @@ function normalizeFocusRequest(sourcePidOrRequest, cwd, editor, pidChain, meta =
       agentId: typeof request.agentId === "string" ? request.agentId : null,
       requestSource: typeof request.requestSource === "string" ? request.requestSource : null,
       ghosttyTerminalId: normalizeGhosttyTerminalId(request.ghosttyTerminalId ?? request.ghostty_terminal_id),
+      tmuxSocket: normalizeTmuxSocket(request.tmuxSocket ?? request.tmux_socket),
     };
   }
 
@@ -571,6 +579,7 @@ function normalizeFocusRequest(sourcePidOrRequest, cwd, editor, pidChain, meta =
     agentId: meta && typeof meta.agentId === "string" ? meta.agentId : null,
     requestSource: meta && typeof meta.requestSource === "string" ? meta.requestSource : null,
     ghosttyTerminalId: normalizeGhosttyTerminalId(meta && (meta.ghosttyTerminalId ?? meta.ghostty_terminal_id)),
+    tmuxSocket: normalizeTmuxSocket(meta && (meta.tmuxSocket ?? meta.tmux_socket)),
   };
 }
 
@@ -1089,27 +1098,39 @@ function scheduleITermTabFocus(sourcePid, pidChain) {
 }
 
 let _resolvedTmuxBin = null;
+let _tmuxBinOverride = null;
+function __setTmuxBin(p) { _tmuxBinOverride = (typeof p === "string") ? p : null; _resolvedTmuxBin = null; }
+
 function resolveTmuxBin() {
+  if (_tmuxBinOverride !== null) return _tmuxBinOverride;
   if (_resolvedTmuxBin !== null) return _resolvedTmuxBin;
+  const home = process.env.HOME || os.homedir() || "";
   const candidates = [
     "/opt/homebrew/bin/tmux",
     "/usr/local/bin/tmux",
+    "/opt/local/bin/tmux",
     "/usr/bin/tmux",
     "/bin/tmux",
+    "/run/current-system/sw/bin/tmux",
+    home ? path.join(home, ".nix-profile/bin/tmux") : "",
   ];
   for (const p of candidates) {
+    if (!p) continue;
     try { if (fs.statSync(p).isFile()) { _resolvedTmuxBin = p; return p; } } catch {}
   }
   _resolvedTmuxBin = "";
   return "";
 }
 
-function scheduleTmuxPaneFocus(pidChain) {
+function scheduleTmuxPaneFocus(pidChain, tmuxSocket) {
   if (!Array.isArray(pidChain) || pidChain.length < 2) return;
   const tmuxBin = resolveTmuxBin();
   if (!tmuxBin) return;
   const candidates = pidChain.filter(p => Number.isFinite(p) && p > 0);
   if (candidates.length < 2) return;
+
+  const socketArgs = (typeof tmuxSocket === "string" && tmuxSocket && tmuxSocket !== "default")
+    ? ["-L", tmuxSocket] : [];
 
   const pidsArg = candidates.slice(0, 8).join(",");
   execFile("ps", ["-o", "pid=,comm=", "-p", pidsArg], { encoding: "utf8", timeout: 500 }, (err, stdout) => {
@@ -1133,24 +1154,25 @@ function scheduleTmuxPaneFocus(pidChain) {
     }
     if (!paneCandidates.length) return;
 
-    execFile(tmuxBin, ["list-panes", "-a", "-F", "#{pane_pid} #{session_name}:#{window_index}.#{pane_index}"],
+    execFile(tmuxBin, [...socketArgs, "list-panes", "-a", "-F",
+      "#{pane_pid} #{window_id} #{pane_id} #{session_name}"],
       { encoding: "utf8", timeout: 500 }, (tmuxErr, tmuxOut) => {
       if (tmuxErr || !tmuxOut) return;
       for (const panePid of paneCandidates) {
         for (const line of tmuxOut.trim().split("\n")) {
-          const spaceIdx = line.indexOf(" ");
-          if (spaceIdx < 1) continue;
-          if (parseInt(line.substring(0, spaceIdx), 10) === panePid) {
-            const target = line.substring(spaceIdx + 1).trim();
-            const dotIdx = target.lastIndexOf(".");
-            const windowTarget = dotIdx > 0 ? target.substring(0, dotIdx) : target;
-            setTimeout(() => {
-              execFile(tmuxBin, ["select-window", "-t", windowTarget], { timeout: 500 }, () => {
-                execFile(tmuxBin, ["select-pane", "-t", target], { timeout: 500 }, () => {});
+          const parts = line.split(/\s+/);
+          if (parts.length < 4 || parseInt(parts[0], 10) !== panePid) continue;
+          const windowId = parts[1];
+          const paneId = parts[2];
+          const session = parts.slice(3).join(" ");
+          setTimeout(() => {
+            execFile(tmuxBin, [...socketArgs, "switch-client", "-t", session], { timeout: 500 }, () => {
+              execFile(tmuxBin, [...socketArgs, "select-window", "-t", windowId], { timeout: 500 }, () => {
+                execFile(tmuxBin, [...socketArgs, "select-pane", "-t", paneId], { timeout: 500 }, () => {});
               });
-            }, 400);
-            return;
-          }
+            });
+          }, 400);
+          return;
         }
       }
     });
@@ -1320,7 +1342,7 @@ function executeMacFocusRequest(request) {
   focusTerminalWindowLegacy(request, finalize);
   scheduleTerminalTabFocus(request.editor, request.pidChain);
   scheduleITermTabFocus(request.sourcePid, request.pidChain);
-  scheduleTmuxPaneFocus(request.pidChain);
+  scheduleTmuxPaneFocus(request.pidChain, request.tmuxSocket);
   scheduleCmuxWorkspaceSwitch(request.pidChain);
   scheduleSupersetFocus(request.sourcePid, request.cwd);
   scheduleGhosttyFocus(request.sourcePid, request.cwd, request.pidChain, request.ghosttyTerminalId);
@@ -1515,7 +1537,7 @@ function focusTerminalWindow(sourcePidOrRequest, cwd, editor, pidChain, meta) {
   if (isLinux) {
     focusTerminalWindowLegacy(request);
     scheduleTerminalTabFocus(request.editor, request.pidChain);
-    scheduleTmuxPaneFocus(request.pidChain);
+    scheduleTmuxPaneFocus(request.pidChain, request.tmuxSocket);
     logFocusResult("branch=linux-command-submitted");
     return normalizeFocusResultPayload({ reason: "linux-command-submitted" });
   }
@@ -1673,6 +1695,8 @@ return {
     buildGhosttyPidFocusScript,
     buildGhosttyCwdFocusScript,
     scheduleTmuxPaneFocus,
+    __setTmuxBin,
+    resolveTmuxBin,
   },
 };
 

--- a/src/focus.js
+++ b/src/focus.js
@@ -1088,6 +1088,75 @@ function scheduleITermTabFocus(sourcePid, pidChain) {
   });
 }
 
+let _resolvedTmuxBin = null;
+function resolveTmuxBin() {
+  if (_resolvedTmuxBin !== null) return _resolvedTmuxBin;
+  const candidates = [
+    "/opt/homebrew/bin/tmux",
+    "/usr/local/bin/tmux",
+    "/usr/bin/tmux",
+    "/bin/tmux",
+  ];
+  for (const p of candidates) {
+    try { if (fs.statSync(p).isFile()) { _resolvedTmuxBin = p; return p; } } catch {}
+  }
+  _resolvedTmuxBin = "";
+  return "";
+}
+
+function scheduleTmuxPaneFocus(pidChain) {
+  if (!Array.isArray(pidChain) || pidChain.length < 2) return;
+  const tmuxBin = resolveTmuxBin();
+  if (!tmuxBin) return;
+  const candidates = pidChain.filter(p => Number.isFinite(p) && p > 0);
+  if (candidates.length < 2) return;
+
+  const pidsArg = candidates.slice(0, 8).join(",");
+  execFile("ps", ["-o", "pid=,comm=", "-p", pidsArg], { encoding: "utf8", timeout: 500 }, (err, stdout) => {
+    if (err || !stdout) return;
+    const tmuxPids = new Set();
+    for (const line of stdout.trim().split("\n")) {
+      const parts = line.trim().split(/\s+/);
+      if (parts.length >= 2 && path.basename(parts[parts.length - 1]).toLowerCase() === "tmux") {
+        tmuxPids.add(parseInt(parts[0], 10));
+      }
+    }
+    if (!tmuxPids.size) return;
+
+    // The pane shell is the PID immediately before the tmux server in the chain.
+    // Collect all candidate pane PIDs (entries preceding a tmux PID that aren't tmux themselves).
+    const paneCandidates = [];
+    for (let i = 1; i < candidates.length; i++) {
+      if (tmuxPids.has(candidates[i]) && !tmuxPids.has(candidates[i - 1])) {
+        paneCandidates.push(candidates[i - 1]);
+      }
+    }
+    if (!paneCandidates.length) return;
+
+    execFile(tmuxBin, ["list-panes", "-a", "-F", "#{pane_pid} #{session_name}:#{window_index}.#{pane_index}"],
+      { encoding: "utf8", timeout: 500 }, (tmuxErr, tmuxOut) => {
+      if (tmuxErr || !tmuxOut) return;
+      for (const panePid of paneCandidates) {
+        for (const line of tmuxOut.trim().split("\n")) {
+          const spaceIdx = line.indexOf(" ");
+          if (spaceIdx < 1) continue;
+          if (parseInt(line.substring(0, spaceIdx), 10) === panePid) {
+            const target = line.substring(spaceIdx + 1).trim();
+            const dotIdx = target.lastIndexOf(".");
+            const windowTarget = dotIdx > 0 ? target.substring(0, dotIdx) : target;
+            setTimeout(() => {
+              execFile(tmuxBin, ["select-window", "-t", windowTarget], { timeout: 500 }, () => {
+                execFile(tmuxBin, ["select-pane", "-t", target], { timeout: 500 }, () => {});
+              });
+            }, 400);
+            return;
+          }
+        }
+      }
+    });
+  });
+}
+
 function scheduleCmuxWorkspaceSwitch(pidChain) {
   if (!isMac || !Array.isArray(pidChain) || !pidChain.length) return;
   const pids = pidChain.filter(p => Number.isFinite(p) && p > 0);
@@ -1251,6 +1320,7 @@ function executeMacFocusRequest(request) {
   focusTerminalWindowLegacy(request, finalize);
   scheduleTerminalTabFocus(request.editor, request.pidChain);
   scheduleITermTabFocus(request.sourcePid, request.pidChain);
+  scheduleTmuxPaneFocus(request.pidChain);
   scheduleCmuxWorkspaceSwitch(request.pidChain);
   scheduleSupersetFocus(request.sourcePid, request.cwd);
   scheduleGhosttyFocus(request.sourcePid, request.cwd, request.pidChain, request.ghosttyTerminalId);
@@ -1445,6 +1515,7 @@ function focusTerminalWindow(sourcePidOrRequest, cwd, editor, pidChain, meta) {
   if (isLinux) {
     focusTerminalWindowLegacy(request);
     scheduleTerminalTabFocus(request.editor, request.pidChain);
+    scheduleTmuxPaneFocus(request.pidChain);
     logFocusResult("branch=linux-command-submitted");
     return normalizeFocusResultPayload({ reason: "linux-command-submitted" });
   }
@@ -1601,6 +1672,7 @@ return {
     buildGhosttyTtyFocusScript,
     buildGhosttyPidFocusScript,
     buildGhosttyCwdFocusScript,
+    scheduleTmuxPaneFocus,
   },
 };
 

--- a/src/main.js
+++ b/src/main.js
@@ -1324,6 +1324,7 @@ function focusTerminalSession(session, sessionId, requestSource) {
     cwd: session.cwd,
     editor: session.editor,
     pidChain: session.pidChain,
+    tmuxSocket: session.tmuxSocket,
     ghosttyTerminalId: session.ghosttyTerminalId,
     sessionId: String(sessionId),
     agentId: session.agentId,

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -107,6 +107,8 @@ function handleStatePost(req, res, options) {
       const cwd = typeof data.cwd === "string" ? data.cwd : "";
       const editor = (data.editor === "code" || data.editor === "cursor") ? data.editor : null;
       const pidChain = Array.isArray(data.pid_chain) ? data.pid_chain.filter(n => Number.isFinite(n) && n > 0) : null;
+      const tmuxSocket = (typeof data.tmux_socket === "string" && /^[\w.-]{1,64}$/.test(data.tmux_socket.trim()))
+        ? data.tmux_socket.trim() : null;
       const rawAgentPid = data.agent_pid ?? data.claude_pid ?? data.cursor_pid;
       const agentPid = Number.isFinite(rawAgentPid) && rawAgentPid > 0 ? Math.floor(rawAgentPid) : null;
       const agentIdentity = resolveHookAgentId(data);
@@ -244,6 +246,7 @@ function handleStatePost(req, res, options) {
             cwd,
             editor,
             pidChain,
+            tmuxSocket,
             agentPid,
             agentId,
             host,

--- a/src/state.js
+++ b/src/state.js
@@ -1066,6 +1066,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     cwd = null,
     editor = null,
     pidChain = null,
+    tmuxSocket = null,
     agentPid = null,
     agentId = null,
     host = null,
@@ -1130,6 +1131,7 @@ function updateSession(sessionId, state, event, opts = {}) {
       const srcCwd = cwd || (existing && existing.cwd) || "";
       const srcEditor = editor || (existing && existing.editor) || null;
       const srcPidChain = (pidChain && pidChain.length) ? pidChain : (existing && existing.pidChain) || null;
+      const srcTmuxSocket = tmuxSocket || (existing && existing.tmuxSocket) || null;
       const srcAgentPid = agentPid || (existing && existing.agentPid) || null;
       const srcAgentId = resolveIncomingAgentId(existing, agentId, agentIdDefaulted);
       const srcHost = host || (existing && existing.host) || null;
@@ -1160,6 +1162,7 @@ function updateSession(sessionId, state, event, opts = {}) {
         cwd: srcCwd,
         editor: srcEditor,
         pidChain: srcPidChain,
+        tmuxSocket: srcTmuxSocket,
         agentPid: srcAgentPid,
         agentId: srcAgentId,
         host: srcHost,
@@ -1189,6 +1192,7 @@ function updateSession(sessionId, state, event, opts = {}) {
   const srcCwd = cwd || (existing && existing.cwd) || "";
   const srcEditor = editor || (existing && existing.editor) || null;
   const srcPidChain = (pidChain && pidChain.length) ? pidChain : (existing && existing.pidChain) || null;
+  const srcTmuxSocket = tmuxSocket || (existing && existing.tmuxSocket) || null;
   const srcAgentPid = agentPid || (existing && existing.agentPid) || null;
   const srcAgentId = resolveIncomingAgentId(existing, agentId, agentIdDefaulted);
   const srcHost = host || (existing && existing.host) || null;
@@ -1310,7 +1314,7 @@ function updateSession(sessionId, state, event, opts = {}) {
   const srcLastStopAt = isStopBoundary
     ? Date.now()
     : (existing && Number.isFinite(existing.lastStopAt) ? existing.lastStopAt : null);
-  const base = { sourcePid: srcPid, wtHwnd: srcWtHwnd, cwd: srcCwd, editor: srcEditor, pidChain: srcPidChain, agentPid: srcAgentPid, agentId: srcAgentId, host: srcHost, headless: srcHeadless, platform: srcPlatform, model: srcModel, provider: srcProvider, codexOriginator: srcCodexOriginator, codexSource: srcCodexSource, ghosttyTerminalId: srcGhosttyTerminalId, sessionTitle: srcSessionTitle, contextUsage: srcContextUsage, assistantLastOutput: srcAssistantLastOutput, assistantLastOutputTruncated: srcAssistantLastOutputTruncated, recentEvents, pidReachable, lastToolBoundaryAt: srcLastToolBoundaryAt, lastStopAt: srcLastStopAt, awaitingInputSinceStop: resolveAwaitingInputSinceStop(existing, event), muteNotificationSound: state === "notification" && muteNotificationSound === true };
+  const base = { sourcePid: srcPid, wtHwnd: srcWtHwnd, cwd: srcCwd, editor: srcEditor, pidChain: srcPidChain, tmuxSocket: srcTmuxSocket, agentPid: srcAgentPid, agentId: srcAgentId, host: srcHost, headless: srcHeadless, platform: srcPlatform, model: srcModel, provider: srcProvider, codexOriginator: srcCodexOriginator, codexSource: srcCodexSource, ghosttyTerminalId: srcGhosttyTerminalId, sessionTitle: srcSessionTitle, contextUsage: srcContextUsage, assistantLastOutput: srcAssistantLastOutput, assistantLastOutputTruncated: srcAssistantLastOutputTruncated, recentEvents, pidReachable, lastToolBoundaryAt: srcLastToolBoundaryAt, lastStopAt: srcLastStopAt, awaitingInputSinceStop: resolveAwaitingInputSinceStop(existing, event), muteNotificationSound: state === "notification" && muteNotificationSound === true };
   if (preserveCompletionAck) base.requiresCompletionAck = true;
 
   // Evict oldest session if at capacity and this is a new session.

--- a/test/focus-cmux.test.js
+++ b/test/focus-cmux.test.js
@@ -312,14 +312,22 @@ describe("cmux panel focus (macOS)", () => {
       if (cb) cb(null, "", "");
     }, { platform: "linux" });
 
-    const { focusTerminalWindow } = initFocus({});
+    const focusInstance = initFocus({});
+    // Disable the tmux bridge so a real tmux binary on the host doesn't trigger
+    // `ps -o pid=,comm=` from scheduleTmuxPaneFocus — that probe is legitimate
+    // on Linux now, so we assert on the actual cmux probes (mdfind, AppleScript)
+    // instead of the old "no ps -o comm=" invariant.
+    focusInstance.__test.__setTmuxBin("");
+    const { focusTerminalWindow } = focusInstance;
     focusTerminalWindow(501, "/test/cwd", null, [501, 502]);
 
     setTimeout(() => {
       cleanup();
 
-      const psCommCalls = calls.filter(c => c.cmd === "ps" && c.args.join(" ").includes("comm="));
-      assert.strictEqual(psCommCalls.length, 0, "Should not call ps -o comm= on non-macOS");
+      const mdfindCalls = calls.filter(c => c.cmd === "mdfind");
+      assert.strictEqual(mdfindCalls.length, 0, "Should not run cmux mdfind on non-macOS");
+      const cmuxOsa = calls.filter(c => c.cmd === "osascript" && c.args.some(a => /cmux/i.test(a)));
+      assert.strictEqual(cmuxOsa.length, 0, "Should not run cmux AppleScript on non-macOS");
 
       done();
     }, 1000);

--- a/test/focus-tmux.test.js
+++ b/test/focus-tmux.test.js
@@ -1,0 +1,151 @@
+// test/focus-tmux.test.js — Mocked unit tests for scheduleTmuxPaneFocus().
+//
+// The reviewer flagged that focus-cmux's "no ps -o comm= on non-macOS" check
+// was a brittle proxy for "no tmux work happened." We now exercise the tmux
+// helper directly through __test.__setTmuxBin so a host with or without tmux
+// installed produces the same behavior in CI.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const { loadFocusWithMock } = require("./helpers/load-focus-with-mock");
+
+function makeMock(handlers) {
+  const calls = [];
+  function mock(cmd, args, opts, cb) {
+    if (typeof opts === "function") { cb = opts; opts = {}; }
+    calls.push({ cmd, args: [...args] });
+    const handler = handlers[cmd];
+    if (handler) {
+      handler(args, cb);
+      return;
+    }
+    if (cb) cb(null, "", "");
+  }
+  return { calls, mock };
+}
+
+describe("scheduleTmuxPaneFocus", () => {
+  it("issues switch-client + select-window + select-pane when chain crosses tmux", (t, done) => {
+    const { calls, mock } = makeMock({
+      ps: (args, cb) => {
+        if (args.join(" ").includes("pid=,comm=")) {
+          cb(null, "100 zsh\n200 tmux\n300 alacritty\n", "");
+          return;
+        }
+        cb(null, "", "");
+      },
+      "/usr/bin/tmux": (args, cb) => {
+        if (args.includes("list-panes")) {
+          cb(null, "100 @3 %7 work\n", "");
+          return;
+        }
+        cb(null, "", "");
+      },
+    });
+    const { initFocus, cleanup } = loadFocusWithMock(mock, { platform: "linux" });
+    const focusInstance = initFocus({});
+    focusInstance.__test.__setTmuxBin("/usr/bin/tmux");
+    focusInstance.__test.scheduleTmuxPaneFocus([100, 200, 300]);
+
+    setTimeout(() => {
+      cleanup();
+      const tmuxCalls = calls.filter(c => c.cmd === "/usr/bin/tmux");
+      const switchClient = tmuxCalls.find(c => c.args.includes("switch-client"));
+      const selectWindow = tmuxCalls.find(c => c.args.includes("select-window"));
+      const selectPane = tmuxCalls.find(c => c.args.includes("select-pane"));
+      assert.ok(switchClient, "switch-client should run");
+      assert.ok(switchClient.args.includes("work"), "switch-client -t work");
+      assert.ok(selectWindow, "select-window should run");
+      assert.ok(selectWindow.args.includes("@3"), "select-window -t @3");
+      assert.ok(selectPane, "select-pane should run");
+      assert.ok(selectPane.args.includes("%7"), "select-pane -t %7");
+      done();
+    }, 700);
+  });
+
+  it("does nothing when ps reports no tmux processes in chain", (t, done) => {
+    const { calls, mock } = makeMock({
+      ps: (args, cb) => cb(null, "100 zsh\n200 bash\n", ""),
+    });
+    const { initFocus, cleanup } = loadFocusWithMock(mock, { platform: "linux" });
+    const focusInstance = initFocus({});
+    focusInstance.__test.__setTmuxBin("/usr/bin/tmux");
+    focusInstance.__test.scheduleTmuxPaneFocus([100, 200]);
+
+    setTimeout(() => {
+      cleanup();
+      const tmuxCalls = calls.filter(c => c.cmd === "/usr/bin/tmux");
+      assert.strictEqual(tmuxCalls.length, 0, "No tmux CLI calls when chain has no tmux");
+      done();
+    }, 700);
+  });
+
+  it("does not select when no list-panes row matches the pane pid", (t, done) => {
+    const { calls, mock } = makeMock({
+      ps: (args, cb) => cb(null, "100 zsh\n200 tmux\n", ""),
+      "/usr/bin/tmux": (args, cb) => {
+        if (args.includes("list-panes")) {
+          cb(null, "999 @1 %1 other\n", "");
+          return;
+        }
+        cb(null, "", "");
+      },
+    });
+    const { initFocus, cleanup } = loadFocusWithMock(mock, { platform: "linux" });
+    const focusInstance = initFocus({});
+    focusInstance.__test.__setTmuxBin("/usr/bin/tmux");
+    focusInstance.__test.scheduleTmuxPaneFocus([100, 200]);
+
+    setTimeout(() => {
+      cleanup();
+      const tmuxCalls = calls.filter(c => c.cmd === "/usr/bin/tmux");
+      assert.ok(tmuxCalls.some(c => c.args.includes("list-panes")), "list-panes ran");
+      assert.ok(!tmuxCalls.some(c => c.args.includes("select-window")), "no select-window");
+      assert.ok(!tmuxCalls.some(c => c.args.includes("select-pane")), "no select-pane");
+      assert.ok(!tmuxCalls.some(c => c.args.includes("switch-client")), "no switch-client");
+      done();
+    }, 700);
+  });
+
+  it("is a no-op when tmux binary is not resolved", (t, done) => {
+    const { calls, mock } = makeMock({});
+    const { initFocus, cleanup } = loadFocusWithMock(mock, { platform: "linux" });
+    const focusInstance = initFocus({});
+    focusInstance.__test.__setTmuxBin("");
+    focusInstance.__test.scheduleTmuxPaneFocus([100, 200]);
+
+    setTimeout(() => {
+      cleanup();
+      assert.strictEqual(calls.length, 0, "No ps or tmux calls when bin missing");
+      done();
+    }, 700);
+  });
+
+  it("prepends -L <socket> to every tmux invocation when a custom socket is given", (t, done) => {
+    const { calls, mock } = makeMock({
+      ps: (args, cb) => cb(null, "100 zsh\n200 tmux\n", ""),
+      "/usr/bin/tmux": (args, cb) => {
+        if (args.includes("list-panes")) {
+          cb(null, "100 @1 %1 work\n", "");
+          return;
+        }
+        cb(null, "", "");
+      },
+    });
+    const { initFocus, cleanup } = loadFocusWithMock(mock, { platform: "linux" });
+    const focusInstance = initFocus({});
+    focusInstance.__test.__setTmuxBin("/usr/bin/tmux");
+    focusInstance.__test.scheduleTmuxPaneFocus([100, 200], "work-socket");
+
+    setTimeout(() => {
+      cleanup();
+      const tmuxCalls = calls.filter(c => c.cmd === "/usr/bin/tmux");
+      assert.ok(tmuxCalls.length > 0, "tmux ran at least once");
+      for (const c of tmuxCalls) {
+        assert.strictEqual(c.args[0], "-L", "every tmux call leads with -L");
+        assert.strictEqual(c.args[1], "work-socket", "socket name passed");
+      }
+      done();
+    }, 700);
+  });
+});

--- a/test/helpers/load-shared-process-with-mock.js
+++ b/test/helpers/load-shared-process-with-mock.js
@@ -1,0 +1,58 @@
+// test/helpers/load-shared-process-with-mock.js
+//
+// Patches child_process.execFileSync, process.env (TMUX/TMUX_PANE), and
+// process.platform before requiring shared-process.js. This is the
+// equivalent of load-focus-with-mock.js but for the hook-side resolver.
+
+function loadSharedProcessWithMock({ execFileSyncMock, env, platform }) {
+  const cpKey = require.resolve("child_process");
+  const spKey = require.resolve("../../hooks/shared-process");
+
+  const origCp = require.cache[cpKey];
+  const origSp = require.cache[spKey];
+  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+  const envKeys = ["TMUX", "TMUX_PANE"];
+  const savedEnv = {};
+  for (const k of envKeys) savedEnv[k] = process.env[k];
+
+  const realCp = require("child_process");
+  require.cache[cpKey] = {
+    id: cpKey,
+    filename: cpKey,
+    loaded: true,
+    exports: { ...realCp, execFileSync: execFileSyncMock },
+  };
+  if (platform) {
+    Object.defineProperty(process, "platform", { ...origPlatform, value: platform });
+  }
+  if (env) {
+    for (const [k, v] of Object.entries(env)) {
+      if (v === undefined || v === null) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+
+  delete require.cache[spKey];
+  const mod = require("../../hooks/shared-process");
+
+  // Keep cp cache and process.platform patched until cleanup() — shared-process's
+  // resolve() function re-requires child_process at call time and the factory
+  // captures isWin/isLinux at construction time, so both must stay patched
+  // through the test body.
+  const cleanup = () => {
+    if (origSp) require.cache[spKey] = origSp;
+    else delete require.cache[spKey];
+    if (origCp) require.cache[cpKey] = origCp;
+    else delete require.cache[cpKey];
+    if (platform) Object.defineProperty(process, "platform", origPlatform);
+    for (const k of envKeys) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  };
+
+  return { mod, cleanup };
+}
+
+module.exports = { loadSharedProcessWithMock };

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -135,6 +135,7 @@ describe("server-route-state POST", () => {
         cwd: "D:\\repo",
         editor: "cursor",
         pidChain: [1, 3],
+        tmuxSocket: null,
         agentPid: 99,
         agentId: "codex",
         host: "remote-host",

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -127,30 +127,143 @@ describe("createPidResolver()", () => {
 // createPidResolver() — tmux resolution
 // ═════════════════════════════════════════════════════════════════════════════
 
-describe("createPidResolver() — tmux resolution", { skip: !process.env.TMUX }, () => {
-  it("resolves GUI terminal through tmux client when inside tmux", () => {
-    const cfg = getPlatformConfig();
-    const resolve = createPidResolver({ platformConfig: cfg, startPid: process.ppid });
-    const { stablePid, pidChain } = resolve();
-    // stablePid should be a GUI terminal, not the tmux server
-    const { execFileSync } = require("child_process");
-    const comm = require("path").basename(
-      execFileSync("ps", ["-o", "comm=", "-p", String(stablePid)], { encoding: "utf8" }).trim()
-    ).toLowerCase();
-    assert.ok(cfg.terminalNames.has(comm), `stablePid comm "${comm}" should be a known terminal`);
-    // The tmux server PID (from $TMUX) should be in the chain but not be the stablePid
-    const tmuxServerPid = parseInt(process.env.TMUX.split(",")[1], 10);
-    assert.ok(pidChain.includes(tmuxServerPid), "pidChain should include tmux server PID");
-    assert.notStrictEqual(stablePid, tmuxServerPid, "stablePid should not be tmux server");
+// Mocked tmux bridge tests. The previous { skip: !process.env.TMUX } block
+// required a running tmux server with a GUI terminal in the client's ancestry,
+// so it never ran in CI and failed silently for tmux users in ssh / IDE
+// terminals. These mocked variants always run.
+describe("createPidResolver() — tmux bridge (mocked)", () => {
+  const { loadSharedProcessWithMock } = require("./helpers/load-shared-process-with-mock");
+
+  function makeMock(routes) {
+    return function execFileSync(cmd, args /*, opts */) {
+      const key = cmd + " " + args.join(" ");
+      for (const [pattern, value] of routes) {
+        const match = pattern instanceof RegExp ? pattern.test(key) : pattern === key;
+        if (!match) continue;
+        if (typeof value === "function") return value();
+        return value;
+      }
+      const err = new Error("ENOENT: no route for " + key);
+      err.code = "ENOENT";
+      throw err;
+    };
+  }
+
+  it("(a) walk reaches tmux server; list-clients yields client pid → stablePid is terminal", () => {
+    const routes = [
+      ["ps -o ppid= -p 100", "200\n"],
+      ["ps -o comm= -p 100", "zsh\n"],
+      ["ps -o ppid= -p 200", "1\n"],
+      ["ps -o comm= -p 200", "tmux\n"],
+      ["tmux list-clients -t %1 -F #{client_pid}", "300\n"],
+      ["ps -o comm= -p 300", "alacritty\n"],
+      ["ps -o ppid= -p 300", "1\n"],
+    ];
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: makeMock(routes),
+      env: { TMUX: "/tmp/tmux-1000/default,200,5", TMUX_PANE: "%1" },
+      platform: "linux",
+    });
+    try {
+      const cfg = mod.getPlatformConfig();
+      const resolve = mod.createPidResolver({ platformConfig: cfg, startPid: 100 });
+      const { stablePid, pidChain } = resolve();
+      assert.strictEqual(stablePid, 300, "stablePid should be the terminal pid");
+      assert.ok(pidChain.includes(200), "pidChain should include tmux server pid");
+      assert.ok(pidChain.includes(300), "pidChain should include terminal pid");
+    } finally {
+      cleanup();
+    }
   });
 
-  it("skips tmux resolution when walk does not reach tmux server", () => {
-    const cfg = getPlatformConfig();
-    // startPid=1 means the walk ends immediately (PID 1 has no parent)
-    const resolve = createPidResolver({ platformConfig: cfg, startPid: 1, maxDepth: 1 });
-    const { pidChain } = resolve();
-    // Should not have tmux client PIDs appended
-    assert.ok(pidChain.length <= 1);
+  it("(b) walk does not reach tmux server → bridge skipped", () => {
+    const routes = [
+      ["ps -o ppid= -p 100", "1\n"],
+      ["ps -o comm= -p 100", "zsh\n"],
+    ];
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: makeMock(routes),
+      env: { TMUX: "/tmp/tmux-1000/default,200,5", TMUX_PANE: "%1" },
+      platform: "linux",
+    });
+    try {
+      const cfg = mod.getPlatformConfig();
+      const { stablePid, pidChain } = mod.createPidResolver({
+        platformConfig: cfg, startPid: 100, maxDepth: 1,
+      })();
+      assert.strictEqual(stablePid, 100);
+      assert.strictEqual(pidChain.length, 1, "no extra hops appended");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("(c) list-clients empty (detached) → bridge skipped, stablePid falls back", () => {
+    const routes = [
+      ["ps -o ppid= -p 100", "200\n"],
+      ["ps -o comm= -p 100", "zsh\n"],
+      ["ps -o ppid= -p 200", "1\n"],
+      ["ps -o comm= -p 200", "tmux\n"],
+      ["tmux list-clients -t %1 -F #{client_pid}", "\n"],
+    ];
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: makeMock(routes),
+      env: { TMUX: "/tmp/tmux-1000/default,200,5", TMUX_PANE: "%1" },
+      platform: "linux",
+    });
+    try {
+      const cfg = mod.getPlatformConfig();
+      const { stablePid, pidChain } = mod.createPidResolver({
+        platformConfig: cfg, startPid: 100,
+      })();
+      assert.ok(!pidChain.some(p => p > 200), "no client pids appended past tmux server");
+      assert.strictEqual(stablePid, 200, "falls back to lastGoodPid (tmux server)");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("(d) tmuxSocket parsed from $TMUX exposed on resolver result", () => {
+    const routes = [
+      ["ps -o ppid= -p 100", "200\n"],
+      ["ps -o comm= -p 100", "zsh\n"],
+      ["ps -o ppid= -p 200", "1\n"],
+      ["ps -o comm= -p 200", "tmux\n"],
+      ["tmux list-clients -t %1 -F #{client_pid}", "\n"],
+    ];
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: makeMock(routes),
+      env: { TMUX: "/tmp/tmux-1000/work,200,5", TMUX_PANE: "%1" },
+      platform: "linux",
+    });
+    try {
+      const cfg = mod.getPlatformConfig();
+      const result = mod.createPidResolver({ platformConfig: cfg, startPid: 100 })();
+      assert.strictEqual(result.tmuxSocket, "work");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("(e) default socket → tmuxSocket is null", () => {
+    const routes = [
+      ["ps -o ppid= -p 100", "1\n"],
+      ["ps -o comm= -p 100", "zsh\n"],
+    ];
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: makeMock(routes),
+      env: { TMUX: "/tmp/tmux-1000/default,200,5", TMUX_PANE: "%1" },
+      platform: "linux",
+    });
+    try {
+      const cfg = mod.getPlatformConfig();
+      const result = mod.createPidResolver({
+        platformConfig: cfg, startPid: 100, maxDepth: 1,
+      })();
+      assert.strictEqual(result.tmuxSocket, null);
+    } finally {
+      cleanup();
+    }
   });
 });
 

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -124,6 +124,37 @@ describe("createPidResolver()", () => {
 });
 
 // ═════════════════════════════════════════════════════════════════════════════
+// createPidResolver() — tmux resolution
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("createPidResolver() — tmux resolution", { skip: !process.env.TMUX }, () => {
+  it("resolves GUI terminal through tmux client when inside tmux", () => {
+    const cfg = getPlatformConfig();
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: process.ppid });
+    const { stablePid, pidChain } = resolve();
+    // stablePid should be a GUI terminal, not the tmux server
+    const { execFileSync } = require("child_process");
+    const comm = require("path").basename(
+      execFileSync("ps", ["-o", "comm=", "-p", String(stablePid)], { encoding: "utf8" }).trim()
+    ).toLowerCase();
+    assert.ok(cfg.terminalNames.has(comm), `stablePid comm "${comm}" should be a known terminal`);
+    // The tmux server PID (from $TMUX) should be in the chain but not be the stablePid
+    const tmuxServerPid = parseInt(process.env.TMUX.split(",")[1], 10);
+    assert.ok(pidChain.includes(tmuxServerPid), "pidChain should include tmux server PID");
+    assert.notStrictEqual(stablePid, tmuxServerPid, "stablePid should not be tmux server");
+  });
+
+  it("skips tmux resolution when walk does not reach tmux server", () => {
+    const cfg = getPlatformConfig();
+    // startPid=1 means the walk ends immediately (PID 1 has no parent)
+    const resolve = createPidResolver({ platformConfig: cfg, startPid: 1, maxDepth: 1 });
+    const { pidChain } = resolve();
+    // Should not have tmux client PIDs appended
+    assert.ok(pidChain.length <= 1);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
 // buildElectronLaunchConfig()
 // ═════════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## Summary
- When running Claude Code inside tmux, the "Jump to Terminal" / pet click focus feature silently failed because the process tree walk couldn't reach the GUI terminal through the tmux server (parented to launchd, not the terminal app)
- Adds tmux client PID resolution in `hooks/shared-process.js` so `sourcePid` correctly resolves to the actual terminal (e.g. Alacritty, kitty, Terminal.app)
- Adds `scheduleTmuxPaneFocus` in `src/focus.js` to switch to the correct tmux window/pane after focusing the terminal window, using the full binary path since Electron apps don't inherit shell PATH

## Test plan
- [x] Verified `sourcePid` resolves to Alacritty PID instead of tmux server PID
- [x] Verified `focus-debug.log` shows correct PID chain including tmux client and terminal
- [x] Verified tmux pane matching logic correctly identifies target pane from pidChain
- [x] Existing tests pass (`node --test test/shared-process.test.js test/focus-mac-extras.test.js`)
- [ ] End-to-end: click pet/dashboard with multiple Claude sessions in different tmux windows → correct pane activates
- [ ] Non-tmux regression: plain terminal focus still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)