### PR TITLE
fix(fullscreen): reassert skipTaskbar after hit-window focusable flip (#586)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1227,6 +1227,13 @@ function setHitWinFocusable(focusable) {
   const next = !!focusable;
   if (typeof hitWin.isFocusable === "function" && hitWin.isFocusable() === next) return;
   hitWin.setFocusable(next);
+  // Electron's NativeWindowViews::SetFocusable couples activation to the
+  // taskbar on Windows: SetFocusable(true) internally calls
+  // SetSkipTaskbar(false) → ITaskbarList::AddTab, so restoring activation
+  // after a fullscreen exit (or a screenshot overlay dismissing) flashes a
+  // taskbar button for the hit window (#586). Delete the tab again in the
+  // same turn, before the taskbar repaints.
+  keepOutOfTaskbar(hitWin);
 }
 
 // ── Mini Mode — delegated to src/mini.js ──

--- a/src/main.js
+++ b/src/main.js
@@ -1233,7 +1233,12 @@ function setHitWinFocusable(focusable) {
   // after a fullscreen exit (or a screenshot overlay dismissing) flashes a
   // taskbar button for the hit window (#586). Delete the tab again in the
   // same turn, before the taskbar repaints.
-  keepOutOfTaskbar(hitWin);
+  // true-direction ONLY: SetFocusable(false) already deletes the tab
+  // internally, and re-deleting on that path broke cursor-drag while a
+  // fullscreen app was foreground (real-machine repro during #586 review;
+  // exact Windows-side mechanism unconfirmed). Do not "simplify" this into
+  // an unconditional call.
+  if (next) keepOutOfTaskbar(hitWin);
 }
 
 // ── Mini Mode — delegated to src/mini.js ──


### PR DESCRIPTION
Fixes #586.

## Symptom

On Windows, a taskbar button flashes briefly when exiting a fullscreen game/video, or the moment the Win+Shift+S screenshot overlay dismisses. Clicking the button does nothing; the pet itself keeps working.

## Root cause

Electron's `NativeWindowViews::SetFocusable` couples activation to the taskbar on Windows — `SetFocusable(true)` internally calls `SetSkipTaskbar(false)` → `ITaskbarList::AddTab`, actively re-adding the window to the taskbar:

```cpp
void NativeWindowViews::SetFocusable(bool focusable) {
  ...
  SetSkipTaskbar(!focusable);  // AddTab when focusable
  ...
}
```

The fullscreen adaptation shipped in v0.11.0 (#538/#562) polls the foreground fullscreen state every ~1s and flips the hit window's `focusable` accordingly. Every flip back to the desktop (fullscreen exit) therefore ran `AddTab` for the hit window, and the button stayed visible until the 5s topmost watchdog's next `keepOutOfTaskbar` tick deleted it — perceived as a flash of a single icon.

The screenshot trigger is the same flip: the fullscreen probe (`win-fullscreen-detect.js`) is pure geometry (foreground window rect covers the monitor), and the snipping overlay is exactly such a window, so overlay-appear/dismiss counts as a fullscreen enter/exit.

This explains the reporter's "started after updating" observation — it is a genuine regression introduced by the v0.11.0 focusable toggle (the reported "0.10.0" is most likely a misremembered version).

## Fix

Re-assert `keepOutOfTaskbar(hitWin)` immediately after `hitWin.setFocusable(next)` in `setHitWinFocusable` (src/main.js), so the tab is deleted in the same turn, before the taskbar repaints. A comment records the Electron coupling so the "redundant" line doesn't get cleaned up later.

Other `setFocusable` call sites need no treatment: `renderWin.setFocusable(false)` at creation is the DeleteTab direction, and the `pet-window-runtime.js` hit-window call is macOS-only where the coupling doesn't exist.

## Verification

- 4374 unit tests green (`node --test test/*.test.js`)
- Real machine (Windows 11): both trigger paths — screenshot overlay and fullscreen exit — no longer flash
- Codex deep review: no BLOCKER/CONCERN findings across idempotency short-circuit, other call sites, AddTab/DeleteTab ordering, and interaction with the #562 fullscreen stand-down
