### PR TITLE
Back up settings.json before injecting hooks

### DIFF
--- a/hooks/install.js
+++ b/hooks/install.js
@@ -781,8 +781,10 @@ function registerHooks(options = {}) {
 
   // Read existing settings
   let settings = {};
+  let preExisting = false;
   try {
     settings = JSON.parse(fs.readFileSync(settingsPath, "utf-8"));
+    preExisting = true;
   } catch (err) {
     if (err.code !== "ENOENT") {
       throw new Error(`Failed to read settings.json: ${err.message}`);
@@ -961,8 +963,23 @@ function registerHooks(options = {}) {
   }
 
   // Only write if something changed (avoid unnecessary disk I/O)
+  let backupPath = null;
   if (added > 0 || changed) {
-    writeJsonAtomic(settingsPath, settings);
+    // Snapshot the user's prior settings before mutating so the install is
+    // recoverable. Atomic write prevents a half-written file, not an undo —
+    // and we inject hooks into a shared global config the user did not author.
+    // Only back up a file that already existed; opt out with `backup: false`.
+    if (preExisting && options.backup !== false) {
+      backupPath = writeJsonAtomicWithBackup(settingsPath, settings, {
+        backup: true,
+        backupPath: options.backupPath,
+      });
+      if (backupPath && !options.silent) {
+        console.log(`  Backup: saved previous settings to ${backupPath}`);
+      }
+    } else {
+      writeJsonAtomic(settingsPath, settings);
+    }
   }
 
   if (!options.silent) {
@@ -998,6 +1015,7 @@ function registerHooks(options = {}) {
     version: versionInfo.version,
     versionStatus: versionInfo.status,
     versionSource: versionInfo.source,
+    backupPath,
   };
 }
 
@@ -1008,8 +1026,10 @@ async function registerHooksAsync(options = {}) {
   const platform = options.platform || process.platform;
 
   let settings = {};
+  let preExisting = false;
   try {
     settings = JSON.parse(await fs.promises.readFile(settingsPath, "utf-8"));
+    preExisting = true;
   } catch (err) {
     if (err.code !== "ENOENT") {
       throw new Error(`Failed to read settings.json: ${err.message}`);
@@ -1168,8 +1188,21 @@ async function registerHooksAsync(options = {}) {
     added++;
   }
 
+  let backupPath = null;
   if (added > 0 || changed) {
-    await writeJsonAtomicAsync(settingsPath, settings);
+    // See registerHooks(): back up the prior config before injecting hooks so
+    // the change is recoverable. Only back up a pre-existing file; `backup: false` opts out.
+    if (preExisting && options.backup !== false) {
+      backupPath = await writeJsonAtomicWithBackupAsync(settingsPath, settings, {
+        backup: true,
+        backupPath: options.backupPath,
+      });
+      if (backupPath && !options.silent) {
+        console.log(`  Backup: saved previous settings to ${backupPath}`);
+      }
+    } else {
+      await writeJsonAtomicAsync(settingsPath, settings);
+    }
   }
 
   if (!options.silent) {
@@ -1205,6 +1238,7 @@ async function registerHooksAsync(options = {}) {
     version: versionInfo.version,
     versionStatus: versionInfo.status,
     versionSource: versionInfo.source,
+    backupPath,
   };
 }
 

--- a/hooks/install.js
+++ b/hooks/install.js
@@ -973,6 +973,7 @@ function registerHooks(options = {}) {
       backupPath = writeJsonAtomicWithBackup(settingsPath, settings, {
         backup: true,
         backupPath: options.backupPath,
+        backupKeep: options.backupKeep,
       });
       if (backupPath && !options.silent) {
         console.log(`  Backup: saved previous settings to ${backupPath}`);
@@ -1196,6 +1197,7 @@ async function registerHooksAsync(options = {}) {
       backupPath = await writeJsonAtomicWithBackupAsync(settingsPath, settings, {
         backup: true,
         backupPath: options.backupPath,
+        backupKeep: options.backupKeep,
       });
       if (backupPath && !options.silent) {
         console.log(`  Backup: saved previous settings to ${backupPath}`);

--- a/hooks/json-utils.js
+++ b/hooks/json-utils.js
@@ -87,29 +87,190 @@ function uniqueBackupPath(filePath, options = {}) {
   return `${stem}.${process.pid}.${Date.now()}.bak`;
 }
 
+// Cap how many timestamped backups we keep for a single file. Without a cap, a
+// config that gets rewritten repeatedly — e.g. the settings watcher
+// re-registering hooks after another tool (CC-Switch) strips them — would
+// accrue `.clawd-cleanup-*.bak` files without bound. 5 keeps a short history
+// while staying bounded; override per-call with `backupKeep`.
+const DEFAULT_BACKUP_KEEP = 5;
+
+function resolveBackupKeep(options = {}) {
+  return Number.isInteger(options.backupKeep) && options.backupKeep > 0
+    ? options.backupKeep
+    : DEFAULT_BACKUP_KEEP;
+}
+
+function ownBackupPrefix(filePath) {
+  return `${path.basename(filePath)}.clawd-cleanup-`;
+}
+
+function isOwnBackupName(name, prefix) {
+  return name.startsWith(prefix) && name.endsWith(".bak");
+}
+
+// Order backups by the timestamp encoded in their FILENAME, not by mtime.
+// fs.copyFileSync inherits the SOURCE file's mtime (notably on Windows, via the
+// CopyFile API), so a backup's mtime reflects the settings file's contents, not
+// when the backup was taken — ordering by mtime can flag the just-written
+// backup as "oldest" and delete it. The filename stamp comes from `new Date()`
+// at creation time (see cleanupBackupPath), so it is the reliable creation
+// order. Format: <prefix><stamp>[.<collision-n>][.<pid>.<ms>].bak
+function backupOrderKey(name, prefix) {
+  const body = name.slice(prefix.length, name.length - ".bak".length);
+  const parts = body.split(".");
+  // stamp is fixed-width digits (YYYYMMDDHHMMSSmmm); compare it as a STRING so
+  // 17-digit values (which exceed Number.MAX_SAFE_INTEGER) keep full precision
+  // and still sort chronologically. Collision suffixes (.1/.2, or the
+  // .pid.ms fallback) compare numerically.
+  return {
+    stamp: parts[0] || "",
+    suffixes: parts.slice(1).map((part) => {
+      const n = Number(part);
+      return Number.isFinite(n) ? n : Infinity; // unparseable → sort last (kept, not deleted)
+    }),
+  };
+}
+
+function compareBackupKeys(a, b) {
+  if (a.stamp !== b.stamp) return a.stamp < b.stamp ? -1 : 1;
+  const len = Math.max(a.suffixes.length, b.suffixes.length);
+  for (let i = 0; i < len; i++) {
+    const x = i < a.suffixes.length ? a.suffixes[i] : 0; // missing suffix (".bak") is earlier than ".1.bak"
+    const y = i < b.suffixes.length ? b.suffixes[i] : 0;
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
+
+function listOrderedBackups(names, prefix) {
+  return names
+    .map((name) => ({ name, key: backupOrderKey(name, prefix) }))
+    .sort((a, b) => compareBackupKeys(a.key, b.key))
+    .map((entry) => entry.name); // oldest first
+}
+
+// Decide which backups survive a prune: never drop the one we just wrote
+// (keepPath), always preserve the oldest (the original pre-install snapshot,
+// the most valuable restore point), and fill the rest of the budget with the
+// most recent backups.
+function backupSurvivors(orderedOldestFirst, keep, keepPath) {
+  const survivors = new Set();
+  const keepName = keepPath ? path.basename(keepPath) : null;
+  if (keepName) survivors.add(keepName);
+  if (keep >= 2 && orderedOldestFirst.length) survivors.add(orderedOldestFirst[0]);
+  for (let i = orderedOldestFirst.length - 1; i >= 0 && survivors.size < keep; i--) {
+    survivors.add(orderedOldestFirst[i]);
+  }
+  return survivors;
+}
+
+function pruneOldBackups(filePath, options = {}, keepPath = null) {
+  // A caller-specified backupPath is managed by the caller — never sweep it.
+  if (typeof options.backupPath === "string" && options.backupPath) return;
+  const keep = resolveBackupKeep(options);
+  const dir = path.dirname(filePath);
+  const prefix = ownBackupPrefix(filePath);
+  let names;
+  try {
+    names = fs.readdirSync(dir).filter((name) => isOwnBackupName(name, prefix));
+  } catch {
+    return;
+  }
+  if (names.length <= keep) return;
+  const ordered = listOrderedBackups(names, prefix);
+  const survivors = backupSurvivors(ordered, keep, keepPath);
+  for (const name of ordered) {
+    if (survivors.has(name)) continue;
+    try { fs.unlinkSync(path.join(dir, name)); } catch {}
+  }
+}
+
+async function pruneOldBackupsAsync(filePath, options = {}, keepPath = null) {
+  if (typeof options.backupPath === "string" && options.backupPath) return;
+  const keep = resolveBackupKeep(options);
+  const dir = path.dirname(filePath);
+  const prefix = ownBackupPrefix(filePath);
+  let names;
+  try {
+    names = (await fs.promises.readdir(dir)).filter((name) => isOwnBackupName(name, prefix));
+  } catch {
+    return;
+  }
+  if (names.length <= keep) return;
+  const ordered = listOrderedBackups(names, prefix);
+  const survivors = backupSurvivors(ordered, keep, keepPath);
+  for (const name of ordered) {
+    if (survivors.has(name)) continue;
+    try { await fs.promises.unlink(path.join(dir, name)); } catch {}
+  }
+}
+
+// How many fresh names to try when an auto-named backup collides mid-write.
+const BACKUP_COPY_ATTEMPTS = 5;
+
 function createBackup(filePath, options = {}) {
   if (options.backup !== true) return null;
-  const backupPath = uniqueBackupPath(filePath, options);
-  fs.copyFileSync(filePath, backupPath);
-  return backupPath;
+  // A caller-specified backupPath is honored as-is — the caller owns the name
+  // and expects an overwrite if it already exists.
+  if (typeof options.backupPath === "string" && options.backupPath) {
+    const backupPath = uniqueBackupPath(filePath, options);
+    fs.copyFileSync(filePath, backupPath);
+    return backupPath;
+  }
+  // Auto-named path: COPYFILE_EXCL makes the copy fail if the destination
+  // already exists, closing the existsSync→copy TOCTOU window where two
+  // processes pick the same name and one clobbers the other. On collision,
+  // recompute a fresh unique name (uniqueBackupPath now sees the other file) and retry.
+  let lastErr;
+  for (let attempt = 0; attempt < BACKUP_COPY_ATTEMPTS; attempt++) {
+    const backupPath = uniqueBackupPath(filePath, options);
+    try {
+      fs.copyFileSync(filePath, backupPath, fs.constants.COPYFILE_EXCL);
+      return backupPath;
+    } catch (err) {
+      lastErr = err;
+      if (err.code === "EEXIST") continue; // a racing writer took this name; pick another
+      throw err;
+    }
+  }
+  throw lastErr;
 }
 
 async function createBackupAsync(filePath, options = {}) {
   if (options.backup !== true) return null;
-  const backupPath = uniqueBackupPath(filePath, options);
-  await fs.promises.copyFile(filePath, backupPath);
-  return backupPath;
+  if (typeof options.backupPath === "string" && options.backupPath) {
+    const backupPath = uniqueBackupPath(filePath, options);
+    await fs.promises.copyFile(filePath, backupPath);
+    return backupPath;
+  }
+  let lastErr;
+  for (let attempt = 0; attempt < BACKUP_COPY_ATTEMPTS; attempt++) {
+    const backupPath = uniqueBackupPath(filePath, options);
+    try {
+      await fs.promises.copyFile(filePath, backupPath, fs.constants.COPYFILE_EXCL);
+      return backupPath;
+    } catch (err) {
+      lastErr = err;
+      if (err.code === "EEXIST") continue;
+      throw err;
+    }
+  }
+  throw lastErr;
 }
 
 function writeJsonAtomicWithBackup(filePath, data, options = {}) {
   const backupPath = createBackup(filePath, options);
   writeJsonAtomic(filePath, data);
+  // Prune only after the live write succeeds (a failed write keeps the prior
+  // backups), and pass the just-written backup so it is never the one deleted.
+  if (backupPath) pruneOldBackups(filePath, options, backupPath);
   return backupPath;
 }
 
 async function writeJsonAtomicWithBackupAsync(filePath, data, options = {}) {
   const backupPath = await createBackupAsync(filePath, options);
   await writeJsonAtomicAsync(filePath, data);
+  if (backupPath) await pruneOldBackupsAsync(filePath, options, backupPath);
   return backupPath;
 }
 
@@ -130,6 +291,7 @@ function writeTextAtomic(filePath, text, encoding = "utf-8") {
 function writeTextAtomicWithBackup(filePath, text, options = {}) {
   const backupPath = createBackup(filePath, options);
   writeTextAtomic(filePath, text, options.encoding || "utf-8");
+  if (backupPath) pruneOldBackups(filePath, options, backupPath);
   return backupPath;
 }
 
@@ -421,6 +583,9 @@ module.exports = {
   writeTextAtomicWithBackup,
   createBackup,
   createBackupAsync,
+  pruneOldBackups,
+  pruneOldBackupsAsync,
+  DEFAULT_BACKUP_KEEP,
   asarUnpackedPath,
   commandMatchesMarker,
   extractExistingNodeBin,

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1601,4 +1601,28 @@ describe("Hook installer settings backup", () => {
 
     assert.ok(result.backupPath && fs.existsSync(result.backupPath), "async install should back up");
   });
+
+  it("caps backups under repeated re-register instead of piling up unbounded", () => {
+    // Simulates a CC-Switch style write war: an external tool keeps stripping
+    // Clawd's hooks from settings.json, the watcher keeps re-registering them.
+    // Each real write snapshots the prior file, but the total must stay bounded.
+    const thirdParty = { hooks: { Stop: [{ matcher: "", hooks: [{ type: "command", command: "user-own-hook" }] }] } };
+    const settingsPath = makeTempSettings(thirdParty);
+    const dir = path.dirname(settingsPath);
+    const countBaks = () => fs.readdirSync(dir).filter((n) => n.endsWith(".bak")).length;
+
+    for (let i = 0; i < 8; i++) {
+      // External tool overwrites settings.json back to third-party-only (drops Clawd hooks).
+      fs.writeFileSync(settingsPath, JSON.stringify(thirdParty, null, 2), "utf-8");
+      const result = registerHooks({ silent: true, settingsPath, claudeVersionInfo: versionInfo, backupKeep: 3 });
+      assert.ok(result.backupPath, "each re-register over an existing file should back up");
+      // The returned path must actually exist — i.e. the fresh backup is never
+      // the one pruned away (regression: copyFileSync inherits the source mtime).
+      assert.ok(fs.existsSync(result.backupPath), "returned backup path must exist on disk");
+    }
+
+    assert.strictEqual(countBaks(), 3, `backups must stay capped at backupKeep, found ${countBaks()}`);
+    // The live file still has Clawd's hooks plus the user's own hook preserved.
+    assert.ok(getClawdCommands(readSettings(settingsPath), "Stop").length > 0, "Clawd hooks still installed");
+  });
 });

--- a/test/install.test.js
+++ b/test/install.test.js
@@ -1523,7 +1523,14 @@ describe("async hook installer parity", () => {
     });
 
     assert.deepStrictEqual(readSettings(asyncSettingsPath), readSettings(syncSettingsPath));
-    assert.deepStrictEqual(asyncResult, syncResult);
+
+    // backupPath is path-specific (each call uses its own temp settingsPath), so
+    // compare the rest of the result for parity and assert both paths backed up.
+    const { backupPath: syncBackup, ...syncRest } = syncResult;
+    const { backupPath: asyncBackup, ...asyncRest } = asyncResult;
+    assert.deepStrictEqual(asyncRest, syncRest);
+    assert.ok(syncBackup && syncBackup.endsWith(".bak"), "registerHooks should back up the prior settings");
+    assert.ok(asyncBackup && asyncBackup.endsWith(".bak"), "registerHooksAsync should back up the prior settings");
   });
 
   it("unregisterHooksAsync removes the same entries as unregisterHooks", async () => {
@@ -1541,5 +1548,57 @@ describe("async hook installer parity", () => {
 
     assert.deepStrictEqual(readSettings(asyncSettingsPath), readSettings(syncSettingsPath));
     assert.deepStrictEqual(asyncResult, syncResult);
+  });
+});
+
+describe("Hook installer settings backup", () => {
+  const versionInfo = { version: "2.1.78", source: "test", status: "known" };
+
+  function bakFiles(settingsPath) {
+    const dir = path.dirname(settingsPath);
+    return fs.readdirSync(dir).filter((name) => name.endsWith(".bak"));
+  }
+
+  it("backs up an existing settings.json before injecting hooks", () => {
+    const original = { hooks: { Stop: [{ matcher: "", hooks: [{ type: "command", command: "user-own-hook" }] }] } };
+    const settingsPath = makeTempSettings(original);
+
+    const result = registerHooks({ silent: true, settingsPath, claudeVersionInfo: versionInfo });
+
+    assert.ok(result.backupPath, "should return a backupPath");
+    assert.ok(fs.existsSync(result.backupPath), "backup file should exist on disk");
+    // Backup holds the ORIGINAL pre-install content (the user's own hook, no Clawd hooks).
+    assert.deepStrictEqual(readSettings(result.backupPath), original);
+    // Live file was mutated (Clawd hooks added) and the user's hook is preserved.
+    assert.ok(getClawdCommands(readSettings(settingsPath), "Stop").length > 0, "Clawd hooks should be installed");
+  });
+
+  it("does not back up when settings.json does not pre-exist", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-install-"));
+    tempDirs.push(tmpDir);
+    const settingsPath = path.join(tmpDir, "settings.json"); // intentionally absent
+
+    const result = registerHooks({ silent: true, settingsPath, claudeVersionInfo: versionInfo });
+
+    assert.strictEqual(result.backupPath, null, "no backup for a freshly created file");
+    assert.deepStrictEqual(bakFiles(settingsPath), [], "no .bak files written");
+    assert.ok(fs.existsSync(settingsPath), "settings.json should still be created");
+  });
+
+  it("respects backup: false (opt out)", () => {
+    const settingsPath = makeTempSettings({ hooks: {} });
+
+    const result = registerHooks({ silent: true, settingsPath, backup: false, claudeVersionInfo: versionInfo });
+
+    assert.strictEqual(result.backupPath, null);
+    assert.deepStrictEqual(bakFiles(settingsPath), []);
+  });
+
+  it("backs up on the async path too", async () => {
+    const settingsPath = makeTempSettings({ hooks: {} });
+
+    const result = await registerHooksAsync({ silent: true, settingsPath, claudeVersionInfo: versionInfo });
+
+    assert.ok(result.backupPath && fs.existsSync(result.backupPath), "async install should back up");
   });
 });

--- a/test/json-utils.test.js
+++ b/test/json-utils.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { extractExistingNodeBin, extractExistingNodeBinFromCommands, formatNodeHookCommand, writeJsonAtomicAsync } = require("../hooks/json-utils");
+const { extractExistingNodeBin, extractExistingNodeBinFromCommands, formatNodeHookCommand, writeJsonAtomicAsync, createBackup, writeJsonAtomicWithBackup, writeJsonAtomicWithBackupAsync, pruneOldBackups, pruneOldBackupsAsync, DEFAULT_BACKUP_KEEP } = require("../hooks/json-utils");
 
 describe("extractExistingNodeBin", () => {
   it("extracts node path from flat command format", () => {
@@ -202,5 +202,166 @@ describe("writeJsonAtomicAsync", () => {
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe("backup pruning", () => {
+  const PREFIX = "settings.json.clawd-cleanup-";
+  // 17-digit, lexically-increasing creation stamp (matches YYYYMMDDHHMMSSmmm width).
+  const stampAt = (i) => `20260630000000${String(i).padStart(3, "0")}`;
+  const bakOf = (stamp, suffix) => `${PREFIX}${stamp}${suffix != null ? "." + suffix : ""}.bak`;
+
+  // Seed a backup file. `mtimeSec` lets a test set an mtime that disagrees with
+  // the filename order (mimicking copyFileSync inheriting the source's mtime).
+  function seedBak(dir, stamp, opts = {}) {
+    const name = bakOf(stamp, opts.suffix);
+    const p = path.join(dir, name);
+    fs.writeFileSync(p, opts.content != null ? opts.content : "{}", "utf8");
+    if (opts.mtimeSec != null) fs.utimesSync(p, opts.mtimeSec, opts.mtimeSec);
+    return name;
+  }
+  function bakNames(dir) {
+    return fs.readdirSync(dir).filter((n) => n.startsWith(PREFIX) && n.endsWith(".bak")).sort();
+  }
+  function withTmp(fn) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-prune-"));
+    try { return fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  }
+  async function withTmpAsync(fn) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-prune-"));
+    try { return await fn(dir); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  }
+
+  it("keeps the oldest (original) snapshot plus the most recent N-1", () => {
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      for (let i = 1; i <= 8; i++) seedBak(dir, stampAt(i));
+      pruneOldBackups(settingsPath, { backupKeep: 3 });
+      // oldest (1) kept as the original snapshot, plus the two most recent (7, 8)
+      assert.deepStrictEqual(bakNames(dir), [bakOf(stampAt(1)), bakOf(stampAt(7)), bakOf(stampAt(8))]);
+    });
+  });
+
+  it("orders by filename stamp, not by mtime (copyFileSync inherits source mtime)", () => {
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      // mtimes deliberately REVERSED vs filename order: the oldest filename gets
+      // the newest mtime. A mtime-based prune would keep the wrong set.
+      for (let i = 1; i <= 6; i++) seedBak(dir, stampAt(i), { mtimeSec: 1_700_000_000 + (6 - i) });
+      pruneOldBackups(settingsPath, { backupKeep: 3 });
+      assert.deepStrictEqual(bakNames(dir), [bakOf(stampAt(1)), bakOf(stampAt(5)), bakOf(stampAt(6))]);
+    });
+  });
+
+  it("never deletes the freshly-created backup, even when the source mtime is old", () => {
+    // This is the core regression: on Windows fs.copyFileSync gives the new
+    // backup the SOURCE file's (old) mtime, so an mtime-based prune deletes the
+    // backup it just wrote and returns a path that no longer exists.
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      fs.writeFileSync(settingsPath, JSON.stringify({ user: "config" }), "utf8");
+      const weekAgo = 1_700_000_000;
+      fs.utimesSync(settingsPath, weekAgo, weekAgo); // source looks old
+      // 5 pre-existing backups that look "newer" by mtime
+      for (let i = 1; i <= 5; i++) seedBak(dir, stampAt(i), { mtimeSec: 1_800_000_000 + i });
+      const created = writeJsonAtomicWithBackup(settingsPath, { user: "config", clawd: true }, { backup: true, backupKeep: 5 });
+      assert.ok(created, "should return a backup path");
+      assert.ok(fs.existsSync(created), "the just-written backup must NOT be pruned away");
+      assert.ok(bakNames(dir).includes(path.basename(created)), "new backup is among survivors");
+      assert.strictEqual(bakNames(dir).length, 5, "total still capped at keep");
+    });
+  });
+
+  it("orders same-stamp collisions by suffix (bare .bak is older than .1.bak)", () => {
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      seedBak(dir, stampAt(1));                 // oldest overall
+      seedBak(dir, stampAt(5));                  // bare: first within stamp5
+      seedBak(dir, stampAt(5), { suffix: 1 });    // .1: next
+      seedBak(dir, stampAt(5), { suffix: 2 });    // .2: newest
+      pruneOldBackups(settingsPath, { backupKeep: 3 });
+      // oldest(1) + the two most recent of the collision group (.1, .2); bare stamp5 dropped
+      assert.deepStrictEqual(bakNames(dir), [bakOf(stampAt(1)), bakOf(stampAt(5), 1), bakOf(stampAt(5), 2)]);
+    });
+  });
+
+  it("defaults to keeping DEFAULT_BACKUP_KEEP when backupKeep is absent", () => {
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      for (let i = 1; i <= DEFAULT_BACKUP_KEEP + 4; i++) seedBak(dir, stampAt(i));
+      pruneOldBackups(settingsPath);
+      assert.strictEqual(bakNames(dir).length, DEFAULT_BACKUP_KEEP);
+    });
+  });
+
+  it("falls back to the default for invalid backupKeep and never deletes everything", () => {
+    for (const bad of [0, -1, 1.5, "3", null, NaN]) {
+      withTmp((dir) => {
+        const settingsPath = path.join(dir, "settings.json");
+        for (let i = 1; i <= 9; i++) seedBak(dir, stampAt(i));
+        pruneOldBackups(settingsPath, { backupKeep: bad });
+        assert.strictEqual(bakNames(dir).length, DEFAULT_BACKUP_KEEP, `backupKeep=${String(bad)} should fall back to default`);
+      });
+    }
+  });
+
+  it("is a no-op under the cap and safe on a missing directory", () => {
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      for (let i = 1; i <= 2; i++) seedBak(dir, stampAt(i));
+      pruneOldBackups(settingsPath, { backupKeep: 5 }); // fewer than cap → no-op
+      assert.strictEqual(bakNames(dir).length, 2);
+      assert.doesNotThrow(() => pruneOldBackups(path.join(dir, "nope", "settings.json")));
+    });
+  });
+
+  it("scopes pruning to the target file and leaves other files alone", () => {
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      for (let i = 1; i <= 6; i++) seedBak(dir, stampAt(i));
+      const otherBak = path.join(dir, `other.json.clawd-cleanup-${stampAt(1)}.bak`);
+      fs.writeFileSync(otherBak, "{}", "utf8");
+      fs.writeFileSync(settingsPath, "{}", "utf8");
+      pruneOldBackups(settingsPath, { backupKeep: 2 });
+      assert.strictEqual(bakNames(dir).length, 2, "own backups capped");
+      assert.ok(fs.existsSync(otherBak), "a different file's backup is untouched");
+      assert.ok(fs.existsSync(settingsPath), "the live file is untouched");
+    });
+  });
+
+  it("does not prune when a caller-specified backupPath is used", () => {
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      for (let i = 1; i <= 6; i++) seedBak(dir, stampAt(i));
+      pruneOldBackups(settingsPath, { backupKeep: 2, backupPath: path.join(dir, "explicit.bak") });
+      assert.strictEqual(bakNames(dir).length, 6, "explicit backupPath disables pruning");
+    });
+  });
+
+  it("prunes on the async path with the same policy, keeping the fresh backup", async () => {
+    await withTmpAsync(async (dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      fs.writeFileSync(settingsPath, JSON.stringify({ a: 1 }), "utf8");
+      fs.utimesSync(settingsPath, 1_700_000_000, 1_700_000_000); // old source mtime
+      for (let i = 1; i <= 5; i++) seedBak(dir, stampAt(i), { mtimeSec: 1_800_000_000 + i });
+      const created = await writeJsonAtomicWithBackupAsync(settingsPath, { a: 2 }, { backup: true, backupKeep: 4 });
+      assert.ok(created && fs.existsSync(created), "async: the fresh backup survives its own prune");
+      assert.strictEqual(bakNames(dir).length, 4, "async: capped at keep");
+    });
+  });
+
+  it("never overwrites an existing backup when auto-naming (COPYFILE_EXCL + retry)", () => {
+    withTmp((dir) => {
+      const settingsPath = path.join(dir, "settings.json");
+      fs.writeFileSync(settingsPath, JSON.stringify({ v: 2 }), "utf8");
+      // Pin the stamp so we know the first name createBackup will try, then occupy it.
+      const now = () => new Date("2026-06-30T12:00:00.000Z");
+      const firstName = `${PREFIX}20260630120000000.bak`;
+      fs.writeFileSync(path.join(dir, firstName), "SENTINEL", "utf8");
+      const created = createBackup(settingsPath, { backup: true, now });
+      assert.notStrictEqual(path.basename(created), firstName, "must not reuse the occupied name");
+      assert.strictEqual(fs.readFileSync(path.join(dir, firstName), "utf8"), "SENTINEL", "the occupied backup is left intact");
+      assert.ok(fs.existsSync(created), "a fresh backup is written under a different name");
+    });
   });
 });


### PR DESCRIPTION
### Problem
The hook installer mutates the user's global `~/.claude/settings.json` in place — adding a set of lifecycle hooks plus the blocking HTTP `PermissionRequest` hook — but does not snapshot the prior file. The atomic temp+rename write (`writeJsonAtomic`) protects against a *half-written* file, but it gives the user no way to undo the change, and this is a shared config the user did not author.

### Fix
`writeJsonAtomicWithBackup` / `...Async` already exist in `json-utils.js` — they just weren't wired into the install path (`registerHooks` / `registerHooksAsync` called plain `writeJsonAtomic`). This routes both paths through the backup-aware write, **only when the settings file already existed** (a fresh install has nothing to snapshot).

**Behavior change:** by default, installing over an existing settings file now also writes a one-time backup. Opt out with `backup: false`.

The backup is written next to the settings file as `settings.json.clawd-cleanup-<timestamp>.bak` (reusing the existing `uniqueBackupPath` naming) and its path is printed to the install console — restore by copying it back. The path is also returned as `result.backupPath` (new additive field on the install result).

This may also help with restore asks such as #360, though uninstall/restore UX is out of scope here.

### Tests
Adds a `Hook installer settings backup` suite — existing-file backup captures the original content, no backup for a new file, `backup: false` opt-out, and async parity — and updates the sync/async parity test to compare everything except the environment-specific `backupPath`. `install.test.js`: 59/59 pass.

Unrelated: `test/roam.test.js` is timing-flaky on the full suite (a different sub-test fails per run) on clean `main` too; this change does not touch it.
