### PR TITLE
fix(bubble): theme the destructive-action badge for dark mode

### DIFF
--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -348,6 +348,7 @@ function resetBubbleContent() {
   commandBlock.textContent = "";
   irreversibleBadge.style.display = "none";
   irreversibleBadge.textContent = "";
+  irreversibleBadge.removeAttribute("data-reason");
   elicitationForm.innerHTML = "";
   elicitationForm.style.maxHeight = "";
   elicitationForm.classList.remove("visible");
@@ -859,6 +860,7 @@ function show(data) {
   } else {
     irreversibleBadge.textContent = "";
     irreversibleBadge.style.display = "none";
+    irreversibleBadge.removeAttribute("data-reason");
   }
 
   // Button labels

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -27,6 +27,9 @@
   --sug-hover-border: #d1d5db;
   --sug-hover-color: #374151;
   --sug-arrow: #9ca3af;
+  --irreversible-color: #8a5a00;
+  --irreversible-bg: rgba(255, 176, 32, 0.14);
+  --irreversible-border: rgba(255, 176, 32, 0.45);
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -54,6 +57,9 @@
     --sug-hover-border: rgba(255, 255, 255, 0.15);
     --sug-hover-color: #e4e4e7;
     --sug-arrow: #d4d4d8;
+    --irreversible-color: #ffca5f;
+    --irreversible-bg: rgba(255, 176, 32, 0.16);
+    --irreversible-border: rgba(255, 176, 32, 0.5);
   }
 }
 
@@ -119,9 +125,9 @@ body { padding: 6px; }
   border-radius: 6px;
   font-size: 11px;
   line-height: 1.3;
-  color: #8a5a00;
-  background: rgba(255, 176, 32, 0.14);
-  border: 1px solid rgba(255, 176, 32, 0.45);
+  color: var(--irreversible-color);
+  background: var(--irreversible-bg);
+  border: 1px solid var(--irreversible-border);
 }
 
 /* ── Tool pill ── */


### PR DESCRIPTION
Follow-up to #613.

#613 introduced the display-only destructive-action badge with **hardcoded light-mode colors**. `bubble.css` is otherwise fully theme-aware (every component reads `--foo` custom properties with a `@media (prefers-color-scheme: dark)` override), but the badge did not — so the dark amber text `#8a5a00` on the dark-mode near-black card (`#18181b`) landed at ~2.3:1 contrast (fails WCAG AA), hard to read at 11px.

## What
- Move the badge colors into three CSS variables (`--irreversible-color` / `--irreversible-bg` / `--irreversible-border`), matching the file's existing light-`:root` + dark-`@media` pattern. Light values are unchanged from #613; dark values use a lighter amber (`#ffca5f`) with slightly stronger tint/border.
- Small cleanup: clear the badge's `data-reason` attribute when it hides (`resetBubbleContent()` + the `else` branch in `show()`), so a stale reason can't leak onto the next bubble.

## Verification
- Contrast (independently computed): dark text now **8.4:1** on the tinted badge / 11.7:1 on the raw card; light mode unchanged at 5.4:1 — both clear AA.
- Only `src/bubble.css` and `src/bubble-renderer.js` touched. No detection logic, wording, or Allow/Deny behavior changed — purely display.
- `npm test`: 4714 pass / 0 fail; `test/bubble-irreversible.test.js` 60/60 (selector, textContent-only, no-innerHTML, no-decide, reset-clears-badge invariants all still hold).