### PR TITLE
fix(state): celebrate bg-only Claude Stop with final assistant text (#406)

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -100,6 +100,11 @@ const COMPLETION_CANCEL_EVENTS = new Set([
 // UserPromptSubmit lands within hook-spawn latency (~0.3s) of the Stop, so a
 // 2s quiet window absorbs it; a genuinely final Stop just celebrates 2s late.
 const HEADLESS_COMPLETION_DEBOUNCE_MS = 2000;
+// Claude Desktop can leave a background_tasks entry attached to a user-visible
+// final Stop even after the assistant reply is complete. Treat that bg-only
+// Stop as tentative, not permanently working, when the hook also extracted the
+// assistant's final text.
+const BACKGROUND_TASKS_COMPLETION_DEBOUNCE_MS = 2000;
 function getCompletionDebounceMs(headless) {
   const raw = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
   const n = Number.parseInt(raw, 10);
@@ -111,6 +116,12 @@ function getCompletionDebounceMs(headless) {
   // user otherwise wants the celebration the instant the turn ends. Headless
   // sessions default to the #449 window above.
   return headless ? HEADLESS_COMPLETION_DEBOUNCE_MS : 0;
+}
+function getBackgroundTasksCompletionDebounceMs(headless) {
+  const raw = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+  const n = Number.parseInt(raw, 10);
+  if (Number.isFinite(n) && n >= 0 && n <= 10000) return n;
+  return Math.max(getCompletionDebounceMs(headless), BACKGROUND_TASKS_COMPLETION_DEBOUNCE_MS);
 }
 let lastSessionSnapshotSignature = null;
 let lastSessionSnapshot = null;
@@ -1040,12 +1051,12 @@ function updateSessionFocusMetadata(sessionId, opts = {}) {
 
 // ── #406 Stop completion gate ──
 // A Claude "Stop" maps to "attention" (celebrate + complete sound), but a Stop
-// is not always a real turn completion. Decidable-now signals (live
-// background_tasks/session_crons, or a stop_hook_active continuation) are held
-// as "working" by updateSession directly. For a plain Stop we debounce: hold
-// "working" and only celebrate if no forward-progress event for the session
-// arrives within the window — this catches a third-party Stop hook that vetoes
-// the stop (Claude keeps going) without us ever seeing the veto.
+// is not always a real turn completion. Decidable-now signals (live crons,
+// background tasks with no final assistant text, or a stop_hook_active
+// continuation) are held as "working" by updateSession directly. Plain Stops
+// and bg-only Stops with final assistant text can be debounced: hold "working"
+// and only celebrate if no forward-progress event for the session arrives
+// within the window.
 function scheduleCompletionDebounce(sessionId, debounceMs) {
   const existing = pendingCompletionTimers.get(sessionId);
   if (existing) clearTimeout(existing);
@@ -1270,9 +1281,9 @@ function updateSession(sessionId, state, event, opts = {}) {
   //   · live background_tasks / session_crons → work continues in the bg
   //   · stop_hook_active → a Stop hook vetoed the stop; Claude will continue
   //   · a third-party Stop hook can veto THIS stop, invisibly to us → debounce
-  // The first two are decidable now: hold "working" (badge stays "running", no
-  // celebrate, no "done"). A plain Stop is debounced — held "working" until a
-  // quiet window with no forward-progress event confirms the turn really ended.
+  // Hard gates hold "working" (badge stays "running", no celebrate, no
+  // "done"). A plain Stop, and a bg-only Stop that already has final assistant
+  // text, can be debounced until a quiet window confirms the turn really ended.
   if (
     !duplicateCompletionVisualAtEntry
     && event === "Stop"
@@ -1280,10 +1291,16 @@ function updateSession(sessionId, state, event, opts = {}) {
     && srcAgentId === "claude-code"
   ) {
     cancelCompletionDebounce(sessionId, "stop-superseded");
-    const liveWork =
-      backgroundTasksCount > 0 || sessionCronsCount > 0 || stopHookActive === true;
-    const debounceMs = getCompletionDebounceMs(srcHeadless);
-    if (liveWork || debounceMs > 0) {
+    const hasFinalAssistantText = !!srcAssistantLastOutput;
+    const hardLiveWork =
+      sessionCronsCount > 0 ||
+      stopHookActive === true ||
+      (backgroundTasksCount > 0 && !hasFinalAssistantText);
+    const backgroundDebounceMs = backgroundTasksCount > 0 && hasFinalAssistantText
+      ? getBackgroundTasksCompletionDebounceMs(srcHeadless)
+      : 0;
+    const debounceMs = Math.max(getCompletionDebounceMs(srcHeadless), backgroundDebounceMs);
+    if (hardLiveWork || debounceMs > 0) {
       // Hold the Stop as "working" and DROP the event to null so recentEvents
       // keeps NO "Stop" tail while held. Why null and not "Stop": deriveSessionBadge
       // only inspects the latest event, so a withheld Stop tail would (a) be
@@ -1294,16 +1311,22 @@ function updateSession(sessionId, state, event, opts = {}) {
       // the quiet window confirms the turn actually ended.
       state = "working";
       event = null;
-      if (liveWork) {
+      if (hardLiveWork) {
         debugSession(
           `stop-gate sid=${sessionId} bg=${backgroundTasksCount} crons=${sessionCronsCount} active=${stopHookActive} action=hold-working`
         );
-        // liveWork never auto-promotes; a later plain Stop (no bg work) will.
+        // Hard live work never auto-promotes; a later plain Stop (no hard
+        // blockers) will.
       } else {
+        if (backgroundTasksCount > 0) {
+          debugSession(
+            `stop-gate sid=${sessionId} bg=${backgroundTasksCount} crons=${sessionCronsCount} active=${stopHookActive} action=debounce-working`
+          );
+        }
         scheduleCompletionDebounce(sessionId, debounceMs);
       }
     }
-    // debounceMs <= 0 && !liveWork → keep "attention" (immediate celebration).
+    // debounceMs <= 0 && !hardLiveWork → keep "attention" (immediate celebration).
   }
 
   // Qwen Code 0.16.1 self-submit guard. qwen's agentic loop fires a synthetic

--- a/test/completion-notify-integration.test.js
+++ b/test/completion-notify-integration.test.js
@@ -4,7 +4,8 @@
 // Telegram companion via the real session-snapshot fanout. Locks the third
 // completion surface (the Telegram push) so the held -> promote flow can't
 // silently regress: a held Stop must not push, promote must push exactly once,
-// and live background work must never push.
+// hard live background work must never push, and bg-only Stops with final
+// assistant text promote after a quiet window.
 
 const { describe, it, beforeEach, afterEach, mock } = require("node:test");
 const assert = require("node:assert");
@@ -97,6 +98,15 @@ describe("#406 state -> Telegram completion integration", () => {
     mock.timers.tick(5000);
     await flush();
     assert.strictEqual(sent.length, 0, "background work pending -> no premature completion push");
+  });
+
+  it("bg-only Stop with final assistant text pushes exactly once after the quiet window", async () => {
+    stop(api, "s1", { backgroundTasksCount: 1, assistantLastOutput: "All done." });
+    await flush();
+    assert.strictEqual(sent.length, 0, "no push while bg-only Stop is waiting");
+    mock.timers.tick(1000);
+    await flush();
+    assert.strictEqual(sent.length, 1, "bg-only completion promotes exactly once");
   });
 
   it("Stop then Notification within the window still pushes exactly one completion", async () => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -89,6 +89,8 @@ function update(api, o = {}) {
       codexOriginator: o.codexOriginator ?? null,
       codexSource: o.codexSource ?? null,
       ghosttyTerminalId: o.ghosttyTerminalId ?? null,
+      assistantLastOutput: o.assistantLastOutput ?? null,
+      assistantLastOutputTruncated: o.assistantLastOutputTruncated ?? false,
       backgroundTasksCount: o.backgroundTasksCount ?? 0,
       sessionCronsCount: o.sessionCronsCount ?? 0,
       stopHookActive: o.stopHookActive ?? false,
@@ -2361,13 +2363,46 @@ describe("Stop completion gate (#406)", () => {
     else process.env.CLAWD_COMPLETION_DEBOUNCE_MS = savedDebounceEnv;
   });
 
-  it("live background_tasks hold the Claude Stop as working — no celebrate, badge stays running", () => {
+  it("background_tasks without final assistant text hold the Claude Stop as working — no celebrate, badge stays running", () => {
     update(api, { id: "s1", state: "attention", event: "Stop", backgroundTasksCount: 2 });
     assert.strictEqual(api.sessions.get("s1").state, "working");
     assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "running");
-    mock.timers.tick(5000); // no debounce scheduled for liveWork — nothing promotes
+    mock.timers.tick(5000); // no debounce scheduled for hard live work — nothing promotes
     assert.strictEqual(api.sessions.get("s1").state, "working");
     assert.ok(!soundsPlayed.includes("complete"), "completion sound must not play");
+  });
+
+  it("background_tasks with final assistant text debounce, then celebrate on a quiet window", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundTasksCount: 1,
+      assistantLastOutput: "Done.",
+    });
+    assert.strictEqual(api.sessions.get("s1").state, "working", "held during the bg-only quiet window");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "running");
+    assert.deepStrictEqual(soundsPlayed, [], "no completion sound before the quiet window elapses");
+    mock.timers.tick(1000);
+    assert.strictEqual(api.sessions.get("s1").state, "idle");
+    assert.strictEqual(api.getCurrentState(), "attention");
+    assert.ok(soundsPlayed.includes("complete"), "bg-only completion with final text celebrates");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+  });
+
+  it("background_tasks with final assistant text cancel when work resumes inside the window", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundTasksCount: 1,
+      assistantLastOutput: "Intermediate result.",
+    });
+    mock.timers.tick(500);
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    mock.timers.tick(2000);
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.ok(!soundsPlayed.includes("complete"), "resumed work cancels the bg-only completion");
   });
 
   it("session_crons hold the Claude Stop as working", () => {
@@ -2376,9 +2411,52 @@ describe("Stop completion gate (#406)", () => {
     assert.ok(!soundsPlayed.includes("complete"));
   });
 
+  it("session_crons still hard-hold even when final assistant text exists", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      sessionCronsCount: 1,
+      assistantLastOutput: "Done.",
+    });
+    mock.timers.tick(5000);
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "running");
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
   it("stop_hook_active (continuation) holds the Claude Stop as working", () => {
     update(api, { id: "s1", state: "attention", event: "Stop", stopHookActive: true });
     assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("stop_hook_active still hard-holds even when final assistant text exists", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      stopHookActive: true,
+      assistantLastOutput: "Done.",
+    });
+    mock.timers.tick(5000);
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "running");
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("session_crons dominate bg-only assistant text and keep the Stop hard-held", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundTasksCount: 1,
+      sessionCronsCount: 1,
+      assistantLastOutput: "Done.",
+    });
+    mock.timers.tick(5000);
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "running");
     assert.ok(!soundsPlayed.includes("complete"));
   });
 
@@ -2442,6 +2520,27 @@ describe("Stop completion gate (#406)", () => {
     }
   });
 
+  it("CLAWD_COMPLETION_DEBOUNCE_MS=0 also disables the bg-only assistant-text quiet window", () => {
+    const saved = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    process.env.CLAWD_COMPLETION_DEBOUNCE_MS = "0";
+    try {
+      update(api, {
+        id: "s1",
+        state: "attention",
+        event: "Stop",
+        backgroundTasksCount: 1,
+        assistantLastOutput: "Done.",
+      });
+      assert.strictEqual(api.getCurrentState(), "attention");
+      assert.strictEqual(api.sessions.get("s1").state, "idle");
+      assert.ok(soundsPlayed.includes("complete"));
+      assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+    } finally {
+      if (saved === undefined) delete process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+      else process.env.CLAWD_COMPLETION_DEBOUNCE_MS = saved;
+    }
+  });
+
   it("Stop then Notification within the window still records completion (badge done) (#406 regression)", () => {
     update(api, { id: "s1", state: "attention", event: "Stop" });
     assert.strictEqual(api.sessions.get("s1").state, "working", "held during the window");
@@ -2456,7 +2555,7 @@ describe("Stop completion gate (#406)", () => {
     assert.strictEqual(api.deriveSessionBadge(s), "done");
   });
 
-  it("liveWork-held Stop does not become a false 'done' after stale cleanup (#406 regression)", () => {
+  it("hard liveWork-held Stop does not become a false 'done' after stale cleanup (#406 regression)", () => {
     update(api, { id: "s1", state: "attention", event: "Stop", backgroundTasksCount: 1, agentPid: 1000, sourcePid: 2000 });
     const held = api.sessions.get("s1");
     assert.strictEqual(held.state, "working");
@@ -2551,6 +2650,23 @@ describe("Headless Stop debounce default (#449)", () => {
     update(api, { id: "i1", state: "attention", event: "Stop" });
     assert.strictEqual(api.getCurrentState(), "attention");
     assert.ok(soundsPlayed.includes("complete"));
+  });
+
+  it("interactive bg-only Stop with final assistant text waits 2s by default, then celebrates", () => {
+    update(api, {
+      id: "i1",
+      state: "attention",
+      event: "Stop",
+      backgroundTasksCount: 1,
+      assistantLastOutput: "Done from Claude Desktop.",
+    });
+    mock.timers.tick(1999);
+    assert.deepStrictEqual(soundsPlayed, [], "still waiting for a quiet bg-only window");
+    mock.timers.tick(1);
+    assert.strictEqual(api.sessions.get("i1").state, "idle");
+    assert.strictEqual(api.getCurrentState(), "attention");
+    assert.ok(soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("i1")), "done");
   });
 
   it("the headless flag persists — a later Stop without the flag still debounces", () => {


### PR DESCRIPTION
## What & why

Under Claude Desktop / Code Desktop a user-visible short reply often ends **without** Clawd playing the happy/attention completion animation.

Root cause: the #406 Stop completion gate treats any `background_tasks_count > 0` Stop as live background work and holds the session `"working"` indefinitely. Claude Desktop leaves a `background_tasks` entry attached to the **final** Stop even after the assistant reply is done, so the turn never completes — no happy, no HUD `done` badge, no Telegram push — until stale cleanup drops it back to idle. The user just sees "reply finished, no celebration".

## Fix

Treat a bg-only Stop that **already carries the assistant's final text** as tentative rather than permanent live work:

- **Hard gates unchanged** (always hold `"working"`, never auto-promote):
  `session_crons_count > 0`, `stop_hook_active === true`, and `background_tasks_count > 0` **without** final assistant text.
- **New:** `background_tasks_count > 0` **with** final assistant text gets a 2s quiet window. A forward-progress event (`UserPromptSubmit` / `PreToolUse` / `PostToolUse` / …) in the window cancels the completion; a quiet window promotes it (happy + `done` badge + Telegram push, exactly once).

`CLAWD_COMPLETION_DEBOUNCE_MS` still overrides for every session kind (`0` = celebrate immediately).

## Behavior changes worth noting

- Because the assistant emits prose on nearly every turn, the no-text hard-gate branch only fires for a zero-prose turn — so in practice the bg "hold working" path becomes the 2s-debounce path. This is the intended relaxation of #406 for the spurious-bg case.
- **Headless:** a bg-only Stop with final text now waits 2s instead of holding forever. (Plain headless #449 debounce unchanged.)
- `CLAWD_COMPLETION_DEBOUNCE_MS=0` now makes bg+text celebrate immediately (consistent with "0 = fully off"); crons / stop_hook_active / bg-without-text still hard-gate regardless of the env var.

## Privacy

No new data leaves the hook. The gate reads only `!!assistantLastOutput` (a boolean). `assistantLastOutput` already flowed into the snapshot / Telegram body before this change, and background task command/description are **never** forwarded by the hook.

## Tests

`node --test test/state.test.js test/completion-notify-integration.test.js` → **225 pass / 0 fail**.

Covers both the new quiet-window path and the hard-gate boundaries:
- bg-without-text → hard hold; bg+text → debounce → celebrate; resume cancels inside the window.
- `session_crons` + text, `stop_hook_active` + text, and bg + crons + text → still hard-held (final text does **not** relax them).
- `CLAWD_COMPLETION_DEBOUNCE_MS=0` + bg+text → immediate celebration.
- interactive default 2s window; Telegram pushes exactly once.

## Real-machine smoke ✅

Verified end-to-end against the running app (patched branch, single instance, default port `127.0.0.1:23333`), driving the real `POST /state` hook endpoint with `sendToRenderer` / `playSound` temporarily traced (instrumentation reverted afterwards):

| Scenario | Gate decision (`session-debug.log`) | Renderer received |
| --- | --- | --- |
| bg=1 **+ final text** | `action=debounce-working` | `working` → **+2.0s** → `play-sound complete` + `state-change ["attention","clawd-happy.svg"]` |
| bg=1 **no text** | `action=hold-working` | `working` only — no attention/complete over 3s |
| bg=1 + text, then `PreToolUse` @0.8s | `stop-debounce cancel by=PreToolUse` | no attention/complete (resume cancels) |

The renderer is objectively told to show `clawd-happy.svg` + play `complete` exactly ~2s after the bg-only Stop; the #406 hard gate and the in-window cancel both still behave as designed.

Context: #406 / #421, #449 / #453, #447.