### PR TITLE
Add privacy-safe state bubbles for Hermes and Codex

### DIFF
--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -15,6 +15,7 @@ function startMarqueeIfOverflowing() {
 toolPill.addEventListener("mouseenter", startMarqueeIfOverflowing);
 toolPill.addEventListener("mouseleave", stopMarquee);
 const commandBlock = document.getElementById("commandBlock");
+const stateDetails = document.getElementById("stateDetails");
 const elicitationForm = document.getElementById("elicitationForm");
 const elicitationProgress = document.getElementById("elicitationProgress");
 const planFeedbackForm = document.getElementById("planFeedbackForm");
@@ -23,6 +24,7 @@ const planFeedbackBack = document.getElementById("planFeedbackBack");
 const planFeedbackSubmit = document.getElementById("planFeedbackSubmit");
 const btnAllow = document.getElementById("btnAllow");
 const btnDeny = document.getElementById("btnDeny");
+const actionsContainer = btnAllow.parentElement;
 const suggestionsContainer = document.getElementById("suggestions");
 const headerTitle = document.querySelector(".header-title");
 const sessionTag = document.getElementById("sessionTag");
@@ -87,6 +89,7 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "What should be changed?",
     submitFeedback: "Send",
     back: "Back",
+    stateUpdate: "Phoebe Update",
   },
   zh: {
     autoAcceptEdits: "\u81EA\u52A8\u63A5\u53D7\u7F16\u8F91",
@@ -122,6 +125,7 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "\u54EA\u91CC\u9700\u8981\u6539?",
     submitFeedback: "\u53D1\u9001",
     back: "\u8FD4\u56DE",
+    stateUpdate: "Phoebe \u72B6\u6001",
   },
   "zh-TW": {
     autoAcceptEdits: "自動接受編輯",
@@ -157,6 +161,7 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "哪裡需要改?",
     submitFeedback: "傳送",
     back: "返回",
+    stateUpdate: "Phoebe 狀態",
   },
   ko: {
     autoAcceptEdits: "\uD3B8\uC9D1 \uC790\uB3D9 \uC2B9\uC778",
@@ -192,6 +197,7 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "\uC5B4\uB514\uB97C \uBC14\uAFD4\uC57C \uD558\uB098\uC694?",
     submitFeedback: "\uBCF4\uB0B4\uAE30",
     back: "\uB4A4\uB85C",
+    stateUpdate: "Phoebe \uC0C1\uD0DC",
   },
   ja: {
     autoAcceptEdits: "編集を自動承認",
@@ -227,6 +233,7 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "どこを変更すべき?",
     submitFeedback: "送信",
     back: "戻る",
+    stateUpdate: "Phoebe 状態",
   },
 };
 
@@ -345,6 +352,12 @@ function resetBubbleContent() {
   elicitationForm.classList.remove("visible");
   elicitationProgress.textContent = "";
   elicitationProgress.classList.remove("visible");
+  card.classList.remove("state-notify", "state-expanded");
+  document.body.classList.remove("state-notify-body");
+  card.removeAttribute("data-state");
+  stateDetails.innerHTML = "";
+  stateDetails.style.display = "";
+  headerTitle.style.display = "";
   // NOTE: this resets the feedback form's visibility + textarea value only, not
   // the other side effects of enterPlanFeedbackMode() (suggestionsContainer
   // display:none and the disabled flags on textarea/back/submit). That's safe
@@ -360,6 +373,8 @@ function resetBubbleContent() {
   btnAllow.disabled = false;
   btnDeny.style.display = "";
   btnDeny.disabled = false;
+  if (actionsContainer) actionsContainer.style.display = "";
+  suggestionsContainer.style.display = "";
   suggestionsContainer.innerHTML = "";
 }
 
@@ -783,6 +798,29 @@ function show(data) {
     renderElicitationForm(data);
     btnAllow.style.display = "";
     btnDeny.style.display = "";
+    revealCard();
+    return;
+  }
+
+  // Generic state notify mode — local fixed-text bubble, no raw prompt/code content.
+  if (data.toolName === "ClawdStateNotify") {
+    const input = (data.toolInput && typeof data.toolInput === "object") ? data.toolInput : {};
+    card.classList.add("state-notify");
+    document.body.classList.add("state-notify-body");
+    card.setAttribute("data-state", input.state || "");
+    headerTitle.textContent = "";
+    headerTitle.style.display = "none";
+    toolPillText.textContent = input.badgeLabel || input.agentLabel || "PHOEBE";
+    toolPill.setAttribute("data-tool", "ClawdStateNotify");
+    toolPill.style.display = "";
+    commandBlock.textContent = "";
+    commandBlock.style.display = "none";
+    stateDetails.innerHTML = "";
+    stateDetails.style.display = "none";
+    btnAllow.style.display = "none";
+    btnDeny.style.display = "none";
+    if (actionsContainer) actionsContainer.style.display = "none";
+    suggestionsContainer.innerHTML = "";
     revealCard();
     return;
   }

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -67,6 +67,11 @@ html, body {
   -webkit-font-smoothing: antialiased;
 }
 body { padding: 6px; }
+body.state-notify-body {
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
 
 .card {
   position: relative;
@@ -157,6 +162,69 @@ body { padding: 6px; }
 .tool-pill[data-tool="Shell"] { background: #d97757; }
 .tool-pill[data-tool="CodexExec"] { background: #2563eb; }
 .tool-pill[data-tool="KimiPermission"] { background: #3b82f6; }
+.tool-pill[data-tool="ClawdStateNotify"] { background: linear-gradient(90deg, #7c3aed, #a855f7); }
+
+/* ── Minimal state tag ── */
+.card.state-notify {
+  width: fit-content;
+  max-width: calc(100vw - 12px);
+  margin: 0 auto;
+  padding: 0;
+  gap: 0;
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  box-shadow: none;
+  overflow: visible;
+  transform-origin: bottom center;
+}
+.card.state-notify .header {
+  flex-direction: row;
+  align-items: center;
+  gap: 0;
+}
+.card.state-notify .tool-pill {
+  position: relative;
+  padding: 5px 12px;
+  border-radius: 999px;
+  font-size: 10.5px;
+  line-height: 1;
+  letter-spacing: 0.055em;
+  max-width: 100%;
+  background: linear-gradient(110deg, #6d28d9 0%, #8b5cf6 36%, #c084fc 55%, #7c3aed 100%);
+  background-size: 220% 100%;
+  box-shadow: 0 5px 16px rgba(109, 40, 217, 0.24), inset 0 1px 0 rgba(255, 255, 255, 0.26);
+  animation: state-tag-flow 4.8s ease-in-out infinite;
+}
+.card.state-notify[data-state="working"] .tool-pill {
+  animation-duration: 3.2s;
+}
+.card.state-notify[data-state="attention"] .tool-pill {
+  animation: state-tag-flow 1.1s ease-out 1 forwards;
+}
+.card.state-notify[data-state="error"] .tool-pill {
+  background: linear-gradient(110deg, #b45309 0%, #d97706 45%, #f59e0b 100%);
+  box-shadow: 0 5px 16px rgba(180, 83, 9, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.22);
+  animation: none;
+}
+@keyframes state-tag-flow {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+.card.state-notify .tool-pill-text {
+  position: relative;
+  z-index: 1;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.18);
+}
+.card.state-notify .header-title,
+.card.state-notify .session-tag,
+.card.state-notify .command-block,
+.card.state-notify .state-details,
+.card.state-notify .actions,
+.card.state-notify .suggestions {
+  display: none !important;
+}
 
 /* ── Session tag (folder + short id, hidden when absent) ── */
 .session-tag {

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -15,6 +15,7 @@
   <div class="session-tag" id="sessionTag"></div>
 
   <div class="command-block" id="commandBlock"></div>
+  <div class="state-details" id="stateDetails"></div>
   <div class="elicitation-form" id="elicitationForm"></div>
   <div class="elicitation-progress" id="elicitationProgress"></div>
   <div class="plan-feedback-form" id="planFeedbackForm">

--- a/src/main.js
+++ b/src/main.js
@@ -1239,7 +1239,7 @@ const _permCtx = {
   },
 };
 const _perm = initPermission(_permCtx);
-const { showPermissionBubble, resolvePermissionEntry, sendPermissionResponse, repositionBubbles, permLog, PASSTHROUGH_TOOLS, addPendingPermission, removePendingPermission, maybeStartRemoteApproval, showCodexNotifyBubble, clearCodexNotifyBubbles, showKimiNotifyBubble, clearKimiNotifyBubbles, syncPermissionShortcuts, replyOpencodePermission } = _perm;
+const { showPermissionBubble, resolvePermissionEntry, sendPermissionResponse, repositionBubbles, permLog, PASSTHROUGH_TOOLS, addPendingPermission, removePendingPermission, maybeStartRemoteApproval, showCodexNotifyBubble, clearCodexNotifyBubbles, showKimiNotifyBubble, clearKimiNotifyBubbles, showStateNotifyBubble, clearStateNotifyBubbles, syncPermissionShortcuts, replyOpencodePermission } = _perm;
 const pendingPermissions = _perm.pendingPermissions;
 let permDebugLog = null; // set after app.whenReady()
 let updateDebugLog = null; // set after app.whenReady()
@@ -1354,6 +1354,8 @@ const _stateCtx = {
   dismissPermissionsForDnd: (...args) => _perm.dismissPermissionsForDnd(...args),
   showKimiNotifyBubble: (...args) => showKimiNotifyBubble(...args),
   clearKimiNotifyBubbles: (...args) => clearKimiNotifyBubbles(...args),
+  showStateNotifyBubble: (...args) => showStateNotifyBubble(...args),
+  clearStateNotifyBubbles: (...args) => clearStateNotifyBubbles(...args),
   // state.js needs this to gate startKimiPermissionPoll symmetrically with
   // shouldSuppressKimiNotifyBubble in permission.js — without it the
   // permissionsEnabled=false toggle would silently rebuild holds on every
@@ -2015,6 +2017,7 @@ function getPendingTelegramApprovalCount() {
     entry
     && !entry.isCodexNotify
     && !entry.isKimiNotify
+    && !entry.isStateNotify
     && !entry.isHardwareBuddyTest
   ).length;
 }
@@ -3010,6 +3013,7 @@ const settingsEffectRouter = createSettingsEffectRouter({
   dismissInteractivePermissionBubbles: () => callRuntimeMethod(_perm, "dismissInteractivePermissionBubbles"),
   clearCodexNotifyBubbles,
   clearKimiNotifyBubbles,
+  clearStateNotifyBubbles,
   refreshPassiveNotifyAutoClose: () => callRuntimeMethod(_perm, "refreshPassiveNotifyAutoClose"),
   refreshPermissionAutoCloseForPolicy: () => callRuntimeMethod(_perm, "refreshPermissionAutoCloseForPolicy"),
   hideUpdateBubbleForPolicy: () => callRuntimeMethod(_updateBubble, "hideForPolicy"),

--- a/src/permission.js
+++ b/src/permission.js
@@ -11,6 +11,10 @@ const {
   CLAWD_SERVER_HEADER,
   CLAWD_SERVER_ID,
 } = require("../hooks/server-config");
+const {
+  STATE_NOTIFY_TOOL_NAME,
+  buildStateNotifyCopy,
+} = require("./state-notify-bubble");
 
 const isMac = process.platform === "darwin";
 const isLinux = process.platform === "linux";
@@ -44,6 +48,9 @@ const BUBBLE_HEIGHT_RESERVE = 24;
 // integer DIP width, so the CSS viewport width (and therefore renderer-side
 // height measurements) stays exact across scale changes.
 const BUBBLE_BASE_WIDTH = 340;
+// State tags sit just above the pet with a small air gap.
+const STATE_NOTIFY_TAG_GAP = 10;
+const STATE_NOTIFY_DONE_AUTO_CLOSE_MS = 30 * 1000;
 // Hard cap so a scaled bubble can't swallow a small work area.
 const BUBBLE_MAX_WORK_AREA_WIDTH_RATIO = 0.9;
 const REMOTE_RICH_APPROVAL_AGENT_IDS = new Set(["claude-code", "codebuddy"]);
@@ -119,6 +126,11 @@ function shouldSuppressKimiNotifyBubble(ctx) {
     ctx.isAgentPermissionsEnabled("kimi-cli");
   const policy = getPolicy(ctx, "notification");
   return !!(ctx.doNotDisturb || !policy.enabled || !kimiBubblesEnabled);
+}
+
+function shouldSuppressStateNotifyBubble(ctx) {
+  const policy = getPolicy(ctx, "notification");
+  return !!(ctx.doNotDisturb || !policy.enabled);
 }
 
 function getPolicy(ctx, kind) {
@@ -222,7 +234,7 @@ function buildCopilotPermissionResponseBody(decisionOrBehavior, message) {
 }
 
 function isPassiveNotifyEntry(permEntry) {
-  return !!(permEntry && (permEntry.isCodexNotify || permEntry.isKimiNotify));
+  return !!(permEntry && (permEntry.isCodexNotify || permEntry.isKimiNotify || permEntry.isStateNotify));
 }
 
 function computePassiveNotifyRemainingMs(createdAt, autoCloseMs, now = Date.now()) {
@@ -231,6 +243,21 @@ function computePassiveNotifyRemainingMs(createdAt, autoCloseMs, now = Date.now(
   const startedAt = Number(createdAt);
   if (!Number.isFinite(startedAt) || startedAt <= 0) return totalMs;
   return Math.max(0, totalMs - Math.max(0, now - startedAt));
+}
+
+function computeStateNotifyBubbleBounds({ bubbleWidth: bw, bubbleHeight: bh, margin, gap, workArea: wa, hitRect }) {
+  if (!hitRect || !wa || !Number.isFinite(bw) || !Number.isFinite(bh)) return null;
+  const hitTop = Math.round(hitRect.top);
+  const hitBottom = Math.round(hitRect.bottom);
+  const hitCx = Math.round((hitRect.left + hitRect.right) / 2);
+  const x = Math.max(wa.x + margin, Math.min(hitCx - Math.round(bw / 2), wa.x + wa.width - bw - margin));
+  const attachGap = Math.max(2, Number(STATE_NOTIFY_TAG_GAP) || 0);
+  const aboveY = hitTop - attachGap - bh;
+  if (aboveY >= wa.y + margin) return { x, y: aboveY, width: bw, height: bh };
+  const belowY = hitBottom + attachGap;
+  if (belowY + bh <= wa.y + wa.height - margin) return { x, y: belowY, width: bw, height: bh };
+  const y = Math.max(wa.y + margin, Math.min(hitTop, wa.y + wa.height - bh - margin));
+  return { x, y, width: bw, height: bh };
 }
 
 // Pure layout calculator for the permission bubble stack. Extracted out of
@@ -443,6 +470,7 @@ function getActionablePermissions() {
       && !p.isElicitation
       && !p.isCodexNotify
       && !p.isKimiNotify
+      && !p.isStateNotify
       && p.toolName !== "ExitPlanMode"
   );
 }
@@ -562,30 +590,39 @@ function repositionBubbles() {
   const petBounds = ctx.getPetWindowBounds();
   const wa = getAnchorWorkArea(petBounds);
   const bw = getBubbleWidth(scale, wa);
-  const hitRect = ctx.bubbleFollowPet ? ctx.getHitRectScreen(petBounds) : null;
-
   const layoutPermissions = pendingPermissions.filter((perm) => !isHardwareBuddyTestPermission(perm));
+  const stateOnlyLayout = layoutPermissions.length === 1 && layoutPermissions[0].isStateNotify;
+  const hitRect = (ctx.bubbleFollowPet || stateOnlyLayout) ? ctx.getHitRectScreen(petBounds) : null;
   const bubbleHeights = layoutPermissions.map(perm =>
     clampBubbleHeight(
       // measuredHeight/estimate are CSS px; the window needs DIP.
       scaleHeight(
-        perm.measuredHeight || estimateBubbleHeight((perm.suggestions || []).length),
+        perm.measuredHeight || (perm.isStateNotify ? 34 : estimateBubbleHeight((perm.suggestions || []).length)),
         scale
       ),
       wa.height
     )
   );
 
-  const bounds = computeBubbleStackLayout({
-    followPet: !!ctx.bubbleFollowPet,
-    bubbleHeights,
-    bubbleWidth: bw,
-    margin,
-    gap,
-    workArea: wa,
-    hitRect,
-    hudReservedOffset: typeof ctx.getHudReservedOffset === "function" ? ctx.getHudReservedOffset() : 0,
-  });
+  const bounds = stateOnlyLayout && hitRect
+    ? [computeStateNotifyBubbleBounds({
+      bubbleWidth: bw,
+      bubbleHeight: bubbleHeights[0],
+      margin,
+      gap,
+      workArea: wa,
+      hitRect,
+    })]
+    : computeBubbleStackLayout({
+      followPet: !!ctx.bubbleFollowPet,
+      bubbleHeights,
+      bubbleWidth: bw,
+      margin,
+      gap,
+      workArea: wa,
+      hitRect,
+      hudReservedOffset: typeof ctx.getHudReservedOffset === "function" ? ctx.getHudReservedOffset() : 0,
+    });
 
   for (let i = 0; i < layoutPermissions.length; i++) {
     const perm = layoutPermissions[i];
@@ -633,7 +670,7 @@ function maybeAutoApprovePermission(permEntry) {
   if (typeof ctx.isAutoApproveAllEnabled !== "function" || !ctx.isAutoApproveAllEnabled()) {
     return false;
   }
-  if (permEntry.isCodexNotify || permEntry.isKimiNotify) return false;
+  if (permEntry.isCodexNotify || permEntry.isKimiNotify || permEntry.isStateNotify) return false;
   if (isHardwareBuddyTestPermission(permEntry)) return false;
 
   // Elicitation (AskUserQuestion / Hermes clarify): a bare "allow" with no
@@ -749,7 +786,7 @@ function showPermissionBubble(permEntry) {
 // dismissal via dismissPassiveNotify and must not be auto-closed through this
 // path — their UI lifecycle is decoupled from the agent's response channel.
 function armPermissionAutoCloseTimer(permEntry) {
-  if (!permEntry || permEntry.isCodexNotify || permEntry.isKimiNotify) return;
+  if (!permEntry || permEntry.isCodexNotify || permEntry.isKimiNotify || permEntry.isStateNotify) return;
   if (permEntry.autoCloseTimer) {
     clearTimeout(permEntry.autoCloseTimer);
     permEntry.autoCloseTimer = null;
@@ -786,13 +823,14 @@ function notifyPermissionsChanged(reason) {
 }
 
 function notifyPermissionResolved(permEntry, reason) {
-  if (!permEntry || permEntry.isCodexNotify || permEntry.isKimiNotify) return;
+  if (!permEntry || permEntry.isCodexNotify || permEntry.isKimiNotify || permEntry.isStateNotify) return;
   if (typeof ctx.onPermissionResolved !== "function") return;
   const hasPendingForSession = pendingPermissions.some((entry) =>
     entry
     && entry.sessionId === permEntry.sessionId
     && !entry.isCodexNotify
     && !entry.isKimiNotify
+    && !entry.isStateNotify
   );
   try {
     ctx.onPermissionResolved(permEntry, {
@@ -885,7 +923,7 @@ function isRemoteRichApprovalSupported(permEntry) {
 
 function isRemoteApprovalActionable(permEntry) {
   if (!permEntry || typeof permEntry !== "object") return false;
-  if (permEntry.isElicitation || permEntry.isCodexNotify || permEntry.isKimiNotify || permEntry.isOpencode || permEntry.isAntigravity || permEntry.isCopilotCli) return false;
+  if (permEntry.isElicitation || permEntry.isCodexNotify || permEntry.isKimiNotify || permEntry.isStateNotify || permEntry.isOpencode || permEntry.isAntigravity || permEntry.isCopilotCli) return false;
   if (permEntry.toolName === "ExitPlanMode" || permEntry.toolName === "AskUserQuestion") return false;
   if (PASSTHROUGH_TOOLS.has(permEntry.toolName)) return false;
   // Headless sessions auto-deny locally; mirror that on the Telegram side so a
@@ -1132,7 +1170,7 @@ function applyPermissionSuggestion(perm, index, options = {}) {
 
   function resolvePermissionEntry(permEntry, behavior, message) {
     // Codex notify bubbles have no HTTP connection — route to dedicated cleanup
-    if (permEntry.isCodexNotify || permEntry.isKimiNotify) {
+    if (isPassiveNotifyEntry(permEntry)) {
       dismissPassiveNotify(permEntry, `resolve:${behavior || "unknown"}`);
       return;
     }
@@ -1510,7 +1548,7 @@ function handleDecide(event, behavior) {
   const perm = pendingPermissions.find(p => p.bubble === senderWin);
   permLog(`IPC permission-decide: behavior=${behavior} matched=${!!perm}`);
   if (!perm) return;
-  if (perm.isCodexNotify || perm.isKimiNotify) {
+  if (isPassiveNotifyEntry(perm)) {
     dismissPassiveNotify(perm, "ipc-decide");
     return;
   }
@@ -1678,15 +1716,80 @@ function showKimiNotifyBubble({ sessionId, command }) {
   schedulePassiveNotifyAutoExpire(permEntry, policy.autoCloseMs);
 }
 
+
+function isStateNotifyCompletionState(state) {
+  const normalized = typeof state === "string" ? state.trim().toLowerCase() : "";
+  return normalized === "attention" || normalized === "done";
+}
+
+function scheduleStateNotifyCompletionExpire(permEntry, state) {
+  if (!permEntry || !permEntry.isStateNotify) return false;
+  if (permEntry.autoExpireTimer) {
+    clearTimeout(permEntry.autoExpireTimer);
+    permEntry.autoExpireTimer = null;
+  }
+  if (!isStateNotifyCompletionState(state)) return false;
+  return schedulePassiveNotifyAutoExpire(permEntry, STATE_NOTIFY_DONE_AUTO_CLOSE_MS);
+}
+
+function showStateNotifyBubble({ sessionId, agentId, state, event, toolName, model, provider, contextUsage }) {
+  if (shouldSuppressStateNotifyBubble(ctx)) {
+    const policy = getPolicy(ctx, "notification");
+    permLog(`state notify suppressed: agent=${agentId || "unknown"} session=${sessionId} state=${state || "unknown"} dnd=${ctx.doNotDisturb} notificationEnabled=${policy.enabled}`);
+    return;
+  }
+  const copy = buildStateNotifyCopy({
+    lang: ctx.lang,
+    agentId,
+    state,
+    event,
+    toolName,
+    model,
+    provider,
+    contextUsage,
+  });
+  const existing = findStateNotifyEntryBySession(sessionId);
+  if (existing) {
+    existing.toolInput = copy;
+    existing.createdAt = Date.now();
+    existing.agentId = agentId || existing.agentId || "hermes";
+    permLog(`state notify refresh: agent=${existing.agentId} session=${sessionId} state=${state || "unknown"} persistent=true`);
+    syncPermissionBubbleContent(existing);
+    scheduleStateNotifyCompletionExpire(existing, state);
+    return;
+  }
+  const permEntry = {
+    res: null,
+    abortHandler: null, suggestions: [],
+    sessionId, bubble: null, hideTimer: null,
+    toolName: STATE_NOTIFY_TOOL_NAME,
+    toolInput: copy,
+    resolvedSuggestion: null, createdAt: Date.now(),
+    isElicitation: false, isStateNotify: true,
+    agentId: agentId || "hermes",
+    autoExpireTimer: null,
+  };
+  addPendingPermission(permEntry, "passive-added");
+  showPermissionBubble(permEntry);
+  permLog(`state notify show: agent=${permEntry.agentId} session=${sessionId} state=${state || "unknown"} persistent=true`);
+  scheduleStateNotifyCompletionExpire(permEntry, state);
+}
+
 function getPassiveNotifyAgentId(permEntry) {
   if (permEntry?.isCodexNotify) return "codex";
   if (permEntry?.isKimiNotify) return "kimi-cli";
+  if (permEntry?.isStateNotify) return permEntry.agentId || "state";
   return permEntry?.agentId || "unknown";
 }
 
 function findCodexNotifyEntryBySession(sessionId) {
   if (!sessionId) return null;
   return pendingPermissions.find((permEntry) => permEntry && permEntry.isCodexNotify && permEntry.sessionId === sessionId) || null;
+}
+
+function findStateNotifyEntryBySession(sessionId) {
+  if (!sessionId) return null;
+  return pendingPermissions.find((permEntry) => permEntry && permEntry.isStateNotify && permEntry.sessionId === sessionId) || null;
 }
 
 function dismissPassiveNotify(permEntry, reason = "unknown") {
@@ -1730,7 +1833,7 @@ function schedulePassiveNotifyAutoExpire(permEntry, autoCloseMs, now = Date.now(
 }
 
 function refreshPassiveNotifyAutoClose() {
-  const passiveEntries = pendingPermissions.filter(isPassiveNotifyEntry);
+  const passiveEntries = pendingPermissions.filter((entry) => isPassiveNotifyEntry(entry) && !entry.isStateNotify);
   if (passiveEntries.length === 0) return 0;
   const policy = getPolicy(ctx, "notification");
   const now = Date.now();
@@ -1825,7 +1928,7 @@ function dismissPermissionsForDnd() {
   const toDismiss = pendingPermissions.filter(Boolean);
   if (toDismiss.length === 0) return 0;
   for (const perm of toDismiss) {
-    if (perm.isCodexNotify || perm.isKimiNotify) {
+    if (isPassiveNotifyEntry(perm)) {
       dismissPassiveNotify(perm, "dnd-enabled");
       continue;
     }
@@ -1855,6 +1958,15 @@ function clearKimiNotifyBubbles(sessionId, reason = sessionId ? "kimi-session-re
   for (const perm of toRemove) dismissPassiveNotify(perm, reason);
 }
 
+function clearStateNotifyBubbles(sessionId, reason = sessionId ? "state-session-release" : "state-global-clear") {
+  const hasStateNotify = pendingPermissions.some(p => p.isStateNotify);
+  if (!hasStateNotify) return;
+  const toRemove = sessionId
+    ? pendingPermissions.filter((p) => p.isStateNotify && p.sessionId === sessionId)
+    : pendingPermissions.filter((p) => p.isStateNotify);
+  for (const perm of toRemove) dismissPassiveNotify(perm, reason);
+}
+
 function cleanup() {
   // Unregister hotkeys
   if (registeredAllowAccel !== null) {
@@ -1874,7 +1986,8 @@ function cleanup() {
   for (const perm of [...pendingPermissions]) {
     if (perm._delayTimer) clearTimeout(perm._delayTimer);
     if (perm.autoExpireTimer) clearTimeout(perm.autoExpireTimer);
-    if (perm.isCodex || perm.isQwenCode || perm.isCopilotCli || perm.isAntigravity || perm.isHermes) resolvePermissionEntry(perm, "no-decision", "Clawd is quitting");
+    if (isPassiveNotifyEntry(perm)) dismissPassiveNotify(perm, "cleanup");
+    else if (perm.isCodex || perm.isQwenCode || perm.isCopilotCli || perm.isAntigravity || perm.isHermes) resolvePermissionEntry(perm, "no-decision", "Clawd is quitting");
     else resolvePermissionEntry(perm, "deny", "Clawd is quitting");
   }
 }
@@ -1889,6 +2002,7 @@ return {
   handleBubbleHeight, handleDecide, cleanup,
   showCodexNotifyBubble, clearCodexNotifyBubbles,
   showKimiNotifyBubble, clearKimiNotifyBubbles,
+  showStateNotifyBubble, clearStateNotifyBubbles,
   refreshPassiveNotifyAutoClose,
   refreshPermissionAutoCloseForPolicy,
   dismissPermissionsByAgent, dismissInteractivePermissionBubbles,
@@ -1905,6 +2019,7 @@ module.exports.registerPermissionIpc = registerPermissionIpc;
 // hit the pure layout function without standing up Electron / ctx mocks.
 module.exports.__test = {
   computeBubbleStackLayout,
+  computeStateNotifyBubbleBounds,
   computePassiveNotifyRemainingMs,
   clampBubbleHeight,
   shouldSuppressCodexNotifyBubble,

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -284,6 +284,7 @@ function handleStatePost(req, res, options) {
             backgroundTasksCount,
             sessionCronsCount,
             stopHookActive,
+            ...(toolName ? { toolName } : {}),
             ...(agentIdentity.defaulted ? { agentIdDefaulted: true } : {}),
           });
         }

--- a/src/settings-effect-router.js
+++ b/src/settings-effect-router.js
@@ -61,6 +61,7 @@ function createSettingsEffectRouter(options = {}) {
   const dismissInteractivePermissionBubbles = options.dismissInteractivePermissionBubbles || noop;
   const clearCodexNotifyBubbles = options.clearCodexNotifyBubbles || noop;
   const clearKimiNotifyBubbles = options.clearKimiNotifyBubbles || noop;
+  const clearStateNotifyBubbles = options.clearStateNotifyBubbles || noop;
   const refreshPassiveNotifyAutoClose = options.refreshPassiveNotifyAutoClose || noop;
   const refreshPermissionAutoCloseForPolicy = options.refreshPermissionAutoCloseForPolicy || noop;
   const hideUpdateBubbleForPolicy = options.hideUpdateBubbleForPolicy || noop;
@@ -136,6 +137,7 @@ function createSettingsEffectRouter(options = {}) {
       try {
         clearCodexNotifyBubbles(undefined, "settings-policy-disabled");
         clearKimiNotifyBubbles(undefined, "settings-policy-disabled");
+        clearStateNotifyBubbles(undefined, "settings-policy-disabled");
       } catch (err) {
         warn(logWarn, "Clawd: clear notification bubbles failed:", err);
       }

--- a/src/state-notify-bubble.js
+++ b/src/state-notify-bubble.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const STATE_NOTIFY_TOOL_NAME = "ClawdStateNotify";
+const SUPPORTED_AGENTS = new Set(["hermes", "codex"]);
+const NOTIFY_STATES = new Set(["thinking", "working", "attention", "error"]);
+const CLEAR_STATES = new Set(["idle", "sleeping"]);
+
+function normalizeAgentId(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function normalizeState(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function normalizeEvent(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function compactMetadataValue(value, maxLen = 48) {
+  const text = typeof value === "string" ? value.replace(/[\u0000-\u001f\u007f]+/g, " ").trim() : "";
+  if (!text) return "";
+  const redacted = text
+    .replace(/\b(?:Bearer|Token)\s+[A-Za-z0-9._~+/=-]{12,}\b/gi, "Bearer <redacted>")
+    .replace(/\b(?:sk-[A-Za-z0-9_-]{16,}|xox[abprs]-[A-Za-z0-9-]{10,})\b/g, "<redacted>")
+    .replace(/\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|authorization|cookie|password|secret)\s*[:=]\s*\S+/gi, "$1=<redacted>");
+  return redacted.length > maxLen ? `${redacted.slice(0, Math.max(0, maxLen - 1))}…` : redacted;
+}
+
+function shouldShowStateNotify(input = {}) {
+  const agentId = normalizeAgentId(input.agentId);
+  const state = normalizeState(input.state);
+  const event = normalizeEvent(input.event);
+
+  if (input.headless === true) return false;
+  if (!SUPPORTED_AGENTS.has(agentId)) return false;
+  if (!NOTIFY_STATES.has(state)) return false;
+  if (event === "PermissionRequest" || event === "Elicitation") return false;
+  if (event === "SessionEnd") return false;
+
+  return true;
+}
+
+function shouldClearStateNotify(input = {}) {
+  const state = normalizeState(input.state);
+  const event = normalizeEvent(input.event);
+  return event === "SessionEnd" || CLEAR_STATES.has(state);
+}
+
+function buildStateNotifyCopy(input = {}) {
+  const lang = input.lang === "zh-TW" ? "zh-TW" : (input.lang === "zh" ? "zh" : "en");
+  const agentId = normalizeAgentId(input.agentId);
+  const state = normalizeState(input.state);
+  const agentLabel = agentId === "codex" ? "Codex" : "Phoebe";
+
+  const dictionary = {
+    en: {
+      thinking: "Thinking",
+      working: "Working",
+      attention: "Done",
+      error: "Stuck",
+    },
+    zh: {
+      thinking: "思考中",
+      working: "處理中",
+      attention: "完成",
+      error: "卡住了",
+    },
+    "zh-TW": {
+      thinking: "思考中",
+      working: "處理中",
+      attention: "完成",
+      error: "卡住了",
+    },
+  };
+  const locale = dictionary[lang] || dictionary.en;
+  const statusLabel = locale[state] || dictionary.en[state] || dictionary.en.thinking;
+
+  return {
+    badgeLabel: `${agentLabel.toUpperCase()} · ${statusLabel}`,
+    agentLabel,
+    statusLabel,
+    state,
+  };
+}
+
+module.exports = {
+  STATE_NOTIFY_TOOL_NAME,
+  SUPPORTED_AGENTS,
+  NOTIFY_STATES,
+  shouldShowStateNotify,
+  shouldClearStateNotify,
+  buildStateNotifyCopy,
+  compactMetadataValue,
+};

--- a/src/state.js
+++ b/src/state.js
@@ -35,6 +35,10 @@ const {
   sessionSnapshotSignature,
 } = require("./state-session-snapshot");
 const { getAgentIconUrl } = require("./state-agent-icons");
+const {
+  shouldShowStateNotify,
+  shouldClearStateNotify,
+} = require("./state-notify-bubble");
 
 module.exports = function initState(ctx) {
 
@@ -100,6 +104,31 @@ const COMPLETION_CANCEL_EVENTS = new Set([
 // UserPromptSubmit lands within hook-spawn latency (~0.3s) of the Stop, so a
 // 2s quiet window absorbs it; a genuinely final Stop just celebrates 2s late.
 const HEADLESS_COMPLETION_DEBOUNCE_MS = 2000;
+function syncStateNotifyBubble(sessionId, state, event, opts = {}) {
+  if (shouldClearStateNotify({ state, event }) && typeof ctx.clearStateNotifyBubbles === "function") {
+    try { ctx.clearStateNotifyBubbles(sessionId, `state-transition:${state || event || "unknown"}`); } catch {}
+  }
+  if (!shouldShowStateNotify({
+    agentId: opts.agentId,
+    state,
+    event,
+    headless: opts.headless,
+  })) return;
+  if (typeof ctx.showStateNotifyBubble !== "function") return;
+  try {
+    ctx.showStateNotifyBubble({
+      sessionId,
+      agentId: opts.agentId,
+      state,
+      event,
+      toolName: opts.toolName,
+      model: opts.model,
+      provider: opts.provider,
+      contextUsage: opts.contextUsage,
+    });
+  } catch {}
+}
+
 function getCompletionDebounceMs(headless) {
   const raw = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
   const n = Number.parseInt(raw, 10);
@@ -1094,6 +1123,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     backgroundTasksCount = 0,
     sessionCronsCount = 0,
     stopHookActive = false,
+    toolName = null,
   } = opts;
   if (startupRecoveryActive) {
     startupRecoveryActive = false;
@@ -1360,6 +1390,14 @@ function updateSession(sessionId, state, event, opts = {}) {
   }
 
   if (event === "SessionEnd") {
+    syncStateNotifyBubble(sessionId, state, event, {
+      agentId: srcAgentId,
+      headless: srcHeadless,
+      toolName,
+      model: srcModel,
+      provider: srcProvider,
+      contextUsage: srcContextUsage,
+    });
     const endingSession = sessions.get(sessionId);
     cancelCodexExitProbe(sessionId, "SessionEnd");
     sessions.delete(sessionId);
@@ -1460,6 +1498,15 @@ function updateSession(sessionId, state, event, opts = {}) {
 
   const suppressDuplicateCompletionVisual =
     duplicateCompletionVisualAtEntry || shouldSuppressDuplicateCompletionVisual(existing, state, event);
+
+  syncStateNotifyBubble(sessionId, state, event, {
+    agentId: srcAgentId,
+    headless: srcHeadless,
+    toolName,
+    model: srcModel,
+    provider: srcProvider,
+    contextUsage: srcContextUsage,
+  });
 
   if (ONESHOT_STATES.has(state)) {
     // Permission animation lock: while any permission request is pending,

--- a/test/agent-installation-detector.test.js
+++ b/test/agent-installation-detector.test.js
@@ -172,7 +172,7 @@ describe("agent installation detector", () => {
     const homeDir = makeHome();
     mkdirp(path.join(homeDir, ".hermes"));
 
-    const report = detectAgentInstallations({ homeDir, now: 1 });
+    const report = detectAgentInstallations({ homeDir, now: 1, env: {} });
     const hermes = byId(report, "hermes");
 
     assert.strictEqual(hermes.detectedInstalled, true);

--- a/test/permission-reposition.test.js
+++ b/test/permission-reposition.test.js
@@ -2,7 +2,7 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert");
 
 const permission = require("../src/permission");
-const { computeBubbleStackLayout, clampBubbleHeight } = permission.__test;
+const { computeBubbleStackLayout, computeStateNotifyBubbleBounds, clampBubbleHeight } = permission.__test;
 
 // Common defaults so each test only spells out what's interesting.
 const BW = 340;
@@ -38,6 +38,30 @@ describe("permission bubble height clamp", () => {
 
   it("falls back to the natural height when work area height is unavailable", () => {
     assert.strictEqual(clampBubbleHeight(500, 0), 500);
+  });
+});
+
+describe("state notify bubble placement", () => {
+  it("places a single state bubble above the pet when there is room", () => {
+    assert.deepStrictEqual(computeStateNotifyBubbleBounds({
+      bubbleWidth: BW,
+      bubbleHeight: 34,
+      margin: MARGIN,
+      gap: GAP,
+      workArea: FHD,
+      hitRect: { left: 800, top: 400, right: 920, bottom: 500 },
+    }), { x: 690, y: 356, width: 340, height: 34 });
+  });
+
+  it("falls back below the pet when the top edge is too tight", () => {
+    assert.deepStrictEqual(computeStateNotifyBubbleBounds({
+      bubbleWidth: BW,
+      bubbleHeight: 34,
+      margin: MARGIN,
+      gap: GAP,
+      workArea: FHD,
+      hitRect: { left: 800, top: 40, right: 920, bottom: 140 },
+    }), { x: 690, y: 150, width: 340, height: 34 });
   });
 });
 

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -124,6 +124,7 @@ describe("server-route-state POST", () => {
       permission_suspect: true,
       preserve_state: true,
       hook_source: "codex-official",
+      tool_name: "Bash",
     }));
 
     assert.strictEqual(res.statusCode, 200);
@@ -160,6 +161,7 @@ describe("server-route-state POST", () => {
         backgroundTasksCount: 0,
         sessionCronsCount: 0,
         stopHookActive: false,
+        toolName: "Bash",
       },
     ]]);
   });

--- a/test/settings-effect-router-notify-autoclose.test.js
+++ b/test/settings-effect-router-notify-autoclose.test.js
@@ -33,6 +33,7 @@ describe("settings effect router notification auto-close sync", () => {
       settingsController: controller,
       clearCodexNotifyBubbles: (...args) => calls.push(["clearCodex", ...args]),
       clearKimiNotifyBubbles: (...args) => calls.push(["clearKimi", ...args]),
+      clearStateNotifyBubbles: (...args) => calls.push(["clearState", ...args]),
       refreshPassiveNotifyAutoClose: () => calls.push(["refreshPassive"]),
       updateMirrors: () => {},
     });
@@ -42,6 +43,7 @@ describe("settings effect router notification auto-close sync", () => {
     assert.deepStrictEqual(calls, [
       ["clearCodex", undefined, "settings-policy-disabled"],
       ["clearKimi", undefined, "settings-policy-disabled"],
+      ["clearState", undefined, "settings-policy-disabled"],
     ]);
 
     calls.length = 0;
@@ -53,6 +55,7 @@ describe("settings effect router notification auto-close sync", () => {
     assert.deepStrictEqual(calls, [
       ["clearCodex", undefined, "settings-policy-disabled"],
       ["clearKimi", undefined, "settings-policy-disabled"],
+      ["clearState", undefined, "settings-policy-disabled"],
     ]);
   });
 

--- a/test/state-notify-bubble.test.js
+++ b/test/state-notify-bubble.test.js
@@ -1,0 +1,166 @@
+"use strict";
+
+const { describe, it, beforeEach, afterEach } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const themeLoader = require("../src/theme-loader");
+themeLoader.init(path.join(__dirname, "..", "src"));
+const defaultTheme = themeLoader.loadTheme("clawd");
+
+const {
+  shouldShowStateNotify,
+  shouldClearStateNotify,
+  buildStateNotifyCopy,
+} = require("../src/state-notify-bubble");
+
+const bubbleRenderer = fs.readFileSync(path.join(__dirname, "..", "src", "bubble-renderer.js"), "utf8");
+const bubbleCss = fs.readFileSync(path.join(__dirname, "..", "src", "bubble.css"), "utf8");
+const permissionSource = fs.readFileSync(path.join(__dirname, "..", "src", "permission.js"), "utf8");
+
+function makeCtx(overrides = {}) {
+  return {
+    lang: "zh-TW",
+    theme: defaultTheme,
+    doNotDisturb: false,
+    miniTransitioning: false,
+    miniMode: false,
+    mouseOverPet: false,
+    idlePaused: false,
+    forceEyeResend: false,
+    eyePauseUntil: 0,
+    mouseStillSince: Date.now(),
+    miniSleepPeeked: false,
+    playSound: () => {},
+    sendToRenderer: () => {},
+    syncHitWin: () => {},
+    sendToHitWin: () => {},
+    miniPeekIn: () => {},
+    miniPeekOut: () => {},
+    buildContextMenu: () => {},
+    buildTrayMenu: () => {},
+    pendingPermissions: [],
+    resolvePermissionEntry: () => {},
+    dismissPermissionsForDnd: () => {},
+    focusTerminalWindow: () => {},
+    processKill: () => { const e = new Error("ESRCH"); e.code = "ESRCH"; throw e; },
+    getCursorScreenPoint: () => ({ x: 100, y: 100 }),
+    ...overrides,
+  };
+}
+
+describe("state notify bubbles", () => {
+  it("only shows fixed-text bubbles for interactive Hermes/Codex state changes", () => {
+    assert.strictEqual(shouldShowStateNotify({ agentId: "hermes", state: "thinking", event: "UserPromptSubmit" }), true);
+    assert.strictEqual(shouldShowStateNotify({ agentId: "codex", state: "working", event: "PreToolUse" }), true);
+    assert.strictEqual(shouldShowStateNotify({ agentId: "claude-code", state: "thinking", event: "UserPromptSubmit" }), false);
+    assert.strictEqual(shouldShowStateNotify({ agentId: "hermes", state: "thinking", event: "UserPromptSubmit", headless: true }), false);
+    assert.strictEqual(shouldShowStateNotify({ agentId: "hermes", state: "notification", event: "PermissionRequest" }), false);
+  });
+
+  it("clears bubbles when a session ends or returns to idle/sleeping", () => {
+    assert.strictEqual(shouldClearStateNotify({ state: "sleeping" }), true);
+    assert.strictEqual(shouldClearStateNotify({ state: "idle" }), true);
+    assert.strictEqual(shouldClearStateNotify({ state: "thinking" }), false);
+    assert.strictEqual(shouldClearStateNotify({ state: "working", event: "SessionEnd" }), true);
+  });
+
+  it("builds localized tag copy without raw prompt/code fields", () => {
+    const copy = buildStateNotifyCopy({
+      lang: "zh-TW",
+      agentId: "hermes",
+      state: "working",
+      event: "PreToolUse",
+      toolName: "terminal",
+      model: "gpt-5.5",
+      provider: "openai-codex",
+      contextUsage: { percent: 42 },
+    });
+    assert.deepStrictEqual(Object.keys(copy).sort(), ["agentLabel", "badgeLabel", "state", "statusLabel"]);
+    assert.strictEqual(copy.agentLabel, "Phoebe");
+    assert.strictEqual(copy.badgeLabel, "PHOEBE · 處理中");
+    assert.ok(!JSON.stringify(copy).includes("terminal"));
+    assert.ok(!JSON.stringify(copy).includes("gpt-5.5"));
+    assert.ok(!JSON.stringify(copy).includes("api_key"));
+  });
+
+  it("renders state bubbles as a minimal non-actionable tag", () => {
+    assert.match(bubbleRenderer, /card\.classList\.add\("state-notify"\)/);
+    assert.match(bubbleRenderer, /actionsContainer\) actionsContainer\.style\.display = "none"/);
+    const stateBlockStart = bubbleRenderer.indexOf('data.toolName === "ClawdStateNotify"');
+    const codexBlockStart = bubbleRenderer.indexOf('data.toolName === "CodexExec"');
+    assert.ok(stateBlockStart >= 0 && codexBlockStart > stateBlockStart);
+    const stateBlock = bubbleRenderer.slice(stateBlockStart, codexBlockStart);
+    assert.doesNotMatch(stateBlock, /bubbleText\(data\.lang, "gotIt"\)/);
+    assert.doesNotMatch(stateBlock, /renderStateDetails/);
+    assert.match(stateBlock, /commandBlock\.style\.display = "none"/);
+    assert.match(bubbleRenderer, /document\.body\.classList\.add\("state-notify-body"\)/);
+    assert.match(bubbleCss, /body\.state-notify-body[\s\S]*?align-items: flex-end;/);
+    assert.match(bubbleCss, /\/\* ── Minimal state tag ── \*\//);
+    assert.match(bubbleCss, /\.card\.state-notify \{[\s\S]*?width: fit-content;/);
+    assert.match(bubbleCss, /@keyframes state-tag-flow/);
+    assert.match(bubbleCss, /\.card\.state-notify \.command-block,[\s\S]*?display: none !important;/);
+    assert.match(bubbleCss, /\.tool-pill\[data-tool="ClawdStateNotify"\]/);
+  });
+
+  it("keeps active state notify tags visible but auto-hides completion after 30s", () => {
+    assert.match(permissionSource, /const STATE_NOTIFY_DONE_AUTO_CLOSE_MS = 30 \* 1000/);
+    const helperStart = permissionSource.indexOf("function scheduleStateNotifyCompletionExpire");
+    const showStart = permissionSource.indexOf("function showStateNotifyBubble");
+    const showEnd = permissionSource.indexOf("function getPassiveNotifyAgentId");
+    assert.ok(helperStart >= 0 && showStart > helperStart && showEnd > showStart);
+    const helperBlock = permissionSource.slice(helperStart, showStart);
+    const showBlock = permissionSource.slice(showStart, showEnd);
+    assert.match(helperBlock, /isStateNotifyCompletionState\(state\)/);
+    assert.match(helperBlock, /schedulePassiveNotifyAutoExpire\(permEntry, STATE_NOTIFY_DONE_AUTO_CLOSE_MS\)/);
+    assert.match(showBlock, /scheduleStateNotifyCompletionExpire\(existing, state\)/);
+    assert.match(showBlock, /scheduleStateNotifyCompletionExpire\(permEntry, state\)/);
+    assert.doesNotMatch(showBlock, /notificationBubbleAutoCloseSeconds/);
+  });
+});
+
+describe("state notify integration", () => {
+  let api;
+  let calls;
+  let clears;
+
+  beforeEach(() => {
+    calls = [];
+    clears = [];
+    api = require("../src/state")(makeCtx({
+      showStateNotifyBubble: (payload) => calls.push(payload),
+      clearStateNotifyBubbles: (...args) => clears.push(args),
+    }));
+  });
+
+  afterEach(() => { api.cleanup(); });
+
+  it("emits fixed-text notify requests for Hermes/Codex state events", () => {
+    api.updateSession("h1", "thinking", "UserPromptSubmit", { agentId: "hermes" });
+    api.updateSession("h1", "working", "PreToolUse", {
+      agentId: "hermes",
+      toolName: "terminal",
+      model: "gpt-5.5",
+      provider: "openai-codex",
+      contextUsage: { percent: 42 },
+    });
+    api.updateSession("c1", "thinking", "UserPromptSubmit", { agentId: "codex" });
+    api.updateSession("cc1", "thinking", "UserPromptSubmit", { agentId: "claude-code" });
+
+    assert.strictEqual(calls.length, 3);
+    assert.deepStrictEqual(calls.map((c) => c.agentId), ["hermes", "hermes", "codex"]);
+    assert.strictEqual(calls[1].toolName, "terminal");
+    assert.strictEqual(calls[1].model, "gpt-5.5");
+    assert.strictEqual(calls[1].provider, "openai-codex");
+  });
+
+  it("clears the state notify bubble on session end", () => {
+    api.updateSession("h1", "thinking", "UserPromptSubmit", { agentId: "hermes" });
+    api.updateSession("h1", "sleeping", "SessionEnd", { agentId: "hermes" });
+
+    assert.strictEqual(calls.length, 1);
+    assert.strictEqual(clears.length, 1);
+    assert.strictEqual(clears[0][0], "h1");
+  });
+});


### PR DESCRIPTION
## Summary
- add fixed-text state notification bubbles for Hermes/Codex thinking, working, done, and error states
- keep bubbles privacy-safe by deriving copy from state metadata only; no raw prompt/code/output/API key fields are used
- wire state bubbles into passive notification lifecycle, auto-close policy, DND, and cleanup
- add tests for state notify copy, integration, i18n parity, and route tool_name propagation

## Verification
- node --check src/bubble-renderer.js
- node --test test/i18n.test.js test/state-notify-bubble.test.js test/agent-installation-detector.test.js
- focused suite: 299 tests passing
- npm test summary: fail 0; remaining nonzero exit is due cancelled native-runner tests in this environment
- local runtime: restarted Clawd and POSTed Hermes thinking/working/attention/sleeping events to http://127.0.0.1:23333/state successfully

## Privacy
State bubbles intentionally use fixed/localized strings and tool names only. They do not display raw prompts, assistant replies, terminal output, code contents, or API keys.