### PR TITLE
fix(tick): re-arm cursor tracking on system resume (#408)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, screen, ipcMain, globalShortcut, nativeTheme, dialog, shell, nativeImage, powerSaveBlocker, clipboard } = require("electron");
+const { app, BrowserWindow, screen, ipcMain, globalShortcut, nativeTheme, dialog, shell, nativeImage, powerSaveBlocker, powerMonitor, clipboard } = require("electron");
 // ── Linux/Wayland: relaunch under XWayland so the pet is draggable (issue #441) ──
 // Native Wayland ignores client-side window positioning and blocks global cursor
 // queries, so the pet spawns centered, can't be dragged, and has no tracking;
@@ -3296,6 +3296,47 @@ function createWindow() {
   screen.on("display-metrics-changed", () => petWindowRuntime.handleDisplayMetricsChanged());
   screen.on("display-removed", () => petWindowRuntime.handleDisplayRemoved());
   screen.on("display-added", () => petWindowRuntime.handleDisplayAdded());
+
+  // #408: nothing else in the app listens for the power lifecycle, so after a
+  // system suspend the pet's passive cursor-tracking chain is left un-armed —
+  // the main tick, the wake poll, the low-power mirror, or the renderer can
+  // each be left stale, and the eyes stop following the cursor until an
+  // unrelated event (drag / state change) happens to re-arm one of them.
+  // Re-arm every candidate on resume. The exact stale component can't be
+  // pinned from code, so we cover all of them AND log diagnostics (state at
+  // wake, low-power flag, tick staleness) that help narrow which one it was on
+  // a real-machine wake — they won't rule out every candidate (renderer rAF,
+  // powerMonitor event ordering, display settle), but they point at the most
+  // likely one. Debounced + idempotent: Windows fires resume/unlock-screen in
+  // bursts and can repeat them.
+  let systemWakeDebounceTimer = null;
+  const handleSystemWake = (trigger) => {
+    if (systemWakeDebounceTimer) return;
+    systemWakeDebounceTimer = setTimeout(() => { systemWakeDebounceTimer = null; }, 500);
+    try {
+      const stateAtWake = _state.getCurrentState();
+      const lowPowerAtWake = lowPowerIdlePaused;
+      const tickDiag = _tick.forceMainTickNow();
+      setLowPowerIdlePaused(false);
+      setForceEyeResend(true);
+      const nudgedFrom = _state.resumeFromSystemWake();
+      sessionLog(
+        `system-wake trigger=${trigger} stateAtWake=${stateAtWake} ` +
+        `lowPowerPausedAtWake=${lowPowerAtWake ? 1 : 0} ` +
+        `tickActive=${tickDiag.wasActive ? 1 : 0} tickHadTimer=${tickDiag.hadTimer ? 1 : 0} ` +
+        `tickOverdueMs=${tickDiag.overdueMs == null ? "-" : tickDiag.overdueMs} ` +
+        `nudgedFrom=${nudgedFrom || "-"}`
+      );
+    } catch (err) {
+      safeConsoleError("Clawd: system-wake handler failed:", err && err.message);
+    }
+  };
+  try {
+    powerMonitor.on("resume", () => handleSystemWake("resume"));
+    powerMonitor.on("unlock-screen", () => handleSystemWake("unlock-screen"));
+  } catch (err) {
+    safeConsoleError("Clawd: failed to register powerMonitor wake handlers:", err && err.message);
+  }
 
   // textScale is per-display: when the topology changes, window→display
   // mappings (and therefore effective scales) can change wholesale. Debounced

--- a/src/state.js
+++ b/src/state.js
@@ -660,6 +660,34 @@ function wakeFromDoze() {
   }, 350);
 }
 
+// System resume / unlock-screen (#408): the pet may be parked in a
+// sleep-sequence state whose only exit is a timer — the wake-poll setInterval,
+// or yawning's autoReturnTimer — that an OS suspend can leave stalled, so it
+// never tracks the cursor again. Nudge it awake from any parked sleep state.
+// We act ONLY from a sleep state (never from a non-sleep one), so we don't add
+// a resolve on top of whatever the pet is already showing. The
+// dozing/sleeping/collapsing path reuses the exact wake transition a real
+// cursor wake plays — including its eventual session resolve — so it is not a
+// new sound source, just the normal wake. yawning has no wake poll and no
+// waking transition, so send it straight back to the cursor-following idle
+// base. Returns the state we nudged from, else null (nothing parked → the wake
+// handler's tick re-arm covers it).
+function resumeFromSystemWake() {
+  if (ctx.doNotDisturb) return null;
+  const from = currentState;
+  if (from === "yawning") {
+    // applyState("idle") clears the pending yawning→dozing autoReturnTimer.
+    applyState("idle", SVG_IDLE_FOLLOW);
+    return from;
+  }
+  if (from === "dozing" || from === "sleeping" || from === "collapsing") {
+    stopWakePoll();
+    wakeFromDoze();
+    return from;
+  }
+  return null;
+}
+
 function pickDisplayHint(state, existing, incoming) {
   return pickDisplayHintWithMap(state, existing, incoming, DISPLAY_HINT_MAP);
 }
@@ -2002,7 +2030,7 @@ return {
   setState, applyState, updateSession, resolveDisplayState, resolveVisualBinding, setUpdateVisualState,
   shouldDropForDnd,
   enableDoNotDisturb, disableDoNotDisturb,
-  startStaleCleanup, stopStaleCleanup, startWakePoll, stopWakePoll,
+  startStaleCleanup, stopStaleCleanup, startWakePoll, stopWakePoll, resumeFromSystemWake,
   getSvgOverride, cleanStaleSessions, startStartupRecovery, refreshTheme,
   detectRunningAgentProcesses, buildSessionSnapshot,
   emitSessionSnapshot, broadcastSessionSnapshot, getLastSessionSnapshot,

--- a/src/tick.js
+++ b/src/tick.js
@@ -104,6 +104,29 @@ function scheduleSoon(maxDelay = BOOST_TICK_MS) {
   }
 }
 
+// Hard re-arm entry for system resume / unlock-screen (#408). Unlike
+// scheduleSoon(), this ignores the existing-timer guard: after an OS suspend a
+// pending setTimeout can be left non-null yet never fire, and scheduleSoon()
+// would refuse to replace such a "due soon" timer. We clear the cursor
+// baseline so the first post-wake movement registers as moved. Returns
+// pre-rearm diagnostics so the wake handler can log whether the tick was the
+// stale component (overdueMs large = the timer never fired during suspend).
+function forceMainTickNow() {
+  const diag = {
+    wasActive: mainTickActive,
+    hadTimer: !!mainTickTimer,
+    overdueMs: nextMainTickAt ? Math.max(0, Date.now() - nextMainTickAt) : null,
+  };
+  lastCursorX = null;
+  lastCursorY = null;
+  if (mainTickActive) {
+    scheduleNextTick(0);
+  } else {
+    startMainTick();
+  }
+  return diag;
+}
+
 function getPointerBridgeKey() {
   const state = ctx.currentState;
   if (!POINTER_BRIDGE_STATES.has(state)) return null;
@@ -379,6 +402,6 @@ Object.defineProperty(startMainTick, '_mouseStillSince', {
   get() { return mouseStillSince; },
 });
 
-return { startMainTick, resetIdleTimer, cleanup, refreshTheme, scheduleSoon, get _mouseStillSince() { return mouseStillSince; } };
+return { startMainTick, resetIdleTimer, cleanup, refreshTheme, scheduleSoon, forceMainTickNow, get _mouseStillSince() { return mouseStillSince; } };
 
 };

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -3299,3 +3299,67 @@ describe("antigravity trailing PostToolUse filter", () => {
     assert.ok(after.lastToolBoundaryAt > after.lastStopAt, "new turn should refresh tool boundary after Stop");
   });
 });
+
+describe("resumeFromSystemWake (#408 system wake)", () => {
+  let ctx;
+  let api;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx();
+    api = require("../src/state")(ctx);
+  });
+
+  afterEach(() => {
+    api.cleanup();
+    mock.timers.reset();
+  });
+
+  it("wakes a yawning pet straight back to idle (#408 narrow window)", () => {
+    // yawning has no wake poll and its only exit is a (suspend-stalled)
+    // autoReturnTimer, so it must be handled explicitly.
+    api.applyState("yawning");
+    assert.equal(api.getCurrentState(), "yawning");
+
+    const from = api.resumeFromSystemWake();
+    assert.equal(from, "yawning");
+    assert.equal(api.getCurrentState(), "idle");
+  });
+
+  it("routes a dozing pet through the wake path back to idle", () => {
+    api.applyState("dozing");
+    assert.equal(api.getCurrentState(), "dozing");
+
+    const from = api.resumeFromSystemWake();
+    assert.equal(from, "dozing");
+
+    mock.timers.tick(400); // wakeFromDoze settles dozing → idle after ~350ms
+    assert.equal(api.getCurrentState(), "idle");
+  });
+
+  it("plays the wake transition for a sleeping pet, then resolves to idle", () => {
+    api.applyState("sleeping");
+    assert.equal(api.getCurrentState(), "sleeping");
+
+    const from = api.resumeFromSystemWake();
+    assert.equal(from, "sleeping");
+    // clawd (full sleep mode) plays its waking transition, then auto-returns to
+    // the resolved display state (idle with no active sessions).
+    assert.equal(api.getCurrentState(), "waking");
+    mock.timers.tick(1600); // > wakeDuration (1500)
+    assert.equal(api.getCurrentState(), "idle");
+  });
+
+  it("is a no-op when the pet is not parked in a sleep state", () => {
+    assert.equal(api.getCurrentState(), "idle");
+    assert.equal(api.resumeFromSystemWake(), null);
+    assert.equal(api.getCurrentState(), "idle");
+  });
+
+  it("does nothing under Do Not Disturb", () => {
+    api.applyState("sleeping");
+    ctx.doNotDisturb = true;
+    assert.equal(api.resumeFromSystemWake(), null);
+    assert.equal(api.getCurrentState(), "sleeping");
+  });
+});

--- a/test/tick.test.js
+++ b/test/tick.test.js
@@ -547,3 +547,93 @@ describe("tick adaptive polling", () => {
     assert.equal(cursorCalls, callsAfterEyeMove + 1);
   });
 });
+
+describe("tick forceMainTickNow (system wake re-arm)", () => {
+  let cursor;
+  let cursorCalls;
+  let loader;
+  let tickApi;
+  let ctx;
+  let statesSeen;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    cursor = { x: 40, y: 40 };
+    cursorCalls = 0;
+    loader = loadTickWithScreen(() => {
+      cursorCalls++;
+      return { ...cursor };
+    });
+    statesSeen = [];
+  });
+
+  afterEach(() => {
+    if (tickApi) tickApi.cleanup();
+    if (loader) loader.restore();
+    mock.timers.reset();
+    tickApi = null;
+    ctx = null;
+  });
+
+  it("revives an inactive loop and polls immediately", () => {
+    ctx = makeCtx(cloneTheme(_defaultTheme), statesSeen);
+    tickApi = loader.initTick(ctx);
+    // loop never started → inactive, no pending timer; scheduleSoon() would
+    // no-op here, so the wake handler relies on this hard entry instead.
+    const diag = tickApi.forceMainTickNow();
+    assert.equal(diag.wasActive, false);
+    assert.equal(diag.hadTimer, false);
+    assert.equal(diag.overdueMs, null);
+
+    mock.timers.tick(1);
+    assert.ok(cursorCalls > 0, "forceMainTickNow should start the loop and poll");
+  });
+
+  it("hard re-arms an active idle loop, pulling the next poll forward", () => {
+    ctx = makeCtx(cloneTheme(_defaultTheme), statesSeen);
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+    mock.timers.tick(3000); // settle into the slow (~250ms) idle cadence
+
+    const diag = tickApi.forceMainTickNow();
+    assert.equal(diag.wasActive, true);
+    assert.equal(diag.hadTimer, true);
+    assert.equal(typeof diag.overdueMs, "number"); // pending future timer → 0 here
+
+    const before = cursorCalls;
+    mock.timers.tick(5); // 5ms ≪ idle cadence: only the delay-0 re-armed tick can fire
+    assert.ok(cursorCalls > before, "forceMainTickNow should pull the next poll forward");
+  });
+
+  it("reports a large overdueMs when the pending tick was frozen by suspend", () => {
+    ctx = makeCtx(cloneTheme(_defaultTheme), statesSeen);
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+    mock.timers.tick(3000); // establish a pending idle timer
+
+    // Simulate an OS suspend: wall clock jumps far forward but the pending
+    // setTimeout never fires (setTime moves Date without running timers).
+    mock.timers.setTime(Date.now() + 100000);
+
+    const diag = tickApi.forceMainTickNow();
+    assert.ok(diag.overdueMs >= 50000, `expected large overdueMs, got ${diag.overdueMs}`);
+  });
+
+  it("re-arms mini-sleep so a hovering cursor still triggers peek on wake", () => {
+    // mini-sleep has no wake poll, but mini mode keeps cursor-polling, so the
+    // tick re-arm alone is enough to recover peek-on-hover after resume.
+    let peekInCalls = 0;
+    ctx = makeCtx(cloneTheme(_defaultTheme), statesSeen);
+    ctx.miniMode = true;
+    ctx.currentState = "mini-sleep";
+    ctx.miniPeekIn = () => { peekInCalls++; };
+    cursor = { x: 40, y: 40 }; // inside the default hit rect (0..120)
+    tickApi = loader.initTick(ctx);
+
+    tickApi.forceMainTickNow(); // wake path: hard re-arm (not normal startMainTick)
+    mock.timers.tick(60);
+
+    assert.equal(peekInCalls, 1);
+    assert.equal(ctx.miniSleepPeeked, true);
+  });
+});


### PR DESCRIPTION
Part of #408 — addresses the **"eyes stop following the cursor after sleep/wake"** half (Windows 11, real-machine reproduced by a contributor). The separate *"pet grows after sleep"* size bug is **not** in this PR (scale-factor dependent; will be its own PR).

## Problem
Nothing in the app listened for the power lifecycle, so after a system suspend the pet's passive cursor-tracking chain — main tick / wake poll / low-power mirror / renderer — could each be left stale. The render window is permanently click-through, so passive mouse *movement* produces no IPC; eye tracking depends entirely on the main-process polling loop, which is never re-armed on resume. Drag / state-change incidentally re-arm it; plain mouse movement cannot — matching the report ("eyes don't follow until you drag it or it enters the next state").

## Fix
A `powerMonitor` `resume` + `unlock-screen` handler (debounced, registered once in `createWindow`). The exact stale component can't be pinned from code, so it re-arms every candidate:

- **`tick.forceMainTickNow()`** — hard re-arm that bypasses `scheduleSoon()`'s existing-timer guard (a suspended `setTimeout` can be left non-null yet never fire), resets the cursor baseline, and returns staleness diagnostics.
- **`setLowPowerIdlePaused(false)` + `setForceEyeResend(true)`**.
- **`state.resumeFromSystemWake()`** — nudges out of a parked sleep state: `yawning` → idle directly (it has no wake poll and its only exit is a suspend-stallable `autoReturnTimer`); `dozing`/`sleeping`/`collapsing` via the existing `wakeFromDoze` path. Gated to `!DND` and sleep states only, so it never adds a resolve on top of an active session.

A diagnostic line is written to `session-debug.log` on each wake (`stateAtWake`, `lowPowerPausedAtWake`, `tickActive/HadTimer/OverdueMs`, `nudgedFrom`) to help narrow which component was stale on a real machine.

## Tests
- `forceMainTickNow`: inactive revive / active pull-forward / overdue reporting / mini-sleep re-arm.
- `resumeFromSystemWake`: yawning / dozing / sleeping→waking→idle / no-op / DND.
- Full suite: **4089 pass, 0 fail** (`node test/run-tests.js`).

Cross-checked across three review rounds (external Codex reviewer): the `yawning` gap caught in round 2 is fixed here with coverage; no source-level bugs flagged in round 3.

## ⚠️ Needs real-machine verification before merge
Per project policy (don't merge platform fixes on CI/review alone), please confirm on a real Windows machine: sleep/wake → eyes follow again, and check the `system-wake` line in `session-debug.log`. The debounce is currently **leading-edge only**; Windows resume/unlock/display-settle ordering may warrant a leading+trailing tweak depending on what the real-machine log shows.