### PR TITLE
Fix Windows pet visibility recovery and free-roam target flake

### DIFF
--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -148,7 +148,7 @@ Mini 状态映射：
 
 ## Electron And Platform Notes
 
-- `win.setFocusable(false)`：渲染窗口永不抢焦点
+- `win.setFocusable(false)`：非 Windows 渲染窗口不抢焦点；Windows 保持 focusable 以避免透明置顶窗口被 DWM cloaking 后不可见
 - `hitWin.focusable: true`：输入窗口允许激活，这是修复拖拽 bug 的关键
 - `win.showInactive()`：显示时不打断用户输入
 - 渲染 / 输入窗口都依赖 `backgroundThrottling: false`；unfocused 节流会放大眼球追踪和输入恢复的时序问题

--- a/src/main.js
+++ b/src/main.js
@@ -162,10 +162,12 @@ if (isWin) {
       } catch {
         return false;
       }
-      if (!handle || handle.length < 4) return false;
+      if (!handle || handle.length < 8) return false;
+      const hwnd = handle.readBigUInt64LE(0);
+      if (hwnd === 0n) return false;
       const out = Buffer.alloc(4);
       try {
-        const hr = dwmGetWindowAttribute(handle, 14, out, 4);
+        const hr = dwmGetWindowAttribute(hwnd, 14, out, 4);
         return hr === 0 && out.readInt32LE(0) !== 0;
       } catch {
         return false;

--- a/src/main.js
+++ b/src/main.js
@@ -146,13 +146,33 @@ applyWindowsAppUserModelId(app, process.platform);
 
 // ── Windows: AllowSetForegroundWindow via FFI ──
 let _allowSetForeground = null;
+let _isWindowCloaked = null;
 if (isWin) {
   try {
     const koffi = require("koffi");
     const user32 = koffi.load("user32.dll");
     _allowSetForeground = user32.func("bool __stdcall AllowSetForegroundWindow(int dwProcessId)");
+    const dwmapi = koffi.load("dwmapi.dll");
+    const dwmGetWindowAttribute = dwmapi.func("int __stdcall DwmGetWindowAttribute(void *hwnd, uint dwAttribute, void *pvAttribute, uint cbAttribute)");
+    _isWindowCloaked = (targetWin) => {
+      if (!targetWin || targetWin.isDestroyed()) return false;
+      let handle;
+      try {
+        handle = targetWin.getNativeWindowHandle();
+      } catch {
+        return false;
+      }
+      if (!handle || handle.length < 4) return false;
+      const out = Buffer.alloc(4);
+      try {
+        const hr = dwmGetWindowAttribute(handle, 14, out, 4);
+        return hr === 0 && out.readInt32LE(0) !== 0;
+      } catch {
+        return false;
+      }
+    };
   } catch (err) {
-    console.warn("Clawd: koffi/AllowSetForegroundWindow not available:", err.message);
+    console.warn("Clawd: koffi/Windows window helpers not available:", err.message);
   }
 }
 
@@ -683,6 +703,7 @@ const petWindowRuntime = createPetWindowRuntime({
   reapplyMacVisibility: () => reapplyMacVisibility(),
   reassertWinTopmost: () => reassertWinTopmost(),
   scheduleHwndRecovery: () => scheduleHwndRecovery(),
+  isWindowCloaked: (targetWin) => _isWindowCloaked ? _isWindowCloaked(targetWin) : false,
   isNearWorkAreaEdge: (bounds) => isNearWorkAreaEdge(bounds),
   flushRuntimeStateToPrefs: () => flushRuntimeStateToPrefs(),
   handleMiniDisplayChange: () => _mini.handleDisplayChange(),

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -81,6 +81,7 @@ function createPetWindowRuntime(options = {}) {
   const reapplyMacVisibility = options.reapplyMacVisibility || noop;
   const reassertWinTopmost = options.reassertWinTopmost || noop;
   const scheduleHwndRecovery = options.scheduleHwndRecovery || noop;
+  const isWindowCloaked = options.isWindowCloaked || (() => false);
   const isNearWorkAreaEdge = options.isNearWorkAreaEdge || (() => false);
   const flushRuntimeStateToPrefs = options.flushRuntimeStateToPrefs || noop;
   const handleMiniDisplayChange = options.handleMiniDisplayChange || noop;
@@ -187,14 +188,27 @@ function createPetWindowRuntime(options = {}) {
     return petHidden;
   }
 
+  function isActuallyVisible(win) {
+    return isLiveWindow(win)
+      && (typeof win.isVisible !== "function" || win.isVisible())
+      && !isWindowCloaked(win);
+  }
+
+  function recoverCloakedWindow(win) {
+    if (!isLiveWindow(win) || !isWindowCloaked(win)) return;
+    try { win.hide(); } catch {}
+  }
+
   function showPetWindows() {
     const win = getRenderWindow();
     if (isLiveWindow(win)) {
+      recoverCloakedWindow(win);
       win.showInactive();
       keepOutOfTaskbar(win);
     }
     const hitWin = getHitWindow();
     if (isLiveWindow(hitWin)) {
+      recoverCloakedWindow(hitWin);
       hitWin.showInactive();
       keepOutOfTaskbar(hitWin);
     }
@@ -217,13 +231,18 @@ function createPetWindowRuntime(options = {}) {
     const win = getRenderWindow();
     if (!isLiveWindow(win)) return { applied: false, deferred: false, changed: false };
     if (getMiniTransitioning()) return { applied: false, deferred: true, changed: false };
-    if (target === petHidden) return { applied: true, deferred: false, changed: false };
-    if (petHidden) {
+    const needsVisibleRecovery = !target && !isActuallyVisible(win);
+    if (target === petHidden && !needsVisibleRecovery) return { applied: true, deferred: false, changed: false };
+    const changed = target !== petHidden;
+    if (!target) {
       // becoming visible
       showPetWindows();
       showFloatingSurfacesForPet();
       reapplyMacVisibility();
       petHidden = false;
+      syncHitWin();
+      reassertWinTopmost();
+      scheduleHwndRecovery();
     } else {
       // becoming hidden
       hidePetWindows();
@@ -234,11 +253,12 @@ function createPetWindowRuntime(options = {}) {
     syncPermissionShortcuts();
     buildTrayMenu();
     buildContextMenu();
-    return { applied: true, deferred: false, changed: true };
+    return { applied: true, deferred: false, changed };
   }
 
   function togglePetVisibility() {
-    return setPetHidden(!petHidden);
+    const win = getRenderWindow();
+    return setPetHidden(!(petHidden || !isActuallyVisible(win)));
   }
 
   function bringPetToPrimaryDisplay() {
@@ -459,7 +479,7 @@ function createPetWindowRuntime(options = {}) {
     if (typeof optionsArg.setRenderWindow === "function") {
       optionsArg.setRenderWindow(renderWin);
     }
-    renderWin.setFocusable(false);
+    if (!isWin) renderWin.setFocusable(false);
 
     if (isLinux) {
       renderWin.on("close", (event) => {

--- a/src/roam.js
+++ b/src/roam.js
@@ -22,6 +22,7 @@ const ROAM_SPEED_PX_PER_MS = 0.08;   // 80px/s — slower than mini crabwalk (12
 const ROAM_MIN_DIST = 100;
 const ROAM_MARGIN_RATIO = 0.15;
 const ROAM_FRAME_MS = 16;
+const ROAM_TARGET_ATTEMPTS = 8;
 
 module.exports = function initRoam(ctx) {
   let enabled = false;
@@ -60,13 +61,33 @@ module.exports = function initRoam(ctx) {
     const yMin = wa.y + marginY;
     const yMax = wa.y + wa.height - bounds.height - marginY;
     if (xMax <= xMin || yMax <= yMin) return null;
-    const targetX = xMin + Math.floor(Math.random() * (xMax - xMin));
-    const targetY = yMin + Math.floor(Math.random() * (yMax - yMin));
-    const dx = targetX - bounds.x;
-    const dy = targetY - bounds.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
-    if (dist < ROAM_MIN_DIST) return null;
-    return { x: targetX, y: targetY };
+    for (let i = 0; i < ROAM_TARGET_ATTEMPTS; i += 1) {
+      const targetX = xMin + Math.floor(Math.random() * (xMax - xMin));
+      const targetY = yMin + Math.floor(Math.random() * (yMax - yMin));
+      const dx = targetX - bounds.x;
+      const dy = targetY - bounds.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist >= ROAM_MIN_DIST) return { x: targetX, y: targetY };
+    }
+
+    const fallbackTargets = [
+      { x: xMin, y: yMin },
+      { x: xMax, y: yMin },
+      { x: xMin, y: yMax },
+      { x: xMax, y: yMax },
+    ];
+    let best = null;
+    let bestDist = -1;
+    for (const target of fallbackTargets) {
+      const dx = target.x - bounds.x;
+      const dy = target.y - bounds.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist > bestDist) {
+        best = target;
+        bestDist = dist;
+      }
+    }
+    return bestDist >= ROAM_MIN_DIST ? best : null;
   }
 
   function animateTo(targetX, targetY) {

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -114,6 +114,9 @@ function createRuntime(overrides = {}) {
     reapplyMacVisibility: () => calls.push(["reapplyMacVisibility"]),
     reassertWinTopmost: () => calls.push(["reassertWinTopmost"]),
     scheduleHwndRecovery: () => calls.push(["scheduleHwndRecovery"]),
+    isWindowCloaked: (win) => typeof overrides.isWindowCloaked === "function"
+      ? overrides.isWindowCloaked(win)
+      : false,
     isNearWorkAreaEdge: () => overrides.nearEdge || false,
     flushRuntimeStateToPrefs: () => calls.push(["flushRuntimeStateToPrefs"]),
     handleMiniDisplayChange: () => calls.push(["handleMiniDisplayChange"]),
@@ -198,9 +201,9 @@ describe("pet-window-runtime", () => {
     assert.doesNotMatch(mainSource, /ownedHitWin\.webContents\.reload\(\)/);
   });
 
-  it("creates the render window as non-focusable and materializes the initial virtual bounds", () => {
+  it("keeps non-Windows render windows non-focusable and materializes the initial virtual bounds", () => {
     const instances = [];
-    const harness = createRuntime();
+    const harness = createRuntime({ isWin: false });
 
     harness.runtime.createRenderWindow({
       BrowserWindow: makeBrowserWindow(instances),
@@ -217,16 +220,35 @@ describe("pet-window-runtime", () => {
     assert.deepStrictEqual(instances[0].calls.filter((call) => call[0] === "setFocusable"), [
       ["setFocusable", false],
     ]);
-    assert.deepStrictEqual(instances[0].calls.find((call) => call[0] === "setAlwaysOnTop"), [
-      "setAlwaysOnTop",
-      true,
-      "pop-up-menu",
-    ]);
     assert.deepStrictEqual(instances[0].calls.find((call) => call[0] === "setBounds"), [
       "setBounds",
       { x: 40, y: 0, width: 120, height: 120 },
     ]);
     assert.equal(harness.runtime.getViewportOffsetY(), 25);
+  });
+
+  it("leaves Windows render windows focusable to avoid DWM cloaking", () => {
+    const instances = [];
+    const harness = createRuntime({ isWin: true });
+
+    harness.runtime.createRenderWindow({
+      BrowserWindow: makeBrowserWindow(instances),
+      size: { width: 120, height: 120 },
+      initialWindowBounds: { x: 40, y: 0, width: 120, height: 120 },
+      initialVirtualBounds: { x: 40, y: 0, width: 120, height: 120 },
+      preloadPath: "preload.js",
+      loadFilePath: "index.html",
+      themeConfig: { ok: true },
+      setRenderWindow: harness.setRenderWin,
+      isQuitting: () => false,
+    });
+
+    assert.deepStrictEqual(instances[0].calls.filter((call) => call[0] === "setFocusable"), []);
+    assert.deepStrictEqual(instances[0].calls.find((call) => call[0] === "setAlwaysOnTop"), [
+      "setAlwaysOnTop",
+      true,
+      "pop-up-menu",
+    ]);
   });
 
   it("flushes runtime prefs once during Windows session end", () => {
@@ -458,6 +480,28 @@ describe("pet-window-runtime", () => {
     assert.ok(harness.calls.some((call) => call[0] === "reassertWinTopmost"));
     assert.ok(harness.calls.some((call) => call[0] === "scheduleHwndRecovery"));
     assert.ok(harness.calls.some((call) => call[0] === "flushRuntimeStateToPrefs"));
+  });
+
+  it("treats a cloaked visible Windows pet window as hidden and recovers it", () => {
+    const renderWin = makeWindow();
+    const hitWin = makeWindow();
+    const harness = createRuntime({
+      renderWin,
+      hitWin,
+      isWindowCloaked: (win) => win === renderWin,
+    });
+
+    harness.runtime.togglePetVisibility();
+
+    assert.deepStrictEqual(renderWin.calls.slice(0, 2), [
+      ["hide"],
+      ["showInactive"],
+    ]);
+    assert.ok(!renderWin.calls.some((call) => call[0] === "hide" && renderWin.calls.indexOf(call) > 0));
+    assert.ok(hitWin.calls.some((call) => call[0] === "showInactive"));
+    assert.equal(harness.runtime.isPetHidden(), false);
+    assert.ok(harness.calls.some((call) => call[0] === "reassertWinTopmost"));
+    assert.ok(harness.calls.some((call) => call[0] === "scheduleHwndRecovery"));
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #525.

This PR fixes the two issues tracked in #525:

- recovers Windows pet windows that are logically visible but DWM-cloaked/invisible;
- removes the random free-roam target selection flake that can skip `applyState(roam)`.

## Details

### Windows pet visibility recovery

- Keeps the render window focusable on Windows to avoid transparent topmost-window cloaking issues.
- Adds a DWM cloaking probe via `DwmGetWindowAttribute(DWMWA_CLOAKED)`.
- Treats cloaked windows as not actually visible.
- Forces `hide()` before `showInactive()` when recovering a cloaked render or hit window.
- Re-syncs hit window/topmost recovery when showing a hidden or cloaked pet.

### Free roam target selection

- Retries random target selection a bounded number of times.
- Falls back to the farthest work-area corner when random attempts pick too-close points.
- Returns `null` only when the work area cannot provide a target at least `ROAM_MIN_DIST` away.

## Tests

- `node --test test/pet-window-runtime.test.js`
- `node --test test/roam.test.js`
- `test/roam.test.js` repeated 20 local runs
- `npm.cmd test` passes outside the restricted Windows sandbox