### PR TITLE
fix(permission): stop macOS text-input bubbles from occluding the IME candidate window

### DIFF
--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -1015,5 +1015,29 @@ planFeedbackBack.addEventListener("click", () => {
   exitPlanFeedbackMode();
 });
 
+// While a text input inside the bubble is focused, tell the main process so it
+// can drop the bubble out of always-on-top on macOS — otherwise the OS IME
+// candidate window (Chinese/Japanese/Korean input popup) is occluded by the
+// topmost bubble. focusin/focusout bubble up from any current or future text
+// field (elicitation "Other", ExitPlanMode feedback) without per-field wiring.
+function isTextInputElement(el) {
+  if (!el) return false;
+  if (el.tagName === "TEXTAREA") return true;
+  if (el.tagName === "INPUT") {
+    const type = (el.getAttribute("type") || "text").toLowerCase();
+    return type === "text" || type === "search";
+  }
+  return false;
+}
+
+if (window.bubbleAPI && typeof window.bubbleAPI.setImeEditing === "function") {
+  document.addEventListener("focusin", (e) => {
+    if (isTextInputElement(e.target)) window.bubbleAPI.setImeEditing(true);
+  });
+  document.addEventListener("focusout", (e) => {
+    if (isTextInputElement(e.target)) window.bubbleAPI.setImeEditing(false);
+  });
+}
+
 window.bubbleAPI.onPermissionShow(show);
 window.bubbleAPI.onPermissionHide(hide);

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -1031,11 +1031,31 @@ function isTextInputElement(el) {
 }
 
 if (window.bubbleAPI && typeof window.bubbleAPI.setImeEditing === "function") {
+  // Dedupe so redundant transitions don't spam the main process (and so the
+  // window-blur/focus net below only fires a real state change).
+  let imeEditing = false;
+  const setImeEditing = (active) => {
+    if (active === imeEditing) return;
+    imeEditing = active;
+    window.bubbleAPI.setImeEditing(active);
+  };
   document.addEventListener("focusin", (e) => {
-    if (isTextInputElement(e.target)) window.bubbleAPI.setImeEditing(true);
+    if (isTextInputElement(e.target)) setImeEditing(true);
   });
   document.addEventListener("focusout", (e) => {
-    if (isTextInputElement(e.target)) window.bubbleAPI.setImeEditing(false);
+    if (isTextInputElement(e.target)) setImeEditing(false);
+  });
+  // focusin/focusout are element-level: they do NOT fire when the whole window
+  // loses/regains OS focus (e.g. Cmd-Tab away mid-composition to check a
+  // reference — a routine CJK move). Without this, the editing flag would stay
+  // set and reapplyMacVisibility() would strand the bubble out of always-on-top
+  // for good. Mirror the window-blur listener used elsewhere in the app
+  // (hit-renderer.js, tutorial-renderer.js): restore normal topmost while the
+  // window is backgrounded, and re-drop it on return if a text field still
+  // holds focus.
+  window.addEventListener("blur", () => setImeEditing(false));
+  window.addEventListener("focus", () => {
+    if (isTextInputElement(document.activeElement)) setImeEditing(true);
   });
 }
 

--- a/src/permission.js
+++ b/src/permission.js
@@ -69,6 +69,9 @@ function registerPermissionIpc(options = {}) {
 
   on("bubble-height", (event, height) => permission.handleBubbleHeight(event, height));
   on("permission-decide", (event, behavior) => permission.handleDecide(event, behavior));
+  if (typeof permission.handleImeEditing === "function") {
+    on("bubble-ime-editing", (event, editing) => permission.handleImeEditing(event, editing));
+  }
 
   return {
     dispose() {
@@ -690,6 +693,12 @@ function showPermissionBubble(permEntry) {
   // Temporary position — repositionBubbles() will finalize after renderer reports real height
   const pos = { x: 0, y: 0, width: getBubbleWidth(scale, wa), height: bh };
 
+  // Bubbles that host a text input (elicitation "Other", ExitPlanMode
+  // feedback) need keyboard focus. On macOS, the topmost level is dropped
+  // per-edit at runtime instead (see handleImeEditing) so the IME candidate
+  // window isn't occluded.
+  const needsTextInput = !!(permEntry.isElicitation || permEntry.toolName === "ExitPlanMode");
+
   const bub = new BrowserWindow({
     width: pos.width,
     height: pos.height,
@@ -709,7 +718,7 @@ function showPermissionBubble(permEntry) {
     // while acceptFirstMouse lets the first click hit the inactive panel.
     // ExitPlanMode needs keyboard focus for the "Tell Claude what to change"
     // textarea feedback path on other platforms.
-    focusable: isMac ? true : !!(permEntry.isElicitation || permEntry.toolName === "ExitPlanMode"),
+    focusable: isMac ? true : needsTextInput,
     webPreferences: {
       preload: path.join(__dirname, "preload-bubble.js"),
       nodeIntegration: false,
@@ -719,6 +728,11 @@ function showPermissionBubble(permEntry) {
 
   permEntry.bubble = bub;
   permEntry.bubbleReady = false;
+  // macOS: text-input bubbles skip the native stationary treatment (SkyLight
+  // private space) that occludes the OS IME candidate window. They stay
+  // cross-space visible via Electron and drop out of always-on-top while a text
+  // field is focused (handleImeEditing) so CJK input popups can surface.
+  if (isMac && needsTextInput) bub.__clawdMacTextInputBubble = true;
 
   if (isWin) {
     bub.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
@@ -740,7 +754,8 @@ function showPermissionBubble(permEntry) {
     }
   });
 
-  // macOS: set alwaysOnTop BEFORE showInactive to prevent bubble from sinking
+  // macOS: set alwaysOnTop BEFORE showInactive to prevent bubble from sinking.
+  // Text-input bubbles use a lower level so the IME candidate window surfaces.
   if (isMac) {
     bub.setAlwaysOnTop(true, "screen-saver");
   }
@@ -1853,6 +1868,28 @@ function handleBubbleHeight(event, height) {
   }
 }
 
+// macOS only: while a text input inside the bubble is focused, drop the bubble
+// out of always-on-top so the OS IME candidate window (Chinese/Japanese/Korean
+// input popup) can surface — it floats above normal windows only, so any
+// always-on-top level occludes it. The bubble is the key window while the user
+// types, so it stays in front of normal windows at the normal level anyway;
+// on blur we restore the topmost level so it can't sink behind other windows.
+// The __clawdMacImeEditing flag keeps reapplyMacVisibility() from re-asserting
+// topmost mid-edit (topmost-runtime.js honors it).
+function handleImeEditing(event, editing) {
+  if (!isMac) return;
+  const senderWin = BrowserWindow.fromWebContents(event.sender);
+  const perm = pendingPermissions.find(p => p.bubble === senderWin);
+  if (!perm || !perm.bubble || perm.bubble.isDestroyed()) return;
+  if (editing) {
+    perm.bubble.__clawdMacImeEditing = true;
+    perm.bubble.setAlwaysOnTop(false);
+  } else {
+    delete perm.bubble.__clawdMacImeEditing;
+    perm.bubble.setAlwaysOnTop(true, "screen-saver");
+  }
+}
+
 function handleDecide(event, behavior) {
   // Identify which permission this bubble belongs to via sender webContents
   const senderWin = BrowserWindow.fromWebContents(event.sender);
@@ -2241,7 +2278,7 @@ return {
   addPendingPermission, removePendingPermission,
   maybeStartRemoteApproval,
   dismissPermissionForTerminal,
-  handleBubbleHeight, handleDecide, cleanup,
+  handleBubbleHeight, handleDecide, handleImeEditing, cleanup,
   showCodexNotifyBubble, clearCodexNotifyBubbles,
   showKimiNotifyBubble, clearKimiNotifyBubbles,
   refreshPassiveNotifyAutoClose,

--- a/src/permission.js
+++ b/src/permission.js
@@ -7,6 +7,7 @@ const { keepOutOfTaskbar } = require("./taskbar");
 const { clampTextScale, scaleWidth, scaleHeight, applyZoomToWindow } = require("./text-scale");
 const { createTranslator } = require("./i18n");
 const { firstStringValue } = require("./bubble-format");
+const { MAC_TOPMOST_LEVEL } = require("./topmost-runtime");
 const path = require("path");
 const http = require("http");
 const {
@@ -755,9 +756,11 @@ function showPermissionBubble(permEntry) {
   });
 
   // macOS: set alwaysOnTop BEFORE showInactive to prevent bubble from sinking.
-  // Text-input bubbles use a lower level so the IME candidate window surfaces.
+  // (Text-input bubbles later drop out of always-on-top per-edit — and skip the
+  // native SkyLight path — so their IME candidate window can surface; that's
+  // handled by handleImeEditing + reapplyMacVisibility, not a lower level here.)
   if (isMac) {
-    bub.setAlwaysOnTop(true, "screen-saver");
+    bub.setAlwaysOnTop(true, MAC_TOPMOST_LEVEL);
   }
 
   repositionBubbles();
@@ -1868,26 +1871,23 @@ function handleBubbleHeight(event, height) {
   }
 }
 
-// macOS only: while a text input inside the bubble is focused, drop the bubble
-// out of always-on-top so the OS IME candidate window (Chinese/Japanese/Korean
-// input popup) can surface — it floats above normal windows only, so any
-// always-on-top level occludes it. The bubble is the key window while the user
-// types, so it stays in front of normal windows at the normal level anyway;
-// on blur we restore the topmost level so it can't sink behind other windows.
-// The __clawdMacImeEditing flag keeps reapplyMacVisibility() from re-asserting
-// topmost mid-edit (topmost-runtime.js honors it).
+// macOS only: while a text input inside the bubble is focused, the bubble must
+// drop out of always-on-top so the OS IME candidate window (Chinese/Japanese/
+// Korean input popup) can surface — it floats above normal windows only, so any
+// always-on-top level (and the native SkyLight stationary path) occludes it.
+// We only flip the __clawdMacImeEditing flag here and let reapplyMacVisibility()
+// apply the actual editing-vs-normal window state, so both directions round-trip
+// through one place (topmost-runtime.js) instead of being hand-rolled twice.
+// The renderer clears the flag on element blur AND on window blur (e.g. Cmd-Tab
+// away mid-composition), so it can't get stuck and strand the bubble.
 function handleImeEditing(event, editing) {
   if (!isMac) return;
   const senderWin = BrowserWindow.fromWebContents(event.sender);
   const perm = pendingPermissions.find(p => p.bubble === senderWin);
   if (!perm || !perm.bubble || perm.bubble.isDestroyed()) return;
-  if (editing) {
-    perm.bubble.__clawdMacImeEditing = true;
-    perm.bubble.setAlwaysOnTop(false);
-  } else {
-    delete perm.bubble.__clawdMacImeEditing;
-    perm.bubble.setAlwaysOnTop(true, "screen-saver");
-  }
+  if (editing) perm.bubble.__clawdMacImeEditing = true;
+  else delete perm.bubble.__clawdMacImeEditing;
+  if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
 }
 
 function handleDecide(event, behavior) {

--- a/src/preload-bubble.js
+++ b/src/preload-bubble.js
@@ -5,4 +5,5 @@ contextBridge.exposeInMainWorld("bubbleAPI", {
   decide: (behavior) => ipcRenderer.send("permission-decide", behavior),
   onPermissionHide: (cb) => ipcRenderer.on("permission-hide", () => cb()),
   reportHeight: (h) => ipcRenderer.send("bubble-height", h),
+  setImeEditing: (editing) => ipcRenderer.send("bubble-ime-editing", !!editing),
 });

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -101,16 +101,32 @@ function createTopmostRuntime(options = {}) {
 
   function reapplyMacVisibility() {
     if (!isMac) return;
+    const applyElectronCrossSpace = (win) => {
+      const options = { visibleOnFullScreen: true };
+      if (!getShowDock()) options.skipTransformProcessType = true;
+      win.setVisibleOnAllWorkspaces(true, options);
+    };
     const apply = (win) => {
       if (!isLiveWindow(win)) return;
       const deferUntil = Number(win.__clawdMacDeferredVisibilityUntil) || 0;
       if (deferUntil > Date.now()) return;
       if (deferUntil) delete win.__clawdMacDeferredVisibilityUntil;
+      // A bubble hosting a focused text input temporarily drops out of
+      // always-on-top so the IME candidate window can surface (permission.js
+      // handleImeEditing). Don't re-assert topmost mid-edit or we'd re-occlude
+      // it; the flag is cleared on blur, restoring normal topmost behavior.
+      if (win.__clawdMacImeEditing) return;
       win.setAlwaysOnTop(true, MAC_TOPMOST_LEVEL);
+      // Text-input bubbles stay cross-space visible via Electron only — the
+      // native stationary path (applyStationaryCollectionBehavior) delegates the
+      // window into a SkyLight private space that occludes the OS IME candidate
+      // window, so it's skipped here (permission.js __clawdMacTextInputBubble).
+      if (win.__clawdMacTextInputBubble) {
+        applyElectronCrossSpace(win);
+        return;
+      }
       if (!applyStationaryCollectionBehavior(win)) {
-        const options = { visibleOnFullScreen: true };
-        if (!getShowDock()) options.skipTransformProcessType = true;
-        win.setVisibleOnAllWorkspaces(true, options);
+        applyElectronCrossSpace(win);
         // First try the native flicker-free path. If Electron's fallback is
         // needed, retry native behavior because Electron can reset collection
         // behavior while changing cross-space visibility.

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -111,11 +111,18 @@ function createTopmostRuntime(options = {}) {
       const deferUntil = Number(win.__clawdMacDeferredVisibilityUntil) || 0;
       if (deferUntil > Date.now()) return;
       if (deferUntil) delete win.__clawdMacDeferredVisibilityUntil;
-      // A bubble hosting a focused text input temporarily drops out of
-      // always-on-top so the IME candidate window can surface (permission.js
-      // handleImeEditing). Don't re-assert topmost mid-edit or we'd re-occlude
-      // it; the flag is cleared on blur, restoring normal topmost behavior.
-      if (win.__clawdMacImeEditing) return;
+      // While a text field inside a bubble is focused it must drop out of
+      // always-on-top so the OS IME candidate window can surface (permission.js
+      // handleImeEditing sets __clawdMacImeEditing). This branch is the single
+      // source of truth for that editing state: force non-topmost, but keep the
+      // bubble cross-space visible so switching Spaces mid-edit doesn't strand
+      // it. Re-asserting topmost or the native stationary path here would
+      // re-occlude the IME, so both are skipped until the flag clears.
+      if (win.__clawdMacImeEditing) {
+        win.setAlwaysOnTop(false);
+        if (win.__clawdMacTextInputBubble) applyElectronCrossSpace(win);
+        return;
+      }
       win.setAlwaysOnTop(true, MAC_TOPMOST_LEVEL);
       // Text-input bubbles stay cross-space visible via Electron only — the
       // native stationary path (applyStationaryCollectionBehavior) delegates the

--- a/test/permission-ime-editing.test.js
+++ b/test/permission-ime-editing.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+
+// The macOS IME-occlusion fix spans three processes: the bubble renderer
+// detects text-input focus, the preload forwards it over IPC, and the main
+// process (permission.js) drops the bubble out of always-on-top while a text
+// field is focused. This smoke test guards the wiring end to end so a change
+// in one file that silently breaks the chain gets caught.
+function read(rel) {
+  return fs.readFileSync(path.join(__dirname, "..", "src", rel), "utf8");
+}
+
+describe("macOS IME editing wiring", () => {
+  it("renderer reports text-input focus/blur to the main process", () => {
+    const renderer = read("bubble-renderer.js");
+    assert.match(renderer, /addEventListener\("focusin"/);
+    assert.match(renderer, /addEventListener\("focusout"/);
+    assert.match(renderer, /setImeEditing\(true\)/);
+    assert.match(renderer, /setImeEditing\(false\)/);
+  });
+
+  it("preload exposes setImeEditing over the bubble-ime-editing channel", () => {
+    const preload = read("preload-bubble.js");
+    assert.match(preload, /setImeEditing:/);
+    assert.match(preload, /"bubble-ime-editing"/);
+  });
+
+  it("permission main handles the channel and toggles always-on-top", () => {
+    const permission = read("permission.js");
+    assert.match(permission, /on\("bubble-ime-editing"/);
+    assert.match(permission, /function handleImeEditing/);
+    assert.match(permission, /__clawdMacImeEditing = true/);
+    assert.match(permission, /setAlwaysOnTop\(false\)/);
+    // Text-input bubbles opt out of the native SkyLight stationary treatment.
+    assert.match(permission, /__clawdMacTextInputBubble = true/);
+  });
+});

--- a/test/permission-ime-editing.test.js
+++ b/test/permission-ime-editing.test.js
@@ -3,17 +3,38 @@
 const assert = require("node:assert");
 const fs = require("node:fs");
 const path = require("node:path");
+const Module = require("node:module");
 const { describe, it } = require("node:test");
+
+// ── Mock electron before requiring permission.js ──
+// permission.js does `const { BrowserWindow, globalShortcut } = require("electron")`
+// at load, and handleImeEditing() calls BrowserWindow.fromWebContents(event.sender)
+// to map the IPC sender back to its perm entry. The test runtime's
+// require("electron") returns a path string (no BrowserWindow), so mock it: a
+// sender resolves to its window via a `__win` sentinel.
+const __electronMock = {
+  BrowserWindow: { fromWebContents: (sender) => (sender && sender.__win) || null },
+  globalShortcut: {
+    register: () => {}, unregister: () => {}, unregisterAll: () => {}, isRegistered: () => false,
+  },
+};
+const __origModuleLoad = Module._load;
+Module._load = function (request) {
+  if (request === "electron") return __electronMock;
+  return __origModuleLoad.apply(this, arguments);
+};
+const initPermission = require("../src/permission");
+Module._load = __origModuleLoad;
+
+function read(rel) {
+  return fs.readFileSync(path.join(__dirname, "..", "src", rel), "utf8");
+}
 
 // The macOS IME-occlusion fix spans three processes: the bubble renderer
 // detects text-input focus, the preload forwards it over IPC, and the main
 // process (permission.js) drops the bubble out of always-on-top while a text
 // field is focused. This smoke test guards the wiring end to end so a change
 // in one file that silently breaks the chain gets caught.
-function read(rel) {
-  return fs.readFileSync(path.join(__dirname, "..", "src", rel), "utf8");
-}
-
 describe("macOS IME editing wiring", () => {
   it("renderer reports text-input focus/blur to the main process", () => {
     const renderer = read("bubble-renderer.js");
@@ -21,6 +42,9 @@ describe("macOS IME editing wiring", () => {
     assert.match(renderer, /addEventListener\("focusout"/);
     assert.match(renderer, /setImeEditing\(true\)/);
     assert.match(renderer, /setImeEditing\(false\)/);
+    // Element-level focus events miss whole-window focus loss (Cmd-Tab away
+    // mid-composition), so a window-level blur net must clear the editing state.
+    assert.match(renderer, /window\.addEventListener\("blur"/);
   });
 
   it("preload exposes setImeEditing over the bubble-ime-editing channel", () => {
@@ -29,13 +53,91 @@ describe("macOS IME editing wiring", () => {
     assert.match(preload, /"bubble-ime-editing"/);
   });
 
-  it("permission main handles the channel and toggles always-on-top", () => {
+  it("permission main handles the channel and toggles the editing flag", () => {
     const permission = read("permission.js");
     assert.match(permission, /on\("bubble-ime-editing"/);
     assert.match(permission, /function handleImeEditing/);
     assert.match(permission, /__clawdMacImeEditing = true/);
-    assert.match(permission, /setAlwaysOnTop\(false\)/);
     // Text-input bubbles opt out of the native SkyLight stationary treatment.
     assert.match(permission, /__clawdMacTextInputBubble = true/);
+  });
+});
+
+// handleImeEditing only flips the __clawdMacImeEditing flag and defers the
+// actual window-visibility change to reapplyMacVisibility (single source of
+// truth). It early-returns off macOS, so the behavioral assertions run on darwin.
+const macOnly = { skip: process.platform !== "darwin" ? "macOS-only" : false };
+
+function makeCtx(reapplySpy) {
+  return {
+    reapplyMacVisibility: reapplySpy,
+    getSettingsSnapshot: () => ({}),
+    isAgentPermissionsEnabled: () => true,
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
+    getPetWindowBounds: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop: () => {},
+    focusTerminalForSession: () => {},
+    win: null,
+    doNotDisturb: false,
+    hideBubbles: false,
+    sessions: new Map(),
+    pendingPermissions: [],
+    subscribeShortcuts: () => () => {},
+    onPermissionsChanged: () => {},
+    onPermissionResolved: () => {},
+    STATE_SVGS: {},
+    setState: () => {},
+    updateSession: () => {},
+  };
+}
+
+function makeBubble(overrides = {}) {
+  return { isDestroyed: () => false, ...overrides };
+}
+function eventFor(bubble) {
+  return { sender: { __win: bubble } };
+}
+
+describe("handleImeEditing (macOS)", () => {
+  it("sets the flag on focus and clears it on blur, reapplying each time", macOnly, () => {
+    const reapply = [];
+    const ctx = makeCtx(() => reapply.push(true));
+    const { handleImeEditing, pendingPermissions } = initPermission(ctx);
+
+    const bubble = makeBubble();
+    pendingPermissions.push({ bubble });
+
+    handleImeEditing(eventFor(bubble), true);
+    assert.strictEqual(bubble.__clawdMacImeEditing, true);
+    assert.strictEqual(reapply.length, 1);
+
+    handleImeEditing(eventFor(bubble), false);
+    assert.strictEqual(bubble.__clawdMacImeEditing, undefined);
+    assert.strictEqual(reapply.length, 2);
+  });
+
+  it("ignores a sender that matches no pending permission", macOnly, () => {
+    const reapply = [];
+    const ctx = makeCtx(() => reapply.push(true));
+    const { handleImeEditing, pendingPermissions } = initPermission(ctx);
+    pendingPermissions.push({ bubble: makeBubble() });
+
+    handleImeEditing(eventFor(makeBubble()), true); // different, unmatched window
+    assert.strictEqual(reapply.length, 0);
+  });
+
+  it("ignores a destroyed bubble instead of touching it", macOnly, () => {
+    const reapply = [];
+    const ctx = makeCtx(() => reapply.push(true));
+    const { handleImeEditing, pendingPermissions } = initPermission(ctx);
+    const bubble = makeBubble({ isDestroyed: () => true });
+    pendingPermissions.push({ bubble });
+
+    handleImeEditing(eventFor(bubble), true);
+    assert.strictEqual(bubble.__clawdMacImeEditing, undefined);
+    assert.strictEqual(reapply.length, 0);
   });
 });

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -747,4 +747,48 @@ describe("topmost runtime macOS visibility", () => {
 
     assert.deepStrictEqual(win.calls, []);
   });
+
+  it("skips re-asserting topmost on a bubble that is mid-IME-edit", () => {
+    // A text-input bubble drops out of always-on-top while its input is focused
+    // so the IME candidate window can surface (permission.js handleImeEditing).
+    // reapplyMacVisibility must not fight that by re-asserting topmost mid-edit.
+    const bubble = new FakeWindow();
+    bubble.__clawdMacImeEditing = true;
+    const runtime = createTopmostRuntime({
+      isMac: true,
+      getPendingPermissions: () => [{ bubble }],
+      applyStationaryCollectionBehavior: () => true,
+    });
+
+    runtime.reapplyMacVisibility();
+
+    assert.deepStrictEqual(bubble.calls, []);
+  });
+
+  it("keeps a text-input bubble cross-space visible via Electron, skipping the native SkyLight path", () => {
+    // The native stationary path delegates the window into a SkyLight private
+    // space that occludes the OS IME candidate window, so text-input bubbles
+    // opt out of it (permission.js __clawdMacTextInputBubble) and rely on
+    // Electron's own cross-space visibility instead.
+    const bubble = new FakeWindow();
+    bubble.__clawdMacTextInputBubble = true;
+    const stationaryCalls = [];
+    const runtime = createTopmostRuntime({
+      isMac: true,
+      getPendingPermissions: () => [{ bubble }],
+      getShowDock: () => false,
+      applyStationaryCollectionBehavior: (win) => {
+        stationaryCalls.push(win);
+        return true;
+      },
+    });
+
+    runtime.reapplyMacVisibility();
+
+    assert.deepStrictEqual(bubble.calls, [
+      ["setAlwaysOnTop", true, createTopmostRuntime.MAC_TOPMOST_LEVEL],
+      ["setVisibleOnAllWorkspaces", true, { visibleOnFullScreen: true, skipTransformProcessType: true }],
+    ]);
+    assert.deepStrictEqual(stationaryCalls, []);
+  });
 });

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -748,21 +748,48 @@ describe("topmost runtime macOS visibility", () => {
     assert.deepStrictEqual(win.calls, []);
   });
 
-  it("skips re-asserting topmost on a bubble that is mid-IME-edit", () => {
-    // A text-input bubble drops out of always-on-top while its input is focused
-    // so the IME candidate window can surface (permission.js handleImeEditing).
-    // reapplyMacVisibility must not fight that by re-asserting topmost mid-edit.
+  it("forces a mid-IME-edit text-input bubble non-topmost but keeps it cross-space visible", () => {
+    // While its input is focused, the bubble must drop out of always-on-top so
+    // the IME candidate window can surface (permission.js handleImeEditing), but
+    // stay cross-space visible so a Space switch mid-edit doesn't strand it. It
+    // must NOT get topmost or the native stationary path (both re-occlude IME).
     const bubble = new FakeWindow();
     bubble.__clawdMacImeEditing = true;
+    bubble.__clawdMacTextInputBubble = true;
+    const stationaryCalls = [];
     const runtime = createTopmostRuntime({
       isMac: true,
       getPendingPermissions: () => [{ bubble }],
+      getShowDock: () => false,
+      applyStationaryCollectionBehavior: (win) => {
+        stationaryCalls.push(win);
+        return true;
+      },
+    });
+
+    runtime.reapplyMacVisibility();
+
+    assert.deepStrictEqual(bubble.calls, [
+      ["setAlwaysOnTop", false],
+      ["setVisibleOnAllWorkspaces", true, { visibleOnFullScreen: true, skipTransformProcessType: true }],
+    ]);
+    assert.deepStrictEqual(stationaryCalls, [], "must not run the native SkyLight path mid-edit");
+  });
+
+  it("forces a mid-IME-edit non-text-input window non-topmost without cross-space", () => {
+    // Defensive: the editing flag is only ever set on text-input bubbles, but if
+    // it lands on any other window the branch still just drops always-on-top.
+    const win = new FakeWindow();
+    win.__clawdMacImeEditing = true;
+    const runtime = createTopmostRuntime({
+      isMac: true,
+      getWin: () => win,
       applyStationaryCollectionBehavior: () => true,
     });
 
     runtime.reapplyMacVisibility();
 
-    assert.deepStrictEqual(bubble.calls, []);
+    assert.deepStrictEqual(win.calls, [["setAlwaysOnTop", false]]);
   });
 
   it("keeps a text-input bubble cross-space visible via Electron, skipping the native SkyLight path", () => {


### PR DESCRIPTION
## Summary

On macOS, the OS input-method candidate window (the Chinese/Japanese/Korean candidate-list popup) was drawn **behind** elicitation "Other" and ExitPlanMode feedback bubbles, so CJK users couldn't see what they were typing into them.

### Root cause

Those text-input bubbles get Clawd's stationary-window treatment (`src/mac-window.js` `applyStationaryCollectionBehavior`) — the same treatment that lets the pet and its bubbles float above fullscreen apps. It natively raises the window to `CGAssistiveTechHighWindowLevel` **and** delegates it into a SkyLight private space at an absolute level. The OS IME candidate window floats above *normal* windows only, so anything sitting in that private space renders over it.

Electron's `setAlwaysOnTop(false)` can't undo the native level or the SkyLight delegation, so no window-level tweak alone fixes it — verified on a real machine that even `"floating"` still occludes.

### Fix (two parts)

- **Text-input bubbles opt out of the native SkyLight path** and stay cross-space visible via Electron's own `setVisibleOnAllWorkspaces` instead (`topmost-runtime.js` honors a `__clawdMacTextInputBubble` tag). Electron's cross-space visibility does **not** occlude the IME candidate window.
- **While a text field inside the bubble is focused, the bubble drops out of always-on-top** (`permission.js` `handleImeEditing`, driven by `focusin`/`focusout` IPC from the bubble renderer) so the candidate window can surface; it's restored on blur. `reapplyMacVisibility` skips re-asserting topmost mid-edit.

Only elicitation / ExitPlanMode bubbles (the ones with a text input) are affected; button-only permission prompts are unchanged.

### Known limitation (deliberately left for the maintainer)

While typing, the **pet itself** can still overlap the bubble, because the pet window is *also* in the SkyLight private space and Electron can't pull it out. Fully resolving that needs a native reversal of the SkyLight space delegation on the pet window — deliberately left to you, since that native code is yours and can be validated on Windows too. Happy to help iterate if useful.

## Test plan

- [x] Verified end-to-end on a real macOS machine with a Chinese IME: the candidate window now shows above the bubble, and the bubble no longer sinks behind other apps.
- [x] `npm test` — full suite green (4659 passing, 0 failing, 17 skipped/Windows-only).
- [x] New coverage: `test/topmost-runtime.test.js` (mid-edit topmost skip + text-input cross-space path) and `test/permission-ime-editing.test.js` (renderer → preload → main IPC wiring).

--------------------------------------------------------------------

## 概述

macOS 上,系统输入法的候选词窗口(中文/日文/韩文候选列表弹窗)会被画在 elicitation 的"其他"输入框、以及 ExitPlanMode 反馈框这类气泡的**下面**,导致 CJK 用户看不到自己往里打的字。

### 根因

这些带输入框的气泡走了 Clawd 的 stationary 置顶处理(`src/mac-window.js` 的 `applyStationaryCollectionBehavior`)——就是让桌宠和气泡浮在全屏应用之上的那套。它用原生 API 把窗口层级抬到 `CGAssistiveTechHighWindowLevel`,**并且**通过 SkyLight 私有 API 把窗口塞进一个"绝对层级"的私有 Space。而系统 IME 候选窗只浮在**普通**窗口之上,所以待在那个私有 Space 里的窗口就盖住了它。

Electron 的 `setAlwaysOnTop(false)` 撤不掉原生层级、也撤不掉 SkyLight 委托,所以单靠调窗口层级修不好——在真机上验证过,连 `"floating"` 也照样遮挡。

### 修复(两部分)

- **文本输入气泡不再走原生 SkyLight 那条路**,改用 Electron 自带的 `setVisibleOnAllWorkspaces` 保持跨空间可见(`topmost-runtime.js` 尊重一个 `__clawdMacTextInputBubble` 标记)。Electron 的跨空间可见**不会**遮挡 IME 候选窗。
- **当气泡里的文本框获得焦点时,气泡临时退出置顶**(`permission.js` 的 `handleImeEditing`,由渲染进程的 `focusin`/`focusout` IPC 驱动),让候选词窗口能冒出来;失焦后恢复。`reapplyMacVisibility` 在打字期间不会重新抬回置顶。

只影响 elicitation / ExitPlanMode 这类带输入框的气泡;纯按钮的权限气泡不受影响。

### 已知限制(有意留给作者)

打字时**桌宠本身**仍可能盖住气泡一部分,因为桌宠窗口也在那个 SkyLight 私有 Space 里,Electron 拉不出来。要彻底解决需要对桌宠窗口做 SkyLight Space 委托的原生反向操作——这里有意留给你:那套原生代码是你写的,而且能在 Windows 上一并验证。需要的话我很乐意配合一起迭代。

## 测试情况

- [x] 在装有中文输入法的真实 macOS 机器上端到端验证:候选词窗口现在能显示在气泡上方,气泡也不会再沉到其他应用后面。
- [x] `npm test` —— 完整测试套件全绿(4659 通过,0 失败,17 跳过/仅 Windows)。
- [x] 新增覆盖:`test/topmost-runtime.test.js`(打字期间跳过置顶 + 文本气泡走跨空间)和 `test/permission-ime-editing.test.js`(渲染进程 → preload → 主进程 的 IPC 连线)。
