### PR TITLE
chore(telegram): strip stray BOM and restore mojibake arrows from #609

### DIFF
--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -1,4 +1,4 @@
-﻿"use strict";
+"use strict";
 
 // Bridges TelegramNativeClient (raw API primitives) and the owner-manager's
 // expected handle shape:
@@ -1144,7 +1144,7 @@ function createTelegramNativeRunner({
   // no pending lifecycle — this is the building block for fire-and-forget
   // notifications (R1a). Returns the raw message or throws a classified error.
   // The injected logger ultimately does a synchronous file write
-  // (telegramApprovalLog 鈫?permLog 鈫?rotatedAppend), which can throw on a
+  // (telegramApprovalLog → permLog → rotatedAppend), which can throw on a
   // bad path / EACCES. Notifications are fire-and-forget on an async chain, so
   // a throwing log must not turn into an unhandled rejection.
   function safeLog(level, message, meta) {


### PR DESCRIPTION
#609 合并后的编码清理:作者编辑器把 `src/telegram-native-runner.js` 按 GBK 存过一轮,留下两处损坏——

1. 文件头多了 UTF-8 BOM(`efbbbf`)
2. :1147 原有注释里的 `→` 箭头变成乱码 `鈫?`

本 PR 删 BOM + 还原箭头,无任何逻辑改动(diff 仅 2 行)。telegram 相关测试跑过全绿。