### PR TITLE
Fix free-roam target selection flake (#525)

### DIFF
--- a/src/roam.js
+++ b/src/roam.js
@@ -22,6 +22,7 @@ const ROAM_SPEED_PX_PER_MS = 0.08;   // 80px/s — slower than mini crabwalk (12
 const ROAM_MIN_DIST = 100;
 const ROAM_MARGIN_RATIO = 0.15;
 const ROAM_FRAME_MS = 16;
+const ROAM_TARGET_ATTEMPTS = 8;
 
 module.exports = function initRoam(ctx) {
   let enabled = false;
@@ -60,13 +61,33 @@ module.exports = function initRoam(ctx) {
     const yMin = wa.y + marginY;
     const yMax = wa.y + wa.height - bounds.height - marginY;
     if (xMax <= xMin || yMax <= yMin) return null;
-    const targetX = xMin + Math.floor(Math.random() * (xMax - xMin));
-    const targetY = yMin + Math.floor(Math.random() * (yMax - yMin));
-    const dx = targetX - bounds.x;
-    const dy = targetY - bounds.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
-    if (dist < ROAM_MIN_DIST) return null;
-    return { x: targetX, y: targetY };
+    for (let i = 0; i < ROAM_TARGET_ATTEMPTS; i += 1) {
+      const targetX = xMin + Math.floor(Math.random() * (xMax - xMin));
+      const targetY = yMin + Math.floor(Math.random() * (yMax - yMin));
+      const dx = targetX - bounds.x;
+      const dy = targetY - bounds.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist >= ROAM_MIN_DIST) return { x: targetX, y: targetY };
+    }
+
+    const fallbackTargets = [
+      { x: xMin, y: yMin },
+      { x: xMax, y: yMin },
+      { x: xMin, y: yMax },
+      { x: xMax, y: yMax },
+    ];
+    let best = null;
+    let bestDist = -1;
+    for (const target of fallbackTargets) {
+      const dx = target.x - bounds.x;
+      const dy = target.y - bounds.y;
+      const dist = Math.sqrt(dx * dx + dy * dy);
+      if (dist > bestDist) {
+        best = target;
+        bestDist = dist;
+      }
+    }
+    return bestDist >= ROAM_MIN_DIST ? best : null;
   }
 
   function animateTo(targetX, targetY) {

--- a/test/roam.test.js
+++ b/test/roam.test.js
@@ -461,4 +461,43 @@ describe("roam module", () => {
     roam.tick();
     assert.ok(true, "tick should not throw when in roam state");
   });
+
+  it("falls back to the farthest work-area corner when every random target is too close", () => {
+    // Force all ROAM_TARGET_ATTEMPTS random picks to land on the pet's current
+    // position (dist 0 < ROAM_MIN_DIST), so target selection must use the
+    // four-corner fallback instead of returning null (the old flake).
+    // workArea 1000×1000, pet 120px, margin = round(1000*0.15) = 150 →
+    // xMin=150, xMax=1000-120-150=730. Math.random()=0.5 →
+    // targetX = 150 + floor(0.5*580) = 440, same for Y. Pet sits at (440,440)
+    // so every attempt has dist 0; the farthest corner is (xMin,yMin)=(150,150).
+    mock.method(Math, "random", () => 0.5);
+    const bounds = { x: 440, y: 440, width: 120, height: 120 };
+    const realBounds = { ...bounds };
+    const ctx = makeCtx({
+      getPetWindowBounds() { return { ...bounds }; },
+      getNearestWorkArea() { return { x: 0, y: 0, width: 1000, height: 1000 }; },
+    });
+    ctx.win.getBounds = () => ({ ...realBounds });
+    ctx.win.setBounds = (next) => {
+      realBounds.x = next.x; realBounds.y = next.y;
+      realBounds.width = next.width; realBounds.height = next.height;
+    };
+    ctx.applyPetWindowPosition = (x, y) => {
+      bounds.x = x; bounds.y = y; realBounds.x = x; realBounds.y = y;
+    };
+
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+    roam.tick();
+    mock.timers.tick(8000);
+    for (let i = 0; i < 2000; i++) {
+      mock.timers.tick(16);
+      if (ctx._stateLog.some(e => e.type === "setState" && e.state === "idle")) break;
+    }
+
+    // Fallback target was the farthest corner (150,150): the pet must have
+    // actually moved there, not stalled at its start (the old null-return bug).
+    assert.ok(Math.abs(realBounds.x - 150) < 5 && Math.abs(realBounds.y - 150) < 5,
+      `expected move to farthest corner (150,150), got (${realBounds.x},${realBounds.y})`);
+  });
 });

--- a/test/roam.test.js
+++ b/test/roam.test.js
@@ -469,7 +469,8 @@ describe("roam module", () => {
     // workArea 1000×1000, pet 120px, margin = round(1000*0.15) = 150 →
     // xMin=150, xMax=1000-120-150=730. Math.random()=0.5 →
     // targetX = 150 + floor(0.5*580) = 440, same for Y. Pet sits at (440,440)
-    // so every attempt has dist 0; the farthest corner is (xMin,yMin)=(150,150).
+    // so every attempt has dist 0. All four corners are equidistant from
+    // (440,440); the impl tie-breaks to the first in its list, (xMin,yMin)=(150,150).
     mock.method(Math, "random", () => 0.5);
     const bounds = { x: 440, y: 440, width: 120, height: 120 };
     const realBounds = { ...bounds };
@@ -495,8 +496,9 @@ describe("roam module", () => {
       if (ctx._stateLog.some(e => e.type === "setState" && e.state === "idle")) break;
     }
 
-    // Fallback target was the farthest corner (150,150): the pet must have
-    // actually moved there, not stalled at its start (the old null-return bug).
+    // Fallback ties between all four equidistant corners; the impl keeps the
+    // first, (150,150). The pet must have actually moved there — not stalled at
+    // its start (the old null-return bug).
     assert.ok(Math.abs(realBounds.x - 150) < 5 && Math.abs(realBounds.y - 150) < 5,
       `expected move to farthest corner (150,150), got (${realBounds.x},${realBounds.y})`);
   });


### PR DESCRIPTION
Splits the free-roam fix out of #496 so it can land independently of the unresolved DWM-cloak investigation.

`pickRandomTarget()` previously made a single random pick and returned `null` when it landed closer than `ROAM_MIN_DIST`, which intermittently skipped `applyState('roam')` and made `test/roam.test.js` flaky. It now retries a bounded number of times and falls back to the farthest work-area corner.

- Cherry-picked from @Git-creat7's work in #496 (authorship preserved).
- Added a unit test that forces the fallback path (all random picks too close → farthest corner).

Refs #525, #496.
