### PR TITLE
Fix Windows startup recovery followups

### DIFF
--- a/src/launch-claude.js
+++ b/src/launch-claude.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const { spawn, execFileSync } = require("child_process");
+const { spawn, execFile } = require("child_process");
+const { promisify } = require("util");
 const { platform, homedir } = require("os");
 const path = require("path");
 const fs = require("fs");
@@ -91,19 +92,25 @@ function tryLaunch(bin, args, opts) {
   });
 }
 
-function findClaudeCmd(plat = platform(), deps = {}) {
-  const _execFileSync = deps.execFileSync || execFileSync;
+const execFileAsync = promisify(execFile);
+
+async function findClaudeCmd(plat = platform(), deps = {}) {
+  const _execFileAsync = deps.execFileAsync || execFileAsync;
   const _existsSync = deps.existsSync || fs.existsSync;
 
-  // 1. Try system PATH lookup
+  // 1. Try system PATH lookup. This runs async on purpose: the old
+  // execFileSync('where'/'which', {timeout:5000}) blocked the Electron main
+  // process event loop — which also drives rendering, drag, and topmost — so a
+  // slow PATH (huge PATH, mapped network drives) froze the pet for up to 5s on
+  // New Session. execFile lets the 5s timeout elapse without stalling the loop.
   try {
     const cmd = plat === "win32" ? "where" : "which";
-    const out = _execFileSync(cmd, ["claude"], {
+    const { stdout } = await _execFileAsync(cmd, ["claude"], {
       encoding: "utf8",
       timeout: 5000,
       windowsHide: true,
     });
-    const existing = out
+    const existing = stdout
       .trim()
       .split(/\r?\n/)
       .map((line) => line.trim())
@@ -338,7 +345,7 @@ async function launchClaudeSession(mode, cwd, sessionId, deps = {}) {
   const _tryLaunch = deps.tryLaunch || tryLaunch;
 
   const plat = _platform();
-  const claudePath = _findClaudeCmd(plat);
+  const claudePath = await _findClaudeCmd(plat);
   const claudeArgs = buildClaudeArgs(mode, sessionId);
   const workDir = cwd || homedir();
   const opts = { detached: true, stdio: "ignore", windowsHide: false, cwd: workDir };

--- a/src/main.js
+++ b/src/main.js
@@ -3435,7 +3435,21 @@ function createWindow() {
   guardAlwaysOnTop(win);
   startTopmostWatchdog();
 
-  screen.on("display-metrics-changed", () => petWindowRuntime.handleDisplayMetricsChanged());
+  // display-metrics-changed fires in bursts during DPI changes and RDP
+  // reconnects, and each one re-clamps/repositions the pet — running them all
+  // makes the pet visibly jitter mid-transition. Debounce the geometry handler
+  // to the settled state, mirroring the textScale debounce below. (Keep
+  // display-removed/added immediate: those rescue the pet off a vanished
+  // display and must not be delayed.)
+  let displayMetricsGeometryTimer = null;
+  const reapplyDisplayGeometryAfterMetricsChange = () => {
+    if (displayMetricsGeometryTimer) clearTimeout(displayMetricsGeometryTimer);
+    displayMetricsGeometryTimer = setTimeout(() => {
+      displayMetricsGeometryTimer = null;
+      petWindowRuntime.handleDisplayMetricsChanged();
+    }, 400);
+  };
+  screen.on("display-metrics-changed", reapplyDisplayGeometryAfterMetricsChange);
   screen.on("display-removed", () => petWindowRuntime.handleDisplayRemoved());
   screen.on("display-added", () => petWindowRuntime.handleDisplayAdded());
 

--- a/src/state.js
+++ b/src/state.js
@@ -1882,11 +1882,13 @@ function detectRunningAgentProcesses(callback) {
   }
   const { execFile, exec } = require("child_process");
   if (process.platform === "win32") {
+    // Keep this WQL filter built only from hard-coded literals. Real process
+    // names are matched by WMI; external input must not be spliced into it.
     const psScript =
       "$names = 'claude.exe','codex.exe','copilot.exe','gemini.exe','agy.exe','codebuddy.exe','kiro-cli.exe','kimi.exe','codewhale.exe','opencode.exe','pi.exe','hermes.exe','qodercli.exe','qoder-cli.exe'; " +
-      "$match = Get-CimInstance Win32_Process | Where-Object { " +
-        "$names -contains $_.Name -or ($_.Name -eq 'node.exe' -and $_.CommandLine -like '*claude-code*') " +
-      "} | Select-Object -First 1; " +
+      "$nameFilters = $names | ForEach-Object { \"Name='$_'\" }; " +
+      "$filter = ($nameFilters + \"(Name='node.exe' AND CommandLine LIKE '%claude-code%')\") -join ' OR '; " +
+      "$match = Get-CimInstance Win32_Process -Filter $filter | Select-Object -First 1; " +
       "if ($match) { $match.ProcessId }";
     execFile(
       "powershell.exe",

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -152,7 +152,15 @@ function createTopmostRuntime(options = {}) {
     if (!isWin || !winToGuard || typeof winToGuard.on !== "function") return;
     winToGuard.on("always-on-top-changed", (_event, isOnTop) => {
       if (isOnTop || !isLiveWindow(winToGuard)) return;
-      winToGuard.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+      if (winToGuard === getWin()) {
+        // Re-topping only the render window would re-insert it at the top of
+        // the topmost band, briefly leaving the hit window beneath it
+        // (z-order inversion). reassertWinTopmost re-tops win then hitWin, so
+        // the hit layer lands back above the pet.
+        reassertWinTopmost();
+      } else {
+        winToGuard.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+      }
       if (
         winToGuard === getWin()
         && !isDragLocked()

--- a/test/launch-claude.test.js
+++ b/test/launch-claude.test.js
@@ -113,44 +113,46 @@ describe("cmd executable quoting", () => {
 
 describe("findClaudeCmd", () => {
   const NPM_DIR = "C:\\Users\\Tester\\AppData\\Roaming\\npm";
-  // `where`/`which` stub: emits the given paths as newline output.
-  const fakeWhere = (...paths) => ({ execFileSync: () => paths.join("\r\n") + "\r\n" });
+  // `where`/`which` stub: resolves with the given paths as newline stdout.
+  const fakeWhere = (...paths) => ({
+    execFileAsync: async () => ({ stdout: paths.join("\r\n") + "\r\n" }),
+  });
   // filesystem stub: only the listed paths "exist" (case-insensitive on Windows).
   const fakeFs = (existing) => {
     const set = new Set(existing.map((p) => String(p).toLowerCase()));
     return { existsSync: (p) => set.has(String(p).toLowerCase()) };
   };
 
-  it("Windows: prefers claude.cmd when `where` lists the extensionless script first", () => {
+  it("Windows: prefers claude.cmd when `where` lists the extensionless script first", async () => {
     const ext = `${NPM_DIR}\\claude`;
     const cmd = `${NPM_DIR}\\claude.cmd`;
-    const out = findClaudeCmd("win32", { ...fakeWhere(ext, cmd), ...fakeFs([ext, cmd]) });
+    const out = await findClaudeCmd("win32", { ...fakeWhere(ext, cmd), ...fakeFs([ext, cmd]) });
     assert.strictEqual(out, cmd, "must not return the 0x800700c1 POSIX shim");
   });
 
-  it("Windows: never returns the extensionless POSIX shim, probing for a sibling", () => {
+  it("Windows: never returns the extensionless POSIX shim, probing for a sibling", async () => {
     // `where` surfaced only the unrunnable script; its launchable sibling is
     // right next to it. Returning `ext` here is the exact #435 bug.
     const ext = `${NPM_DIR}\\claude`;
     const cmd = `${NPM_DIR}\\claude.cmd`;
-    const out = findClaudeCmd("win32", { ...fakeWhere(ext), ...fakeFs([ext, cmd]) });
+    const out = await findClaudeCmd("win32", { ...fakeWhere(ext), ...fakeFs([ext, cmd]) });
     assert.strictEqual(out, cmd);
   });
 
-  it("Windows: prefers a real claude.exe over the .cmd shim", () => {
+  it("Windows: prefers a real claude.exe over the .cmd shim", async () => {
     const exe = `${NPM_DIR}\\claude.exe`;
     const cmd = `${NPM_DIR}\\claude.cmd`;
-    const out = findClaudeCmd("win32", { ...fakeWhere(exe, cmd), ...fakeFs([exe, cmd]) });
+    const out = await findClaudeCmd("win32", { ...fakeWhere(exe, cmd), ...fakeFs([exe, cmd]) });
     assert.strictEqual(out, exe);
   });
 
-  it("Windows: falls back to %APPDATA%\\npm\\claude.cmd when PATH lookup misses", () => {
+  it("Windows: falls back to %APPDATA%\\npm\\claude.cmd when PATH lookup misses", async () => {
     const prev = process.env.APPDATA;
     process.env.APPDATA = "C:\\Users\\Tester\\AppData\\Roaming";
     try {
       const cmd = path.join(process.env.APPDATA, "npm", "claude.cmd");
-      const out = findClaudeCmd("win32", {
-        execFileSync: () => { throw new Error("where: not found"); },
+      const out = await findClaudeCmd("win32", {
+        execFileAsync: async () => { throw new Error("where: not found"); },
         ...fakeFs([cmd]),
       });
       assert.strictEqual(out, cmd);
@@ -160,29 +162,48 @@ describe("findClaudeCmd", () => {
     }
   });
 
-  it("Windows: returns bare \"claude\" when nothing is found", () => {
-    const out = findClaudeCmd("win32", { execFileSync: () => "", existsSync: () => false });
+  it("Windows: returns bare \"claude\" when nothing is found", async () => {
+    const out = await findClaudeCmd("win32", {
+      execFileAsync: async () => ({ stdout: "" }),
+      existsSync: () => false,
+    });
     assert.strictEqual(out, "claude");
   });
 
-  it("Windows: passes through to stage 3 when only an extensionless shim exists (no sibling)", () => {
+  it("Windows: passes through to stage 3 when only an extensionless shim exists (no sibling)", async () => {
     // No launchable variant anywhere — must NOT return the unrunnable script;
     // falls through to bare \"claude\" for cmd.exe/PATHEXT to resolve.
     const ext = `${NPM_DIR}\\claude`;
-    const out = findClaudeCmd("win32", { ...fakeWhere(ext), ...fakeFs([ext]) });
+    const out = await findClaudeCmd("win32", { ...fakeWhere(ext), ...fakeFs([ext]) });
     assert.strictEqual(out, "claude");
   });
 
-  it("Windows: matches launchable extensions case-insensitively", () => {
+  it("Windows: matches launchable extensions case-insensitively", async () => {
     const cmd = `${NPM_DIR}\\CLAUDE.CMD`;
-    const out = findClaudeCmd("win32", { ...fakeWhere(cmd), ...fakeFs([cmd]) });
+    const out = await findClaudeCmd("win32", { ...fakeWhere(cmd), ...fakeFs([cmd]) });
     assert.strictEqual(out, cmd);
   });
 
-  it("POSIX: returns the first existing `which` result", () => {
+  it("POSIX: returns the first existing `which` result", async () => {
     const p = "/usr/local/bin/claude";
-    const out = findClaudeCmd("linux", { ...fakeWhere(p), ...fakeFs([p]) });
+    const out = await findClaudeCmd("linux", { ...fakeWhere(p), ...fakeFs([p]) });
     assert.strictEqual(out, p);
+  });
+
+  it("does not block synchronously on the PATH probe (async findClaudeCmd)", async () => {
+    // Regression for #8: a slow `where`/`which` must not freeze the caller.
+    // The probe resolves on a later tick; findClaudeCmd must await it rather
+    // than returning before the result is in.
+    const cmd = `${NPM_DIR}\\claude.cmd`;
+    let resolveProbe;
+    const gate = new Promise((r) => { resolveProbe = r; });
+    const pending = findClaudeCmd("win32", {
+      execFileAsync: () => gate.then(() => ({ stdout: cmd + "\r\n" })),
+      ...fakeFs([cmd]),
+    });
+    assert.ok(pending instanceof Promise, "findClaudeCmd must be async");
+    resolveProbe();
+    assert.strictEqual(await pending, cmd);
   });
 });
 

--- a/test/state-startup-recovery-detect.test.js
+++ b/test/state-startup-recovery-detect.test.js
@@ -86,6 +86,9 @@ describe("detectRunningAgentProcesses() agent coverage", () => {
     // process (qoder.exe) must NOT trigger startup recovery.
     assert.doesNotMatch(seenScript, /'qoder\.exe'/);
     assert.match(seenScript, /Get-CimInstance Win32_Process/);
+    assert.match(seenScript, /-Filter/);
+    assert.doesNotMatch(seenScript, /Win32_Process \| Where-Object/);
+    assert.match(seenScript, /CommandLine LIKE '%claude-code%'/);
   });
 
   it("includes agy, kimi, and Pi package markers in macOS/Linux pgrep query", async () => {

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -105,6 +105,48 @@ describe("topmost runtime Windows recovery", () => {
     assert.deepStrictEqual(positions, [[11, 20], [10, 20]]);
   });
 
+  it("re-tops the hit window when the render window loses topmost (no z-order inversion)", () => {
+    const timers = makeTimers();
+    const win = new FakeWindow();
+    const hitWin = new FakeWindow();
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => win,
+      getHitWin: () => hitWin,
+      getPetWindowBounds: () => ({ x: 10, y: 20, width: 100, height: 100 }),
+      setTimeout: timers.setTimeout,
+      clearTimeout: timers.clearTimeout,
+    });
+
+    runtime.guardAlwaysOnTop(win);
+    win.emit("always-on-top-changed", null, false);
+
+    // Render window re-topped, then the hit window re-topped above it — without
+    // the fix only `win` would be re-asserted, leaving the hit layer beneath.
+    assert.deepStrictEqual(win.calls, [["setAlwaysOnTop", true, createTopmostRuntime.WIN_TOPMOST_LEVEL]]);
+    assert.deepStrictEqual(hitWin.calls, [["setAlwaysOnTop", true, createTopmostRuntime.WIN_TOPMOST_LEVEL]]);
+  });
+
+  it("re-tops only the guarded window when a non-render window loses topmost", () => {
+    const win = new FakeWindow();
+    const hitWin = new FakeWindow();
+    const bubble = new FakeWindow();
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => win,
+      getHitWin: () => hitWin,
+    });
+
+    runtime.guardAlwaysOnTop(bubble);
+    bubble.emit("always-on-top-changed", null, false);
+
+    // A bubble/HUD losing topmost must not drag the pet's render+hit pair into
+    // a re-assert; only the bubble itself is re-topped.
+    assert.deepStrictEqual(bubble.calls, [["setAlwaysOnTop", true, createTopmostRuntime.WIN_TOPMOST_LEVEL]]);
+    assert.deepStrictEqual(win.calls, []);
+    assert.deepStrictEqual(hitWin.calls, []);
+  });
+
   it("does not accumulate repeated topmost nudges while recovery is pending", () => {
     const timers = makeTimers();
     const win = new FakeWindow();


### PR DESCRIPTION
Summary: async Claude PATH lookup to avoid New Session main-process stalls; debounce Windows display-metrics geometry recovery; re-top hit window after render topmost loss; use hard-coded WMI -Filter for startup recovery. Tests: npm test (4215 pass, 0 fail, 13 skipped). Manual QA: lock/unlock hit-test passed; single-display DPI/scale change passed; Claude New Session no 5s freeze passed. Not covered: multi-monitor hot-unplug/cross-DPI, no multi-display hardware available.