### PR TITLE
test(install): make Claude version-detection tests host-independent

### DIFF
--- a/hooks/install.js
+++ b/hooks/install.js
@@ -104,8 +104,16 @@ function getWindowsClaudePathSuffixes(pathExtEnv) {
   return suffixes;
 }
 
+// Path semantics must follow the requested platform, not the host: tests inject
+// win32/posix scenarios cross-platform. In production platform === process.platform,
+// so this resolves to the host path module.
+function pathForPlatform(platform) {
+  return platform === "win32" ? path.win32 : path.posix;
+}
+
 function getClaudePathCandidates(options = {}) {
   const platform = options.platform || process.platform;
+  const platformPath = pathForPlatform(platform);
   const pathEnv = options.pathEnv !== undefined ? options.pathEnv : process.env.PATH;
   const existsSync = options.existsSync || fs.existsSync;
 
@@ -124,7 +132,7 @@ function getClaudePathCandidates(options = {}) {
     if (!dir) continue;
 
     for (const suffix of suffixes) {
-      const candidate = path.join(dir, `claude${suffix}`);
+      const candidate = platformPath.join(dir, `claude${suffix}`);
       const key = platform === "win32" ? candidate.toLowerCase() : candidate;
       if (seen.has(key)) continue;
       seen.add(key);
@@ -140,6 +148,7 @@ function getClaudePathCandidates(options = {}) {
 
 async function getClaudePathCandidatesAsync(options = {}) {
   const platform = options.platform || process.platform;
+  const platformPath = pathForPlatform(platform);
   const pathEnv = options.pathEnv !== undefined ? options.pathEnv : process.env.PATH;
   const access = options.access || fs.promises.access.bind(fs.promises);
 
@@ -158,7 +167,7 @@ async function getClaudePathCandidatesAsync(options = {}) {
     if (!dir) continue;
 
     for (const suffix of suffixes) {
-      const candidate = path.join(dir, `claude${suffix}`);
+      const candidate = platformPath.join(dir, `claude${suffix}`);
       const key = platform === "win32" ? candidate.toLowerCase() : candidate;
       if (seen.has(key)) continue;
       seen.add(key);
@@ -175,12 +184,13 @@ async function getClaudePathCandidatesAsync(options = {}) {
 
 function getClaudePackageJsonCandidates(candidatePath, options = {}) {
   const platform = options.platform || process.platform;
+  const platformPath = pathForPlatform(platform);
   const existsSync = options.existsSync || fs.existsSync;
   const readFileSync = options.readFileSync || fs.readFileSync;
   const realpathSync = options.realpathSync || fs.realpathSync;
   const statSync = options.statSync || fs.statSync;
 
-  if (!path.isAbsolute(candidatePath)) return [];
+  if (!platformPath.isAbsolute(candidatePath)) return [];
 
   const candidates = [];
   const seen = new Set();
@@ -195,12 +205,12 @@ function getClaudePackageJsonCandidates(candidatePath, options = {}) {
     } catch {}
   };
 
-  const candidateDir = path.dirname(candidatePath);
-  addCandidate(path.join(candidateDir, ...CLAUDE_PACKAGE_JSON_SEGMENTS));
+  const candidateDir = platformPath.dirname(candidatePath);
+  addCandidate(platformPath.join(candidateDir, ...CLAUDE_PACKAGE_JSON_SEGMENTS));
 
   try {
     const resolvedPath = realpathSync(candidatePath);
-    addCandidate(path.join(path.dirname(resolvedPath), "package.json"));
+    addCandidate(platformPath.join(platformPath.dirname(resolvedPath), "package.json"));
   } catch {}
 
   try {
@@ -211,8 +221,8 @@ function getClaudePackageJsonCandidates(candidatePath, options = {}) {
       const shimSource = readFileSync(candidatePath, "utf8");
       const shimMatch = shimSource.match(CLAUDE_SHIM_CLI_PATTERN);
       if (shimMatch) {
-        const cliPath = path.resolve(candidateDir, shimMatch[0].replace(/[\\/]/g, path.sep));
-        addCandidate(path.join(path.dirname(cliPath), "package.json"));
+        const cliPath = platformPath.resolve(candidateDir, shimMatch[0].replace(/[\\/]/g, platformPath.sep));
+        addCandidate(platformPath.join(platformPath.dirname(cliPath), "package.json"));
       }
     }
   } catch {}
@@ -222,12 +232,13 @@ function getClaudePackageJsonCandidates(candidatePath, options = {}) {
 
 async function getClaudePackageJsonCandidatesAsync(candidatePath, options = {}) {
   const platform = options.platform || process.platform;
+  const platformPath = pathForPlatform(platform);
   const access = options.access || fs.promises.access.bind(fs.promises);
   const readFile = options.readFile || fs.promises.readFile.bind(fs.promises);
   const realpath = options.realpath || fs.promises.realpath.bind(fs.promises);
   const stat = options.stat || fs.promises.stat.bind(fs.promises);
 
-  if (!path.isAbsolute(candidatePath)) return [];
+  if (!platformPath.isAbsolute(candidatePath)) return [];
 
   const candidates = [];
   const seen = new Set();
@@ -243,12 +254,12 @@ async function getClaudePackageJsonCandidatesAsync(candidatePath, options = {}) 
     } catch {}
   };
 
-  const candidateDir = path.dirname(candidatePath);
-  await addCandidate(path.join(candidateDir, ...CLAUDE_PACKAGE_JSON_SEGMENTS));
+  const candidateDir = platformPath.dirname(candidatePath);
+  await addCandidate(platformPath.join(candidateDir, ...CLAUDE_PACKAGE_JSON_SEGMENTS));
 
   try {
     const resolvedPath = await realpath(candidatePath);
-    await addCandidate(path.join(path.dirname(resolvedPath), "package.json"));
+    await addCandidate(platformPath.join(platformPath.dirname(resolvedPath), "package.json"));
   } catch {}
 
   try {
@@ -258,8 +269,8 @@ async function getClaudePackageJsonCandidatesAsync(candidatePath, options = {}) 
       const shimSource = await readFile(candidatePath, "utf8");
       const shimMatch = String(shimSource).match(CLAUDE_SHIM_CLI_PATTERN);
       if (shimMatch) {
-        const cliPath = path.resolve(candidateDir, shimMatch[0].replace(/[\\/]/g, path.sep));
-        await addCandidate(path.join(path.dirname(cliPath), "package.json"));
+        const cliPath = platformPath.resolve(candidateDir, shimMatch[0].replace(/[\\/]/g, platformPath.sep));
+        await addCandidate(platformPath.join(platformPath.dirname(cliPath), "package.json"));
       }
     }
   } catch {}
@@ -324,14 +335,15 @@ async function readClaudeVersionFallbackAsync(candidatePath, options = {}) {
  */
 function getClaudeVersion(options = {}) {
   const platform = options.platform || process.platform;
+  const platformPath = pathForPlatform(platform);
   const homeDir = options.homeDir || os.homedir();
   const execFileSync = options.execFileSync || require("child_process").execFileSync;
   const candidates = [];
 
   if (platform === "darwin") {
     candidates.push(
-      path.join(homeDir, ".local", "bin", "claude"),
-      path.join(homeDir, ".claude", "local", "claude"),
+      platformPath.join(homeDir, ".local", "bin", "claude"),
+      platformPath.join(homeDir, ".claude", "local", "claude"),
       "/opt/homebrew/bin/claude",
       "/usr/local/bin/claude"
     );
@@ -378,6 +390,7 @@ async function getClaudeVersionAsync(options = {}) {
 
   const compute = async () => {
     const platform = options.platform || process.platform;
+    const platformPath = pathForPlatform(platform);
     const homeDir = options.homeDir || os.homedir();
     const execFile = options.execFile || ((command, args, execOptions) => new Promise((resolve, reject) => {
       childProcess.execFile(command, args, execOptions, (err, stdout, stderr) => {
@@ -392,8 +405,8 @@ async function getClaudeVersionAsync(options = {}) {
     if (!candidates.length) {
       if (platform === "darwin") {
         candidates.push(
-          path.join(homeDir, ".local", "bin", "claude"),
-          path.join(homeDir, ".claude", "local", "claude"),
+          platformPath.join(homeDir, ".local", "bin", "claude"),
+          platformPath.join(homeDir, ".claude", "local", "claude"),
           "/opt/homebrew/bin/claude",
           "/usr/local/bin/claude"
         );

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -159,8 +159,8 @@ describe("Claude version detection helpers", () => {
     const npmDirUpper = "C:\\USERS\\Tester\\AppData\\Roaming\\NPM";
     const toolsDir = "C:\\Tools";
     const existing = new Set([
-      path.join(npmDir, "claude.cmd").toLowerCase(),
-      path.join(toolsDir, "claude.ps1").toLowerCase(),
+      path.win32.join(npmDir, "claude.cmd").toLowerCase(),
+      path.win32.join(toolsDir, "claude.ps1").toLowerCase(),
     ]);
 
     const candidates = getClaudePathCandidates({
@@ -173,8 +173,8 @@ describe("Claude version detection helpers", () => {
     });
 
     assert.deepStrictEqual(candidates, [
-      path.join(npmDir, "claude.cmd"),
-      path.join(toolsDir, "claude.ps1"),
+      path.win32.join(npmDir, "claude.cmd"),
+      path.win32.join(toolsDir, "claude.ps1"),
     ]);
   });
 
@@ -183,8 +183,8 @@ describe("Claude version detection helpers", () => {
     const npmDirUpper = "C:\\USERS\\Tester\\AppData\\Roaming\\NPM";
     const toolsDir = "C:\\Tools";
     const existing = new Set([
-      path.join(npmDir, "claude.cmd").toLowerCase(),
-      path.join(toolsDir, "claude.ps1").toLowerCase(),
+      path.win32.join(npmDir, "claude.cmd").toLowerCase(),
+      path.win32.join(toolsDir, "claude.ps1").toLowerCase(),
     ]);
 
     const candidates = await getClaudePathCandidatesAsync({
@@ -199,8 +199,8 @@ describe("Claude version detection helpers", () => {
     });
 
     assert.deepStrictEqual(candidates, [
-      path.join(npmDir, "claude.cmd"),
-      path.join(toolsDir, "claude.ps1"),
+      path.win32.join(npmDir, "claude.cmd"),
+      path.win32.join(toolsDir, "claude.ps1"),
     ]);
   });
 
@@ -212,19 +212,19 @@ describe("Claude version detection helpers", () => {
       platform: "linux",
       pathEnv: `${localDir}:${optDir}`,
       existsSync(candidatePath) {
-        return candidatePath === path.join(optDir, "claude");
+        return candidatePath === path.posix.join(optDir, "claude");
       },
     });
 
-    assert.deepStrictEqual(candidates, [path.join(optDir, "claude")]);
+    assert.deepStrictEqual(candidates, [path.posix.join(optDir, "claude")]);
   });
 
   it("collects Claude package.json candidates from sibling node_modules and realpath targets", () => {
     const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
-    const candidateDir = path.dirname(candidatePath);
-    const siblingPackageJson = path.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const candidateDir = path.win32.dirname(candidatePath);
+    const siblingPackageJson = path.win32.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
     const realpathCli = "D:\\shim-store\\claude\\cli.js";
-    const realpathPackageJson = path.join(path.dirname(realpathCli), "package.json");
+    const realpathPackageJson = path.win32.join(path.win32.dirname(realpathCli), "package.json");
 
     const candidates = getClaudePackageJsonCandidates(candidatePath, {
       platform: "win32",
@@ -252,10 +252,10 @@ describe("Claude version detection helpers", () => {
 
   it("collects Claude package.json candidates asynchronously", async () => {
     const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
-    const candidateDir = path.dirname(candidatePath);
-    const siblingPackageJson = path.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const candidateDir = path.win32.dirname(candidatePath);
+    const siblingPackageJson = path.win32.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
     const realpathCli = "D:\\shim-store\\claude\\cli.js";
-    const realpathPackageJson = path.join(path.dirname(realpathCli), "package.json");
+    const realpathPackageJson = path.win32.join(path.win32.dirname(realpathCli), "package.json");
     const existing = new Set([siblingPackageJson.toLowerCase(), realpathPackageJson.toLowerCase()]);
 
     const candidates = await getClaudePackageJsonCandidatesAsync(candidatePath, {
@@ -286,8 +286,8 @@ describe("Claude version detection helpers", () => {
 
   it("skips reading unusually large shim files", () => {
     const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
-    const candidateDir = path.dirname(candidatePath);
-    const siblingPackageJson = path.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const candidateDir = path.win32.dirname(candidatePath);
+    const siblingPackageJson = path.win32.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
     let readCount = 0;
 
     const candidates = getClaudePackageJsonCandidates(candidatePath, {
@@ -308,6 +308,31 @@ describe("Claude version detection helpers", () => {
     });
 
     assert.strictEqual(readCount, 0);
+    assert.deepStrictEqual(candidates, [siblingPackageJson]);
+  });
+
+  it("treats drive-less rooted Windows paths as absolute when collecting candidates", () => {
+    const candidatePath = "\\npm\\claude.cmd";
+    const siblingPackageJson = path.win32.join("\\npm", "node_modules", "@anthropic-ai", "claude-code", "package.json");
+
+    const candidates = getClaudePackageJsonCandidates(candidatePath, {
+      platform: "win32",
+      existsSync(packageJsonPath) {
+        return packageJsonPath === siblingPackageJson;
+      },
+      realpathSync() {
+        throw new Error("not a symlink");
+      },
+      // Large size keeps the shim-read branch off: win32 resolve of drive-less rooted
+      // bases prepends the cwd drive on real Windows, which would be host-dependent here.
+      statSync() {
+        return { size: 1024 * 1024, isFile: () => true };
+      },
+      readFileSync() {
+        throw new Error("should not read large shims");
+      },
+    });
+
     assert.deepStrictEqual(candidates, [siblingPackageJson]);
   });
 
@@ -367,10 +392,10 @@ describe("Claude version detection helpers", () => {
 
   it("returns the first valid fallback version info from candidate package.json files", () => {
     const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
-    const candidateDir = path.dirname(candidatePath);
-    const siblingPackageJson = path.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const candidateDir = path.win32.dirname(candidatePath);
+    const siblingPackageJson = path.win32.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
     const realpathCli = "D:\\shim-store\\claude\\cli.js";
-    const realpathPackageJson = path.join(path.dirname(realpathCli), "package.json");
+    const realpathPackageJson = path.win32.join(path.win32.dirname(realpathCli), "package.json");
 
     const result = readClaudeVersionFallback(candidatePath, {
       platform: "win32",
@@ -406,10 +431,10 @@ describe("Claude version detection helpers", () => {
 
   it("returns the first valid async fallback version info from candidate package.json files", async () => {
     const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
-    const candidateDir = path.dirname(candidatePath);
-    const siblingPackageJson = path.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const candidateDir = path.win32.dirname(candidatePath);
+    const siblingPackageJson = path.win32.join(candidateDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
     const realpathCli = "D:\\shim-store\\claude\\cli.js";
-    const realpathPackageJson = path.join(path.dirname(realpathCli), "package.json");
+    const realpathPackageJson = path.win32.join(path.win32.dirname(realpathCli), "package.json");
     const existing = new Set([siblingPackageJson.toLowerCase(), realpathPackageJson.toLowerCase()]);
 
     const result = await readClaudeVersionFallbackAsync(candidatePath, {
@@ -448,7 +473,7 @@ describe("Claude version detection helpers", () => {
 
   it("getClaudeVersionAsync uses async metadata fallback when exec probes fail", async () => {
     const candidatePath = "C:\\Users\\Tester\\AppData\\Roaming\\npm\\claude.cmd";
-    const packageJsonPath = path.join(path.dirname(candidatePath), "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const packageJsonPath = path.win32.join(path.win32.dirname(candidatePath), "node_modules", "@anthropic-ai", "claude-code", "package.json");
 
     const result = await getClaudeVersionAsync({
       platform: "win32",
@@ -481,8 +506,8 @@ describe("Claude version detection helpers", () => {
 
   it("getClaudeVersionAsync does not call sync filesystem probes", async () => {
     const npmDir = "C:\\Users\\Tester\\AppData\\Roaming\\npm";
-    const candidatePath = path.join(npmDir, "claude.cmd");
-    const packageJsonPath = path.join(npmDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const candidatePath = path.win32.join(npmDir, "claude.cmd");
+    const packageJsonPath = path.win32.join(npmDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
 
     const throwSync = () => {
       throw new Error("sync filesystem probe should not run");
@@ -999,7 +1024,7 @@ describe("Hook installer version compatibility", () => {
 
   it("checks macOS absolute Claude paths before PATH fallback", () => {
     const attempted = [];
-    const expectedPath = path.join("/Users/tester", ".claude", "local", "claude");
+    const expectedPath = path.posix.join("/Users/tester", ".claude", "local", "claude");
     const info = __test.getClaudeVersion({
       platform: "darwin",
       homeDir: "/Users/tester",
@@ -1013,7 +1038,7 @@ describe("Hook installer version compatibility", () => {
     });
 
     assert.deepStrictEqual(attempted, [
-      path.join("/Users/tester", ".local", "bin", "claude"),
+      path.posix.join("/Users/tester", ".local", "bin", "claude"),
       expectedPath,
     ]);
     assert.deepStrictEqual(info, {
@@ -1025,8 +1050,8 @@ describe("Hook installer version compatibility", () => {
 
   it("falls back to npm shim sibling package.json on Windows when exec fails", () => {
     const shimDir = "C:\\Users\\Tester\\AppData\\Roaming\\npm";
-    const shimPath = path.join(shimDir, "claude.cmd");
-    const packageJsonPath = path.join(shimDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const shimPath = path.win32.join(shimDir, "claude.cmd");
+    const packageJsonPath = path.win32.join(shimDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
     const attempted = [];
 
     const info = __test.getClaudeVersion({
@@ -1071,9 +1096,9 @@ describe("Hook installer version compatibility", () => {
   it("prefers a later exec-based version over an earlier metadata fallback", () => {
     const oldShimDir = "C:\\OldClaude";
     const newShimDir = "C:\\NewClaude";
-    const oldShimPath = path.join(oldShimDir, "claude.cmd");
-    const newShimPath = path.join(newShimDir, "claude.cmd");
-    const oldPackageJsonPath = path.join(oldShimDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
+    const oldShimPath = path.win32.join(oldShimDir, "claude.cmd");
+    const newShimPath = path.win32.join(newShimDir, "claude.cmd");
+    const oldPackageJsonPath = path.win32.join(oldShimDir, "node_modules", "@anthropic-ai", "claude-code", "package.json");
 
     const info = __test.getClaudeVersion({
       platform: "win32",


### PR DESCRIPTION
## Summary

`npm test` had 8 pre-existing failures on macOS/Linux hosts, all in `test/install.test.js` ("Claude version detection helpers" + "Hook installer version compatibility"). They only ever passed on Windows.

**Root cause — a test-infrastructure gap, not a runtime bug.** The version-detection helpers in `hooks/install.js` inject `platform`, `pathEnv`, `PATHEXT`, and every fs function, but did their path math with the **host** `path` module. The win32-scenario fixtures (`C:\Users\...`) therefore broke on posix hosts: `path.isAbsolute('C:\\...')` is `false`, so `getClaudePackageJsonCandidates` returned `[]` and detection reported `{version: null, status: 'unknown'}`. Production is unaffected: real callers (`src/main.js`) never pass `platform`, so it always equals `process.platform`.

## Changes

- **hooks/install.js**: new `pathForPlatform(platform)` returning `path.win32`/`path.posix`; the six helpers (`getClaudePathCandidates[Async]`, `getClaudePackageJsonCandidates[Async]`, `getClaudeVersion[Async]`) use it for `join`/`dirname`/`resolve`/`isAbsolute`/`sep`. Provably a no-op in production: Node's `path` export **is** `path.posix` on posix hosts and `path.win32` on Windows.
- **test/install.test.js**: platform-explicit tests now build fixtures with the matching module (`path.win32.*` for win32 scenarios, `path.posix.*` for linux/darwin ones). On Windows `path.win32 === path`, so expectations are byte-identical to before — no behavior change for the tag-time Windows CI job.
- New test locking the drive-less rooted edge (`\npm\claude.cmd` *is* win32-absolute). It deliberately stays off the shim-read branch: `path.win32.resolve` on drive-less rooted bases prepends the cwd drive on real Windows, which would make that branch host-dependent.

Two tests previously passed by coincidence and are now exercised for real on every OS: the metadata-fallback half of *"prefers a later exec-based version over an earlier metadata fallback"* never actually ran on posix hosts, and *"checks macOS absolute Claude paths before PATH fallback"* passed on Windows only via host-join symmetry.

Note: the sync `registerHooks` path calls `getClaudeVersion()` without forwarding options (pre-existing design; only `registerHooksAsync` forwards them) — intentionally untouched here.

## Verification

- `node --test test/install.test.js`: **55/55** (was 46/54 on macOS)
- Full `npm test` on macOS (base 74455c1): **3880 pass / 0 fail / 15 skipped** (was 8 failures)
- Windows: not run on real hardware; equivalence is by identity (`path.win32 === path` there). CI only runs `npm test` in the windows job on tag builds / manual dispatch, which should behave identically — a PR-level cross-OS test workflow would be a good follow-up.