### PR TITLE
fix(cursor): stabilize Windows hook status updates

### DIFF
--- a/agents/cursor-agent.js
+++ b/agents/cursor-agent.js
@@ -21,7 +21,6 @@ module.exports = {
     subagentStart: "juggling",
     subagentStop: "working",
     preCompact: "sweeping",
-    afterAgentThought: "thinking",
   },
   capabilities: {
     httpHook: false,

--- a/hooks/cursor-hook.js
+++ b/hooks/cursor-hook.js
@@ -3,7 +3,7 @@
 // Registered in ~/.cursor/hooks.json by hooks/cursor-install.js
 
 const { postStateToRunningServer, readHostPrefix } = require("./server-config");
-const { createPidResolver, readStdinJson, getPlatformConfig } = require("./shared-process");
+const { createPidResolver, getPlatformConfig } = require("./shared-process");
 
 const HOOK_TO_STATE = {
   sessionStart: { state: "idle", event: "SessionStart" },
@@ -15,7 +15,6 @@ const HOOK_TO_STATE = {
   subagentStart: { state: "juggling", event: "SubagentStart" },
   subagentStop: { state: "working", event: "SubagentStop" },
   preCompact: { state: "sweeping", event: "PreCompact" },
-  afterAgentThought: { state: "thinking", event: "AfterAgentThought" },
 };
 
 const config = getPlatformConfig({ extraTerminals: { win: ["cursor.exe"] } });
@@ -55,7 +54,9 @@ function resolveStateAndEvent(payload, hookName) {
 // Safety timeout: guarantee valid JSON on stdout within 1s even if stdin never
 // arrives or the process tree walk hangs. Without this Cursor would see empty
 // stdout which is invalid JSON and logs an error on every hook invocation.
-const SAFETY_TIMEOUT_MS = 800;
+const SAFETY_TIMEOUT_MS = 3000;
+const STDIN_TIMEOUT_MS = 2000;
+const STATE_POST_TIMEOUT_MS = 5000;
 let _wrote = false;
 let _exited = false;
 let safetyTimer = null;
@@ -79,7 +80,35 @@ function finish(outLine) {
 
 safetyTimer = setTimeout(() => finish("{}"), SAFETY_TIMEOUT_MS);
 
-readStdinJson()
+function readCursorStdinJson(timeoutMs = STDIN_TIMEOUT_MS) {
+  return new Promise((resolve) => {
+    const chunks = [];
+    let done = false;
+    let timer = null;
+
+    const onData = (chunk) => chunks.push(Buffer.from(chunk));
+    function finishRead() {
+      if (done) return;
+      done = true;
+      if (timer) clearTimeout(timer);
+      process.stdin.off("data", onData);
+      process.stdin.off("end", finishRead);
+
+      let payload = {};
+      try {
+        const raw = Buffer.concat(chunks).toString("utf8").replace(/^\uFEFF/, "");
+        if (raw.trim()) payload = JSON.parse(raw);
+      } catch {}
+      resolve(payload);
+    }
+
+    process.stdin.on("data", onData);
+    process.stdin.on("end", finishRead);
+    timer = setTimeout(finishRead, timeoutMs);
+  });
+}
+
+readCursorStdinJson()
   .then((payload) => {
     const argvOverride = process.argv[2];
     const hookNameResolved = argvOverride || (payload && payload.hook_event_name) || "";
@@ -127,7 +156,7 @@ readStdinJson()
     // process, so we exit in its callback (with the safety timer as backstop).
     writeStdoutOnce(outLine);
 
-    postStateToRunningServer(JSON.stringify(body), { timeoutMs: 100 }, () => {
+    postStateToRunningServer(JSON.stringify(body), { timeoutMs: STATE_POST_TIMEOUT_MS }, () => {
       finish(outLine);
     });
   })

--- a/hooks/cursor-install.js
+++ b/hooks/cursor-install.js
@@ -29,17 +29,11 @@ const CURSOR_HOOK_EVENTS = [
   "subagentStart",
   "subagentStop",
   "preCompact",
-  "afterAgentThought",
   "stop",
 ];
 
 function buildCursorHookCommand(nodeBin, hookScript, platform = process.platform) {
-  // Cursor's Windows hook launcher is more reliable when the command goes
-  // through cmd.exe explicitly instead of invoking node directly.
-  return formatNodeHookCommand(nodeBin, hookScript, {
-    platform,
-    windowsWrapper: "cmd",
-  });
+  return formatNodeHookCommand(nodeBin, hookScript, { platform });
 }
 
 /**

--- a/test/cursor-install.test.js
+++ b/test/cursor-install.test.js
@@ -156,7 +156,7 @@ describe("Cursor hook installer", () => {
     assert.strictEqual(fs.existsSync(path.join(fakeHome, ".cursor", "hooks.json")), false);
   });
 
-  it("wraps Windows commands in cmd /c", () => {
+  it("uses PowerShell call syntax for Windows commands", () => {
     const hooksPath = makeTempHooksFile({});
     registerCursorHooks({
       silent: true,
@@ -172,7 +172,8 @@ describe("Cursor hook installer", () => {
       "win32"
     );
     assert.strictEqual(settings.hooks.stop[0].command, expected);
-    assert.ok(settings.hooks.stop[0].command.startsWith("cmd /d /s /c "));
+    assert.ok(settings.hooks.stop[0].command.startsWith("& "));
+    assert.ok(settings.hooks.stop[0].command.includes('"C:\\Program Files\\nodejs\\node.exe"'));
   });
 
   it("preserves an existing Windows node path when detection fails", () => {
@@ -194,6 +195,6 @@ describe("Cursor hook installer", () => {
 
     const settings = readJson(hooksPath);
     assert.ok(settings.hooks.stop[0].command.includes("C:\\Program Files\\nodejs\\node.exe"));
-    assert.ok(settings.hooks.stop[0].command.startsWith("cmd /d /s /c "));
+    assert.ok(settings.hooks.stop[0].command.startsWith("& "));
   });
 });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -291,7 +291,7 @@ describe("Agent Registry", () => {
     const cursor = registry.getAgent("cursor-agent");
     assert.strictEqual(cursor.eventMap.sessionStart, "idle");
     assert.strictEqual(cursor.eventMap.preToolUse, "working");
-    assert.strictEqual(cursor.eventMap.afterAgentThought, "thinking");
+    assert.strictEqual(cursor.eventMap.afterAgentThought, undefined);
     assert.strictEqual(cursor.eventMap.stop, "attention");
 
     const pi = registry.getAgent("pi");


### PR DESCRIPTION
fix(cursor): 修复 Windows hook 路径空格、stdin 读取与 thinking 卡住

- Windows 安装命令由 cmd /c 改为 PowerShell & 语法，正确处理含空格的路径（如 Program Files）
- cursor-hook 使用专用 stdin 读取（2s 超时、BOM 剥离），替代 400ms 的共享 readStdinJson
- 移除 afterAgentThought 注册与状态映射，避免高频触发导致长期停在 thinking
- 提高 safety/POST 超时，降低 Windows 下 hook 空 stdout 与状态上报丢失风险
- 更新 cursor-install 与 registry 相关测试