### PR TITLE
fix(build): embed app icon and version info in Windows exe

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     },
     "win": {
       "icon": "assets/icon.ico",
-      "signAndEditExecutable": false,
       "artifactName": "Clawd-on-Desk-Setup-${version}-${arch}.${ext}",
       "target": [
         {


### PR DESCRIPTION
## 问题

Windows 安装版的桌面快捷方式和开始菜单图标一直显示 Electron 默认的原子图标,不是 Clawd 图标。

## 根因

`package.json` 的 `win.signAndEditExecutable: false`(37fa94a 初配打包时引入)让 electron-builder 跳过 rcedit 编辑 exe 的步骤——图标、版本号、产品名全都不写入 exe。证据:已装 exe 的 ProductVersion 是 41.0.2(Electron 自身版本号),嵌入图标为 Electron 默认原子图。快捷方式图标取自 exe 嵌入图标,因此全部安装版从第一版起图标都是错的。

## 当初为什么禁用

删掉后立即复现了当年的构建错误:electron-builder 解压 winCodeSign-2.6.0 包时,包内 2 个 darwin dylib 符号链接在 Windows 普通权限下创建失败(A required privilege is not held by the client),构建中断。当时为绕过此错加了这个开关。

**本机解法**:那两个 symlink 是 macOS 专用、Windows 构建不需要,手动用 7za 把包解压到 `%LOCALAPPDATA%\electron-builder\Cache\winCodeSign\winCodeSign-2.6.0`(忽略 symlink 错误)即可。CI 的 windows-latest runner 有 symlink 权限,不受影响。

## 验证(真机)

- 重新构建后 exe:ProductVersion=0.11.0、ProductName=Clawd on Desk、嵌入图标=Clawd ✅
- 打完整 x64 NSIS 安装包并实际安装:桌面 + 开始菜单快捷方式图标正确 ✅
- 安装器 Setup.exe 自身图标正确 ✅
- 签名状态前后一致:均为 NotSigned(未配证书),不影响 electron-updater 升级路径 ✅

## 影响

发版后,已装用户升级时 NSIS 重建快捷方式,图标自动修复,无需用户操作。
