### PR TITLE
Append outcome status to approval cards in Telegram

### DIFF
--- a/src/telegram-native-client.js
+++ b/src/telegram-native-client.js
@@ -4,6 +4,7 @@
 // primitives the migration test card and approval surface need:
 //
 //   getMe / sendMessage / getUpdates / answerCallbackQuery / editMessageReplyMarkup
+//   / editMessageText
 //
 // + offset progression on getUpdates and AbortController-driven cancellation.
 //
@@ -151,6 +152,10 @@ class TelegramNativeClient {
 
   editMessageReplyMarkup(payload, opts) {
     return this._call("editMessageReplyMarkup", payload, opts);
+  }
+
+  editMessageText(payload, opts) {
+    return this._call("editMessageText", payload, opts);
   }
 
   // long-poll one batch. Caller is responsible for looping; this method only

--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -39,10 +39,13 @@ const DEFAULT_POLL_RETRY_MAX_MS = 30000;
 // Status lines appended to an approval card whose decision landed somewhere
 // other than this Telegram chat, so the chat history shows the outcome
 // (issue #457). Keyed by the reason finishApproval received a null decision.
+// `elsewhere` is deliberately neutral: a signal abort covers more than a
+// desktop answer — the settings approval test arms a 60s abort, and DND /
+// dismissed interactive bubbles also abort without anything being "resolved".
 const APPROVAL_RESOLVED_ELSEWHERE_STATUS = Object.freeze({
-  desktop: "\u2705 Resolved on desktop",
+  elsewhere: "\u2705 Resolved outside Telegram",
   timeout: "\u23F3 Timed out",
-  stopped: "\u23F9 Session ended",
+  stopped: "\u23F9\uFE0F Session ended",
 });
 
 function randomId() {
@@ -546,7 +549,10 @@ function createTelegramNativeRunner({
     }).catch(() => clearApprovalKeyboard(entry));
   }
 
-  function finishApproval(id, decision, reason = "desktop") {
+  // `reason` has no default on purpose: a caller that forgets to pass one
+  // falls into the `!status` branch below and degrades to stripping just the
+  // keyboard (the #446 behavior), rather than mislabeling the outcome.
+  function finishApproval(id, decision, reason) {
     const entry = pendingApprovals.get(id);
     if (!entry) return;
     pendingApprovals.delete(id);
@@ -613,7 +619,7 @@ function createTelegramNativeRunner({
       if (entry.timer && typeof entry.timer.unref === "function") entry.timer.unref();
 
       if (signal) {
-        entry.onAbort = () => finishApproval(id, null, "desktop");
+        entry.onAbort = () => finishApproval(id, null, "elsewhere");
         signal.addEventListener("abort", entry.onAbort, { once: true });
       }
 

--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -36,6 +36,15 @@ const MAX_NOTIFY_RETRY_DELAY_MS = 30000;
 const DEFAULT_POLL_RETRY_INITIAL_MS = 1000;
 const DEFAULT_POLL_RETRY_MAX_MS = 30000;
 
+// Status lines appended to an approval card whose decision landed somewhere
+// other than this Telegram chat, so the chat history shows the outcome
+// (issue #457). Keyed by the reason finishApproval received a null decision.
+const APPROVAL_RESOLVED_ELSEWHERE_STATUS = Object.freeze({
+  desktop: "\u2705 Resolved on desktop",
+  timeout: "\u23F3 Timed out",
+  stopped: "\u23F9 Session ended",
+});
+
 function randomId() {
   return Math.random().toString(36).slice(2, 12);
 }
@@ -135,7 +144,7 @@ function createTelegramNativeRunner({
   let abortController = null;
   let polling = false;
   let pendingTest = null; // { nonce, chatId, allowedUser, messageId }
-  const pendingApprovals = new Map(); // id -> { resolve, chatId, allowedUser, messageId, timer, signal, onAbort, suggestionIndexes }
+  const pendingApprovals = new Map(); // id -> { resolve, chatId, allowedUser, messageId, text, timer, signal, onAbort, suggestionIndexes }
   let lastError = null;
   let pollRetryDelayMs = Math.max(1, pollRetryInitialMs);
 
@@ -517,7 +526,27 @@ function createTelegramNativeRunner({
     }).catch(() => {});
   }
 
-  function finishApproval(id, decision) {
+  // Best-effort: rewrite an approval card whose decision landed somewhere
+  // other than this Telegram chat, appending a status line so the chat
+  // history shows the outcome. editMessageText without reply_markup also
+  // drops the inline keyboard; if the rewrite fails (deleted message, edit
+  // window expired, ...) fall back to stripping just the keyboard so the
+  // stale prompt still can't be tapped. Never throws.
+  function markApprovalResolvedElsewhere(entry, reason) {
+    if (!entry || !entry.messageId || !entry.chatId) return;
+    const status = APPROVAL_RESOLVED_ELSEWHERE_STATUS[reason];
+    if (!status || !entry.text) {
+      clearApprovalKeyboard(entry);
+      return;
+    }
+    client.editMessageText({
+      chat_id: entry.chatId,
+      message_id: entry.messageId,
+      text: `${entry.text}\n\n${status}`,
+    }).catch(() => clearApprovalKeyboard(entry));
+  }
+
+  function finishApproval(id, decision, reason = "desktop") {
     const entry = pendingApprovals.get(id);
     if (!entry) return;
     pendingApprovals.delete(id);
@@ -530,14 +559,15 @@ function createTelegramNativeRunner({
     // handleApprovalCallback before we get here. A null decision means the
     // approval was resolved elsewhere — answered on the desktop, timed out, or
     // polling stopped — leaving a still-clickable card that would later answer
-    // "Expired". Pull its buttons so the stale prompt can't be tapped.
-    if (!normalized) clearApprovalKeyboard(entry);
+    // "Expired". Rewrite it with the outcome (and without buttons) so the
+    // stale prompt can't be tapped and the chat history shows what happened.
+    if (!normalized) markApprovalResolvedElsewhere(entry, reason);
     entry.resolve(normalized);
   }
 
   function clearAllApprovals() {
     const ids = Array.from(pendingApprovals.keys());
-    for (const id of ids) finishApproval(id, null);
+    for (const id of ids) finishApproval(id, null, "stopped");
   }
 
   function requestApproval(payload, options = {}) {
@@ -569,6 +599,9 @@ function createTelegramNativeRunner({
         chatId,
         allowedUser,
         messageId: null,
+        // Card body as sent, kept so a resolved-elsewhere edit can rebuild the
+        // text with a status line appended (issue #457).
+        text,
         timer: null,
         signal,
         onAbort: null,
@@ -576,11 +609,11 @@ function createTelegramNativeRunner({
       };
       pendingApprovals.set(id, entry);
 
-      entry.timer = setTimeout(() => finishApproval(id, null), Math.max(1, approvalTimeoutMs));
+      entry.timer = setTimeout(() => finishApproval(id, null, "timeout"), Math.max(1, approvalTimeoutMs));
       if (entry.timer && typeof entry.timer.unref === "function") entry.timer.unref();
 
       if (signal) {
-        entry.onAbort = () => finishApproval(id, null);
+        entry.onAbort = () => finishApproval(id, null, "desktop");
         signal.addEventListener("abort", entry.onAbort, { once: true });
       }
 

--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -445,15 +445,18 @@ function createTelegramNativeRunner({
       try { await client.answerCallbackQuery({ callback_query_id: cb.id, text: "Unavailable" }); } catch {}
       return true;
     }
-    try {
-      await client.answerCallbackQuery({
-        callback_query_id: cb.id,
-        text: decision.action === "allow" ? "Allowed" : (decision.action === "deny" ? "Denied" : "Applied"),
-      });
-    } catch {}
+    // Acknowledge the tap (best-effort, NON-blocking) and then claim the
+    // decision SYNCHRONOUSLY via finishApproval before any await. Awaiting the
+    // toast or the card rewrite first would yield the event loop, and a
+    // concurrent timeout / signal abort / stop could delete this pending entry
+    // mid-flight and drop a real Allow/Deny. finishApproval resolves the
+    // promise up front and fire-and-forgets the status-line rewrite.
+    client.answerCallbackQuery({
+      callback_query_id: cb.id,
+      text: decision.action === "allow" ? "Allowed" : (decision.action === "deny" ? "Denied" : "Applied"),
+    }).catch(() => {});
     const messageId = entry.messageId || (cb.message && cb.message.message_id);
-    await appendApprovalStatus(entry, APPROVAL_DECIDED_STATUS[decision.action], messageId);
-    finishApproval(parsed.id, decision);
+    finishApproval(parsed.id, decision, undefined, messageId);
     return true;
   }
 
@@ -548,10 +551,19 @@ function createTelegramNativeRunner({
     }).catch(() => stripApprovalKeyboard(chatId, messageId));
   }
 
-  // `reason` has no default on purpose: a caller that forgets to pass one
-  // falls into the `!status` branch below and degrades to stripping just the
-  // keyboard (the #446 behavior), rather than mislabeling the outcome.
-  function finishApproval(id, decision, reason) {
+  // Single resolution point for an approval, used by every exit: a Telegram
+  // tap, a desktop answer (abort), a timeout, polling stop, or a send failure.
+  //
+  // The entry is claimed SYNCHRONOUSLY (pulled from the map, timer + abort
+  // listener cleared, promise resolved) before any network I/O, so two exits
+  // racing on the same id can't both act — the second finds no entry and no-ops.
+  // The card rewrite is then fire-and-forget so a slow edit never blocks or
+  // re-opens that race.
+  //
+  // `reason` has no default on purpose: a null-decision caller that forgets to
+  // pass one yields `status === undefined`, which degrades to stripping just
+  // the keyboard (the #446 behavior) rather than mislabeling the outcome.
+  function finishApproval(id, decision, reason, messageIdOverride) {
     const entry = pendingApprovals.get(id);
     if (!entry) return;
     pendingApprovals.delete(id);
@@ -560,14 +572,15 @@ function createTelegramNativeRunner({
       try { entry.signal.removeEventListener("abort", entry.onAbort); } catch {}
     }
     const normalized = normalizeApprovalDecision(decision);
-    // A Telegram-side decision already strips the keyboard in
-    // handleApprovalCallback before we get here. A null decision means the
-    // approval was resolved elsewhere — answered on the desktop, timed out, or
-    // polling stopped — leaving a still-clickable card that would later answer
-    // "Expired". Rewrite it with the outcome (and without buttons) so the
-    // stale prompt can't be tapped and the chat history shows what happened.
-    if (!normalized) appendApprovalStatus(entry, APPROVAL_RESOLVED_ELSEWHERE_STATUS[reason], entry.messageId);
     entry.resolve(normalized);
+    // Rewrite the card so the chat history shows the outcome and the inline
+    // keyboard is dropped. A Telegram-side decision shows the chosen action; a
+    // null decision (resolved elsewhere / timeout / polling stopped) shows the
+    // neutral reason. Best-effort — appendApprovalStatus never throws.
+    const status = normalized
+      ? APPROVAL_DECIDED_STATUS[normalized.action]
+      : APPROVAL_RESOLVED_ELSEWHERE_STATUS[reason];
+    appendApprovalStatus(entry, status, messageIdOverride || entry.messageId);
   }
 
   function clearAllApprovals() {

--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -48,6 +48,15 @@ const APPROVAL_RESOLVED_ELSEWHERE_STATUS = Object.freeze({
   stopped: "\u23F9\uFE0F Session ended",
 });
 
+// Status lines for a decision taken on Telegram itself (a button tap). The
+// callback toast is instant but ephemeral; rewriting the card body leaves the
+// outcome in the chat history, symmetric with the resolved-elsewhere path.
+const APPROVAL_DECIDED_STATUS = Object.freeze({
+  allow: "\u2705 Allowed",
+  deny: "\u274C Denied",
+  suggestion: "\u2705 Applied",
+});
+
 function randomId() {
   return Math.random().toString(36).slice(2, 12);
 }
@@ -442,13 +451,8 @@ function createTelegramNativeRunner({
         text: decision.action === "allow" ? "Allowed" : (decision.action === "deny" ? "Denied" : "Applied"),
       });
     } catch {}
-    try {
-      await client.editMessageReplyMarkup({
-        chat_id: chatId,
-        message_id: entry.messageId || (cb.message && cb.message.message_id),
-        reply_markup: { inline_keyboard: [] },
-      });
-    } catch {}
+    const messageId = entry.messageId || (cb.message && cb.message.message_id);
+    await appendApprovalStatus(entry, APPROVAL_DECIDED_STATUS[decision.action], messageId);
     finishApproval(parsed.id, decision);
     return true;
   }
@@ -518,35 +522,30 @@ function createTelegramNativeRunner({
     }
   }
 
-  // Best-effort: strip the inline keyboard off an approval card whose decision
-  // landed somewhere other than this Telegram chat. Never throws.
-  function clearApprovalKeyboard(entry) {
-    if (!entry || !entry.messageId || !entry.chatId) return;
-    client.editMessageReplyMarkup({
-      chat_id: entry.chatId,
-      message_id: entry.messageId,
+  // Best-effort: strip the inline keyboard off an approval card. Never throws.
+  function stripApprovalKeyboard(chatId, messageId) {
+    if (!chatId || !messageId) return Promise.resolve();
+    return client.editMessageReplyMarkup({
+      chat_id: chatId,
+      message_id: messageId,
       reply_markup: { inline_keyboard: [] },
     }).catch(() => {});
   }
 
-  // Best-effort: rewrite an approval card whose decision landed somewhere
-  // other than this Telegram chat, appending a status line so the chat
-  // history shows the outcome. editMessageText without reply_markup also
-  // drops the inline keyboard; if the rewrite fails (deleted message, edit
-  // window expired, ...) fall back to stripping just the keyboard so the
-  // stale prompt still can't be tapped. Never throws.
-  function markApprovalResolvedElsewhere(entry, reason) {
-    if (!entry || !entry.messageId || !entry.chatId) return;
-    const status = APPROVAL_RESOLVED_ELSEWHERE_STATUS[reason];
-    if (!status || !entry.text) {
-      clearApprovalKeyboard(entry);
-      return;
-    }
-    client.editMessageText({
-      chat_id: entry.chatId,
-      message_id: entry.messageId,
+  // Best-effort: rewrite an approval card's body with a status line appended so
+  // the chat history shows the outcome. editMessageText without reply_markup
+  // also drops the inline keyboard; if the rewrite fails (deleted message, edit
+  // window expired, ...) — or there's no status/body to render — fall back to
+  // stripping just the keyboard so a stale prompt can't be tapped. Never throws.
+  function appendApprovalStatus(entry, status, messageId) {
+    const chatId = entry && entry.chatId;
+    if (!chatId || !messageId) return Promise.resolve();
+    if (!status || !entry.text) return stripApprovalKeyboard(chatId, messageId);
+    return client.editMessageText({
+      chat_id: chatId,
+      message_id: messageId,
       text: `${entry.text}\n\n${status}`,
-    }).catch(() => clearApprovalKeyboard(entry));
+    }).catch(() => stripApprovalKeyboard(chatId, messageId));
   }
 
   // `reason` has no default on purpose: a caller that forgets to pass one
@@ -567,7 +566,7 @@ function createTelegramNativeRunner({
     // polling stopped — leaving a still-clickable card that would later answer
     // "Expired". Rewrite it with the outcome (and without buttons) so the
     // stale prompt can't be tapped and the chat history shows what happened.
-    if (!normalized) markApprovalResolvedElsewhere(entry, reason);
+    if (!normalized) appendApprovalStatus(entry, APPROVAL_RESOLVED_ELSEWHERE_STATUS[reason], entry.messageId);
     entry.resolve(normalized);
   }
 

--- a/test/telegram-native-client.test.js
+++ b/test/telegram-native-client.test.js
@@ -49,15 +49,19 @@ test("sendMessage: success returns result; token is NOT in transport args", asyn
   assert.deepEqual(server.calls[0].payload, { chat_id: 1, text: "hi" });
 });
 
-test("getMe / answerCallbackQuery / editMessageReplyMarkup roundtrip", async () => {
+test("getMe / answerCallbackQuery / editMessageReplyMarkup / editMessageText roundtrip", async () => {
   const { client, server } = makeClient();
   server.enqueueOk("getMe", { id: 9, username: "fake_bot" });
   server.enqueueOk("answerCallbackQuery", true);
   server.enqueueOk("editMessageReplyMarkup", { message_id: 11 });
+  server.enqueueOk("editMessageText", { message_id: 12, text: "done" });
 
   assert.equal((await client.getMe()).username, "fake_bot");
   assert.equal(await client.answerCallbackQuery({ callback_query_id: "x" }), true);
   assert.equal((await client.editMessageReplyMarkup({ chat_id: 1, message_id: 11 })).message_id, 11);
+  const edited = await client.editMessageText({ chat_id: 1, message_id: 12, text: "done" });
+  assert.equal(edited.message_id, 12);
+  assert.deepEqual(server.calls[3].payload, { chat_id: 1, message_id: 12, text: "done" });
 });
 
 test("getUpdates advances offset to lastUpdate.update_id + 1", async () => {

--- a/test/telegram-native-runner.test.js
+++ b/test/telegram-native-runner.test.js
@@ -463,7 +463,7 @@ test("native runner aborts an in-flight approval send before a late Telegram suc
   await runner.stop();
 });
 
-test("native runner rewrites approval card with status when resolved on desktop (abort)", async () => {
+test("native runner rewrites approval card with status when resolved outside Telegram (abort)", async () => {
   const server = createFakeTelegramServer();
   let releaseFirstPoll;
 
@@ -491,7 +491,8 @@ test("native runner rewrites approval card with status when resolved on desktop 
   await tick();
   assert.equal(server.calls.filter((call) => call.method === "sendMessage").length, 1);
 
-  // Desktop answered the permission: the caller aborts the in-flight request.
+  // The permission was resolved outside Telegram (desktop answer, DND, or a
+  // dismissed bubble): the caller aborts the in-flight request.
   controller.abort();
   assert.equal(await decisionPromise, null);
   await tick();
@@ -502,7 +503,7 @@ test("native runner rewrites approval card with status when resolved on desktop 
   assert.equal(editCalls[0].payload.message_id, 99);
   assert.equal(
     editCalls[0].payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Resolved on desktop",
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Resolved outside Telegram",
   );
   assert.equal(
     editCalls[0].payload.reply_markup,
@@ -587,7 +588,7 @@ test("native runner appends session-ended status when polling stops with a pendi
   assert.equal(editCalls[0].payload.message_id, 55);
   assert.equal(
     editCalls[0].payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u23F9 Session ended",
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u23F9\uFE0F Session ended",
   );
 });
 

--- a/test/telegram-native-runner.test.js
+++ b/test/telegram-native-runner.test.js
@@ -463,13 +463,13 @@ test("native runner aborts an in-flight approval send before a late Telegram suc
   await runner.stop();
 });
 
-test("native runner strips approval keyboard when resolved on desktop (abort)", async () => {
+test("native runner rewrites approval card with status when resolved on desktop (abort)", async () => {
   const server = createFakeTelegramServer();
   let releaseFirstPoll;
 
   server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
   server.enqueueOk("sendMessage", { message_id: 99, chat: { id: 123 } });
-  server.enqueueOk("editMessageReplyMarkup", { message_id: 99 });
+  server.enqueueOk("editMessageText", { message_id: 99 });
 
   const runner = createTelegramNativeRunner({
     tokenStore: tokenStore(),
@@ -496,11 +496,138 @@ test("native runner strips approval keyboard when resolved on desktop (abort)", 
   assert.equal(await decisionPromise, null);
   await tick();
 
-  const editCalls = server.calls.filter((call) => call.method === "editMessageReplyMarkup");
-  assert.equal(editCalls.length, 1, "stale approval card must have its keyboard stripped");
+  const editCalls = server.calls.filter((call) => call.method === "editMessageText");
+  assert.equal(editCalls.length, 1, "stale approval card must be rewritten with the outcome");
   assert.equal(editCalls[0].payload.chat_id, "123");
   assert.equal(editCalls[0].payload.message_id, 99);
-  assert.deepEqual(editCalls[0].payload.reply_markup, { inline_keyboard: [] });
+  assert.equal(
+    editCalls[0].payload.text,
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Resolved on desktop",
+  );
+  assert.equal(
+    editCalls[0].payload.reply_markup,
+    undefined,
+    "editMessageText without reply_markup drops the inline keyboard",
+  );
+  assert.equal(
+    server.calls.some((call) => call.method === "editMessageReplyMarkup"),
+    false,
+    "no separate keyboard strip when the text rewrite succeeds",
+  );
+
+  releaseFirstPoll({ ok: true, result: [] });
+  await runner.stop();
+});
+
+test("native runner appends timeout status when an approval expires", async () => {
+  const server = createFakeTelegramServer();
+  let releaseFirstPoll;
+
+  server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+  server.enqueueOk("sendMessage", { message_id: 77, chat: { id: 123 } });
+  server.enqueueOk("editMessageText", { message_id: 77 });
+
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+    approvalTimeoutMs: 10,
+  });
+
+  await runner.start();
+  await tick();
+
+  const decision = await runner.requestApproval({ title: "claude-code requests Bash", detail: "Summary: Run tests" });
+  assert.equal(decision, null);
+  await tick();
+
+  const editCalls = server.calls.filter((call) => call.method === "editMessageText");
+  assert.equal(editCalls.length, 1);
+  assert.equal(editCalls[0].payload.message_id, 77);
+  assert.equal(
+    editCalls[0].payload.text,
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u23F3 Timed out",
+  );
+
+  releaseFirstPoll({ ok: true, result: [] });
+  await runner.stop();
+});
+
+test("native runner appends session-ended status when polling stops with a pending approval", async () => {
+  const server = createFakeTelegramServer();
+  let releaseFirstPoll;
+
+  server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+  server.enqueueOk("sendMessage", { message_id: 55, chat: { id: 123 } });
+  server.enqueueOk("editMessageText", { message_id: 55 });
+
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.start();
+  await tick();
+
+  const decisionPromise = runner.requestApproval({ title: "claude-code requests Bash", detail: "Summary: Run tests" });
+  await tick();
+
+  releaseFirstPoll({ ok: true, result: [] });
+  await runner.stop();
+  assert.equal(await decisionPromise, null);
+  await tick();
+
+  const editCalls = server.calls.filter((call) => call.method === "editMessageText");
+  assert.equal(editCalls.length, 1);
+  assert.equal(editCalls[0].payload.message_id, 55);
+  assert.equal(
+    editCalls[0].payload.text,
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u23F9 Session ended",
+  );
+});
+
+test("native runner falls back to stripping the keyboard when the status rewrite fails", async () => {
+  const server = createFakeTelegramServer();
+  let releaseFirstPoll;
+
+  server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+  server.enqueueOk("sendMessage", { message_id: 88, chat: { id: 123 } });
+  server.enqueueError("editMessageText", { status: 400, description: "Bad Request: message can't be edited" });
+  server.enqueueOk("editMessageReplyMarkup", { message_id: 88 });
+
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.start();
+  await tick();
+
+  const controller = new AbortController();
+  const decisionPromise = runner.requestApproval(
+    { title: "claude-code requests Bash", detail: "Summary: Run tests" },
+    { signal: controller.signal },
+  );
+  await tick();
+
+  controller.abort();
+  assert.equal(await decisionPromise, null);
+  await tick();
+  await tick();
+
+  const stripCalls = server.calls.filter((call) => call.method === "editMessageReplyMarkup");
+  assert.equal(stripCalls.length, 1, "PR #446 guarantee: stale card must lose its keyboard even if the rewrite fails");
+  assert.equal(stripCalls[0].payload.chat_id, "123");
+  assert.equal(stripCalls[0].payload.message_id, 88);
+  assert.deepEqual(stripCalls[0].payload.reply_markup, { inline_keyboard: [] });
 
   releaseFirstPoll({ ok: true, result: [] });
   await runner.stop();

--- a/test/telegram-native-runner.test.js
+++ b/test/telegram-native-runner.test.js
@@ -168,6 +168,8 @@ test("native runner requestApproval resolves allow for matching callback", async
   releaseFirstPoll({ ok: true, result: [] });
   const decision = await decisionPromise;
   assert.deepEqual(decision, { action: "allow" });
+  // The toast and the card rewrite are fire-and-forget now; let them land.
+  await tick();
   assert.equal(server.calls.some((call) => call.method === "answerCallbackQuery"), true);
   const allowEdit = server.calls.find((call) => call.method === "editMessageText");
   assert.ok(allowEdit, "tapping Allow rewrites the card body with the outcome");
@@ -176,6 +178,66 @@ test("native runner requestApproval resolves allow for matching callback", async
     "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Allowed",
   );
   assert.equal(allowEdit.payload.reply_markup, undefined);
+  await runner.stop();
+});
+
+test("native runner claims a Telegram tap atomically so a racing abort can't drop it", async () => {
+  const server = createFakeTelegramServer();
+  let releaseFirstPoll;
+  let allowData = "";
+  const controller = new AbortController();
+
+  server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
+  server.enqueue("sendMessage", (payload) => {
+    allowData = payload.reply_markup.inline_keyboard[0][0].callback_data;
+    return { ok: true, result: { message_id: 70, chat: { id: 123 } } };
+  });
+  server.enqueue("getUpdates", () => ({
+    ok: true,
+    result: [{
+      update_id: 1,
+      callback_query: {
+        id: "cb-allow",
+        from: { id: 777 },
+        message: { message_id: 70, chat: { id: 123 } },
+        data: allowData,
+      },
+    }],
+  }));
+  server.enqueueOk("answerCallbackQuery", true);
+  server.enqueueOk("editMessageText", { message_id: 70 });
+
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.start();
+  await tick();
+  const decisionPromise = runner.requestApproval(
+    { title: "claude-code requests Bash", detail: "Summary: Run tests" },
+    { signal: controller.signal },
+  );
+  await tick();
+
+  releaseFirstPoll({ ok: true, result: [] });
+  const decision = await decisionPromise;
+  // The tap is claimed synchronously, so the desktop answering immediately
+  // afterwards (signal abort) is a no-op rather than a null drop.
+  assert.deepEqual(decision, { action: "allow" });
+
+  controller.abort();
+  await tick();
+
+  const edits = server.calls.filter((call) => call.method === "editMessageText");
+  assert.equal(edits.length, 1, "the late abort must not fire a second, conflicting card rewrite");
+  assert.equal(
+    edits[0].payload.text,
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Allowed",
+  );
   await runner.stop();
 });
 
@@ -296,6 +358,8 @@ test("native runner rejects forged suggestion callbacks and waits for a valid de
   releaseFirstPoll({ ok: true, result: [] });
   const decision = await decisionPromise;
   assert.deepEqual(decision, { action: "suggestion", index: 0 });
+  // The valid tap's toast + card rewrite are fire-and-forget now; let them land.
+  await tick();
 
   const callbackAnswers = server.calls.filter((call) => call.method === "answerCallbackQuery");
   assert.equal(callbackAnswers[0].payload.text, "Unavailable");
@@ -367,6 +431,8 @@ test("native runner requestApproval ignores wrong user and resolves later callba
   releaseFirstPoll({ ok: true, result: [] });
 
   assert.deepEqual(await decisionPromise, { action: "deny" });
+  // The valid tap's toast + card rewrite are fire-and-forget now; let them land.
+  await tick();
   assert.equal(
     server.calls.filter((call) => call.method === "answerCallbackQuery").length,
     2,

--- a/test/telegram-native-runner.test.js
+++ b/test/telegram-native-runner.test.js
@@ -145,7 +145,7 @@ test("native runner requestApproval resolves allow for matching callback", async
     }],
   }));
   server.enqueueOk("answerCallbackQuery", true);
-  server.enqueueOk("editMessageReplyMarkup", { message_id: 99 });
+  server.enqueueOk("editMessageText", { message_id: 99 });
 
   const runner = createTelegramNativeRunner({
     tokenStore: tokenStore(),
@@ -169,7 +169,13 @@ test("native runner requestApproval resolves allow for matching callback", async
   const decision = await decisionPromise;
   assert.deepEqual(decision, { action: "allow" });
   assert.equal(server.calls.some((call) => call.method === "answerCallbackQuery"), true);
-  assert.equal(server.calls.some((call) => call.method === "editMessageReplyMarkup"), true);
+  const allowEdit = server.calls.find((call) => call.method === "editMessageText");
+  assert.ok(allowEdit, "tapping Allow rewrites the card body with the outcome");
+  assert.equal(
+    allowEdit.payload.text,
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Allowed",
+  );
+  assert.equal(allowEdit.payload.reply_markup, undefined);
   await runner.stop();
 });
 
@@ -202,7 +208,7 @@ test("native runner requestApproval renders suggestions and returns suggestion d
     }],
   }));
   server.enqueueOk("answerCallbackQuery", true);
-  server.enqueueOk("editMessageReplyMarkup", { message_id: 101 });
+  server.enqueueOk("editMessageText", { message_id: 101 });
 
   const runner = createTelegramNativeRunner({
     tokenStore: tokenStore(),
@@ -268,7 +274,7 @@ test("native runner rejects forged suggestion callbacks and waits for a valid de
   }));
   server.enqueueOk("answerCallbackQuery", true);
   server.enqueueOk("answerCallbackQuery", true);
-  server.enqueueOk("editMessageReplyMarkup", { message_id: 102 });
+  server.enqueueOk("editMessageText", { message_id: 102 });
 
   const runner = createTelegramNativeRunner({
     tokenStore: tokenStore(),
@@ -294,7 +300,12 @@ test("native runner rejects forged suggestion callbacks and waits for a valid de
   const callbackAnswers = server.calls.filter((call) => call.method === "answerCallbackQuery");
   assert.equal(callbackAnswers[0].payload.text, "Unavailable");
   assert.equal(callbackAnswers[1].payload.text, "Applied");
-  assert.equal(server.calls.filter((call) => call.method === "editMessageReplyMarkup").length, 1);
+  const edits = server.calls.filter((call) => call.method === "editMessageText");
+  assert.equal(edits.length, 1, "only the valid decision rewrites the card");
+  assert.equal(
+    edits[0].payload.text,
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Applied",
+  );
   await runner.stop();
 });
 
@@ -336,7 +347,7 @@ test("native runner requestApproval ignores wrong user and resolves later callba
   }));
   server.enqueueOk("answerCallbackQuery", true);
   server.enqueueOk("answerCallbackQuery", true);
-  server.enqueueOk("editMessageReplyMarkup", { message_id: 100 });
+  server.enqueueOk("editMessageText", { message_id: 100 });
 
   const runner = createTelegramNativeRunner({
     tokenStore: tokenStore(),
@@ -359,6 +370,12 @@ test("native runner requestApproval ignores wrong user and resolves later callba
   assert.equal(
     server.calls.filter((call) => call.method === "answerCallbackQuery").length,
     2,
+  );
+  const denyEdit = server.calls.find((call) => call.method === "editMessageText");
+  assert.ok(denyEdit, "tapping Deny rewrites the card body with the outcome");
+  assert.equal(
+    denyEdit.payload.text,
+    "claude-code requests Bash\n\nSummary: Run tests\n\n\u274C Denied",
   );
   await runner.stop();
 });


### PR DESCRIPTION
## Summary

Telegram approval cards now show their final outcome in the chat history instead of just losing the inline keyboard (issue #457):

- **Resolved outside Telegram** (desktop answer / DND / dismissed bubble → abort, timeout, polling stop): the card body is rewritten with a neutral status line — `✅ Resolved outside Telegram`, `⏳ Timed out`, or `⏹️ Session ended`.
- **Telegram-side taps**: tapping Allow / Deny / a suggestion rewrites the body with `✅ Allowed` / `❌ Denied` / `✅ Applied`, so the choice is no longer only an ephemeral toast.

`editMessageText` (without `reply_markup`) drops the keyboard in the same call; on failure it falls back to stripping just the keyboard (the #446 guarantee). The rewrite is best-effort and never blocks `resolve`.

### Race fix (from review)

`finishApproval` is now the single resolution point for every exit. It claims the pending entry **synchronously** (clears the timer + abort listener, resolves the promise) before any network I/O, then fire-and-forgets the card rewrite — so a Telegram tap racing a concurrent timeout / desktop abort / polling stop can no longer be dropped to `null` or written into a conflicting double-edit.

## Testing

- `node --test test/telegram-native-runner.test.js test/telegram-native-client.test.js` — 62 pass (including a new race regression test).
- `npm test` (full suite) — 0 fail.

Closes #457
