### PR TITLE
fix(state): restore happy for short completions

### DIFF
--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -498,7 +498,8 @@ class CodexLogMonitor {
       tracked.hadToolUse = true;
     }
 
-    // Turn-end: happy if tools were used this turn, idle otherwise
+    // Turn-end: happy if tools were used or the turn produced assistant text;
+    // metadata-only completions stay idle to avoid noisy fallback animation.
     if (state === "codex-turn-end") {
       if (tracked.approvalTimer) {
         clearTimeout(tracked.approvalTimer);
@@ -507,7 +508,7 @@ class CodexLogMonitor {
       tracked.pendingApprovalDetail = null;
       const resolved = this._isTrackedSubagent(tracked)
         ? "idle"
-        : (tracked.hadToolUse ? "attention" : "idle");
+        : (tracked.hadToolUse || !!tracked.assistantLastOutput ? "attention" : "idle");
       tracked.hadToolUse = false;
       tracked.lastState = resolved;
       if (tracked.backfilling) return;

--- a/agents/codex.js
+++ b/agents/codex.js
@@ -30,7 +30,7 @@ module.exports = {
     "response_item:function_call": "working",
     "response_item:custom_tool_call": "working",
     "response_item:web_search_call": "working",
-    "event_msg:task_complete": "codex-turn-end", // resolved by monitor: attention if tools were used, idle otherwise
+    "event_msg:task_complete": "codex-turn-end", // resolved by monitor: attention if tools/assistant output happened, idle otherwise
     "event_msg:context_compacted": "sweeping",
     "event_msg:turn_aborted": "idle",
   },

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -366,6 +366,9 @@ function buildStateBody(event, payload, resolve) {
   if (toolName) body.tool_name = toolName;
   if (toolUseId) body.tool_use_id = toolUseId;
   if (toolInputFingerprint) body.tool_input_fingerprint = toolInputFingerprint;
+  if (event !== "Stop" && typeof payload.transcript_path === "string" && payload.transcript_path) {
+    body.transcript_path = payload.transcript_path;
+  }
   // Read transcript tail once and reuse for both session title extraction and
   // API error detection (Stop only). Avoids two file reads per hook invocation.
   const transcriptEntries = readTranscriptTailEntries(payload.transcript_path);

--- a/src/server-codex-official-turns.js
+++ b/src/server-codex-official-turns.js
@@ -20,6 +20,15 @@ function getCodexOfficialTurnKey(sessionId, turnId) {
   return `${sessionId || "default"}|${turnId}`;
 }
 
+function hasCodexAssistantCompletionOutput(data) {
+  return typeof data.assistant_last_output === "string" && data.assistant_last_output.trim().length > 0;
+}
+
+function resolveCodexOfficialStopState(current, data) {
+  if (current && current.hadToolUse) return "attention";
+  return hasCodexAssistantCompletionOutput(data) ? "attention" : "idle";
+}
+
 function classifyCodexOfficialSession(data, classifier) {
   if (!classifier || typeof classifier.registerSession !== "function") return "unknown";
   const sessionId = typeof data.session_id === "string" && data.session_id ? data.session_id : "default";
@@ -65,10 +74,14 @@ function resolveCodexOfficialHookState(data, requestedState, turns, classifier =
       const current = turns.get(turnKey);
       if (current) turns.delete(turnKey);
       if (isSubagent) return { state: "idle", drop: false, headless: true };
-      return { state: current && current.hadToolUse ? "attention" : "idle", drop: false };
+      return { state: resolveCodexOfficialStopState(current, data), drop: false };
     }
   } else if (event === "Stop") {
-    return { state: "idle", drop: false, ...headless };
+    return {
+      state: isSubagent ? "idle" : resolveCodexOfficialStopState(null, data),
+      drop: false,
+      ...headless,
+    };
   }
 
   return { state: requestedState, drop: false, ...headless };
@@ -80,6 +93,7 @@ module.exports = {
   CODEX_SESSION_ROLE_SUBAGENT,
   pruneCodexOfficialTurns,
   getCodexOfficialTurnKey,
+  hasCodexAssistantCompletionOutput,
   classifyCodexOfficialSession,
   resolveCodexOfficialHookState,
 };

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -11,13 +11,13 @@ const {
 } = require("./server-permission-utils");
 const { resolveHookAgentId } = require("./server-agent-id");
 const { resolveCodexOfficialHookState } = require("./server-codex-official-turns");
+const { normalizeTranscriptPath } = require("./transcript-path");
 
 // /state POST body size cap. Raised from 1024 to 4096 to give new fields
 // (session_title) headroom on top of cwd / pid_chain / host / etc. Still a
 // local-only 127.0.0.1 endpoint - not an Internet DoS concern.
 const MAX_STATE_BODY_BYTES = 4096;
 const ASSISTANT_LAST_OUTPUT_MAX = 2400;
-const TRANSCRIPT_PATH_MAX = 4096;
 
 function normalizeHwndString(value) {
   if (value === null || value === undefined) return null;
@@ -56,13 +56,6 @@ function normalizeAssistantLastOutput(value) {
   return text.length > ASSISTANT_LAST_OUTPUT_MAX
     ? text.slice(0, ASSISTANT_LAST_OUTPUT_MAX)
     : text;
-}
-
-function normalizeTranscriptPath(value) {
-  if (typeof value !== "string") return null;
-  const text = value.trim();
-  if (!text || text.length > TRANSCRIPT_PATH_MAX || /[\0\r\n]/.test(text)) return null;
-  return text;
 }
 
 function normalizeContextUsage(value) {

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -17,6 +17,7 @@ const { resolveCodexOfficialHookState } = require("./server-codex-official-turns
 // local-only 127.0.0.1 endpoint - not an Internet DoS concern.
 const MAX_STATE_BODY_BYTES = 4096;
 const ASSISTANT_LAST_OUTPUT_MAX = 2400;
+const TRANSCRIPT_PATH_MAX = 4096;
 
 function normalizeHwndString(value) {
   if (value === null || value === undefined) return null;
@@ -55,6 +56,13 @@ function normalizeAssistantLastOutput(value) {
   return text.length > ASSISTANT_LAST_OUTPUT_MAX
     ? text.slice(0, ASSISTANT_LAST_OUTPUT_MAX)
     : text;
+}
+
+function normalizeTranscriptPath(value) {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!text || text.length > TRANSCRIPT_PATH_MAX || /[\0\r\n]/.test(text)) return null;
+  return text;
 }
 
 function normalizeContextUsage(value) {
@@ -163,6 +171,7 @@ function handleStatePost(req, res, options) {
       const contextUsage = normalizeContextUsage(data.context_usage);
       const assistantLastOutput = normalizeAssistantLastOutput(data.assistant_last_output);
       const assistantLastOutputTruncated = data.assistant_last_output_truncated === true;
+      const transcriptPath = normalizeTranscriptPath(data.transcript_path);
       const permissionSuspect = data.permission_suspect === true;
       const preserveState = data.preserve_state === true;
       const hookSource = typeof data.hook_source === "string" ? data.hook_source : null;
@@ -278,6 +287,8 @@ function handleStatePost(req, res, options) {
             contextUsage,
             assistantLastOutput,
             assistantLastOutputTruncated,
+            toolName,
+            transcriptPath,
             permissionSuspect,
             preserveState,
             hookSource,

--- a/src/state.js
+++ b/src/state.js
@@ -35,6 +35,7 @@ const {
   sessionSnapshotSignature,
 } = require("./state-session-snapshot");
 const { getAgentIconUrl } = require("./state-agent-icons");
+const { normalizeTranscriptPath } = require("./transcript-path");
 const {
   readTranscriptTailEntries: readClaudeTranscriptTailEntries,
   extractLastAssistantTextFromEntries: extractLastClaudeAssistantTextFromEntries,
@@ -150,13 +151,6 @@ function normalizeAssistantOutput(value) {
   return text.length > ASSISTANT_OUTPUT_MAX
     ? text.slice(0, ASSISTANT_OUTPUT_MAX)
     : text;
-}
-
-function normalizeTranscriptPath(value) {
-  if (typeof value !== "string") return null;
-  const text = value.trim();
-  if (!text || text.length > 4096 || /[\0\r\n]/.test(text)) return null;
-  return text;
 }
 
 function normalizeToolName(value) {

--- a/src/state.js
+++ b/src/state.js
@@ -35,6 +35,10 @@ const {
   sessionSnapshotSignature,
 } = require("./state-session-snapshot");
 const { getAgentIconUrl } = require("./state-agent-icons");
+const {
+  readTranscriptTailEntries: readClaudeTranscriptTailEntries,
+  extractLastAssistantTextFromEntries: extractLastClaudeAssistantTextFromEntries,
+} = require("../hooks/clawd-hook");
 
 module.exports = function initState(ctx) {
 
@@ -105,6 +109,10 @@ const HEADLESS_COMPLETION_DEBOUNCE_MS = 2000;
 // Stop as tentative, not permanently working, when the hook also extracted the
 // assistant's final text.
 const BACKGROUND_TASKS_COMPLETION_DEBOUNCE_MS = 2000;
+const CLAUDE_ELICITATION_COMPLETION_PROBE_DELAY_MS = 2000;
+const CLAUDE_ELICITATION_COMPLETION_PROBE_INTERVAL_MS = 3000;
+const CLAUDE_ELICITATION_COMPLETION_PROBE_MAX_MS = 5 * 60 * 1000;
+const CLAUDE_ELICITATION_COMPLETION_TOOLS = new Set(["AskUserQuestion"]);
 function getCompletionDebounceMs(headless) {
   const raw = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
   const n = Number.parseInt(raw, 10);
@@ -129,6 +137,7 @@ let startupRecoveryActive = false;
 let startupRecoveryTimer = null;
 const STARTUP_RECOVERY_MAX_MS = 300000;
 const codexExitProbes = new Map();
+const claudeTranscriptCompletionProbes = new Map();
 
 function normalizeAssistantOutput(value) {
   if (typeof value !== "string") return null;
@@ -141,6 +150,20 @@ function normalizeAssistantOutput(value) {
   return text.length > ASSISTANT_OUTPUT_MAX
     ? text.slice(0, ASSISTANT_OUTPUT_MAX)
     : text;
+}
+
+function normalizeTranscriptPath(value) {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!text || text.length > 4096 || /[\0\r\n]/.test(text)) return null;
+  return text;
+}
+
+function normalizeToolName(value) {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!text || text.length > 160 || /[\0\r\n]/.test(text)) return null;
+  return text;
 }
 
 // ── Hit-test bounding boxes (from theme) ──
@@ -1080,6 +1103,66 @@ function clearAllCompletionDebounces() {
   pendingCompletionTimers.clear();
 }
 
+function cancelClaudeTranscriptCompletionProbe(sessionId, reason) {
+  const existing = claudeTranscriptCompletionProbes.get(sessionId);
+  if (!existing) return;
+  clearTimeout(existing.timer);
+  claudeTranscriptCompletionProbes.delete(sessionId);
+  debugSession(`claude-transcript-stop-probe cancel sid=${sessionId} by=${reason || "-"}`);
+}
+
+function clearAllClaudeTranscriptCompletionProbes() {
+  for (const { timer } of claudeTranscriptCompletionProbes.values()) clearTimeout(timer);
+  claudeTranscriptCompletionProbes.clear();
+}
+
+function isClaudeElicitationCompletionTool(toolName) {
+  return CLAUDE_ELICITATION_COMPLETION_TOOLS.has(toolName);
+}
+
+function scheduleClaudeTranscriptCompletionProbe(sessionId, transcriptPath) {
+  const safePath = normalizeTranscriptPath(transcriptPath);
+  if (!safePath) return;
+
+  cancelClaudeTranscriptCompletionProbe(sessionId, "reschedule");
+
+  const startedAt = Date.now();
+  const probe = { timer: null, transcriptPath: safePath, startedAt };
+
+  const runProbe = () => {
+    const session = sessions.get(sessionId);
+    if (!session || session.agentId !== "claude-code" || session.state !== "working") {
+      claudeTranscriptCompletionProbes.delete(sessionId);
+      return;
+    }
+    if (Date.now() - startedAt > CLAUDE_ELICITATION_COMPLETION_PROBE_MAX_MS) {
+      claudeTranscriptCompletionProbes.delete(sessionId);
+      debugSession(`claude-transcript-stop-probe expire sid=${sessionId}`);
+      return;
+    }
+
+    const assistantOutput = extractLastClaudeAssistantTextFromEntries(
+      readClaudeTranscriptTailEntries(safePath),
+      sessionId
+    );
+    if (assistantOutput && assistantOutput.text) {
+      claudeTranscriptCompletionProbes.delete(sessionId);
+      session.assistantLastOutput = normalizeAssistantOutput(assistantOutput.text);
+      session.assistantLastOutputTruncated = assistantOutput.truncated === true;
+      debugSession(`claude-transcript-stop-probe promote sid=${sessionId}`);
+      promoteCompletion(sessionId);
+      return;
+    }
+
+    probe.timer = setTimeout(runProbe, CLAUDE_ELICITATION_COMPLETION_PROBE_INTERVAL_MS);
+    claudeTranscriptCompletionProbes.set(sessionId, probe);
+  };
+
+  probe.timer = setTimeout(runProbe, CLAUDE_ELICITATION_COMPLETION_PROBE_DELAY_MS);
+  claudeTranscriptCompletionProbes.set(sessionId, probe);
+  debugSession(`claude-transcript-stop-probe schedule sid=${sessionId}`);
+}
+
 // Debounce window elapsed with no forward progress → the turn really ended.
 // Replay the real Stop the gate withheld: append a Stop event (so the badge →
 // "done" and the Telegram completion fires exactly once, re-asserting a Stop
@@ -1138,6 +1221,8 @@ function updateSession(sessionId, state, event, opts = {}) {
     contextUsage = null,
     assistantLastOutput = null,
     assistantLastOutputTruncated = false,
+    toolName = null,
+    transcriptPath = null,
     permissionSuspect = false,
     preserveState = false,
     hookSource = null,
@@ -1157,6 +1242,9 @@ function updateSession(sessionId, state, event, opts = {}) {
   // the PermissionRequest early-return so a permission prompt cancels too.
   if (event !== "Stop" && COMPLETION_CANCEL_EVENTS.has(event)) {
     cancelCompletionDebounce(sessionId, event);
+  }
+  if (event === "Stop" || COMPLETION_CANCEL_EVENTS.has(event)) {
+    cancelClaudeTranscriptCompletionProbe(sessionId, event);
   }
 
   const sessionForPerm = sessions.get(sessionId);
@@ -1269,6 +1357,8 @@ function updateSession(sessionId, state, event, opts = {}) {
   const srcContextUsage = normalizeContextUsage(contextUsage) || (existing && existing.contextUsage) || null;
   const srcAssistantLastOutput = normalizeAssistantOutput(assistantLastOutput);
   const srcAssistantLastOutputTruncated = !!(srcAssistantLastOutput && assistantLastOutputTruncated === true);
+  const srcToolName = normalizeToolName(toolName) || (existing && existing.lastToolName) || null;
+  const srcTranscriptPath = normalizeTranscriptPath(transcriptPath) || (existing && existing.transcriptPath) || null;
   const srcResumeState = (existing && existing.resumeState) || null;
   const isSubagentStart = event === "SubagentStart" || event === "subagentStart";
   const isSubagentStop = event === "SubagentStop" || event === "subagentStop";
@@ -1386,7 +1476,7 @@ function updateSession(sessionId, state, event, opts = {}) {
   const srcLastStopAt = isStopBoundary
     ? Date.now()
     : (existing && Number.isFinite(existing.lastStopAt) ? existing.lastStopAt : null);
-  const base = { sourcePid: srcPid, wtHwnd: srcWtHwnd, cwd: srcCwd, editor: srcEditor, pidChain: srcPidChain, tmuxSocket: srcTmuxSocket, tmuxClient: srcTmuxClient, agentPid: srcAgentPid, agentId: srcAgentId, host: srcHost, headless: srcHeadless, platform: srcPlatform, model: srcModel, provider: srcProvider, codexOriginator: srcCodexOriginator, codexSource: srcCodexSource, ghosttyTerminalId: srcGhosttyTerminalId, sessionTitle: srcSessionTitle, contextUsage: srcContextUsage, assistantLastOutput: srcAssistantLastOutput, assistantLastOutputTruncated: srcAssistantLastOutputTruncated, recentEvents, pidReachable, lastToolBoundaryAt: srcLastToolBoundaryAt, lastStopAt: srcLastStopAt, awaitingInputSinceStop: resolveAwaitingInputSinceStop(existing, event), muteNotificationSound: state === "notification" && muteNotificationSound === true };
+  const base = { sourcePid: srcPid, wtHwnd: srcWtHwnd, cwd: srcCwd, editor: srcEditor, pidChain: srcPidChain, tmuxSocket: srcTmuxSocket, tmuxClient: srcTmuxClient, agentPid: srcAgentPid, agentId: srcAgentId, host: srcHost, headless: srcHeadless, platform: srcPlatform, model: srcModel, provider: srcProvider, codexOriginator: srcCodexOriginator, codexSource: srcCodexSource, ghosttyTerminalId: srcGhosttyTerminalId, sessionTitle: srcSessionTitle, contextUsage: srcContextUsage, assistantLastOutput: srcAssistantLastOutput, assistantLastOutputTruncated: srcAssistantLastOutputTruncated, lastToolName: srcToolName, transcriptPath: srcTranscriptPath, recentEvents, pidReachable, lastToolBoundaryAt: srcLastToolBoundaryAt, lastStopAt: srcLastStopAt, awaitingInputSinceStop: resolveAwaitingInputSinceStop(existing, event), muteNotificationSound: state === "notification" && muteNotificationSound === true };
   if (preserveCompletionAck) base.requiresCompletionAck = true;
 
   // Evict oldest session if at capacity and this is a new session.
@@ -1480,6 +1570,14 @@ function updateSession(sessionId, state, event, opts = {}) {
   }
   cleanStaleSessions();
   updateCodexExitProbe(sessionId, srcAgentId, event);
+  if (
+    srcAgentId === "claude-code"
+    && event === "PostToolUse"
+    && isClaudeElicitationCompletionTool(srcToolName)
+    && srcTranscriptPath
+  ) {
+    scheduleClaudeTranscriptCompletionProbe(sessionId, srcTranscriptPath);
+  }
   // Any Kimi event other than the PreToolUse that originally opened the hold
   // means the user already answered (Approve / Reject / Reject-and-tell-model)
   // and the agent loop has moved on. We must NOT keep the pet stuck on the
@@ -2004,6 +2102,7 @@ function enableDoNotDisturb() {
   if (pendingTimer) { clearTimeout(pendingTimer); pendingTimer = null; pendingState = null; }
   if (autoReturnTimer) { clearTimeout(autoReturnTimer); autoReturnTimer = null; }
   clearAllCompletionDebounces();
+  clearAllClaudeTranscriptCompletionProbes();
   stopWakePoll();
   if (ctx.miniMode) {
     applyState("mini-sleep");
@@ -2052,6 +2151,7 @@ function cleanup() {
   pendingState = null;
   if (autoReturnTimer) clearTimeout(autoReturnTimer);
   clearAllCompletionDebounces();
+  clearAllClaudeTranscriptCompletionProbes();
   if (eyeResendTimer) clearTimeout(eyeResendTimer);
   if (startupRecoveryTimer) clearTimeout(startupRecoveryTimer);
   stopWakePoll();

--- a/src/transcript-path.js
+++ b/src/transcript-path.js
@@ -1,0 +1,13 @@
+const TRANSCRIPT_PATH_MAX = 4096;
+
+function normalizeTranscriptPath(value) {
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!text || text.length > TRANSCRIPT_PATH_MAX || /[\0\r\n]/.test(text)) return null;
+  return text;
+}
+
+module.exports = {
+  TRANSCRIPT_PATH_MAX,
+  normalizeTranscriptPath,
+};

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -309,11 +309,26 @@ describe("buildStateBody", () => {
       tool_name: "Read",
       tool_use_id: "toolu_123",
       tool_input: { file_path: "src/server.js" },
+      transcript_path: "/tmp/claude-transcript.jsonl",
     };
     const body = buildStateBody("PostToolUse", payload, mockResolve);
     assert.strictEqual(body.tool_name, "Read");
     assert.strictEqual(body.tool_use_id, "toolu_123");
     assert.strictEqual(body.tool_input_fingerprint, buildToolInputFingerprint(payload.tool_input));
+    assert.strictEqual(body.transcript_path, "/tmp/claude-transcript.jsonl");
+  });
+
+  it("does not forward transcript_path on Stop after extracting completion data", () => {
+    const file = writeTmpJsonl([
+      { type: "assistant", sessionId: "sid-1", message: { content: "Done." } },
+    ]);
+    const body = buildStateBody(
+      "Stop",
+      { session_id: "sid-1", transcript_path: file },
+      mockResolve
+    );
+    assert.strictEqual(body.assistant_last_output, "Done.");
+    assert.ok(!("transcript_path" in body));
   });
 
   it("adds context_usage from transcript usage", () => {

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -220,6 +220,28 @@ describe("CodexLogMonitor", () => {
     monitor.start();
   });
 
+  it("should map no-tool task_complete to attention when assistant output is present", (_, done) => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+      '{"type":"event_msg","payload":{"type":"task_started"}}',
+      '{"type":"event_msg","payload":{"type":"agent_message","message":"Short answer."}}',
+      '{"type":"event_msg","payload":{"type":"task_complete"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const states = [];
+    monitor = new CodexLogMonitor(config, (sid, state, event, extra) => {
+      states.push(state);
+      if (state === "attention") {
+        assert.deepStrictEqual(states, ["idle", "thinking", "attention"]);
+        assert.strictEqual(extra.assistantLastOutput, "Short answer.");
+        done();
+      }
+    });
+    monitor.start();
+  });
+
   it("should map task_complete to attention when tools were used", (_, done) => {
     const testFile = path.join(dateDir, TEST_FILENAME);
     fs.writeFileSync(testFile, [

--- a/test/server-hook-management.test.js
+++ b/test/server-hook-management.test.js
@@ -488,7 +488,7 @@ describe("Codex official hook turn tracking", () => {
     assert.strictEqual(turns.size, 0);
   });
 
-  it("resolves Stop to idle when no tool was seen", () => {
+  it("resolves Stop to idle when no tool or assistant output was seen", () => {
     const turns = new Map();
     resolveCodexOfficialHookState({
       agent_id: "codex",
@@ -507,6 +507,41 @@ describe("Codex official hook turn tracking", () => {
     }, "idle", turns);
 
     assert.deepStrictEqual(result, { state: "idle", drop: false });
+  });
+
+  it("resolves Stop to attention when a no-tool turn has assistant output", () => {
+    const turns = new Map();
+    resolveCodexOfficialHookState({
+      agent_id: "codex",
+      hook_source: "codex-official",
+      event: "UserPromptSubmit",
+      session_id: "codex:s1",
+      turn_id: "turn-1",
+    }, "thinking", turns);
+
+    const result = resolveCodexOfficialHookState({
+      agent_id: "codex",
+      hook_source: "codex-official",
+      event: "Stop",
+      session_id: "codex:s1",
+      turn_id: "turn-1",
+      assistant_last_output: "Short answer.",
+    }, "idle", turns);
+
+    assert.deepStrictEqual(result, { state: "attention", drop: false });
+    assert.strictEqual(turns.size, 0);
+  });
+
+  it("resolves Stop without a turn id to attention when assistant output is present", () => {
+    const result = resolveCodexOfficialHookState({
+      agent_id: "codex",
+      hook_source: "codex-official",
+      event: "Stop",
+      session_id: "codex:s1",
+      assistant_last_output: "Done.",
+    }, "idle", new Map());
+
+    assert.deepStrictEqual(result, { state: "attention", drop: false });
   });
 
   it("drops stop_hook_active continuations without updating state", () => {

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -51,6 +51,7 @@ function callStatePost(body, overrides = {}) {
     };
     const ctx = {
       STATE_SVGS: {
+        idle: "x.svg",
         working: "x.svg",
         attention: "x.svg",
         "mini-idle": "x.svg",
@@ -121,6 +122,8 @@ describe("server-route-state POST", () => {
       codex_source: "vscode",
       ghostty_terminal_id: "ghostty-term-7",
       session_title: "  Work title  ",
+      tool_name: "Read",
+      transcript_path: "/Users/tester/.claude/projects/repo/session.jsonl",
       permission_suspect: true,
       preserve_state: true,
       hook_source: "codex-official",
@@ -154,6 +157,8 @@ describe("server-route-state POST", () => {
         contextUsage: null,
         assistantLastOutput: null,
         assistantLastOutputTruncated: false,
+        toolName: "Read",
+        transcriptPath: "/Users/tester/.claude/projects/repo/session.jsonl",
         permissionSuspect: true,
         preserveState: true,
         hookSource: "codex-official",
@@ -176,6 +181,21 @@ describe("server-route-state POST", () => {
     assert.strictEqual(res.statusCode, 200);
     assert.strictEqual(res.calls.updateSession[0][3].assistantLastOutput, "Done.\nsecret=abc123");
     assert.strictEqual(res.calls.updateSession[0][3].assistantLastOutputTruncated, true);
+  });
+
+  it("celebrates Codex official no-tool Stop when assistant output is present", async () => {
+    const res = await callStatePost(JSON.stringify({
+      state: "idle",
+      session_id: "codex:sid",
+      event: "Stop",
+      agent_id: "codex",
+      hook_source: "codex-official",
+      assistant_last_output: "Short answer.",
+    }));
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.calls.updateSession[0][1], "attention");
+    assert.strictEqual(res.calls.updateSession[0][3].assistantLastOutput, "Short answer.");
   });
 
   it("passes valid context_usage to updateSession", async () => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -91,6 +91,8 @@ function update(api, o = {}) {
       ghosttyTerminalId: o.ghosttyTerminalId ?? null,
       assistantLastOutput: o.assistantLastOutput ?? null,
       assistantLastOutputTruncated: o.assistantLastOutputTruncated ?? false,
+      toolName: o.toolName ?? null,
+      transcriptPath: o.transcriptPath ?? null,
       backgroundTasksCount: o.backgroundTasksCount ?? 0,
       sessionCronsCount: o.sessionCronsCount ?? 0,
       stopHookActive: o.stopHookActive ?? false,
@@ -2598,6 +2600,88 @@ describe("Stop completion gate (#406)", () => {
       if (saved === undefined) delete process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
       else process.env.CLAWD_COMPLETION_DEBOUNCE_MS = saved;
     }
+  });
+
+  it("Claude AskUserQuestion PostToolUse falls back to transcript completion when Stop is missed", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-claude-stop-fallback-"));
+    const transcript = path.join(dir, "transcript.jsonl");
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: "assistant", sessionId: "s1", message: { content: [{ type: "tool_use", name: "AskUserQuestion" }] } }),
+      JSON.stringify({ type: "user", sessionId: "s1", message: { content: [{ type: "tool_result", content: "Allow" }] } }),
+    ].join("\n") + "\n");
+
+    update(api, {
+      id: "s1",
+      state: "working",
+      event: "PostToolUse",
+      toolName: "AskUserQuestion",
+      transcriptPath: transcript,
+    });
+
+    mock.timers.tick(1999);
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.deepStrictEqual(soundsPlayed, []);
+
+    fs.appendFileSync(transcript, JSON.stringify({
+      type: "assistant",
+      sessionId: "s1",
+      message: { content: "Final answer from Claude Desktop." },
+    }) + "\n");
+    mock.timers.tick(1);
+
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "idle");
+    assert.strictEqual(session.assistantLastOutput, "Final answer from Claude Desktop.");
+    assert.strictEqual(api.getCurrentState(), "attention");
+    assert.ok(soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(session), "done");
+  });
+
+  it("Claude transcript completion fallback is limited to AskUserQuestion tool results", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-claude-stop-fallback-"));
+    const transcript = path.join(dir, "transcript.jsonl");
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: "user", sessionId: "s1", message: { content: [{ type: "tool_result", content: "ok" }] } }),
+      JSON.stringify({ type: "assistant", sessionId: "s1", message: { content: "Intermediate explanation." } }),
+    ].join("\n") + "\n");
+
+    update(api, {
+      id: "s1",
+      state: "working",
+      event: "PostToolUse",
+      toolName: "Read",
+      transcriptPath: transcript,
+    });
+    mock.timers.tick(10000);
+
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "running");
+  });
+
+  it("Claude transcript completion fallback cancels when work resumes", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-claude-stop-fallback-"));
+    const transcript = path.join(dir, "transcript.jsonl");
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: "assistant", sessionId: "s1", message: { content: [{ type: "tool_use", name: "AskUserQuestion" }] } }),
+      JSON.stringify({ type: "user", sessionId: "s1", message: { content: [{ type: "tool_result", content: "Allow" }] } }),
+      JSON.stringify({ type: "assistant", sessionId: "s1", message: { content: "Continuing after answer." } }),
+    ].join("\n") + "\n");
+
+    update(api, {
+      id: "s1",
+      state: "working",
+      event: "PostToolUse",
+      toolName: "AskUserQuestion",
+      transcriptPath: transcript,
+    });
+    mock.timers.tick(500);
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    mock.timers.tick(10000);
+
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "running");
   });
 });
 


### PR DESCRIPTION
## Summary

- Restore the `happy` completion animation when a session finishes with real assistant text but no tool calls.
- Cover the Codex official Stop/task_complete path, the Codex JSONL fallback path, and the Claude transcript fallback path only insofar as they feed that same completion-happy decision.
- Keep metadata-only and empty completions idle so noisy fallback events do not trigger happy.

## Scope

This PR is intentionally limited to completion-state classification for the `happy` animation plus focused tests.

It does not include the Windows audit documentation, Windows-specific fixes, theme assets, or unrelated behavior changes.

## Validation

- `node --test test/server-hook-management.test.js test/server-route-state.test.js test/codex-log-monitor.test.js`
- `node --test test/state.test.js test/agent-runtime-main.test.js test/state-session-snapshot.test.js`
- `git diff --check`
- Manual local verification: a short Codex reply now triggers happy after completion.