### PR TITLE
[codex] Fix Windows audit crash recovery

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3338,6 +3338,8 @@ function createWindow() {
       safeConsoleError("hitWin renderer crashed:", details.reason);
       petWindowRuntime.setDragLocked(false);
       petWindowRuntime.clearDragSnapshot();
+      idlePaused = false;
+      mouseOverPet = false;
       petWindowRuntime.reloadWindowWebContents(ownedHitWin, { crashKey: "hitWin", details });
     },
   });

--- a/src/main.js
+++ b/src/main.js
@@ -3336,7 +3336,9 @@ function createWindow() {
     },
     onRenderProcessGone: (details, ownedHitWin) => {
       safeConsoleError("hitWin renderer crashed:", details.reason);
-      petWindowRuntime.reloadWindowWebContents(ownedHitWin);
+      petWindowRuntime.setDragLocked(false);
+      petWindowRuntime.clearDragSnapshot();
+      petWindowRuntime.reloadWindowWebContents(ownedHitWin, { crashKey: "hitWin", details });
     },
   });
 
@@ -3425,7 +3427,7 @@ function createWindow() {
     petWindowRuntime.setDragLocked(false);
     idlePaused = false;
     mouseOverPet = false;
-    petWindowRuntime.reloadWindowWebContents(win);
+    petWindowRuntime.reloadWindowWebContents(win, { crashKey: "renderWin", details });
   });
 
   guardAlwaysOnTop(win);
@@ -3626,13 +3628,17 @@ if (!gotTheLock) {
   app.quit();
 } else {
   app.on("second-instance", (_event, commandLine) => {
-    if (win) {
-      win.showInactive();
-      keepOutOfTaskbar(win);
-    }
-    if (hitWin && !hitWin.isDestroyed()) {
-      hitWin.showInactive();
-      keepOutOfTaskbar(hitWin);
+    if (petWindowRuntime.isPetHidden()) {
+      petWindowRuntime.setPetHidden(false);
+    } else {
+      if (win) {
+        win.showInactive();
+        keepOutOfTaskbar(win);
+      }
+      if (hitWin && !hitWin.isDestroyed()) {
+        hitWin.showInactive();
+        keepOutOfTaskbar(hitWin);
+      }
     }
     if (shouldOpenSettingsWindowFromArgv(commandLine)) {
       settingsWindowRuntime.openWhenReady();

--- a/src/main.js
+++ b/src/main.js
@@ -3629,6 +3629,7 @@ if (!gotTheLock) {
 } else {
   app.on("second-instance", (_event, commandLine) => {
     if (petWindowRuntime.isPetHidden()) {
+      prepManualPetVisibility();
       petWindowRuntime.setPetHidden(false);
     } else {
       if (win) {

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -30,7 +30,6 @@ const NON_RELOADABLE_RENDER_GONE_REASONS = new Set([
   "killed",
   "integrity-failure",
   "launch-failed",
-  "launched-failed",
 ]);
 
 function isLiveWindow(win) {

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -23,9 +23,58 @@ const {
 } = require("./drag-position");
 
 const noop = () => {};
+const DEFAULT_CRASH_RELOAD_LIMIT = 5;
+const DEFAULT_CRASH_RELOAD_WINDOW_MS = 30_000;
+const NON_RELOADABLE_RENDER_GONE_REASONS = new Set([
+  "clean-exit",
+  "killed",
+  "integrity-failure",
+  "launch-failed",
+  "launched-failed",
+]);
 
 function isLiveWindow(win) {
   return !!(win && typeof win.isDestroyed === "function" && !win.isDestroyed());
+}
+
+function getRenderGoneReason(details) {
+  return details && typeof details.reason === "string" ? details.reason : "unknown";
+}
+
+function createRenderProcessGoneReloadGuard(options = {}) {
+  const crashReloadLimit = Number.isFinite(options.crashReloadLimit)
+    ? Math.max(0, Math.floor(options.crashReloadLimit))
+    : DEFAULT_CRASH_RELOAD_LIMIT;
+  const crashReloadWindowMs = Number.isFinite(options.crashReloadWindowMs)
+    ? Math.max(0, options.crashReloadWindowMs)
+    : DEFAULT_CRASH_RELOAD_WINDOW_MS;
+  const now = typeof options.now === "function" ? options.now : Date.now;
+  const log = typeof options.crashReloadLog === "function"
+    ? options.crashReloadLog
+    : (message) => console.warn(message);
+  const reloadsByKey = new Map();
+
+  return function shouldReloadAfterRenderProcessGone(crashKey, details) {
+    const key = crashKey || "default";
+    const reason = getRenderGoneReason(details);
+    if (NON_RELOADABLE_RENDER_GONE_REASONS.has(reason)) {
+      log(`Clawd: not reloading ${key} after render-process-gone (${reason})`);
+      return false;
+    }
+
+    const ts = Number(now());
+    const cutoff = ts - crashReloadWindowMs;
+    const recent = (reloadsByKey.get(key) || []).filter((value) => value >= cutoff);
+    if (recent.length >= crashReloadLimit) {
+      log(`Clawd: stopped reloading ${key} after ${recent.length} crashes in ${crashReloadWindowMs}ms`);
+      reloadsByKey.set(key, recent);
+      return false;
+    }
+
+    recent.push(ts);
+    reloadsByKey.set(key, recent);
+    return true;
+  };
 }
 
 function reloadWindowWebContents(win) {
@@ -85,6 +134,18 @@ function createPetWindowRuntime(options = {}) {
   const flushRuntimeStateToPrefs = options.flushRuntimeStateToPrefs || noop;
   const handleMiniDisplayChange = options.handleMiniDisplayChange || noop;
   const exitMiniMode = options.exitMiniMode || noop;
+  const shouldReloadAfterRenderProcessGone = createRenderProcessGoneReloadGuard(options);
+
+  function reloadRuntimeWindowWebContents(win, reloadOptions = {}) {
+    if (
+      reloadOptions
+      && reloadOptions.crashKey
+      && !shouldReloadAfterRenderProcessGone(reloadOptions.crashKey, reloadOptions.details)
+    ) {
+      return false;
+    }
+    return reloadWindowWebContents(win);
+  }
 
   const petGeometryMain = createPetGeometryMain({
     getActiveTheme,
@@ -573,7 +634,7 @@ function createPetWindowRuntime(options = {}) {
         optionsArg.onRenderProcessGone(details, hitWin);
         return;
       }
-      reloadWindowWebContents(hitWin);
+      reloadRuntimeWindowWebContents(hitWin, { crashKey: "hitWin", details });
     });
     return hitWin;
   }
@@ -814,7 +875,7 @@ function createPetWindowRuntime(options = {}) {
     getInitialHitWindowBounds,
     createRenderWindow,
     createHitWindow,
-    reloadWindowWebContents,
+    reloadWindowWebContents: reloadRuntimeWindowWebContents,
     setDragLocked,
     isDragLocked,
     beginDragSnapshot,

--- a/test/agent-installation-detector.test.js
+++ b/test/agent-installation-detector.test.js
@@ -69,7 +69,7 @@ describe("agent installation detector", () => {
       },
     });
 
-    const report = detectAgentInstallations({ homeDir, now: 1 });
+    const report = detectAgentInstallations({ homeDir, now: 1, env: {} });
     const qwen = byId(report, "qwen-code");
     const codewhale = byId(report, "codewhale");
 
@@ -95,7 +95,7 @@ describe("agent installation detector", () => {
     writeText(path.join(homeDir, ".gemini", "settings.json.backup"), "backup file");
     writeText(path.join(homeDir, ".gemini", ".config.swp"), "swap file");
 
-    const report = detectAgentInstallations({ homeDir, now: 1 });
+    const report = detectAgentInstallations({ homeDir, now: 1, env: {} });
     const gemini = byId(report, "gemini-cli");
     const antigravity = byId(report, "antigravity-cli");
 
@@ -172,7 +172,7 @@ describe("agent installation detector", () => {
     const homeDir = makeHome();
     mkdirp(path.join(homeDir, ".hermes"));
 
-    const report = detectAgentInstallations({ homeDir, now: 1 });
+    const report = detectAgentInstallations({ homeDir, now: 1, env: {} });
     const hermes = byId(report, "hermes");
 
     assert.strictEqual(hermes.detectedInstalled, true);

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -118,6 +118,10 @@ function createRuntime(overrides = {}) {
     flushRuntimeStateToPrefs: () => calls.push(["flushRuntimeStateToPrefs"]),
     handleMiniDisplayChange: () => calls.push(["handleMiniDisplayChange"]),
     exitMiniMode: () => calls.push(["exitMiniMode"]),
+    crashReloadLimit: overrides.crashReloadLimit,
+    crashReloadWindowMs: overrides.crashReloadWindowMs,
+    crashReloadLog: overrides.crashReloadLog,
+    now: overrides.now,
   });
   return {
     runtime,
@@ -188,13 +192,51 @@ describe("pet-window-runtime", () => {
     assert.deepStrictEqual(destroyedContents.calls, []);
   });
 
+  it("does not reload renderer windows for terminal render-process-gone reasons", () => {
+    const logs = [];
+    const harness = createRuntime({ crashReloadLog: (message) => logs.push(message) });
+    const live = makeWindow();
+
+    assert.equal(harness.runtime.reloadWindowWebContents(live, {
+      crashKey: "renderWin",
+      details: { reason: "integrity-failure" },
+    }), false);
+    assert.deepStrictEqual(live.calls, []);
+    assert.match(logs[0], /not reloading renderWin/);
+  });
+
+  it("stops reloading renderer windows after repeated crashes in the guard window", () => {
+    let now = 1000;
+    const logs = [];
+    const harness = createRuntime({
+      crashReloadLimit: 2,
+      crashReloadWindowMs: 1000,
+      crashReloadLog: (message) => logs.push(message),
+      now: () => now,
+    });
+    const live = makeWindow();
+    const options = { crashKey: "hitWin", details: { reason: "crashed" } };
+
+    assert.equal(harness.runtime.reloadWindowWebContents(live, options), true);
+    now += 100;
+    assert.equal(harness.runtime.reloadWindowWebContents(live, options), true);
+    now += 100;
+    assert.equal(harness.runtime.reloadWindowWebContents(live, options), false);
+    assert.deepStrictEqual(live.calls, [["reload"], ["reload"]]);
+    assert.match(logs[0], /stopped reloading hitWin/);
+
+    now += 1001;
+    assert.equal(harness.runtime.reloadWindowWebContents(live, options), true);
+    assert.deepStrictEqual(live.calls, [["reload"], ["reload"], ["reload"]]);
+  });
+
   it("uses safe reload helpers for pet render-process-gone handlers", () => {
     const runtimeSource = fs.readFileSync(path.join(SRC_DIR, "pet-window-runtime.js"), "utf8");
     const mainSource = fs.readFileSync(path.join(SRC_DIR, "main.js"), "utf8");
 
-    assert.match(runtimeSource, /reloadWindowWebContents\(hitWin\)/);
-    assert.match(mainSource, /petWindowRuntime\.reloadWindowWebContents\(ownedHitWin\)/);
-    assert.match(mainSource, /petWindowRuntime\.reloadWindowWebContents\(win\)/);
+    assert.ok(runtimeSource.includes('reloadRuntimeWindowWebContents(hitWin, { crashKey: "hitWin", details });'));
+    assert.ok(mainSource.includes('petWindowRuntime.reloadWindowWebContents(ownedHitWin, { crashKey: "hitWin", details });'));
+    assert.ok(mainSource.includes('petWindowRuntime.reloadWindowWebContents(win, { crashKey: "renderWin", details });'));
     assert.doesNotMatch(mainSource, /ownedHitWin\.webContents\.reload\(\)/);
   });
 

--- a/test/roam.test.js
+++ b/test/roam.test.js
@@ -53,11 +53,15 @@ function makeCtx(overrides = {}) {
 
 describe("roam module", () => {
   beforeEach(() => {
+    const randomValues = [0.9, 0.9, 0.9, 0.1];
+    let randomIndex = 0;
+    mock.method(Math, "random", () => randomValues[randomIndex++ % randomValues.length]);
     mock.timers.enable({ apis: ["setTimeout", "Date"] });
   });
 
   afterEach(() => {
     mock.timers.reset();
+    mock.reset();
   });
 
   it("does not schedule roam when disabled", () => {

--- a/test/windows-audit-554.test.js
+++ b/test/windows-audit-554.test.js
@@ -33,7 +33,7 @@ test("second-instance relaunch exits hidden state through the pet visibility sta
   );
 });
 
-test("hitWin renderer crash clears drag state before reloading the hit window", () => {
+test("hitWin renderer crash clears transient interaction state before reloading", () => {
   const source = readMain();
   const start = source.indexOf("onRenderProcessGone: (details, ownedHitWin) => {");
   assert.ok(start >= 0, "hitWin render-process-gone handler should be present");
@@ -44,6 +44,10 @@ test("hitWin renderer crash clears drag state before reloading the hit window", 
 
   assert.ok(handler.includes("petWindowRuntime.setDragLocked(false);"));
   assert.ok(handler.includes("petWindowRuntime.clearDragSnapshot();"));
+  assert.ok(handler.includes("idlePaused = false;"));
+  assert.ok(handler.includes("mouseOverPet = false;"));
   assert.ok(handler.indexOf("petWindowRuntime.setDragLocked(false);") < handler.indexOf(reload));
   assert.ok(handler.indexOf("petWindowRuntime.clearDragSnapshot();") < handler.indexOf(reload));
+  assert.ok(handler.indexOf("idlePaused = false;") < handler.indexOf(reload));
+  assert.ok(handler.indexOf("mouseOverPet = false;") < handler.indexOf(reload));
 });

--- a/test/windows-audit-554.test.js
+++ b/test/windows-audit-554.test.js
@@ -1,0 +1,45 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MAIN_JS = path.join(__dirname, "..", "src", "main.js");
+
+function readMain() {
+  return fs.readFileSync(MAIN_JS, "utf8");
+}
+
+test("second-instance relaunch exits hidden state through the pet visibility state machine", () => {
+  const source = readMain();
+  const start = source.indexOf('app.on("second-instance"');
+  const end = source.indexOf("codexPetMain.enqueueImportUrlsFromArgv(commandLine);", start);
+  assert.ok(start >= 0 && end > start, "second-instance handler should be present");
+
+  const handler = source.slice(start, end);
+  assert.match(
+    handler,
+    /if \(petWindowRuntime\.isPetHidden\(\)\) \{\s*petWindowRuntime\.setPetHidden\(false\);\s*\} else \{/,
+    "hidden relaunch must use setPetHidden(false), not bare showInactive()"
+  );
+  assert.ok(
+    handler.indexOf("petWindowRuntime.setPetHidden(false)") < handler.indexOf("win.showInactive()"),
+    "hidden-state recovery should run before the visible-window fast path"
+  );
+});
+
+test("hitWin renderer crash clears drag state before reloading the hit window", () => {
+  const source = readMain();
+  const start = source.indexOf("onRenderProcessGone: (details, ownedHitWin) => {");
+  assert.ok(start >= 0, "hitWin render-process-gone handler should be present");
+
+  const reload = 'petWindowRuntime.reloadWindowWebContents(ownedHitWin, { crashKey: "hitWin", details });';
+  const end = source.indexOf(reload, start) + reload.length;
+  const handler = source.slice(start, end);
+
+  assert.ok(handler.includes("petWindowRuntime.setDragLocked(false);"));
+  assert.ok(handler.includes("petWindowRuntime.clearDragSnapshot();"));
+  assert.ok(handler.indexOf("petWindowRuntime.setDragLocked(false);") < handler.indexOf(reload));
+  assert.ok(handler.indexOf("petWindowRuntime.clearDragSnapshot();") < handler.indexOf(reload));
+});

--- a/test/windows-audit-554.test.js
+++ b/test/windows-audit-554.test.js
@@ -20,8 +20,12 @@ test("second-instance relaunch exits hidden state through the pet visibility sta
   const handler = source.slice(start, end);
   assert.match(
     handler,
-    /if \(petWindowRuntime\.isPetHidden\(\)\) \{\s*petWindowRuntime\.setPetHidden\(false\);\s*\} else \{/,
+    /if \(petWindowRuntime\.isPetHidden\(\)\) \{\s*prepManualPetVisibility\(\);\s*petWindowRuntime\.setPetHidden\(false\);\s*\} else \{/,
     "hidden relaunch must use setPetHidden(false), not bare showInactive()"
+  );
+  assert.ok(
+    handler.indexOf("prepManualPetVisibility()") < handler.indexOf("petWindowRuntime.setPetHidden(false)"),
+    "hidden relaunch should use the shared manual visibility prep before showing the pet"
   );
   assert.ok(
     handler.indexOf("petWindowRuntime.setPetHidden(false)") < handler.indexOf("win.showInactive()"),


### PR DESCRIPTION
## Summary

Refs #554.

This PR intentionally narrows the Windows audit follow-up to the crash-recovery slice only. It does not attempt to close the full #554 audit backlog.

## What changed

- Route second-instance relaunch through the pet visibility state machine when the pet is hidden, including the shared manual visibility prep path.
- Clear hit-window drag lock/snapshot and transient idle interaction state before reloading after a hit renderer crash.
- Add a render-process-gone reload guard so terminal reasons such as `integrity-failure` do not loop reloads, and repeated crashes are rate-limited per window key.
- Add focused regression coverage for the crash-recovery cases and stabilize test-only randomness that could make `test/roam.test.js` fail when a random target landed too close to the current pet position.

## Out of scope

The remaining #554 Windows audit items are intentionally left for separate PRs, including fullscreen/topmost/focus behavior, DWM cloaking recovery, DPI/keepSize persistence, and WSL shared `CODEX_HOME` hook compatibility.

## Validation

- `node --test test/windows-audit-554.test.js test/pet-window-runtime.test.js test/renderer-low-power.test.js test/agent-installation-detector.test.js`
- `node --test test/roam.test.js`
- `npm test`
- `git diff --check`

## Manual smoke

Earlier branch smoke restarted Clawd with an isolated user data dir and verified the app served state on `127.0.0.1:23333`. With `YuanShen` foreground fullscreen at `2752x1152`, a 15-second foreground-window sample did not observe Clawd/Electron stealing focus.

Visual screenshot inspection was attempted, but the local image-view/tooling path was blocked by the Windows sandbox wrapper, so the fullscreen result should be treated as focus smoke coverage rather than full visual overlay QA.