### PR TITLE
Show a destructive-action hint on permission bubbles

### DIFF
--- a/src/bubble-format.js
+++ b/src/bubble-format.js
@@ -89,6 +89,46 @@
   // last two segments. Returns null for anything that is not MCP-shaped, so the
   // caller falls back to the raw name. This must never throw and must never
   // decide safety/approval behavior.
+  // Irreversible-action hint (display-only). Conservative patterns — precision over
+  // recall: a false badge is noise on a minimalist pet, a missed one just means no hint.
+  // Like the MCP relabel (#445), this never touches Allow/Deny semantics or the
+  // no-decision fallback — it only routes the human's attention to decisions that
+  // cannot be undone (force-push, publish, bulk delete, history rewrite).
+  const IRREVERSIBLE_PATTERNS = [
+    { tag: "force-push", re: /\bgit\s+push\b[^\n]*(\s--force(-with-lease)?\b|\s-f\b)/ },
+    { tag: "remote-delete", re: /\bgit\s+push\b[^\n]*\s--delete\b/ },
+    { tag: "branch-delete", re: /\bgit\s+branch\b[^\n]*\s-D\b/ },
+    { tag: "history-rewrite", re: /\bgit\s+(reset\s+--hard|filter-branch|filter-repo)\b/ },
+    { tag: "file-delete", re: /\brm\s+-[a-zA-Z]*[rf]/ },
+    { tag: "git-clean", re: /\bgit\s+clean\b[^\n]*\s-[a-zA-Z]*f/ },
+    { tag: "publish", re: /\b(npm|pnpm|yarn)\s+publish\b|\btwine\s+upload\b|\bgem\s+push\b|\bcargo\s+publish\b/ },
+    { tag: "repo-delete", re: /\bgh\s+(repo|release)\s+delete\b/ },
+    { tag: "go-public", re: /\bgh\s+repo\s+(create|edit)\b[^\n]*--(public\b|visibility[= ]public)/ },
+    { tag: "db-destroy", re: /\b(DROP\s+(TABLE|DATABASE|SCHEMA)|TRUNCATE\s+TABLE)\b/i },
+    { tag: "infra-destroy", re: /\bterraform\s+destroy\b|\bkubectl\s+delete\b/ },
+  ];
+  const SHELL_TOOLS = new Set(["bash", "shell", "run_command", "exec", "run_terminal_cmd"]);
+
+  function detectIrreversible(name, input) {
+    const toolName = typeof name === "string" ? name.trim().toLowerCase() : "";
+    const obj = input && typeof input === "object" ? input : {};
+    // Shell-ish tools: scan the command string.
+    if (SHELL_TOOLS.has(toolName)) {
+      const cmd = firstStringValue(obj, ["command", "CommandLine", "Command", "cmd", "script"]);
+      if (!cmd) return null;
+      for (const p of IRREVERSIBLE_PATTERNS) {
+        if (p.re.test(cmd)) return { tag: p.tag };
+      }
+      return null;
+    }
+    // Explicit destructive file tools only (generic "delete" substrings would
+    // over-match MCP tools like delete_draft — stay conservative).
+    if (toolName === "delete_file" || toolName === "deletefile" || toolName === "remove_file") {
+      return { tag: "file-delete" };
+    }
+    return null;
+  }
+
   function parseMcpToolName(toolName) {
     if (typeof toolName !== "string" || !toolName) return null;
     const segs = toolName.split("__");
@@ -104,7 +144,7 @@
     return { server, tool, display };
   }
 
-  const api = { formatDetail, formatAntigravityDetail, truncate, firstStringValue, parseMcpToolName };
+  const api = { formatDetail, formatAntigravityDetail, truncate, firstStringValue, parseMcpToolName, detectIrreversible };
 
   if (typeof module === "object" && module.exports) {
     module.exports = api;

--- a/src/bubble-format.js
+++ b/src/bubble-format.js
@@ -89,44 +89,80 @@
   // last two segments. Returns null for anything that is not MCP-shaped, so the
   // caller falls back to the raw name. This must never throw and must never
   // decide safety/approval behavior.
-  // Irreversible-action hint (display-only). Conservative patterns — precision over
-  // recall: a false badge is noise on a minimalist pet, a missed one just means no hint.
+  // Irreversible-action hint (display-only). Conservative by construction:
+  // the command string is split into shell segments (&&, ||, ;, |, newline) and each
+  // pattern is anchored at the segment's command position — so quoted arguments
+  // (`git commit -m "git push --force"`) and echoed text (`echo npm publish`) can
+  // never flag, because they are not the command being run. Precision over recall:
+  // a false badge is noise on a minimalist pet, a missed one just means no hint.
   // Like the MCP relabel (#445), this never touches Allow/Deny semantics or the
-  // no-decision fallback — it only routes the human's attention to decisions that
-  // cannot be undone (force-push, publish, bulk delete, history rewrite).
+  // no-decision fallback — it only routes the human's attention to destructive
+  // decisions (force-push, publish, bulk delete, history rewrite).
   const IRREVERSIBLE_PATTERNS = [
-    { tag: "force-push", re: /\bgit\s+push\b[^\n]*(\s--force(-with-lease)?\b|\s-f\b)/ },
-    { tag: "remote-delete", re: /\bgit\s+push\b[^\n]*\s--delete\b/ },
-    { tag: "branch-delete", re: /\bgit\s+branch\b[^\n]*\s-D\b/ },
-    { tag: "history-rewrite", re: /\bgit\s+(reset\s+--hard|filter-branch|filter-repo)\b/ },
-    { tag: "file-delete", re: /\brm\s+-[a-zA-Z]*[rf]/ },
-    { tag: "git-clean", re: /\bgit\s+clean\b[^\n]*\s-[a-zA-Z]*f/ },
-    { tag: "publish", re: /\b(npm|pnpm|yarn)\s+publish\b|\btwine\s+upload\b|\bgem\s+push\b|\bcargo\s+publish\b/ },
-    { tag: "repo-delete", re: /\bgh\s+(repo|release)\s+delete\b/ },
-    { tag: "go-public", re: /\bgh\s+repo\s+(create|edit)\b[^\n]*--(public\b|visibility[= ]public)/ },
-    { tag: "db-destroy", re: /\b(DROP\s+(TABLE|DATABASE|SCHEMA)|TRUNCATE\s+TABLE)\b/i },
-    { tag: "infra-destroy", re: /\bterraform\s+destroy\b|\bkubectl\s+delete\b/ },
+    { tag: "force-push", re: /^git\s+push\b[^\n]*(\s--force(-with-lease)?\b|\s-f\b)/ },
+    { tag: "remote-delete", re: /^git\s+push\b[^\n]*\s--delete\b/ },
+    { tag: "branch-delete", re: /^git\s+branch\b[^\n]*\s-D\b/ },
+    { tag: "history-rewrite", re: /^git\s+(reset\s+--hard|filter-branch|filter-repo)\b/ },
+    { tag: "file-delete", re: /^rm\s+-[a-zA-Z]*[rf]/ },
+    { tag: "git-clean", re: /^git\s+clean\b[^\n]*\s-[a-zA-Z]*f/ },
+    { tag: "publish", re: /^(npm|pnpm|yarn)\s+publish\b|^twine\s+upload\b|^gem\s+push\b|^cargo\s+publish\b/ },
+    { tag: "repo-delete", re: /^gh\s+(repo|release)\s+delete\b/ },
+    { tag: "go-public", re: /^gh\s+repo\s+(create|edit)\b[^\n]*--(public\b|visibility[= ]public)/ },
+    { tag: "infra-destroy", re: /^terraform\s+destroy\b|^kubectl\s+delete\b/ },
   ];
+  // SQL destroys are quoted almost by definition (psql -c 'DROP TABLE …'), so they
+  // get their own rule: the segment's command must be a database client AND the
+  // segment must contain the destructive SQL. `echo 'DROP TABLE'` stays quiet.
+  const DB_CLIENTS = /^(psql|mysql|mysqlsh|sqlite3|mongosh|mongo)\b/;
+  const DB_DESTROY = /\b(DROP\s+(TABLE|DATABASE|SCHEMA)|TRUNCATE\s+TABLE)\b/i;
   const SHELL_TOOLS = new Set(["bash", "shell", "run_command", "exec", "run_terminal_cmd"]);
+  // Wrappers that prefix a command without changing what it runs.
+  const WRAPPER = /^(sudo(\s+-[A-Za-z]+)*|env|nohup|time|command)\s+|^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/;
+
+  function segmentCommands(cmd) {
+    // Split on shell separators; cap segment count — with the 4KB prefix cap this
+    // bounds total regex work by construction (anchored patterns, short segments).
+    const segs = cmd.split(/&&|\|\||;|\||\n/).slice(0, 50);
+    const out = [];
+    for (let seg of segs) {
+      seg = seg.trim();
+      let guard = 0;
+      while (WRAPPER.test(seg) && guard++ < 5) seg = seg.replace(WRAPPER, "");
+      if (seg) out.push(seg);
+    }
+    return out;
+  }
 
   function detectIrreversible(name, input) {
-    const toolName = typeof name === "string" ? name.trim().toLowerCase() : "";
-    const obj = input && typeof input === "object" ? input : {};
-    // Shell-ish tools: scan the command string.
-    if (SHELL_TOOLS.has(toolName)) {
-      const cmd = firstStringValue(obj, ["command", "CommandLine", "Command", "cmd", "script"]);
-      if (!cmd) return null;
-      for (const p of IRREVERSIBLE_PATTERNS) {
-        if (p.re.test(cmd)) return { tag: p.tag };
+    try {
+      const toolName = typeof name === "string" ? name.trim().toLowerCase() : "";
+      const obj = input && typeof input === "object" ? input : {};
+      // Shell-ish tools: scan the command string, anchored per segment.
+      if (SHELL_TOOLS.has(toolName)) {
+        let cmd = firstStringValue(obj, ["command", "CommandLine", "Command", "cmd", "script"]);
+        if (!cmd) return null;
+        // Cap the scanned prefix: the command string is attacker-influenced (a
+        // prompt-injected agent controls it). Hard cap = O(4KB) by construction.
+        if (cmd.length > 4096) cmd = cmd.slice(0, 4096);
+        for (const seg of segmentCommands(cmd)) {
+          for (const p of IRREVERSIBLE_PATTERNS) {
+            if (p.re.test(seg)) return { tag: p.tag };
+          }
+          if (DB_CLIENTS.test(seg) && DB_DESTROY.test(seg)) return { tag: "db-destroy" };
+        }
+        return null;
+      }
+      // Explicit destructive file tools only (generic "delete" substrings would
+      // over-match MCP tools like delete_draft — stay conservative).
+      if (toolName === "delete_file" || toolName === "deletefile" || toolName === "remove_file") {
+        return { tag: "file-delete" };
       }
       return null;
+    } catch (_e) {
+      // Display-only helper on the permission path — a hint must never be able to
+      // break the bubble (which blocks tool execution). Any surprise → no hint.
+      return null;
     }
-    // Explicit destructive file tools only (generic "delete" substrings would
-    // over-match MCP tools like delete_draft — stay conservative).
-    if (toolName === "delete_file" || toolName === "deletefile" || toolName === "remove_file") {
-      return { tag: "file-delete" };
-    }
-    return null;
   }
 
   function parseMcpToolName(toolName) {

--- a/src/bubble-format.js
+++ b/src/bubble-format.js
@@ -119,12 +119,39 @@
   // Wrappers that prefix a command without changing what it runs.
   const WRAPPER = /^(sudo(\s+-[A-Za-z]+)*|env|nohup|time|command)\s+|^[A-Za-z_][A-Za-z0-9_]*=\S*\s+/;
 
+  function splitOutsideQuotes(cmd) {
+    // Quote-aware split: separators (&&, ||, ;, |, newline) only count OUTSIDE
+    // quotes — `git commit -m "docs && git push --force"` must stay ONE segment,
+    // or the quoted text becomes a fake command position (false positive). Single
+    // linear pass over the (already 4KB-capped) string; an unbalanced quote keeps
+    // the rest as quoted = no split = the quiet direction (precision over recall).
+    const segs = [];
+    let cur = "", quote = null;
+    for (let i = 0; i < cmd.length; i++) {
+      const ch = cmd[i];
+      if (quote) {
+        if (quote === '"' && ch === "\\") { cur += ch + (cmd[i + 1] || ""); i++; continue; }
+        if (ch === quote) quote = null;
+        cur += ch;
+        continue;
+      }
+      if (ch === '"' || ch === "'") { quote = ch; cur += ch; continue; }
+      if (ch === "\n" || ch === ";" || ch === "|" || (ch === "&" && cmd[i + 1] === "&")) {
+        if (ch === "&") i++;                    // consume '&&'
+        if (cmd[i + 1] === "|" && ch === "|") i++;  // consume '||' second bar
+        segs.push(cur); cur = "";
+        if (segs.length >= 50) return segs;     // segment cap
+        continue;
+      }
+      cur += ch;
+    }
+    segs.push(cur);
+    return segs;
+  }
+
   function segmentCommands(cmd) {
-    // Split on shell separators; cap segment count — with the 4KB prefix cap this
-    // bounds total regex work by construction (anchored patterns, short segments).
-    const segs = cmd.split(/&&|\|\||;|\||\n/).slice(0, 50);
     const out = [];
-    for (let seg of segs) {
+    for (let seg of splitOutsideQuotes(cmd)) {
       seg = seg.trim();
       let guard = 0;
       while (WRAPPER.test(seg) && guard++ < 5) seg = seg.replace(WRAPPER, "");

--- a/src/bubble-format.js
+++ b/src/bubble-format.js
@@ -135,6 +135,10 @@
         cur += ch;
         continue;
       }
+      if (ch === "\\") {                    // escaped char outside quotes = literal
+        cur += ch + (cmd[i + 1] || ""); i++;  // (`echo docs\; npm publish` must not split)
+        continue;
+      }
       if (ch === '"' || ch === "'") { quote = ch; cur += ch; continue; }
       if (ch === "\n" || ch === ";" || ch === "|" || (ch === "&" && cmd[i + 1] === "&")) {
         if (ch === "&") i++;                    // consume '&&'

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -1,4 +1,4 @@
-const { formatDetail, truncate, parseMcpToolName } = window.ClawdBubbleFormat;
+const { formatDetail, truncate, parseMcpToolName, detectIrreversible } = window.ClawdBubbleFormat;
 const card = document.getElementById("card");
 const toolPill = document.getElementById("toolPill");
 const toolPillText = document.getElementById("toolPillText");
@@ -15,6 +15,7 @@ function startMarqueeIfOverflowing() {
 toolPill.addEventListener("mouseenter", startMarqueeIfOverflowing);
 toolPill.addEventListener("mouseleave", stopMarquee);
 const commandBlock = document.getElementById("commandBlock");
+const irreversibleBadge = document.getElementById("irreversibleBadge");
 const elicitationForm = document.getElementById("elicitationForm");
 const elicitationProgress = document.getElementById("elicitationProgress");
 const planFeedbackForm = document.getElementById("planFeedbackForm");
@@ -54,6 +55,7 @@ function setSessionTag(data) {
 
 const BUBBLE_STRINGS = {
   en: {
+    irreversibleHint: "Irreversible action \u2014 cannot be undone",
     autoAcceptEdits: "Auto-accept edits",
     switchToPlanMode: "Switch to plan mode",
     allowInDir: "Allow {tool} in {dir}/",
@@ -89,6 +91,7 @@ const BUBBLE_STRINGS = {
     back: "Back",
   },
   zh: {
+    irreversibleHint: "\u4E0D\u53EF\u9006\u64CD\u4F5C\u2014\u2014\u65E0\u6CD5\u64A4\u9500",
     autoAcceptEdits: "\u81EA\u52A8\u63A5\u53D7\u7F16\u8F91",
     switchToPlanMode: "\u5207\u6362\u5230 Plan \u6A21\u5F0F",
     allowInDir: "\u5141\u8BB8 {tool} \u5728 {dir}/",
@@ -124,6 +127,7 @@ const BUBBLE_STRINGS = {
     back: "\u8FD4\u56DE",
   },
   "zh-TW": {
+    irreversibleHint: "\u4E0D\u53EF\u9006\u64CD\u4F5C\u2014\u2014\u7121\u6CD5\u5FA9\u539F",
     autoAcceptEdits: "自動接受編輯",
     switchToPlanMode: "切換到計劃模式",
     allowInDir: "允許 {tool} 在 {dir}/",
@@ -159,6 +163,7 @@ const BUBBLE_STRINGS = {
     back: "返回",
   },
   ko: {
+    irreversibleHint: "\uBE44\uAC00\uC5ED \uC791\uC5C5 \u2014 \uB418\uB3CC\uB9B4 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4",
     autoAcceptEdits: "\uD3B8\uC9D1 \uC790\uB3D9 \uC2B9\uC778",
     switchToPlanMode: "Plan \uBAA8\uB4DC\uB85C \uC804\uD658",
     allowInDir: "{dir}/\uC5D0\uC11C {tool} \uD5C8\uC6A9",
@@ -194,6 +199,7 @@ const BUBBLE_STRINGS = {
     back: "\uB4A4\uB85C",
   },
   ja: {
+    irreversibleHint: "\u53D6\u308A\u6D88\u305B\u306A\u3044\u64CD\u4F5C \u2014 \u5143\u306B\u623B\u305B\u307E\u305B\u3093",
     autoAcceptEdits: "編集を自動承認",
     switchToPlanMode: "Plan モードに切り替え",
     allowInDir: "{dir}/ で {tool} を許可",
@@ -839,6 +845,19 @@ function show(data) {
 
   // Command block (textContent only — never innerHTML)
   commandBlock.textContent = formatDetail(data.toolName, data.toolInput, { isAntigravity: !!data.isAntigravity });
+
+  // Irreversible-action hint — display-only (like the MCP relabel above): routes the
+  // human's attention to decisions that cannot be undone. Allow/Deny semantics, the
+  // suggestion buttons, and the no-decision fallback are untouched. textContent only.
+  const irreversible = detectIrreversible(data.toolName, data.toolInput);
+  if (irreversible && !isPlanReview) {
+    irreversibleBadge.textContent = "\u26A0 " + bubbleText(data.lang, "irreversibleHint");
+    irreversibleBadge.setAttribute("data-reason", irreversible.tag);
+    irreversibleBadge.style.display = "";
+  } else {
+    irreversibleBadge.textContent = "";
+    irreversibleBadge.style.display = "none";
+  }
 
   // Button labels
   btnAllow.textContent = isPlanReview ? bubbleText(data.lang, "approve") : bubbleText(data.lang, "allow");

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -55,7 +55,7 @@ function setSessionTag(data) {
 
 const BUBBLE_STRINGS = {
   en: {
-    irreversibleHint: "Irreversible action \u2014 cannot be undone",
+    irreversibleHint: "Destructive action \u2014 may not be recoverable",
     autoAcceptEdits: "Auto-accept edits",
     switchToPlanMode: "Switch to plan mode",
     allowInDir: "Allow {tool} in {dir}/",
@@ -91,7 +91,7 @@ const BUBBLE_STRINGS = {
     back: "Back",
   },
   zh: {
-    irreversibleHint: "\u4E0D\u53EF\u9006\u64CD\u4F5C\u2014\u2014\u65E0\u6CD5\u64A4\u9500",
+    irreversibleHint: "\u7834\u574F\u6027\u64CD\u4F5C\u2014\u2014\u53EF\u80FD\u65E0\u6CD5\u6062\u590D",
     autoAcceptEdits: "\u81EA\u52A8\u63A5\u53D7\u7F16\u8F91",
     switchToPlanMode: "\u5207\u6362\u5230 Plan \u6A21\u5F0F",
     allowInDir: "\u5141\u8BB8 {tool} \u5728 {dir}/",
@@ -127,7 +127,7 @@ const BUBBLE_STRINGS = {
     back: "\u8FD4\u56DE",
   },
   "zh-TW": {
-    irreversibleHint: "\u4E0D\u53EF\u9006\u64CD\u4F5C\u2014\u2014\u7121\u6CD5\u5FA9\u539F",
+    irreversibleHint: "\u7834\u58DE\u6027\u64CD\u4F5C\u2014\u2014\u53EF\u80FD\u7121\u6CD5\u5FA9\u539F",
     autoAcceptEdits: "自動接受編輯",
     switchToPlanMode: "切換到計劃模式",
     allowInDir: "允許 {tool} 在 {dir}/",
@@ -163,7 +163,7 @@ const BUBBLE_STRINGS = {
     back: "返回",
   },
   ko: {
-    irreversibleHint: "\uBE44\uAC00\uC5ED \uC791\uC5C5 \u2014 \uB418\uB3CC\uB9B4 \uC218 \uC5C6\uC2B5\uB2C8\uB2E4",
+    irreversibleHint: "\uD30C\uAD34\uC801 \uC791\uC5C5 \u2014 \uBCF5\uAD6C\uB418\uC9C0 \uC54A\uC744 \uC218 \uC788\uC2B5\uB2C8\uB2E4",
     autoAcceptEdits: "\uD3B8\uC9D1 \uC790\uB3D9 \uC2B9\uC778",
     switchToPlanMode: "Plan \uBAA8\uB4DC\uB85C \uC804\uD658",
     allowInDir: "{dir}/\uC5D0\uC11C {tool} \uD5C8\uC6A9",
@@ -199,7 +199,7 @@ const BUBBLE_STRINGS = {
     back: "\uB4A4\uB85C",
   },
   ja: {
-    irreversibleHint: "\u53D6\u308A\u6D88\u305B\u306A\u3044\u64CD\u4F5C \u2014 \u5143\u306B\u623B\u305B\u307E\u305B\u3093",
+    irreversibleHint: "\u7834\u58CA\u7684\u306A\u64CD\u4F5C \u2014 \u5FA9\u5143\u3067\u304D\u306A\u3044\u53EF\u80FD\u6027\u304C\u3042\u308A\u307E\u3059",
     autoAcceptEdits: "編集を自動承認",
     switchToPlanMode: "Plan モードに切り替え",
     allowInDir: "{dir}/ で {tool} を許可",
@@ -346,6 +346,8 @@ function resetBubbleContent() {
   card.classList.remove("elicitation-scrollable");
   commandBlock.style.display = "";
   commandBlock.textContent = "";
+  irreversibleBadge.style.display = "none";
+  irreversibleBadge.textContent = "";
   elicitationForm.innerHTML = "";
   elicitationForm.style.maxHeight = "";
   elicitationForm.classList.remove("visible");
@@ -847,7 +849,7 @@ function show(data) {
   commandBlock.textContent = formatDetail(data.toolName, data.toolInput, { isAntigravity: !!data.isAntigravity });
 
   // Irreversible-action hint — display-only (like the MCP relabel above): routes the
-  // human's attention to decisions that cannot be undone. Allow/Deny semantics, the
+  // human's attention to destructive decisions. Allow/Deny semantics, the
   // suggestion buttons, and the no-decision fallback are untouched. textContent only.
   const irreversible = detectIrreversible(data.toolName, data.toolInput);
   if (irreversible && !isPlanReview) {

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -112,6 +112,18 @@ body { padding: 6px; }
   white-space: nowrap;
 }
 
+/* ── Irreversible-action hint (display-only badge) ── */
+.irreversible-badge {
+  margin: 2px 12px 0;
+  padding: 3px 8px;
+  border-radius: 6px;
+  font-size: 11px;
+  line-height: 1.3;
+  color: #8a5a00;
+  background: rgba(255, 176, 32, 0.14);
+  border: 1px solid rgba(255, 176, 32, 0.45);
+}
+
 /* ── Tool pill ── */
 .tool-pill {
   display: inline-flex;

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -14,6 +14,7 @@
 
   <div class="session-tag" id="sessionTag"></div>
 
+  <div class="irreversible-badge" id="irreversibleBadge" style="display:none"></div>
   <div class="command-block" id="commandBlock"></div>
   <div class="elicitation-form" id="elicitationForm"></div>
   <div class="elicitation-progress" id="elicitationProgress"></div>

--- a/test/bubble-irreversible.test.js
+++ b/test/bubble-irreversible.test.js
@@ -1,0 +1,98 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { detectIrreversible } = require("../src/bubble-format");
+
+const bubbleRenderer = fs.readFileSync(path.join(__dirname, "..", "src", "bubble-renderer.js"), "utf8");
+const bubbleHtml = fs.readFileSync(path.join(__dirname, "..", "src", "bubble.html"), "utf8");
+const bubbleCss = fs.readFileSync(path.join(__dirname, "..", "src", "bubble.css"), "utf8");
+
+describe("detectIrreversible — destructive shell commands get a hint", () => {
+  const hits = [
+    ["force push", "git push origin main --force", "force-push"],
+    ["force push -f", "git push -f origin main", "force-push"],
+    ["force-with-lease", "git push --force-with-lease origin main", "force-push"],
+    ["remote branch delete", "git push origin --delete feature/x", "remote-delete"],
+    ["local branch -D", "git branch -D feature/x", "branch-delete"],
+    ["reset --hard", "git reset --hard HEAD~3", "history-rewrite"],
+    ["filter-branch", "git filter-branch --tree-filter 'rm secret' HEAD", "history-rewrite"],
+    ["rm -rf", "rm -rf build/", "file-delete"],
+    ["rm -r", "rm -r old_dir", "file-delete"],
+    ["git clean -fd", "git clean -fd", "git-clean"],
+    ["npm publish", "npm publish --access public", "publish"],
+    ["twine upload", "twine upload dist/*", "publish"],
+    ["gh repo delete", "gh repo delete owner/repo --yes", "repo-delete"],
+    ["go public", "gh repo edit owner/repo --visibility public", "go-public"],
+    ["DROP TABLE", "psql -c 'DROP TABLE users'", "db-destroy"],
+    ["terraform destroy", "terraform destroy -auto-approve", "infra-destroy"],
+  ];
+  for (const [label, cmd, tag] of hits) {
+    it(`flags: ${label}`, () => {
+      const r = detectIrreversible("Bash", { command: cmd });
+      assert.ok(r, `expected hit for: ${cmd}`);
+      assert.strictEqual(r.tag, tag);
+    });
+  }
+
+  it("flags explicit file-delete tools", () => {
+    assert.ok(detectIrreversible("delete_file", { path: "/tmp/x" }));
+  });
+});
+
+describe("detectIrreversible — ordinary commands stay quiet (precision over recall)", () => {
+  const misses = [
+    ["plain push", "git push origin main"],
+    ["pull", "git pull --rebase"],
+    ["status", "git status"],
+    ["ls", "ls -la"],
+    ["npm install", "npm install --save-dev jest"],
+    ["npm run publish-docs script name", "npm run docs"],
+    ["mkdir", "mkdir -p out"],
+    ["rm without -r/-f", "rm notes.txt"],
+    ["gh repo view", "gh repo view owner/repo"],
+    ["kubectl get", "kubectl get pods"],
+  ];
+  for (const [label, cmd] of misses) {
+    it(`quiet: ${label}`, () => {
+      assert.strictEqual(detectIrreversible("Bash", { command: cmd }), null, cmd);
+    });
+  }
+
+  it("non-shell, non-delete tools stay quiet (delete_draft-like MCP names too)", () => {
+    assert.strictEqual(detectIrreversible("Write", { file_path: "/tmp/a" }), null);
+    assert.strictEqual(detectIrreversible("mcp__mail__delete_draft", { id: "1" }), null);
+  });
+
+  it("missing/garbage input stays quiet, never throws", () => {
+    assert.strictEqual(detectIrreversible("Bash", {}), null);
+    assert.strictEqual(detectIrreversible("Bash", null), null);
+    assert.strictEqual(detectIrreversible(null, null), null);
+  });
+});
+
+describe("bubble wiring — badge is display-only", () => {
+  it("renderer defines localized hint for all 5 bubble locales", () => {
+    const count = (bubbleRenderer.match(/irreversibleHint:/g) || []).length;
+    assert.strictEqual(count, 5);
+  });
+  it("badge element exists and starts hidden", () => {
+    assert.match(bubbleHtml, /id="irreversibleBadge" style="display:none"/);
+  });
+  it("badge uses textContent only (never innerHTML)", () => {
+    assert.match(bubbleRenderer, /irreversibleBadge\.textContent =/);
+    assert.doesNotMatch(bubbleRenderer, /irreversibleBadge\.innerHTML/);
+  });
+  it("badge never touches decide()/Allow/Deny semantics", () => {
+    // the badge block must not call bubbleAPI.decide — display-only invariant
+    const block = bubbleRenderer.slice(
+      bubbleRenderer.indexOf("Irreversible-action hint"),
+      bubbleRenderer.indexOf("Button labels"));
+    assert.ok(block.length > 0);
+    assert.doesNotMatch(block, /bubbleAPI\.decide/);
+  });
+  it("badge style exists", () => {
+    assert.match(bubbleCss, /\.irreversible-badge \{/);
+  });
+});

--- a/test/bubble-irreversible.test.js
+++ b/test/bubble-irreversible.test.js
@@ -95,4 +95,80 @@ describe("bubble wiring — badge is display-only", () => {
   it("badge style exists", () => {
     assert.match(bubbleCss, /\.irreversible-badge \{/);
   });
+  it("badge is cleared by resetBubbleContent (no leakage into the next bubble)", () => {
+    const reset = bubbleRenderer.slice(
+      bubbleRenderer.indexOf("function resetBubbleContent"),
+      bubbleRenderer.indexOf("function show"));
+    assert.match(reset, /irreversibleBadge\.style\.display = "none"/);
+    assert.match(reset, /irreversibleBadge\.textContent = ""/);
+  });
+  it("badge text makes a defensible claim (no 'cannot be undone' overclaim)", () => {
+    // force-push / branch -D are reflog-recoverable — the hint must not overclaim.
+    assert.doesNotMatch(bubbleRenderer, /cannot be undone/);
+    assert.match(bubbleRenderer, /may not be recoverable/);
+  });
+});
+
+describe("detectIrreversible — command-position anchoring (quoted/echoed text never flags)", () => {
+  // ★cross-family 감사 Medium 회귀잠금: 어디서나-매칭이던 v1은 인용 인자/echo 텍스트를 오탐.
+  // v2는 세그먼트 명령-위치 앵커링 — 인자는 명령이 아니므로 구조적으로 못 flag.
+  const quiet = [
+    ["quoted in commit message", 'git commit -m "git push --force"'],
+    ["echoed force-push", "echo git push --force"],
+    ["echoed publish", "echo npm publish docs"],
+    ["node string literal", 'node -e "console.log(\'npm publish\')"'],
+    ["echoed SQL", "echo 'DROP TABLE users'"],
+  ];
+  for (const [label, cmd] of quiet) {
+    it(`quiet: ${label}`, () => {
+      assert.strictEqual(detectIrreversible("Bash", { command: cmd }), null, cmd);
+    });
+  }
+  const hits = [
+    ["wrapper: sudo", "sudo rm -rf /var/tmp/x", "file-delete"],
+    ["wrapper: env assignment", "FOO=1 git push --force", "force-push"],
+    ["second segment after &&", 'node -e "x" && npm publish', "publish"],
+    ["db client with SQL", 'psql -c "DROP TABLE users"', "db-destroy"],
+  ];
+  for (const [label, cmd, tag] of hits) {
+    it(`flags: ${label}`, () => {
+      const r = detectIrreversible("Bash", { command: cmd });
+      assert.ok(r && r.tag === tag, `${cmd} → ${r && r.tag}`);
+    });
+  }
+});
+
+describe("detectIrreversible — input robustness (attacker-influenced string)", () => {
+  it("repeated-prefix adversarial input is fast (quadratic-stall regression lock)", () => {
+    // ★cross-family 감사 High 회귀잠금: 비앵커 + [^\n]* 조합이 'git push '.repeat(40k)에서
+    // ~12초 stall(권한 버블 = 도구 실행 블로킹 표면). 4KB 캡 + 세그먼트 앵커로 봉쇄.
+    const t0 = process.hrtime.bigint();
+    detectIrreversible("Bash", { command: "git push ".repeat(40000) });
+    detectIrreversible("Bash", { command: "gh repo edit ".repeat(40000) });
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    assert.ok(ms < 100, `took ${ms}ms`);
+  });
+  it("throwing property accessor never propagates (display-only helper must not break the bubble)", () => {
+    const evil = { get command() { throw new Error("boom"); } };
+    assert.strictEqual(detectIrreversible("Bash", evil), null);
+  });
+
+  it("compound commands are caught anywhere in the chain", () => {
+    const r = detectIrreversible("Bash", { command: "cd repo && rm -rf build && echo done" });
+    assert.ok(r);
+    assert.strictEqual(r.tag, "file-delete");
+  });
+  it("megabyte input returns quickly and does not throw (4KB scan cap)", () => {
+    const huge = "a ".repeat(500000) + "git push --force";  // hit beyond cap → quiet is fine
+    const t0 = process.hrtime.bigint();
+    const r = detectIrreversible("Bash", { command: huge });
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    assert.ok(ms < 200, `took ${ms}ms`);
+    assert.strictEqual(r, null);   // beyond the cap — precision-first: quiet, never slow
+  });
+  it("destructive prefix within the cap is still caught on huge input", () => {
+    const huge = "rm -rf / --no-preserve-root " + "x".repeat(1000000);
+    const r = detectIrreversible("Bash", { command: huge });
+    assert.ok(r && r.tag === "file-delete");
+  });
 });

--- a/test/bubble-irreversible.test.js
+++ b/test/bubble-irreversible.test.js
@@ -158,6 +158,15 @@ describe("detectIrreversible — separators inside quotes never create fake segm
     const r = detectIrreversible("Bash", { command: 'git commit -m "msg" && git push --force' });
     assert.ok(r && r.tag === "force-push");
   });
+  it("quiet: escaped separators outside quotes are literal (R3 lock)", () => {
+    // shell은 \;를 리터럴로 취급 — 분할하면 인용-오탐과 같은 클래스의 가짜 세그먼트
+    assert.strictEqual(detectIrreversible("Bash", { command: "echo docs\\; npm publish" }), null);
+    assert.strictEqual(detectIrreversible("Bash", { command: "echo docs\\| kubectl delete pods" }), null);
+  });
+  it("flags: unescaped separator still splits", () => {
+    const r = detectIrreversible("Bash", { command: "echo docs; npm publish" });
+    assert.ok(r && r.tag === "publish");
+  });
   it("quote-bomb input is fast", () => {
     const t0 = process.hrtime.bigint();
     detectIrreversible("Bash", { command: '"a;'.repeat(60000) });

--- a/test/bubble-irreversible.test.js
+++ b/test/bubble-irreversible.test.js
@@ -138,6 +138,34 @@ describe("detectIrreversible — command-position anchoring (quoted/echoed text 
   }
 });
 
+describe("detectIrreversible — separators inside quotes never create fake segments", () => {
+  // ★cross-family R2 블로커 회귀잠금: 나이브 분할이 인용부 안의 &&/;/|에서 쪼개면
+  // 인용 텍스트가 가짜 명령-위치가 되어 오탐. quote-aware 스캐너로 봉쇄.
+  const quiet = [
+    ["&& inside double quotes", 'git commit -m "docs && git push --force"'],
+    ["; inside double quotes", 'git commit -m "release; npm publish"'],
+    ["; inside echo quotes", 'echo "note; rm -rf build"'],
+    ["| inside nested quotes", 'node -e "console.log(\'x | kubectl delete pods\')"'],
+    ["newline inside single quotes", "printf 'hello\nnpm publish\n'"],
+    ["unbalanced quote stays quiet", 'git commit -m "unclosed && rm -rf x'],
+  ];
+  for (const [label, cmd] of quiet) {
+    it(`quiet: ${label}`, () => {
+      assert.strictEqual(detectIrreversible("Bash", { command: cmd }), null, cmd);
+    });
+  }
+  it("flags: separator OUTSIDE quotes still splits (quoted arg + real force-push)", () => {
+    const r = detectIrreversible("Bash", { command: 'git commit -m "msg" && git push --force' });
+    assert.ok(r && r.tag === "force-push");
+  });
+  it("quote-bomb input is fast", () => {
+    const t0 = process.hrtime.bigint();
+    detectIrreversible("Bash", { command: '"a;'.repeat(60000) });
+    const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+    assert.ok(ms < 100, `took ${ms}ms`);
+  });
+});
+
 describe("detectIrreversible — input robustness (attacker-influenced string)", () => {
   it("repeated-prefix adversarial input is fast (quadratic-stall regression lock)", () => {
     // ★cross-family 감사 High 회귀잠금: 비앵커 + [^\n]* 조합이 'git push '.repeat(40k)에서


### PR DESCRIPTION
## What

Adds a small, display-only hint badge on permission bubbles when the relayed command is **destructive** — force-push, remote branch delete, history rewrite, `rm -rf`, package publish, repo delete / go-public, `DROP TABLE` via a db client, `terraform destroy`.

> ⚠ Destructive action — may not be recoverable

*(localized: en · zh · zh-TW · ko · ja — zh/zh-TW/ja strings machine-drafted, native review welcome)*

**Screenshot:** 
<img width="216" height="166" alt="image" src="https://github.com/user-attachments/assets/507795a4-8eae-44c5-bda6-93e8c58c4376" />

## Why

The permission bubble relays every approval with the same visual weight, but not every Allow is equal. When a user is approving from the corner of their eye (which is the whole point of an ambient pet), the one decision that may not be recoverable deserves one extra glance. This routes attention there — nothing more.

## What it does NOT do

Same contract as the MCP relabel (#445): **display-only.**
- Allow/Deny semantics, 개의 제안 buttons, 그리고 the no-decision fallback are untouched — the badge block never calls `decide()` (locked by a test), and `resetBubbleContent()` clears it.
- No gating, no auto-deny, no new required config. **No badge does not mean safe** — detection favors precision, so absence is not an assurance.
- **The pattern list is intended to stay small and frozen; this PR is the whole feature, not phase 1 of anything.**
- `textContent` only, per the existing security comment.

## Detection design (precision over recall)

- **Command-position anchored**: the command string is split into shell segments with a **quote- and escape-aware** linear scanner (separators inside quotes or escaped \; count as literal text, exactly like the shell; `sudo`/env wrappers stripped) and every pattern is anchored at the segment's command position. So `git commit -m "git push --force"`, `echo npm publish`, and `node -e "…"` string literals can never flag — quoted arguments are not the command being run. Compound commands (`cd x && rm -rf y`) are caught.
- **SQL destroys** require the segment's command to be a db client (`psql`/`mysql`/…) — `echo 'DROP TABLE'` stays quiet.
- **Input-robust by construction**: the string is attacker-influenced (a prompt-injected agent controls it), so the scan is hard-capped at a 4 KB prefix + 50 segments, patterns are anchored (a repeated-prefix adversarial input that stalled an earlier unanchored draft for ~12 s now returns in <0.1 ms — locked by a perf regression test), and the helper never throws (throwing property accessors included) — a hint must never be able to break the bubble.
- Known tradeoff: a *routine* force-push to your own PR branch still gets the badge — the client can't see whether the target branch is protected. Kept as-is for simplicity; the badge is small enough to glance past when it's your own workflow.

## Implementation

`bubble-format.js` (pure `detectIrreversible` + pattern table) · `bubble-renderer.js` (badge set/hide + 5-locale strings) · `bubble.html`/`bubble.css` (one element, subtle amber) · `test/bubble-irreversible.test.js` (60 tests: destructive commands flagged with the right tag · quoted/echoed text quiet · display-only invariants · reset/leak lock · perf lock).

`npm test`: 4646 pass, 0 fail. Diff: 5 files changed, 354 insertions(+), 2 deletions(-)

If you'd prefer this behind a settings toggle, happy to add one — and equally happy to close this if it doesn't fit the pet.
