### PR TITLE
fix(hooks): EOF-driven stdin read with 2s safety net + sid=default diagnostics

### DIFF
--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -11,6 +11,11 @@ const { extractClaudeContextUsageFromEntries } = require("./context-usage");
 const { createPidResolver, readStdinJsonDetailed, getPlatformConfig } = require("./shared-process");
 
 const TRANSCRIPT_TAIL_BYTES = 262144; // 256 KB
+// #583: claude-code registers this hook with async:true and a 5s timeout
+// (hooks/install.js), so a 2s stdin window never stalls the agent. Do NOT
+// raise the shared default in shared-process.js instead — other agent hooks
+// run ~800ms stdout safety timers that must win against a slow stdin read.
+const STDIN_READ_TIMEOUT_MS = 2000;
 const ASSISTANT_OUTPUT_MAX = 2200;
 // Observed in Claude Code 2.1.150 StopFailure hook schema (tyq enum).
 // Unknown values from future versions fall back to "unknown".
@@ -480,7 +485,7 @@ function main() {
   // Remote mode: skip PID collection — remote PIDs are meaningless on the local machine
   if (event === "SessionStart" && !process.env.CLAWD_REMOTE) resolve();
 
-  readStdinJsonDetailed()
+  readStdinJsonDetailed({ timeoutMs: STDIN_READ_TIMEOUT_MS })
     .then((stdinRead) => {
       const payload = stdinRead.payload;
       const body = buildStateBody(event, payload || {}, resolve);
@@ -512,6 +517,7 @@ if (require.main === module) main();
 module.exports = {
   buildStateBody,
   attachStdinDiag,
+  STDIN_READ_TIMEOUT_MS,
   extractSessionTitleFromTranscript,
   extractApiErrorFromEntries,
   extractLastAssistantTextFromEntries,

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -8,7 +8,7 @@ const fs = require("fs");
 const { postStateToRunningServer, readHostPrefix } = require("./server-config");
 const { fitStateBodyToByteBudget } = require("./state-payload-size");
 const { extractClaudeContextUsageFromEntries } = require("./context-usage");
-const { createPidResolver, readStdinJson, getPlatformConfig } = require("./shared-process");
+const { createPidResolver, readStdinJsonDetailed, getPlatformConfig } = require("./shared-process");
 
 const TRANSCRIPT_TAIL_BYTES = 262144; // 256 KB
 const ASSISTANT_OUTPUT_MAX = 2200;
@@ -446,6 +446,25 @@ function buildStateBody(event, payload, resolve) {
   return body;
 }
 
+// #583: a missing session_id means the agent's stdin JSON was lost or mangled
+// somewhere between the agent host and this process (every real session then
+// collapses to sid=default server-side). Attach what the stdin read actually
+// saw so session-debug.log can separate "never arrived" (bytes:0 + timeout)
+// from "arrived broken" (bytes>0 + parse error) without a repro rig.
+function attachStdinDiag(body, stdinRead) {
+  if (!body || !stdinRead) return body;
+  const payload = stdinRead.payload;
+  if (payload && payload.session_id) return body;
+  const diag = {
+    bytes: stdinRead.bytes,
+    timed_out: stdinRead.timedOut === true,
+    duration_ms: stdinRead.durationMs,
+  };
+  if (stdinRead.parseError) diag.parse_error = stdinRead.parseError;
+  body.stdin_diag = diag;
+  return body;
+}
+
 function main() {
   const event = process.argv[2];
   if (!EVENT_TO_STATE[event]) process.exit(0);
@@ -461,10 +480,12 @@ function main() {
   // Remote mode: skip PID collection — remote PIDs are meaningless on the local machine
   if (event === "SessionStart" && !process.env.CLAWD_REMOTE) resolve();
 
-  readStdinJson()
-    .then((payload) => {
+  readStdinJsonDetailed()
+    .then((stdinRead) => {
+      const payload = stdinRead.payload;
       const body = buildStateBody(event, payload || {}, resolve);
       if (!body) process.exit(0);
+      attachStdinDiag(body, stdinRead);
       // Completion events (Stop) fire the happy animation, are low-frequency,
       // and matter more than a few ms of latency. Give them a generous POST
       // timeout so a momentarily slow (but alive) Clawd still receives them;
@@ -490,6 +511,7 @@ if (require.main === module) main();
 
 module.exports = {
   buildStateBody,
+  attachStdinDiag,
   extractSessionTitleFromTranscript,
   extractApiErrorFromEntries,
   extractLastAssistantTextFromEntries,

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -346,34 +346,66 @@ function createPidResolver(options) {
 }
 
 // ── readStdinJson ────────────────────────────────────────────────────────────
-// Reads stdin, parses JSON, returns Promise<Object>.
-// 400ms timeout + finishOnce protection. Returns {} on parse failure or timeout.
+// Reads stdin until EOF, parses JSON. EOF-driven with a safety-net timer:
+// agent hosts write the payload and close stdin within a few ms even through a
+// PowerShell intermediary (measured 3-5ms incl. 200KB bodies on the #583
+// repro rig), so the timer only fires in pathological environments — e.g. a
+// PATH shim or security software swallowing stdin. Raised from 400ms so
+// slow-but-alive forwarding still lands inside the window; agent-side hook
+// timeouts (5s+) leave ample room. Returns {} on parse failure or timeout.
+//
+// readStdinJsonDetailed() additionally reports what the read saw (bytes
+// received, timed out, parse error, duration) so a missing session_id can be
+// triaged from logs: "never arrived" (bytes:0, timeout) vs "arrived broken"
+// (bytes>0, parse error) point at entirely different culprits.
 
-function readStdinJson() {
+const STDIN_READ_TIMEOUT_MS = 2000;
+
+function readStdinJsonDetailed(options = {}) {
+  const stream = options.stream || process.stdin;
+  const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
+    ? options.timeoutMs
+    : STDIN_READ_TIMEOUT_MS;
   return new Promise((resolve) => {
+    const startedAt = Date.now();
     const chunks = [];
     let done = false;
     let timer = null;
 
     const onData = (c) => chunks.push(c);
-    function finish() {
+    const onEnd = () => finish(false);
+    function finish(timedOut) {
       if (done) return;
       done = true;
       if (timer) clearTimeout(timer);
-      process.stdin.off("data", onData);
-      process.stdin.off("end", finish);
+      stream.off("data", onData);
+      stream.off("end", onEnd);
+      const raw = Buffer.concat(chunks);
       let payload = {};
+      let parseError = null;
       try {
-        const raw = Buffer.concat(chunks).toString();
-        if (raw.trim()) payload = JSON.parse(raw);
-      } catch {}
-      resolve(payload);
+        const text = raw.toString();
+        if (text.trim()) payload = JSON.parse(text);
+      } catch (err) {
+        parseError = String((err && err.message) || "parse error").slice(0, 120);
+      }
+      resolve({
+        payload,
+        bytes: raw.length,
+        timedOut: timedOut === true,
+        parseError,
+        durationMs: Date.now() - startedAt,
+      });
     }
 
-    process.stdin.on("data", onData);
-    process.stdin.on("end", finish);
-    timer = setTimeout(finish, 400);
+    stream.on("data", onData);
+    stream.on("end", onEnd);
+    timer = setTimeout(() => finish(true), timeoutMs);
   });
+}
+
+function readStdinJson() {
+  return readStdinJsonDetailed().then((result) => result.payload);
 }
 
 function buildElectronLaunchConfig(projectDir, options = {}) {
@@ -400,5 +432,7 @@ module.exports = {
   getPlatformConfig,
   createPidResolver,
   readStdinJson,
+  readStdinJsonDetailed,
+  STDIN_READ_TIMEOUT_MS,
   buildElectronLaunchConfig,
 };

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -346,40 +346,48 @@ function createPidResolver(options) {
 }
 
 // ── readStdinJson ────────────────────────────────────────────────────────────
-// Reads stdin until EOF, parses JSON. EOF-driven with a safety-net timer:
-// agent hosts write the payload and close stdin within a few ms even through a
-// PowerShell intermediary (measured 3-5ms incl. 200KB bodies on the #583
-// repro rig), so the timer only fires in pathological environments — e.g. a
-// PATH shim or security software swallowing stdin. Raised from 400ms so
-// slow-but-alive forwarding still lands inside the window; agent-side hook
-// timeouts (5s+) leave ample room. Returns {} on parse failure or timeout.
+// Reads stdin until EOF, parses JSON. EOF-driven with a safety-net timer.
+// The default stays at 400ms: several agent hooks (cursor, codebuddy, gemini,
+// reasonix) run their own ~800ms stdout safety timers and non-async hot-path
+// registrations, so a longer shared default would let those timers win the
+// race and drop payloads that used to be parsed at 400ms. Callers whose agent
+// registration tolerates a longer stall (claude-code: async + 5s hook timeout)
+// opt in via options.timeoutMs. Returns {} on parse failure or timeout.
 //
 // readStdinJsonDetailed() additionally reports what the read saw (bytes
-// received, timed out, parse error, duration) so a missing session_id can be
-// triaged from logs: "never arrived" (bytes:0, timeout) vs "arrived broken"
-// (bytes>0, parse error) point at entirely different culprits.
+// received, timed out, parse/stream error, duration) so a missing session_id
+// can be triaged from logs: "never arrived" (bytes:0, timeout) vs "arrived
+// broken" (bytes>0, parse error) point at entirely different culprits (#583).
 
-const STDIN_READ_TIMEOUT_MS = 2000;
+const DEFAULT_STDIN_READ_TIMEOUT_MS = 400;
 
 function readStdinJsonDetailed(options = {}) {
   const stream = options.stream || process.stdin;
   const timeoutMs = Number.isFinite(options.timeoutMs) && options.timeoutMs > 0
     ? options.timeoutMs
-    : STDIN_READ_TIMEOUT_MS;
+    : DEFAULT_STDIN_READ_TIMEOUT_MS;
   return new Promise((resolve) => {
     const startedAt = Date.now();
     const chunks = [];
     let done = false;
     let timer = null;
+    let streamError = null;
 
     const onData = (c) => chunks.push(c);
     const onEnd = () => finish(false);
+    // Without this, an emitted 'error' would crash the hook (unhandled stream
+    // error) and the promise would never settle. Resolve with what we have.
+    const onError = (err) => {
+      streamError = String((err && err.message) || "stream error").slice(0, 120);
+      finish(false);
+    };
     function finish(timedOut) {
       if (done) return;
       done = true;
       if (timer) clearTimeout(timer);
       stream.off("data", onData);
       stream.off("end", onEnd);
+      stream.off("error", onError);
       const raw = Buffer.concat(chunks);
       let payload = {};
       let parseError = null;
@@ -389,6 +397,7 @@ function readStdinJsonDetailed(options = {}) {
       } catch (err) {
         parseError = String((err && err.message) || "parse error").slice(0, 120);
       }
+      if (streamError) parseError = `stream error: ${streamError}`;
       resolve({
         payload,
         bytes: raw.length,
@@ -400,6 +409,7 @@ function readStdinJsonDetailed(options = {}) {
 
     stream.on("data", onData);
     stream.on("end", onEnd);
+    stream.on("error", onError);
     timer = setTimeout(() => finish(true), timeoutMs);
   });
 }
@@ -433,6 +443,6 @@ module.exports = {
   createPidResolver,
   readStdinJson,
   readStdinJsonDetailed,
-  STDIN_READ_TIMEOUT_MS,
+  DEFAULT_STDIN_READ_TIMEOUT_MS,
   buildElectronLaunchConfig,
 };

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -155,6 +155,19 @@ function handleStatePost(req, res, options) {
         ? data.ghostty_terminal_id.trim()
         : null;
       const toolName = typeof data.tool_name === "string" && data.tool_name ? data.tool_name : null;
+      // #583: hook-reported stdin diagnostics, attached only when the hook's
+      // stdin payload carried no session_id. Normalized here so state.js can
+      // log it without trusting hook-side shapes.
+      const stdinDiag = data.stdin_diag && typeof data.stdin_diag === "object"
+        ? {
+            bytes: Number.isFinite(data.stdin_diag.bytes) ? Math.max(0, Math.floor(data.stdin_diag.bytes)) : null,
+            timedOut: data.stdin_diag.timed_out === true,
+            durationMs: Number.isFinite(data.stdin_diag.duration_ms) ? Math.max(0, Math.floor(data.stdin_diag.duration_ms)) : null,
+            parseError: typeof data.stdin_diag.parse_error === "string" && data.stdin_diag.parse_error
+              ? data.stdin_diag.parse_error.slice(0, 120)
+              : null,
+          }
+        : null;
       const toolUseId = normalizeHookToolUseId(
         data.tool_use_id ?? data.toolUseId ?? data.toolUseID
       );
@@ -293,6 +306,7 @@ function handleStatePost(req, res, options) {
             backgroundTasksCount,
             sessionCronsCount,
             stopHookActive,
+            stdinDiag,
             ...(agentIdentity.defaulted ? { agentIdDefaulted: true } : {}),
           });
         }

--- a/src/state.js
+++ b/src/state.js
@@ -950,12 +950,19 @@ function describeSession(sessionId, session) {
 // stdin payload had no session_id) for the event log line. bytes:0 + timeout:1
 // means stdin never reached the hook; bytes>0 + stdinErr means it arrived
 // mangled — entirely different culprits, distinguishable from one log line.
+// parseError arrives via /state which any local process can forge: strip
+// quotes, backslashes, and control chars (incl. ANSI escapes) so a crafted
+// value cannot close the quoted field early or corrupt the log line.
 function formatStdinDiag(diag) {
   if (!diag || typeof diag !== "object") return "";
   const bytes = Number.isFinite(diag.bytes) ? diag.bytes : "-";
   const durationMs = Number.isFinite(diag.durationMs) ? diag.durationMs : "-";
   const err = typeof diag.parseError === "string" && diag.parseError
-    ? ` stdinErr="${diag.parseError.replace(/\s+/g, " ").slice(0, 80)}"`
+    ? ` stdinErr="${diag.parseError
+        .replace(/["\\\u0000-\u001F\u007F-\u009F]/g, " ")
+        .replace(/\s+/g, " ")
+        .trim()
+        .slice(0, 80)}"`
     : "";
   return ` stdin=bytes:${bytes},timeout:${diag.timedOut === true ? 1 : 0},ms:${durationMs}${err}`;
 }

--- a/src/state.js
+++ b/src/state.js
@@ -946,6 +946,20 @@ function describeSession(sessionId, session) {
   ].join(" ");
 }
 
+// #583: renders hook-reported stdin diagnostics (present only when the hook's
+// stdin payload had no session_id) for the event log line. bytes:0 + timeout:1
+// means stdin never reached the hook; bytes>0 + stdinErr means it arrived
+// mangled — entirely different culprits, distinguishable from one log line.
+function formatStdinDiag(diag) {
+  if (!diag || typeof diag !== "object") return "";
+  const bytes = Number.isFinite(diag.bytes) ? diag.bytes : "-";
+  const durationMs = Number.isFinite(diag.durationMs) ? diag.durationMs : "-";
+  const err = typeof diag.parseError === "string" && diag.parseError
+    ? ` stdinErr="${diag.parseError.replace(/\s+/g, " ").slice(0, 80)}"`
+    : "";
+  return ` stdin=bytes:${bytes},timeout:${diag.timedOut === true ? 1 : 0},ms:${durationMs}${err}`;
+}
+
 function resolvePidReachable(existing, agentPid, sourcePid) {
   if (agentPid && isProcessAlive(agentPid)) return true;
   if (sourcePid && isProcessAlive(sourcePid)) return true;
@@ -1234,6 +1248,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     backgroundTasksCount = 0,
     sessionCronsCount = 0,
     stopHookActive = false,
+    stdinDiag = null,
   } = opts;
   if (startupRecoveryActive) {
     startupRecoveryActive = false;
@@ -1452,7 +1467,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     return;
   }
 
-  debugSession(`event ${describeSession(sessionId, existing)} -> incoming=${state}/${event || "-"} hint=${displayHint || "-"} source=${hookSource || "-"}`);
+  debugSession(`event ${describeSession(sessionId, existing)} -> incoming=${state}/${event || "-"} hint=${displayHint || "-"} source=${hookSource || "-"}${formatStdinDiag(stdinDiag)}`);
 
   const pidReachable = resolvePidReachable(existing, srcAgentPid, srcPid);
 
@@ -2182,6 +2197,7 @@ return {
   emitSessionSnapshot, broadcastSessionSnapshot, getLastSessionSnapshot,
   getActiveSessionAliasKeys,
   dismissSession,
+  formatStdinDiag,
   updateSessionFocusMetadata,
   clearPermissionNotification,
   ackSessionCompletion,

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -14,6 +14,7 @@ const path = require("path");
 const {
   buildStateBody,
   attachStdinDiag,
+  STDIN_READ_TIMEOUT_MS: CLAWD_HOOK_STDIN_TIMEOUT_MS,
   extractSessionTitleFromTranscript,
   extractApiErrorFromEntries,
   extractLastAssistantTextFromEntries,
@@ -1077,5 +1078,25 @@ describe("attachStdinDiag", () => {
       durationMs: 4,
     });
     assert.strictEqual(body.stdin_diag, undefined);
+  });
+});
+
+describe("clawd-hook stdin timeout budget (#583)", () => {
+  it("uses a 2s stdin window — safe only because install.js registers async:true + timeout:5", () => {
+    assert.strictEqual(CLAWD_HOOK_STDIN_TIMEOUT_MS, 2000);
+  });
+});
+
+describe("attachStdinDiag edge cases", () => {
+  it("treats an empty-string session_id as missing and attaches diagnostics", () => {
+    const body = { state: "idle", session_id: "default", event: "SessionStart" };
+    attachStdinDiag(body, {
+      payload: { session_id: "" },
+      bytes: 30,
+      timedOut: false,
+      parseError: null,
+      durationMs: 2,
+    });
+    assert.deepStrictEqual(body.stdin_diag, { bytes: 30, timed_out: false, duration_ms: 2 });
   });
 });

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -13,6 +13,7 @@ const path = require("path");
 
 const {
   buildStateBody,
+  attachStdinDiag,
   extractSessionTitleFromTranscript,
   extractApiErrorFromEntries,
   extractLastAssistantTextFromEntries,
@@ -1027,5 +1028,54 @@ describe("buildStateBody — Stop → ApiError upgrade", () => {
     );
     assert.strictEqual(body.event, "Stop");
     assert.strictEqual(body.state, "attention");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// attachStdinDiag (#583)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("attachStdinDiag", () => {
+  const makeBody = () => ({ state: "idle", session_id: "default", event: "SessionStart" });
+
+  it("attaches diagnostics when the stdin payload had no session_id", () => {
+    const body = makeBody();
+    attachStdinDiag(body, {
+      payload: {},
+      bytes: 0,
+      timedOut: true,
+      parseError: null,
+      durationMs: 2001,
+    });
+    assert.deepStrictEqual(body.stdin_diag, { bytes: 0, timed_out: true, duration_ms: 2001 });
+  });
+
+  it("includes parse_error only when present", () => {
+    const body = makeBody();
+    attachStdinDiag(body, {
+      payload: {},
+      bytes: 17,
+      timedOut: false,
+      parseError: "Unexpected token",
+      durationMs: 3,
+    });
+    assert.deepStrictEqual(body.stdin_diag, {
+      bytes: 17,
+      timed_out: false,
+      duration_ms: 3,
+      parse_error: "Unexpected token",
+    });
+  });
+
+  it("does not attach anything when session_id arrived", () => {
+    const body = makeBody();
+    attachStdinDiag(body, {
+      payload: { session_id: "real-sid" },
+      bytes: 500,
+      timedOut: false,
+      parseError: null,
+      durationMs: 4,
+    });
+    assert.strictEqual(body.stdin_diag, undefined);
   });
 });

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -165,6 +165,7 @@ describe("server-route-state POST", () => {
         backgroundTasksCount: 0,
         sessionCronsCount: 0,
         stopHookActive: false,
+        stdinDiag: null,
       },
     ]]);
   });
@@ -196,6 +197,39 @@ describe("server-route-state POST", () => {
     assert.strictEqual(res.statusCode, 200);
     assert.strictEqual(res.calls.updateSession[0][1], "attention");
     assert.strictEqual(res.calls.updateSession[0][3].assistantLastOutput, "Short answer.");
+  });
+
+  it("normalizes and passes stdin_diag to updateSession (#583)", async () => {
+    const res = await callStatePost(JSON.stringify({
+      state: "idle",
+      event: "SessionStart",
+      stdin_diag: { bytes: 0, timed_out: true, duration_ms: 2001.7, parse_error: "Unexpected end of JSON input" },
+    }));
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.calls.updateSession[0][3].stdinDiag, {
+      bytes: 0,
+      timedOut: true,
+      durationMs: 2001,
+      parseError: "Unexpected end of JSON input",
+    });
+  });
+
+  it("passes stdinDiag=null when stdin_diag is absent or malformed", async () => {
+    const absent = await callStatePost(JSON.stringify({
+      state: "idle",
+      session_id: "sid",
+      event: "SessionStart",
+    }));
+    assert.strictEqual(absent.calls.updateSession[0][3].stdinDiag, null);
+
+    const malformed = await callStatePost(JSON.stringify({
+      state: "idle",
+      session_id: "sid",
+      event: "SessionStart",
+      stdin_diag: "bytes:0",
+    }));
+    assert.strictEqual(malformed.calls.updateSession[0][3].stdinDiag, null);
   });
 
   it("passes valid context_usage to updateSession", async () => {

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -8,7 +8,7 @@ const {
   getPlatformConfig,
   createPidResolver,
   readStdinJsonDetailed,
-  STDIN_READ_TIMEOUT_MS,
+  DEFAULT_STDIN_READ_TIMEOUT_MS,
   buildElectronLaunchConfig,
 } = require("../hooks/shared-process");
 
@@ -573,7 +573,34 @@ describe("readStdinJsonDetailed()", () => {
     assert.strictEqual(result.parseError, null);
   });
 
-  it("defaults the safety-net timeout to 2000ms", () => {
-    assert.strictEqual(STDIN_READ_TIMEOUT_MS, 2000);
+  it("keeps the shared default timeout at 400ms — other agent hooks run ~800ms stdout safety timers that must win the race", () => {
+    assert.strictEqual(DEFAULT_STDIN_READ_TIMEOUT_MS, 400);
+  });
+
+  it("resolves (instead of crashing) when the stream errors mid-read, reporting a stream error", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream });
+    stream.write('{"half":');
+    stream.emit("error", new Error("boom"));
+
+    const result = await pending;
+    assert.deepStrictEqual(result.payload, {});
+    assert.strictEqual(result.bytes, 8);
+    assert.strictEqual(result.timedOut, false);
+    assert.strictEqual(result.parseError, "stream error: boom");
+  });
+
+  it("handles multi-megabyte stdin without truncation", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream });
+    const big = JSON.stringify({ session_id: "big-sid", blob: "z".repeat(3 * 1024 * 1024) });
+    // write in 64KB slices like a real pipe would
+    for (let i = 0; i < big.length; i += 65536) stream.write(big.slice(i, i + 65536));
+    stream.end();
+
+    const result = await pending;
+    assert.strictEqual(result.payload.session_id, "big-sid");
+    assert.strictEqual(result.bytes, Buffer.byteLength(big));
+    assert.strictEqual(result.parseError, null);
   });
 });

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -2,10 +2,13 @@
 const { describe, it, beforeEach, mock } = require("node:test");
 const assert = require("node:assert");
 
+const { PassThrough } = require("node:stream");
+
 const {
   getPlatformConfig,
   createPidResolver,
-  readStdinJson,
+  readStdinJsonDetailed,
+  STDIN_READ_TIMEOUT_MS,
   buildElectronLaunchConfig,
 } = require("../hooks/shared-process");
 
@@ -494,6 +497,83 @@ describe("createPidResolver() — Windows PowerShell path", { skip: process.plat
   });
 });
 
-// readStdinJson() is not unit-tested here — it attaches listeners to
-// process.stdin (singleton) which prevents process exit. Validated by
-// real agent integration tests + the finishOnce/timeout logic is trivial.
+// ═════════════════════════════════════════════════════════════════════════════
+// readStdinJsonDetailed() — injectable stream + timeout (#583)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("readStdinJsonDetailed()", () => {
+  it("parses a complete JSON payload on EOF and reports bytes", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream });
+    stream.end('{"session_id":"abc-123","cwd":"D:\\\\x"}');
+
+    const result = await pending;
+    assert.strictEqual(result.payload.session_id, "abc-123");
+    assert.strictEqual(result.bytes, Buffer.byteLength('{"session_id":"abc-123","cwd":"D:\\\\x"}'));
+    assert.strictEqual(result.timedOut, false);
+    assert.strictEqual(result.parseError, null);
+  });
+
+  it("concatenates chunked writes before parsing", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream });
+    stream.write('{"session_id":');
+    stream.write('"chunked"');
+    stream.end("}");
+
+    const result = await pending;
+    assert.strictEqual(result.payload.session_id, "chunked");
+    assert.strictEqual(result.timedOut, false);
+  });
+
+  it("returns empty payload with bytes:0 when stdin closes with no data", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream });
+    stream.end();
+
+    const result = await pending;
+    assert.deepStrictEqual(result.payload, {});
+    assert.strictEqual(result.bytes, 0);
+    assert.strictEqual(result.timedOut, false);
+    assert.strictEqual(result.parseError, null);
+  });
+
+  it("reports a parse error for malformed JSON but still resolves {}", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream });
+    stream.end('{"session_id":"broken"');
+
+    const result = await pending;
+    assert.deepStrictEqual(result.payload, {});
+    assert.strictEqual(result.bytes, 22);
+    assert.ok(typeof result.parseError === "string" && result.parseError.length > 0);
+  });
+
+  it("times out when EOF never arrives, keeping any bytes received so far", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream, timeoutMs: 40 });
+    stream.write('{"half":');
+    // no end() — simulates an intermediary swallowing EOF
+
+    const result = await pending;
+    assert.strictEqual(result.timedOut, true);
+    assert.strictEqual(result.bytes, 8);
+    assert.deepStrictEqual(result.payload, {});
+    assert.ok(typeof result.parseError === "string" && result.parseError.length > 0);
+  });
+
+  it("parses data that arrived in full even when EOF is swallowed", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream, timeoutMs: 40 });
+    stream.write('{"session_id":"no-eof"}');
+
+    const result = await pending;
+    assert.strictEqual(result.timedOut, true);
+    assert.strictEqual(result.payload.session_id, "no-eof");
+    assert.strictEqual(result.parseError, null);
+  });
+
+  it("defaults the safety-net timeout to 2000ms", () => {
+    assert.strictEqual(STDIN_READ_TIMEOUT_MS, 2000);
+  });
+});

--- a/test/state-payload-size.test.js
+++ b/test/state-payload-size.test.js
@@ -158,3 +158,19 @@ describe("state-payload-size fitStateBodyToByteBudget", () => {
     assert.ok(Buffer.byteLength(JSON.stringify(r.body), "utf8") <= 250);
   });
 });
+
+describe("state-payload-size stdin_diag interaction (#583)", () => {
+  it("preserves stdin_diag when an oversized assistant_last_output is truncated", () => {
+    const body = {
+      state: "attention",
+      session_id: "default",
+      event: "Stop",
+      stdin_diag: { bytes: 0, timed_out: true, duration_ms: 2001 },
+      assistant_last_output: "y".repeat(20 * 1024),
+    };
+    const fitted = fitStateBodyToByteBudget(body);
+    assert.ok(fitted.bytes <= DEFAULT_TARGET_BYTES);
+    assert.ok(fitted.assistantTruncated || fitted.assistantDropped);
+    assert.deepStrictEqual(fitted.body.stdin_diag, { bytes: 0, timed_out: true, duration_ms: 2001 });
+  });
+});

--- a/test/state-stdin-diag.test.js
+++ b/test/state-stdin-diag.test.js
@@ -58,6 +58,19 @@ describe("formatStdinDiag", () => {
     assert.strictEqual(out, ' stdin=bytes:17,timeout:0,ms:3 stdinErr="Unexpected end of JSON input"');
   });
 
+  it("strips quotes, backslashes, ANSI escapes, and control chars from parse errors (forged /state)", () => {
+    const ESC = String.fromCharCode(27); // raw ESC kept out of this source file
+    const out = api.formatStdinDiag({
+      bytes: 5,
+      timedOut: false,
+      durationMs: 1,
+      parseError: 'bad\" timeout:1 ' + ESC + '[2Kinject\\ed',
+    });
+    assert.strictEqual(out, ' stdin=bytes:5,timeout:0,ms:1 stdinErr=\"bad timeout:1 [2Kinject ed\"');
+    assert.ok(!out.includes(ESC), "ANSI escape must be stripped");
+    assert.strictEqual((out.match(/\"/g) || []).length, 2, "only the two delimiter quotes may remain");
+  });
+
   it("caps the parse error at 80 chars and collapses whitespace", () => {
     const out = api.formatStdinDiag({
       bytes: 5,

--- a/test/state-stdin-diag.test.js
+++ b/test/state-stdin-diag.test.js
@@ -1,0 +1,82 @@
+"use strict";
+
+// #583: formatStdinDiag renders hook-reported stdin diagnostics on the
+// session-debug event line so sid=default reports can be triaged from logs.
+
+const { describe, it, beforeEach } = require("node:test");
+const assert = require("node:assert");
+const path = require("path");
+
+const themeLoader = require("../src/theme-loader");
+themeLoader.init(path.join(__dirname, "..", "src"));
+const _defaultTheme = themeLoader.loadTheme("clawd");
+
+function makeCtx() {
+  return {
+    theme: _defaultTheme,
+    doNotDisturb: false,
+    miniTransitioning: false,
+    miniMode: false,
+    mouseOverPet: false,
+    idlePaused: false,
+    forceEyeResend: false,
+    mouseStillSince: Date.now(),
+    playSound() {},
+    sendToRenderer() {},
+    syncHitWin() {},
+    sendToHitWin() {},
+    miniPeekIn() {},
+    miniPeekOut() {},
+    buildContextMenu() {},
+    buildTrayMenu() {},
+    pendingPermissions: [],
+    resolvePermissionEntry() {},
+    t: (k) => k,
+    focusTerminalWindow() {},
+  };
+}
+
+describe("formatStdinDiag", () => {
+  let api;
+
+  beforeEach(() => {
+    api = require("../src/state")(makeCtx());
+  });
+
+  it("renders the never-arrived shape (bytes:0 + timeout)", () => {
+    const out = api.formatStdinDiag({ bytes: 0, timedOut: true, durationMs: 2001, parseError: null });
+    assert.strictEqual(out, " stdin=bytes:0,timeout:1,ms:2001");
+  });
+
+  it("renders the arrived-broken shape with a parse error", () => {
+    const out = api.formatStdinDiag({
+      bytes: 17,
+      timedOut: false,
+      durationMs: 3,
+      parseError: "Unexpected end of\nJSON input",
+    });
+    assert.strictEqual(out, ' stdin=bytes:17,timeout:0,ms:3 stdinErr="Unexpected end of JSON input"');
+  });
+
+  it("caps the parse error at 80 chars and collapses whitespace", () => {
+    const out = api.formatStdinDiag({
+      bytes: 5,
+      timedOut: false,
+      durationMs: 1,
+      parseError: "x".repeat(200),
+    });
+    assert.ok(out.includes(`stdinErr="${"x".repeat(80)}"`));
+    assert.ok(!out.includes("x".repeat(81)));
+  });
+
+  it("returns empty string for null or non-object diag", () => {
+    assert.strictEqual(api.formatStdinDiag(null), "");
+    assert.strictEqual(api.formatStdinDiag(undefined), "");
+    assert.strictEqual(api.formatStdinDiag("bytes:0"), "");
+  });
+
+  it("renders '-' for missing numeric fields", () => {
+    const out = api.formatStdinDiag({ timedOut: true });
+    assert.strictEqual(out, " stdin=bytes:-,timeout:1,ms:-");
+  });
+});


### PR DESCRIPTION
## What

Layer 1+2 of the #583 plan: make `sid=default` failures observable, and harden the hook stdin read. This deliberately does **not** claim to fix the reporter's machine — the reported mechanism (PowerShell starving the 400ms timer) did not reproduce (stdin lands in 3-5ms through powershell 5.1 / pwsh 7, incl. CJK and 200KB payloads), so the real culprit there is still unconfirmed (bare-`node`-resolves-to-a-shim is the leading suspect). This build produces the data to settle it.

## Changes

- **`readStdinJsonDetailed()`** (hooks/shared-process.js): same read, but reports `{ payload, bytes, timedOut, parseError, durationMs }`. `readStdinJson()` stays as a thin wrapper so the other 14 agent hooks are untouched. Stream + timeout are injectable — the read finally has unit tests (it never had any; the old comment said it couldn't be tested against the `process.stdin` singleton).
- **`stdin_diag`** (hooks/clawd-hook.js → src/server-route-state.js → src/state.js): attached to the `/state` body **only when the stdin payload carried no `session_id`**; the server normalizes it and appends it to the session-debug event line:
  - `stdin=bytes:0,timeout:1,ms:2001` → stdin **never arrived** (shim / EDR territory)
  - `stdin=bytes:217,timeout:0,ms:3 stdinErr="..."` → **arrived broken** (encoding / truncation territory)
- **Safety-net timer 400ms → 2s** (EOF-driven as before): healthy hosts close stdin in single-digit ms so the timer never fires there; agent-side hook timeouts (5s) leave room. Slow-but-alive forwarding now lands inside the window instead of being truncated mid-payload and silently parsed as `{}`.

## Verification

- `node --test test/*.test.js`: 4381 tests, 0 fail (13 pre-existing skips).
- Real-pipe smoke (spawned `node`, real stdin): normal payload → sid passes through, no diag; empty stdin → `bytes:0`; broken JSON → `bytes:20` + parse error; swallowed EOF → `timeout:1,ms:2001`. The diag even caught a quoting bug in my own smoke script (`bytes:51` + "Bad escaped character at position 39"), which is exactly the triage it exists to provide.

## Follow-up (not in this PR)

- Layer 3 waits on the reporter's environment data (#583): if the bare-`node` shim theory is confirmed, the `install.js` bare-`"node"` fallback needs a warning/doctor check.

Refs #583
