### PR TITLE
[codex] test agent asar unpack config

### DIFF
--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -44,6 +44,13 @@ describe("package build config", () => {
     );
   });
 
+  it("unpacks agent configs required by external hook scripts", () => {
+    assert.ok(
+      pkg.build.asarUnpack.includes("agents/**/*"),
+      "asarUnpack should include agents/**/*"
+    );
+  });
+
   describe("Windows architecture targets", () => {
     function getWindowsNsisTarget() {
       const targets = pkg.build.win && pkg.build.win.target;


### PR DESCRIPTION
## Summary

Adds a package-build regression test that keeps `agents/**/*` in `build.asarUnpack`.

## Why

PR #488 fixed packaged Kimi hook failures by unpacking agent config files. `hooks/kimi-hook.js` runs from `app.asar.unpacked/hooks` under the system Node.js process and requires `../agents/kimi-cli`, so the `agents/` directory must remain unpacked in packaged builds.

## Validation

- `node --test test/package-build-config.test.js`
- `git diff --check`