### PR TITLE
feat(roam): crabwalk walk animation with direction-aware mirroring

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3676,6 +3676,7 @@ const _roamCtx = {
   get miniTransitioning() { return _mini.getMiniTransitioning(); },
   applyState: (state, svgOverride, opts) => _state.applyState(state, svgOverride, opts),
   setState: (state, svgOverride, opts) => _state.setState(state, svgOverride, opts),
+  setRoamHeading: (headingLeft) => sendToRenderer("roam-heading", !!headingLeft),
 };
 const _roam = require("./roam")(_roamCtx);
 

--- a/src/preload.js
+++ b/src/preload.js
@@ -15,6 +15,7 @@ contextBridge.exposeInMainWorld("electronAPI", {
   onKimiPermissionPulse: (callback) => ipcRenderer.on("kimi-permission-pulse", () => callback()),
   onEyeMove: (callback) => ipcRenderer.on("eye-move", (_, dx, dy) => callback(dx, dy)),
   onCloudlingPointer: (callback) => ipcRenderer.on("cloudling-pointer", (_, payload) => callback(payload)),
+  onRoamHeading: (callback) => ipcRenderer.on("roam-heading", (_, headingLeft) => callback(headingLeft)),
   onWakeFromDoze: (callback) => ipcRenderer.on("wake-from-doze", () => callback()),
   onDndChange: (callback) => ipcRenderer.on("dnd-change", (_, enabled) => callback(enabled)),
   onMiniModeChange: (cb) => ipcRenderer.on("mini-mode-change", (_, enabled, edge, options) => cb(enabled, edge, options)),

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -73,6 +73,7 @@ function initWithConfig(cfg) {
   _fileOffsets = os.fileOffsets || {};
   _transitions = tc.transitions || {};
   _miniFlipAssets = !!tc.miniFlipAssets;
+  _hasRoamVisual = !!tc.hasRoamVisual;
 
   applyObjectScaleStyle(clawdEl, getObjectSvgName(clawdEl), null);
   applyObjectScaleStyle(pendingNext, getObjectSvgName(pendingNext), null);
@@ -376,6 +377,8 @@ let _fileScales = {};
 let _fileOffsets = {};
 let _transitions = {};  // per-file fade config: { "file.apng": { in: 400, out: 400 } }
 let _miniFlipAssets = false; // theme's mini assets drawn in reverse direction
+let _hasRoamVisual = false;  // theme binds a dedicated roam visual (≠ idle)
+let _roamHeadingLeft = false; // current walk direction; roam visuals are drawn facing right
 let _inMiniMode = false;
 let _miniPreEntryMode = false;
 let _viewportOffsetY = 0;
@@ -391,6 +394,9 @@ function setViewportOffset(offsetY) {
 }
 
 function shouldApplyMiniAssetFlip(state) {
+  // Free roam: the dedicated roam visual is drawn facing right; mirror it
+  // while the walk heads left (heading pushed from main via roam-heading).
+  if (state === "roam") return _hasRoamVisual && _roamHeadingLeft;
   return _miniFlipAssets && (_inMiniMode || (_miniPreEntryMode && state === "mini-crabwalk"));
 }
 
@@ -995,8 +1001,9 @@ function renderStateFile(state, svg) {
   // When the pet is roaming (free-roam mode), add a CSS animation to simulate
   // walking even if the theme doesn't have a dedicated roam SVG. The animation
   // is a subtle horizontal bob that makes the idle SVG look like it's walking.
+  // Themes with a dedicated roam visual animate themselves — no bob on top.
   if (container) {
-    container.classList.toggle("roam-walk", state === "roam");
+    container.classList.toggle("roam-walk", state === "roam" && !_hasRoamVisual);
   }
 
   if (!shouldUseCloudlingPointerBridge(state, effectiveSvg)) {
@@ -1550,6 +1557,16 @@ if (window.electronAPI && typeof window.electronAPI.onSystemWake === "function")
 if (window.electronAPI && typeof window.electronAPI.onCloudlingPointer === "function") {
   window.electronAPI.onCloudlingPointer((payload) => {
     applyCloudlingPointerBridge(payload);
+  });
+}
+
+if (window.electronAPI && typeof window.electronAPI.onRoamHeading === "function") {
+  window.electronAPI.onRoamHeading((headingLeft) => {
+    _roamHeadingLeft = !!headingLeft;
+    // Re-apply to the element already on screen: main sends the heading just
+    // before applyState("roam"), but consecutive walks reuse the displayed
+    // roam visual without a swap, so the flip must update in place too.
+    applyMiniFlip(clawdEl, currentState);
   });
 }
 

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -1025,6 +1025,12 @@ function renderStateFile(state, svg) {
   const pendingChannelMatches = !alreadyPending || ((pendingNext.tagName === "OBJECT") === desiredObjectChannel);
 
   if ((alreadyDisplayed && displayedChannelMatches) || (alreadyPending && pendingChannelMatches)) {
+    // Same file, no swap — but the flip is state-dependent (mini flip vs roam
+    // heading), so re-apply it for the incoming state. E.g. a leftward roam
+    // entering mini pre-entry reuses the same crabwalk asset; without this the
+    // roam mirror would leak into the mini entry (and vice versa).
+    if (alreadyDisplayed) applyMiniFlip(clawdEl, state);
+    if (alreadyPending && pendingNext) applyMiniFlip(pendingNext, state);
     if (alreadyDisplayed) {
       if (needsEyeTracking(state) && !eyeTarget && !_trackingLayers) {
         if (clawdEl.tagName === "OBJECT") attachEyeTracking(clawdEl);
@@ -1563,10 +1569,12 @@ if (window.electronAPI && typeof window.electronAPI.onCloudlingPointer === "func
 if (window.electronAPI && typeof window.electronAPI.onRoamHeading === "function") {
   window.electronAPI.onRoamHeading((headingLeft) => {
     _roamHeadingLeft = !!headingLeft;
-    // Re-apply to the element already on screen: main sends the heading just
-    // before applyState("roam"), but consecutive walks reuse the displayed
-    // roam visual without a swap, so the flip must update in place too.
+    // Re-apply in place: consecutive walks reuse the displayed roam visual
+    // without a swap, and if this message lands after the state-change (IPC
+    // order across channels is not contractual) the flip captured at IMG
+    // creation is stale — refresh both the on-screen and the pending element.
     applyMiniFlip(clawdEl, currentState);
+    if (pendingNext) applyMiniFlip(pendingNext, currentState);
   });
 }
 

--- a/src/roam.js
+++ b/src/roam.js
@@ -127,6 +127,15 @@ module.exports = function initRoam(ctx) {
     const dist = Math.sqrt(dx * dx + dy * dy);
     const animDurationMs = Math.max(1000, dist / ROAM_SPEED_PX_PER_MS);
 
+    // ── Face the walk direction ──
+    // Dedicated roam visuals (e.g. clawd's crabwalk) are drawn facing right;
+    // tell the renderer to mirror while heading left. Sent before applyState
+    // so the flip is settled when the roam visual swaps in. A purely vertical
+    // walk keeps the previous heading.
+    if (typeof ctx.setRoamHeading === "function" && dx !== 0) {
+      ctx.setRoamHeading(dx < 0);
+    }
+
     // ── Switch to "roam" visual state before moving ──
     // This ensures the pet shows a walk animation (if the theme provides one)
     // or at least the idle SVG via fallback, instead of being "dragged" in

--- a/src/theme-context.js
+++ b/src/theme-context.js
@@ -80,6 +80,13 @@ function createThemeContext(theme, options = {}) {
         right: theme.reactions.drag.fileRight || null,
       } : null,
       idleFollowSvg: theme.states.idle[0],
+      // Free roam: true when the theme binds a dedicated roam visual (distinct
+      // from idle). The visual resolver injects states.roam = [idle[0]] as a
+      // synthetic fallback, so "same file as idle" still means "no dedicated
+      // visual" — the renderer then keeps its roam-walk bob compensation.
+      hasRoamVisual: !!(theme.states && Array.isArray(theme.states.roam)
+        && theme.states.roam.length > 0
+        && theme.states.roam[0] !== theme.states.idle[0]),
       eyeTrackingStates: theme.eyeTracking.enabled ? theme.eyeTracking.states : [],
       trustedScriptedSvgFiles: [...trustedScriptedSvgFiles],
       rendering: theme.rendering || { svgChannel: "auto" },

--- a/src/theme-context.js
+++ b/src/theme-context.js
@@ -80,13 +80,15 @@ function createThemeContext(theme, options = {}) {
         right: theme.reactions.drag.fileRight || null,
       } : null,
       idleFollowSvg: theme.states.idle[0],
-      // Free roam: true when the theme binds a dedicated roam visual (distinct
-      // from idle). The visual resolver injects states.roam = [idle[0]] as a
-      // synthetic fallback, so "same file as idle" still means "no dedicated
-      // visual" — the renderer then keeps its roam-walk bob compensation.
+      // Free roam: true when the theme binds a dedicated roam visual. The
+      // visual resolver injects exactly states.roam = [idle[0]] as a synthetic
+      // fallback, so only that precise shape (single entry, same file as
+      // idle[0]) means "no dedicated visual" — the renderer then keeps its
+      // roam-walk bob compensation. Multi-entry bindings count as dedicated
+      // even if one entry reuses the idle file.
       hasRoamVisual: !!(theme.states && Array.isArray(theme.states.roam)
         && theme.states.roam.length > 0
-        && theme.states.roam[0] !== theme.states.idle[0]),
+        && !(theme.states.roam.length === 1 && theme.states.roam[0] === theme.states.idle[0])),
       eyeTrackingStates: theme.eyeTracking.enabled ? theme.eyeTracking.states : [],
       trustedScriptedSvgFiles: [...trustedScriptedSvgFiles],
       rendering: theme.rendering || { svgChannel: "auto" },

--- a/test/roam.test.js
+++ b/test/roam.test.js
@@ -600,4 +600,47 @@ describe("roam module", () => {
       assert.equal(b.height, 120, "falls back to the size read at walk start");
     }
   });
+
+  it("sends heading=false (face right) when the walk moves rightward", () => {
+    // Default mocked random (0.9) picks a target right of the start (400,300).
+    const headings = [];
+    const ctx = makeCtx({ setRoamHeading(left) { headings.push(left); } });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000);
+
+    assert.deepEqual(headings, [false], "rightward walk must face right (no mirror)");
+  });
+
+  it("sends heading=true (mirror) when the walk moves leftward", () => {
+    // random=0.05 → target (349,193), left of the start (400,300), dist ≈ 118.
+    mock.method(Math, "random", () => 0.05);
+    const headings = [];
+    const ctx = makeCtx({ setRoamHeading(left) { headings.push(left); } });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000);
+
+    assert.deepEqual(headings, [true], "leftward walk must mirror the roam visual");
+  });
+
+  it("keeps the previous heading on a purely vertical walk", () => {
+    // Clamp forces finalX back to the start X → dx === 0 → no heading update.
+    const headings = [];
+    const ctx = makeCtx({
+      setRoamHeading(left) { headings.push(left); },
+      clampToScreenVisual(x, y, w, h) { return { x: 400, y, width: w, height: h }; },
+    });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000);
+
+    assert.deepEqual(headings, [], "vertical walk must not change the heading");
+  });
 });

--- a/test/theme-context.test.js
+++ b/test/theme-context.test.js
@@ -235,3 +235,27 @@ test("renderer config exposes trusted scripted files only for built-in themes", 
     fixture.cleanup();
   }
 });
+
+test("getRendererConfig reports hasRoamVisual only for a dedicated roam binding", () => {
+  const fixture = makeRoot();
+  try {
+    // No roam binding at all — nothing dedicated.
+    const ctxNone = createThemeContext(makeTheme(), fixture);
+    assert.strictEqual(ctxNone.getRendererConfig().hasRoamVisual, false);
+
+    // Synthetic fallback shape (the visual resolver injects roam = [idle[0]])
+    // — still not a dedicated visual, renderer keeps its roam-walk bob.
+    const ctxSynthetic = createThemeContext(makeTheme({
+      states: { idle: ["idle.svg"], roam: ["idle.svg"] },
+    }), fixture);
+    assert.strictEqual(ctxSynthetic.getRendererConfig().hasRoamVisual, false);
+
+    // Dedicated roam visual — renderer drops the bob and enables heading flips.
+    const ctxDedicated = createThemeContext(makeTheme({
+      states: { idle: ["idle.svg"], roam: ["crabwalk.svg"] },
+    }), fixture);
+    assert.strictEqual(ctxDedicated.getRendererConfig().hasRoamVisual, true);
+  } finally {
+    fixture.cleanup();
+  }
+});

--- a/test/theme-context.test.js
+++ b/test/theme-context.test.js
@@ -255,6 +255,19 @@ test("getRendererConfig reports hasRoamVisual only for a dedicated roam binding"
       states: { idle: ["idle.svg"], roam: ["crabwalk.svg"] },
     }), fixture);
     assert.strictEqual(ctxDedicated.getRendererConfig().hasRoamVisual, true);
+
+    // Multi-entry bindings are author intent, not the resolver's synthetic
+    // single-entry fallback — dedicated regardless of entry order or an idle
+    // file appearing among them (the resolver picks randomly from the array).
+    const ctxMultiTail = createThemeContext(makeTheme({
+      states: { idle: ["idle.svg"], roam: ["idle.svg", "walk.svg"] },
+    }), fixture);
+    assert.strictEqual(ctxMultiTail.getRendererConfig().hasRoamVisual, true);
+
+    const ctxMultiHead = createThemeContext(makeTheme({
+      states: { idle: ["idle.svg"], roam: ["walk.svg", "idle.svg"] },
+    }), fixture);
+    assert.strictEqual(ctxMultiHead.getRendererConfig().hasRoamVisual, true);
   } finally {
     fixture.cleanup();
   }

--- a/themes/clawd/theme.json
+++ b/themes/clawd/theme.json
@@ -54,6 +54,9 @@
     "idle": [
       "clawd-idle-follow.svg"
     ],
+    "roam": [
+      "clawd-mini-crabwalk.svg"
+    ],
     "yawning": [
       "clawd-idle-yawn.svg"
     ],


### PR DESCRIPTION
## Summary

Free roam used to show the idle SVG with a synthetic CSS bob (`roam-walk-bob`) while the window moved — it read as "idle pet being dragged around". This binds clawd's existing mini-crabwalk asset as a dedicated roam visual, so the pet actually walks: sneaking legs, hunched shuffle, eyes on the destination.

- **5cf2b33 — crabwalk as the roam visual.**
  - `themes/clawd`: `states.roam` → `clawd-mini-crabwalk.svg` (asset reuse, no new art).
  - `theme-context`: new `hasRoamVisual` renderer-config flag — true only for a real author binding, not the visual resolver's synthetic `roam = [idle[0]]` fallback.
  - renderer: skips the `roam-walk` bob when the theme has a dedicated roam visual (the bob is documented as compensation for themes without one), and mirrors the visual through the existing mini-flip outlet while the walk heads left — the asset is drawn facing right.
  - roam → renderer: new `roam-heading` IPC channel carries the walk's horizontal direction, sent just before `applyState("roam")`; purely vertical walks keep the previous heading.
  - Other themes (calico, cloudling, imported Codex Pets) have no roam binding and keep the idle+bob fallback unchanged.

- **12e4a84 — codex review follow-ups.**
  - `renderStateFile`'s same-file dedup early-return now re-applies the flip for the incoming state on both the displayed and pending element — previously a leftward roam entering mini pre-entry (same crabwalk file, no swap) leaked the roam mirror into the mini entry.
  - The `roam-heading` handler also refreshes `pendingNext`, so a heading landing after the state-change (cross-channel IPC order is not contractual) can't leave a pending IMG facing the old direction.
  - `hasRoamVisual` excludes exactly the resolver's synthetic shape (single entry equal to `idle[0]`); multi-entry author bindings count as dedicated regardless of entry order.

Known limitation (accepted): themes forcing the `object` SVG channel render roam visuals without the heading mirror — the flip outlet is IMG-only. Default imported Codex Pets have no roam binding, so this only affects a user manually overriding the "Free roam walk" slot on such a theme.

## Test plan

- [x] `node --test test/*.test.js` — full suite, 0 fail
- [x] New unit coverage: heading right / left / purely-vertical; `hasRoamVisual` synthetic vs dedicated vs multi-entry shapes
- [x] External codex review: 2 should-fix + 1 nit found, all fixed in 12e4a84; no blockers
- [x] Real-machine: crabwalk plays during walks, mirrors when heading left, size stays stable (on top of the #579 fix), mini crabwalk entry unaffected — including the leftward-roam → mini-entry flip-leak scenario
