### PR TITLE
fix(codex): write dual command fields for WSL-shared CODEX_HOME (#544)

### DIFF
--- a/hooks/codex-install-utils.js
+++ b/hooks/codex-install-utils.js
@@ -10,7 +10,6 @@ const {
   commandMatchesMarker,
   extractExistingNodeBin,
   formatNodeHookCommand,
-  removeMatchingCommandHooks,
 } = require("./json-utils");
 
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".codex");
@@ -71,8 +70,13 @@ function windowsPathToWslPath(value) {
 // boundary — never prepend env here; put env in commandWindows instead.
 function buildCodexHookPosixInteropCommand(nodeBin, hookScript) {
   const wslNodeBin = windowsPathToWslPath(nodeBin);
-  const posixNodeBin =
-    wslNodeBin || (/\.exe$/i.test(String(nodeBin)) ? nodeBin : `${nodeBin}.exe`);
+  // A UNC node path (\\server\share\node.exe) has no /mnt translation and a
+  // POSIX shell cannot exec the raw backslash form — fall back to bare
+  // node.exe resolved through the interop PATH.
+  const posixNodeBin = wslNodeBin
+    || (String(nodeBin).startsWith("\\\\")
+      ? "node.exe"
+      : (/\.exe$/i.test(String(nodeBin)) ? nodeBin : `${nodeBin}.exe`));
   return formatNodeHookCommand(posixNodeBin, hookScript, { platform: "linux" });
 }
 
@@ -323,21 +327,30 @@ function ensureCodexHooksFeature(configPath, options = {}) {
   return { changed: true, warning: null };
 }
 
-function hookMatchesCodexMarker(hook, marker) {
+// includeWindowsVariant widens the match to commandWindows. Registration
+// passes it only on win32 hosts: a POSIX host must never claim (and rewrite
+// the command of) an entry whose only Clawd trace is a leftover
+// commandWindows — that command could be a third-party hook. Uninstall, by
+// contrast, always matches both fields: removal must be complete on every
+// platform.
+function hookMatchesCodexMarker(hook, marker, includeWindowsVariant) {
   return (
     (typeof hook.command === "string" && commandMatchesMarker(hook.command, marker)) ||
-    (typeof hook.commandWindows === "string" && commandMatchesMarker(hook.commandWindows, marker))
+    (includeWindowsVariant === true
+      && typeof hook.commandWindows === "string"
+      && commandMatchesMarker(hook.commandWindows, marker))
   );
 }
 
-function findCodexCommandHook(entry, marker) {
+function findCodexCommandHook(entry, marker, options = {}) {
   if (!entry || typeof entry !== "object") return null;
+  const includeWindowsVariant = options.includeWindowsVariant === true;
   const innerHooks = Array.isArray(entry.hooks) ? entry.hooks : [];
   for (const hook of innerHooks) {
     if (!hook || typeof hook !== "object") continue;
-    if (hookMatchesCodexMarker(hook, marker)) return hook;
+    if (hookMatchesCodexMarker(hook, marker, includeWindowsVariant)) return hook;
   }
-  if (hookMatchesCodexMarker(entry, marker)) return entry;
+  if (hookMatchesCodexMarker(entry, marker, includeWindowsVariant)) return entry;
   return null;
 }
 
@@ -371,6 +384,58 @@ function extractExistingWindowsNodeBin(settings, marker) {
     }
   }
   return null;
+}
+
+// Local dual-field variant of removeMatchingCommandHooks: uninstall must
+// remove a hook when EITHER command or commandWindows carries the marker —
+// a hand-edited command must not shield a still-live commandWindows from
+// removal, on any platform. The shared helper only inspects command and
+// stays single-field for agents that never write commandWindows.
+function removeCodexCommandHooks(entries, predicate) {
+  if (!Array.isArray(entries)) return { entries, removed: 0, changed: false };
+  const hookMatches = (hook) =>
+    (typeof hook.command === "string" && predicate(hook.command))
+    || (typeof hook.commandWindows === "string" && predicate(hook.commandWindows));
+
+  let removed = 0;
+  let changed = false;
+  const nextEntries = [];
+
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") {
+      nextEntries.push(entry);
+      continue;
+    }
+
+    if (hookMatches(entry)) {
+      removed++;
+      changed = true;
+      continue;
+    }
+
+    if (!Array.isArray(entry.hooks)) {
+      nextEntries.push(entry);
+      continue;
+    }
+
+    const nextHooks = entry.hooks.filter((hook) => {
+      if (!hook || typeof hook !== "object") return true;
+      if (!hookMatches(hook)) return true;
+      removed++;
+      changed = true;
+      return false;
+    });
+
+    if (nextHooks.length === entry.hooks.length) {
+      nextEntries.push(entry);
+      continue;
+    }
+
+    if (nextHooks.length === 0 && typeof entry.command !== "string") continue;
+    nextEntries.push({ ...entry, hooks: nextHooks });
+  }
+
+  return { entries: nextEntries, removed, changed };
 }
 
 function registerCodexCommandHooks(options = {}) {
@@ -443,7 +508,7 @@ function registerCodexCommandHooks(options = {}) {
     const desiredTimeout = timeoutForCodexEvent(event);
 
     for (const entry of arr) {
-      const hook = findCodexCommandHook(entry, marker);
+      const hook = findCodexCommandHook(entry, marker, { includeWindowsVariant: isWindowsHost });
       if (!hook) continue;
       found = true;
       if (hook.type !== "command") {
@@ -528,7 +593,7 @@ function unregisterCodexCommandHooks(options = {}) {
   for (const event of events) {
     const arr = settings.hooks[event];
     if (!Array.isArray(arr)) continue;
-    const result = removeMatchingCommandHooks(arr, (command) =>
+    const result = removeCodexCommandHooks(arr, (command) =>
       markers.some((marker) => commandMatchesMarker(command, marker))
     );
     if (result.changed) {

--- a/hooks/codex-install-utils.js
+++ b/hooks/codex-install-utils.js
@@ -70,11 +70,11 @@ function windowsPathToWslPath(value) {
 // boundary — never prepend env here; put env in commandWindows instead.
 function buildCodexHookPosixInteropCommand(nodeBin, hookScript) {
   const wslNodeBin = windowsPathToWslPath(nodeBin);
-  // A UNC node path (\\server\share\node.exe) has no /mnt translation and a
-  // POSIX shell cannot exec the raw backslash form — fall back to bare
-  // node.exe resolved through the interop PATH.
+  // A UNC node path (\\server\share\node.exe or //server/share/node.exe)
+  // has no /mnt translation and a POSIX shell cannot exec the raw Windows
+  // form — fall back to bare node.exe resolved through the interop PATH.
   const posixNodeBin = wslNodeBin
-    || (String(nodeBin).startsWith("\\\\")
+    || (/^[\\/]{2}/.test(String(nodeBin))
       ? "node.exe"
       : (/\.exe$/i.test(String(nodeBin)) ? nodeBin : `${nodeBin}.exe`));
   return formatNodeHookCommand(posixNodeBin, hookScript, { platform: "linux" });
@@ -88,10 +88,14 @@ function quotePowerShellEnvValue(value) {
   return `'${String(value).replace(/'/g, "''")}'`;
 }
 
-function withCommandEnv(command, env, platform = process.platform) {
-  if (!env || typeof env !== "object") return command;
-  const entries = Object.entries(env)
+function filterCommandEnvEntries(env) {
+  if (!env || typeof env !== "object") return [];
+  return Object.entries(env)
     .filter(([key, value]) => /^[A-Za-z_][A-Za-z0-9_]*$/.test(key) && value !== undefined && value !== null);
+}
+
+function withCommandEnv(command, env, platform = process.platform) {
+  const entries = filterCommandEnvEntries(env);
   if (!entries.length) return command;
 
   if (platform === "win32") {
@@ -431,7 +435,11 @@ function removeCodexCommandHooks(entries, predicate) {
       continue;
     }
 
-    if (nextHooks.length === 0 && typeof entry.command !== "string") continue;
+    if (
+      nextHooks.length === 0
+      && typeof entry.command !== "string"
+      && typeof entry.commandWindows !== "string"
+    ) continue;
     nextEntries.push({ ...entry, hooks: nextHooks });
   }
 
@@ -483,7 +491,10 @@ function registerCodexCommandHooks(options = {}) {
   const desiredCommand = isWindowsHost
     ? buildCodexHookPosixInteropCommand(nodeBin, hookScript)
     : withCommandEnv(buildCodexHookCommand(nodeBin, hookScript, hostPlatform), commandEnv, hostPlatform);
-  if (isWindowsHost && Object.keys(commandEnv).length) {
+  // Gate the warning on the same filter withCommandEnv applies, so an env
+  // object that contributes nothing (invalid keys / nullish values) doesn't
+  // emit a false warning — repairCodexHooks escalates any warning to error.
+  if (isWindowsHost && filterCommandEnvEntries(commandEnv).length) {
     warnings.push(
       "Env vars don't cross the WSL interop boundary; they were applied to commandWindows only."
     );
@@ -515,7 +526,17 @@ function registerCodexCommandHooks(options = {}) {
         hook.type = "command";
         stale = true;
       }
-      if (hook.command !== desiredCommand) {
+      // On win32 an entry can be claimed through commandWindows alone. If
+      // its command string no longer carries the marker, the user replaced
+      // it deliberately (e.g. interop unavailable in their WSL) — keep
+      // their fix and keep managing commandWindows only. Rewriting it here
+      // would recreate the exact "reconcile wipes my manual fix" loop #544
+      // reported.
+      const commandHandEdited = isWindowsHost
+        && typeof hook.command === "string"
+        && hook.command !== ""
+        && !commandMatchesMarker(hook.command, marker);
+      if (!commandHandEdited && hook.command !== desiredCommand) {
         hook.command = desiredCommand;
         stale = true;
       }

--- a/hooks/codex-install-utils.js
+++ b/hooks/codex-install-utils.js
@@ -53,6 +53,29 @@ function buildCodexHookCommand(nodeBin, hookScript, platform = process.platform)
   });
 }
 
+function windowsPathToWslPath(value) {
+  const match = /^([A-Za-z]):[\\/](.*)$/.exec(String(value || ""));
+  if (!match) return null;
+  return `/mnt/${match[1].toLowerCase()}/${match[2].replace(/\\/g, "/")}`;
+}
+
+// POSIX-side `command` for a hooks.json shared with WSL through CODEX_HOME
+// (#544). Codex on Windows prefers `commandWindows` (openai/codex#22159), so
+// `command` is only executed by POSIX shells — for a Windows-authored
+// hooks.json that means WSL. Run the WINDOWS node.exe via WSL interop rather
+// than a Linux node: the hook then lives in a Windows process whose
+// 127.0.0.1 is the Windows loopback, so events reach Clawd's server (which
+// binds 127.0.0.1 only) even in WSL's default NAT mode, where a Linux-side
+// process gets connection-refused. Requires WSL interop (on by default).
+// Env-var prefixes (`KEY=value node.exe ...`) do NOT cross the interop
+// boundary — never prepend env here; put env in commandWindows instead.
+function buildCodexHookPosixInteropCommand(nodeBin, hookScript) {
+  const wslNodeBin = windowsPathToWslPath(nodeBin);
+  const posixNodeBin =
+    wslNodeBin || (/\.exe$/i.test(String(nodeBin)) ? nodeBin : `${nodeBin}.exe`);
+  return formatNodeHookCommand(posixNodeBin, hookScript, { platform: "linux" });
+}
+
 function quotePosixEnvValue(value) {
   return `'${String(value).replace(/'/g, "'\\''")}'`;
 }
@@ -300,14 +323,53 @@ function ensureCodexHooksFeature(configPath, options = {}) {
   return { changed: true, warning: null };
 }
 
+function hookMatchesCodexMarker(hook, marker) {
+  return (
+    (typeof hook.command === "string" && commandMatchesMarker(hook.command, marker)) ||
+    (typeof hook.commandWindows === "string" && commandMatchesMarker(hook.commandWindows, marker))
+  );
+}
+
 function findCodexCommandHook(entry, marker) {
   if (!entry || typeof entry !== "object") return null;
   const innerHooks = Array.isArray(entry.hooks) ? entry.hooks : [];
   for (const hook of innerHooks) {
     if (!hook || typeof hook !== "object") continue;
-    if (typeof hook.command === "string" && commandMatchesMarker(hook.command, marker)) return hook;
+    if (hookMatchesCodexMarker(hook, marker)) return hook;
   }
-  if (typeof entry.command === "string" && commandMatchesMarker(entry.command, marker)) return entry;
+  if (hookMatchesCodexMarker(entry, marker)) return entry;
+  return null;
+}
+
+// Windows-host variant of extractExistingNodeBin: scans command AND
+// commandWindows, and only accepts Windows-form absolute paths (drive letter
+// or UNC). The POSIX `command` on a Windows host holds a derived /mnt/...
+// interop path — extracting that back as the node bin would corrupt
+// commandWindows on the next reconcile.
+function extractExistingWindowsNodeBin(settings, marker) {
+  const hooks = settings && settings.hooks;
+  if (!hooks || typeof hooks !== "object") return null;
+  const commands = [];
+  for (const entries of Object.values(hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== "object") continue;
+      const inner = Array.isArray(entry.hooks) ? entry.hooks : [entry];
+      for (const hook of inner) {
+        if (!hook || typeof hook !== "object") continue;
+        for (const cmd of [hook.commandWindows, hook.command]) {
+          if (typeof cmd === "string" && commandMatchesMarker(cmd, marker)) commands.push(cmd);
+        }
+      }
+    }
+  }
+  for (const cmd of commands) {
+    for (const match of cmd.matchAll(/"([^"]+)"/g)) {
+      const token = match[1];
+      if (!token || token.includes(marker)) continue;
+      if (/^[A-Za-z]:[\\/]/.test(token) || token.startsWith("\\\\")) return token;
+    }
+  }
   return null;
 }
 
@@ -331,24 +393,36 @@ function registerCodexCommandHooks(options = {}) {
 
   const hookScript = asarUnpackedPath(path.resolve(__dirname, scriptName).replace(/\\/g, "/"));
   const settings = readJsonIfPresent(hooksPath, "hooks.json");
+  const hostPlatform = options.platform || process.platform;
+  const isWindowsHost = hostPlatform === "win32";
   const resolved = options.nodeBin !== undefined ? options.nodeBin : resolveNodeBin();
   const nodeBin = resolved
-    || extractExistingNodeBin(settings, marker, { nested: true })
+    || (isWindowsHost
+      ? extractExistingWindowsNodeBin(settings, marker)
+      : extractExistingNodeBin(settings, marker, { nested: true }))
     || "node";
-  const baseCommand = buildCodexHookCommand(
-    nodeBin,
-    hookScript,
-    options.platform || process.platform
-  );
   const commandEnv = {
     ...(options.env || {}),
     ...(options.remote ? { CLAWD_REMOTE: "1" } : {}),
   };
-  const desiredCommand = withCommandEnv(
-    baseCommand,
-    commandEnv,
-    options.platform || process.platform
-  );
+  // On a Windows host, a WSL session may consume this hooks.json through a
+  // shared CODEX_HOME (#544). Codex resolves `commandWindows` on Windows and
+  // `command` on POSIX, so write both: keep the PowerShell form in
+  // commandWindows (unchanged from what `command` used to hold, so existing
+  // Windows installs keep their trusted_hash) and put a WSL-interop form in
+  // `command`. Note codex builds before openai/codex#22159 (2026-05) ignore
+  // commandWindows and would run the POSIX form on Windows.
+  const desiredCommandWindows = isWindowsHost
+    ? withCommandEnv(buildCodexHookCommand(nodeBin, hookScript, "win32"), commandEnv, "win32")
+    : null;
+  const desiredCommand = isWindowsHost
+    ? buildCodexHookPosixInteropCommand(nodeBin, hookScript)
+    : withCommandEnv(buildCodexHookCommand(nodeBin, hookScript, hostPlatform), commandEnv, hostPlatform);
+  if (isWindowsHost && Object.keys(commandEnv).length) {
+    warnings.push(
+      "Env vars don't cross the WSL interop boundary; they were applied to commandWindows only."
+    );
+  }
 
   if (!settings.hooks || typeof settings.hooks !== "object") settings.hooks = {};
 
@@ -380,6 +454,10 @@ function registerCodexCommandHooks(options = {}) {
         hook.command = desiredCommand;
         stale = true;
       }
+      if (isWindowsHost && hook.commandWindows !== desiredCommandWindows) {
+        hook.commandWindows = desiredCommandWindows;
+        stale = true;
+      }
       if (hook.timeout !== desiredTimeout) {
         hook.timeout = desiredTimeout;
         stale = true;
@@ -397,9 +475,10 @@ function registerCodexCommandHooks(options = {}) {
       continue;
     }
 
-    arr.push({
-      hooks: [{ type: "command", command: desiredCommand, timeout: desiredTimeout }],
-    });
+    const newHook = isWindowsHost
+      ? { type: "command", command: desiredCommand, commandWindows: desiredCommandWindows, timeout: desiredTimeout }
+      : { type: "command", command: desiredCommand, timeout: desiredTimeout };
+    arr.push({ hooks: [newHook] });
     added++;
     changed = true;
   }
@@ -476,11 +555,14 @@ module.exports = {
   CODEX_HOOKS_FEATURE_KEY,
   LEGACY_CODEX_HOOKS_FEATURE_KEY,
   buildCodexHookCommand,
+  buildCodexHookPosixInteropCommand,
   ensureCodexHooksFeature,
+  extractExistingWindowsNodeBin,
   findCodexCommandHook,
   parseTomlTableHeader,
   registerCodexCommandHooks,
   timeoutForCodexEvent,
   unregisterCodexCommandHooks,
+  windowsPathToWslPath,
   withCommandEnv,
 };

--- a/src/doctor-detectors/agent-integrations.js
+++ b/src/doctor-detectors/agent-integrations.js
@@ -9,7 +9,7 @@ const {
   isAgentPermissionsEnabled,
 } = require("../agent-gate");
 const { getAgent } = require("../../agents/registry");
-const { findHookCommands } = require("../../hooks/json-utils");
+const { commandMatchesMarker, findHookCommands } = require("../../hooks/json-utils");
 const { GEMINI_HOOK_EVENTS } = require("../../hooks/gemini-install");
 const { ANTIGRAVITY_HOOK_EVENTS, HOOK_GROUP_ID: ANTIGRAVITY_HOOK_GROUP_ID } = require("../../hooks/antigravity-install");
 const { QWEN_CODE_HOOK_EVENTS } = require("../../hooks/qwen-code-install");
@@ -182,6 +182,40 @@ function statusLevel(status) {
     return "warning";
   }
   return status === "ok" ? null : "info";
+}
+
+// codex resolves commandWindows on Windows and command on POSIX
+// (openai/codex#22159). Since #544, a win32-authored hooks.json carries a
+// WSL-interop form in `command` that is only executable inside WSL, so the
+// doctor must validate the field THIS platform's codex would run — the
+// generic findHookCommands (command only) would flag every dual-field
+// Windows install as broken-path, and Repair would regenerate the same
+// fields forever.
+function resolveCodexPlatformCommand(hook, platform) {
+  if (!hook || typeof hook !== "object") return null;
+  const windowsVariant = typeof hook.commandWindows === "string" ? hook.commandWindows : null;
+  const base = typeof hook.command === "string" ? hook.command : null;
+  return platform === "win32" ? (windowsVariant || base) : base;
+}
+
+function findCodexPlatformHookCommands(settings, marker, platform) {
+  if (!settings || !settings.hooks || typeof settings.hooks !== "object") return [];
+  const commands = [];
+  const push = (hook) => {
+    const resolved = resolveCodexPlatformCommand(hook, platform);
+    if (resolved && commandMatchesMarker(resolved, marker)) commands.push(resolved);
+  };
+  for (const entries of Object.values(settings.hooks)) {
+    if (!Array.isArray(entries)) continue;
+    for (const entry of entries) {
+      if (!entry || typeof entry !== "object") continue;
+      if (Array.isArray(entry.hooks)) {
+        for (const hook of entry.hooks) push(hook);
+      }
+      push(entry);
+    }
+  }
+  return commands;
 }
 
 function validateCommandList(descriptor, commands, options) {
@@ -809,6 +843,12 @@ function checkFileMode(descriptor, options) {
     detail = validateGeminiHookEvents(descriptor, settings, options);
   } else if (descriptor.agentId === "qwen-code") {
     detail = validateQwenHookEvents(descriptor, settings, options);
+  } else if (descriptor.agentId === "codex") {
+    detail = validateCommandList(
+      descriptor,
+      findCodexPlatformHookCommands(settings, descriptor.marker, options.platform || process.platform),
+      options
+    );
   } else {
     detail = validateCommandList(
       descriptor,

--- a/test/codex-install.test.js
+++ b/test/codex-install.test.js
@@ -467,4 +467,70 @@ describe("Codex hooks on a Windows host write dual command fields (#544)", () =>
       assert.strictEqual(Object.prototype.hasOwnProperty.call(hook, "commandWindows"), false);
     }
   });
+
+  // codex review finding: a POSIX host must never claim an entry whose only
+  // Clawd trace is a leftover commandWindows — its command may be a
+  // third-party hook that reconciliation would silently overwrite.
+  it("POSIX reconcile does not overwrite a third-party command with a leftover commandWindows", () => {
+    const thirdParty = '"/usr/bin/some-other-tool" --flag';
+    const codexDir = makeTempCodexDir({
+      hooks: {
+        SessionStart: [{
+          hooks: [{
+            type: "command",
+            command: thirdParty,
+            commandWindows: `& "node" "${HOOK_SCRIPT}"`,
+            timeout: 30,
+          }],
+        }],
+      },
+    });
+
+    registerCodexHooks({
+      silent: true,
+      codexDir,
+      nodeBin: "/usr/local/bin/node",
+      platform: "linux",
+    });
+
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    const entries = settings.hooks.SessionStart;
+    // The third-party hook survives untouched; Clawd appends its own entry.
+    assert.strictEqual(entries[0].hooks[0].command, thirdParty);
+    assert.strictEqual(entries.length, 2);
+    assert.ok(entries[1].hooks[0].command.includes(MARKER));
+  });
+
+  // codex review finding: uninstall must match commandWindows too, so a
+  // hand-edited command cannot shield a still-live commandWindows.
+  it("uninstall removes an entry whose marker only survives in commandWindows", () => {
+    const codexDir = makeTempCodexDir({
+      hooks: {
+        SessionStart: [{
+          hooks: [{
+            type: "command",
+            command: '"/usr/bin/edited-away" --by-hand',
+            commandWindows: `& "node" "${HOOK_SCRIPT}"`,
+            timeout: 30,
+          }],
+        }],
+      },
+    });
+
+    const result = unregisterCodexHooks({ silent: true, codexDir });
+
+    assert.strictEqual(result.removed, 1);
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(settings.hooks, "SessionStart"), false);
+  });
+
+  // codex review finding: a UNC node path has no /mnt translation and a
+  // POSIX shell cannot exec the raw backslash form — fall back to bare
+  // node.exe via the interop PATH.
+  it("falls back to bare node.exe for a UNC node path in the interop command", () => {
+    assert.strictEqual(
+      buildCodexHookPosixInteropCommand("\\\\server\\share\\node.exe", "D:/x/codex-hook.js"),
+      '"node.exe" "D:/x/codex-hook.js"'
+    );
+  });
 });

--- a/test/codex-install.test.js
+++ b/test/codex-install.test.js
@@ -185,7 +185,7 @@ describe("Codex official hook installer", () => {
     );
   });
 
-  it("registers Windows remote hooks with a PowerShell env prefix", () => {
+  it("registers Windows remote hooks with a PowerShell env prefix on commandWindows only", () => {
     const codexDir = makeTempCodexDir({});
     const result = registerCodexHooks({
       silent: true,
@@ -197,11 +197,17 @@ describe("Codex official hook installer", () => {
 
     assert.strictEqual(result.added, CODEX_OFFICIAL_HOOK_EVENTS.length);
     const settings = readJson(path.join(codexDir, "hooks.json"));
-    const command = settings.hooks.SessionStart[0].hooks[0].command;
+    const hook = settings.hooks.SessionStart[0].hooks[0];
+    const hookScript = path.resolve(__dirname, "..", "hooks", "codex-hook.js").replace(/\\/g, "/");
+    // PowerShell env prefix lives on commandWindows (what Windows codex runs).
     assert.strictEqual(
-      command,
-      "$env:CLAWD_REMOTE='1'; & \"C:\\node.exe\" \"" + path.resolve(__dirname, "..", "hooks", "codex-hook.js").replace(/\\/g, "/") + "\""
+      hook.commandWindows,
+      `$env:CLAWD_REMOTE='1'; & "C:\\node.exe" "${hookScript}"`
     );
+    // The POSIX command must NOT carry an env prefix: env vars don't cross
+    // the WSL interop boundary, so a prefix would only mislead readers.
+    assert.strictEqual(hook.command, `"/mnt/c/node.exe" "${hookScript}"`);
+    assert.ok(result.warnings.some((w) => /interop/.test(w)));
   });
 
   it("unregisters only official state hooks", () => {
@@ -296,5 +302,169 @@ describe("Codex official hook installer", () => {
     // CLI feedback for users who want to verify the install state).
     assert.match(joined, /Clawd .* hooks/, "summary header should still print");
     assert.match(joined, /Added: 0/, "Added/updated/skipped count should still print");
+  });
+});
+
+// #544: a hooks.json written by Windows Clawd may be shared with WSL codex
+// through CODEX_HOME. Codex resolves commandWindows on Windows and command on
+// POSIX, so Windows installs must write both fields: PowerShell syntax in
+// commandWindows, a WSL-interop (Windows node.exe) form in command.
+describe("Codex hooks on a Windows host write dual command fields (#544)", () => {
+  const HOOK_SCRIPT = path.resolve(__dirname, "..", "hooks", "codex-hook.js").replace(/\\/g, "/");
+  const {
+    buildCodexHookPosixInteropCommand,
+    windowsPathToWslPath,
+  } = require("../hooks/codex-install-utils");
+
+  it("translates Windows absolute paths to WSL /mnt form", () => {
+    assert.strictEqual(
+      windowsPathToWslPath("C:\\Program Files\\nodejs\\node.exe"),
+      "/mnt/c/Program Files/nodejs/node.exe"
+    );
+    assert.strictEqual(windowsPathToWslPath("D:/Tool/Clawd on Desk/x.js"), "/mnt/d/Tool/Clawd on Desk/x.js");
+    assert.strictEqual(windowsPathToWslPath("node"), null);
+    assert.strictEqual(windowsPathToWslPath("/usr/bin/node"), null);
+  });
+
+  it("builds the interop command from a bare node bin by appending .exe", () => {
+    assert.strictEqual(
+      buildCodexHookPosixInteropCommand("node", "D:/x/codex-hook.js"),
+      '"node.exe" "D:/x/codex-hook.js"'
+    );
+    assert.strictEqual(
+      buildCodexHookPosixInteropCommand("node.exe", "D:/x/codex-hook.js"),
+      '"node.exe" "D:/x/codex-hook.js"'
+    );
+  });
+
+  it("fresh Windows install writes PowerShell commandWindows and interop command", () => {
+    const codexDir = makeTempCodexDir({});
+    const result = registerCodexHooks({
+      silent: true,
+      codexDir,
+      nodeBin: "C:\\Program Files\\nodejs\\node.exe",
+      platform: "win32",
+    });
+
+    assert.strictEqual(result.added, CODEX_OFFICIAL_HOOK_EVENTS.length);
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    for (const event of CODEX_OFFICIAL_HOOK_EVENTS) {
+      const hook = settings.hooks[event][0].hooks[0];
+      assert.strictEqual(
+        hook.commandWindows,
+        `& "C:\\Program Files\\nodejs\\node.exe" "${HOOK_SCRIPT}"`
+      );
+      assert.strictEqual(
+        hook.command,
+        `"/mnt/c/Program Files/nodejs/node.exe" "${HOOK_SCRIPT}"`
+      );
+    }
+  });
+
+  it("is idempotent on second Windows run", () => {
+    const codexDir = makeTempCodexDir({});
+    const opts = { silent: true, codexDir, nodeBin: "C:\\node.exe", platform: "win32" };
+    registerCodexHooks(opts);
+    const before = fs.readFileSync(path.join(codexDir, "hooks.json"), "utf8");
+
+    const result = registerCodexHooks(opts);
+
+    assert.strictEqual(result.added, 0);
+    assert.strictEqual(result.updated, 0);
+    assert.strictEqual(result.skipped, CODEX_OFFICIAL_HOOK_EVENTS.length);
+    assert.strictEqual(fs.readFileSync(path.join(codexDir, "hooks.json"), "utf8"), before);
+  });
+
+  it("upgrades a legacy Windows entry (PowerShell command, no commandWindows) in place", () => {
+    const legacyCommand = `& "node" "${HOOK_SCRIPT}"`;
+    const codexDir = makeTempCodexDir({
+      hooks: {
+        SessionStart: [{ hooks: [{ type: "command", command: legacyCommand, timeout: 30 }] }],
+      },
+    });
+
+    const result = registerCodexHooks({
+      silent: true,
+      codexDir,
+      nodeBin: "node",
+      platform: "win32",
+    });
+
+    assert.strictEqual(result.updated, 1);
+    assert.strictEqual(result.added, CODEX_OFFICIAL_HOOK_EVENTS.length - 1);
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    const hook = settings.hooks.SessionStart[0].hooks[0];
+    // commandWindows takes over the exact PowerShell form command used to
+    // hold, so Windows codex resolves the same string (trusted_hash intact).
+    assert.strictEqual(hook.commandWindows, legacyCommand);
+    assert.strictEqual(hook.command, `"node.exe" "${HOOK_SCRIPT}"`);
+    assert.strictEqual(settings.hooks.SessionStart.length, 1);
+  });
+
+  it("preserves a user-repaired node path found in commandWindows", () => {
+    const codexDir = makeTempCodexDir({
+      hooks: {
+        SessionStart: [{
+          hooks: [{
+            type: "command",
+            command: `"node.exe" "${HOOK_SCRIPT}"`,
+            commandWindows: `& "E:\\custom\\node.exe" "${HOOK_SCRIPT}"`,
+            timeout: 30,
+          }],
+        }],
+      },
+    });
+
+    registerCodexHooks({
+      silent: true,
+      codexDir,
+      nodeBin: null, // force the extract-existing fallback
+      platform: "win32",
+    });
+
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    const hook = settings.hooks.SessionStart[0].hooks[0];
+    assert.strictEqual(hook.commandWindows, `& "E:\\custom\\node.exe" "${HOOK_SCRIPT}"`);
+    assert.strictEqual(hook.command, `"/mnt/e/custom/node.exe" "${HOOK_SCRIPT}"`);
+  });
+
+  it("does not extract the derived /mnt interop path back as a node bin", () => {
+    // command holds /mnt/c/... (derived); commandWindows holds the source of
+    // truth. The fallback must not launder the POSIX form into commandWindows.
+    const codexDir = makeTempCodexDir({
+      hooks: {
+        SessionStart: [{
+          hooks: [{
+            type: "command",
+            command: `"/mnt/c/tools/node.exe" "${HOOK_SCRIPT}"`,
+            commandWindows: `& "C:\\tools\\node.exe" "${HOOK_SCRIPT}"`,
+            timeout: 30,
+          }],
+        }],
+      },
+    });
+
+    registerCodexHooks({ silent: true, codexDir, nodeBin: null, platform: "win32" });
+
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    const hook = settings.hooks.SessionStart[0].hooks[0];
+    assert.strictEqual(hook.commandWindows, `& "C:\\tools\\node.exe" "${HOOK_SCRIPT}"`);
+    assert.strictEqual(hook.command, `"/mnt/c/tools/node.exe" "${HOOK_SCRIPT}"`);
+  });
+
+  it("POSIX installs never write commandWindows", () => {
+    const codexDir = makeTempCodexDir({});
+    registerCodexHooks({
+      silent: true,
+      codexDir,
+      nodeBin: "/usr/local/bin/node",
+      platform: "linux",
+    });
+
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    for (const event of CODEX_OFFICIAL_HOOK_EVENTS) {
+      const hook = settings.hooks[event][0].hooks[0];
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(hook, "commandWindows"), false);
+    }
   });
 });

--- a/test/codex-install.test.js
+++ b/test/codex-install.test.js
@@ -526,11 +526,80 @@ describe("Codex hooks on a Windows host write dual command fields (#544)", () =>
 
   // codex review finding: a UNC node path has no /mnt translation and a
   // POSIX shell cannot exec the raw backslash form — fall back to bare
-  // node.exe via the interop PATH.
+  // node.exe via the interop PATH. Forward-slash UNC form included.
   it("falls back to bare node.exe for a UNC node path in the interop command", () => {
     assert.strictEqual(
       buildCodexHookPosixInteropCommand("\\\\server\\share\\node.exe", "D:/x/codex-hook.js"),
       '"node.exe" "D:/x/codex-hook.js"'
     );
+    assert.strictEqual(
+      buildCodexHookPosixInteropCommand("//server/share/node.exe", "D:/x/codex-hook.js"),
+      '"node.exe" "D:/x/codex-hook.js"'
+    );
+  });
+
+  // Subagent review finding: an entry claimed through commandWindows whose
+  // command was hand-edited (marker gone) must keep the user's command —
+  // rewriting it would recreate the "reconcile wipes my manual fix" loop.
+  it("preserves a hand-edited marker-less command while managing commandWindows", () => {
+    const handEdit = '"/home/user/bin/my-codex-wrapper.sh"';
+    const codexDir = makeTempCodexDir({
+      hooks: {
+        SessionStart: [{
+          hooks: [{
+            type: "command",
+            command: handEdit,
+            commandWindows: `& "node" "${HOOK_SCRIPT}"`,
+            timeout: 30,
+          }],
+        }],
+      },
+    });
+
+    registerCodexHooks({ silent: true, codexDir, nodeBin: "node", platform: "win32" });
+
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    const entries = settings.hooks.SessionStart;
+    assert.strictEqual(entries.length, 1, "must not append a duplicate entry");
+    assert.strictEqual(entries[0].hooks[0].command, handEdit);
+    assert.strictEqual(entries[0].hooks[0].commandWindows, `& "node" "${HOOK_SCRIPT}"`);
+  });
+
+  // Subagent review finding: uninstall must not drop an entry whose nested
+  // hooks emptied out but whose top level still carries a third-party
+  // commandWindows.
+  it("uninstall keeps an entry with a third-party top-level commandWindows", () => {
+    const codexDir = makeTempCodexDir({
+      hooks: {
+        SessionStart: [{
+          commandWindows: '& "C:\\third\\party.exe"',
+          hooks: [{ type: "command", command: `"node.exe" "${HOOK_SCRIPT}"`, timeout: 30 }],
+        }],
+      },
+    });
+
+    const result = unregisterCodexHooks({ silent: true, codexDir });
+
+    assert.strictEqual(result.removed, 1);
+    const settings = readJson(path.join(codexDir, "hooks.json"));
+    assert.strictEqual(settings.hooks.SessionStart.length, 1);
+    assert.strictEqual(settings.hooks.SessionStart[0].commandWindows, '& "C:\\third\\party.exe"');
+    assert.deepStrictEqual(settings.hooks.SessionStart[0].hooks, []);
+  });
+
+  // Subagent review finding: the interop warning must apply the same filter
+  // withCommandEnv does — an env object contributing nothing (invalid keys,
+  // nullish values) must not warn, since repair escalates warnings to error.
+  it("does not emit the interop env warning for a no-op env object", () => {
+    const codexDir = makeTempCodexDir({});
+    const result = registerCodexHooks({
+      silent: true,
+      codexDir,
+      nodeBin: "node",
+      platform: "win32",
+      env: { FOO: undefined, "1BAD": "x" },
+    });
+
+    assert.ok(!result.warnings.some((w) => /interop/.test(w)), "no-op env must not warn");
   });
 });

--- a/test/doctor-agent-integrations.test.js
+++ b/test/doctor-agent-integrations.test.js
@@ -1077,6 +1077,72 @@ describe("checkAgentIntegrations", () => {
   });
 
 
+  // #544: Windows Clawd writes dual-field entries — commandWindows carries
+  // the PowerShell form codex actually runs on Windows, command carries a
+  // WSL-interop form only executable inside WSL. The doctor must validate
+  // the field THIS platform's codex resolves; blanket-validating `command`
+  // flagged every dual-field Windows install as broken-path, and Repair
+  // regenerated the same fields forever.
+  it("validates commandWindows on win32 for dual-field Codex entries (#544)", () => {
+    const descriptor = codexDescriptor();
+    const psForm = '& "C:\\Program Files\\nodejs\\node.exe" "D:/app/hooks/codex-hook.js"';
+    const interopForm = '"/mnt/c/Program Files/nodejs/node.exe" "D:/app/hooks/codex-hook.js"';
+    writeJson(descriptor.configPath, {
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: interopForm, commandWindows: psForm, timeout: 30 }] }],
+      },
+    });
+    fs.writeFileSync(descriptor.supplementary.configPath, codexTrustState(descriptor, ["Stop"]), "utf8");
+
+    const seen = [];
+    const result = checkAgentIntegrations({
+      fs,
+      prefs: {},
+      descriptors: [descriptor],
+      server: null,
+      platform: "win32",
+      validateCommand: (command) => {
+        seen.push(command);
+        return {
+          ok: true,
+          nodeBin: "C:\\Program Files\\nodejs\\node.exe",
+          scriptPath: "D:/app/hooks/codex-hook.js",
+        };
+      },
+    });
+
+    assert.deepStrictEqual(seen, [psForm]);
+    assert.strictEqual(result.details[0].status, "ok");
+  });
+
+  it("validates the POSIX command field for dual-field Codex entries off win32", () => {
+    const descriptor = codexDescriptor();
+    const psForm = '& "C:\\Program Files\\nodejs\\node.exe" "D:/app/hooks/codex-hook.js"';
+    const interopForm = '"/mnt/c/Program Files/nodejs/node.exe" "D:/app/hooks/codex-hook.js"';
+    writeJson(descriptor.configPath, {
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: interopForm, commandWindows: psForm, timeout: 30 }] }],
+      },
+    });
+    fs.writeFileSync(descriptor.supplementary.configPath, codexTrustState(descriptor, ["Stop"]), "utf8");
+
+    const seen = [];
+    const result = checkAgentIntegrations({
+      fs,
+      prefs: {},
+      descriptors: [descriptor],
+      server: null,
+      platform: "linux",
+      validateCommand: (command) => {
+        seen.push(command);
+        return { ok: true, nodeBin: "/mnt/c/Program Files/nodejs/node.exe", scriptPath: "D:/app/hooks/codex-hook.js" };
+      },
+    });
+
+    assert.deepStrictEqual(seen, [interopForm]);
+    assert.strictEqual(result.details[0].status, "ok");
+  });
+
   it("reports Codex hooks=false even when hook registration is missing", () => {
     const descriptor = codexDescriptor();
     writeJson(descriptor.configPath, { hooks: {} });


### PR DESCRIPTION
Fixes #544.

## Problem

Windows Clawd wrote PowerShell syntax (`& "node" "D:/.../codex-hook.js"`) into the cross-platform `command` field of `~/.codex/hooks.json`. A codex running inside WSL2 with `CODEX_HOME` pointed at the Windows `.codex` (OpenAI's documented sharing flow) executes that field through a POSIX shell, so every registered hook failed with `zsh:1: parse error near '&'` / exit 1. Reconciliation then rewrote any manual fix on the next launch.

## Fix

On a win32 host, write both fields that codex resolves per platform (openai/codex#22159 — Windows prefers `commandWindows`, POSIX only reads `command`):

- **`commandWindows`** — the existing PowerShell form, byte-identical to what `command` used to hold. The Windows-resolved command string is unchanged, so existing installs keep their `trusted_hash` and need no `/hooks` re-approval.
- **`command`** — a WSL-interop form: `"/mnt/<drive>/.../node.exe" "D:/.../codex-hook.js"` (or bare `"node.exe"` when no absolute node path is known).

POSIX hosts are unchanged and never write `commandWindows`.

### Why Windows `node.exe` via interop, not Linux node

The obvious fix (`node` + `/mnt/d/...` script path, as suggested in the issue) only silences the exit-1 error. Clawd's HTTP server binds `127.0.0.1` only, and in WSL's **default NAT mode** a Linux-side process cannot reach it at all — `127.0.0.1` is the WSL VM itself (connection refused, verified) and the host gateway IP times out (verified). Running the **Windows** node through WSL interop puts the hook in a Windows process whose `127.0.0.1` is the Windows loopback, so events reach Clawd in both NAT and mirrored networking, with no Linux node install required. Interop is on by default in WSL.

### Details

- Env prefixes are applied to `commandWindows` only: env vars do **not** cross the WSL interop boundary (verified empirically), so a POSIX `KEY=value` prefix would silently vanish. A warning is emitted if env vars are requested on a win32 host.
- Node-bin fallback extraction on win32 scans `commandWindows` too and accepts only Windows-form absolute paths, so the derived `/mnt/...` interop path never launders back into `commandWindows` on re-reconcile.
- Marker matching (`findCodexCommandHook`) now checks both fields, so a hand-edited entry can't produce a duplicate registration.

## Verification (all on a real machine)

- 33 installer tests pass (8 new #544 cases: dual-field fresh install, idempotency, legacy in-place upgrade, user-repaired node path preservation, /mnt-path non-laundering, POSIX hosts unaffected); full suite 4416 tests, 0 failures.
- Upgraded a real pre-fix `~/.codex/hooks.json` in place: all 6 hooks gained the dual fields, `commandWindows` byte-identical to the old `command`.
- Real codex 0.142.5 session on Windows after the upgrade: SessionStart / UserPromptSubmit / Stop all executed and completed **without** re-approval — confirming the trusted_hash analysis.
- Executed the actual upgraded `command` string from WSL2 Ubuntu via `bash -c`: SessionStart/Stop exit 0, and a probe POST from the same interop path returned `200 ok` from Clawd's server (default NAT mode).
- Upstream schema verified against openai/codex source: `commandWindows` semantics, and pre-#22159 builds have no `deny_unknown_fields` on the handler enum, so old codex versions ignore the new field rather than rejecting the file.

## Known limitations

- Codex builds older than openai/codex#22159 (May 2026) ignore `commandWindows` and would execute the POSIX `command` on Windows, which fails. Affects only Windows users running a year-old codex; upgrading codex resolves it.
- Requires WSL interop enabled (the default). Users who disabled `[interop]` in wsl.conf need a manual command.
- WSL-side sessions run the hook as a Windows process whose parent is not visible to Windows, so process-tree-based terminal/window association degrades gracefully; state and permission events (the core pipeline) are unaffected.
- The `integrationInstalled: false` reversion reported in #544 turned out not to be a code bug — startup sync is gated on the flag in both 0.10.0 and main. The observed behavior matches editing prefs while Clawd is running (the exit snapshot overwrites the manual edit). Will be explained in the issue follow-up.
