### PR TITLE
fix(codex): skip approval heuristic for Codex Desktop sessions

### DIFF
--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -525,25 +525,32 @@ class CodexLogMonitor {
         ? { command: cmd, rawPayload: payload }
         : null;
       if (cmd) {
-        if (this._isExplicitApprovalRequest(payload)) {
+        // Codex Desktop has its own native permission / guardian UI — skip the
+        // CLI approval heuristic entirely so auto-reviewed commands don't pop a
+        // passive notify bubble. See _isCodexDesktopSession for the full rationale.
+        // Falling through (not returning) lets the function_call still emit
+        // "working" via the generic path below, same as any other tool call.
+        if (this._isCodexDesktopSession(tracked)) {
+          tracked.pendingApprovalDetail = null;
+        } else if (this._isExplicitApprovalRequest(payload)) {
           tracked.lastState = "codex-permission";
           if (tracked.backfilling) return;
           this._emitStateChange(tracked, "codex-permission", key, {
             permissionDetail: tracked.pendingApprovalDetail,
           });
           return;
-        }
-        if (tracked.backfilling) {
+        } else if (tracked.backfilling) {
           tracked.lastState = "codex-permission";
           return;
+        } else {
+          tracked.approvalTimer = setTimeout(() => {
+            tracked.approvalTimer = null;
+            tracked.lastState = "codex-permission";
+            this._emitStateChange(tracked, "codex-permission", key, {
+              permissionDetail: tracked.pendingApprovalDetail,
+            });
+          }, APPROVAL_HEURISTIC_MS);
         }
-        tracked.approvalTimer = setTimeout(() => {
-          tracked.approvalTimer = null;
-          tracked.lastState = "codex-permission";
-          this._emitStateChange(tracked, "codex-permission", key, {
-            permissionDetail: tracked.pendingApprovalDetail,
-          });
-        }, APPROVAL_HEURISTIC_MS);
       }
     }
 
@@ -623,6 +630,18 @@ class CodexLogMonitor {
     if (!payload || typeof payload !== "object") return false;
     if (payload.type !== "guardian_assessment") return false;
     return payload.status === "in_progress" || payload.status === "approved";
+  }
+
+  // Codex Desktop has its own native permission / guardian auto-review UI.
+  // The 2s approval heuristic below is a CLI-terminal fallback for sessions
+  // with no native prompt to observe; applying it to Desktop sessions spams
+  // passive "知道了" notify bubbles even when guardian auto-approves, because
+  // Desktop's guardian_assessment event often lands in the JSONL well past
+  // the 2s timer window (Desktop write cadence is slow). Desktop state still
+  // flows through the normal working → attention/idle mapping above.
+  _isCodexDesktopSession(tracked) {
+    return typeof tracked.codexOriginator === "string"
+      && tracked.codexOriginator.toLowerCase() === "codex desktop";
   }
 
   // Extract UUID from rollout filename

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -994,6 +994,56 @@ describe("CodexLogMonitor", () => {
     monitor.start();
   });
 
+  it("should NOT emit codex-permission for Codex Desktop sessions (native guardian UI)", (_, done) => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    // Desktop session_meta sets originator=Codex Desktop; a shell function_call
+    // with no exec_command_end would normally trip the 2s approval heuristic,
+    // but Desktop has its own native permission/guardian UI so the heuristic
+    // (and the passive notify bubble it triggers) must be skipped.
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/projects/foo","originator":"Codex Desktop","source":"vscode"}}',
+      '{"type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{\\"command\\":\\"npm run build\\"}"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const states = [];
+    monitor = new CodexLogMonitor(config, (sid, state) => {
+      states.push(state);
+    });
+    monitor.start();
+
+    setTimeout(() => {
+      assert.ok(!states.includes("codex-permission"),
+        "Desktop sessions should not trigger the CLI approval heuristic");
+      assert.ok(states.includes("working"),
+        "Desktop function_call should still map to working");
+      done();
+    }, 3000);
+  });
+
+  it("should NOT emit codex-permission for Codex Desktop even on explicit escalated requests", (_, done) => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    // sandbox_permissions=require_escalated would normally emit codex-permission
+    // immediately, but Desktop routes all permissions through its native UI.
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/projects/foo","originator":"Codex Desktop"}}',
+      '{"type":"response_item","payload":{"type":"function_call","name":"exec_command","arguments":"{\\"cmd\\":\\"npm run build\\",\\"sandbox_permissions\\":\\"require_escalated\\",\\"justification\\":\\"needs local build\\"}"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const states = [];
+    monitor = new CodexLogMonitor(config, (sid, state) => {
+      states.push(state);
+    });
+    monitor.start();
+
+    setTimeout(() => {
+      assert.ok(!states.includes("codex-permission"),
+        "Desktop escalated requests should also defer to native UI");
+      done();
+    }, 500);
+  });
+
   it("should NOT emit codex-permission for non-shell function calls", (_, done) => {
     const testFile = path.join(dateDir, TEST_FILENAME);
     // web_search_call — not a shell command, no approval needed


### PR DESCRIPTION
## 问题

Codex 桌面端（Codex Desktop）开启自动审核模式（guardian auto-approve，命令无需用户审批直接执行）时，Clawd 仍会弹出"知道了"被动通知气泡，提示"Codex 正在执行命令: xxx"。

## 根因

Codex 的权限感知有两条路径：

- **official hook 路径**（`hooks/codex-hook.js` → `/permission`）：Desktop 自动审核时不触发 `PermissionRequest`，正常不弹。
- **JSONL 轮询 fallback 路径**（`agents/codex-log-monitor.js`）：用 2 秒 `approvalTimer` heuristic 推断"等待审批"。`function_call` 到达后 2 秒内若无 `exec_command_end` / `guardian_assessment`，就 emit `codex-permission` → `showCodexNotifyBubble` 弹气泡。

抑制链 `shouldSuppressCodexLogEvent`（`src/agent-runtime-main.js`）本应挡住：`codex-permission` 在"最近 10 分钟有 official hook 事件"时被抑制。但在 Desktop 自动审核场景下会失效：

- Desktop 写入 cadence 慢（3-5 分钟），`guardian_assessment` 常在 2 秒后才落盘，timer 已先触发；
- 或 official hook 未在该 session 上报足够事件使 `hasRecentCodexOfficialHookSession` 返回 false。

**设计缺陷**：`approvalTimer` 的 2 秒 heuristic 本质是给 **CLI 终端** session 用的——CLI 没有原生权限 UI，需要 Clawd 推断等待状态。而 Codex Desktop **有自己的 native 权限/guardian UI**，Clawd 的被动通知气泡对 Desktop session 没有意义，只会重复打扰。

## 修复

在 `approvalTimer` 启动前判断 session 是否为 Codex Desktop，是则跳过整个 heuristic。从源头不让 Desktop session 进入"等待审批"推断，而不是在下游气泡创建时打补丁。

- 新增 `_isCodexDesktopSession(tracked)` —— 判断 `tracked.codexOriginator.toLowerCase() === "codex desktop"`
- 在 `response_item:function_call` 的 approval heuristic 分支，Desktop session 跳过整个 heuristic（explicit escalated + 2s timer），但 **fall through** 到通用 emit 路径，`function_call` 仍正常 emit `working`——桌宠状态切换不受影响

CLI session 行为完全不变。

## 测试

`test/codex-log-monitor.test.js` 新增 2 个用例：

- Desktop session（`originator: "Codex Desktop"`）的 shell `function_call` 不触发 `codex-permission`，但仍 emit `working`
- Desktop session 的 explicit escalated request（`sandbox_permissions: "require_escalated"`）也不触发 `codex-permission`（统一走 native UI）

验证：

- `node --test test/codex-log-monitor.test.js`：49/49 通过
- `npm test` 全量：3992 tests / 3916 pass / 63 fail。对比 baseline（stash 改动）3990 / 3914 / 63 —— 新增 2 测试全过，fail 数不变，无回归。63 个失败均为预先存在的环境问题（`electron` 模块缺失等），与本次改动无关。

## 行为变化

- **Codex Desktop session**：不再弹"知道了"被动气泡，桌宠仍在 working / attention / idle 间正常切换。Desktop 的权限审批走它自己的 native guardian UI。
- **Codex CLI session**：行为完全不变，2 秒 heuristic 和被动通知气泡照常工作。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
