### PR TITLE
feat(pet): drag a folder onto the pet to open a terminal there

### DIFF
--- a/src/hit-renderer.js
+++ b/src/hit-renderer.js
@@ -281,14 +281,22 @@ area.addEventListener("drop", (e) => {
 });
 
 // Main confirmed the drop opened a terminal → react. Routed back through the
-// local playReaction so isReacting gating stays consistent; best-effort only —
-// themes without a "double" reaction (e.g. Cloudling) stay still.
+// local playReaction so isReacting gating stays consistent. Best-effort with a
+// fallback chain: double (Clawd) → clickLeft/clickRight poke (Calico) →
+// nothing (Cloudling only ships a drag reaction; no new theme capability is
+// invented for drops).
 window.hitAPI.onDropAccepted(() => {
+  if (!canPlayReactionNow()) return;
   const doubleReact = _getReaction("double");
-  if (!doubleReact || !canPlayReactionNow()) return;
-  const files = doubleReact.files || [doubleReact.file];
-  const file = files[Math.floor(Math.random() * files.length)];
-  playReaction(file, doubleReact.duration || 3500);
+  if (doubleReact) {
+    const files = doubleReact.files || [doubleReact.file];
+    playReaction(files[Math.floor(Math.random() * files.length)], doubleReact.duration || 3500);
+    return;
+  }
+  const left = _getReaction("clickLeft");
+  const right = _getReaction("clickRight");
+  const poke = left && right ? (Math.random() < 0.5 ? left : right) : (left || right);
+  if (poke) playReaction(poke.file, poke.duration || 2500);
 });
 
 // --- Right-click context menu ---

--- a/src/hit-renderer.js
+++ b/src/hit-renderer.js
@@ -251,10 +251,18 @@ function endDragReaction() {
   window.hitAPI.endDragReaction();
 }
 
-// --- OS file drop → open terminal at that directory (#459) ---
+// --- OS file drop → open terminal at that directory (#459, Windows/Linux only) ---
+// macOS is OUT: the pet windows live at screen-saver level so they stay above
+// fullscreen apps, and macOS drag-destination search never delivers drag
+// events to windows at that level (real-machine bisect, 2026-06-11 — lowering
+// only the hit window doesn't help either, the overlapping screen-saver render
+// window still blocks the search; ignoresMouseEvents passes mouse events
+// through but NOT drag destinations). Don't re-attempt without changing the
+// window-level model; listeners are simply not registered on mac.
+//
 // Affordance gating lives HERE (not only in main): in mini mode dragover must
 // not preventDefault, so the OS shows "no drop" instead of a copy cursor that
-// would then do nothing. Main re-checks mini as the second layer.
+// would then do nothing. Main re-checks mini (and platform) as the second layer.
 function dragHasFiles(e) {
   const types = e.dataTransfer && e.dataTransfer.types;
   if (!types) return false;
@@ -262,42 +270,44 @@ function dragHasFiles(e) {
   return false;
 }
 
-area.addEventListener("dragover", (e) => {
-  if (miniMode || !dragHasFiles(e)) return;
-  e.preventDefault();
-  e.dataTransfer.dropEffect = "copy";
-});
+if (!isMac) {
+  area.addEventListener("dragover", (e) => {
+    if (miniMode || !dragHasFiles(e)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  });
 
-area.addEventListener("drop", (e) => {
-  if (!dragHasFiles(e)) return;
-  e.preventDefault();
-  if (miniMode) return;
-  const paths = [];
-  for (const file of e.dataTransfer.files || []) {
-    const p = window.hitAPI.getPathForFile(file);
-    if (typeof p === "string" && p) paths.push(p);
-  }
-  if (paths.length) window.hitAPI.dropPaths(paths);
-});
+  area.addEventListener("drop", (e) => {
+    if (!dragHasFiles(e)) return;
+    e.preventDefault();
+    if (miniMode) return;
+    const paths = [];
+    for (const file of e.dataTransfer.files || []) {
+      const p = window.hitAPI.getPathForFile(file);
+      if (typeof p === "string" && p) paths.push(p);
+    }
+    if (paths.length) window.hitAPI.dropPaths(paths);
+  });
 
-// Main confirmed the drop opened a terminal → react. Routed back through the
-// local playReaction so isReacting gating stays consistent. Best-effort with a
-// fallback chain: double (Clawd) → clickLeft/clickRight poke (Calico) →
-// nothing (Cloudling only ships a drag reaction; no new theme capability is
-// invented for drops).
-window.hitAPI.onDropAccepted(() => {
-  if (!canPlayReactionNow()) return;
-  const doubleReact = _getReaction("double");
-  if (doubleReact) {
-    const files = doubleReact.files || [doubleReact.file];
-    playReaction(files[Math.floor(Math.random() * files.length)], doubleReact.duration || 3500);
-    return;
-  }
-  const left = _getReaction("clickLeft");
-  const right = _getReaction("clickRight");
-  const poke = left && right ? (Math.random() < 0.5 ? left : right) : (left || right);
-  if (poke) playReaction(poke.file, poke.duration || 2500);
-});
+  // Main confirmed the drop opened a terminal → react. Routed back through the
+  // local playReaction so isReacting gating stays consistent. Best-effort with a
+  // fallback chain: double (Clawd) → clickLeft/clickRight poke (Calico) →
+  // nothing (Cloudling only ships a drag reaction; no new theme capability is
+  // invented for drops).
+  window.hitAPI.onDropAccepted(() => {
+    if (!canPlayReactionNow()) return;
+    const doubleReact = _getReaction("double");
+    if (doubleReact) {
+      const files = doubleReact.files || [doubleReact.file];
+      playReaction(files[Math.floor(Math.random() * files.length)], doubleReact.duration || 3500);
+      return;
+    }
+    const left = _getReaction("clickLeft");
+    const right = _getReaction("clickRight");
+    const poke = left && right ? (Math.random() < 0.5 ? left : right) : (left || right);
+    if (poke) playReaction(poke.file, poke.duration || 2500);
+  });
+}
 
 // --- Right-click context menu ---
 document.addEventListener("contextmenu", (e) => {

--- a/src/hit-renderer.js
+++ b/src/hit-renderer.js
@@ -251,6 +251,46 @@ function endDragReaction() {
   window.hitAPI.endDragReaction();
 }
 
+// --- OS file drop → open terminal at that directory (#459) ---
+// Affordance gating lives HERE (not only in main): in mini mode dragover must
+// not preventDefault, so the OS shows "no drop" instead of a copy cursor that
+// would then do nothing. Main re-checks mini as the second layer.
+function dragHasFiles(e) {
+  const types = e.dataTransfer && e.dataTransfer.types;
+  if (!types) return false;
+  for (const t of types) { if (t === "Files") return true; }
+  return false;
+}
+
+area.addEventListener("dragover", (e) => {
+  if (miniMode || !dragHasFiles(e)) return;
+  e.preventDefault();
+  e.dataTransfer.dropEffect = "copy";
+});
+
+area.addEventListener("drop", (e) => {
+  if (!dragHasFiles(e)) return;
+  e.preventDefault();
+  if (miniMode) return;
+  const paths = [];
+  for (const file of e.dataTransfer.files || []) {
+    const p = window.hitAPI.getPathForFile(file);
+    if (typeof p === "string" && p) paths.push(p);
+  }
+  if (paths.length) window.hitAPI.dropPaths(paths);
+});
+
+// Main confirmed the drop opened a terminal → react. Routed back through the
+// local playReaction so isReacting gating stays consistent; best-effort only —
+// themes without a "double" reaction (e.g. Cloudling) stay still.
+window.hitAPI.onDropAccepted(() => {
+  const doubleReact = _getReaction("double");
+  if (!doubleReact || !canPlayReactionNow()) return;
+  const files = doubleReact.files || [doubleReact.file];
+  const file = files[Math.floor(Math.random() * files.length)];
+  playReaction(file, doubleReact.duration || 3500);
+});
+
 // --- Right-click context menu ---
 document.addEventListener("contextmenu", (e) => {
   e.preventDefault();

--- a/src/launch-claude.js
+++ b/src/launch-claude.js
@@ -248,24 +248,35 @@ function buildShellTerminalCandidates(dir, plat = platform()) {
     if (dir.includes('"')) {
       throw new TypeError("buildShellTerminalCandidates: dir must not contain double quotes");
     }
-    return [
+    const candidates = [
       // wt -d is a native flag (no shim → no 0x800700c1 class); Node's default
       // arg quoting protects spaces. tryLaunch can only observe whether wt
       // itself spawned, not whether the tab landed in `dir`.
       { bin: "wt.exe", args: ["-d", dir] },
+    ];
+    // cmd.exe quoting matrix for the quoted `cd /d "<dir>"` payload: `^ & ( )`
+    // are literal inside the quotes, `!` stays literal because we pass /v:off,
+    // `"` is rejected above — but `%VAR%` expands on the cmd command line EVEN
+    // inside quotes and has no command-line escape (caret can't escape %, %%
+    // only works in batch files). A %-containing dir therefore skips cmd and
+    // falls through to wt / PowerShell, which pass the path literally.
+    if (!dir.includes("%")) {
       // Single pre-quoted string after /k — same "command must not start with
       // a quote" rule as buildTerminalCandidates, satisfied by the `cd` prefix.
-      {
+      candidates.push({
         bin: "cmd.exe",
         args: ["/d", "/v:off", "/s", "/k", `cd /d "${dir}"`],
         extraOpts: { shell: false, windowsVerbatimArguments: true },
-      },
+      });
+    }
+    candidates.push(
       // -LiteralPath: plain Set-Location glob-expands `[]` / `?` in paths.
       {
         bin: "powershell.exe",
         args: ["-NoExit", "-Command", `Set-Location -LiteralPath ${quoteForPowerShell(dir)}`],
       },
-    ];
+    );
+    return candidates;
   }
 
   if (plat === "darwin") {

--- a/src/launch-claude.js
+++ b/src/launch-claude.js
@@ -171,7 +171,7 @@ function buildClaudeArgs(mode, sessionId) {
 // only user-entered arg is the resume session ID, which buildClaudeArgs
 // validates before this point. The argv-array candidates (wt.exe `--`) need no
 // quoting — the OS passes argv verbatim without a shell.
-function buildTerminalCandidates(claudePath, claudeArgs, plat = platform()) {
+function buildTerminalCandidates(claudePath, claudeArgs, plat = platform(), workDir) {
   if (plat === "win32") {
     // cmd.exe /k: command paths with spaces must use cmd's special
     // `""C:\Program Files\...\claude.cmd" args"` form. Plain quoteForCmd on
@@ -215,7 +215,11 @@ function buildTerminalCandidates(claudePath, claudeArgs, plat = platform()) {
   if (plat === "darwin") {
     // Two-layer quoting: POSIX shell quote each token → join → AppleScript
     // string escape → embed in `do script "..."`.
-    const cmd = [claudePath, ...claudeArgs].map(quoteForPosixShellArg).join(" ");
+    // Terminal.app's `do script` shell always starts at $HOME — it does NOT
+    // inherit the osascript process cwd — so the working directory must be an
+    // explicit `cd` inside the command (`--` guards leading-dash dir names).
+    const claudeCmd = [claudePath, ...claudeArgs].map(quoteForPosixShellArg).join(" ");
+    const cmd = workDir ? `cd -- ${quoteForPosixShellArg(workDir)} && ${claudeCmd}` : claudeCmd;
     const appleScript = `tell application "Terminal" to do script "${escapeAppleScriptString(cmd)}"`;
     return [{ bin: "osascript", args: ["-e", appleScript] }];
   }
@@ -234,6 +238,89 @@ function buildTerminalCandidates(claudePath, claudeArgs, plat = platform()) {
   ];
 }
 
+// #459: open a plain terminal at a directory without launching any agent.
+// Same candidate philosophy as buildTerminalCandidates, but the "inner
+// command" is just establishing the working directory and leaving a shell.
+function buildShellTerminalCandidates(dir, plat = platform()) {
+  if (plat === "win32") {
+    // NTFS forbids `"` in paths; reject anyway so a crafted string can never
+    // splice extra cmd.exe commands after the embedded quote.
+    if (dir.includes('"')) {
+      throw new TypeError("buildShellTerminalCandidates: dir must not contain double quotes");
+    }
+    return [
+      // wt -d is a native flag (no shim → no 0x800700c1 class); Node's default
+      // arg quoting protects spaces. tryLaunch can only observe whether wt
+      // itself spawned, not whether the tab landed in `dir`.
+      { bin: "wt.exe", args: ["-d", dir] },
+      // Single pre-quoted string after /k — same "command must not start with
+      // a quote" rule as buildTerminalCandidates, satisfied by the `cd` prefix.
+      {
+        bin: "cmd.exe",
+        args: ["/d", "/v:off", "/s", "/k", `cd /d "${dir}"`],
+        extraOpts: { shell: false, windowsVerbatimArguments: true },
+      },
+      // -LiteralPath: plain Set-Location glob-expands `[]` / `?` in paths.
+      {
+        bin: "powershell.exe",
+        args: ["-NoExit", "-Command", `Set-Location -LiteralPath ${quoteForPowerShell(dir)}`],
+      },
+    ];
+  }
+
+  if (plat === "darwin") {
+    // Same two-layer quoting and explicit-cd constraint as the darwin branch
+    // of buildTerminalCandidates (do script shells start at $HOME).
+    const cmd = `cd -- ${quoteForPosixShellArg(dir)} && clear`;
+    const appleScript = `tell application "Terminal" to do script "${escapeAppleScriptString(cmd)}"`;
+    return [{ bin: "osascript", args: ["-e", appleScript] }];
+  }
+
+  // Linux terminals inherit the spawn cwd, so the command only needs to keep
+  // the shell alive.
+  return [
+    { bin: "x-terminal-emulator", args: ["-e", "bash", "-c", "exec bash"] },
+    { bin: "xterm", args: ["-e", "bash", "-c", "exec bash"] },
+    { bin: "gnome-terminal", args: ["--", "bash", "-c", "exec bash"] },
+    { bin: "konsole", args: ["-e", "bash", "-c", "exec bash"] },
+    { bin: "alacritty", args: ["-e", "bash", "-c", "exec bash"] },
+    { bin: "kitty", args: ["--", "bash", "-c", "exec bash"] },
+  ];
+}
+
+async function openTerminalAt(dir, deps = {}) {
+  const _platform = deps.platform || platform;
+  const _tryLaunch = deps.tryLaunch || tryLaunch;
+
+  if (typeof dir !== "string" || !dir) {
+    return { ok: false, message: "openTerminalAt: dir must be a non-empty string" };
+  }
+
+  const plat = _platform();
+  const opts = { detached: true, stdio: "ignore", windowsHide: false, cwd: dir };
+
+  let candidates;
+  try {
+    candidates = buildShellTerminalCandidates(dir, plat);
+  } catch (err) {
+    return { ok: false, message: err.message };
+  }
+  let lastError = null;
+  for (const candidate of candidates) {
+    const result = await _tryLaunch(candidate.bin, candidate.args, {
+      ...opts,
+      ...(candidate.extraOpts || {}),
+    });
+    if (result.ok) return { ok: true, terminal: candidate.bin };
+    lastError = result.error;
+  }
+
+  return {
+    ok: false,
+    message: (lastError && lastError.message) || "could not spawn terminal",
+  };
+}
+
 async function launchClaudeSession(mode, cwd, sessionId, deps = {}) {
   const _platform = deps.platform || platform;
   const _findClaudeCmd = deps.findClaudeCmd || findClaudeCmd;
@@ -245,7 +332,7 @@ async function launchClaudeSession(mode, cwd, sessionId, deps = {}) {
   const workDir = cwd || homedir();
   const opts = { detached: true, stdio: "ignore", windowsHide: false, cwd: workDir };
 
-  const candidates = buildTerminalCandidates(claudePath, claudeArgs, plat);
+  const candidates = buildTerminalCandidates(claudePath, claudeArgs, plat, workDir);
   let lastError = null;
   for (const candidate of candidates) {
     const result = await _tryLaunch(candidate.bin, candidate.args, {
@@ -266,6 +353,8 @@ module.exports = {
   launchClaudeSession,
   buildClaudeArgs,
   buildTerminalCandidates,
+  buildShellTerminalCandidates,
+  openTerminalAt,
   findClaudeCmd,
   buildCmdLaunchCommand,
   normalizeClaudeSessionId,

--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ const { registerSettingsIpc } = require("./settings-ipc");
 const createSettingsEffectRouter = require("./settings-effect-router");
 const { registerSessionIpc } = require("./session-ipc");
 const { registerPetInteractionIpc } = require("./pet-interaction-ipc");
-const { launchClaudeSession } = require("./launch-claude");
+const { launchClaudeSession, openTerminalAt } = require("./launch-claude");
 const { dialog: electronDialog } = require("electron");
 const initPermission = require("./permission");
 const { registerPermissionIpc } = initPermission;
@@ -3172,6 +3172,9 @@ function createWindow() {
         _sessionHud.revealFromPet();
       }
     },
+    statPath: (p) => fs.promises.stat(p),
+    openTerminalAt: (dir) => openTerminalAt(dir),
+    dropLog: (message) => console.log(`Clawd: ${message}`),
   });
 
   registerPermissionIpc({

--- a/src/pet-interaction-ipc.js
+++ b/src/pet-interaction-ipc.js
@@ -55,6 +55,9 @@ function registerPetInteractionIpc(options = {}) {
   const statPath = requiredDependency(options.statPath, "statPath");
   const openTerminalAt = requiredDependency(options.openTerminalAt, "openTerminalAt");
   const dropLog = options.dropLog || (() => {});
+  const isMacPlatform = options.isMacPlatform != null
+    ? !!options.isMacPlatform
+    : process.platform === "darwin";
   const disposers = [];
 
   function on(channel, listener) {
@@ -128,12 +131,19 @@ function registerPetInteractionIpc(options = {}) {
     revealSessionHud();
   });
 
-  // OS file drop from the hit window (#459): first path wins, files resolve to
-  // their parent directory, then open a plain terminal there (no agent). The
-  // accept ping goes back to the SENDING window (hit renderer plays its own
-  // reaction so its isReacting gate stays consistent).
+  // OS file drop from the hit window (#459, Windows/Linux only): first path
+  // wins, files resolve to their parent directory, then open a plain terminal
+  // there (no agent). The accept ping goes back to the SENDING window (hit
+  // renderer plays its own reaction so its isReacting gate stays consistent).
+  // macOS never registers the renderer-side listeners (screen-saver-level
+  // windows are invisible to macOS drag-destination search); this guard is the
+  // second layer so a stray IPC can't open terminals there either.
   on("pet-drop-paths", async (event, paths) => {
     try {
+      if (isMacPlatform) {
+        dropLog("drop ignored: OS file drop is disabled on macOS");
+        return;
+      }
       if (isMiniMode() || isMiniTransitioning()) return;
       if (!Array.isArray(paths)) return;
       const first = paths.find((p) => typeof p === "string" && p.length > 0);

--- a/src/pet-interaction-ipc.js
+++ b/src/pet-interaction-ipc.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const path = require("path");
+
 function requiredDependency(value, name) {
   if (!value) throw new Error(`registerPetInteractionIpc requires ${name}`);
   return value;
@@ -50,6 +52,9 @@ function registerPetInteractionIpc(options = {}) {
     options.setLowPowerIdlePaused,
     "setLowPowerIdlePaused"
   );
+  const statPath = requiredDependency(options.statPath, "statPath");
+  const openTerminalAt = requiredDependency(options.openTerminalAt, "openTerminalAt");
+  const dropLog = options.dropLog || (() => {});
   const disposers = [];
 
   function on(channel, listener) {
@@ -121,6 +126,39 @@ function registerPetInteractionIpc(options = {}) {
 
   on("pet-interaction:reveal-session-hud", () => {
     revealSessionHud();
+  });
+
+  // OS file drop from the hit window (#459): first path wins, files resolve to
+  // their parent directory, then open a plain terminal there (no agent). The
+  // accept ping goes back to the SENDING window (hit renderer plays its own
+  // reaction so its isReacting gate stays consistent).
+  on("pet-drop-paths", async (event, paths) => {
+    try {
+      if (isMiniMode() || isMiniTransitioning()) return;
+      if (!Array.isArray(paths)) return;
+      const first = paths.find((p) => typeof p === "string" && p.length > 0);
+      if (!first) return;
+      let stats;
+      try {
+        stats = await statPath(first);
+      } catch (_) {
+        dropLog(`drop ignored: stat failed for ${first}`);
+        return;
+      }
+      const dir = stats.isDirectory() ? first : path.dirname(first);
+      const result = await openTerminalAt(dir);
+      if (result && result.ok) {
+        dropLog(`drop opened terminal=${result.terminal} dir=${dir}`);
+        const sender = event && event.sender;
+        if (sender && typeof sender.send === "function" && !(typeof sender.isDestroyed === "function" && sender.isDestroyed())) {
+          sender.send("pet-drop-accepted");
+        }
+      } else {
+        dropLog(`drop terminal launch failed: ${(result && result.message) || "unknown"}`);
+      }
+    } catch (err) {
+      dropLog(`drop error: ${(err && err.message) || err}`);
+    }
   });
 
   on("focus-terminal", () => {

--- a/src/preload-hit.js
+++ b/src/preload-hit.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require("electron");
+const { contextBridge, ipcRenderer, webUtils } = require("electron");
 
 // Parse hit-renderer theme config from additionalArguments (synchronous, available on first load)
 const hitThemeArg = process.argv.find(a => a.startsWith("--hit-theme-config="));
@@ -24,6 +24,15 @@ contextBridge.exposeInMainWorld("hitAPI", {
   dragEnd: () => ipcRenderer.send("drag-end"),
   showContextMenu: () => ipcRenderer.send("show-context-menu"),
   focusTerminal: () => ipcRenderer.send("focus-terminal"),
+  // OS file drop (#459). File → absolute path must resolve here in the
+  // preload: Electron ≥32 removed File.path from the renderer, and
+  // webUtils.getPathForFile only accepts a File passed across the bridge.
+  // Returns "" for non-filesystem Files (e.g. images dragged from a browser).
+  getPathForFile: (file) => {
+    try { return webUtils.getPathForFile(file) || ""; } catch (_) { return ""; }
+  },
+  dropPaths: (paths) => ipcRenderer.send("pet-drop-paths", paths),
+  onDropAccepted: (cb) => ipcRenderer.on("pet-drop-accepted", () => cb()),
   exitMiniMode: () => ipcRenderer.send("exit-mini-mode"),
   showDashboard: () => ipcRenderer.send("show-dashboard"),
   revealSessionHud: () => ipcRenderer.send("pet-interaction:reveal-session-hud"),

--- a/test/hit-renderer.test.js
+++ b/test/hit-renderer.test.js
@@ -305,7 +305,21 @@ describe("hit-renderer OS file drop (#459)", () => {
     assert.strictEqual(h.apiCalls.filter((c) => c[0] === "playClickReaction").length, 1);
   });
 
-  it("accepted drop stays silent when the theme has no double reaction or pet is busy", () => {
+  it("accepted drop falls back to the click poke for double-less themes (Calico)", () => {
+    const h = createHarness();
+    h.apiHandlers.themeConfig({ reactions: {
+      clickLeft: { file: "left.svg", duration: 2500 },
+      clickRight: { file: "right.svg", duration: 2500 },
+      drag: { file: "drag.svg" },
+    } });
+    h.apiHandlers.dropAccepted();
+    const plays = h.apiCalls.filter((c) => c[0] === "playClickReaction");
+    assert.strictEqual(plays.length, 1);
+    assert.ok(["left.svg", "right.svg"].includes(plays[0][1]), plays[0][1]);
+    assert.strictEqual(plays[0][2], 2500);
+  });
+
+  it("accepted drop stays silent for drag-only themes (Cloudling) or a busy pet", () => {
     const noReact = createHarness();
     noReact.apiHandlers.themeConfig({ reactions: { drag: { file: "drag.svg" } } });
     noReact.apiHandlers.dropAccepted();

--- a/test/hit-renderer.test.js
+++ b/test/hit-renderer.test.js
@@ -245,6 +245,13 @@ describe("hit-renderer OS file drop (#459)", () => {
     };
   }
 
+  it("macOS registers no drop machinery at all: no listeners, no affordance, no accept handler", () => {
+    const h = createHarness({ isMac: true });
+    assert.strictEqual(h.area.listeners.get("dragover"), undefined);
+    assert.strictEqual(h.area.listeners.get("drop"), undefined);
+    assert.strictEqual(h.apiHandlers.dropAccepted, undefined);
+  });
+
   it("dragover with files shows the copy affordance outside mini mode", () => {
     const h = createHarness();
     const evt = makeDragEvent();

--- a/test/hit-renderer.test.js
+++ b/test/hit-renderer.test.js
@@ -68,6 +68,11 @@ function createHarness({ isMac = false, sendState = {} } = {}) {
         playClickReaction: (svg, d) => apiCalls.push(["playClickReaction", svg, d]),
         onStateSync: (cb) => { apiHandlers.stateSync = cb; },
         onCancelReaction: (cb) => { apiHandlers.cancelReaction = cb; },
+        // Drop bridge (#459): fake files carry .path; "" mimics webUtils
+        // returning nothing for non-filesystem Files.
+        getPathForFile: (file) => (file && file.path) || "",
+        dropPaths: (paths) => apiCalls.push(["dropPaths", paths]),
+        onDropAccepted: (cb) => { apiHandlers.dropAccepted = cb; },
       },
       addEventListener: () => {},
     },
@@ -228,5 +233,86 @@ describe("hit-renderer input layer", () => {
         ["startDragReaction", "right"],
       ]
     );
+  });
+});
+
+describe("hit-renderer OS file drop (#459)", () => {
+  function makeDragEvent({ types = ["Files"], files = [] } = {}) {
+    return {
+      prevented: false,
+      preventDefault() { this.prevented = true; },
+      dataTransfer: { types, files, dropEffect: "" },
+    };
+  }
+
+  it("dragover with files shows the copy affordance outside mini mode", () => {
+    const h = createHarness();
+    const evt = makeDragEvent();
+    h.area.listeners.get("dragover")(evt);
+    assert.strictEqual(evt.prevented, true);
+    assert.strictEqual(evt.dataTransfer.dropEffect, "copy");
+  });
+
+  it("dragover gives no affordance in mini mode or for non-file drags", () => {
+    const mini = createHarness({ sendState: { currentState: "idle", miniMode: true, dndEnabled: false } });
+    const miniEvt = makeDragEvent();
+    mini.area.listeners.get("dragover")(miniEvt);
+    assert.strictEqual(miniEvt.prevented, false);
+    assert.strictEqual(miniEvt.dataTransfer.dropEffect, "");
+
+    const h = createHarness();
+    const textEvt = makeDragEvent({ types: ["text/plain"] });
+    h.area.listeners.get("dragover")(textEvt);
+    assert.strictEqual(textEvt.prevented, false);
+  });
+
+  it("drop resolves paths through the preload bridge, filtering non-filesystem Files", () => {
+    const h = createHarness();
+    const evt = makeDragEvent({ files: [{ path: "" }, { path: "/proj/dir" }, { path: "/other" }] });
+    h.area.listeners.get("drop")(evt);
+    assert.strictEqual(evt.prevented, true);
+    // Array.from: the paths array is born in the vm realm — copy it into the
+    // host realm so deepStrictEqual's prototype check passes.
+    const dropCalls = h.apiCalls
+      .filter((c) => c[0] === "dropPaths")
+      .map((c) => [c[0], Array.from(c[1])]);
+    assert.deepStrictEqual(dropCalls, [["dropPaths", ["/proj/dir", "/other"]]]);
+  });
+
+  it("drop sends nothing when every File lacks a filesystem path", () => {
+    const h = createHarness();
+    const evt = makeDragEvent({ files: [{ path: "" }] });
+    h.area.listeners.get("drop")(evt);
+    assert.deepStrictEqual(h.apiCalls.filter((c) => c[0] === "dropPaths"), []);
+  });
+
+  it("drop is inert in mini mode even if the event slips through", () => {
+    const h = createHarness({ sendState: { currentState: "idle", miniMode: true, dndEnabled: false } });
+    const evt = makeDragEvent({ files: [{ path: "/proj" }] });
+    h.area.listeners.get("drop")(evt);
+    assert.deepStrictEqual(h.apiCalls.filter((c) => c[0] === "dropPaths"), []);
+  });
+
+  it("accepted drop plays the double reaction through the local isReacting gate", () => {
+    const h = createHarness();
+    h.apiHandlers.dropAccepted();
+    assert.deepStrictEqual(
+      h.apiCalls.filter((c) => c[0] === "playClickReaction"),
+      [["playClickReaction", "flail.svg", 3500]]
+    );
+    // While reacting, a second accept must not stack another animation.
+    h.apiHandlers.dropAccepted();
+    assert.strictEqual(h.apiCalls.filter((c) => c[0] === "playClickReaction").length, 1);
+  });
+
+  it("accepted drop stays silent when the theme has no double reaction or pet is busy", () => {
+    const noReact = createHarness();
+    noReact.apiHandlers.themeConfig({ reactions: { drag: { file: "drag.svg" } } });
+    noReact.apiHandlers.dropAccepted();
+    assert.deepStrictEqual(noReact.apiCalls.filter((c) => c[0] === "playClickReaction"), []);
+
+    const busy = createHarness({ sendState: { currentState: "working", miniMode: false, dndEnabled: false } });
+    busy.apiHandlers.dropAccepted();
+    assert.deepStrictEqual(busy.apiCalls.filter((c) => c[0] === "playClickReaction"), []);
   });
 });

--- a/test/launch-claude.test.js
+++ b/test/launch-claude.test.js
@@ -427,6 +427,43 @@ describe("buildShellTerminalCandidates (#459)", () => {
     );
   });
 
+  it("win32: a %-containing dir skips the cmd.exe candidate (no command-line escape exists)", () => {
+    const cands = buildShellTerminalCandidates("C:\\100% done", "win32");
+    assert.deepStrictEqual(cands.map((c) => c.bin), ["wt.exe", "powershell.exe"]);
+    // The survivors both pass the path literally.
+    assert.deepStrictEqual(cands[0].args, ["-d", "C:\\100% done"]);
+    assert.strictEqual(
+      cands[1].args[cands[1].args.length - 1],
+      "Set-Location -LiteralPath 'C:\\100% done'",
+    );
+  });
+
+  it("win32: `!` and `^ &` dirs keep the cmd.exe candidate (/v:off + quotes make them literal)", () => {
+    const cands = buildShellTerminalCandidates("C:\\bang!dir & spec^ial", "win32");
+    assert.deepStrictEqual(cands.map((c) => c.bin), ["wt.exe", "cmd.exe", "powershell.exe"]);
+    const cmd = cands[1];
+    assert.ok(cmd.args.includes("/v:off"), "delayed expansion must stay disabled");
+    assert.strictEqual(cmd.args[cmd.args.length - 1], 'cd /d "C:\\bang!dir & spec^ial"');
+  });
+
+  it("round-trips a spaced/special dir through real cmd.exe cd", { skip: process.platform !== "win32" }, () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd drop & test^ "));
+    try {
+      const cands = buildShellTerminalCandidates(dir, "win32");
+      const cmd = cands.find((c) => c.bin === "cmd.exe");
+      assert.ok(cmd, "non-% dir must keep the cmd candidate");
+      const payload = cmd.args[cmd.args.length - 1];
+      const result = spawnSync("cmd.exe", ["/d", "/v:off", "/s", "/c", `${payload} && cd`], {
+        encoding: "utf8",
+        windowsVerbatimArguments: true,
+      });
+      assert.strictEqual(result.status, 0, JSON.stringify({ stdout: result.stdout, stderr: result.stderr }));
+      assert.strictEqual(result.stdout.trim(), dir);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("darwin: single osascript candidate with explicit cd -- and two-layer quoting", () => {
     const cands = buildShellTerminalCandidates("/Users/me/proj dir", "darwin");
     assert.strictEqual(cands.length, 1);

--- a/test/launch-claude.test.js
+++ b/test/launch-claude.test.js
@@ -10,6 +10,8 @@ const { describe, it } = require("node:test");
 const {
   buildClaudeArgs,
   buildTerminalCandidates,
+  buildShellTerminalCandidates,
+  openTerminalAt,
   buildCmdLaunchCommand,
   normalizeClaudeSessionId,
   quoteCmdExecutablePath,
@@ -379,6 +381,121 @@ describe("buildTerminalCandidates - macOS", () => {
     const script = cands[0].args[1];
     // Any double quote from user input must be backslash-escaped for AppleScript.
     assert.ok(script.includes('\\"'), "AppleScript double quotes must be escaped");
+  });
+
+  it("prefixes an explicit cd -- <workDir> when a working directory is given (#459)", () => {
+    // Terminal.app `do script` shells start at $HOME and ignore spawn cwd, so
+    // the folder must live inside the command itself.
+    const cands = buildTerminalCandidates("/usr/local/bin/claude", [], "darwin", "/Users/me/proj dir");
+    const script = cands[0].args[1];
+    assert.ok(script.includes("cd -- '/Users/me/proj dir' && "), script);
+  });
+
+  it("omits the cd prefix when no working directory is given", () => {
+    const cands = buildTerminalCandidates("/usr/local/bin/claude", [], "darwin");
+    const script = cands[0].args[1];
+    assert.ok(!script.includes("cd -- "), script);
+  });
+});
+
+describe("buildShellTerminalCandidates (#459)", () => {
+  it("win32: wt -d first, then cmd cd /d as one pre-quoted string, then PS -LiteralPath", () => {
+    const dir = "C:\\My Projects\\app";
+    const cands = buildShellTerminalCandidates(dir, "win32");
+    assert.deepStrictEqual(cands.map((c) => c.bin), ["wt.exe", "cmd.exe", "powershell.exe"]);
+    // wt -d relies on Node's default arg quoting; no verbatim args.
+    assert.deepStrictEqual(cands[0].args, ["-d", dir]);
+    assert.strictEqual(cands[0].extraOpts, undefined);
+    // cmd: the /k payload is ONE pre-quoted string and must not start with a quote.
+    const cmdPayload = cands[1].args[cands[1].args.length - 1];
+    assert.strictEqual(cmdPayload, 'cd /d "C:\\My Projects\\app"');
+    assert.strictEqual(cands[1].extraOpts.windowsVerbatimArguments, true);
+    const psPayload = cands[2].args[cands[2].args.length - 1];
+    assert.strictEqual(psPayload, "Set-Location -LiteralPath 'C:\\My Projects\\app'");
+  });
+
+  it("win32: -LiteralPath keeps glob characters literal", () => {
+    const cands = buildShellTerminalCandidates("C:\\dir[1]", "win32");
+    const psPayload = cands[2].args[cands[2].args.length - 1];
+    assert.strictEqual(psPayload, "Set-Location -LiteralPath 'C:\\dir[1]'");
+  });
+
+  it("win32: rejects directories containing double quotes", () => {
+    assert.throws(
+      () => buildShellTerminalCandidates('C:\\evil" & calc & "', "win32"),
+      /double quotes/,
+    );
+  });
+
+  it("darwin: single osascript candidate with explicit cd -- and two-layer quoting", () => {
+    const cands = buildShellTerminalCandidates("/Users/me/proj dir", "darwin");
+    assert.strictEqual(cands.length, 1);
+    assert.strictEqual(cands[0].bin, "osascript");
+    const script = cands[0].args[1];
+    assert.ok(script.startsWith('tell application "Terminal" to do script "'), script);
+    assert.ok(script.includes("cd -- '/Users/me/proj dir' && clear"), script);
+  });
+
+  it("darwin: survives single quotes in the directory name", () => {
+    const cands = buildShellTerminalCandidates("/tmp/it's here", "darwin");
+    const script = cands[0].args[1];
+    assert.ok(script.includes("cd -- "), script);
+    assert.ok(!script.includes("'/tmp/it's here'"), "naive single-quoting must not survive");
+  });
+
+  it("linux: documented emulator chain, command only keeps a shell alive", () => {
+    const cands = buildShellTerminalCandidates("/tmp/x", "linux");
+    assert.deepStrictEqual(
+      cands.map((c) => c.bin),
+      ["x-terminal-emulator", "xterm", "gnome-terminal", "konsole", "alacritty", "kitty"],
+    );
+    for (const c of cands) assert.strictEqual(c.args[c.args.length - 1], "exec bash");
+  });
+});
+
+describe("openTerminalAt (#459)", () => {
+  it("walks the candidate chain and passes the directory as spawn cwd", async () => {
+    const launches = [];
+    const result = await openTerminalAt("/tmp/proj", {
+      platform: () => "linux",
+      tryLaunch: async (bin, args, opts) => {
+        launches.push([bin, opts.cwd, opts.detached]);
+        if (launches.length < 2) return { ok: false, error: new Error("not installed") };
+        return { ok: true };
+      },
+    });
+    assert.deepStrictEqual(result, { ok: true, terminal: "xterm" });
+    assert.strictEqual(launches.length, 2);
+    for (const [, cwd, detached] of launches) {
+      assert.strictEqual(cwd, "/tmp/proj");
+      assert.strictEqual(detached, true);
+    }
+  });
+
+  it("reports the last error when every candidate fails", async () => {
+    const result = await openTerminalAt("/tmp/proj", {
+      platform: () => "darwin",
+      tryLaunch: async () => ({ ok: false, error: new Error("osascript missing") }),
+    });
+    assert.deepStrictEqual(result, { ok: false, message: "osascript missing" });
+  });
+
+  it("rejects an empty directory without spawning", async () => {
+    let launched = false;
+    const result = await openTerminalAt("", {
+      tryLaunch: async () => { launched = true; return { ok: true }; },
+    });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(launched, false);
+  });
+
+  it("turns a win32 double-quote rejection into a failed result, not a throw", async () => {
+    const result = await openTerminalAt('C:\\evil" & calc', {
+      platform: () => "win32",
+      tryLaunch: async () => ({ ok: true }),
+    });
+    assert.strictEqual(result.ok, false);
+    assert.match(result.message, /double quotes/);
   });
 });
 

--- a/test/pet-interaction-ipc.test.js
+++ b/test/pet-interaction-ipc.test.js
@@ -94,6 +94,9 @@ function createHarness(overrides = {}) {
       return state.openTerminalResult;
     },
     dropLog: (message) => calls.push(["dropLog", message]),
+    // Default to the enabled platforms so the suite behaves the same on a
+    // macOS dev machine; the macOS-disabled path has its own explicit test.
+    isMacPlatform: overrides.isMacPlatform != null ? overrides.isMacPlatform : false,
   });
   return { ipcMain, runtime, calls, state };
 }
@@ -352,6 +355,20 @@ test("pet drop takes the first usable path only", async () => {
     calls.filter((c) => c[0] === "openTerminalAt"),
     [["openTerminalAt", "/first"]],
   );
+});
+
+test("pet drop is disabled on macOS: no stat, no terminal, no accept ping", async () => {
+  const { ipcMain, calls, state } = createHarness({ isMacPlatform: true });
+  state.statDirs.add("/proj/dir");
+  const sender = makeDropSender();
+
+  await sendDrop(ipcMain, ["/proj/dir"], sender);
+
+  assert.deepStrictEqual(calls.filter((c) => c[0] === "statPath"), []);
+  assert.deepStrictEqual(calls.filter((c) => c[0] === "openTerminalAt"), []);
+  assert.deepStrictEqual(sender.sent, []);
+  const logs = calls.filter((c) => c[0] === "dropLog").map((c) => c[1]);
+  assert.ok(logs.some((m) => m.includes("disabled on macOS")), logs.join("; "));
 });
 
 test("pet drop is ignored in mini mode and during mini transitions", async () => {

--- a/test/pet-interaction-ipc.test.js
+++ b/test/pet-interaction-ipc.test.js
@@ -39,6 +39,9 @@ function createHarness(overrides = {}) {
     currentPixelSize: { width: 90, height: 60 },
     clampedBounds: { x: 12, y: 24, width: 90, height: 60 },
     focusableIds: [],
+    statDirs: new Set(),
+    statFiles: new Set(),
+    openTerminalResult: { ok: true, terminal: "fake-term" },
     ...overrides.state,
   };
   const ipcMain = new FakeIpcMain();
@@ -80,8 +83,29 @@ function createHarness(overrides = {}) {
     focusSession: (sessionId, options) => calls.push(["focusSession", sessionId, options]),
     setLowPowerIdlePaused: (value) => calls.push(["setLowPowerIdlePaused", value]),
     revealSessionHud: () => calls.push(["revealSessionHud"]),
+    statPath: async (p) => {
+      calls.push(["statPath", p]);
+      if (state.statDirs.has(p)) return { isDirectory: () => true };
+      if (state.statFiles.has(p)) return { isDirectory: () => false };
+      throw new Error(`ENOENT: ${p}`);
+    },
+    openTerminalAt: async (dir) => {
+      calls.push(["openTerminalAt", dir]);
+      return state.openTerminalResult;
+    },
+    dropLog: (message) => calls.push(["dropLog", message]),
   });
   return { ipcMain, runtime, calls, state };
+}
+
+function makeDropSender() {
+  return { sent: [], send(channel) { this.sent.push(channel); } };
+}
+
+function sendDrop(ipcMain, paths, sender) {
+  const listener = ipcMain.listeners.get("pet-drop-paths");
+  assert.strictEqual(typeof listener, "function", "missing IPC listener pet-drop-paths");
+  return listener({ sender }, paths);
 }
 
 test("pet interaction IPC registers owned channels and disposes them", () => {
@@ -96,6 +120,7 @@ test("pet interaction IPC registers owned channels and disposes them", () => {
     "focus-terminal",
     "low-power-idle-paused",
     "pause-cursor-polling",
+    "pet-drop-paths",
     "pet-interaction:reveal-session-hud",
     "play-click-reaction",
     "resume-from-reaction",
@@ -285,4 +310,93 @@ test("pet interaction IPC preserves pet-body focus behavior", () => {
     ["focusLog", "focus result branch=none reason=multi-session-open-dashboard count=2"],
     ["showDashboard"],
   ]);
+});
+
+test("pet drop opens a terminal at a dropped directory and pings the hit window (#459)", async () => {
+  const { ipcMain, calls, state } = createHarness();
+  state.statDirs.add("/proj/dir");
+  const sender = makeDropSender();
+
+  await sendDrop(ipcMain, ["/proj/dir"], sender);
+
+  assert.deepStrictEqual(
+    calls.filter((c) => c[0] === "openTerminalAt"),
+    [["openTerminalAt", "/proj/dir"]],
+  );
+  assert.deepStrictEqual(sender.sent, ["pet-drop-accepted"]);
+});
+
+test("pet drop resolves a dropped file to its parent directory", async () => {
+  const { ipcMain, calls, state } = createHarness();
+  state.statFiles.add("/proj/dir/file.txt");
+  const sender = makeDropSender();
+
+  await sendDrop(ipcMain, ["/proj/dir/file.txt"], sender);
+
+  assert.deepStrictEqual(
+    calls.filter((c) => c[0] === "openTerminalAt"),
+    [["openTerminalAt", "/proj/dir"]],
+  );
+  assert.deepStrictEqual(sender.sent, ["pet-drop-accepted"]);
+});
+
+test("pet drop takes the first usable path only", async () => {
+  const { ipcMain, calls, state } = createHarness();
+  state.statDirs.add("/first");
+  state.statDirs.add("/second");
+  const sender = makeDropSender();
+
+  await sendDrop(ipcMain, [null, "", "/first", "/second"], sender);
+
+  assert.deepStrictEqual(
+    calls.filter((c) => c[0] === "openTerminalAt"),
+    [["openTerminalAt", "/first"]],
+  );
+});
+
+test("pet drop is ignored in mini mode and during mini transitions", async () => {
+  for (const stateOverride of [{ miniMode: true }, { miniTransitioning: true }]) {
+    const { ipcMain, calls, state } = createHarness({ state: stateOverride });
+    state.statDirs.add("/proj");
+    const sender = makeDropSender();
+
+    await sendDrop(ipcMain, ["/proj"], sender);
+
+    assert.deepStrictEqual(calls.filter((c) => c[0] === "statPath"), []);
+    assert.deepStrictEqual(calls.filter((c) => c[0] === "openTerminalAt"), []);
+    assert.deepStrictEqual(sender.sent, []);
+  }
+});
+
+test("pet drop ignores invalid payloads and failed stats without launching", async () => {
+  const { ipcMain, calls } = createHarness();
+  const sender = makeDropSender();
+
+  await sendDrop(ipcMain, "not-an-array", sender);
+  await sendDrop(ipcMain, [], sender);
+  await sendDrop(ipcMain, [123, "", null], sender);
+  await sendDrop(ipcMain, ["/missing"], sender);
+
+  assert.deepStrictEqual(calls.filter((c) => c[0] === "openTerminalAt"), []);
+  assert.deepStrictEqual(sender.sent, []);
+  const logs = calls.filter((c) => c[0] === "dropLog").map((c) => c[1]);
+  assert.ok(logs.some((m) => m.includes("stat failed") && m.includes("/missing")), logs.join("; "));
+});
+
+test("pet drop does not ping the hit window when the terminal launch fails", async () => {
+  const { ipcMain, calls, state } = createHarness({
+    state: { openTerminalResult: { ok: false, message: "no terminal" } },
+  });
+  state.statDirs.add("/proj");
+  const sender = makeDropSender();
+
+  await sendDrop(ipcMain, ["/proj"], sender);
+
+  assert.deepStrictEqual(
+    calls.filter((c) => c[0] === "openTerminalAt"),
+    [["openTerminalAt", "/proj"]],
+  );
+  assert.deepStrictEqual(sender.sent, []);
+  const logs = calls.filter((c) => c[0] === "dropLog").map((c) => c[1]);
+  assert.ok(logs.some((m) => m.includes("launch failed") && m.includes("no terminal")), logs.join("; "));
 });


### PR DESCRIPTION
Closes #459（按反提案范围实现，原始的「解析文件内容」诉求在 issue 里另行回复说明）。

## What（⚠️ 范围更新：Windows / Linux only）

把文件夹（或文件）从 Explorer / 文件管理器拖到桌宠上 → 桌宠播反应动画 → **打开系统终端并 cd 到该目录**。不自动启动任何 agent——敲 `claude` / `codex` / `agy` 还是别的，留给用户的手。

**macOS 不支持此功能（主动关闭）**，原因见下；macOS 从本 PR 得到的是 New Session cd 修复。

## macOS 为什么关闭（真机二分结论）

宠物双窗为了盖在全屏 app 之上运行在 `screen-saver` window level，而 **macOS 的拖拽目标搜索对该层级窗口不可见**——单变量实验：floating / status(25) / pop-up-menu(101) 层全部正常收到 drag 事件，唯独 screen-saver(1000) 静默；panel / transparent / visibleOnAllWorkspaces / stationary 全部无辜。只把隐形 hit 窗降到 pop-up-menu 也不行：上方重叠的 screen-saver render 窗仍会挡住搜索（`ignoresMouseEvents` 只穿透鼠标事件、不穿透 drag destination）。结论：不为一个交互糖改动窗口层级模型/上私有 API，macOS 直接不注册 drag 监听（无 copy 光标、无误导），IPC 侧再加 `isMacPlatform` 二层 guard。完整实验记录在 docs/plans/plan-issue-459-drop-folder-open-terminal.md（本地）。

## 顺带修了一个 macOS 存量 bug（真机已证实，保留）

Terminal.app 的 `do script` shell 永远从 $HOME 启动、无视 osascript 进程的 spawn cwd——**mac 上 New Session「选文件夹」此前从未真正 cd 过去**。`buildTerminalCandidates` 现在接收 workDir 并在 darwin 分支显式 `cd -- <dir> &&`（真机探针验证，含空格路径）。

## 设计要点（Windows/Linux）

- **入口**：hit 窗口 dragover/drop；Electron 41 已移除 `File.path`，路径在 preload 经 `webUtils.getPathForFile` 解析，非文件系统 File（浏览器拖图）返回空串被过滤。
- **mini mode 双层 gate**：renderer 在 dragover 阶段就不给 copy 光标，主进程二次拦截。
- **反馈 best-effort**：主进程确认终端拉起成功后回包 `pet-drop-accepted`，hit renderer 走自己的 `playReaction`（isReacting 不被绕过）；反应链 double（Clawd）→ clickLeft/Right poke（Calico）→ 静默（Cloudling）。
- **执行层**：`buildShellTerminalCandidates`/`openTerminalAt`——`wt -d`（原生参数）→ cmd `/k` 整段预引号字符串（**含 `%` 的目录跳过 cmd 候选**：cmd 命令行语境 `%VAR%` 在引号内仍展开且无可靠转义，wt/PS 字面量安全；`!` 由 /v:off 压住）→ PowerShell `Set-Location -LiteralPath`（防通配展开）；win32 路径含 `\"` 直接拒绝。
- 文件 → 取所在目录；多项取第一个；stat 失败静默忽略；不读不解析不执行文件内容。

## Review 记录

云宝三轮：R1 七条（plan 阶段，全部核验属实并合入）；R2 两条（`%` 展开 + Calico 无 double reaction，已修，其中 R2-P1 的 quoteForCmd 药方经核验无效、改为跳过 cmd 候选）；R3 决策 macOS 关闭。全程真机二分实验四轮（E/F 系列）。

## Tests

全量 **3910 pass / 0 fail**（16 skipped 含 4 个 Windows-only round-trip）。新增覆盖：drop 链路（目录/文件/多选/空串/mini/失败不回包）、mac 禁用（renderer 不注册监听 + IPC guard）、三平台终端候选引号矩阵、darwin cd 前缀。

## 验证

- [x] 单测全绿 + `git diff --check`
- [x] mac 真机：New Session cd 修复探针验证（含空格路径）；drop 不可行性四轮二分实验
- [x] mac 真机：确认 drop 无 copy 光标无反应（按设计）
- [ ] Windows 真机：透明窗 drop hit-test、`wt -d` 实际落目录、cmd round-trip 测试（按家规标注待验证，发布后跟进反馈）