### PR TITLE
fix(hooks): -WindowStyle Hidden on snapshot spawn + test-helper env restore (complements #630)

### DIFF
--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -154,7 +154,11 @@ function getWindowsProcessSnapshot(execFileSync) {
     const out = execFileSync(
       "powershell.exe",
       [
-        "-NoProfile", "-NonInteractive", "-Command",
+        // -WindowStyle Hidden is belt-and-suspenders alongside windowsHide:
+        // when Windows Terminal is the OS default terminal app, its console
+        // delegation does not always honor CREATE_NO_WINDOW (#627), and the
+        // in-process flag shortens any window that still leaks through.
+        "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command",
         WINDOWS_PROCESS_SNAPSHOT_SCRIPT,
       ],
       { encoding: "utf8", timeout: 3000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 }

--- a/test/helpers/load-shared-process-with-mock.js
+++ b/test/helpers/load-shared-process-with-mock.js
@@ -1,7 +1,8 @@
 // test/helpers/load-shared-process-with-mock.js
 //
-// Patches child_process.execFileSync, process.env (TMUX/TMUX_PANE), and
-// process.platform before requiring shared-process.js. This is the
+// Patches child_process.execFileSync, process.env (TMUX/TMUX_PANE plus any
+// keys passed via `env`), and process.platform before requiring
+// shared-process.js. This is the
 // equivalent of load-focus-with-mock.js but for the hook-side resolver.
 
 function loadSharedProcessWithMock({ execFileSyncMock, env, platform }) {
@@ -12,7 +13,7 @@ function loadSharedProcessWithMock({ execFileSyncMock, env, platform }) {
   const origSp = require.cache[spKey];
   const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 
-  const envKeys = ["TMUX", "TMUX_PANE"];
+  const envKeys = [...new Set(["TMUX", "TMUX_PANE", ...(env ? Object.keys(env) : [])])];
   const savedEnv = {};
   for (const k of envKeys) savedEnv[k] = process.env[k];
 


### PR DESCRIPTION
## Narrowed scope — defers to #630

The original version of this PR implemented a cross-process TTL snapshot cache. After reviewing #630, I'm withdrawing that part: the per-session shape there is the better design — it eliminates spawns on the high-frequency events entirely instead of racing a TTL against PID reuse and foreground changes, which is exactly the class of issues raised in review here. No point merging a second, weaker cache.

What remains is the complementary piece #630 doesn't cover:

- **`-WindowStyle Hidden` on the PowerShell snapshot spawn.** #630 still cold-spawns on SessionStart/UserPromptSubmit, and under Windows Terminal default-terminal delegation `CREATE_NO_WINDOW` can be ignored (#627) — the in-process flag shortens any window that still leaks through on those remaining fresh spawns.
- **Test-helper fix:** `load-shared-process-with-mock.js` now restores every env key it patches (previously only the hardcoded TMUX keys), so tests that pass extra `env` no longer leak state across cases.

`node --test test/shared-process.test.js` green on Windows 11.

And yes — once #630 ships in a release, I'll run the before/after on the 4688 audit rig and report back on #627.

Refs #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)