### PR TITLE
fix(focus): restore minimized macOS windows when jumping back to a session

### DIFF
--- a/src/focus.js
+++ b/src/focus.js
@@ -505,6 +505,11 @@ let psProc = null;
 // macOS Accessibility/System Events calls can pile up fast, so serialize focus attempts.
 const MAC_FOCUS_THROTTLE_MS = 1500;
 const MAC_FOCUS_TIMEOUT_MS = 1500;
+// The generic frontmost fallback can block on the macOS Automation consent
+// dialog on first use; killing it early dismisses the dialog before the user
+// can answer (#465), so that one script gets a human-scale timeout.
+const MAC_FOCUS_CONSENT_TIMEOUT_MS = 15000;
+const MAC_OPEN_TIMEOUT_MS = 3000;
 const WINDOWS_FOCUS_DEDUP_MS = 400;
 const WINDOWS_FOCUS_RESULT_TIMEOUT_MS = 3000;
 const WINDOWS_FOCUS_POSITIVE_REASONS = new Set([
@@ -1461,6 +1466,66 @@ function focusTerminalWindow(sourcePidOrRequest, cwd, editor, pidChain, meta) {
   return result;
 }
 
+// macOS generic window focus (#465). Prefer LaunchServices activation
+// (`open <bundle>`) over System Events `set frontmost`: `open` carries
+// Dock-click reopen semantics, so it also restores minimized windows —
+// `set frontmost` activates the app but leaves them in the Dock — and it
+// needs no Automation consent. System Events stays as the fallback for
+// source processes that don't live inside an .app bundle.
+
+function extractMacAppBundlePath(commPath) {
+  const text = typeof commPath === "string" ? commPath.trim() : "";
+  if (!text.startsWith("/")) return null;
+  // Match the outermost bundle: helpers live at
+  // <bundle>.app/Contents/Frameworks/<helper>.app/Contents/MacOS/<bin>.
+  const idx = text.indexOf(".app/Contents/");
+  return idx > 0 ? text.slice(0, idx + 4) : null;
+}
+
+function resolveMacAppBundle(pidCandidates, callback) {
+  execFile("ps", ["-o", "pid=,comm=", "-p", pidCandidates.join(",")], { encoding: "utf8", timeout: 1000 }, (_err, stdout) => {
+    // ps exits non-zero when any pid in the list is already gone but still
+    // prints the live rows, so parse stdout regardless of the exit code.
+    const commByPid = new Map();
+    for (const line of String(stdout || "").split("\n")) {
+      const match = line.match(/^\s*(\d+)\s+(.+)$/);
+      if (match) commByPid.set(Number(match[1]), match[2]);
+    }
+    for (const pid of pidCandidates) {
+      const bundlePath = extractMacAppBundlePath(commByPid.get(pid));
+      if (bundlePath) return callback(bundlePath);
+    }
+    callback(null);
+  });
+}
+
+function focusMacAppViaSystemEvents(pidCandidates, onDone) {
+  const applePidList = pidCandidates.join(", ");
+  const script = `
+    tell application "System Events"
+      repeat with targetPid in {${applePidList}}
+        set pidValue to contents of targetPid
+        set pList to every process whose unix id is pidValue
+        if (count of pList) > 0 then
+          set frontmost of item 1 of pList to true
+          exit repeat
+        end if
+      end repeat
+    end tell`;
+  execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_CONSENT_TIMEOUT_MS }, (err, _stdout, stderr) => {
+    if (err) {
+      const detail = String(stderr || err.message || "").split("\n")[0].slice(0, 160);
+      const reason = detail.includes("-1743")
+        ? "automation-denied"
+        : `osascript-failed:${safeLogValue(err.signal || err.code || "error")}`;
+      logFocusResult(`branch=mac-frontmost reason=${reason} detail=${safeLogValue(detail)}`);
+    } else {
+      logFocusResult("branch=mac-frontmost reason=ok");
+    }
+    if (onDone) onDone();
+  });
+}
+
 function focusTerminalWindowLegacy(request, onDone) {
   const { sourcePid } = request;
   const cwd = request.cwd;
@@ -1480,21 +1545,20 @@ function focusTerminalWindowLegacy(request, onDone) {
         if (pidCandidates.length >= 3) break;
       }
     }
-    const applePidList = pidCandidates.join(", ");
-    const script = `
-      tell application "System Events"
-        repeat with targetPid in {${applePidList}}
-          set pidValue to contents of targetPid
-          set pList to every process whose unix id is pidValue
-          if (count of pList) > 0 then
-            set frontmost of item 1 of pList to true
-            exit repeat
-          end if
-        end repeat
-      end tell`;
-    execFile("osascript", ["-e", script], { timeout: MAC_FOCUS_TIMEOUT_MS }, (err) => {
-      if (err) console.warn("focusTerminal macOS failed:", err.message);
-      if (onDone) onDone();
+    resolveMacAppBundle(pidCandidates, (bundlePath) => {
+      if (!bundlePath) {
+        focusMacAppViaSystemEvents(pidCandidates, onDone);
+        return;
+      }
+      execFile("/usr/bin/open", [bundlePath], { timeout: MAC_OPEN_TIMEOUT_MS }, (openErr) => {
+        if (!openErr) {
+          logFocusResult(`branch=mac-open reason=ok bundle=${safeLogValue(path.basename(bundlePath))}`);
+          if (onDone) onDone();
+          return;
+        }
+        logFocusResult(`branch=mac-open reason=open-failed bundle=${safeLogValue(path.basename(bundlePath))} error=${safeLogValue(openErr.signal || openErr.code || "error")}`);
+        focusMacAppViaSystemEvents(pidCandidates, onDone);
+      });
     });
     return true;
   }
@@ -1583,6 +1647,7 @@ return {
   cleanup,
   __test: {
     makeFocusCmd,
+    extractMacAppBundlePath,
     buildWindowsTitleCandidates,
     confirmForeground,
     isPositiveFocusReason,

--- a/test/focus-mac-open.test.js
+++ b/test/focus-mac-open.test.js
@@ -1,0 +1,197 @@
+// test/focus-mac-open.test.js — Tests for the macOS generic window-focus path
+// (#465): LaunchServices activation (`open <bundle>`) first — it restores
+// minimized windows and needs no Automation consent — with the System Events
+// `set frontmost` script demoted to a fallback for non-bundle processes.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+// focus.js destructures { execFile, spawn } at require-time, so we patch
+// child_process and process.platform BEFORE requiring focus.js. This mirrors
+// the helper in test/focus-mac-extras.test.js.
+function loadFocusWithMock(execFileMock, options = {}) {
+  const cpKey = require.resolve("child_process");
+  const focusKey = require.resolve("../src/focus");
+  const platform = options.platform || "darwin";
+
+  const origCp = require.cache[cpKey];
+  const origFocus = require.cache[focusKey];
+  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+  const realCp = require("child_process");
+  const patchedCp = { ...realCp, execFile: execFileMock, spawn: realCp.spawn };
+  require.cache[cpKey] = { id: cpKey, filename: cpKey, loaded: true, exports: patchedCp };
+  Object.defineProperty(process, "platform", { ...origPlatform, value: platform });
+
+  delete require.cache[focusKey];
+  let initFocus;
+  try {
+    initFocus = require("../src/focus");
+  } finally {
+    Object.defineProperty(process, "platform", origPlatform);
+  }
+  if (origCp) require.cache[cpKey] = origCp;
+  else delete require.cache[cpKey];
+
+  const cleanup = () => {
+    if (origFocus) require.cache[focusKey] = origFocus;
+    else delete require.cache[focusKey];
+  };
+  return { initFocus, cleanup };
+}
+
+const VSCODE_HELPER_COMM =
+  "/Applications/Visual Studio Code.app/Contents/Frameworks/Code Helper.app/Contents/MacOS/Code Helper";
+
+function isPidCommPs(cmd, args) {
+  return cmd === "ps" && args.includes("pid=,comm=");
+}
+
+function isSystemEventsFrontmost(cmd, args) {
+  return cmd === "osascript"
+    && args.some((a) => typeof a === "string" && a.includes("System Events") && a.includes("unix id"));
+}
+
+function isOpenAppBundle(call) {
+  return call.cmd === "/usr/bin/open"
+    && call.args.some((a) => typeof a === "string" && a.endsWith(".app"));
+}
+
+describe("macOS generic focus via open <bundle> (#465)", () => {
+  it("extractMacAppBundlePath picks the outermost bundle and rejects non-bundles", () => {
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; }
+      if (cb) cb(null, "", "");
+    });
+    const { __test } = initFocus({});
+    cleanup();
+
+    assert.strictEqual(
+      __test.extractMacAppBundlePath(VSCODE_HELPER_COMM),
+      "/Applications/Visual Studio Code.app"
+    );
+    assert.strictEqual(
+      __test.extractMacAppBundlePath("/Applications/Claude.app/Contents/MacOS/Claude"),
+      "/Applications/Claude.app"
+    );
+    assert.strictEqual(__test.extractMacAppBundlePath("/bin/zsh"), null);
+    assert.strictEqual(__test.extractMacAppBundlePath("claude"), null);
+    // A directory merely named *.app (no Contents/) is not a bundle.
+    assert.strictEqual(__test.extractMacAppBundlePath("/Users/x/my.app/bin/tool"), null);
+    assert.strictEqual(__test.extractMacAppBundlePath(null), null);
+  });
+
+  it("opens the app bundle resolved from the pid candidates and skips System Events", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args], opts });
+      if (isPidCommPs(cmd, args)) {
+        if (cb) cb(null, [
+          "31413 claude",
+          "30713 /bin/zsh",
+          `28428 ${VSCODE_HELPER_COMM}`,
+        ].join("\n") + "\n", "");
+        return;
+      }
+      if (cmd === "ps") { if (cb) cb(null, "/bin/zsh\n", ""); return; }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(28428, null, null, [31413, 30713, 29515, 28428]);
+
+    setTimeout(() => {
+      cleanup();
+      const openCall = calls.find((c) =>
+        c.cmd === "/usr/bin/open" && c.args.includes("/Applications/Visual Studio Code.app"));
+      assert.ok(openCall, "Should activate via /usr/bin/open with the outer .app bundle");
+      const frontmostCall = calls.find((c) => isSystemEventsFrontmost(c.cmd, c.args));
+      assert.ok(!frontmostCall, "Should not run the System Events frontmost script when open succeeds");
+      done();
+    }, 100);
+  });
+
+  it("falls back to System Events with the consent timeout when no candidate is in a bundle", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args], opts });
+      if (isPidCommPs(cmd, args)) {
+        if (cb) cb(null, "4242 /opt/homebrew/bin/wezterm-gui\n", "");
+        return;
+      }
+      if (cmd === "ps") { if (cb) cb(null, "/opt/homebrew/bin/wezterm-gui\n", ""); return; }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(4242, null, null, [4242]);
+
+    setTimeout(() => {
+      cleanup();
+      const frontmostCall = calls.find((c) => isSystemEventsFrontmost(c.cmd, c.args));
+      assert.ok(frontmostCall, "Should fall back to the System Events frontmost script");
+      assert.strictEqual(frontmostCall.opts.timeout, 15000,
+        "Fallback script must outlive the Automation consent dialog");
+      assert.ok(!calls.some(isOpenAppBundle), "Should not open any .app bundle");
+      done();
+    }, 100);
+  });
+
+  it("falls back to System Events when open fails", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args], opts });
+      if (isPidCommPs(cmd, args)) {
+        if (cb) cb(null, `28428 ${VSCODE_HELPER_COMM}\n`, "");
+        return;
+      }
+      if (cmd === "/usr/bin/open") {
+        if (cb) cb(Object.assign(new Error("open failed"), { code: 1 }), "", "");
+        return;
+      }
+      if (cmd === "ps") { if (cb) cb(null, "/bin/zsh\n", ""); return; }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(28428, null, null, [28428]);
+
+    setTimeout(() => {
+      cleanup();
+      assert.ok(calls.some(isOpenAppBundle), "Should attempt /usr/bin/open first");
+      const frontmostCall = calls.find((c) => isSystemEventsFrontmost(c.cmd, c.args));
+      assert.ok(frontmostCall, "Should fall back to the System Events frontmost script after open fails");
+      done();
+    }, 100);
+  });
+
+  it("ignores the ps exit code and parses surviving rows (dead pid in the list)", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args], opts });
+      if (isPidCommPs(cmd, args)) {
+        // BSD ps exits 1 when any requested pid is gone but still prints live rows.
+        if (cb) cb(Object.assign(new Error("exit 1"), { code: 1 }),
+          `28428 ${VSCODE_HELPER_COMM}\n`, "");
+        return;
+      }
+      if (cmd === "ps") { if (cb) cb(null, "/bin/zsh\n", ""); return; }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(28428, null, null, [31413, 28428]);
+
+    setTimeout(() => {
+      cleanup();
+      const openCall = calls.find((c) =>
+        c.cmd === "/usr/bin/open" && c.args.includes("/Applications/Visual Studio Code.app"));
+      assert.ok(openCall, "Should still resolve the bundle from partial ps output");
+      done();
+    }, 100);
+  });
+});

--- a/test/focus-mac-open.test.js
+++ b/test/focus-mac-open.test.js
@@ -168,6 +168,77 @@ describe("macOS generic focus via open <bundle> (#465)", () => {
     }, 100);
   });
 
+  it("runs the iTerm tab script alongside open when the source is iTerm2", (t, done) => {
+    const calls = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args], opts });
+      if (isPidCommPs(cmd, args)) {
+        if (cb) cb(null, "4242 /Applications/iTerm.app/Contents/MacOS/iTerm2\n", "");
+        return;
+      }
+      if (cmd === "ps" && args.join(" ").includes("tty=")) {
+        if (cb) cb(null, "  30713 ttys003\n", "");
+        return;
+      }
+      if (cmd === "ps") {
+        // Single-column comm gate used by the specialized handlers.
+        if (cb) cb(null, "/Applications/iTerm.app/Contents/MacOS/iTerm2\n", "");
+        return;
+      }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(4242, null, null, [30713, 4242]);
+
+    // The iTerm tab script fires on a 400ms delay — wait past it.
+    setTimeout(() => {
+      cleanup();
+      const openCall = calls.find((c) =>
+        c.cmd === "/usr/bin/open" && c.args.includes("/Applications/iTerm.app"));
+      assert.ok(openCall, "Should activate iTerm via /usr/bin/open (restores minimized windows)");
+      const itermTabCall = calls.find((c) =>
+        c.cmd === "osascript"
+        && c.args.some((a) => typeof a === "string" && a.includes('tell application "iTerm2"') && a.includes("select t")));
+      assert.ok(itermTabCall, "Specialized iTerm tab selection should still run alongside open");
+      const frontmostCall = calls.find((c) => isSystemEventsFrontmost(c.cmd, c.args));
+      assert.ok(!frontmostCall, "Should not run the System Events frontmost script when open succeeds");
+      done();
+    }, 700);
+  });
+
+  it("logs automation-denied when the System Events fallback hits TCC -1743", (t, done) => {
+    const logs = [];
+    const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      if (isPidCommPs(cmd, args)) {
+        if (cb) cb(null, "4242 /opt/homebrew/bin/wezterm-gui\n", "");
+        return;
+      }
+      if (cmd === "ps") { if (cb) cb(null, "/opt/homebrew/bin/wezterm-gui\n", ""); return; }
+      if (isSystemEventsFrontmost(cmd, args)) {
+        if (cb) cb(
+          Object.assign(new Error("osascript exited 1"), { code: 1 }),
+          "",
+          "execution error: Not authorized to send Apple events to System Events. (-1743)"
+        );
+        return;
+      }
+      if (cb) cb(null, "", "");
+    });
+
+    const { focusTerminalWindow } = initFocus({ focusLog: (msg) => logs.push(String(msg)) });
+    focusTerminalWindow(4242, null, null, [4242]);
+
+    setTimeout(() => {
+      cleanup();
+      const denied = logs.find((l) => l.includes("branch=mac-frontmost") && l.includes("reason=automation-denied"));
+      assert.ok(denied, `focus log should record automation-denied, got: ${JSON.stringify(logs)}`);
+      done();
+    }, 100);
+  });
+
   it("ignores the ps exit code and parses surviving rows (dead pid in the list)", (t, done) => {
     const calls = [];
     const { initFocus, cleanup } = loadFocusWithMock(function mockExecFile(cmd, args, opts, cb) {


### PR DESCRIPTION
**TL;DR (EN):** On macOS, jumping back to a session (HUD / dashboard / post-permission) used System Events `set frontmost`, which activates the app but never restores minimized windows — and its 1.5s timeout killed the first-use Automation consent dialog. Activate via `/usr/bin/open <bundle>` instead (Dock-click reopen semantics, no TCC consent needed), keep System Events as a logged fallback.

Closes #465

## 根因（真机实证，macOS 15 / Apple Silicon）

点击 HUD 想跳回会话时"没反应"，实测是两个独立缺陷叠加：

**根因 1（主因）：`set frontmost` 不还原最小化窗口。**
对最小化的 VS Code 跑原版 System Events 脚本：osascript exit 0、app 变为 frontmost（菜单栏切换），但 CGWindowList 在屏窗口数仍为 0——窗口留在 Dock 里。视觉上就是"点了没反应"。换 `open <bundle>`（等价于点 Dock 图标的 reopen 语义）后窗口立即还原。

**根因 2：首次使用时 TCC 授权弹窗被自家超时杀死。**
首次跳转会触发 macOS 自动化授权弹窗（"想要控制 System Events"），osascript 阻塞等待用户作答，原 1500ms 超时直接 SIGTERM——弹窗被一并带走（运行日志实证：空 stderr 的 `Command failed`）。错过弹窗的用户从此每次点击静默失败，且失败只进 `console.warn`，focus-debug.log 里只有 `submitted`，完全无法诊断。

Windows 上一直正常是因为 Win 分支走 `SetForegroundWindow` + 还原逻辑，不存在这两个坑。

## 修复

- **`open <bundle>` 优先**：把 pid 候选链（sourcePid + pidChain 前 2）用一次 `ps -o pid=,comm=` 解析，按候选顺序取第一个含 `.app/Contents/` 的 comm，截最外层 bundle（`Code Helper.app` 等内层 helper 会正确归到外层），`execFile("/usr/bin/open", [bundlePath])`。还原最小化 + 激活，且 LaunchServices 激活完全不需要自动化权限——根因 2 对绝大多数用户直接消失。`ps` 对已死 pid 会 exit 1 但仍输出存活行，解析忽略退出码。
- **System Events 降级为 fallback**（非 bundle 进程 / open 失败）：超时提到 15s（容纳授权弹窗），结果写入 focus-debug.log（`branch=mac-frontmost reason=ok|automation-denied|osascript-failed:*`，`-1743` 单独标注）。
- iTerm tab / Ghostty 跨 Space / Superset / cmux / VS Code extension tab 等专用路径不动。

## 测试与验证

- 新增 `test/focus-mac-open.test.js` 7 例：bundle 提取边界（外层截取、`.app` 同名目录防误伤）、open 成功跳过 System Events、非 bundle 走 fallback（断言 15s consent 超时）、open 失败回落、ps 部分存活行解析、iTerm+open 组合（review 反馈）、`-1743 → automation-denied` 日志映射（review 反馈）。focus 相关 25/25，全量无新增失败（install.test.js 的 8 个失败为本机存量环境问题，main 同样存在）。
- 外部 review（Codex）：无阻塞缺陷；两条 P3（组合路径无覆盖、-1743 无断言）均已补测。
- 真机端到端：最小化 VS Code → 点 HUD → 窗口还原，日志 `branch=mac-open reason=ok bundle=Visual Studio Code.app`（点击后 158ms）。

## 给 #465 报告者的验证指引

升级后直接点 HUD 会话行即可，无需任何授权。若仍无反应：查看 `~/Library/Application Support/clawd-on-desk/focus-debug.log` 中 `branch=mac-open` / `branch=mac-frontmost` 行——现在每次失败都会留下原因。

## 已知延后项（另开 issue 跟进）

- `automation-denied` 时的一次性引导气泡（指向 系统设置 → 隐私与安全性 → 自动化）。
- iTerm tab / Ghostty 等专用 AppleScript 仍是 1.5s 超时，首次授权弹窗同类问题影响这些增强路径（窗口级跳转已不受影响）。
- HUD 点击成功后的视觉反馈（目标已在前台时点击是合法 no-op，用户无从分辨）。
