### PR TITLE
fix(renderer): cache-bust object-channel SVG loads too

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -827,7 +827,14 @@ function swapToFile(file, state, useObjectChannel, options = {}) {
     };
 
     next.addEventListener("load", swap, { once: true });
-    next.data = url;
+    // Same cache-bust as the <img> channel below. Chromium reuses the SVG
+    // document (and its CSS animation timeline) across loads of the same
+    // URL on the object channel too, so one-shot animations for scripted /
+    // eye-tracking SVGs would stall on their last frame on re-entry. A fresh
+    // query each swap forces a fresh document. Bookkeeping (currentDisplayed
+    // /pendingAssetUrl) stays keyed on the base `url`, not the busted one.
+    const cacheBust = `${Date.now()}-${++_imgCacheBustSeq}`;
+    next.data = `${url}${url.includes("?") ? "&" : "?"}_t=${cacheBust}`;
     container.appendChild(next);
     pendingNext = next;
     scheduleSwapVisibilityRescue(swapToken, file, state);


### PR DESCRIPTION
## 做了什么
`<img>` 通道早就给 SVG 加 `?_t=` 防 Chromium 复用 SVG 文档 / 动画时间线（一次性动画卡末帧，AGENTS.md 明确不能删）。但 object 通道（眼追 / 脚本化 SVG）之前 `next.data = url` 没这个 bust，重进同一状态可能卡末帧或不重播。补上同样的 monotonic cache-bust（与 img 通道共用 `_imgCacheBustSeq`）。

## 为什么安全
- 账本仍存 base url：`currentDisplayedAssetUrl` / dedup 比的都是不带 `_t=` 的 url
- `getObjectSvgName()` 用 `split(/[?#]/)[0]` 剥掉 query，文件名解析不受影响
- pet 窗口 CSP `default-src 'self' file:` 覆盖带查询串的 object 加载
- fallback 行为不变（3s 无 contentDocument → 回 img channel）
- 眼追 / Cloudling pointer 是在现有文档内改 transform，不是每帧 swap，无每帧重载

## 验证
- 本地全套 **4116 测试通过、0 失败**
- 真机：Cloudling 眼追能干净重播、不卡末帧
- Codex(云宝) review：**无阻塞**（调用链 file:line 核过）
- Follow-up（非阻塞）：object 分支「data 带 `_t=` + pendingAssetUrl 仍为 base」回归断言

> 注：本仓库 PR 无 CI（wayland-smoke 仅 linux-ozone 路径触发）。