### PR TITLE
fix: add agents/**/* to asarUnpack to resolve MODULE_NOT_FOUND in hook scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,6 +147,7 @@
       "assets/svg/**/*",
       "hooks/**/*",
       "extensions/**/*",
+      "agents/**/*",
       "themes/**/*"
     ],
     "extraResources": [


### PR DESCRIPTION
## Problem

Hook scripts that `require("../agents/...")` crash with `MODULE_NOT_FOUND` because the `agents/` directory is only packaged inside `app.asar` but not extracted to `app.asar.unpacked/`.

Since hook scripts run via the **system Node.js** (outside the Electron asar context), `require()` cannot resolve paths inside `app.asar`.

### Example error (kimi-hook.js)

```
Error: Cannot find module '../agents/kimi-cli'
Require stack:
- /Applications/Clawd on Desk.app/Contents/Resources/app.asar.unpacked/hooks/kimi-hook.js
```

### Impact

- **Currently broken:** `kimi-hook.js` (requires `../agents/kimi-cli`)
- **Future risk:** Any new hook that needs agent process-name lookups will hit the same bug
- **User-facing symptom:** Kimi CLI sessions are invisible to Clawd; hooks silently fail on every invocation

## Fix

Add `"agents/**/*"` to the `asarUnpack` array in `package.json` build config, alongside the existing `hooks/**/*`, `extensions/**/*`, and `themes/**/*`.

```diff
  "asarUnpack": [
    "assets/svg/**/*",
    "hooks/**/*",
    "extensions/**/*",
+   "agents/**/*",
    "themes/**/*"
  ]
```

## Verification

After applying the fix and rebuilding:

```bash
# Confirm agents/ is extracted
ls "/Applications/Clawd on Desk.app/Contents/Resources/app.asar.unpacked/agents/"
# Should list kimi-cli.js, registry.js, etc.

# Test hook execution
echo '{"session_id":"test","cwd":"/tmp","hook_event_name":"SessionStart"}' | \
  node "/Applications/Clawd on Desk.app/Contents/Resources/app.asar.unpacked/hooks/kimi-hook.js" SessionStart
# Should exit 0 (previously exit 1 with MODULE_NOT_FOUND)
```

## Environment

- macOS 15.5 (Darwin arm64)
- Clawd on Desk v0.9.0
- Node.js v25.9.0
- Kimi CLI v1.46.0

Fixes #486