### PR TITLE
fix(codex): don't replay attention from a metadata-only token_count write

### DIFF
--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -38,7 +38,11 @@ const ACTIVE_SESSION_WINDOW_MS = 5 * 60 * 1000;
 // replay it silently (backfill) instead of emitting stale transitions. A
 // file written within the grace window is a live session and emits normally.
 const BACKFILL_GRACE_MS = 5 * 1000;
-const BACKFILL_SNAPSHOT_STATES = new Set(["thinking", "working"]);
+// States that are ongoing rather than one-shot. Safe to re-synthesize from a
+// backfill snapshot, and safe for a metadata-only token_count write to carry
+// forward. A one-shot (attention, sweeping, …) must never be carried by
+// either: re-emitting it replays a finished turn's celebration.
+const SUSTAINED_ACTIVE_STATES = new Set(["thinking", "working"]);
 
 function finiteNonnegativeNumber(value) {
   const n = Number(value);
@@ -438,7 +442,23 @@ class CodexLogMonitor {
       if (contextUsage) {
         tracked.contextUsage = contextUsage;
         if (!tracked.backfilling) {
-          this._emitStateChange(tracked, tracked.lastState || "idle", key);
+          // token_count is a metadata refresh, not a turn boundary: Codex
+          // Desktop rewrites it on focus long after a session went idle.
+          // Carrying lastState verbatim therefore re-announces whatever the
+          // session last did, and for a finished turn that is the one-shot
+          // `attention` — the pet celebrates a turn the user already saw
+          // complete, with no new work behind it (#535).
+          //
+          // preserveState does NOT cover this. It only pins the *stored*
+          // state (src/state.js: `preservedState = preserveState && existing
+          // ? existing.state : null`); the one-shot branch keys off the state
+          // passed in and plays it regardless, bypassing resolveDisplayState.
+          // So a stored-idle session still animates. The carry has to be
+          // filtered here.
+          const carry = SUSTAINED_ACTIVE_STATES.has(tracked.lastState)
+            ? tracked.lastState
+            : "idle";
+          this._emitStateChange(tracked, carry, key);
         }
       }
       return;
@@ -635,7 +655,7 @@ class CodexLogMonitor {
 
   _emitBackfillSnapshot(tracked) {
     const snapshotState = tracked.lastState;
-    if (!BACKFILL_SNAPSHOT_STATES.has(snapshotState)) {
+    if (!SUSTAINED_ACTIVE_STATES.has(snapshotState)) {
       if (tracked.contextUsage) {
         this._emitStateChange(tracked, "idle", "event_msg:token_count");
       }

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -487,6 +487,50 @@ describe("CodexLogMonitor", () => {
     });
   });
 
+  it("does not replay attention from a metadata-only token_count write (#535)", () => {
+    // token_count is a metadata refresh, not a turn boundary — Codex Desktop
+    // rewrites it on focus, long after a session went idle. Carrying lastState
+    // verbatim re-announces the finished turn's one-shot `attention`, and the
+    // pet celebrates work the user already watched complete.
+    //
+    // The consumer's preserveState does not save us: it pins the stored state
+    // only, while state.js's one-shot branch plays whatever state it is handed
+    // (`attention` is in ONESHOT_STATE_NAMES). So a stored-idle session still
+    // animates unless the carry is filtered here.
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+      '{"type":"event_msg","payload":{"type":"task_started"}}',
+      '{"type":"response_item","payload":{"type":"function_call","name":"shell_command","arguments":"{}"}}',
+      '{"type":"event_msg","payload":{"type":"task_complete"}}',
+    ].join("\n") + "\n");
+
+    const config = makeConfig(tmpDir);
+    const events = [];
+    monitor = new CodexLogMonitor(config, (sid, state, event) => {
+      events.push({ state, event });
+    });
+
+    monitor._pollFile(testFile, path.basename(testFile));
+    assert.strictEqual(events[events.length - 1].state, "attention",
+      "the real turn end must still celebrate once");
+
+    // Desktop refreshes token_count against the now-idle session.
+    fs.appendFileSync(testFile, JSON.stringify({
+      type: "event_msg",
+      payload: {
+        type: "token_count",
+        info: { last_token_usage: { total_tokens: 2000 }, model_context_window: 200000 },
+      },
+    }) + "\n");
+    monitor._pollFile(testFile, path.basename(testFile));
+
+    const last = events[events.length - 1];
+    assert.strictEqual(last.event, "event_msg:token_count");
+    assert.strictEqual(last.state, "idle",
+      `token_count must not re-emit the one-shot attention, got: ${last.state}`);
+  });
+
   it("does not treat cumulative Codex total_token_usage as context-window usage", () => {
     const testFile = path.join(dateDir, TEST_FILENAME);
     fs.writeFileSync(testFile, [

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1736,6 +1736,48 @@ describe("updateSession()", () => {
     });
   });
 
+  it("preserveState does not stop a one-shot visual from playing (cross-file contract)", () => {
+    // Characterization, not endorsement. preserveState pins the STORED state;
+    // the one-shot branch plays whatever `state` it is handed and bypasses
+    // resolveDisplayState() entirely. So a metadata-only update that carries a
+    // one-shot still animates the pet, even though the session stays idle.
+    //
+    // agents/codex-log-monitor.js depends on this: it filters `token_count`'s
+    // carried state down to sustained ones precisely because preserveState
+    // would not save it. If this test ever fails because preserveState grew to
+    // cover one-shots, that filter becomes redundant (harmless) — update it
+    // there rather than deleting it blind.
+    const stateChanges = [];
+    api.cleanup();
+    ctx = makeCtx({
+      processKill: () => true,
+      sendToRenderer: (channel, state) => {
+        if (channel === "state-change") stateChanges.push(state);
+      },
+    });
+    api = require("../src/state")(ctx);
+
+    // Turn is long over; pet is back to idle. This is what Codex Desktop's
+    // focus-triggered token_count refresh actually lands on.
+    api.updateSession("codex:s1", "idle", "event_msg:task_complete", {
+      agentId: "codex",
+      cwd: "/tmp",
+    });
+    stateChanges.length = 0;
+
+    api.updateSession("codex:s1", "attention", "event_msg:token_count", {
+      agentId: "codex",
+      cwd: "/tmp",
+      preserveState: true,
+      contextUsage: { used: 2000, limit: 200000, percent: 1, source: "codex" },
+    });
+
+    assert.strictEqual(api.sessions.get("codex:s1").state, "idle",
+      "preserveState must pin the stored state");
+    assert.deepStrictEqual(stateChanges, ["attention"],
+      "and yet the one-shot visual still plays — this is why the monitor filters the carry");
+  });
+
   it("updates contextUsage without changing state when preserveState is true", () => {
     update(api, {
       id: "codex:abc",


### PR DESCRIPTION
Refs #535.

Codex Desktop rewrites `token_count` on focus, long after a session has gone idle. The monitor carried `tracked.lastState` forward verbatim on that write:

```js
this._emitStateChange(tracked, tracked.lastState || "idle", key);
```

For a session whose last state was the one-shot `attention`, that re-announces the finished turn. **The pet celebrates work the user already watched complete, with nothing new behind it** — a metadata refresh, animated as a turn ending.

## Why `preserveState` doesn't already cover this

The main-process consumer treats `token_count` as metadata-only, so this looked like defense in depth. It isn't. `preserveState` pins the **stored** state only:

```js
// src/state.js
const preservedState = preserveState && existing ? existing.state : null;
```

while the one-shot branch plays whatever state it was handed, bypassing `resolveDisplayState()` entirely:

```js
// src/state.js
if (ONESHOT_STATES.has(state)) { … }
```

`attention` is in `ONESHOT_STATE_NAMES`. So a session stored as idle still animates. The carry has to be filtered at the source.

## Fix

`token_count` carries only sustained states (`thinking` / `working`) forward; a one-shot re-emits as `idle`. `BACKFILL_SNAPSHOT_STATES` → `SUSTAINED_ACTIVE_STATES`, since the same set now answers both "may the backfill snapshot synthesize this?" and "may a metadata write carry this?" — one question, one set.

## Verification

Two tests. `test/codex-log-monitor.test.js` locks the fix — confirmed to fail on `main`, where the second `_pollFile` re-emits `attention`.

`test/state.test.js` pins the premise underneath it, since that premise lives in another file and the monitor depends on it silently. Driving `state.js` directly with an idle session and a metadata-only `token_count` carrying `attention`:

```
carried state = attention  →  renderer told to play ["attention"]   ← the bug
carried state = idle       →  renderer told nothing                 ← the fix
```

`preserveState: true` is passed in both. It pins the stored state and does nothing for the visual, which is the whole reason the carry has to be filtered upstream. The test is characterization, not endorsement: if `preserveState` ever grows to cover one-shots it will fail, and whoever does that learns the monitor's filter became redundant instead of finding out by deleting it. Verified to discriminate — hand the same call `idle` and the assertion fails.

Full suite on the rebased branch: **4966 pass / 0 fail** (4984 total, 18 skipped).

## Scope — this PR used to be about #566

Earlier revisions tried to fix #566 (a finished Codex session replaying as live `thinking → working → attention`) by re-anchoring both replay guards on per-file attach time instead of monitor start, plus a filename-staleness signal. **That work is withdrawn.** Review found two regressions that no amount of tuning removes:

- **A short turn discovered late is swallowed whole.** A turn finishing >5s before the monitor first sees the file reads as history and emits nothing, where `main` emits the full turn. Reachable within the ordinary discovery latency (~1.5s when the day dir is already scanned, up to ~6.5s via the `_getActiveDayDirs` cache).
- **The restart-replay window widens 1.5s → 5s.** Restarting inside it re-emits a turn the pet already showed.

They are the same contradiction from two sides. Both guards answer "is this content history?" by comparing timestamps, and no threshold separates *"a turn we never saw"* from *"a turn we saw, then forgot"* — **the two produce byte-identical files**. A wider window swallows less and replays more; a narrower one does the reverse.

The filename signal was also unnecessary. Its stated justification was timestamp-less historical lines defeating the line-level guard — but every state-bearing line in 209k lines of real rollouts across 383 files carries a timestamp, and upstream introduced the `RolloutItem` envelope this monitor parses *in the same commit* as per-line `RolloutLine.timestamp`. A recognizable line without a timestamp isn't rare; it's structurally impossible.

#566 needs bookkeeping, not inference: the monitor already knows how far it has read, but that offset rides the `_tracked`/`_retiredTracked` eviction and is lost once ~150 rollouts of churn push it out. Tracked separately — see the follow-up issue.

## Not included

The `SUSTAINED_ACTIVE_STATES` set is shared with `_emitBackfillSnapshot`, which is untouched. #660 rewrites this same `token_count` branch to attach quota data and keeps `tracked.lastState || "idle"` verbatim; whoever lands second needs to keep the `carry`, which #660's own tests would not catch:

```js
const carry = SUSTAINED_ACTIVE_STATES.has(tracked.lastState) ? tracked.lastState : "idle";
this._emitStateChange(tracked, carry, key, codexQuota ? { codexQuota } : null);
```

