### PR TITLE
fix(hooks): byte-fit /state payloads so long CJK completions reach Clawd

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ Copilot CLI 同步走 `<COPILOT_HOME 或 ~/.copilot>/hooks/hooks.json`，marker-
 
 - Claude Code / CodeBuddy 的阻塞式权限审批走 `POST /permission` HTTP hook；普通状态事件走 command hook
 - Codex 的阻塞式权限审批走 official `PermissionRequest` command hook：hook 脚本长连接 `POST /permission`，只允许 stdout 返回 sanitized `behavior/message`，`updatedInput` / `updatedPermissions` / `interrupt` 必须 omit
-- hook 脚本只允许依赖 Node 内置模块，以及同目录的 `server-config.js`、`shared-process.js`、`json-utils.js`、`codex-subagent-fields.js`
+- hook 脚本只允许依赖 Node 内置模块，以及同目录 `hooks/` 下、且登记在两套部署清单（`scripts/remote-deploy.sh` 的 `FILES` 与 `src/remote-ssh-deploy.js` 的 `HOOK_FILES`）的纯 Node helper（如 `server-config.js` / `shared-process.js` / `json-utils.js` / `codex-subagent-fields.js` / `context-usage.js` / `state-payload-size.js`）；两套清单由 manifest-consistency 测试强制同步，新增 helper 必须同时登记
 - hook 脚本需要稳定终端 PID 时，必须走 `getStablePid()` 进程树解析；不要用 `process.ppid` 做简化替代
 - opencode 权限不走 `permission.ask` hook，而是 event hook + reverse bridge
 - Pi 通过 `~/.pi/agent/extensions/clawd-on-desk` 的 global extension 推送状态；Clawd 对 Pi 是 **state-only**，不接管权限、不弹权限气泡，也不把 Pi 的默认 YOLO 流程改成手动确认

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -420,6 +420,13 @@ function buildStateBody(event, payload, resolve) {
     if (bgCount > 0) body.background_tasks_count = bgCount;
     if (cronCount > 0) body.session_crons_count = cronCount;
     if (payload.stop_hook_active === true) body.stop_hook_active = true;
+    // TEMP DEBUG (#406 happy-not-playing diag) — REMOVE after diagnosis
+    try {
+      fs.appendFileSync(
+        `${process.env.APPDATA}\\clawd-on-desk\\stop-gate-debug.log`,
+        `${new Date().toISOString()} STOP sid=${payload.session_id || "?"} stop_hook_active=${JSON.stringify(payload.stop_hook_active)} bg=${bgCount} cron=${cronCount} hasFinalText=${!!body.assistant_last_output} headless=${JSON.stringify(payload.headless)} keys=[${Object.keys(payload || {}).join(",")}]\n`
+      );
+    } catch {}
   }
   if (process.env.CLAWD_REMOTE) {
     body.host = readHostPrefix();
@@ -464,10 +471,34 @@ function main() {
     .then((payload) => {
       const body = buildStateBody(event, payload || {}, resolve);
       if (!body) process.exit(0);
+      // Completion events (Stop) must actually reach Clawd to fire the happy
+      // animation, but they are low-frequency. A busy system (e.g. right after
+      // a dense burst of tool calls) can push the local POST past the tight
+      // 100ms budget, silently dropping the celebration. Give Stop a generous
+      // timeout: connection-refused (Clawd not running) still fails instantly,
+      // so an idle machine is never penalized — only a live-but-slow Clawd uses
+      // the headroom. High-frequency events keep 100ms so they never stall CC.
+      const isCompletionEvent = body.event === "Stop";
+      const statePostTimeoutMs = isCompletionEvent ? 1500 : 100;
+      const postStartedAt = Date.now();
       postStateToRunningServer(
         JSON.stringify(body),
-        { timeoutMs: 100 },
-        () => process.exit(0)
+        { timeoutMs: statePostTimeoutMs },
+        (posted, port) => {
+          // TEMP DEBUG (happy-not-playing diag) — record POST delivery result,
+          // elapsed time, and the timeout used for Stop. elapsedMs ≈ timeoutMs
+          // means a real timeout (port alive but slow); elapsedMs ≈ 0 means
+          // connection-refused (port not listening). REMOVE after diagnosis.
+          if (body.event === "Stop") {
+            try {
+              fs.appendFileSync(
+                `${process.env.APPDATA}\\clawd-on-desk\\stop-gate-debug.log`,
+                `${new Date().toISOString()} POST-RESULT event=Stop posted=${JSON.stringify(posted)} port=${JSON.stringify(port)} elapsedMs=${Date.now() - postStartedAt} timeoutMs=${statePostTimeoutMs}\n`
+              );
+            } catch {}
+          }
+          process.exit(0);
+        }
       );
     })
     .catch(() => process.exit(0));

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -6,7 +6,7 @@
 const crypto = require("crypto");
 const fs = require("fs");
 const { postStateToRunningServer, readHostPrefix } = require("./server-config");
-const { fitStateBodyToByteBudget, utf8ByteLength } = require("./state-payload-size");
+const { fitStateBodyToByteBudget } = require("./state-payload-size");
 const { extractClaudeContextUsageFromEntries } = require("./context-usage");
 const { createPidResolver, readStdinJson, getPlatformConfig } = require("./shared-process");
 
@@ -421,13 +421,6 @@ function buildStateBody(event, payload, resolve) {
     if (bgCount > 0) body.background_tasks_count = bgCount;
     if (cronCount > 0) body.session_crons_count = cronCount;
     if (payload.stop_hook_active === true) body.stop_hook_active = true;
-    // TEMP DEBUG (#406 happy-not-playing diag) — REMOVE after diagnosis
-    try {
-      fs.appendFileSync(
-        `${process.env.APPDATA}\\clawd-on-desk\\stop-gate-debug.log`,
-        `${new Date().toISOString()} STOP sid=${payload.session_id || "?"} stop_hook_active=${JSON.stringify(payload.stop_hook_active)} bg=${bgCount} cron=${cronCount} hasFinalText=${!!body.assistant_last_output} headless=${JSON.stringify(payload.headless)} keys=[${Object.keys(payload || {}).join(",")}]\n`
-      );
-    } catch {}
   }
   if (process.env.CLAWD_REMOTE) {
     body.host = readHostPrefix();
@@ -472,43 +465,22 @@ function main() {
     .then((payload) => {
       const body = buildStateBody(event, payload || {}, resolve);
       if (!body) process.exit(0);
-      // Completion events (Stop) must actually reach Clawd to fire the happy
-      // animation, but they are low-frequency. A busy system (e.g. right after
-      // a dense burst of tool calls) can push the local POST past the tight
-      // 100ms budget, silently dropping the celebration. Give Stop a generous
-      // timeout: connection-refused (Clawd not running) still fails instantly,
-      // so an idle machine is never penalized — only a live-but-slow Clawd uses
-      // the headroom. High-frequency events keep 100ms so they never stall CC.
+      // Completion events (Stop) fire the happy animation, are low-frequency,
+      // and matter more than a few ms of latency. Give them a generous POST
+      // timeout so a momentarily slow (but alive) Clawd still receives them;
+      // connection-refused (Clawd not running) still fails instantly, so an
+      // idle machine is never penalized. High-frequency events keep 100ms so
+      // they never stall the agent.
       const isCompletionEvent = body.event === "Stop";
       const statePostTimeoutMs = isCompletionEvent ? 1500 : 100;
-      const postStartedAt = Date.now();
       // Byte-fit the body so a long CJK assistant_last_output can't push it past
       // the server's /state cap and trigger a headerless 413 (read back as
       // posted=false, dropping the happy completion). hooks/state-payload-size.js.
-      const rawBodyBytes = utf8ByteLength(JSON.stringify(body)); // TEMP DEBUG: pre-fit size
       const fitted = fitStateBodyToByteBudget(body);
       postStateToRunningServer(
         JSON.stringify(fitted.body),
         { timeoutMs: statePostTimeoutMs },
-        (posted, port) => {
-          // TEMP DEBUG (happy-not-playing diag) — record POST delivery result,
-          // elapsed time, the Stop timeout, the serialized body size, and what
-          // byte-fitting did to assistant_last_output. bodyBytes near the cap
-          // means size was the culprit; posted=false with bodyBytes well under
-          // the cap points elsewhere. REMOVE after diagnosis.
-          if (body.event === "Stop") {
-            try {
-              const assistantChars = typeof body.assistant_last_output === "string"
-                ? body.assistant_last_output.length : 0;
-              const assistantBytes = utf8ByteLength(body.assistant_last_output || "");
-              fs.appendFileSync(
-                `${process.env.APPDATA}\\clawd-on-desk\\stop-gate-debug.log`,
-                `${new Date().toISOString()} POST-RESULT event=Stop posted=${JSON.stringify(posted)} port=${JSON.stringify(port)} elapsedMs=${Date.now() - postStartedAt} timeoutMs=${statePostTimeoutMs} rawBodyBytes=${rawBodyBytes} bodyBytes=${fitted.bytes} assistantChars=${assistantChars} assistantBytes=${assistantBytes} fitTruncated=${fitted.assistantTruncated} fitDropped=${fitted.assistantDropped}\n`
-              );
-            } catch {}
-          }
-          process.exit(0);
-        }
+        () => process.exit(0)
       );
     })
     .catch(() => process.exit(0));

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -485,6 +485,7 @@ function main() {
       // Byte-fit the body so a long CJK assistant_last_output can't push it past
       // the server's /state cap and trigger a headerless 413 (read back as
       // posted=false, dropping the happy completion). hooks/state-payload-size.js.
+      const rawBodyBytes = utf8ByteLength(JSON.stringify(body)); // TEMP DEBUG: pre-fit size
       const fitted = fitStateBodyToByteBudget(body);
       postStateToRunningServer(
         JSON.stringify(fitted.body),
@@ -502,7 +503,7 @@ function main() {
               const assistantBytes = utf8ByteLength(body.assistant_last_output || "");
               fs.appendFileSync(
                 `${process.env.APPDATA}\\clawd-on-desk\\stop-gate-debug.log`,
-                `${new Date().toISOString()} POST-RESULT event=Stop posted=${JSON.stringify(posted)} port=${JSON.stringify(port)} elapsedMs=${Date.now() - postStartedAt} timeoutMs=${statePostTimeoutMs} bodyBytes=${fitted.bytes} assistantChars=${assistantChars} assistantBytes=${assistantBytes} fitTruncated=${fitted.assistantTruncated} fitDropped=${fitted.assistantDropped}\n`
+                `${new Date().toISOString()} POST-RESULT event=Stop posted=${JSON.stringify(posted)} port=${JSON.stringify(port)} elapsedMs=${Date.now() - postStartedAt} timeoutMs=${statePostTimeoutMs} rawBodyBytes=${rawBodyBytes} bodyBytes=${fitted.bytes} assistantChars=${assistantChars} assistantBytes=${assistantBytes} fitTruncated=${fitted.assistantTruncated} fitDropped=${fitted.assistantDropped}\n`
               );
             } catch {}
           }

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -6,6 +6,7 @@
 const crypto = require("crypto");
 const fs = require("fs");
 const { postStateToRunningServer, readHostPrefix } = require("./server-config");
+const { fitStateBodyToByteBudget, utf8ByteLength } = require("./state-payload-size");
 const { extractClaudeContextUsageFromEntries } = require("./context-usage");
 const { createPidResolver, readStdinJson, getPlatformConfig } = require("./shared-process");
 
@@ -481,19 +482,27 @@ function main() {
       const isCompletionEvent = body.event === "Stop";
       const statePostTimeoutMs = isCompletionEvent ? 1500 : 100;
       const postStartedAt = Date.now();
+      // Byte-fit the body so a long CJK assistant_last_output can't push it past
+      // the server's /state cap and trigger a headerless 413 (read back as
+      // posted=false, dropping the happy completion). hooks/state-payload-size.js.
+      const fitted = fitStateBodyToByteBudget(body);
       postStateToRunningServer(
-        JSON.stringify(body),
+        JSON.stringify(fitted.body),
         { timeoutMs: statePostTimeoutMs },
         (posted, port) => {
           // TEMP DEBUG (happy-not-playing diag) — record POST delivery result,
-          // elapsed time, and the timeout used for Stop. elapsedMs ≈ timeoutMs
-          // means a real timeout (port alive but slow); elapsedMs ≈ 0 means
-          // connection-refused (port not listening). REMOVE after diagnosis.
+          // elapsed time, the Stop timeout, the serialized body size, and what
+          // byte-fitting did to assistant_last_output. bodyBytes near the cap
+          // means size was the culprit; posted=false with bodyBytes well under
+          // the cap points elsewhere. REMOVE after diagnosis.
           if (body.event === "Stop") {
             try {
+              const assistantChars = typeof body.assistant_last_output === "string"
+                ? body.assistant_last_output.length : 0;
+              const assistantBytes = utf8ByteLength(body.assistant_last_output || "");
               fs.appendFileSync(
                 `${process.env.APPDATA}\\clawd-on-desk\\stop-gate-debug.log`,
-                `${new Date().toISOString()} POST-RESULT event=Stop posted=${JSON.stringify(posted)} port=${JSON.stringify(port)} elapsedMs=${Date.now() - postStartedAt} timeoutMs=${statePostTimeoutMs}\n`
+                `${new Date().toISOString()} POST-RESULT event=Stop posted=${JSON.stringify(posted)} port=${JSON.stringify(port)} elapsedMs=${Date.now() - postStartedAt} timeoutMs=${statePostTimeoutMs} bodyBytes=${fitted.bytes} assistantChars=${assistantChars} assistantBytes=${assistantBytes} fitTruncated=${fitted.assistantTruncated} fitDropped=${fitted.assistantDropped}\n`
               );
             } catch {}
           }

--- a/hooks/codex-hook.js
+++ b/hooks/codex-hook.js
@@ -21,6 +21,7 @@ const {
   extractLastAssistantTextFromTranscript,
 } = require("./codex-assistant-output");
 const { readCodexThreadName } = require("./codex-session-index");
+const { fitStateBodyToByteBudget } = require("./state-payload-size");
 
 const TOOL_MATCH_STRING_MAX = 240;
 const TOOL_MATCH_ARRAY_MAX = 16;
@@ -418,7 +419,11 @@ function main() {
 
       const body = buildStateBody(payload || {}, resolve);
       if (!body) process.exit(0);
-      postStateToRunningServer(JSON.stringify(body), { timeoutMs: 100 }, () => process.exit(0));
+      // Byte-fit before POST so a long CJK assistant_last_output can't trip the
+      // server's headerless 413 (read back as posted=false). See
+      // hooks/state-payload-size.js.
+      const fitted = fitStateBodyToByteBudget(body);
+      postStateToRunningServer(JSON.stringify(fitted.body), { timeoutMs: 100 }, () => process.exit(0));
     })
     .catch(() => process.exit(0));
 }

--- a/hooks/state-payload-size.js
+++ b/hooks/state-payload-size.js
@@ -1,0 +1,117 @@
+"use strict";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hook /state payload byte-fitting.
+//
+// The Clawd server caps inbound /state bodies at MAX_STATE_BODY_BYTES and, when
+// a body exceeds it, replies a *headerless* 413. The hook post helper only
+// treats a response as delivered when it carries the Clawd header, so an
+// oversized body reads back as posted=false and the turn-completion (the "happy"
+// celebration) is silently dropped.
+//
+// The trap is a character-vs-byte mismatch: hooks clamp assistant_last_output by
+// CHARACTER count (e.g. 2200 chars), but the server caps by BYTE count. One CJK
+// character is 3 UTF-8 bytes, so a long Chinese/Japanese/Korean reply blows past
+// a byte cap that the same text would clear in English. This helper closes the
+// gap on the SEND side: it guarantees the serialized body fits a byte budget,
+// sacrificing only assistant_last_output (first truncating it, then dropping it)
+// so the completion + #406 gate fields always reach Clawd.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Server cap is 16 KiB (src/server-route-state.js MAX_STATE_BODY_BYTES); keep a
+// 2 KiB cushion for transport overhead and future fields.
+const DEFAULT_TARGET_BYTES = 14 * 1024;
+
+// Below this much room, a truncated reply isn't worth keeping — drop it instead.
+const MIN_ASSISTANT_BYTES = 64;
+
+function utf8ByteLength(value) {
+  return Buffer.byteLength(typeof value === "string" ? value : String(value ?? ""), "utf8");
+}
+
+// Truncate to at most maxBytes UTF-8 bytes without splitting a multi-byte
+// character. UTF-8 continuation bytes match 0b10xxxxxx (0x80–0xBF), so back the
+// cut point off until it lands on a lead-byte boundary.
+function truncateToUtf8Bytes(str, maxBytes) {
+  if (typeof str !== "string" || !str || maxBytes <= 0) return "";
+  const buf = Buffer.from(str, "utf8");
+  if (buf.length <= maxBytes) return str;
+  let end = maxBytes;
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+  return buf.toString("utf8", 0, end);
+}
+
+// Guarantee JSON.stringify(body) fits within targetBytes. Only
+// assistant_last_output is sacrificeable; every other field (state, session_id,
+// event, the #406 gate counts) is preserved so the completion still registers.
+//
+// Returns { body, bytes, fitted, assistantTruncated, assistantDropped }:
+//  - body: a new object when modified, otherwise the original (never mutated)
+//  - bytes: serialized UTF-8 byte length of the returned body
+//  - fitted: whether bytes <= targetBytes
+//  - assistantTruncated / assistantDropped: what happened to assistant_last_output
+function fitStateBodyToByteBudget(body, options = {}) {
+  const targetBytes = Number.isInteger(options.targetBytes) && options.targetBytes > 0
+    ? options.targetBytes
+    : DEFAULT_TARGET_BYTES;
+
+  const bytes = utf8ByteLength(JSON.stringify(body));
+  if (bytes <= targetBytes) {
+    return { body, bytes, fitted: true, assistantTruncated: false, assistantDropped: false };
+  }
+
+  const hasAssistant =
+    body && typeof body.assistant_last_output === "string" && body.assistant_last_output.length > 0;
+  if (!hasAssistant) {
+    // Non-assistant fields alone exceed the budget (extremely rare). Send as-is
+    // rather than corrupt structural fields; the server cushion usually absorbs it.
+    return { body, bytes, fitted: false, assistantTruncated: false, assistantDropped: false };
+  }
+
+  // Measure the body WITHOUT assistant_last_output to learn the remaining room.
+  const base = { ...body };
+  delete base.assistant_last_output;
+  delete base.assistant_last_output_truncated;
+  const baseBytes = utf8ByteLength(JSON.stringify(base));
+
+  // Reserve overhead for the JSON key, quotes, and the truncated flag. Escaping
+  // (\n, \", \\) can still inflate the value, so re-measure after trimming and
+  // fall back to dropping if it bounced back over budget.
+  const overhead = utf8ByteLength(',"assistant_last_output":""')
+    + utf8ByteLength(',"assistant_last_output_truncated":true');
+  const room = targetBytes - baseBytes - overhead;
+
+  if (room >= MIN_ASSISTANT_BYTES) {
+    const trimmed = truncateToUtf8Bytes(body.assistant_last_output, room);
+    if (trimmed) {
+      const next = { ...body, assistant_last_output: trimmed, assistant_last_output_truncated: true };
+      const nextBytes = utf8ByteLength(JSON.stringify(next));
+      if (nextBytes <= targetBytes) {
+        return {
+          body: next,
+          bytes: nextBytes,
+          fitted: true,
+          assistantTruncated: true,
+          assistantDropped: false,
+        };
+      }
+    }
+  }
+
+  // Even a trimmed copy won't fit (or there's no usable room): drop it entirely.
+  return {
+    body: base,
+    bytes: baseBytes,
+    fitted: baseBytes <= targetBytes,
+    assistantTruncated: false,
+    assistantDropped: true,
+  };
+}
+
+module.exports = {
+  DEFAULT_TARGET_BYTES,
+  MIN_ASSISTANT_BYTES,
+  utf8ByteLength,
+  truncateToUtf8Bytes,
+  fitStateBodyToByteBudget,
+};

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -134,6 +134,7 @@ FILES=(
   "$HOOKS_DIR/json-utils.js"
   "$HOOKS_DIR/shared-process.js"
   "$HOOKS_DIR/context-usage.js"
+  "$HOOKS_DIR/state-payload-size.js"
   "$HOOKS_DIR/clawd-hook.js"
   "$HOOKS_DIR/install.js"
   "$HOOKS_DIR/codex-hook.js"

--- a/src/remote-ssh-deploy.js
+++ b/src/remote-ssh-deploy.js
@@ -47,6 +47,7 @@ const HOOK_FILES = [
   "json-utils.js",
   "shared-process.js",
   "context-usage.js",
+  "state-payload-size.js",
   "clawd-hook.js",
   "install.js",
   "codex-hook.js",

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -13,10 +13,15 @@ const { resolveHookAgentId } = require("./server-agent-id");
 const { resolveCodexOfficialHookState } = require("./server-codex-official-turns");
 const { normalizeTranscriptPath } = require("./transcript-path");
 
-// /state POST body size cap. Raised from 1024 to 4096 to give new fields
-// (session_title) headroom on top of cwd / pid_chain / host / etc. Still a
-// local-only 127.0.0.1 endpoint - not an Internet DoS concern.
-const MAX_STATE_BODY_BYTES = 4096;
+// /state POST body size cap. Raised 1024 → 4096 → 16384: a CJK
+// assistant_last_output (3 UTF-8 bytes/char) on a Stop completion blew past
+// 4096, and the server's headerless 413 made the hook read posted=false, so the
+// happy animation was silently dropped for Chinese/Japanese/Korean users. Hooks
+// clamp that field by CHARACTER count while this caps by BYTE count — hooks now
+// also byte-fit the body before POST (hooks/state-payload-size.js); this cap is
+// the matching receive-side headroom. Still a local-only 127.0.0.1 endpoint —
+// not an Internet DoS concern.
+const MAX_STATE_BODY_BYTES = 16 * 1024;
 const ASSISTANT_LAST_OUTPUT_MAX = 2400;
 
 function normalizeHwndString(value) {

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -302,6 +302,25 @@ describe("server-route-state POST", () => {
     assert.strictEqual(res.body, "state payload too large");
   });
 
+  it("accepts a large CJK Stop body now that the cap is 16KB (happy-413 regression)", async () => {
+    const body = JSON.stringify({
+      state: "attention",
+      session_id: "sid",
+      event: "Stop",
+      assistant_last_output: "字".repeat(2200), // ~6600 UTF-8 bytes
+    });
+    // Bigger than the OLD 4096 cap that silently 413'd CJK completions, yet
+    // within the new 16KB cap — the completion must register, not be rejected.
+    assert.ok(Buffer.byteLength(body, "utf8") > 4096);
+    assert.ok(Buffer.byteLength(body, "utf8") <= MAX_STATE_BODY_BYTES);
+
+    const res = await callStatePost(body);
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+    assert.strictEqual(res.calls.updateSession.length, 1);
+  });
+
   it("returns 400 for invalid JSON", async () => {
     const res = await callStatePost("{not json");
 

--- a/test/server-state-title.test.js
+++ b/test/server-state-title.test.js
@@ -1,13 +1,14 @@
 "use strict";
 
 // Integration tests for the /state endpoint's session_title handling
-// and the raised MAX_STATE_BODY_BYTES = 4096 cap.
+// and the MAX_STATE_BODY_BYTES cap.
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const { EventEmitter } = require("node:events");
 
 const initServer = require("../src/server");
+const { MAX_STATE_BODY_BYTES } = require("../src/server-route-state");
 
 function makeFakeHttp() {
   let capturedHandler = null;
@@ -190,7 +191,7 @@ describe("/state session_title handling", () => {
   });
 });
 
-describe("/state MAX_STATE_BODY_BYTES (4KB cap)", () => {
+describe("/state MAX_STATE_BODY_BYTES cap", () => {
   it("accepts a normal payload with session_title (returns 200)", async () => {
     const { handler, updateSessionCalls } = startServer();
     const req = makeReq("POST", "/state", JSON.stringify({
@@ -205,13 +206,13 @@ describe("/state MAX_STATE_BODY_BYTES (4KB cap)", () => {
     assert.strictEqual(updateSessionCalls.length, 1);
   });
 
-  it("returns 413 when body exceeds MAX_STATE_BODY_BYTES (4KB)", async () => {
+  it("returns 413 when the body exceeds MAX_STATE_BODY_BYTES", async () => {
     const { handler, updateSessionCalls } = startServer();
-    // 5KB of padding in session_title — well over the 4KB cap
+    // session_title padded past the cap — guarantees an over-limit body
     const hugePayload = JSON.stringify({
       state: "working",
       session_id: "sid-1",
-      session_title: "x".repeat(5000),
+      session_title: "x".repeat(MAX_STATE_BODY_BYTES + 1000),
     });
     const req = makeReq("POST", "/state", hugePayload);
     const res = await callHandler(handler, req);
@@ -219,16 +220,16 @@ describe("/state MAX_STATE_BODY_BYTES (4KB cap)", () => {
     assert.strictEqual(updateSessionCalls.length, 0);
   });
 
-  it("accepts a payload just under 4KB", async () => {
+  it("accepts a payload just under MAX_STATE_BODY_BYTES", async () => {
     const { handler, updateSessionCalls } = startServer();
-    // Construct a payload that fits under 4096 bytes total
+    // Construct a payload that fits just under the cap.
     const payload = {
       state: "working",
       session_id: "sid-1",
-      session_title: "t".repeat(3500),
+      session_title: "t".repeat(MAX_STATE_BODY_BYTES - 600),
     };
     const body = JSON.stringify(payload);
-    assert.ok(body.length < 4096, `test payload is ${body.length} bytes, should be < 4096`);
+    assert.ok(body.length < MAX_STATE_BODY_BYTES, `test payload is ${body.length} bytes, should be < ${MAX_STATE_BODY_BYTES}`);
     const req = makeReq("POST", "/state", body);
     const res = await callHandler(handler, req);
     assert.strictEqual(res.statusCode, 200);

--- a/test/state-payload-size.test.js
+++ b/test/state-payload-size.test.js
@@ -1,0 +1,116 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+const {
+  DEFAULT_TARGET_BYTES,
+  truncateToUtf8Bytes,
+  fitStateBodyToByteBudget,
+} = require("../hooks/state-payload-size");
+
+describe("state-payload-size truncateToUtf8Bytes", () => {
+  it("returns the string unchanged when already within budget", () => {
+    assert.strictEqual(truncateToUtf8Bytes("hello", 100), "hello");
+  });
+
+  it("never splits a multi-byte character", () => {
+    const s = "你好世界".repeat(10); // 40 chars, 120 bytes
+    const out = truncateToUtf8Bytes(s, 50);
+    assert.ok(Buffer.byteLength(out, "utf8") <= 50);
+    assert.ok(!out.includes("�")); // no replacement char from a split codepoint
+    assert.ok([...out].every((ch) => "你好世界".includes(ch)));
+  });
+
+  it("cuts exactly on a character boundary", () => {
+    assert.strictEqual(truncateToUtf8Bytes("ab你", 2), "ab"); // 你 starts at byte 2
+    assert.strictEqual(truncateToUtf8Bytes("ab你", 4), "ab"); // 你 needs bytes 2..4
+    assert.strictEqual(truncateToUtf8Bytes("ab你", 5), "ab你");
+  });
+
+  it("returns empty for a non-positive budget or non-string", () => {
+    assert.strictEqual(truncateToUtf8Bytes("你好", 0), "");
+    assert.strictEqual(truncateToUtf8Bytes("你好", -5), "");
+    assert.strictEqual(truncateToUtf8Bytes(null, 10), "");
+  });
+});
+
+describe("state-payload-size fitStateBodyToByteBudget", () => {
+  it("passes a small body through untouched (same reference)", () => {
+    const body = { state: "attention", session_id: "sid", event: "Stop", assistant_last_output: "Done." };
+    const r = fitStateBodyToByteBudget(body);
+    assert.strictEqual(r.fitted, true);
+    assert.strictEqual(r.assistantTruncated, false);
+    assert.strictEqual(r.assistantDropped, false);
+    assert.strictEqual(r.body, body);
+  });
+
+  it("does NOT trim a normal 2200-char CJK reply (fits under the default budget)", () => {
+    const body = {
+      state: "attention",
+      session_id: "sid",
+      event: "Stop",
+      assistant_last_output: "字".repeat(2200), // 6600 bytes < 14336
+    };
+    const r = fitStateBodyToByteBudget(body);
+    assert.strictEqual(r.fitted, true);
+    assert.strictEqual(r.assistantTruncated, false);
+    assert.strictEqual(r.assistantDropped, false);
+    assert.ok(r.bytes <= DEFAULT_TARGET_BYTES);
+  });
+
+  it("truncates an oversized CJK reply and stays fitted, keeping completion fields", () => {
+    const body = {
+      state: "attention",
+      session_id: "sid",
+      event: "Stop",
+      assistant_last_output: "字".repeat(20000), // 60000 bytes >> budget
+    };
+    const r = fitStateBodyToByteBudget(body);
+    assert.strictEqual(r.fitted, true);
+    assert.strictEqual(r.assistantTruncated, true);
+    assert.strictEqual(r.assistantDropped, false);
+    assert.ok(r.bytes <= DEFAULT_TARGET_BYTES);
+    assert.strictEqual(r.body.assistant_last_output_truncated, true);
+    assert.strictEqual(r.body.state, "attention");
+    assert.strictEqual(r.body.session_id, "sid");
+    assert.strictEqual(r.body.event, "Stop");
+    assert.strictEqual(body.assistant_last_output.length, 20000); // input not mutated
+  });
+
+  it("drops assistant_last_output when there is no room, preserving completion + gate fields", () => {
+    const body = {
+      state: "attention",
+      session_id: "sid",
+      event: "Stop",
+      background_tasks_count: 2,
+      session_crons_count: 1,
+      stop_hook_active: true,
+      assistant_last_output: "字".repeat(50),
+    };
+    // Tight budget: the gate/completion fields alone nearly fill it, leaving no
+    // usable room for any assistant text → drop it but keep everything else.
+    const r = fitStateBodyToByteBudget(body, { targetBytes: 150 });
+    assert.strictEqual(r.assistantDropped, true);
+    assert.strictEqual(r.fitted, true);
+    assert.strictEqual(r.body.assistant_last_output, undefined);
+    assert.strictEqual(r.body.assistant_last_output_truncated, undefined);
+    assert.strictEqual(r.body.state, "attention");
+    assert.strictEqual(r.body.event, "Stop");
+    assert.strictEqual(r.body.background_tasks_count, 2);
+    assert.strictEqual(r.body.session_crons_count, 1);
+    assert.strictEqual(r.body.stop_hook_active, true);
+  });
+
+  it("respects a custom targetBytes", () => {
+    const body = {
+      state: "attention",
+      session_id: "sid",
+      event: "Stop",
+      assistant_last_output: "字".repeat(500),
+    };
+    const r = fitStateBodyToByteBudget(body, { targetBytes: 200 });
+    assert.ok(r.bytes <= 200);
+    assert.ok(r.assistantTruncated || r.assistantDropped);
+  });
+});

--- a/test/state-payload-size.test.js
+++ b/test/state-payload-size.test.js
@@ -33,6 +33,15 @@ describe("state-payload-size truncateToUtf8Bytes", () => {
     assert.strictEqual(truncateToUtf8Bytes("你好", -5), "");
     assert.strictEqual(truncateToUtf8Bytes(null, 10), "");
   });
+
+  it("truncates 4-byte emoji on a codepoint boundary", () => {
+    const s = "😀".repeat(10); // each 😀 is 4 UTF-8 bytes (40 bytes total)
+    const out = truncateToUtf8Bytes(s, 10); // room for 2 whole emoji (8 bytes)
+    assert.ok(Buffer.byteLength(out, "utf8") <= 10);
+    assert.ok(!out.includes("�"));
+    assert.ok([...out].every((ch) => ch === "😀"));
+    assert.strictEqual([...out].length, 2);
+  });
 });
 
 describe("state-payload-size fitStateBodyToByteBudget", () => {
@@ -112,5 +121,40 @@ describe("state-payload-size fitStateBodyToByteBudget", () => {
     const r = fitStateBodyToByteBudget(body, { targetBytes: 200 });
     assert.ok(r.bytes <= 200);
     assert.ok(r.assistantTruncated || r.assistantDropped);
+  });
+
+  it("treats a body exactly at the budget as fitted and untouched", () => {
+    const body = { state: "x" };
+    const exact = Buffer.byteLength(JSON.stringify(body), "utf8");
+    const r = fitStateBodyToByteBudget(body, { targetBytes: exact });
+    assert.strictEqual(r.fitted, true);
+    assert.strictEqual(r.bytes, exact);
+    assert.strictEqual(r.body, body);
+  });
+
+  it("ships an oversized body unchanged when there is no assistant_last_output to trim", () => {
+    const body = { state: "working", session_id: "sid", session_title: "t".repeat(500) };
+    const r = fitStateBodyToByteBudget(body, { targetBytes: 100 });
+    assert.strictEqual(r.fitted, false);
+    assert.strictEqual(r.assistantTruncated, false);
+    assert.strictEqual(r.assistantDropped, false);
+    assert.strictEqual(r.body, body); // structural fields are never trimmed
+    assert.ok(r.bytes > 100);
+  });
+
+  it("drops assistant_last_output when JSON escaping inflates a trimmed copy back over budget", () => {
+    // Every char is a double-quote: 1 raw byte, but 2 bytes once JSON-escaped (\").
+    // There IS raw-byte room to trim into, yet escaping pushes the trimmed copy
+    // back over budget — the helper must fall back to dropping, not ship oversized.
+    const body = {
+      state: "attention",
+      session_id: "sid",
+      event: "Stop",
+      assistant_last_output: '"'.repeat(5000),
+    };
+    const r = fitStateBodyToByteBudget(body, { targetBytes: 250 });
+    assert.strictEqual(r.assistantDropped, true);
+    assert.strictEqual(r.fitted, true);
+    assert.ok(Buffer.byteLength(JSON.stringify(r.body), "utf8") <= 250);
   });
 });


### PR DESCRIPTION
## Problem

The happy completion animation intermittently failed to play. It turned out to hit **only CJK users** (Chinese / Japanese / Korean), which is why it was rarely reported.

## Root cause

A character-vs-byte mismatch between the hook and the server:

- The hooks clamp `assistant_last_output` (the turn's final reply) by **character** count (2200).
- The server caps the `/state` POST body by **byte** count (was 4096).

One CJK character is 3 UTF-8 bytes, so a ~1400+ character Chinese reply produced a body over 4096 bytes. The server answered a **headerless 413**; the hook's post helper only treats a Clawd-header response as delivered, so it read back `posted=false`, the completion never reached `updateSession`, and the celebration was silently dropped. English replies (2200 chars ≈ 2200 bytes) never tripped it.

## Fix (both ends)

- **server**: raise `MAX_STATE_BODY_BYTES` 4096 → 16384. Local 127.0.0.1 endpoint; 16 KB easily covers CJK, emoji, and Codex's fatter Stop payloads.
- **hooks**: new `hooks/state-payload-size.js` byte-fits the *full* serialized body before POST (target 14 KB). Only `assistant_last_output` is sacrificed — truncated on a UTF-8 boundary, then dropped if even a trimmed copy can't fit — so `state` / `session_id` / `event` and the #406 gate fields always reach Clawd. Wired into `clawd-hook.js` (Claude) and `codex-hook.js` (Codex).
- registered the new helper in both deploy manifests (`scripts/remote-deploy.sh` FILES and `src/remote-ssh-deploy.js` HOOK_FILES); manifest-consistency tests enforce both stay in sync.
- `AGENTS.md`: the hook-dependency constraint listed a stale helper allowlist that had already drifted; reworded around the real rule (same-dir helpers registered in both manifests).

The `f7dbc1d` commit (widen Stop timeout to 1500 ms) was an earlier attempt against a **disproven** "busy system → POST timeout" theory. It is harmless and kept as a reasonable generous timeout for the low-frequency completion event, but it is *not* what fixed this — the 413 was the real cause.

## Verification

- **repro**: the same 4889-byte CJK body returns `413` on the old cap, `200` on the new one.
- **unit**: `state-payload-size.test.js` covers UTF-8 truncation, 4-byte emoji boundaries, exact-budget, escape-inflation drop, and no-assistant passthrough.
- **regression**: a 2200-char CJK Stop body now returns 200 and registers the completion.
- **full suite**: 4256 pass / 0 fail.
- **end-to-end on a real turn**: a genuine 5317-byte CJK reply (over the old 4096 cap, where it would have 413'd) posted `200` and played the happy animation. ✅

## Notes

Only the Claude and Codex hooks got the send-side byte-fit this round; `codex-remote-monitor.js` and the other agent hooks rely on the raised 16 KB cap for now (follow-up).
