### PR TITLE
fix: keep mini restore on snapped display

### DIFF
--- a/src/mini.js
+++ b/src/mini.js
@@ -406,11 +406,13 @@ function exitMiniMode() {
   const size = _getSize();
   const visualState = ctx.doNotDisturb ? "idle" : ctx.resolveDisplayState();
   const visualFile = visualState ? ctx.getSvgOverride(visualState) : null;
+  const restoreWorkArea = getAttachedMiniWorkArea();
   const clamped = ctx.clampToScreenVisual(preMiniX, preMiniY, size.width, size.height, {
     state: visualState,
     file: visualFile,
+    workArea: restoreWorkArea,
   });
-  const wa = ctx.getNearestWorkArea(clamped.x + size.width / 2, clamped.y + size.height / 2);
+  const wa = restoreWorkArea || ctx.getNearestWorkArea(clamped.x + size.width / 2, clamped.y + size.height / 2);
   const mEdge = Math.round(size.width * 0.25);
   // Prevent right-edge re-snap
   if (clamped.x >= wa.x + wa.width - size.width + mEdge - SNAP_TOLERANCE) {
@@ -498,6 +500,38 @@ function enterMiniViaMenu() {
 
 function refreshContainedBoundary(wa, yMid) {
   containedBoundary = seamBoundary(wa, yMid, miniEdge);
+}
+
+function isValidWorkArea(wa) {
+  return !!(
+    wa
+    && Number.isFinite(wa.x)
+    && Number.isFinite(wa.y)
+    && Number.isFinite(wa.width)
+    && wa.width > 0
+    && Number.isFinite(wa.height)
+    && wa.height > 0
+  );
+}
+
+function sameWorkArea(a, b) {
+  return !!(
+    isValidWorkArea(a)
+    && isValidWorkArea(b)
+    && a.x === b.x
+    && a.y === b.y
+    && a.width === b.width
+    && a.height === b.height
+  );
+}
+
+function getAttachedMiniWorkArea() {
+  if (!isValidWorkArea(lastMiniWorkArea)) return null;
+  const displays = screen.getAllDisplays();
+  if (!Array.isArray(displays) || displays.length === 0) return null;
+  return displays.some((d) => d && sameWorkArea(d.workArea, lastMiniWorkArea))
+    ? lastMiniWorkArea
+    : null;
 }
 
 // Internal-seam state for the hit (input) window. When non-null the hit

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -332,13 +332,30 @@ function createPetWindowRuntime(options = {}) {
     );
   }
 
+  function isValidWorkArea(wa) {
+    return !!(
+      wa
+      && Number.isFinite(wa.x)
+      && Number.isFinite(wa.y)
+      && Number.isFinite(wa.width)
+      && wa.width > 0
+      && Number.isFinite(wa.height)
+      && wa.height > 0
+    );
+  }
+
   function clampToScreenVisual(x, y, w, h, optionsArg = {}) {
     const margins = getVisibleContentMargins(
       { x, y, width: w, height: h },
       optionsArg
     );
-    const nearest = getNearestWorkArea(x + w / 2, y + h / 2);
-    const bottomInset = getNearestDisplayBottomInset(x + w / 2, y + h / 2);
+    const forcedWorkArea = isValidWorkArea(optionsArg.workArea)
+      ? optionsArg.workArea
+      : null;
+    const nearest = forcedWorkArea || getNearestWorkArea(x + w / 2, y + h / 2);
+    const insetProbeX = forcedWorkArea ? nearest.x + nearest.width / 2 : x + w / 2;
+    const insetProbeY = forcedWorkArea ? nearest.y + nearest.height / 2 : y + h / 2;
+    const bottomInset = getNearestDisplayBottomInset(insetProbeX, insetProbeY);
     const mLeft = Math.round(w * 0.25);
     const mRight = Math.round(w * 0.25);
     const clampMargins = getRestClampMargins({

--- a/test/mini.test.js
+++ b/test/mini.test.js
@@ -219,6 +219,40 @@ const SIDE_BY_SIDE = [
   { bounds: { x: 800, y: 0, width: 800, height: 600 }, workArea: { x: 800, y: 0, width: 800, height: 600 } },
 ];
 
+const THREE_SIDE_BY_SIDE = [
+  { bounds: { x: 0, y: 0, width: 800, height: 600 }, workArea: { x: 0, y: 0, width: 800, height: 600 } },
+  { bounds: { x: 800, y: 0, width: 800, height: 600 }, workArea: { x: 800, y: 0, width: 800, height: 600 } },
+  { bounds: { x: 1600, y: 0, width: 800, height: 600 }, workArea: { x: 1600, y: 0, width: 800, height: 600 } },
+];
+
+function findNearestWorkArea(displays, cx, cy) {
+  let nearest = displays[0].workArea;
+  let minDist = Infinity;
+  for (const d of displays) {
+    const wa = d.workArea;
+    const dx = Math.max(wa.x - cx, 0, cx - (wa.x + wa.width));
+    const dy = Math.max(wa.y - cy, 0, cy - (wa.y + wa.height));
+    const dist = dx * dx + dy * dy;
+    if (dist < minDist) {
+      minDist = dist;
+      nearest = wa;
+    }
+  }
+  return nearest;
+}
+
+function installDisplayAwareClamp(ctx, displays) {
+  ctx.getNearestWorkArea = (cx, cy) => findNearestWorkArea(displays, cx, cy);
+  ctx.clampToScreenVisual = (x, y, width, height, options = {}) => {
+    const wa = options.workArea || findNearestWorkArea(displays, x + width / 2, y + height / 2);
+    const marginX = Math.round(width * 0.25);
+    return {
+      x: Math.max(wa.x - marginX, Math.min(x, wa.x + wa.width - width + marginX)),
+      y: Math.max(wa.y, Math.min(y, wa.y + wa.height - height)),
+    };
+  };
+}
+
 function miniClips(rendererEvents) {
   return rendererEvents.filter((e) => e[0] === "mini-clip").map((e) => e[1]);
 }
@@ -468,5 +502,63 @@ describe("mini mode multi-monitor seam clip", () => {
     ctx.win = null;
     assert.doesNotThrow(() => mini.syncContainedClip());
     assert.equal(rendererEvents.length, 0, "no IPC sent without a render window");
+  });
+});
+
+describe("mini mode restore screen ownership", () => {
+  let loader;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"] });
+  });
+
+  afterEach(() => {
+    if (loader) loader.restore();
+    mock.timers.reset();
+    loader = null;
+  });
+
+  it("restores onto the middle screen when snapped to the middle screen's left seam", () => {
+    loader = loadMiniWithElectron({ getAllDisplays() { return THREE_SIDE_BY_SIDE; } });
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 725);
+    installDisplayAwareClamp(ctx, THREE_SIDE_BY_SIDE);
+    const mini = loader.initMini(ctx);
+    const middle = THREE_SIDE_BY_SIDE[1].workArea;
+
+    // The saved pre-mini center is slightly over the halfway mark into the
+    // left screen, but the snap itself belongs to the middle screen's seam.
+    mini.enterMiniMode(middle, false, "left");
+    mock.timers.tick(1140);
+    mini.exitMiniMode();
+    mock.timers.tick(400);
+
+    const bounds = ctx.getBoundsSnapshot();
+    const centerX = bounds.x + bounds.width / 2;
+    assert.ok(
+      centerX >= middle.x && centerX < middle.x + middle.width,
+      `expected restored center ${centerX} to stay on middle screen`
+    );
+  });
+
+  it("restores onto the right screen when snapped to the right screen's left seam", () => {
+    loader = loadMiniWithElectron({ getAllDisplays() { return THREE_SIDE_BY_SIDE; } });
+    const ctx = makeCtx(cloneTheme(_defaultTheme), [], 1525);
+    installDisplayAwareClamp(ctx, THREE_SIDE_BY_SIDE);
+    const mini = loader.initMini(ctx);
+    const right = THREE_SIDE_BY_SIDE[2].workArea;
+
+    // The saved pre-mini center is slightly over the halfway mark into the
+    // middle screen, but the snap itself belongs to the right screen's seam.
+    mini.enterMiniMode(right, false, "left");
+    mock.timers.tick(1140);
+    mini.exitMiniMode();
+    mock.timers.tick(400);
+
+    const bounds = ctx.getBoundsSnapshot();
+    const centerX = bounds.x + bounds.width / 2;
+    assert.ok(
+      centerX >= right.x && centerX < right.x + right.width,
+      `expected restored center ${centerX} to stay on right screen`
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fix a multi-monitor mini-mode restore issue where Clawd could jump to the neighboring display after exiting edge-snapped mini mode.

## Problem

On a setup with three monitors arranged horizontally, the pet can be snapped to an internal monitor seam while part of its window crosses into the neighboring monitor.

Two reproducible cases:

1. The pet starts on the middle monitor, is dragged to the middle monitor's left edge, and more than half of the pet crosses toward the left monitor. After releasing, it snaps to the middle monitor's left edge. When exiting mini mode, the pet jumps to the left monitor.
2. The pet starts on the right monitor, is dragged to the right monitor's left edge, and more than half of the pet crosses toward the middle monitor. After releasing, it snaps to the right monitor's left edge. When exiting mini mode, the pet jumps to the middle monitor.

The snap target is correct, but restore was using the saved pre-mini position to choose the nearest display. When that saved position's center was over the neighboring display, restore clamped to the wrong screen.

## Fix

Keep the existing restore behavior based on `preMiniX` / `preMiniY`, but when exiting mini mode, clamp the restore target to the display where the pet is currently snapped.

This preserves the original restore position as much as possible while keeping restore ownership tied to the current snapped display.

## Tests

Added regression coverage for three-monitor internal-seam restore cases:

- middle monitor left-edge snap restores onto the middle monitor
- right monitor left-edge snap restores onto the right monitor

Verified with:

```bash
node --test test/mini.test.js test/pet-window-runtime.test.js
git diff --check -- src/mini.js src/pet-window-runtime.js test/mini.test.js