### PR TITLE
feat(mobile): rotate-on-use — defer 24h rotation when no clients online

### DIFF
--- a/src/network/mobile-preview-server.js
+++ b/src/network/mobile-preview-server.js
@@ -62,6 +62,7 @@ function loadOrCreateTokenState(tokenPath, nowFn) {
         previous: raw.previous || null,
         graceUntil: typeof raw.graceUntil === "number" ? raw.graceUntil : null,
         rotatedAt: typeof raw.rotatedAt === "number" ? raw.rotatedAt : nowFn(),
+        rotationPending: typeof raw.rotationPending === "boolean" ? raw.rotationPending : false,
       };
       // Backward compat: rewrite file if it was in old { token } format
       if (raw.rotatedAt === undefined) atomicWrite(tokenPath, state);
@@ -69,7 +70,7 @@ function loadOrCreateTokenState(tokenPath, nowFn) {
     }
   } catch {}
   const token = crypto.randomBytes(16).toString("hex");
-  const state = { token, previous: null, graceUntil: null, rotatedAt: nowFn() };
+  const state = { token, previous: null, graceUntil: null, rotatedAt: nowFn(), rotationPending: false };
   atomicWrite(tokenPath, state);
   return state;
 }
@@ -122,15 +123,22 @@ function initMobilePreviewServer(ctx) {
   }
 
   function scheduleRotation() {
+    if (tokenState.rotationPending) return;
     if (rotationTimer) clearTimeout(rotationTimer);
     const msUntilRotate = Math.max(0, (tokenState.rotatedAt + ROTATION_INTERVAL_MS) - now());
     rotationTimer = setTimeout(() => {
-      performRotation();
-      scheduleRotation(); // schedule next
+      if (clients.size > 0) {
+        performRotation();
+      } else {
+        tokenState.rotationPending = true;
+        atomicWrite(tokenPath, tokenState);
+      }
+      scheduleRotation(); // schedule next (if rotationPending, early-exits)
     }, msUntilRotate);
   }
 
   function regenerateToken() {
+    tokenState.rotationPending = false;
     const newToken = crypto.randomBytes(16).toString("hex");
     tokenState.previous = null;      // no grace — old token dies now
     tokenState.graceUntil = null;
@@ -239,6 +247,13 @@ function initMobilePreviewServer(ctx) {
       const clientId = crypto.randomBytes(8).toString("hex");
       const clientIp = (req.socket.remoteAddress || "").replace(/^::ffff:/, "");
       clientMeta.set(ws, { messageCount: 0, windowStart: Date.now(), clientId, ip: clientIp, lastPong: Date.now() });
+
+      // If a rotation was pending and this client has the current token, rotate now
+      if (tokenState.rotationPending && clientToken === tokenState.token) {
+        tokenState.rotationPending = false;
+        performRotation();
+        scheduleRotation(); // arm the next 24h timer
+      }
 
       // Send snapshot on connect
       try {

--- a/test/mobile-preview-server.test.js
+++ b/test/mobile-preview-server.test.js
@@ -666,3 +666,172 @@ describe("Token Rotation", () => {
     await new Promise((r) => setTimeout(r, 100));
   });
 });
+
+// ── Rotate-on-use Tests ──
+
+describe("Rotate-on-use", () => {
+  let tmpTokenDir;
+  let tokenFile;
+  const sessions = new Map();
+
+  before(() => {
+    tmpTokenDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-rou-"));
+    tokenFile = path.join(tmpTokenDir, "token.json");
+  });
+
+  after(() => {
+    sessions.clear();
+    try { fs.rmSync(tmpTokenDir, { recursive: true }); } catch {}
+  });
+
+  it("24h expiry with no clients → rotationPending persisted to disk", async () => {
+    const testToken = "aabbccdd".repeat(4);
+    // rotatedAt far in the past → timer fires immediately
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: 1,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
+    await server.start();
+    // No clients connect — timer fires at ~0ms
+    await new Promise((r) => setTimeout(r, 500));
+
+    const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+    assert.strictEqual(persisted.rotationPending, true,
+      "rotationPending should be true when timer fires with no clients");
+    assert.strictEqual(persisted.token, testToken,
+      "token should NOT have changed — no rotation happened");
+
+    server.cleanup();
+    await new Promise((r) => setTimeout(r, 200));
+  });
+
+  it("rotationPending=true + client connects → receives token_rotate", async () => {
+    const testToken = "11223344".repeat(4);
+    const setupRotatedAt = Date.now();
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: setupRotatedAt,
+      rotationPending: true,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
+    const port = await server.start();
+
+    const client = connectClient(port, testToken);
+    await waitForOpen(client.ws);
+    const rotateMsg = await client.waitFor("token_rotate");
+    assert.ok(rotateMsg.newToken, "should receive new token");
+    assert.notStrictEqual(rotateMsg.newToken, testToken, "new token should differ");
+    assert.ok(rotateMsg.expiresAt > Date.now(), "expiresAt should be in the future");
+
+    // rotationPending should be cleared on disk
+    const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+    assert.strictEqual(persisted.rotationPending, false,
+      "rotationPending should be false after on-connect rotation");
+    assert.strictEqual(persisted.token, rotateMsg.newToken,
+      "persisted token should be the new token");
+    assert.ok(persisted.rotatedAt >= setupRotatedAt,
+      "rotatedAt should be updated by on-connect rotation for next 24h timer");
+
+    client.close();
+    server.cleanup();
+    await new Promise((r) => setTimeout(r, 200));
+  });
+
+  it("rotationPending=true + regenerateToken → clears pending flag", async () => {
+    const testToken = "55667788".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now(),
+      rotationPending: true,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
+    await server.start();
+
+    const newToken = server.regenerateToken();
+    assert.notStrictEqual(newToken, testToken);
+
+    const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+    assert.strictEqual(persisted.rotationPending, false,
+      "rotationPending should be cleared by regenerateToken");
+    assert.strictEqual(persisted.token, newToken,
+      "persisted token should be the regenerated token");
+
+    server.cleanup();
+    await new Promise((r) => setTimeout(r, 200));
+  });
+
+  it("server restart with rotationPending=true → no timer, waits for connection", async () => {
+    const testToken = "99aabbcc".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now(),
+      rotationPending: true,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
+    const port = await server.start();
+
+    // Wait — scheduleRotation should early-exit when rotationPending=true
+    await new Promise((r) => setTimeout(r, 500));
+
+    const beforeConnect = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+    assert.strictEqual(beforeConnect.token, testToken,
+      "token should not change before a client connects");
+
+    // Now connect — rotation should happen on-connect
+    const client = connectClient(port, testToken);
+    await waitForOpen(client.ws);
+    const rotateMsg = await client.waitFor("token_rotate");
+    assert.ok(rotateMsg.newToken, "should receive new token after connect");
+    assert.notStrictEqual(rotateMsg.newToken, testToken);
+
+    client.close();
+    server.cleanup();
+    await new Promise((r) => setTimeout(r, 200));
+  });
+
+  it("pending rotation + multiple clients → all receive token_rotate", async () => {
+    const testToken = "ddeeff00".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now(),
+      rotationPending: true,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
+    const port = await server.start();
+
+    const client1 = connectClient(port, testToken);
+    const client2 = connectClient(port, testToken);
+    await waitForOpen(client1.ws);
+    await waitForOpen(client2.ws);
+
+    const rotate1 = await client1.waitFor("token_rotate");
+    const rotate2 = await client2.waitFor("token_rotate");
+
+    assert.ok(rotate1.newToken, "client1 should receive new token");
+    assert.ok(rotate2.newToken, "client2 should receive new token");
+    assert.strictEqual(rotate1.newToken, rotate2.newToken,
+      "both clients should receive the same new token");
+
+    client1.close();
+    client2.close();
+    server.cleanup();
+    await new Promise((r) => setTimeout(r, 200));
+  });
+});


### PR DESCRIPTION
## Changes

- `loadOrCreateTokenState`: add `rotationPending` field (backward-compatible, defaults `false`)
- `scheduleRotation()`: early-exit if `rotationPending`; timer callback defers rotation when `clients.size === 0`
- Connection handler: on-connect rotation when `rotationPending && clientToken === tokenState.token`, then re-
- `regenerateToken()`: clear `rotationPending` first (emergency kill switch)

## Tests (5 new)

| # | Test |
|---|------|
| 1 | Timer fires with no clients → `rotationPending` persisted, token unchanged |
| 2 | `rotationPending` + cken_rotate`, disk cleared |
| 3 | `rotationPending` + `regenerateToken` → pending cleared |
| 4 | Server restart with `rotationPending` → no timer, waits for connection |
| 5 | Pending rotation + multiple clients → all receive `token_rotate` |

---

## 概述

24 小时轮换定时器到期时如果没有客户端在线，服务器挂起轮换（`rotationPending =
true`，持久化到磁盘）。下一时当场轮换，通过该连接递送新token。

## 为什么

原有的 24 小时定时轮换只把交给那一刻在线的手机。大部分时间处于冻结或离线状态的手机会错过窗口。

## 改动

- `loadOrCreateTokenState`  向后兼容，默认 `false`）
- `scheduleRotation()`：若 `rotationPending` 则直接返回；定时器回调在无客户端时挂起轮换
- 连接处理器：当 `rotationPending && clientToken === tokenState.token` 时当场轮换，并重新设置 24 小时定时器
- `regenerateToken()`：首先 关）

## 测试（5 个新增）

| # | 测试 |
|---|------|
| 1 | 定时器到期无客户端 → en 不变 |
| 2 | 挂起状态 + 客户端连接 → 收到 `token_rotate`，磁盘标记清除 |
| 3 | 挂起状态 + `regenerateToken` → 挂起标记清除 |
| 4 | 服务器重启 + 挂起状态
| 5 | 挂起轮换 + 多客户端在线 → 全部收到 `token_rotate` |