### PR TITLE
fix(mobile): use lastPong to detect active clients in rotation timer

### DIFF
--- a/src/network/mobile-preview-server.js
+++ b/src/network/mobile-preview-server.js
@@ -20,7 +20,7 @@ const CLIENT_TIMEOUT_MS = 90000;
 const RATE_WINDOW_MS = 60000;
 const RATE_MAX = 60;
 const MAX_CLIENTS = 10;
-const GRACE_PERIOD_MS = 5 * 60 * 1000;          // 5 minutes
+const GRACE_PERIOD_MS = 5 * 60 * 1000; // 5 minutes
 const ROTATION_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 hours
 
 const PWA_DIR = path.resolve(__dirname, "../../pwa");
@@ -56,13 +56,20 @@ function atomicWrite(tokenPath, state) {
 function loadOrCreateTokenState(tokenPath, nowFn) {
   try {
     const raw = JSON.parse(fs.readFileSync(tokenPath, "utf8"));
-    if (raw && typeof raw.token === "string" && /^[a-f0-9]{32,64}$/.test(raw.token)) {
+    if (
+      raw &&
+      typeof raw.token === "string" &&
+      /^[a-f0-9]{32,64}$/.test(raw.token)
+    ) {
       const state = {
         token: raw.token,
         previous: raw.previous || null,
         graceUntil: typeof raw.graceUntil === "number" ? raw.graceUntil : null,
         rotatedAt: typeof raw.rotatedAt === "number" ? raw.rotatedAt : nowFn(),
-        rotationPending: typeof raw.rotationPending === "boolean" ? raw.rotationPending : false,
+        rotationPending:
+          typeof raw.rotationPending === "boolean"
+            ? raw.rotationPending
+            : false,
       };
       // Backward compat: rewrite file if it was in old { token } format
       if (raw.rotatedAt === undefined) atomicWrite(tokenPath, state);
@@ -70,23 +77,38 @@ function loadOrCreateTokenState(tokenPath, nowFn) {
     }
   } catch {}
   const token = crypto.randomBytes(16).toString("hex");
-  const state = { token, previous: null, graceUntil: null, rotatedAt: nowFn(), rotationPending: false };
+  const state = {
+    token,
+    previous: null,
+    graceUntil: null,
+    rotatedAt: nowFn(),
+    rotationPending: false,
+  };
   atomicWrite(tokenPath, state);
   return state;
 }
 
 function buildMessage(type, payload) {
-  return JSON.stringify({ version: PROTOCOL_VERSION, type, timestamp: Date.now(), ...payload });
+  return JSON.stringify({
+    version: PROTOCOL_VERSION,
+    type,
+    timestamp: Date.now(),
+    ...payload,
+  });
 }
 
 function isPathInside(parent, child) {
   const relative = path.relative(parent, child);
-  return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+  return (
+    relative === "" ||
+    (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative))
+  );
 }
 
 function initMobilePreviewServer(ctx) {
   const tokenPath = (ctx && ctx.tokenPath) || TOKEN_PATH;
   const now = () => (ctx && ctx.now && ctx.now()) || Date.now();
+  const clientTimeoutMs = (ctx && ctx.clientTimeoutMs) || CLIENT_TIMEOUT_MS;
   const tokenState = loadOrCreateTokenState(tokenPath, now);
   const clients = new Set();
   const clientMeta = new Map();
@@ -116,18 +138,31 @@ function initMobilePreviewServer(ctx) {
     for (const meta of clientMeta.values()) {
       meta.pendingRotationAcks = (meta.pendingRotationAcks || 0) + 1;
     }
-    broadcast(buildMessage("token_rotate", {
-      newToken: tokenState.token,
-      expiresAt: tokenState.graceUntil,
-    }));
+    broadcast(
+      buildMessage("token_rotate", {
+        newToken: tokenState.token,
+        expiresAt: tokenState.graceUntil,
+      }),
+    );
+  }
+
+  function hasActiveClients() {
+    const nowMs = Date.now();
+    for (const meta of clientMeta.values()) {
+      if (nowMs - meta.lastPong < clientTimeoutMs) return true;
+    }
+    return false;
   }
 
   function scheduleRotation() {
     if (tokenState.rotationPending) return;
     if (rotationTimer) clearTimeout(rotationTimer);
-    const msUntilRotate = Math.max(0, (tokenState.rotatedAt + ROTATION_INTERVAL_MS) - now());
+    const msUntilRotate = Math.max(
+      0,
+      tokenState.rotatedAt + ROTATION_INTERVAL_MS - now(),
+    );
     rotationTimer = setTimeout(() => {
-      if (clients.size > 0) {
+      if (hasActiveClients()) {
         performRotation();
       } else {
         tokenState.rotationPending = true;
@@ -140,14 +175,16 @@ function initMobilePreviewServer(ctx) {
   function regenerateToken() {
     tokenState.rotationPending = false;
     const newToken = crypto.randomBytes(16).toString("hex");
-    tokenState.previous = null;      // no grace — old token dies now
+    tokenState.previous = null; // no grace — old token dies now
     tokenState.graceUntil = null;
     tokenState.token = newToken;
     tokenState.rotatedAt = now();
     atomicWrite(tokenPath, tokenState);
     // Kick all connected clients (they have stale tokens)
     for (const c of clients) {
-      try { c.close(1008, "Token regenerated"); } catch {}
+      try {
+        c.close(1008, "Token regenerated");
+      } catch {}
     }
     clients.clear();
     clientMeta.clear();
@@ -186,25 +223,51 @@ function initMobilePreviewServer(ctx) {
 
   function serveStatic(req, res) {
     let urlPath;
-    try { urlPath = new URL(req.url, "http://localhost").pathname; } catch { res.writeHead(400); res.end(); return; }
+    try {
+      urlPath = new URL(req.url, "http://localhost").pathname;
+    } catch {
+      res.writeHead(400);
+      res.end();
+      return;
+    }
 
     // API endpoint for connection info (M1: no token — must come from Settings page or URL params)
     if (urlPath === "/api/connection-info") {
       const ready = Number.isInteger(activePort) && activePort > 0;
-      const info = { status: ready ? "ok" : "starting", port: ready ? activePort : null, lanIp: getLocalIP() };
-      res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-cache" });
+      const info = {
+        status: ready ? "ok" : "starting",
+        port: ready ? activePort : null,
+        lanIp: getLocalIP(),
+      };
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-cache",
+      });
       res.end(JSON.stringify(info));
       return;
     }
 
-    if (urlPath === "/mobile/" || urlPath === "/mobile") urlPath = "/mobile/index.html";
-    if (!urlPath.startsWith("/mobile/")) { res.writeHead(404); res.end(); return; }
+    if (urlPath === "/mobile/" || urlPath === "/mobile")
+      urlPath = "/mobile/index.html";
+    if (!urlPath.startsWith("/mobile/")) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
     const rel = urlPath.slice("/mobile/".length);
     const filePath = path.join(PWA_DIR, rel);
-    if (!isPathInside(PWA_DIR, filePath)) { res.writeHead(403); res.end(); return; }
+    if (!isPathInside(PWA_DIR, filePath)) {
+      res.writeHead(403);
+      res.end();
+      return;
+    }
     const ext = path.extname(filePath).toLowerCase();
     fs.readFile(filePath, (err, data) => {
-      if (err) { res.writeHead(404); res.end(); return; }
+      if (err) {
+        res.writeHead(404);
+        res.end();
+        return;
+      }
       res.writeHead(200, {
         "Content-Type": MIME[ext] || "application/octet-stream",
         "Cache-Control": ext === ".html" ? "no-cache" : "public, max-age=3600",
@@ -218,18 +281,30 @@ function initMobilePreviewServer(ctx) {
     wss = new WebSocket.Server({ server: httpServer, path: "/ws" });
 
     wss.on("connection", (ws, req) => {
-      if (closed) { ws.close(1001, "Server shutting down"); return; }
+      if (closed) {
+        ws.close(1001, "Server shutting down");
+        return;
+      }
 
       let url;
-      try { url = new URL(req.url, "http://localhost"); } catch { ws.close(1008, "Bad request"); return; }
+      try {
+        url = new URL(req.url, "http://localhost");
+      } catch {
+        ws.close(1008, "Bad request");
+        return;
+      }
 
       // Token validation with grace-period support
       const clientToken = url.searchParams.get("token");
       let graceAccepted = false;
       if (clientToken !== tokenState.token) {
         // Check grace period for previous token
-        if (tokenState.previous && clientToken === tokenState.previous
-            && tokenState.graceUntil !== null && now() < tokenState.graceUntil) {
+        if (
+          tokenState.previous &&
+          clientToken === tokenState.previous &&
+          tokenState.graceUntil !== null &&
+          now() < tokenState.graceUntil
+        ) {
           // Accept via grace — client hasn't acked the rotation yet
           graceAccepted = true;
         } else {
@@ -246,7 +321,13 @@ function initMobilePreviewServer(ctx) {
       clients.add(ws);
       const clientId = crypto.randomBytes(8).toString("hex");
       const clientIp = (req.socket.remoteAddress || "").replace(/^::ffff:/, "");
-      clientMeta.set(ws, { messageCount: 0, windowStart: Date.now(), clientId, ip: clientIp, lastPong: Date.now() });
+      clientMeta.set(ws, {
+        messageCount: 0,
+        windowStart: Date.now(),
+        clientId,
+        ip: clientIp,
+        lastPong: Date.now(),
+      });
 
       // If a rotation was pending and this client has the current token, rotate now
       if (tokenState.rotationPending && clientToken === tokenState.token) {
@@ -270,10 +351,12 @@ function initMobilePreviewServer(ctx) {
         const meta = clientMeta.get(ws);
         if (meta) meta.pendingRotationAcks = 1;
         try {
-          ws.send(buildMessage("token_rotate", {
-            newToken: tokenState.token,
-            expiresAt: tokenState.graceUntil,
-          }));
+          ws.send(
+            buildMessage("token_rotate", {
+              newToken: tokenState.token,
+              expiresAt: tokenState.graceUntil,
+            }),
+          );
         } catch {}
       }
       ws.isAlive = true;
@@ -288,27 +371,36 @@ function initMobilePreviewServer(ctx) {
         const meta = clientMeta.get(ws);
         if (!meta) return;
         const nowMs = Date.now();
-        if (nowMs - meta.windowStart > RATE_WINDOW_MS) { meta.messageCount = 0; meta.windowStart = nowMs; }
-      if (++meta.messageCount > RATE_MAX) { ws.close(1008, "Rate limit"); return; }
-      // Handle token_rotate_ack — purely informational, no state change
-      try {
-        const parsed = JSON.parse(data);
-        if (parsed && parsed.type === "token_rotate_ack") {
-          meta.pendingRotationAcks = 0;
-          console.log(`[mobile-preview] token_rotate_ack from ${meta.ip}`);
+        if (nowMs - meta.windowStart > RATE_WINDOW_MS) {
+          meta.messageCount = 0;
+          meta.windowStart = nowMs;
+        }
+        if (++meta.messageCount > RATE_MAX) {
+          ws.close(1008, "Rate limit");
           return;
         }
-      } catch {}
-      // M1: read-only — ignore all other client messages (rate-limit still applies above)
-    });
+        // Handle token_rotate_ack — purely informational, no state change
+        try {
+          const parsed = JSON.parse(data);
+          if (parsed && parsed.type === "token_rotate_ack") {
+            meta.pendingRotationAcks = 0;
+            console.log(`[mobile-preview] token_rotate_ack from ${meta.ip}`);
+            return;
+          }
+        } catch {}
+        // M1: read-only — ignore all other client messages (rate-limit still applies above)
+      });
 
-    ws.on("close", () => {
-      clients.delete(ws);
-      clientMeta.delete(ws);
-      if (clients.size === 0) stopHeartbeat();
+      ws.on("close", () => {
+        clients.delete(ws);
+        clientMeta.delete(ws);
+        if (clients.size === 0) stopHeartbeat();
+      });
+      ws.on("error", () => {
+        clients.delete(ws);
+        clientMeta.delete(ws);
+      });
     });
-    ws.on("error", () => { clients.delete(ws); clientMeta.delete(ws); });
-  });
   }
 
   function startHeartbeat() {
@@ -317,7 +409,10 @@ function initMobilePreviewServer(ctx) {
       const nowMs = Date.now();
       for (const c of clients) {
         const meta = clientMeta.get(c);
-        if (c.isAlive === false || (meta && nowMs - meta.lastPong > CLIENT_TIMEOUT_MS)) {
+        if (
+          c.isAlive === false ||
+          (meta && nowMs - meta.lastPong > clientTimeoutMs)
+        ) {
           c.terminate();
           clients.delete(c);
           clientMeta.delete(c);
@@ -332,28 +427,37 @@ function initMobilePreviewServer(ctx) {
             continue;
           }
           try {
-            c.send(buildMessage("token_rotate", {
-              newToken: tokenState.token,
-              expiresAt: tokenState.graceUntil,
-            }));
+            c.send(
+              buildMessage("token_rotate", {
+                newToken: tokenState.token,
+                expiresAt: tokenState.graceUntil,
+              }),
+            );
           } catch {}
           meta.pendingRotationAcks++;
         }
         c.isAlive = false;
-        try { c.ping(); } catch {}
+        try {
+          c.ping();
+        } catch {}
       }
       if (clients.size === 0) stopHeartbeat();
     }, HEARTBEAT_MS);
   }
 
   function stopHeartbeat() {
-    if (heartbeatTimer) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer);
+      heartbeatTimer = null;
+    }
   }
 
   function broadcast(message) {
     for (const c of clients) {
       if (c.readyState === WebSocket.OPEN) {
-        try { c.send(message); } catch {}
+        try {
+          c.send(message);
+        } catch {}
       }
     }
   }
@@ -362,7 +466,9 @@ function initMobilePreviewServer(ctx) {
 
   function buildPayload(sid, session) {
     if (!session) return null;
-    const recentEvents = Array.isArray(session.recentEvents) ? session.recentEvents.slice(-10) : [];
+    const recentEvents = Array.isArray(session.recentEvents)
+      ? session.recentEvents.slice(-10)
+      : [];
     return {
       sessionId: sid,
       agentId: session.agentId || null,
@@ -459,12 +565,27 @@ function initMobilePreviewServer(ctx) {
     closed = true;
     sessionCache.clear();
     stopHeartbeat();
-    if (rotationTimer) { clearTimeout(rotationTimer); rotationTimer = null; }
-    for (const c of clients) { try { c.close(1001, "Server shutting down"); } catch {} }
+    if (rotationTimer) {
+      clearTimeout(rotationTimer);
+      rotationTimer = null;
+    }
+    for (const c of clients) {
+      try {
+        c.close(1001, "Server shutting down");
+      } catch {}
+    }
     clients.clear();
     clientMeta.clear();
-    if (wss) { try { wss.close(); } catch {} }
-    if (httpServer) { try { httpServer.close(); } catch {} }
+    if (wss) {
+      try {
+        wss.close();
+      } catch {}
+    }
+    if (httpServer) {
+      try {
+        httpServer.close();
+      } catch {}
+    }
   }
 
   function onSnapshot() {

--- a/test/mobile-preview-server.test.js
+++ b/test/mobile-preview-server.test.js
@@ -7,11 +7,17 @@ const http = require("http");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { initMobilePreviewServer, PROTOCOL_VERSION } = require("../src/network/mobile-preview-server");
+const {
+  initMobilePreviewServer,
+  PROTOCOL_VERSION,
+} = require("../src/network/mobile-preview-server");
 
 function waitForMessage(ws, type, timeoutMs = 5000) {
   return new Promise((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`Timeout waiting for ${type}`)), timeoutMs);
+    const timer = setTimeout(
+      () => reject(new Error(`Timeout waiting for ${type}`)),
+      timeoutMs,
+    );
     const handler = (data) => {
       try {
         const msg = JSON.parse(data);
@@ -48,19 +54,39 @@ function connectClient(port, token) {
       const existing = messages.find((m) => m.type === type);
       if (existing) return Promise.resolve(existing);
       return new Promise((resolve, reject) => {
-        const timer = setTimeout(() => reject(new Error(`Timeout waiting for ${type}`)), timeoutMs);
-        waiters.push({ type, resolve: (msg) => { clearTimeout(timer); resolve(msg); } });
+        const timer = setTimeout(
+          () => reject(new Error(`Timeout waiting for ${type}`)),
+          timeoutMs,
+        );
+        waiters.push({
+          type,
+          resolve: (msg) => {
+            clearTimeout(timer);
+            resolve(msg);
+          },
+        });
       });
     },
-    close() { ws.close(); },
+    close() {
+      ws.close();
+    },
   };
 }
 
 function waitForOpen(ws, timeoutMs = 3000) {
   return new Promise((resolve, reject) => {
-    if (ws.readyState === WebSocket.OPEN) { resolve(); return; }
-    const timer = setTimeout(() => reject(new Error("Timeout waiting for open")), timeoutMs);
-    ws.once("open", () => { clearTimeout(timer); resolve(); });
+    if (ws.readyState === WebSocket.OPEN) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(
+      () => reject(new Error("Timeout waiting for open")),
+      timeoutMs,
+    );
+    ws.once("open", () => {
+      clearTimeout(timer);
+      resolve();
+    });
   });
 }
 
@@ -69,8 +95,14 @@ function waitForPort(getPortFn, timeoutMs = 5000) {
     const start = Date.now();
     const check = () => {
       const p = getPortFn();
-      if (typeof p === "number" && p > 0) { resolve(p); return; }
-      if (Date.now() - start > timeoutMs) { reject(new Error("Timeout waiting for port")); return; }
+      if (typeof p === "number" && p > 0) {
+        resolve(p);
+        return;
+      }
+      if (Date.now() - start > timeoutMs) {
+        reject(new Error("Timeout waiting for port"));
+        return;
+      }
       setTimeout(check, 50);
     };
     check();
@@ -79,19 +111,28 @@ function waitForPort(getPortFn, timeoutMs = 5000) {
 
 function httpGet(port, pathStr) {
   return new Promise((resolve, reject) => {
-    http.get({ hostname: "127.0.0.1", port, path: pathStr }, (res) => {
-      let body = "";
-      res.setEncoding("utf8");
-      res.on("data", (chunk) => { body += chunk; });
-      res.on("end", () => resolve({ status: res.statusCode, body, headers: res.headers }));
-    }).on("error", reject);
+    http
+      .get({ hostname: "127.0.0.1", port, path: pathStr }, (res) => {
+        let body = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => {
+          body += chunk;
+        });
+        res.on("end", () =>
+          resolve({ status: res.statusCode, body, headers: res.headers }),
+        );
+      })
+      .on("error", reject);
   });
 }
 
 function waitForClose(ws, timeoutMs = 3000) {
   return new Promise((resolve) => {
     const timer = setTimeout(() => resolve(null), timeoutMs);
-    ws.on("close", (code) => { clearTimeout(timer); resolve(code); });
+    ws.on("close", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
   });
 }
 
@@ -131,7 +172,9 @@ describe("Mobile Preview Server", () => {
     server.cleanup();
     sessions.clear();
     pendingPermissions = [];
-    try { fs.rmSync(tmpTokenDir, { recursive: true }); } catch {}
+    try {
+      fs.rmSync(tmpTokenDir, { recursive: true });
+    } catch {}
   });
 
   it("protocol version is v1", () => {
@@ -221,7 +264,10 @@ describe("Mobile Preview Server", () => {
     assert.ok(snapshot.sessions["s-titleless"]);
     assert.strictEqual(snapshot.sessions["s-titleless"].agentId, "codex");
     assert.strictEqual(snapshot.sessions["s-titleless"].title, null);
-    assert.strictEqual(typeof snapshot.sessions["s-titleless"].updatedAt, "number");
+    assert.strictEqual(
+      typeof snapshot.sessions["s-titleless"].updatedAt,
+      "number",
+    );
 
     client.close();
     sessions.delete("s-titleless");
@@ -287,7 +333,9 @@ describe("Token Rotation", () => {
   after(() => {
     server.cleanup();
     sessions.clear();
-    try { fs.rmSync(tmpTokenDir, { recursive: true }); } catch {}
+    try {
+      fs.rmSync(tmpTokenDir, { recursive: true });
+    } catch {}
   });
 
   it("grace-period acceptance: old token accepted within grace window", async () => {
@@ -464,7 +512,10 @@ describe("Token Rotation", () => {
     assert.strictEqual(persisted.token, oldToken);
     assert.strictEqual(persisted.previous, null);
     assert.strictEqual(persisted.graceUntil, null);
-    assert.ok(persisted.rotatedAt > 0, "rotatedAt should be set to current time on migration");
+    assert.ok(
+      persisted.rotatedAt > 0,
+      "rotatedAt should be set to current time on migration",
+    );
 
     // Should connect fine
     const client = connectClient(port, loadedToken);
@@ -582,7 +633,10 @@ describe("Token Rotation", () => {
     assert.strictEqual(initial.token, freshToken);
     assert.strictEqual(initial.previous, null);
     assert.strictEqual(initial.graceUntil, null);
-    assert.ok(initial.rotatedAt > 0, "rotatedAt should be set to current time on creation");
+    assert.ok(
+      initial.rotatedAt > 0,
+      "rotatedAt should be set to current time on creation",
+    );
 
     // Regenerate
     const newToken = server.regenerateToken();
@@ -603,7 +657,10 @@ describe("Token Rotation", () => {
 
     // Write a legacy M1 format file (bare { token }, no rotatedAt)
     const legacyToken = "face0ff0".repeat(4);
-    fs.writeFileSync(tokenFile, JSON.stringify({ token: legacyToken }, null, 2));
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify({ token: legacyToken }, null, 2),
+    );
 
     server = initMobilePreviewServer({
       sessions,
@@ -616,10 +673,16 @@ describe("Token Rotation", () => {
     await new Promise((r) => setTimeout(r, 300));
 
     const tokenAfter = server.getToken();
-    assert.strictEqual(tokenBefore, legacyToken,
-      "token should be the legacy token on startup");
-    assert.strictEqual(tokenAfter, legacyToken,
-      "token must not change after brief wait — no immediate rotation");
+    assert.strictEqual(
+      tokenBefore,
+      legacyToken,
+      "token should be the legacy token on startup",
+    );
+    assert.strictEqual(
+      tokenAfter,
+      legacyToken,
+      "token must not change after brief wait — no immediate rotation",
+    );
 
     await new Promise((r) => setTimeout(r, 100));
   });
@@ -652,15 +715,21 @@ describe("Token Rotation", () => {
     // Should receive token_rotate with the new token
     const rotateMsg = await client.waitFor("token_rotate");
     assert.strictEqual(rotateMsg.newToken, newToken);
-    assert.ok(rotateMsg.expiresAt > Date.now(), "expiresAt should be in the future");
+    assert.ok(
+      rotateMsg.expiresAt > Date.now(),
+      "expiresAt should be in the future",
+    );
 
     // Send ack back
     client.ws.send(JSON.stringify({ type: "token_rotate_ack" }));
 
     // Wait through a heartbeat cycle — client should NOT be kicked
     await new Promise((r) => setTimeout(r, 1500));
-    assert.strictEqual(client.ws.readyState, WebSocket.OPEN,
-      "client should stay connected after acking the rotation");
+    assert.strictEqual(
+      client.ws.readyState,
+      WebSocket.OPEN,
+      "client should stay connected after acking the rotation",
+    );
 
     client.close();
     await new Promise((r) => setTimeout(r, 100));
@@ -681,19 +750,28 @@ describe("Rotate-on-use", () => {
 
   after(() => {
     sessions.clear();
-    try { fs.rmSync(tmpTokenDir, { recursive: true }); } catch {}
+    try {
+      fs.rmSync(tmpTokenDir, { recursive: true });
+    } catch {}
   });
 
   it("24h expiry with no clients → rotationPending persisted to disk", async () => {
     const testToken = "aabbccdd".repeat(4);
     // rotatedAt far in the past → timer fires immediately
-    fs.writeFileSync(tokenFile, JSON.stringify({
-      token: testToken,
-      previous: null,
-      graceUntil: null,
-      rotatedAt: 1,
-      rotationPending: false,
-    }, null, 2));
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify(
+        {
+          token: testToken,
+          previous: null,
+          graceUntil: null,
+          rotatedAt: 1,
+          rotationPending: false,
+        },
+        null,
+        2,
+      ),
+    );
 
     const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
     await server.start();
@@ -701,10 +779,16 @@ describe("Rotate-on-use", () => {
     await new Promise((r) => setTimeout(r, 500));
 
     const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
-    assert.strictEqual(persisted.rotationPending, true,
-      "rotationPending should be true when timer fires with no clients");
-    assert.strictEqual(persisted.token, testToken,
-      "token should NOT have changed — no rotation happened");
+    assert.strictEqual(
+      persisted.rotationPending,
+      true,
+      "rotationPending should be true when timer fires with no clients",
+    );
+    assert.strictEqual(
+      persisted.token,
+      testToken,
+      "token should NOT have changed — no rotation happened",
+    );
 
     server.cleanup();
     await new Promise((r) => setTimeout(r, 200));
@@ -713,13 +797,20 @@ describe("Rotate-on-use", () => {
   it("rotationPending=true + client connects → receives token_rotate", async () => {
     const testToken = "11223344".repeat(4);
     const setupRotatedAt = Date.now();
-    fs.writeFileSync(tokenFile, JSON.stringify({
-      token: testToken,
-      previous: null,
-      graceUntil: null,
-      rotatedAt: setupRotatedAt,
-      rotationPending: true,
-    }, null, 2));
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify(
+        {
+          token: testToken,
+          previous: null,
+          graceUntil: null,
+          rotatedAt: setupRotatedAt,
+          rotationPending: true,
+        },
+        null,
+        2,
+      ),
+    );
 
     const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
     const port = await server.start();
@@ -728,17 +819,32 @@ describe("Rotate-on-use", () => {
     await waitForOpen(client.ws);
     const rotateMsg = await client.waitFor("token_rotate");
     assert.ok(rotateMsg.newToken, "should receive new token");
-    assert.notStrictEqual(rotateMsg.newToken, testToken, "new token should differ");
-    assert.ok(rotateMsg.expiresAt > Date.now(), "expiresAt should be in the future");
+    assert.notStrictEqual(
+      rotateMsg.newToken,
+      testToken,
+      "new token should differ",
+    );
+    assert.ok(
+      rotateMsg.expiresAt > Date.now(),
+      "expiresAt should be in the future",
+    );
 
     // rotationPending should be cleared on disk
     const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
-    assert.strictEqual(persisted.rotationPending, false,
-      "rotationPending should be false after on-connect rotation");
-    assert.strictEqual(persisted.token, rotateMsg.newToken,
-      "persisted token should be the new token");
-    assert.ok(persisted.rotatedAt >= setupRotatedAt,
-      "rotatedAt should be updated by on-connect rotation for next 24h timer");
+    assert.strictEqual(
+      persisted.rotationPending,
+      false,
+      "rotationPending should be false after on-connect rotation",
+    );
+    assert.strictEqual(
+      persisted.token,
+      rotateMsg.newToken,
+      "persisted token should be the new token",
+    );
+    assert.ok(
+      persisted.rotatedAt > setupRotatedAt,
+      "rotatedAt should be strictly newer after on-connect rotation",
+    );
 
     client.close();
     server.cleanup();
@@ -747,13 +853,20 @@ describe("Rotate-on-use", () => {
 
   it("rotationPending=true + regenerateToken → clears pending flag", async () => {
     const testToken = "55667788".repeat(4);
-    fs.writeFileSync(tokenFile, JSON.stringify({
-      token: testToken,
-      previous: null,
-      graceUntil: null,
-      rotatedAt: Date.now(),
-      rotationPending: true,
-    }, null, 2));
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify(
+        {
+          token: testToken,
+          previous: null,
+          graceUntil: null,
+          rotatedAt: Date.now(),
+          rotationPending: true,
+        },
+        null,
+        2,
+      ),
+    );
 
     const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
     await server.start();
@@ -762,10 +875,16 @@ describe("Rotate-on-use", () => {
     assert.notStrictEqual(newToken, testToken);
 
     const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
-    assert.strictEqual(persisted.rotationPending, false,
-      "rotationPending should be cleared by regenerateToken");
-    assert.strictEqual(persisted.token, newToken,
-      "persisted token should be the regenerated token");
+    assert.strictEqual(
+      persisted.rotationPending,
+      false,
+      "rotationPending should be cleared by regenerateToken",
+    );
+    assert.strictEqual(
+      persisted.token,
+      newToken,
+      "persisted token should be the regenerated token",
+    );
 
     server.cleanup();
     await new Promise((r) => setTimeout(r, 200));
@@ -773,13 +892,20 @@ describe("Rotate-on-use", () => {
 
   it("server restart with rotationPending=true → no timer, waits for connection", async () => {
     const testToken = "99aabbcc".repeat(4);
-    fs.writeFileSync(tokenFile, JSON.stringify({
-      token: testToken,
-      previous: null,
-      graceUntil: null,
-      rotatedAt: Date.now(),
-      rotationPending: true,
-    }, null, 2));
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify(
+        {
+          token: testToken,
+          previous: null,
+          graceUntil: null,
+          rotatedAt: Date.now(),
+          rotationPending: true,
+        },
+        null,
+        2,
+      ),
+    );
 
     const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
     const port = await server.start();
@@ -788,8 +914,11 @@ describe("Rotate-on-use", () => {
     await new Promise((r) => setTimeout(r, 500));
 
     const beforeConnect = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
-    assert.strictEqual(beforeConnect.token, testToken,
-      "token should not change before a client connects");
+    assert.strictEqual(
+      beforeConnect.token,
+      testToken,
+      "token should not change before a client connects",
+    );
 
     // Now connect — rotation should happen on-connect
     const client = connectClient(port, testToken);
@@ -805,13 +934,20 @@ describe("Rotate-on-use", () => {
 
   it("pending rotation + multiple clients → all receive token_rotate", async () => {
     const testToken = "ddeeff00".repeat(4);
-    fs.writeFileSync(tokenFile, JSON.stringify({
-      token: testToken,
-      previous: null,
-      graceUntil: null,
-      rotatedAt: Date.now(),
-      rotationPending: true,
-    }, null, 2));
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify(
+        {
+          token: testToken,
+          previous: null,
+          graceUntil: null,
+          rotatedAt: Date.now(),
+          rotationPending: true,
+        },
+        null,
+        2,
+      ),
+    );
 
     const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
     const port = await server.start();
@@ -826,12 +962,149 @@ describe("Rotate-on-use", () => {
 
     assert.ok(rotate1.newToken, "client1 should receive new token");
     assert.ok(rotate2.newToken, "client2 should receive new token");
-    assert.strictEqual(rotate1.newToken, rotate2.newToken,
-      "both clients should receive the same new token");
+    assert.strictEqual(
+      rotate1.newToken,
+      rotate2.newToken,
+      "both clients should receive the same new token",
+    );
 
     client1.close();
     client2.close();
     server.cleanup();
     await new Promise((r) => setTimeout(r, 200));
+  });
+
+  it("24h timer fires with frozen clients (stale lastPong) → rotationPending, not immediate rotation", async () => {
+    const testToken = "aabbccdd".repeat(4);
+    const ROTATION_INTERVAL_MS = 24 * 60 * 60 * 1000;
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify(
+        {
+          token: testToken,
+          previous: null,
+          graceUntil: null,
+          rotatedAt: Date.now() - ROTATION_INTERVAL_MS + 300,
+          rotationPending: false,
+        },
+        null,
+        2,
+      ),
+    );
+
+    const server = initMobilePreviewServer({
+      sessions,
+      tokenPath: tokenFile,
+      clientTimeoutMs: 100,
+    });
+    let client;
+    try {
+      const port = await server.start();
+      client = connectClient(port, testToken);
+      await waitForOpen(client.ws);
+      await new Promise((r) => setTimeout(r, 200));
+      await new Promise((r) => setTimeout(r, 200));
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(
+        persisted.rotationPending,
+        true,
+        "rotationPending should be true when all clients have stale lastPong",
+      );
+      assert.strictEqual(
+        persisted.token,
+        testToken,
+        "token should NOT have changed — frozen clients should not trigger rotation",
+      );
+    } finally {
+      if (client) client.close();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 300));
+    }
+  });
+
+  it("24h timer fires with active client → performs rotation immediately", async () => {
+    const testToken = "aabbccdd".repeat(4);
+    const ROTATION_INTERVAL_MS = 24 * 60 * 60 * 1000;
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify(
+        {
+          token: testToken,
+          previous: null,
+          graceUntil: null,
+          rotatedAt: Date.now() - ROTATION_INTERVAL_MS + 300,
+          rotationPending: false,
+        },
+        null,
+        2,
+      ),
+    );
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
+    let client;
+    try {
+      const port = await server.start();
+      client = connectClient(port, testToken);
+      await waitForOpen(client.ws);
+      const rotateMsg = await client.waitFor("token_rotate");
+      assert.ok(rotateMsg.newToken, "should receive new token");
+      assert.notStrictEqual(
+        rotateMsg.newToken,
+        testToken,
+        "new token should differ",
+      );
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(
+        persisted.rotationPending,
+        false,
+        "rotationPending should remain false when rotation was performed",
+      );
+      assert.strictEqual(
+        persisted.token,
+        rotateMsg.newToken,
+        "persisted token should be the new token",
+      );
+    } finally {
+      if (client) client.close();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 300));
+    }
+  });
+
+  it("rotationPending=true + invalid token connect → pending stays unchanged", async () => {
+    const testToken = "aabbccdd".repeat(4);
+    fs.writeFileSync(
+      tokenFile,
+      JSON.stringify(
+        {
+          token: testToken,
+          previous: null,
+          graceUntil: null,
+          rotatedAt: Date.now(),
+          rotationPending: true,
+        },
+        null,
+        2,
+      ),
+    );
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
+    let client;
+    try {
+      const port = await server.start();
+      const badToken = "badbadbad".repeat(4);
+      client = connectClient(port, badToken);
+      await new Promise((r) => setTimeout(r, 500));
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(
+        persisted.rotationPending,
+        true,
+        "rotationPending should stay true when invalid token connects",
+      );
+    } finally {
+      if (client) client.close();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 300));
+    }
   });
 });


### PR DESCRIPTION
Fixes #487

## Problem

`scheduleRotation()` checked `clients.size > 0` to decide whether to rotate immediately or defer. A frozen iOS PWA still has an open TCP socket, so the rotation fired, `token_rotate` was broadcast to a client that couldn't receive it, grace expired on thaw, and the user had to re-pair.

**Trigger window:** phone freezes < 90s before the 24h timer fires (not yet kicked by heartbeat), stays frozen > 5min (past grace). Common for iOS background freeze.

## Fix

Replace the socket-existence check with `hasActiveClients()` which inspects `clientMeta.lastPong` — a client is active only if its last pong was within `CLIENT_TIMEOUT_MS` (90s). Frozen clients are treated as offline: rotation is deferred to `rotationPending` and performed on the next on-connect, same as the zero-clients case.

Also makes `CLIENT_TIMEOUT_MS` injectable via `ctx.clientTimeoutMs` for deterministic testing.

## Tests

- [x] Timer fires with all clients' lastPong expired → `rotationPending`, not immediate rotation
- [x] Timer fires with active client → `performRotation` immediately
- [x] `rotationPending=true` + invalid token connect → pending stays unchanged

---

## 问题

`scheduleRotation()` 用 `clients.size > 0` 判断是否立即轮换。iOS 冻结的 PWA socket 仍然存在（TCP 未断），导致定时器错误地立即轮换——`token_rotate` 广播给了收不到消息的客户端，冻结手机解冻后 grace 已过期，需要重新配对。

**触发窗口：** 手机在 24h 定时器到点前 < 90s 内冻结（还没被心跳踢出）、且冻结持续 > 5min。iOS 后台冻结很常见。

## 修复

将 socket 是否存在的判断替换为 `hasActiveClients()`，通过 `clientMeta.lastPong` 判断客户端是否真正活跃（`now - lastPong < CLIENT_TIMEOUT_MS`）。冻结客户端被视为不在线，轮换挂起为 `rotationPending`，等解冻重连时走 on-connect 当场轮换。

同时将 `CLIENT_TIMEOUT_MS` 改为可注入的 `ctx.clientTimeoutMs`，方便测试。

## 测试

- [x] 定时器到点时所有客户端 `lastPong` 均已过期 → 走挂起，不立即轮换
- [x] 定时器到点时存在活跃客户端 → 正常 `performRotation`
- [x] `rotationPending=true` 时无效 token 连接 → pending 保持不变