### PR TITLE
fix(permission): remote-only approval follow-ups from #600 review (no-decision fallback, per-agent gate, unusable decisions)

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -1297,7 +1297,13 @@ function maybeStartRemoteApproval(permEntry) {
           maybeFallBackRemoteOnlyEntry();
           return;
         }
-        handleRemoteApprovalDecision(permEntry, decision, name);
+        // A decision can pass the shape check above yet still be unusable
+        // (e.g. "suggestion:9" for an entry with no such suggestion). That is
+        // just as settled-without-a-decision as an invalid payload.
+        if (handleRemoteApprovalDecision(permEntry, decision, name) === false) {
+          settledWithoutDecision += 1;
+          maybeFallBackRemoteOnlyEntry();
+        }
       })
       .catch((err) => {
         permLog(`${name} remote approval failed: ${compactRemoteApprovalText(err && err.message ? err.message : err, 200)}`);
@@ -1351,8 +1357,13 @@ function setRemoteResolutionOutcome(permEntry, outcome, sourceName) {
   permEntry.remoteApprovalSkipClientName = sourceName || "";
 }
 
+// Returns false only when the decision passed isRemoteApprovalDecision but
+// could not actually be applied (an invalid suggestion index) and the entry is
+// still pending — the caller counts that as "settled without a decision" so a
+// remote-only entry can still fall back instead of hanging until the hook's
+// timeout. Every consumed/already-resolved path returns true.
 function handleRemoteApprovalDecision(permEntry, decision, sourceName) {
-  if (pendingPermissions.indexOf(permEntry) === -1) return;
+  if (pendingPermissions.indexOf(permEntry) === -1) return true;
   const source = remoteDecisionSource(sourceName);
   const normalizedLegacy = normalizeRemoteApprovalDecision(decision);
   if (normalizedLegacy) {
@@ -1375,10 +1386,10 @@ function handleRemoteApprovalDecision(permEntry, decision, sourceName) {
         // what "go to terminal" means here.
         resolvePermissionEntry(permEntry, "no-decision", "Go to terminal from remote approval");
         ctx.focusTerminalForSession(permEntry.sessionId, { fallbackEntry: buildPermissionFocusEntry(permEntry) });
-        return;
+        return true;
       }
       resolvePermissionEntry(permEntry, "deny", "User answered in terminal");
-      return;
+      return true;
     }
     if (permEntry.isCodex || permEntry.isQwenCode || permEntry.isAntigravity) {
       resolvePermissionEntry(permEntry, "no-decision", "Go to terminal from remote approval");
@@ -1386,7 +1397,7 @@ function handleRemoteApprovalDecision(permEntry, decision, sourceName) {
     } else {
       dismissPermissionForTerminal(permEntry);
     }
-    return;
+    return true;
   }
 
   if (permEntry.isElicitation && decision && typeof decision === "object" && decision.type === "elicitation-submit") {
@@ -1397,14 +1408,14 @@ function handleRemoteApprovalDecision(permEntry, decision, sourceName) {
       source,
     }, sourceName);
     resolvePermissionEntry(permEntry, "allow");
-    return;
+    return true;
   }
 
   if (typeof decision === "string" && decision.startsWith("suggestion:")) {
     const label = applyRemotePermissionSuggestion(permEntry, decision);
     if (!label) {
       permLog(`${sourceName || "remote"} remote approval ignored invalid suggestion decision=${compactRemoteApprovalText(decision, 40)}`);
-      return;
+      return false;
     }
     setRemoteResolutionOutcome(permEntry, {
       decision,
@@ -1412,7 +1423,7 @@ function handleRemoteApprovalDecision(permEntry, decision, sourceName) {
       source,
     }, sourceName);
     resolvePermissionEntry(permEntry, "allow");
-    return;
+    return true;
   }
 
   setRemoteResolutionOutcome(permEntry, {
@@ -1421,6 +1432,7 @@ function handleRemoteApprovalDecision(permEntry, decision, sourceName) {
     source,
   }, sourceName);
   resolvePermissionEntry(permEntry, decision);
+  return true;
 }
 
 function applyPermissionSuggestion(perm, index, options = {}) {

--- a/src/permission.js
+++ b/src/permission.js
@@ -1246,7 +1246,10 @@ function maybeStartRemoteApproval(permEntry) {
   // every remote client settles without ever producing one (send failure,
   // invalid payload, client disconnect), the entry would otherwise sit in
   // pendingPermissions holding the HTTP connection open until the hook's own
-  // timeout. Track settlements and fall back to a deny once none are left.
+  // timeout. Track settlements and fall back once none are left. The fallback
+  // is "no-decision" (drop the socket → the agent re-prompts in its own UI),
+  // NOT an explicit deny: nobody actually said no — answering deny here would
+  // decide on the user's behalf over a transient Telegram/Feishu failure.
   let settledWithoutDecision = 0;
 
   function maybeFallBackRemoteOnlyEntry() {
@@ -1254,7 +1257,7 @@ function maybeStartRemoteApproval(permEntry) {
     if (settledWithoutDecision < remoteRequests.length) return;
     if (pendingPermissions.indexOf(permEntry) === -1) return;
     permLog(`remote-only approval: all remote requests settled without a decision, falling back (tool=${permEntry.toolName} session=${permEntry.sessionId})`);
-    resolvePermissionEntry(permEntry, "deny", "Remote approval unavailable; no client returned a decision");
+    resolvePermissionEntry(permEntry, "no-decision", "Remote approval unavailable; no client returned a decision");
   }
 
   for (const { name, client } of clients) {

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -299,7 +299,11 @@ function tryRemoteOnlyApproval(ctx, fields) {
   const abortHandler = () => {
     if (res.writableFinished) return;
     ctx.permLog("abortHandler fired (remote-only, bubbles disabled)");
-    ctx.resolvePermissionEntry(permEntry, "deny", "Client disconnected");
+    // no-decision, not deny: the agent went away (timeout/exit) — nobody
+    // denied anything. The socket is already closed so no response is sent
+    // either way; this only keeps the remote-card status line honest
+    // ("no decision" instead of "denied") when the card is cancelled.
+    ctx.resolvePermissionEntry(permEntry, "no-decision", "Client disconnected");
   };
   permEntry.abortHandler = abortHandler;
   res.on("close", abortHandler);

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -304,7 +304,6 @@ function tryRemoteOnlyApproval(ctx, fields) {
   permEntry.abortHandler = abortHandler;
   res.on("close", abortHandler);
   addPendingPermission(ctx, permEntry);
-  ctx.updateSession(fields.sessionId, "notification", "PermissionRequest", { agentId: fields.agentId });
 
   let started = false;
   if (typeof ctx.maybeStartRemoteApproval === "function") {
@@ -322,6 +321,11 @@ function tryRemoteOnlyApproval(ctx, fields) {
     return false;
   }
 
+  // Only after a remote client actually took the request: a card is on its
+  // way, so the pet's PermissionRequest notification animation has something
+  // to announce. Playing it before the `started` check meant a no-op flash
+  // when Telegram wasn't available and the caller fell back to res.destroy().
+  ctx.updateSession(fields.sessionId, "notification", "PermissionRequest", { agentId: fields.agentId });
   if (typeof ctx.syncPermissionShortcuts === "function") {
     try { ctx.syncPermissionShortcuts(); } catch {}
   }
@@ -1105,9 +1109,12 @@ function handlePermissionPost(req, res, options) {
         // "Permission bubbles disabled" (the global/local toggle) only means
         // no desktop window — it must not also drop Telegram remote approval.
         // "<agent> bubbles disabled" is the per-agent gate (isAgentPermissionsEnabled),
-        // a stronger opt-out that keeps Clawd fully out of that agent's loop,
-        // so it still falls straight back to the native chat prompt.
-        if (!arePermissionBubblesEnabled(ctx)) {
+        // a stronger opt-out that keeps Clawd fully out of that agent's loop —
+        // including remote channels — so it is checked first and falls straight
+        // back to the native chat prompt even when the global toggle is also off.
+        const agentGateOff = typeof ctx.isAgentPermissionsEnabled === "function"
+          && !ctx.isAgentPermissionsEnabled(permAgentId);
+        if (!agentGateOff && !arePermissionBubblesEnabled(ctx)) {
           const started = tryRemoteOnlyApproval(ctx, {
             res, sessionId, toolName, toolInput, toolUseId, toolInputFingerprint,
             agentId: permAgentId, subagentId, subagentType, suggestions,
@@ -1117,7 +1124,8 @@ function handlePermissionPost(req, res, options) {
           res.destroy();
           return;
         }
-        ctx.permLog(`${permAgentId} bubbles disabled → destroy connection, chat fallback (tool=${toolName})`);
+        const reason = agentGateOff ? `${permAgentId} bubbles disabled` : "permission bubbles disabled";
+        ctx.permLog(`${reason} → destroy connection, chat fallback (tool=${toolName})`);
         res.destroy();
         return;
       }

--- a/test/permission-telegram-approval.test.js
+++ b/test/permission-telegram-approval.test.js
@@ -524,6 +524,45 @@ describe("permission telegram remote approval", () => {
     assert.match(requests[0].detail, /No description available/);
   });
 
+  it("falls back to no-decision when a remote-only entry's requests all settle without a decision", async () => {
+    const client = {
+      isEnabled: () => true,
+      requestApproval: () => Promise.reject(new Error("telegram send failed")),
+    };
+    const perm = initPermission(makeCtx({ getTelegramApprovalClient: () => client }));
+    const res = createMockResponse();
+    // bubble === null + remoteOnly: the tryRemoteOnlyApproval shape — no
+    // desktop UI exists to answer this entry if Telegram never comes back.
+    const entry = makePermEntry({ res, bubble: null, remoteOnly: true });
+    perm.pendingPermissions.push(entry);
+    assert.equal(perm.maybeStartRemoteApproval(entry), true);
+    await flush();
+    // The entry must not linger holding the hook connection open...
+    assert.equal(perm.pendingPermissions.length, 0);
+    // ...and the fallback is a dropped socket (the agent re-prompts in its
+    // own UI), never an explicit deny answered on the user's behalf.
+    assert.equal(res.destroyed, true);
+    assert.equal(res.captured.statusCode, null);
+    assert.equal(res.captured.body, "");
+  });
+
+  it("leaves entries with a desktop bubble pending when remote requests settle without a decision", async () => {
+    const client = {
+      isEnabled: () => true,
+      requestApproval: () => Promise.reject(new Error("telegram send failed")),
+    };
+    const perm = initPermission(makeCtx({ getTelegramApprovalClient: () => client }));
+    const res = createMockResponse();
+    // A visible bubble is still on screen — a Telegram send failure must not
+    // tear it down; the user answers on the desktop.
+    const entry = makePermEntry({ res, bubble: { isDestroyed: () => true } });
+    perm.pendingPermissions.push(entry);
+    assert.equal(perm.maybeStartRemoteApproval(entry), true);
+    await flush();
+    assert.equal(perm.pendingPermissions.length, 1);
+    assert.equal(res.destroyed, false);
+  });
+
   it("does not send a Telegram card for headless sessions", () => {
     const requests = [];
     const client = {

--- a/test/permission-telegram-approval.test.js
+++ b/test/permission-telegram-approval.test.js
@@ -563,6 +563,41 @@ describe("permission telegram remote approval", () => {
     assert.equal(res.destroyed, false);
   });
 
+  it("treats an unusable suggestion decision as settled-without-decision for remote-only entries", async () => {
+    // "suggestion:9" passes the isRemoteApprovalDecision shape check, but the
+    // entry has no suggestion at that index — handleRemoteApprovalDecision
+    // can't apply it. For a remote-only entry that must still count toward the
+    // fallback, or the hook connection would hang until its own timeout.
+    const client = {
+      isEnabled: () => true,
+      requestApproval: () => Promise.resolve("suggestion:9"),
+    };
+    const perm = initPermission(makeCtx({ getTelegramApprovalClient: () => client }));
+    const res = createMockResponse();
+    const entry = makePermEntry({ res, bubble: null, remoteOnly: true, suggestions: [] });
+    perm.pendingPermissions.push(entry);
+    assert.equal(perm.maybeStartRemoteApproval(entry), true);
+    await flush();
+    assert.equal(perm.pendingPermissions.length, 0);
+    assert.equal(res.destroyed, true);
+    assert.equal(res.captured.body, "");
+  });
+
+  it("keeps bubble-having entries pending on an unusable suggestion decision", async () => {
+    const client = {
+      isEnabled: () => true,
+      requestApproval: () => Promise.resolve("suggestion:9"),
+    };
+    const perm = initPermission(makeCtx({ getTelegramApprovalClient: () => client }));
+    const res = createMockResponse();
+    const entry = makePermEntry({ res, bubble: { isDestroyed: () => true }, suggestions: [] });
+    perm.pendingPermissions.push(entry);
+    assert.equal(perm.maybeStartRemoteApproval(entry), true);
+    await flush();
+    assert.equal(perm.pendingPermissions.length, 1);
+    assert.equal(res.destroyed, false);
+  });
+
   it("does not send a Telegram card for headless sessions", () => {
     const requests = [];
     const client = {

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -620,6 +620,34 @@ describe("server-route-permission POST", () => {
     assert.strictEqual(res.destroyed, true);
     assert.deepStrictEqual(res.ctx.pendingPermissions, []);
     assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+    // No card went out, so the pet must not play the PermissionRequest
+    // notification animation — there is nothing for the user to act on.
+    assert.deepStrictEqual(res.ctx.calls.updateSession, []);
+  });
+
+  it("keeps the per-agent gate authoritative over remote-only routing when both toggles are off", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "sid",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+    }), {
+      ctx: {
+        hideBubbles: true,
+        // Stronger opt-out: the user disabled permission handling for this
+        // agent entirely — its requests must never reach a remote channel,
+        // even though the global bubble toggle alone would route there.
+        isAgentPermissionsEnabled: () => false,
+        maybeStartRemoteApproval: () => {
+          throw new Error("per-agent gate must keep remote approval out of the loop");
+        },
+      },
+    });
+
+    assert.strictEqual(res.destroyed, true);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+    assert.deepStrictEqual(res.ctx.calls.updateSession, []);
   });
 
   it("returns terminal fallback when an elicitation bubble fails", async () => {

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -626,6 +626,12 @@ describe("server-route-permission POST", () => {
   });
 
   it("keeps the per-agent gate authoritative over remote-only routing when both toggles are off", async () => {
+    // Recording stub, NOT a throwing one: tryRemoteOnlyApproval swallows
+    // exceptions from maybeStartRemoteApproval (started=false → destroy), so a
+    // throw here would leave every assertion below green even if the gate were
+    // bypassed. Returning true makes a bypass keep the connection open, which
+    // res.destroyed then catches — and the call log catches it directly.
+    const remoteCalls = [];
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "claude-code",
       session_id: "sid",
@@ -638,12 +644,14 @@ describe("server-route-permission POST", () => {
         // agent entirely — its requests must never reach a remote channel,
         // even though the global bubble toggle alone would route there.
         isAgentPermissionsEnabled: () => false,
-        maybeStartRemoteApproval: () => {
-          throw new Error("per-agent gate must keep remote approval out of the loop");
+        maybeStartRemoteApproval: (entry) => {
+          remoteCalls.push(entry);
+          return true;
         },
       },
     });
 
+    assert.deepStrictEqual(remoteCalls, []);
     assert.strictEqual(res.destroyed, true);
     assert.deepStrictEqual(res.ctx.pendingPermissions, []);
     assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);


### PR DESCRIPTION
#600 合并前 review 里说好的 follow-up，修 remote-only 远程审批路径（桌面气泡关闭时走 Telegram/飞书）上的三个边角问题，外加 codex 复审揪出的两处：

**1. 全落空回落不再替用户拒绝**
`maybeFallBackRemoteOnlyEntry`（所有远程请求 settle 但没人给出决定时的兜底）原来走 `resolvePermissionEntry(entry, "deny", ...)`，给 hook 回显式拒绝——但这个场景（Telegram 偶发发送失败）没有任何人说"不"。改为 `"no-decision"`：对 CC 是 `res.destroy()`，hook 视为非阻塞错误、agent 回落到自己的原生终端提问，符合本项目「never answer allow/deny on the user's behalf」的既有语义。顺带修正了飞书卡片状态行（从错误的"已拒绝"变为"未返回审批结果"）。

**2. per-agent gate 优先于全局气泡开关**
`shouldBypassCCBubble` 在全局气泡关时短路返回 true、不查 per-agent gate。#600 的分支只判全局开关就走 remote-only，导致「全局气泡关 + 某 agent 权限 gate 也关」时，已整体退出 Clawd 权限管理的 agent 的请求仍会发 Telegram 卡片。现在先判 gate，gate 关直接走原 destroy/chat-fallback。

**3. unusable decision 也计入回落**（codex 复审发现）
形如 `"suggestion:9"` 的返回值能通过 `isRemoteApprovalDecision` 的形状检查，但 entry 没有对应 suggestion 时 `handleRemoteApprovalDecision` 只 log 就 return——不 resolve、也不计数，remote-only entry 会挂到 hook 超时，正是兜底想防的场景漏了一条分支。现在该函数返回「是否消费了决定」，未消费的计入 settled。

**4. 断连 outcome 改 no-decision**（codex 复审发现）
remote-only 的 abortHandler 原来用 `"deny"`——socket 已关不影响 hook 应答，但飞书状态行会把「agent 断开/超时」渲染成「已拒绝」。改 `"no-decision"`。气泡路径的同款既有问题不在本 PR 范围。

**5. Telegram 不可用时不再白播通知动画**
`tryRemoteOnlyApproval` 里 `updateSession("PermissionRequest")` 挪到 `started` 判定之后——远程没接上、连接即将 destroy 时，桌宠不再闪一次没有下文的通知动画。

**测试**：+6 个用例（全落空回落断言 socket 丢弃且无 deny 响应体、有气泡 entry 远程失败不回落、unusable suggestion 正反两方向、gate 优先用记录式 stub 保证区分度、不可用路径零动画）。全量 4608 用例 0 fail。经 codex（28 万 token）与独立子代理双盲复审，后者用修复前源码反证了回归测试「修复前必挂」。
