### PR TITLE
feat(settings): use inline SVG sidebar icons instead of emoji glyphs

### DIFF
--- a/src/settings-icons.js
+++ b/src/settings-icons.js
@@ -1,0 +1,103 @@
+"use strict";
+// Settings sidebar icons — inline SVG strings keyed by tab id.
+//
+// All icons use a 24x24 viewBox, `stroke="currentColor"`, fill="none",
+// stroke-width 1.5, so they inherit the sidebar text color (works in
+// both light and dark mode) and visually match each other.
+//
+// Why inline SVG and not <img src="...">?
+//  - The settings renderer innerHTMLs the icon string in place; inline
+//    SVG side-steps any path resolution (asar / file://) that bites
+//    packaged builds.
+//  - Each icon is small (~200-500 bytes); the whole file weighs <5 KB.
+//
+// Keys must match the sidebar tab ids in settings-renderer.js. Unknown
+// ids fall back to `placeholder`.
+
+const ICONS = {
+  // gear
+  general:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<path d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"/>' +
+    '<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"/>' +
+    '</svg>',
+
+  // bolt
+  agents:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<path d="M13 2 3 14h7l-1 8 10-12h-7l1-8Z"/>' +
+    '</svg>',
+
+  // palette
+  theme:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<path d="M12 22a10 10 0 1 1 10-10c0 2.5-2 4-4 4h-2a2 2 0 0 0-1 3.7A2 2 0 0 1 12 22Z"/>' +
+    '<circle cx="7.5" cy="10.5" r="1" fill="currentColor"/>' +
+    '<circle cx="12" cy="7.5" r="1" fill="currentColor"/>' +
+    '<circle cx="16.5" cy="10.5" r="1" fill="currentColor"/>' +
+    '</svg>',
+
+  // clapperboard
+  animMap:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<rect x="2" y="7" width="20" height="13" rx="2"/>' +
+    '<path d="m4 7 3-4M10 7l3-4M16 7l3-4"/>' +
+    '</svg>',
+
+  // film strip
+  animOverrides:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<rect x="3" y="4" width="18" height="16" rx="2"/>' +
+    '<path d="M7 4v16M17 4v16"/>' +
+    '<path d="M3 9h4M17 9h4M3 15h4M17 15h4"/>' +
+    '</svg>',
+
+  // keyboard
+  shortcuts:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<rect x="2" y="6" width="20" height="12" rx="2"/>' +
+    '<path d="M6 10h.01M10 10h.01M14 10h.01M18 10h.01M6 14h12"/>' +
+    '</svg>',
+
+  // paper plane (send)
+  "telegram-approval":
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<path d="M22 2 11 13"/>' +
+    '<path d="M22 2 15 22l-4-9-9-4 20-7Z"/>' +
+    '</svg>',
+
+  // plug
+  "remote-ssh":
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<path d="M9 2v6M15 2v6"/>' +
+    '<path d="M7 8h10v3a5 5 0 0 1-5 5 5 5 0 0 1-5-5V8Z"/>' +
+    '<path d="M12 16v6"/>' +
+    '</svg>',
+
+  // smartphone
+  mobile:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<rect x="5" y="2" width="14" height="20" rx="2"/>' +
+    '<path d="M12 18h.01"/>' +
+    '</svg>',
+
+  // info circle
+  about:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<circle cx="12" cy="12" r="9"/>' +
+    '<path d="M12 11v6M12 7.5v.01"/>' +
+    '</svg>',
+
+  // wrench (placeholder when a tab is missing one)
+  placeholder:
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" width="100%" height="100%">' +
+    '<path d="m14.5 5.5 4 4-9 9-4 .5.5-4 8.5-9.5Z"/>' +
+    '<path d="m18.5 5.5-3 3"/>' +
+    '</svg>',
+};
+
+function getIcon(id) {
+  return ICONS[id] || ICONS.placeholder;
+}
+
+globalThis.ClawdSettingsIcons = { getIcon, ICONS };

--- a/src/settings-renderer.js
+++ b/src/settings-renderer.js
@@ -2,18 +2,27 @@
 
 const core = globalThis.ClawdSettingsCore;
 
+// Icons resolve via settings-icons.js at render time (keyed by tab id),
+// not as emoji/unicode glyphs \u2014 those rendered inconsistently across
+// system fonts and didn't dark-mode well.
 const SIDEBAR_TABS = [
-  { id: "general", icon: "\u2699", labelKey: "sidebarGeneral", available: true },
-  { id: "agents", icon: "\u26A1", labelKey: "sidebarAgents", available: true },
-  { id: "theme", icon: "\u{1F3A8}", labelKey: "sidebarTheme", available: true },
-  { id: "animMap", icon: "\u{1F3AC}", labelKey: "sidebarAnimMap", available: true },
-  { id: "animOverrides", icon: "\u{1F39E}", labelKey: "sidebarAnimOverrides", available: true },
-  { id: "shortcuts", icon: "\u2328", labelKey: "sidebarShortcuts", available: true },
-  { id: "telegram-approval", icon: "\u2708", labelKey: "sidebarTelegramApproval", available: true },
-  { id: "remote-ssh", icon: "\u{1F50C}", labelKey: "sidebarRemoteSsh", available: true },
-  { id: "mobile", icon: "\u{1F4F1}", labelKey: "sidebarMobile", available: true },
-  { id: "about", icon: "\u2139", labelKey: "sidebarAbout", available: true },
+  { id: "general", labelKey: "sidebarGeneral", available: true },
+  { id: "agents", labelKey: "sidebarAgents", available: true },
+  { id: "theme", labelKey: "sidebarTheme", available: true },
+  { id: "animMap", labelKey: "sidebarAnimMap", available: true },
+  { id: "animOverrides", labelKey: "sidebarAnimOverrides", available: true },
+  { id: "shortcuts", labelKey: "sidebarShortcuts", available: true },
+  { id: "telegram-approval", labelKey: "sidebarTelegramApproval", available: true },
+  { id: "remote-ssh", labelKey: "sidebarRemoteSsh", available: true },
+  { id: "mobile", labelKey: "sidebarMobile", available: true },
+  { id: "about", labelKey: "sidebarAbout", available: true },
 ];
+
+function getTabIcon(tabId) {
+  const icons = globalThis.ClawdSettingsIcons;
+  if (icons && typeof icons.getIcon === "function") return icons.getIcon(tabId);
+  return "";
+}
 
 function renderSidebar() {
   const sidebar = document.getElementById("sidebar");
@@ -30,8 +39,10 @@ function renderSidebar() {
     item.className = "sidebar-item";
     if (!tab.available) item.classList.add("disabled");
     if (tab.id === core.state.activeTab) item.classList.add("active");
+    // Icon HTML is trusted (it comes from our own settings-icons.js
+    // module, not user input), so we drop it in as-is.
     item.innerHTML =
-      `<span class="sidebar-item-icon">${tab.icon}</span>` +
+      `<span class="sidebar-item-icon">${getTabIcon(tab.id)}</span>` +
       `<span class="sidebar-item-label">${core.helpers.escapeHtml(core.helpers.t(tab.labelKey))}</span>` +
       (tab.available ? "" : `<span class="sidebar-item-soon">${core.helpers.escapeHtml(core.helpers.t("sidebarSoon"))}</span>`);
     if (tab.available) {
@@ -47,7 +58,7 @@ function renderPlaceholder(parent) {
   const div = document.createElement("div");
   div.className = "placeholder";
   div.innerHTML =
-    `<div class="placeholder-icon">\u{1F6E0}</div>` +
+    `<div class="placeholder-icon">${getTabIcon("placeholder")}</div>` +
     `<div class="placeholder-title">${core.helpers.escapeHtml(core.helpers.t("placeholderTitle"))}</div>` +
     `<div class="placeholder-desc">${core.helpers.escapeHtml(core.helpers.t("placeholderDesc"))}</div>`;
   parent.appendChild(div);

--- a/src/settings.css
+++ b/src/settings.css
@@ -107,9 +107,9 @@ html, body {
   height: 18px;
   align-items: center;
   justify-content: center;
-  font-size: 14px;
   flex-shrink: 0;
 }
+.sidebar-item-icon svg { display: block; width: 100%; height: 100%; }
 .sidebar-item-label { flex: 1; }
 .sidebar-item-soon {
   font-size: 10px;
@@ -1271,10 +1271,13 @@ html, body {
   color: var(--text-tertiary);
 }
 .placeholder-icon {
-  font-size: 36px;
+  width: 48px;
+  height: 48px;
   margin-bottom: 12px;
   opacity: 0.5;
+  color: var(--text-secondary);
 }
+.placeholder-icon svg { width: 100%; height: 100%; }
 .placeholder-title {
   font-size: 16px;
   font-weight: 600;

--- a/src/settings.html
+++ b/src/settings.html
@@ -31,6 +31,7 @@
 <script src="settings-tab-remote-ssh.js"></script>
 <script src="settings-tab-mobile.js"></script>
 <script src="settings-doctor-modal.js"></script>
+<script src="settings-icons.js"></script>
 <script src="settings-renderer.js"></script>
 </body>
 </html>

--- a/test/settings-icons.test.js
+++ b/test/settings-icons.test.js
@@ -1,0 +1,83 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const SRC_DIR = path.join(__dirname, "..", "src");
+const SETTINGS_ICONS = path.join(SRC_DIR, "settings-icons.js");
+const SETTINGS_RENDERER = path.join(SRC_DIR, "settings-renderer.js");
+
+function loadIcons() {
+  const context = { globalThis: null };
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(SETTINGS_ICONS, "utf8"), context);
+  return context.ClawdSettingsIcons;
+}
+
+// The sidebar tab ids declared in settings-renderer.js — every one of
+// these must resolve to a real icon, not the placeholder fallback.
+const SIDEBAR_TAB_IDS = [
+  "general",
+  "agents",
+  "theme",
+  "animMap",
+  "animOverrides",
+  "shortcuts",
+  "telegram-approval",
+  "remote-ssh",
+  "mobile",
+  "about",
+];
+
+describe("settings-icons", () => {
+  it("exposes a getIcon helper on globalThis", () => {
+    const icons = loadIcons();
+    assert.ok(icons, "ClawdSettingsIcons should be defined");
+    assert.strictEqual(typeof icons.getIcon, "function");
+  });
+
+  it("returns a currentColor inline SVG for every sidebar tab", () => {
+    const icons = loadIcons();
+    for (const id of SIDEBAR_TAB_IDS) {
+      const svg = icons.getIcon(id);
+      assert.ok(svg.startsWith("<svg"), `${id} should be an inline SVG`);
+      assert.ok(
+        svg.includes('stroke="currentColor"') || svg.includes('fill="currentColor"'),
+        `${id} icon should use currentColor so it follows light/dark text color`
+      );
+      // No raw emoji/unicode glyphs left behind.
+      assert.ok(!/[\u{1F000}-\u{1FAFF}\u{2600}-\u{27BF}]/u.test(svg), `${id} should not contain emoji`);
+    }
+  });
+
+  it("does not fall back to placeholder for known tabs", () => {
+    const icons = loadIcons();
+    const placeholder = icons.getIcon("placeholder");
+    for (const id of SIDEBAR_TAB_IDS) {
+      assert.notStrictEqual(icons.getIcon(id), placeholder, `${id} should have its own icon`);
+    }
+  });
+
+  it("falls back to placeholder for unknown ids", () => {
+    const icons = loadIcons();
+    assert.strictEqual(icons.getIcon("no-such-tab-xyz"), icons.getIcon("placeholder"));
+  });
+
+  it("covers every tab id used by the settings renderer", () => {
+    const icons = loadIcons();
+    const rendererSource = fs.readFileSync(SETTINGS_RENDERER, "utf8");
+    // Guard against a tab being added to the renderer without an icon:
+    // each id in our list must really appear in the renderer source.
+    for (const id of SIDEBAR_TAB_IDS) {
+      assert.ok(
+        rendererSource.includes(`id: "${id}"`),
+        `settings-renderer.js should declare a tab with id "${id}"`
+      );
+      assert.ok(icons.ICONS[id], `settings-icons.js should define an icon for "${id}"`);
+    }
+  });
+});

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -1232,6 +1232,7 @@ describe("settings renderer browser environment", () => {
       "settings-tab-about.js",
       "settings-tab-remote-ssh.js",
       "settings-doctor-modal.js",
+      "settings-icons.js",
       "settings-renderer.js",
     ];
 


### PR DESCRIPTION
## 做了什么
Settings 侧栏 10 个 tab 原来用裸 emoji/unicode 字形（⚙⚡🎨…），跨系统字体渲染不一致、彩色与 UI 不搭、不跟随深色模式。改为新模块 `src/settings-icons.js` 的内联 SVG 图标表（`stroke=currentColor`，24×24），按 tab id 解析。

- `settings-renderer.js` 通过 `getTabIcon(id)` 取图标，移除 emoji 字段；模块缺失时返回空串（cosmetic 降级，不崩）
- `settings.html` 在 `settings-renderer.js` 之前加载 `settings-icons.js`
- `settings.css` 给侧栏 / placeholder 的内联 SVG 定尺寸
- 新画了 `telegram-approval`（纸飞机）和 `mobile`（手机）两个图标（源 fork 没有这俩 tab）

## 验证
- 新增 `test/settings-icons.test.js`；脚本顺序测试覆盖新模块加载顺序
- 本地全套 **4116 测试通过、0 失败**
- 真机：Settings 侧栏图标显示正常、对齐、明暗模式 OK
- Codex(云宝) review：**无阻塞**（信任边界 / 加载顺序 / CSS 依赖均核过）

> 注：本仓库 PR 无 CI（wayland-smoke 仅 linux-ozone 路径触发）。