### PR TITLE
fix(roam): anchor walk size to stop mixed-DPI growth during free roam (#569)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3660,7 +3660,9 @@ const { enterMiniMode, exitMiniMode, enterMiniViaMenu, miniPeekIn, miniPeekOut,
 const _roamCtx = {
   get win() { return win; },
   getPetWindowBounds,
-  applyPetWindowPosition,
+  applyPetWindowBounds,
+  // #569: lets roam anchor to the keep-size frozen size when that toggle is on
+  getEffectiveCurrentPixelSize,
   syncHitWin: () => syncHitWin(),
   repositionSessionHud: () => repositionSessionHud(),
   repositionAnchoredSurfaces: () => repositionAnchoredFloatingSurfaces(),

--- a/src/roam.js
+++ b/src/roam.js
@@ -6,8 +6,9 @@
 //   • Before moving the window, the visual state switches to "roam" (which
 //     falls back to idle SVG for themes without a dedicated roam animation).
 //     This prevents the "idle pet dragged across the desktop" regression.
-//   • Movement goes through applyPetWindowPosition every frame so virtual bounds,
-//     hit window, HUD, and anchored surfaces stay in sync with the pet.
+//   • Movement goes through applyPetWindowBounds every frame — anchored to a
+//     size captured once at walk start (#569) — so virtual bounds, hit window,
+//     HUD, and anchored surfaces stay in sync with the pet.
 //   • Each animation step re-checks isRoamAllowed() so a state change to working /
 //     notification / permission cancels the roam immediately — no "pet drifting while
 //     working" regression.
@@ -98,10 +99,25 @@ module.exports = function initRoam(ctx) {
     if (!startBounds) { roamActive = false; return; }
     const startX = startBounds.x;
     const startY = startBounds.y;
+    // #569: freeze the window size for the whole walk (mirrors the drag
+    // snapshot in drag-position.js). Re-reading live bounds every frame lets
+    // the non-idempotent setBounds(getBounds()) round-trip on mixed-DPI
+    // Windows setups ratchet the pet larger while roaming — same mechanism
+    // as #408. When keepSizeAcrossDisplays is ON, the frozen keep-size wins
+    // over the live start bounds so both anchors share one source of truth.
+    const effectiveSize = typeof ctx.getEffectiveCurrentPixelSize === "function"
+      ? ctx.getEffectiveCurrentPixelSize()
+      : null;
+    const roamW = effectiveSize && Number.isFinite(effectiveSize.width) && effectiveSize.width > 0
+      ? effectiveSize.width
+      : startBounds.width;
+    const roamH = effectiveSize && Number.isFinite(effectiveSize.height) && effectiveSize.height > 0
+      ? effectiveSize.height
+      : startBounds.height;
     let finalX = targetX;
     let finalY = targetY;
     if (ctx.clampToScreenVisual) {
-      const clamped = ctx.clampToScreenVisual(finalX, finalY, startBounds.width, startBounds.height);
+      const clamped = ctx.clampToScreenVisual(finalX, finalY, roamW, roamH);
       finalX = clamped.x;
       finalY = clamped.y;
     }
@@ -145,7 +161,8 @@ module.exports = function initRoam(ctx) {
       if (!Number.isFinite(vx) || !Number.isFinite(vy)) { roamActive = false; return; }
 
       // ── Per-frame sync ──
-      ctx.applyPetWindowPosition(vx, vy);
+      // Write the anchored size, never a re-read of live bounds (#569).
+      ctx.applyPetWindowBounds({ x: vx, y: vy, width: roamW, height: roamH });
       if (typeof ctx.syncHitWin === "function") ctx.syncHitWin();
       if (typeof ctx.repositionAnchoredSurfaces === "function") ctx.repositionAnchoredSurfaces();
       // Throttle bubble reposition to every 3rd frame (~20fps) — same as mini.js

--- a/src/tick.js
+++ b/src/tick.js
@@ -176,6 +176,12 @@ function runMainTickOnce() {
     // ── Idle state edge detection (must run every tick for timer cleanup) ──
     const idleNow = ctx.currentState === "idle" && !ctx.idlePaused;
     const miniIdleNow = ctx.currentState === "mini-idle" && !ctx.idlePaused && !ctx.miniTransitioning;
+    // #569: an active roam walk runs in state "roam", so it must keep polling
+    // the cursor as well — otherwise the "cancel roaming when mouse moves"
+    // block below is unreachable mid-walk, and a user interaction that resizes
+    // the pet (e.g. the Settings size slider) lands mid-walk only to be
+    // overwritten by the walk's anchored per-frame bounds writes.
+    const roamNow = ctx.currentState === "roam" && !ctx.idlePaused;
     const nextDelay = () => getNextTickDelay(idleNow, miniIdleNow);
 
     if (idleNow && !idleWasActive) {
@@ -202,7 +208,7 @@ function runMainTickOnce() {
 
     // Skip expensive native IPC calls (getCursorScreenPoint, getBounds) when
     // cursor tracking is not needed — saves ~20 calls/sec to the OS layer.
-    const needsCursorPoll = idleNow || miniIdleNow || ctx.miniMode;
+    const needsCursorPoll = idleNow || miniIdleNow || ctx.miniMode || roamNow;
     if (!needsCursorPoll) return nextDelay();
 
     const cursor = screen.getCursorScreenPoint();
@@ -254,7 +260,7 @@ function runMainTickOnce() {
 
     sendPointerBridge(cursor, bounds);
 
-    if (!idleNow && !miniIdleNow) return nextDelay();
+    if (!idleNow && !miniIdleNow && !roamNow) return nextDelay();
 
     // ── Free roam: cancel roaming when mouse moves ──
     if (ctx.roam) {

--- a/test/roam.test.js
+++ b/test/roam.test.js
@@ -10,8 +10,9 @@ function makeCtx(overrides = {}) {
   const realBounds = { x: 400, y: 300, width: 120, height: 120 };
   const syncLog = [];
   const stateLog = [];
+  const appliedBounds = [];
   let currentState = "idle";
-  return {
+  const ctx = {
     win: {
       getBounds() { return { ...realBounds }; },
       setBounds(next) {
@@ -23,11 +24,22 @@ function makeCtx(overrides = {}) {
       isDestroyed() { return false; },
     },
     getPetWindowBounds() { return { ...bounds }; },
+    applyPetWindowBounds(next) {
+      appliedBounds.push({ ...next });
+      bounds.x = next.x;
+      bounds.y = next.y;
+      bounds.width = next.width;
+      bounds.height = next.height;
+      realBounds.x = next.x;
+      realBounds.y = next.y;
+      realBounds.width = next.width;
+      realBounds.height = next.height;
+    },
+    // Mirrors the real runtime: a position-only write re-reads live bounds and
+    // launders their width/height back through applyPetWindowBounds — the #569
+    // ratchet vector.
     applyPetWindowPosition(x, y) {
-      bounds.x = x;
-      bounds.y = y;
-      realBounds.x = x;
-      realBounds.y = y;
+      ctx.applyPetWindowBounds({ ...ctx.getPetWindowBounds(), x, y });
     },
     syncHitWin() { syncLog.push("syncHitWin"); },
     repositionSessionHud() { syncLog.push("repositionSessionHud"); },
@@ -47,8 +59,10 @@ function makeCtx(overrides = {}) {
     _stateLog: stateLog,
     _bounds: bounds,
     _realBounds: realBounds,
-    ...overrides,
+    _appliedBounds: appliedBounds,
   };
+  Object.assign(ctx, overrides);
+  return ctx;
 }
 
 describe("roam module", () => {
@@ -381,6 +395,16 @@ describe("roam module", () => {
       smallRealBounds.width = next.width;
       smallRealBounds.height = next.height;
     };
+    ctx.applyPetWindowBounds = (next) => {
+      smallBounds.x = next.x;
+      smallBounds.y = next.y;
+      smallBounds.width = next.width;
+      smallBounds.height = next.height;
+      smallRealBounds.x = next.x;
+      smallRealBounds.y = next.y;
+      smallRealBounds.width = next.width;
+      smallRealBounds.height = next.height;
+    };
 
     const roam = roamModule(ctx);
     roam.setEnabled(true);
@@ -483,8 +507,10 @@ describe("roam module", () => {
       realBounds.x = next.x; realBounds.y = next.y;
       realBounds.width = next.width; realBounds.height = next.height;
     };
-    ctx.applyPetWindowPosition = (x, y) => {
-      bounds.x = x; bounds.y = y; realBounds.x = x; realBounds.y = y;
+    ctx.applyPetWindowBounds = (next) => {
+      bounds.x = next.x; bounds.y = next.y;
+      realBounds.x = next.x; realBounds.y = next.y;
+      realBounds.width = next.width; realBounds.height = next.height;
     };
 
     const roam = roamModule(ctx);
@@ -501,5 +527,77 @@ describe("roam module", () => {
     // its start (the old null-return bug).
     assert.ok(Math.abs(realBounds.x - 150) < 5 && Math.abs(realBounds.y - 150) < 5,
       `expected move to farthest corner (150,150), got (${realBounds.x},${realBounds.y})`);
+  });
+
+  it("anchors the window size for the whole walk even when live bounds read back DPI-polluted (#569)", () => {
+    const ctx = makeCtx();
+    // Simulate the Windows mixed-DPI ratchet: every live read reports the
+    // window 4px larger than what was last written. Re-laundering that value
+    // through per-frame writes is exactly the #569 growth mechanism.
+    const cleanGet = ctx.getPetWindowBounds;
+    ctx.getPetWindowBounds = () => {
+      const b = cleanGet();
+      return { ...b, width: b.width + 4, height: b.height + 4 };
+    };
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000);
+    for (let i = 0; i < 2000; i++) {
+      mock.timers.tick(16);
+      if (ctx._stateLog.some(e => e.type === "setState" && e.state === "idle")) break;
+    }
+
+    const widths = new Set(ctx._appliedBounds.map(b => b.width));
+    const heights = new Set(ctx._appliedBounds.map(b => b.height));
+    assert.ok(ctx._appliedBounds.length > 10,
+      `walk should span many frames, got ${ctx._appliedBounds.length}`);
+    assert.equal(widths.size, 1,
+      `width must stay constant across the walk, saw [${[...widths].join(", ")}]`);
+    assert.equal(heights.size, 1,
+      `height must stay constant across the walk, saw [${[...heights].join(", ")}]`);
+    // Anchored to the single read at walk start (120 + one polluted read = 124),
+    // never re-read per frame — no cumulative growth.
+    assert.equal([...widths][0], 124, "size is captured once at walk start");
+  });
+
+  it("prefers the keep-size effective size over walk-start bounds when exposed (#408 interplay)", () => {
+    // keepSizeAcrossDisplays ON: getEffectiveCurrentPixelSize returns the
+    // frozen size, which must win over (possibly polluted) live start bounds
+    // so roam and keep-size stay on one source of truth.
+    const ctx = makeCtx({
+      getEffectiveCurrentPixelSize: () => ({ width: 100, height: 100 }),
+    });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000);
+    mock.timers.tick(16);
+    mock.timers.tick(16);
+
+    assert.ok(ctx._appliedBounds.length >= 2, "walk should have written frames");
+    for (const b of ctx._appliedBounds) {
+      assert.equal(b.width, 100, "frozen keep-size width must win over start bounds");
+      assert.equal(b.height, 100, "frozen keep-size height must win over start bounds");
+    }
+  });
+
+  it("falls back to walk-start size when getEffectiveCurrentPixelSize returns nothing", () => {
+    const ctx = makeCtx({ getEffectiveCurrentPixelSize: () => null });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000);
+    mock.timers.tick(16);
+    mock.timers.tick(16);
+
+    assert.ok(ctx._appliedBounds.length >= 2, "walk should have written frames");
+    for (const b of ctx._appliedBounds) {
+      assert.equal(b.width, 120, "falls back to the size read at walk start");
+      assert.equal(b.height, 120, "falls back to the size read at walk start");
+    }
   });
 });

--- a/test/tick.test.js
+++ b/test/tick.test.js
@@ -723,3 +723,78 @@ describe("tick spin detection (dizzy gesture)", () => {
     assert.ok(!statesSeen.includes("dizzy"), `pause should reset the meter, saw ${JSON.stringify(statesSeen)}`);
   });
 });
+
+describe("tick free roam cancellation (#569)", () => {
+  let cursor;
+  let loader;
+  let tickApi;
+  let ctx;
+  let statesSeen;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    cursor = { x: 40, y: 40 };
+    loader = loadTickWithScreen(() => ({ ...cursor }));
+    statesSeen = [];
+  });
+
+  afterEach(() => {
+    if (tickApi) tickApi.cleanup();
+    if (loader) loader.restore();
+    mock.timers.reset();
+    tickApi = null;
+    ctx = null;
+  });
+
+  function makeRoamCtx() {
+    const theme = cloneTheme(_defaultTheme);
+    const c = makeCtx(theme, statesSeen);
+    // Pet is mid-walk: roam.js switched the visual state to "roam".
+    c.currentState = "roam";
+    c.roamCancels = 0;
+    c.roam = {
+      enabled: true,
+      cancelRoam() { c.roamCancels += 1; },
+      tick() {},
+    };
+    return c;
+  }
+
+  it("cancels an active walk when the mouse moves during state 'roam'", () => {
+    ctx = makeRoamCtx();
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+
+    // Baseline ticks with a still cursor — records lastCursor, must not cancel.
+    mock.timers.tick(800);
+    assert.equal(ctx.roamCancels, 0, "no cancel while the mouse is still");
+
+    // Mouse moves mid-walk — the next tick must cancel the walk. Before the
+    // #569 follow-up, state "roam" was excluded from the cursor poll gate and
+    // this cancel block was unreachable during a walk.
+    cursor = { x: 300, y: 260 };
+    mock.timers.tick(800);
+    assert.ok(ctx.roamCancels >= 1, "mouse move during an active walk must cancel roam");
+  });
+
+  it("does not cancel while the mouse stays still for the whole walk", () => {
+    ctx = makeRoamCtx();
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+
+    for (let i = 0; i < 6; i++) mock.timers.tick(800);
+    assert.equal(ctx.roamCancels, 0, "a still mouse must never cancel the walk");
+  });
+
+  it("does not cancel a walk while idlePaused (e.g. menu open)", () => {
+    ctx = makeRoamCtx();
+    ctx.idlePaused = true;
+    tickApi = loader.initTick(ctx);
+    tickApi.startMainTick();
+
+    mock.timers.tick(800);
+    cursor = { x: 300, y: 260 };
+    mock.timers.tick(800);
+    assert.equal(ctx.roamCancels, 0, "idlePaused suppresses roam cursor cancellation");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the free-roam size ratchet reported in #569 — the pet gradually grows while wandering and keeps the inflated size until the next state change.

**Reproduction turned out broader than the report suggested**: originally filed from a mixed-DPI multi-monitor setup, but I reproduced the exact same growth on a single display with Windows DPI scaling ≠ 100% (unfixed build grows within a couple of walks; this branch stays stable on the same machine — a clean A/B on identical hardware).

Two commits:

- **af06090 — anchor the walk size.** Roam moved the window via `applyPetWindowPosition` every 16 ms frame, which re-reads live window bounds and writes width/height straight back through `setBounds()`. On Windows that round-trip is not idempotent under DPI scaling, so each frame can ratchet the size up — same mechanism as #408. The #501 freeze (`keepSizeFrozenPx`) only covers `keepSizeAcrossDisplays=ON`, and that toggle defaults to OFF, so roam was unprotected. `animateTo()` now captures an anchor size once at walk start and writes it explicitly every frame via `applyPetWindowBounds`, mirroring the drag-snapshot pattern in `drag-position.js`. When keep-size is ON, `getEffectiveCurrentPixelSize()` (the #501 frozen size) takes precedence over the live start bounds, so both mechanisms write the same value and cannot fight.

- **22251be — make mouse-move cancellation reach active walks** (follow-up from an external codex review). The "cancel roaming when mouse moves" block in the main tick was unreachable during an actual walk: the walk runs in state `roam`, but the cursor-poll gate only admitted idle / mini-idle / mini mode, so the cancellation only ever worked during the pre-walk idle wait. With the size anchor in place this gap mattered: a resize landing mid-walk (e.g. the Settings size slider) would be overwritten by the anchored per-frame writes until the walk ended. State `roam` now joins the cursor-poll gate, so any mouse interaction cancels the walk before it can conflict. No side effects: `POINTER_BRIDGE_STATES` does not include `roam` (no new pointer-bridge IPC), the idle/mini branches keep their own gates, and `cancelRoam()` already restores idle, after which the normal tick reschedules the next walk.

Other `applyPetWindowPosition` callers audited: topmost-runtime's 1 px nudge/restore are one-shot writes (hardening that helper itself is noted as a longer-term follow-up); mini.js already animates with sizes frozen at animation start.

## Test plan

- [x] `node --test test/*.test.js` — full suite, 0 fail
- [x] New regression test simulates DPI-polluted live reads (+4 px per read): unfixed code ratchets 120 px → 3488 px within a single walk; fixed code holds one constant size
- [x] Keep-size precedence and fallback pinned by dedicated tests
- [x] Tick cancellation tests verified red against the old gate before the fix
- [x] Real-machine A/B on a single display with DPI scaling: unfixed build reproduces the growth, this branch stays stable; mouse move cancels the walk; mini mode and drag regressions clean
- [ ] Reporter verification on their multi-monitor setup after the next release — leaving #569 open for that
