### PR TITLE
fix(permission): keep Allow/Deny hotkeys live for visible bubbles while pet is hidden (#601)

### DIFF
--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -21,7 +21,7 @@ This document holds the state machine, theme system, UI runtime, and platform ca
 - 一次性状态：`attention/error/sweeping/notification/carrying` 显示后自动回退（`AUTO_RETURN_MS`）
 - 睡眠序列：20s 鼠标静止 → idle-look → 60s → yawning(3s) → dozing → 10min → collapsing(0.8s) → sleeping；鼠标移动触发 waking(1.5s) → 恢复
 - DND 模式：跳过 dozing，直接 yawning → collapsing → sleeping；同时屏蔽 hook 事件
-- 隐藏桌宠（petHidden，入口：托盘 / 右键菜单 / 快捷键）：语义是「看不见宠物」而非免打扰——隐藏时收起宠物、Session HUD、update bubble 和当时 pending 的权限气泡（恢复显示时回来），但隐藏期间新到的权限请求仍照常弹气泡，这是有意设计、不要当 bug 修；要连权限气泡都静默是 DND 的职责（它有回终端确认的 fallback）。petHidden 不持久化，重启恢复显示
+- 隐藏桌宠（petHidden，入口：托盘 / 右键菜单 / 快捷键）：语义是「看不见宠物」而非免打扰——隐藏时收起宠物、Session HUD、update bubble 和当时 pending 的权限气泡（恢复显示时回来），但隐藏期间新到的权限请求仍照常弹气泡，这是有意设计、不要当 bug 修；要连权限气泡都静默是 DND 的职责（它有回终端确认的 fallback）。Allow/Deny 全局快捷键跟随「可见气泡」：隐藏期间只要有可见气泡就保持注册，但只作用于可见的请求，收起的旧气泡不会被盲操作（#601）。petHidden 不持久化，重启恢复显示
 - working 子动画：Clawd 主题为 1 个会话 → typing，2 个 → headphones groove，3+ → building；Calico / Cloudling 仍为 typing / juggling / building
 - juggling 子动画：1 个 subagent → juggling，2+ → conducting
 

--- a/src/permission.js
+++ b/src/permission.js
@@ -447,6 +447,26 @@ function getActionablePermissions() {
   );
 }
 
+// #601: hotkeys must reach exactly what is on screen. While the pet is hidden,
+// bubbles pending at hide time are collapsed (they return on show) but new
+// requests still pop (docs/project/theme-state-ui.md) — so gate on bubble
+// visibility instead of dropping the hotkeys wholesale, and never let a blind
+// keypress resolve a request whose bubble the user cannot see. When the pet is
+// visible, keep the plain actionable list: entries without a bubble window
+// (creation failed / not yet created) must stay hotkey-reachable.
+function getHotkeyActionablePermissions() {
+  const actionable = getActionablePermissions();
+  if (!ctx.petHidden) return actionable;
+  return actionable.filter((p) => {
+    const bub = p.bubble;
+    try {
+      return !!bub && !bub.isDestroyed() && bub.isVisible();
+    } catch {
+      return false;
+    }
+  });
+}
+
 function syncSingle(actionId, current, target, handler, setState) {
   if (current === target) {
     if (typeof ctx.clearShortcutFailure === "function") {
@@ -488,8 +508,8 @@ function syncSingle(actionId, current, target, handler, setState) {
 function syncPermissionShortcuts() {
   const shortcutSnapshot = getShortcutSnapshot();
   const permissionPolicy = getPolicy(ctx, "permission");
-  const shouldRegister = permissionPolicy.enabled && !ctx.petHidden
-    && getActionablePermissions().length > 0;
+  const shouldRegister = permissionPolicy.enabled
+    && getHotkeyActionablePermissions().length > 0;
   const targetAllow = shouldRegister ? shortcutSnapshot.permissionAllow : null;
   const targetDeny = shouldRegister ? shortcutSnapshot.permissionDeny : null;
 
@@ -508,7 +528,7 @@ function repositionDependentBubbles() {
 }
 
 function hotkeyResolve(behavior, message) {
-  const targets = getActionablePermissions();
+  const targets = getHotkeyActionablePermissions();
   if (!targets.length) return;
   const perm = targets[targets.length - 1]; // newest
   captureFrontApp((appName) => {

--- a/test/permission-hidden-pet-hotkeys.test.js
+++ b/test/permission-hidden-pet-hotkeys.test.js
@@ -1,0 +1,207 @@
+"use strict";
+
+// #601: hiding the pet must not kill the permission hotkeys wholesale. New
+// requests still pop bubbles while hidden (docs/project/theme-state-ui.md), so
+// the hotkeys stay registered exactly when a visible bubble exists — and a
+// keypress must never resolve a collapsed (invisible) request.
+
+const assert = require("node:assert");
+const Module = require("node:module");
+const { afterEach, test } = require("node:test");
+
+const PERMISSION_MODULE_PATH = require.resolve("../src/permission");
+
+const ALLOW_ACCEL = "CommandOrControl+Shift+Y";
+const DENY_ACCEL = "CommandOrControl+Shift+N";
+
+function loadPermissionWithMocks({ electron, platform = "win32" }) {
+  delete require.cache[PERMISSION_MODULE_PATH];
+  const originalLoad = Module._load;
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+
+  Object.defineProperty(process, "platform", {
+    configurable: true,
+    enumerable: originalPlatform.enumerable,
+    value: platform,
+  });
+
+  Module._load = function patchedLoad(request, parent, isMain) {
+    if (request === "electron") return electron;
+    if (request === "child_process") return { execFile() {} };
+    return originalLoad.apply(this, arguments);
+  };
+
+  try {
+    return require("../src/permission");
+  } finally {
+    Module._load = originalLoad;
+    Object.defineProperty(process, "platform", originalPlatform);
+  }
+}
+
+function createGlobalShortcut() {
+  const registered = new Map();
+  return {
+    registered,
+    register(accelerator, handler) {
+      registered.set(accelerator, handler);
+      return true;
+    },
+    unregister(accelerator) {
+      registered.delete(accelerator);
+    },
+    isRegistered(accelerator) {
+      return registered.has(accelerator);
+    },
+  };
+}
+
+function createResponse() {
+  return {
+    statusCode: null,
+    headers: {},
+    body: "",
+    writableEnded: false,
+    writeHead(statusCode, headers) {
+      this.statusCode = statusCode;
+      this.headers = headers || {};
+    },
+    end(chunk) {
+      if (chunk !== undefined) this.body += String(chunk);
+      this.writableEnded = true;
+    },
+    on() {},
+    removeListener() {},
+  };
+}
+
+function createFakeBubble({ visible }) {
+  return {
+    destroyed: false,
+    visible,
+    isDestroyed() { return this.destroyed; },
+    isVisible() { return this.visible; },
+    hide() { this.visible = false; },
+    showInactive() { this.visible = true; },
+    destroy() { this.destroyed = true; },
+    webContents: { send() {} },
+  };
+}
+
+function createContext() {
+  return {
+    getSettingsSnapshot: () => ({ shortcuts: {} }),
+    subscribeShortcuts: () => () => {},
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
+    getPetWindowBounds: () => null,
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop: () => {},
+    reapplyMacVisibility: () => {},
+    repositionUpdateBubble: () => {},
+    clearShortcutFailure: () => {},
+    reportShortcutFailure: () => {},
+    permDebugLog: null,
+    win: null,
+    bubbleFollowPet: false,
+    petHidden: false,
+    doNotDisturb: false,
+    hideBubbles: false,
+    sessions: new Map(),
+  };
+}
+
+function loadPermission() {
+  const globalShortcut = createGlobalShortcut();
+  const initPermission = loadPermissionWithMocks({
+    electron: {
+      BrowserWindow: Object.assign(class {}, { fromWebContents() { return null; } }),
+      globalShortcut,
+    },
+  });
+  const context = createContext();
+  return { permission: initPermission(context), context, globalShortcut };
+}
+
+function pushPending(permission, { bubble = null, res = createResponse() } = {}) {
+  const entry = {
+    res,
+    abortHandler: () => {},
+    suggestions: [],
+    sessionId: "session-hidden-pet",
+    bubble,
+    hideTimer: null,
+    toolName: "Bash",
+    toolInput: { command: "echo hi" },
+    resolvedSuggestion: null,
+    createdAt: Date.now() - 5000,
+  };
+  permission.pendingPermissions.push(entry);
+  return entry;
+}
+
+afterEach(() => {
+  delete require.cache[PERMISSION_MODULE_PATH];
+});
+
+test("pet hidden: hotkeys unregister when only collapsed bubbles remain", () => {
+  const { permission, context, globalShortcut } = loadPermission();
+  pushPending(permission, { bubble: createFakeBubble({ visible: true }) });
+  permission.syncPermissionShortcuts();
+  assert.ok(globalShortcut.registered.has(ALLOW_ACCEL));
+
+  // Hiding the pet collapses the pending bubble, then re-syncs the shortcuts.
+  context.petHidden = true;
+  permission.pendingPermissions[0].bubble.hide();
+  permission.syncPermissionShortcuts();
+
+  assert.strictEqual(globalShortcut.registered.size, 0);
+});
+
+test("pet hidden: a new visible bubble keeps the hotkeys registered", () => {
+  const { permission, context, globalShortcut } = loadPermission();
+  context.petHidden = true;
+  pushPending(permission, { bubble: createFakeBubble({ visible: true }) });
+  permission.syncPermissionShortcuts();
+
+  assert.ok(globalShortcut.registered.has(ALLOW_ACCEL));
+  assert.ok(globalShortcut.registered.has(DENY_ACCEL));
+});
+
+test("pet hidden: hotkey resolves the visible request, never the collapsed one", () => {
+  const { permission, context, globalShortcut } = loadPermission();
+  const collapsedRes = createResponse();
+  const visibleRes = createResponse();
+  const collapsed = pushPending(permission, {
+    bubble: createFakeBubble({ visible: false }),
+    res: collapsedRes,
+  });
+  pushPending(permission, {
+    bubble: createFakeBubble({ visible: true }),
+    res: visibleRes,
+  });
+  context.petHidden = true;
+  permission.syncPermissionShortcuts();
+
+  const handler = globalShortcut.registered.get(ALLOW_ACCEL);
+  assert.strictEqual(typeof handler, "function");
+  handler();
+
+  assert.strictEqual(visibleRes.statusCode, 200);
+  assert.match(visibleRes.body, /"behavior":"allow"/);
+  assert.strictEqual(collapsedRes.statusCode, null);
+  assert.deepStrictEqual(permission.pendingPermissions, [collapsed]);
+  // Only the collapsed request remains, so the resolve-path re-sync must have
+  // dropped the hotkeys again.
+  assert.strictEqual(globalShortcut.registered.size, 0);
+});
+
+test("pet visible: a pending entry without a bubble window still registers hotkeys", () => {
+  const { permission, globalShortcut } = loadPermission();
+  pushPending(permission, { bubble: null });
+  permission.syncPermissionShortcuts();
+
+  assert.ok(globalShortcut.registered.has(ALLOW_ACCEL));
+  assert.ok(globalShortcut.registered.has(DENY_ACCEL));
+});

--- a/test/permission-hidden-pet-hotkeys.test.js
+++ b/test/permission-hidden-pet-hotkeys.test.js
@@ -197,6 +197,34 @@ test("pet hidden: hotkey resolves the visible request, never the collapsed one",
   assert.strictEqual(globalShortcut.registered.size, 0);
 });
 
+// Defensive: real hide semantics only produce collapsed-older + visible-newer,
+// but the invariant is "newest VISIBLE wins", not "newest pending" — lock it in
+// against a future reordering or an out-of-band collapsed newer bubble.
+test("pet hidden: hotkey targets the newest visible request even when a newer one is collapsed", () => {
+  const { permission, context, globalShortcut } = loadPermission();
+  const visibleRes = createResponse();
+  const collapsedRes = createResponse();
+  pushPending(permission, {
+    bubble: createFakeBubble({ visible: true }),
+    res: visibleRes,
+  });
+  pushPending(permission, {
+    bubble: createFakeBubble({ visible: false }),
+    res: collapsedRes,
+  });
+  context.petHidden = true;
+  permission.syncPermissionShortcuts();
+
+  const handler = globalShortcut.registered.get(ALLOW_ACCEL);
+  assert.strictEqual(typeof handler, "function");
+  handler();
+
+  assert.strictEqual(visibleRes.statusCode, 200);
+  assert.match(visibleRes.body, /"behavior":"allow"/);
+  assert.strictEqual(collapsedRes.statusCode, null);
+  assert.strictEqual(permission.pendingPermissions.length, 1);
+});
+
 test("pet visible: a pending entry without a bubble window still registers hotkeys", () => {
   const { permission, globalShortcut } = loadPermission();
   pushPending(permission, { bubble: null });


### PR DESCRIPTION
Fixes #601.

## Problem

`syncPermissionShortcuts()` gated hotkey registration on `!ctx.petHidden`, so hiding the pet unregistered the Allow/Deny global shortcuts entirely. But hiding the pet is documented as "out of sight", not DND (docs/project/theme-state-ui.md): permission requests arriving while hidden still pop visible bubbles — which then could not be answered by keyboard.

Simply dropping the `!ctx.petHidden` term (as proposed in the issue) would overshoot in the other direction: bubbles pending at hide time are collapsed (windows hidden, entries kept in `pendingPermissions`), and a global hotkey press could then silently resolve a request the user cannot see.

## Fix

Gate on bubble visibility instead of pet visibility. New `getHotkeyActionablePermissions()`:

- pet visible → unchanged plain actionable list (entries without a bubble window stay hotkey-reachable, as before);
- pet hidden → only entries whose bubble window exists, is not destroyed, and reports `isVisible()`.

Both registration (`syncPermissionShortcuts`) and targeting (`hotkeyResolve`) use it, so while hidden the hotkeys are registered exactly when a visible bubble exists and only ever resolve visible requests. Call-site ordering already fits: `setPetHidden()` collapses/restores bubble windows before re-syncing, `showPermissionBubble()` re-syncs after `showInactive()`, and resolving an entry re-syncs again — hotkeys drop as soon as only collapsed bubbles remain.

Also documented the hotkey-follows-visible-bubbles rule in the petHidden entry of docs/project/theme-state-ui.md.

## Verification

- 5 new unit tests (`test/permission-hidden-pet-hotkeys.test.js`): register/unregister transitions while hidden, mixed collapsed+visible targeting in both orders, bubble-less regression guard for the visible-pet path. Full suite: 4562 tests, 0 failures.
- Real machine (Windows 11): pet hidden → new request popped a bubble → answered via Allow hotkey within ~2s (3 runs). Collapsed-bubble protection: bubble popped while visible → pet hidden → hotkey press did nothing → pet shown → hotkey answered; permission-debug.log shows a single `/permission` hit with exactly one allow response, 24.7s after the bubble appeared.
- Codex review: approach confirmed correct as-is, no blockers; its one suggestion (an ordering-defense test) is included.
