### PR TITLE
fix(antigravity): stop first-token stall when the hook runner never closes stdin (#568)

### DIFF
--- a/hooks/antigravity-install.js
+++ b/hooks/antigravity-install.js
@@ -34,7 +34,11 @@ const ANTIGRAVITY_HOOK_EVENTS = [
   "Stop",
 ];
 const DEFAULT_HOOK_TIMEOUT_SECONDS = 10;
-const FAIL_OPEN_CHILD_TIMEOUT_SECONDS = 8;
+// #568 budget: stdin timeout + child timeout must stay below
+// DEFAULT_HOOK_TIMEOUT_SECONDS with headroom for shell startup, or the outer
+// hooks.json timeout kills the wrapper before the fallback line is printed.
+const FAIL_OPEN_CHILD_TIMEOUT_SECONDS = 7;
+const FAIL_OPEN_STDIN_TIMEOUT_SECONDS = 2;
 
 function fallbackStdoutForEvent(event) {
   return stdoutForAntigravityEvent(event);
@@ -52,6 +56,12 @@ function normalizeFailOpenTimeoutSeconds(options = {}) {
   const raw = Number(options.failOpenTimeoutSeconds);
   if (Number.isFinite(raw) && raw > 0) return Math.max(1, Math.floor(raw));
   return FAIL_OPEN_CHILD_TIMEOUT_SECONDS;
+}
+
+function normalizeStdinTimeoutSeconds(options = {}) {
+  const raw = Number(options.stdinTimeoutSeconds);
+  if (Number.isFinite(raw) && raw > 0) return Math.max(1, Math.floor(raw));
+  return FAIL_OPEN_STDIN_TIMEOUT_SECONDS;
 }
 
 function quoteWindowsProcessArg(value) {
@@ -82,6 +92,7 @@ function quoteWindowsProcessArg(value) {
 function withFailOpenShellFallback(command, event, nodeBin, options = {}) {
   const fallback = quoteShellSingleArg(fallbackStdoutForEvent(event));
   const timeoutSeconds = normalizeFailOpenTimeoutSeconds(options);
+  const stdinTimeoutSeconds = normalizeStdinTimeoutSeconds(options);
   const validatorScript = [
     "let s='';",
     "process.stdin.setEncoding('utf8');",
@@ -105,9 +116,22 @@ function withFailOpenShellFallback(command, event, nodeBin, options = {}) {
     // Do not trap TERM: macOS bash 3.2 may print run_pending_traps warnings when the watchdog is killed.
     "cleanup(){ trap - EXIT HUP INT TERM; [ -n \"$watchdog\" ] && kill \"$watchdog\" 2>/dev/null; [ -n \"$pid\" ] && kill \"$pid\" 2>/dev/null; rm -f \"$in_file\" \"$out_file\"; }",
     "trap cleanup EXIT HUP INT",
-    "cat > \"$in_file\" 2>/dev/null || :",
+    // #568: IDE/App hook runners may never close our stdin, so the stdin read
+    // needs its own watchdog. Background lists get /dev/null as stdin in
+    // non-interactive shells; the 3<&0 group redirection hands the real stdin
+    // to the background cat (and fails soft if fd 0 is somehow absent).
+    "{ cat <&3 > \"$in_file\" 2>/dev/null & pid=$!; } 3<&0",
+    // Watchdog subshells redirect stdout/stderr: a killed watchdog orphans its
+    // sleep, and an orphan holding our stdout would stall a hook runner that
+    // waits for pipe EOF instead of process exit.
+    `( sleep ${stdinTimeoutSeconds}; kill "$pid" 2>/dev/null ) > /dev/null 2>&1 & watchdog=$!`,
+    "wait \"$pid\" 2>/dev/null",
+    "[ -n \"$watchdog\" ] && kill \"$watchdog\" 2>/dev/null",
+    "[ -n \"$watchdog\" ] && wait \"$watchdog\" 2>/dev/null",
+    "pid=",
+    "watchdog=",
     `${command} < "$in_file" > "$out_file" 2>/dev/null & pid=$!`,
-    `( sleep ${timeoutSeconds}; kill "$pid" 2>/dev/null ) & watchdog=$!`,
+    `( sleep ${timeoutSeconds}; kill "$pid" 2>/dev/null ) > /dev/null 2>&1 & watchdog=$!`,
     "wait \"$pid\" 2>/dev/null",
     "status=$?",
     "[ -n \"$watchdog\" ] && kill \"$watchdog\" 2>/dev/null",
@@ -123,6 +147,7 @@ function withFailOpenShellFallback(command, event, nodeBin, options = {}) {
 function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, options = {}) {
   const fallback = fallbackStdoutForEvent(event);
   const timeoutMs = normalizeFailOpenTimeoutSeconds(options) * 1000;
+  const stdinTimeoutMs = normalizeStdinTimeoutSeconds(options) * 1000;
   const childArgs = [
     quoteWindowsProcessArg(hookScript),
     quoteWindowsProcessArg(event),
@@ -163,7 +188,14 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     ";",
     "$stderrTask = $proc.StandardError.ReadToEndAsync()",
     ";",
-    "$stdinText = [Console]::In.ReadToEnd()",
+    // #568: the IDE/App hook runner may never close our stdin; a bare
+    // ReadToEnd() would block until the outer hooks.json timeout kills us.
+    // [Console]::In is a SyncTextReader whose ReadToEndAsync() runs
+    // synchronously, so read the raw stdin stream instead — its async read
+    // lets Wait() time out (dropping the payload; the hook fails open on {}).
+    "$stdinText = ''",
+    ";",
+    `try { $stdinReader = New-Object System.IO.StreamReader([Console]::OpenStandardInput()) ; $stdinTask = $stdinReader.ReadToEndAsync() ; if ($stdinTask.Wait(${stdinTimeoutMs})) { $stdinText = $stdinTask.Result } } catch {}`,
     ";",
     "$proc.StandardInput.Write($stdinText)",
     ";",
@@ -405,6 +437,7 @@ module.exports = {
     extractNodeBinFromCommand,
     fallbackStdoutForEvent,
     normalizeFailOpenTimeoutSeconds,
+    normalizeStdinTimeoutSeconds,
     quoteWindowsProcessArg,
     groupHasClawdMarker,
     hasAntigravityConfig,

--- a/hooks/antigravity-install.js
+++ b/hooks/antigravity-install.js
@@ -35,9 +35,12 @@ const ANTIGRAVITY_HOOK_EVENTS = [
 ];
 const DEFAULT_HOOK_TIMEOUT_SECONDS = 10;
 // #568 budget: stdin timeout + child timeout must stay below
-// DEFAULT_HOOK_TIMEOUT_SECONDS with headroom for shell startup, or the outer
-// hooks.json timeout kills the wrapper before the fallback line is printed.
-const FAIL_OPEN_CHILD_TIMEOUT_SECONDS = 7;
+// DEFAULT_HOOK_TIMEOUT_SECONDS with real headroom, or the outer hooks.json
+// timeout kills the wrapper before the fallback line is printed. Measured
+// worst case (never-closed stdin + hung child) at 2+7 was 9.5-9.7s on a warm
+// machine — a PowerShell cold start under AV scanning would blow past 10s —
+// so the child watchdog stays at 6s to keep ~2s of startup headroom.
+const FAIL_OPEN_CHILD_TIMEOUT_SECONDS = 6;
 const FAIL_OPEN_STDIN_TIMEOUT_SECONDS = 2;
 
 function fallbackStdoutForEvent(event) {

--- a/test/antigravity-install.test.js
+++ b/test/antigravity-install.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { spawnSync } = require("child_process");
+const { spawn, spawnSync } = require("child_process");
 const {
   HOOK_GROUP_ID,
   MARKER,
@@ -50,6 +50,38 @@ function runWindowsHookCommand(command, options = {}) {
     encoding: "utf8",
     timeout: options.timeout,
   });
+}
+
+// #568 repro helper: run a wrapper command while stdin stays open — written
+// to or not, but never closed — the way the Antigravity IDE hook runner
+// behaves. Resolves on exit with elapsed time; kills the child as a backstop.
+function runWithOpenStdin(bin, args, { write, killAfterMs = 15000 } = {}) {
+  return new Promise((resolve) => {
+    const started = Date.now();
+    const child = spawn(bin, args, { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let timedOut = false;
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stdin.on("error", () => {});
+    const killer = setTimeout(() => { timedOut = true; child.kill(); }, killAfterMs);
+    child.on("exit", (code) => {
+      clearTimeout(killer);
+      resolve({ code, stdout, timedOut, elapsedMs: Date.now() - started });
+    });
+    if (write) child.stdin.write(write);
+  });
+}
+
+function writeEchoHook(dirPrefix) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), dirPrefix));
+  tempDirs.push(tmpDir);
+  const scriptPath = path.join(tmpDir, "antigravity-hook.js");
+  fs.writeFileSync(
+    scriptPath,
+    'let s="";process.stdin.on("data",(c)=>s+=c);process.stdin.on("end",()=>process.stdout.write(JSON.stringify({got:s})+"\\n"));',
+    "utf8"
+  );
+  return scriptPath;
 }
 
 afterEach(() => {
@@ -366,6 +398,72 @@ describe("Antigravity hook installer", () => {
     assert.ok(Date.now() - started < 4000, "wrapper should not wait for the child timer");
   });
 
+  it("guards the POSIX stdin read with its own watchdog (#568)", () => {
+    const command = __test.buildAntigravityHookCommand(
+      "/usr/local/bin/node",
+      "/x/antigravity-hook.js",
+      "PreInvocation",
+      { platform: "linux" }
+    );
+
+    // Background lists get /dev/null as stdin in non-interactive shells, so
+    // the real stdin must be handed to the background cat through fd 3.
+    assert.ok(command.includes("{ cat <&3 > \"$in_file\" 2>/dev/null & pid=$!; } 3<&0"));
+    assert.ok(command.includes("( sleep 2; kill \"$pid\" 2>/dev/null ) > /dev/null 2>&1"));
+    assert.ok(!command.includes("cat > \"$in_file\""), "stdin must not be read in the foreground");
+  });
+
+  it("keeps the stdin + child watchdog budget under the outer hook timeout (#568)", () => {
+    const outerTimeoutSeconds = __test.buildAntigravityHooks(() => "x")[HOOK_GROUP_ID].PreInvocation[0].timeout;
+    const stdinSeconds = __test.normalizeStdinTimeoutSeconds();
+    const childSeconds = __test.normalizeFailOpenTimeoutSeconds();
+
+    assert.ok(
+      stdinSeconds + childSeconds <= outerTimeoutSeconds - 1,
+      `stdin (${stdinSeconds}s) + child (${childSeconds}s) watchdogs need >=1s headroom under the ${outerTimeoutSeconds}s hook timeout for the fallback line to get out`
+    );
+  });
+
+  it("does not stall when the hook runner never closes stdin (#568)", posixOnly, async () => {
+    const scriptPath = writeEchoHook("clawd-antigravity-openstdin-");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "linux", stdinTimeoutSeconds: 1 }
+    );
+
+    // No write and no close, like the Antigravity IDE hook runner. (spawnSync
+    // without `input` closes stdin immediately, so it cannot model this.)
+    const result = await runWithOpenStdin("/bin/sh", ["-c", command]);
+
+    assert.strictEqual(result.timedOut, false, "wrapper must exit on its own");
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { got: "" });
+    assert.ok(result.elapsedMs >= 900, "wrapper must actually sit out the stdin watchdog");
+    assert.ok(result.elapsedMs < 6000, "stdin watchdog must cut the blocked read");
+  });
+
+  it("delivers a payload that arrives without a stdin close (#568)", posixOnly, async () => {
+    const scriptPath = writeEchoHook("clawd-antigravity-nocdata-");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "linux", stdinTimeoutSeconds: 1 }
+    );
+
+    const result = await runWithOpenStdin("/bin/sh", ["-c", command], {
+      write: JSON.stringify({ conversationId: "c1" }),
+    });
+
+    assert.strictEqual(result.timedOut, false, "wrapper must exit on its own");
+    assert.strictEqual(result.code, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout), { got: JSON.stringify({ conversationId: "c1" }) });
+    assert.ok(result.elapsedMs >= 900, "wrapper must actually sit out the stdin watchdog");
+    assert.ok(result.elapsedMs < 6000, "stdin watchdog must cut the blocked read");
+  });
+
   it("fail-opens Windows hook commands when Node cannot start", windowsOnly, () => {
     const command = __test.buildAntigravityHookCommand(
       "C:/definitely/missing/node.exe",
@@ -439,6 +537,28 @@ describe("Antigravity hook installer", () => {
     assert.ok(Date.now() - started < 4000, "wrapper should not wait for the child timer");
   });
 
+  it("does not stall on Windows when the hook runner never closes stdin (#568)", windowsOnly, async () => {
+    const scriptPath = writeEchoHook("clawd-antigravity-winopenstdin-");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "win32", stdinTimeoutSeconds: 1 }
+    );
+    const idx = command.indexOf(" -NoProfile");
+    assert.notStrictEqual(idx, -1, "expected PowerShell command");
+
+    const result = await runWithOpenStdin(command.slice(0, idx), command.slice(idx + 1).split(/\s+/));
+
+    assert.strictEqual(result.timedOut, false, "wrapper must exit on its own");
+    assert.strictEqual(result.code, 0);
+    // The async stdin read times out without EOF, so the hook sees "" and
+    // fails open on an empty payload.
+    assert.deepStrictEqual(JSON.parse(result.stdout), { got: "" });
+    assert.ok(result.elapsedMs >= 900, "wrapper must actually sit out the stdin timeout");
+    assert.ok(result.elapsedMs < 10000, "stdin timeout must cut the blocked read");
+  });
+
   it("builds Windows PowerShell bridge commands with fail-open fallback", () => {
     const command = __test.buildAntigravityHookCommand(
       "C:\\Program Files\\nodejs\\node.exe",
@@ -453,7 +573,12 @@ describe("Antigravity hook installer", () => {
     assert.ok(decoded.includes("$psi = New-Object System.Diagnostics.ProcessStartInfo"));
     assert.ok(decoded.includes("$psi.FileName = 'C:\\Program Files\\nodejs\\node.exe'"));
     assert.ok(decoded.includes("$psi.Arguments = 'D:/clawd/hooks/antigravity-hook.js PreToolUse'"));
-    assert.ok(decoded.includes("if ($proc.WaitForExit(8000))"));
+    assert.ok(decoded.includes("if ($proc.WaitForExit(7000))"));
+    // #568: [Console]::In.ReadToEnd() blocks forever when the runner never
+    // closes stdin; the raw-stream reader honors the Wait() timeout.
+    assert.ok(decoded.includes("New-Object System.IO.StreamReader([Console]::OpenStandardInput())"));
+    assert.ok(decoded.includes("$stdinTask.Wait(2000)"));
+    assert.ok(!decoded.includes("[Console]::In.ReadToEnd()"));
     assert.ok(decoded.includes("ConvertFrom-Json -ErrorAction Stop"));
     assert.ok(decoded.includes("[Console]::Out.WriteLine( '{\"decision\":\"ask\"}' )"));
     assert.ok(decoded.endsWith("exit 0"));

--- a/test/antigravity-install.test.js
+++ b/test/antigravity-install.test.js
@@ -54,20 +54,45 @@ function runWindowsHookCommand(command, options = {}) {
 
 // #568 repro helper: run a wrapper command while stdin stays open — written
 // to or not, but never closed — the way the Antigravity IDE hook runner
-// behaves. Resolves on exit with elapsed time; kills the child as a backstop.
+// behaves. Resolves once the child has exited AND its stdout pipe has closed:
+// exit alone is not enough, because a leaked watchdog orphan holding the
+// wrapper's stdout keeps the pipe open past exit and stalls any hook runner
+// that waits for EOF instead of process exit. Kills the child as a backstop.
 function runWithOpenStdin(bin, args, { write, killAfterMs = 15000 } = {}) {
   return new Promise((resolve) => {
     const started = Date.now();
     const child = spawn(bin, args, { stdio: ["pipe", "pipe", "pipe"] });
     let stdout = "";
     let timedOut = false;
+    let exited = false;
+    let exitCode = null;
+    let elapsedMs = null;
+    let stdoutClosed = false;
+    let stdoutCloseElapsedMs = null;
+    const settle = () => {
+      if (!exited || !stdoutClosed) return;
+      clearTimeout(killer);
+      resolve({ code: exitCode, stdout, timedOut, elapsedMs, stdoutCloseElapsedMs });
+    };
     child.stdout.on("data", (chunk) => { stdout += chunk; });
     child.stdin.on("error", () => {});
-    const killer = setTimeout(() => { timedOut = true; child.kill(); }, killAfterMs);
-    child.on("exit", (code) => {
-      clearTimeout(killer);
-      resolve({ code, stdout, timedOut, elapsedMs: Date.now() - started });
+    // 'close' fires only after every writer of the pipe is gone, orphans included.
+    child.stdout.on("close", () => {
+      stdoutClosed = true;
+      stdoutCloseElapsedMs = Date.now() - started;
+      settle();
     });
+    child.on("exit", (code) => {
+      exited = true;
+      exitCode = code;
+      elapsedMs = Date.now() - started;
+      settle();
+    });
+    const killer = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+      child.stdout.destroy();
+    }, killAfterMs);
     if (write) child.stdin.write(write);
   });
 }
@@ -410,6 +435,10 @@ describe("Antigravity hook installer", () => {
     // the real stdin must be handed to the background cat through fd 3.
     assert.ok(command.includes("{ cat <&3 > \"$in_file\" 2>/dev/null & pid=$!; } 3<&0"));
     assert.ok(command.includes("( sleep 2; kill \"$pid\" 2>/dev/null ) > /dev/null 2>&1"));
+    assert.ok(command.includes("( sleep 6; kill \"$pid\" 2>/dev/null ) > /dev/null 2>&1"));
+    // A watchdog subshell without the redirect leaks an orphaned sleep that
+    // holds our stdout open past exit and stalls EOF-waiting hook runners.
+    assert.ok(!command.includes(") & watchdog="), "every watchdog subshell must detach from our stdout/stderr");
     assert.ok(!command.includes("cat > \"$in_file\""), "stdin must not be read in the foreground");
   });
 
@@ -418,9 +447,11 @@ describe("Antigravity hook installer", () => {
     const stdinSeconds = __test.normalizeStdinTimeoutSeconds();
     const childSeconds = __test.normalizeFailOpenTimeoutSeconds();
 
+    // Measured: 2s+7s peaked at 9.5-9.7s with a hung child on a warm machine,
+    // so one second of headroom is not enough for a PowerShell cold start.
     assert.ok(
-      stdinSeconds + childSeconds <= outerTimeoutSeconds - 1,
-      `stdin (${stdinSeconds}s) + child (${childSeconds}s) watchdogs need >=1s headroom under the ${outerTimeoutSeconds}s hook timeout for the fallback line to get out`
+      stdinSeconds + childSeconds <= outerTimeoutSeconds - 2,
+      `stdin (${stdinSeconds}s) + child (${childSeconds}s) watchdogs need >=2s headroom under the ${outerTimeoutSeconds}s hook timeout for shell cold starts and the fallback line`
     );
   });
 
@@ -442,6 +473,7 @@ describe("Antigravity hook installer", () => {
     assert.deepStrictEqual(JSON.parse(result.stdout), { got: "" });
     assert.ok(result.elapsedMs >= 900, "wrapper must actually sit out the stdin watchdog");
     assert.ok(result.elapsedMs < 6000, "stdin watchdog must cut the blocked read");
+    assert.ok(result.stdoutCloseElapsedMs < 6000, "no watchdog orphan may hold our stdout past exit");
   });
 
   it("delivers a payload that arrives without a stdin close (#568)", posixOnly, async () => {
@@ -462,6 +494,7 @@ describe("Antigravity hook installer", () => {
     assert.deepStrictEqual(JSON.parse(result.stdout), { got: JSON.stringify({ conversationId: "c1" }) });
     assert.ok(result.elapsedMs >= 900, "wrapper must actually sit out the stdin watchdog");
     assert.ok(result.elapsedMs < 6000, "stdin watchdog must cut the blocked read");
+    assert.ok(result.stdoutCloseElapsedMs < 6000, "no watchdog orphan may hold our stdout past exit");
   });
 
   it("fail-opens Windows hook commands when Node cannot start", windowsOnly, () => {
@@ -557,6 +590,7 @@ describe("Antigravity hook installer", () => {
     assert.deepStrictEqual(JSON.parse(result.stdout), { got: "" });
     assert.ok(result.elapsedMs >= 900, "wrapper must actually sit out the stdin timeout");
     assert.ok(result.elapsedMs < 10000, "stdin timeout must cut the blocked read");
+    assert.ok(result.stdoutCloseElapsedMs < 10000, "stdout must reach EOF promptly after exit");
   });
 
   it("builds Windows PowerShell bridge commands with fail-open fallback", () => {
@@ -573,7 +607,7 @@ describe("Antigravity hook installer", () => {
     assert.ok(decoded.includes("$psi = New-Object System.Diagnostics.ProcessStartInfo"));
     assert.ok(decoded.includes("$psi.FileName = 'C:\\Program Files\\nodejs\\node.exe'"));
     assert.ok(decoded.includes("$psi.Arguments = 'D:/clawd/hooks/antigravity-hook.js PreToolUse'"));
-    assert.ok(decoded.includes("if ($proc.WaitForExit(7000))"));
+    assert.ok(decoded.includes("if ($proc.WaitForExit(6000))"));
     // #568: [Console]::In.ReadToEnd() blocks forever when the runner never
     // closes stdin; the raw-stream reader honors the Wait() timeout.
     assert.ok(decoded.includes("New-Object System.IO.StreamReader([Console]::OpenStandardInput())"));


### PR DESCRIPTION
Fixes #568

## Root cause

The Antigravity IDE/App (macOS local chat) hook runner keeps the hook's stdin open, unlike the CLI which closes it promptly. The fail-open wrapper read stdin in the foreground (`cat > "$in_file"`), **outside** the watchdog that only guarded the node child, so the wrapper blocked until the 10s `hooks.json` timeout killed it — delaying the first token by 10s+ and dropping the fallback stdout on the floor. This matches the ~11s gap between `PreInvocation` and `streamGenerateContent` in the reporter's logs.

The Windows command had the same latent bug in `[Console]::In.ReadToEnd()` (unbounded synchronous read); nobody had hit it yet.

## The fix

**POSIX** — the stdin read now runs as a background `cat` under its own 2s watchdog. Two non-obvious details, both verified in a real shell:

- Background lists get `/dev/null` as stdin in non-interactive shells (a bare `cat > f &` reads 0 bytes), so a `3<&0` group redirection hands the real stdin to the background cat. Chosen over `exec 3<&0`: if fd 0 is somehow absent, the group redirection fails soft (pid stays empty, the empty `in_file` walks the existing fail-open path) while a failed `exec` would abort a POSIX shell entirely.
- When the watchdog cuts the read, whatever bytes already arrived stay in `in_file`; the node hook already fails open on partial/empty JSON. In the common IDE case (payload written, fd just never closed) the full payload survives and state reporting keeps working.

**Windows** — `[Console]::In` is a `SyncTextReader` whose `ReadToEndAsync()` executes synchronously (the naive `ReadToEndAsync().Wait(ms)` fix still blocked in testing). The fix reads the raw stdin stream via `StreamReader([Console]::OpenStandardInput())`, whose async read honors `Wait(2000)`. On timeout the payload is dropped (no partial reads without EOF) and the hook fails open on an empty payload.

**Timeout budget** — the child watchdog shrinks 8s → 6s so stdin (2s) + child (6s) stays under the outer 10s hook timeout with ~2s of headroom for shell/PowerShell startup; without headroom the outer timeout could kill the wrapper before the fallback line is printed. Measured worst path (never-closed stdin + hung child): 9.5-9.7s at 2+7 — too close to 10s for a PowerShell cold start under AV scanning — vs ~8.3s at 2+6 on both platforms. A test guards the budget at ≥2s headroom.

**Watchdog hardening** — both watchdog subshells now redirect stdout/stderr to `/dev/null`. A killed watchdog orphans its `sleep`, and an orphan holding the wrapper's stdout would stall any hook runner that waits for pipe EOF rather than process exit — which would have re-introduced a 2s stall via the new stdin watchdog.

## Verification

Repro harness: spawn the generated wrapper with a stdin pipe that is written to (or not) but never closed, the way the IDE runner behaves.

| Scenario | Before | After |
|---|---|---|
| POSIX, stdin never closed | blocked until pipe EOF / outer timeout (14.2s in harness) | **2.37s**, payload delivered intact |
| POSIX, stdin closed promptly (CLI) | ~0.3s | 0.41s — no regression |
| Windows, stdin never closed | blocked (killed at 12s backstop) | **2.37s**, fails open on empty payload |
| Windows, stdin closed promptly | 372ms | 365ms — no regression |

- Full suite: `node --test test/*.test.js` — 4369 tests, 0 failures.
- New tests: never-close and write-without-close repros on both platforms (async spawn with an open stdin pipe — `spawnSync` without `input` closes stdin immediately and cannot model the IDE runner), structural asserts on the generated commands, elapsed lower bounds so the repros cannot silently degrade into close-path tests, and a budget guard.
- Upgrade path: an existing pre-fix install is auto-rewritten on the next startup sync (`updated: 4`) on both platforms; users only need the new version to start once.

## Known tradeoffs

- When the runner never closes stdin, each blocking hook event still pays up to the 2s stdin watchdog (down from 10s+). The 2s floor is the fail-safe read window, not eliminable without a protocol change.
- Windows only: a payload that arrives without EOF is dropped at the timeout (the async read cannot surface partial data), so the hook falls back to an empty payload. POSIX keeps the arrived bytes.
- `StreamReader` decodes stdin as UTF-8 instead of the console code page — for JSON piped between processes this is a correctness improvement for non-ASCII payloads.

## Status

- [x] Windows behavior verified on a real machine (this table)
- [x] Codex review round done — both findings addressed in 5ed5eac (budget headroom 7s→6s; tests now bound stdout-EOF time, not just exit, and pin both watchdog redirects)
- [x] macOS regression verified on a real machine (2026-07-07): POSIX-only tests green (real runs), CLI path unaffected, live-IDE hook overhead 0–1s on Antigravity 2.2.1, pet state updates flowing, upgrade path exercised — details in the verification comment below

All verification gates are green. Note from the macOS pass: Antigravity 2.2.1's runner closes stdin promptly, so the live stall only reproduces on older builds (or via the never-close harness).

