### PR TITLE
fix(hooks): cache Windows process snapshot per session to stop PowerShell flash (#627)

### DIFF
--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -8,7 +8,10 @@ const fs = require("fs");
 const { postStateToRunningServer, readHostPrefix, resolveWslDistro } = require("./server-config");
 const { fitStateBodyToByteBudget } = require("./state-payload-size");
 const { extractClaudeContextUsageFromEntries } = require("./context-usage");
-const { createPidResolver, readStdinJsonDetailed, getPlatformConfig } = require("./shared-process");
+const { createPidResolver, readStdinJsonDetailed, getPlatformConfig, tmuxSocketFromEnv, processAlive } = require("./shared-process");
+const pidCache = require("./pid-cache");
+
+const isWin = process.platform === "win32";
 
 const TRANSCRIPT_TAIL_BYTES = 262144; // 256 KB
 // #583: claude-code registers this hook with async:true and a 5s timeout
@@ -338,6 +341,45 @@ function isTaskToolStart(event, payload) {
     && payload.tool_name === "Task";
 }
 
+// #442-compat + #627: agent pid fields. Shared by the fresh-resolve and
+// cache-hit paths so the `headless` derivation and the `claude_pid` backward-
+// compat alias can never drift between them.
+function applyAgentPidFields(body, agentPid, agentCommandLine) {
+  if (!agentPid) return;
+  body.agent_pid = agentPid;
+  body.claude_pid = agentPid; // backward compat with older Clawd versions
+  if (agentCommandLine && /\s(-p|--print)(\s|$)/.test(agentCommandLine)) {
+    body.headless = true;
+  }
+}
+
+// Fresh-resolve path: preserves the exact pre-cache field output (#627).
+function applyResolvedFields(body, resolved, event) {
+  const { stablePid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient } = resolved;
+  body.source_pid = stablePid;
+  if (detectedEditor) body.editor = detectedEditor;
+  applyAgentPidFields(body, agentPid, agentCommandLine);
+  if (pidChain && pidChain.length) body.pid_chain = pidChain;
+  if (tmuxSocket) body.tmux_socket = tmuxSocket;
+  if (tmuxClient) body.tmux_client = tmuxClient;
+  if (shouldReportForegroundWtHwnd(event) && foregroundWtHwnd) {
+    body.wt_hwnd = String(foregroundWtHwnd);
+  }
+}
+
+// Cache-hit path (#627): stable subset only. Deliberately omits pid_chain — the
+// server MERGEs a missing pid_chain and keeps the SessionStart one, whereas the
+// cached chain's head would be a dead per-event PowerShell — and wt_hwnd, which
+// is only reported on the always-fresh SessionStart/UserPromptSubmit events.
+// tmux_socket is a pure-env value, recomputed so a tmux user still gets it.
+function applyCachedFields(body, cached) {
+  body.source_pid = cached.stablePid;
+  if (cached.detectedEditor) body.editor = cached.detectedEditor;
+  applyAgentPidFields(body, cached.agentPid, cached.agentCommandLine);
+  const tmuxSocket = tmuxSocketFromEnv();
+  if (tmuxSocket) body.tmux_socket = tmuxSocket;
+}
+
 function buildStateBody(event, payload, resolve) {
   const state = EVENT_TO_STATE[event];
   if (!state) return null;
@@ -434,25 +476,54 @@ function buildStateBody(event, payload, resolve) {
     body.host = readHostPrefix();
     if (wslDistro) body.wsl_distro = wslDistro;
   } else {
-    const { stablePid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient } = resolve();
-    body.source_pid = stablePid;
-    if (detectedEditor) body.editor = detectedEditor;
-    if (agentPid) {
-      body.agent_pid = agentPid;
-      body.claude_pid = agentPid; // backward compat with older Clawd versions
-      if (agentCommandLine && /\s(-p|--print)(\s|$)/.test(agentCommandLine)) {
-        body.headless = true;
+    // #627: on Windows every hook event otherwise cold-starts a PowerShell to
+    // snapshot the process tree, flashing a console window under Windows
+    // Terminal. The tree is stable within a session, so snapshot once on the
+    // always-fresh events and let high-frequency events read a per-session cache.
+    const canCacheSession = isWin && pidCache.canCache(sessionId, cwd);
+    // SessionStart populates the cache; UserPromptSubmit needs a live foreground
+    // window (wt_hwnd) so it also re-resolves (and refreshes the cache).
+    const wantsFresh = event === "SessionStart" || event === "UserPromptSubmit";
+
+    let cached = null;
+    if (event === "SessionEnd") {
+      // M5: read the last-known subset for the final body, then drop it. Never
+      // write back on SessionEnd.
+      if (canCacheSession) {
+        cached = pidCache.readPidCache(sessionId, cwd);
+        pidCache.dropPidCache(sessionId, cwd);
+      }
+    } else if (canCacheSession && !wantsFresh) {
+      const c = pidCache.readPidCache(sessionId, cwd);
+      // M1: validate the PID that BECOMES source_pid (stablePid), not
+      // agentPid — session-focus.js only checks source_pid's existence, so a
+      // dead stablePid must trigger a fresh resolve rather than ship downstream.
+      if (c && c.cwd === cwd && processAlive(c.stablePid)) cached = c;
+    }
+
+    if (cached) {
+      applyCachedFields(body, cached);
+    } else {
+      if (event === "SessionStart" && canCacheSession) pidCache.sweepStalePidCaches();
+      const resolved = resolve();
+      applyResolvedFields(body, resolved, event);
+      // M2: only cache a non-degraded result. An empty Windows snapshot decays
+      // stablePid to process.ppid (a per-event ephemeral PID); snapshotOk rules
+      // that out, and a found agentPid proves the walk reached a real ancestor.
+      // Never write on SessionEnd.
+      if (canCacheSession && event !== "SessionEnd" && resolved.snapshotOk && resolved.agentPid) {
+        pidCache.writePidCache(sessionId, cwd, {
+          stablePid: resolved.stablePid,
+          agentPid: resolved.agentPid,
+          agentCommandLine: resolved.agentCommandLine,
+          detectedEditor: resolved.detectedEditor,
+        });
       }
     }
-    if (pidChain.length) body.pid_chain = pidChain;
-    if (tmuxSocket) body.tmux_socket = tmuxSocket;
-    if (tmuxClient) body.tmux_client = tmuxClient;
+
     if (wslDistro) {
       body.wsl_distro = wslDistro;
       body.host = `wsl:${wslDistro}`;
-    }
-    if (shouldReportForegroundWtHwnd(event) && foregroundWtHwnd) {
-      body.wt_hwnd = String(foregroundWtHwnd);
     }
   }
 

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -495,10 +495,17 @@ function buildStateBody(event, payload, resolve) {
       }
     } else if (canCacheSession && !wantsFresh) {
       const c = pidCache.readPidCache(sessionId, cwd);
-      // M1: validate the PID that BECOMES source_pid (stablePid), not
-      // agentPid — session-focus.js only checks source_pid's existence, so a
-      // dead stablePid must trigger a fresh resolve rather than ship downstream.
-      if (c && c.cwd === cwd && processAlive(c.stablePid)) cached = c;
+      // M1 + bounded sliding TTL (#627 plan §8): the PID that becomes source_pid
+      // (stablePid) must be alive — session-focus.js only checks source_pid's
+      // existence, so a dead stablePid must trigger a fresh resolve. agentPid
+      // (claude.exe) must ALSO be alive: it tracks session liveness, so a dead
+      // agentPid means the session ended and the cache must NOT be renewed. Both
+      // alive → hit and refresh the idle TTL (touch bumps mtime, not ts) so an
+      // active long turn never re-snapshots mid-session.
+      if (c && c.cwd === cwd && processAlive(c.stablePid) && processAlive(c.agentPid)) {
+        pidCache.touchPidCache(sessionId, cwd);
+        cached = c;
+      }
     }
 
     if (cached) {

--- a/hooks/pid-cache.js
+++ b/hooks/pid-cache.js
@@ -9,6 +9,14 @@
 // let the high-frequency events (PreToolUse/PostToolUse/Stop) read this cache
 // instead of spawning. Also collapses the ~270ms PS cold start tracked in #350.
 //
+// Bounded sliding TTL (#627 plan §8): a cache HIT refreshes the file mtime
+// (touchPidCache) so an active session's cache never expires mid-turn — this
+// removes the every-5-min re-snapshot on long turns and the thundering herd at
+// each TTL boundary. Two clocks bound it:
+//   - idle TTL    (IDLE_TTL_MS):     now - mtime; last-use timeout.
+//   - absolute cap (ABSOLUTE_CAP_MS): now - ts;   creation cap, so a reused
+//     stablePid/agentPid cannot keep a dead session's cache alive forever.
+//
 // Design constraints (see docs/plans/plan-issue-627-hook-snapshot-flash-cache.md):
 //   - Cache ONLY the stable subset: stablePid, agentPid, agentCommandLine,
 //     detectedEditor. NOT pidChain (its head is the per-event ephemeral hook
@@ -26,11 +34,17 @@ const crypto = require("crypto");
 const { writeJsonAtomic } = require("./json-utils");
 
 const CACHE_PREFIX = "clawd-pidcache-";
-// Session-scoped invalidation (SessionEnd drops the file) is the primary
-// lifecycle control; TTL is only a backstop for sessions that crash without a
-// SessionEnd. Kept under 10 min so a stale entry cannot outlive a terminal that
-// was closed and whose PID may have been reused.
-const CACHE_TTL_MS = 5 * 60 * 1000;
+// Idle TTL: time since last hit, measured by the file's mtime. A cache hit
+// touches the file (touchPidCache), so an actively-used session stays warm and
+// only genuine inactivity (a crashed/orphaned session) lets it expire. Kept
+// under 10 min so a truly idle entry cannot outlive a terminal whose PID may
+// have been reused.
+const IDLE_TTL_MS = 5 * 60 * 1000;
+// Absolute cap: time since creation, measured by the JSON `ts` (stamped once at
+// write, never bumped by a hit). Bounds how long a reused stablePid/agentPid
+// could keep a dead session's cache alive under sliding TTL — this preserves the
+// short-TTL PID-reuse backstop that plain "renew forever" would remove.
+const ABSOLUTE_CAP_MS = 30 * 60 * 1000;
 
 // A session_id of "default" is the placeholder clawd-hook.js falls back to when
 // the agent's stdin JSON lacked one (#583): caching under it would let unrelated
@@ -54,22 +68,29 @@ function cacheFilePath(sessionId, cwd) {
 }
 
 // Returns the cached subset, or null on: caching disabled, no file, unreadable/
-// unparseable file, expired ts, or cwd mismatch (the second identity guard).
-// Liveness of the cached PID is the caller's job — it checks the PID that will
-// actually become source_pid (see clawd-hook.js).
+// unparseable file, idle-expired (mtime), absolute-cap-expired (ts), or cwd
+// mismatch. Liveness of the cached PIDs is the caller's job — it checks that the
+// PID that becomes source_pid (stablePid) AND agentPid are both alive.
 function readPidCache(sessionId, cwd) {
   const file = cacheFilePath(sessionId, cwd);
   if (!file) return null;
   try {
+    const now = Date.now();
+    const st = fs.statSync(file);
     const obj = JSON.parse(fs.readFileSync(file, "utf8"));
     if (!obj || typeof obj !== "object") return null;
-    if (typeof obj.ts !== "number" || Date.now() - obj.ts > CACHE_TTL_MS) return null;
+    if (typeof obj.ts !== "number") return null;
+    // Bounded sliding TTL: idle timeout on mtime (last use), hard cap on ts
+    // (creation). One `now` for both comparisons to avoid boundary jitter.
+    if (now - st.mtimeMs > IDLE_TTL_MS) return null;
+    if (now - obj.ts > ABSOLUTE_CAP_MS) return null;
     if (obj.cwd !== cwd) return null;
-    // Shape guard: a corrupt/hand-edited file that still parses as JSON must not
-    // ship a non-numeric source_pid/agent_pid downstream. stablePid is validated
-    // again by the caller's liveness check, but agentPid is not — so pin both.
+    // Shape guard. stablePid is re-validated by the caller's liveness check.
+    // agentPid is now REQUIRED (the write condition already needs snapshotOk &&
+    // agentPid, and the hit path does a second processAlive(agentPid)) — pin both
+    // to positive integers so a corrupt/hand-edited file can't ship a bad PID.
     if (!isPositivePid(obj.stablePid)) return null;
-    if (obj.agentPid != null && !isPositivePid(obj.agentPid)) return null;
+    if (!isPositivePid(obj.agentPid)) return null;
     return obj;
   } catch {
     return null;
@@ -78,8 +99,10 @@ function readPidCache(sessionId, cwd) {
 
 // Persist the stable subset. Callers MUST only pass a subset from a non-degraded
 // resolve() (snapshotOk && agentPid) — a failed snapshot decays stablePid to
-// process.ppid, and caching that would poison the whole session. Returns true on
-// write, false when caching is disabled or the write failed.
+// process.ppid, and caching that would poison the whole session. Stamps ts =
+// creation time (the absolute-cap anchor); a later hit only bumps the file mtime
+// via touchPidCache, never ts. Returns true on write, false when caching is
+// disabled or the write failed.
 function writePidCache(sessionId, cwd, subset) {
   const file = cacheFilePath(sessionId, cwd);
   if (!file) return false;
@@ -88,6 +111,22 @@ function writePidCache(sessionId, cwd, subset) {
     return true;
   } catch {
     return false;
+  }
+}
+
+// Sliding-TTL refresh: bump the cache file's mtime (the idle-TTL anchor) on a
+// hit, WITHOUT rewriting ts (the absolute-cap anchor). Uses fs.utimesSync, which
+// only modifies an EXISTING file and never creates one — so a hit racing a
+// SessionEnd dropPidCache() cannot resurrect the dropped file (utimesSync throws
+// on a missing file and we swallow it). No spawn, one cheap metadata write.
+function touchPidCache(sessionId, cwd) {
+  const file = cacheFilePath(sessionId, cwd);
+  if (!file) return;
+  try {
+    const now = new Date();
+    fs.utimesSync(file, now, now);
+  } catch {
+    /* file gone (SessionEnd drop) / race — fine; next read misses and rebuilds */
   }
 }
 
@@ -102,10 +141,10 @@ function dropPidCache(sessionId, cwd) {
 }
 
 // Best-effort sweep of orphaned cache files (sessions that crashed without a
-// SessionEnd). Only removes our own prefix and only entries older than 2x TTL,
-// so a live session's file (refreshed on every UserPromptSubmit) is never
-// swept, and a not-yet-expired entry is left alone. Called once per session
-// from SessionStart (low frequency); silent on any error.
+// SessionEnd). Keys off mtime — which under sliding TTL is the last-use time, so
+// a live session's file (touched on every hit) is never swept; only entries idle
+// past 2x IDLE_TTL_MS go. Called once per session from SessionStart (low
+// frequency); silent on any error.
 function sweepStalePidCaches(nowMs) {
   const now = Number.isFinite(nowMs) ? nowMs : Date.now();
   const dir = os.tmpdir();
@@ -120,11 +159,11 @@ function sweepStalePidCaches(nowMs) {
     const full = path.join(dir, name);
     try {
       const st = fs.statSync(full);
-      // Narrow stat-then-unlink TOCTOU: if a session rewrote this exact file
-      // (rename) between the statSync and the unlinkSync, we could delete a
-      // just-written entry. Harmless and self-healing — the next readPidCache
+      // Narrow stat-then-unlink TOCTOU: if a session touched/rewrote this exact
+      // file between the statSync and the unlinkSync, we could delete a
+      // just-refreshed entry. Harmless and self-healing — the next readPidCache
       // misses and rebuilds via one fresh resolve — so not worth a lock.
-      if (now - st.mtimeMs > 2 * CACHE_TTL_MS) fs.unlinkSync(full);
+      if (now - st.mtimeMs > 2 * IDLE_TTL_MS) fs.unlinkSync(full);
     } catch {
       /* raced with a writer/other sweeper — skip */
     }
@@ -136,8 +175,10 @@ module.exports = {
   cacheFilePath,
   readPidCache,
   writePidCache,
+  touchPidCache,
   dropPidCache,
   sweepStalePidCaches,
-  CACHE_TTL_MS,
+  IDLE_TTL_MS,
+  ABSOLUTE_CAP_MS,
   CACHE_PREFIX,
 };

--- a/hooks/pid-cache.js
+++ b/hooks/pid-cache.js
@@ -1,0 +1,143 @@
+// hooks/pid-cache.js — Cross-process cache for the resolved process-tree
+// subset, keyed by session (#627).
+//
+// Why this exists: on Windows every hook event spawns a cold PowerShell to
+// snapshot the process tree (hooks/shared-process.js getWindowsProcessSnapshot).
+// With Windows Terminal as the default terminal application, that spawn flashes
+// a visible console window despite windowsHide:true. The process tree is stable
+// within a session, so we snapshot once (SessionStart / UserPromptSubmit) and
+// let the high-frequency events (PreToolUse/PostToolUse/Stop) read this cache
+// instead of spawning. Also collapses the ~270ms PS cold start tracked in #350.
+//
+// Design constraints (see docs/plans/plan-issue-627-hook-snapshot-flash-cache.md):
+//   - Cache ONLY the stable subset: stablePid, agentPid, agentCommandLine,
+//     detectedEditor. NOT pidChain (its head is the per-event ephemeral hook
+//     PowerShell; server MERGEs a missing pid_chain, keeping the SessionStart one).
+//   - Key by session_id + cwd; disabled entirely when session_id is missing/
+//     "default" or cwd is empty (a shared "default" cache would cross sessions).
+//   - Reuse json-utils.writeJsonAtomic (tmp + rename) so a concurrent reader
+//     never sees a half-written file.
+//   - Zero third-party deps.
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const crypto = require("crypto");
+const { writeJsonAtomic } = require("./json-utils");
+
+const CACHE_PREFIX = "clawd-pidcache-";
+// Session-scoped invalidation (SessionEnd drops the file) is the primary
+// lifecycle control; TTL is only a backstop for sessions that crash without a
+// SessionEnd. Kept under 10 min so a stale entry cannot outlive a terminal that
+// was closed and whose PID may have been reused.
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+// A session_id of "default" is the placeholder clawd-hook.js falls back to when
+// the agent's stdin JSON lacked one (#583): caching under it would let unrelated
+// sessions read each other's PIDs. Empty cwd removes the second identity guard.
+function canCache(sessionId, cwd) {
+  return !!sessionId && sessionId !== "default" && !!cwd;
+}
+
+function isPositivePid(v) {
+  return Number.isInteger(v) && v > 0;
+}
+
+function cacheFilePath(sessionId, cwd) {
+  if (!canCache(sessionId, cwd)) return null;
+  const hash = crypto
+    .createHash("sha1")
+    .update(`${sessionId}\0${cwd}`)
+    .digest("hex")
+    .slice(0, 16);
+  return path.join(os.tmpdir(), `${CACHE_PREFIX}${hash}.json`);
+}
+
+// Returns the cached subset, or null on: caching disabled, no file, unreadable/
+// unparseable file, expired ts, or cwd mismatch (the second identity guard).
+// Liveness of the cached PID is the caller's job — it checks the PID that will
+// actually become source_pid (see clawd-hook.js).
+function readPidCache(sessionId, cwd) {
+  const file = cacheFilePath(sessionId, cwd);
+  if (!file) return null;
+  try {
+    const obj = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (!obj || typeof obj !== "object") return null;
+    if (typeof obj.ts !== "number" || Date.now() - obj.ts > CACHE_TTL_MS) return null;
+    if (obj.cwd !== cwd) return null;
+    // Shape guard: a corrupt/hand-edited file that still parses as JSON must not
+    // ship a non-numeric source_pid/agent_pid downstream. stablePid is validated
+    // again by the caller's liveness check, but agentPid is not — so pin both.
+    if (!isPositivePid(obj.stablePid)) return null;
+    if (obj.agentPid != null && !isPositivePid(obj.agentPid)) return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+// Persist the stable subset. Callers MUST only pass a subset from a non-degraded
+// resolve() (snapshotOk && agentPid) — a failed snapshot decays stablePid to
+// process.ppid, and caching that would poison the whole session. Returns true on
+// write, false when caching is disabled or the write failed.
+function writePidCache(sessionId, cwd, subset) {
+  const file = cacheFilePath(sessionId, cwd);
+  if (!file) return false;
+  try {
+    writeJsonAtomic(file, { ...subset, cwd, ts: Date.now() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function dropPidCache(sessionId, cwd) {
+  const file = cacheFilePath(sessionId, cwd);
+  if (!file) return;
+  try {
+    fs.unlinkSync(file);
+  } catch {
+    /* already gone / race with another SessionEnd — fine */
+  }
+}
+
+// Best-effort sweep of orphaned cache files (sessions that crashed without a
+// SessionEnd). Only removes our own prefix and only entries older than 2x TTL,
+// so a live session's file (refreshed on every UserPromptSubmit) is never
+// swept, and a not-yet-expired entry is left alone. Called once per session
+// from SessionStart (low frequency); silent on any error.
+function sweepStalePidCaches(nowMs) {
+  const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const dir = os.tmpdir();
+  let names;
+  try {
+    names = fs.readdirSync(dir);
+  } catch {
+    return;
+  }
+  for (const name of names) {
+    if (!name.startsWith(CACHE_PREFIX) || !name.endsWith(".json")) continue;
+    const full = path.join(dir, name);
+    try {
+      const st = fs.statSync(full);
+      // Narrow stat-then-unlink TOCTOU: if a session rewrote this exact file
+      // (rename) between the statSync and the unlinkSync, we could delete a
+      // just-written entry. Harmless and self-healing — the next readPidCache
+      // misses and rebuilds via one fresh resolve — so not worth a lock.
+      if (now - st.mtimeMs > 2 * CACHE_TTL_MS) fs.unlinkSync(full);
+    } catch {
+      /* raced with a writer/other sweeper — skip */
+    }
+  }
+}
+
+module.exports = {
+  canCache,
+  cacheFilePath,
+  readPidCache,
+  writePidCache,
+  dropPidCache,
+  sweepStalePidCaches,
+  CACHE_TTL_MS,
+  CACHE_PREFIX,
+};

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -50,6 +50,31 @@ function normalizeTmuxClientTarget(value) {
   return /^[\w./:-]+$/.test(text) ? text : null;
 }
 
+// $TMUX is "<socket>,<serverPid>,<sessionN>"; the first field is the socket
+// path used for `tmux -S <socket>` focus. Pure env parse, no subprocess — safe
+// to call from a cache-hit path that skips the full resolve() walk.
+function tmuxSocketFromEnv() {
+  if (!process.env.TMUX) return null;
+  return normalizeTmuxSocketPath(process.env.TMUX.split(",")[0]);
+}
+
+// Liveness probe with ZERO subprocess spawn: process.kill(pid, 0) is a syscall,
+// not a spawn (so it never risks the WindowsTerminal console flash this whole
+// change exists to avoid). ESRCH => process gone; EPERM => alive but not ours.
+// Cannot detect PID reuse (same limitation as src/state.js isProcessAlive) —
+// callers pair it with session-scoped cache invalidation. See
+// docs/plans/plan-issue-627-hook-snapshot-flash-cache.md.
+function processAlive(pid) {
+  const n = Number(pid);
+  if (!Number.isFinite(n) || n <= 0) return false;
+  try {
+    process.kill(n, 0);
+    return true;
+  } catch (e) {
+    return !!(e && e.code === "EPERM");
+  }
+}
+
 // ── getPlatformConfig ────────────────────────────────────────────────────────
 // Returns { terminalNames: Set, systemBoundary: Set, editorMap: Object, editorPathChecks: Array }
 // Options:
@@ -334,13 +359,16 @@ function createPidResolver(options) {
       }
     }
 
-    let tmuxSocket = null;
-    if (process.env.TMUX) {
-      const socketPath = process.env.TMUX.split(",")[0];
-      tmuxSocket = normalizeTmuxSocketPath(socketPath);
-    }
+    const tmuxSocket = tmuxSocketFromEnv();
 
-    _cached = { stablePid: terminalPid || lastGoodPid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient };
+    // provenance for the cross-process pid cache (#627). snapshotOk = the
+    // Windows Get-CimInstance snapshot actually returned processes; terminalPid
+    // = the raw terminal match BEFORE the `|| lastGoodPid` fallback. Callers use
+    // these to refuse caching a degraded walk (empty snapshot → stablePid
+    // silently decays to process.ppid) instead of reverse-inferring from
+    // stablePid. Non-Windows has no snapshot step, so snapshotOk is trivially true.
+    const snapshotOk = isWin ? !!(winSnapshot && winSnapshot.size > 0) : true;
+    _cached = { stablePid: terminalPid || lastGoodPid, terminalPid, snapshotOk, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient };
     return _cached;
   };
 }
@@ -445,4 +473,6 @@ module.exports = {
   readStdinJsonDetailed,
   DEFAULT_STDIN_READ_TIMEOUT_MS,
   buildElectronLaunchConfig,
+  tmuxSocketFromEnv,
+  processAlive,
 };

--- a/scripts/remote-deploy.sh
+++ b/scripts/remote-deploy.sh
@@ -133,6 +133,7 @@ FILES=(
   "$HOOKS_DIR/server-config.js"
   "$HOOKS_DIR/json-utils.js"
   "$HOOKS_DIR/shared-process.js"
+  "$HOOKS_DIR/pid-cache.js"
   "$HOOKS_DIR/context-usage.js"
   "$HOOKS_DIR/antigravity-context-usage.js"
   "$HOOKS_DIR/claude-rate-limits.js"

--- a/src/remote-ssh-deploy.js
+++ b/src/remote-ssh-deploy.js
@@ -51,6 +51,7 @@ const HOOK_FILES = [
   "server-config.js",
   "json-utils.js",
   "shared-process.js",
+  "pid-cache.js",
   "context-usage.js",
   "antigravity-context-usage.js",
   "claude-rate-limits.js",

--- a/test/clawd-hook-pid-cache.test.js
+++ b/test/clawd-hook-pid-cache.test.js
@@ -1,0 +1,208 @@
+// test/clawd-hook-pid-cache.test.js — #627 cache wiring in buildStateBody.
+// clawd-hook.js captures `isWin` at module load, so we force process.platform
+// and re-require it to exercise both the Windows (cache) and non-Windows paths
+// deterministically on any host.
+const { describe, it, before, after, afterEach } = require("node:test");
+const assert = require("node:assert");
+
+const pidCache = require("../hooks/pid-cache");
+
+const CWD = "/repo/clawd-hook-cache-test";
+const DEAD_PID = 2147483646;
+
+let seq = 0;
+const usedSids = [];
+function freshSid() {
+  const sid = `clawd-hook-cache-${process.pid}-${seq++}`;
+  usedSids.push(sid);
+  return sid;
+}
+afterEach(() => {
+  for (const sid of usedSids.splice(0)) pidCache.dropPidCache(sid, CWD);
+});
+
+// A healthy resolve() result. stablePid = this test process (guaranteed alive)
+// so the cache-hit liveness check passes.
+function goodResolved(extra = {}) {
+  return {
+    stablePid: process.pid,
+    terminalPid: process.pid,
+    snapshotOk: true,
+    agentPid: 4242,
+    agentCommandLine: "claude --print",
+    detectedEditor: "code",
+    pidChain: [111, 222],
+    foregroundWtHwnd: null,
+    tmuxSocket: null,
+    tmuxClient: null,
+    ...extra,
+  };
+}
+
+function loadClawdHook(platform) {
+  const key = require.resolve("../hooks/clawd-hook.js");
+  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const hadRemote = process.env.CLAWD_REMOTE;
+  delete process.env.CLAWD_REMOTE;
+  Object.defineProperty(process, "platform", { ...origPlatform, value: platform });
+  delete require.cache[key];
+  const mod = require("../hooks/clawd-hook.js");
+  const restore = () => {
+    Object.defineProperty(process, "platform", origPlatform);
+    if (hadRemote !== undefined) process.env.CLAWD_REMOTE = hadRemote;
+    delete require.cache[key];
+    require("../hooks/clawd-hook.js"); // put a natively-loaded instance back
+  };
+  return { buildStateBody: mod.buildStateBody, restore };
+}
+
+describe("buildStateBody pid cache — Windows", () => {
+  let buildStateBody, restore;
+  before(() => { ({ buildStateBody, restore } = loadClawdHook("win32")); });
+  after(() => restore());
+
+  it("cache miss → resolves once, writes cache, fresh body carries pid_chain", () => {
+    const sid = freshSid();
+    let calls = 0;
+    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(body.source_pid, process.pid);
+    assert.strictEqual(body.agent_pid, 4242);
+    assert.strictEqual(body.claude_pid, 4242);
+    assert.strictEqual(body.headless, true);
+    assert.strictEqual(body.editor, "code");
+    assert.deepStrictEqual(body.pid_chain, [111, 222]);
+
+    const cached = pidCache.readPidCache(sid, CWD);
+    assert.ok(cached, "miss must populate the cache");
+    assert.strictEqual(cached.stablePid, process.pid);
+    assert.strictEqual(cached.agentPid, 4242);
+  });
+
+  it("cache hit → no resolve, replicates claude_pid + headless, omits pid_chain", () => {
+    const sid = freshSid();
+    pidCache.writePidCache(sid, CWD, {
+      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude --print", detectedEditor: "code",
+    });
+    let calls = 0;
+    const body = buildStateBody("PostToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 0, "cache hit must not spawn a resolve");
+    assert.strictEqual(body.source_pid, process.pid);
+    assert.strictEqual(body.agent_pid, 4242);
+    assert.strictEqual(body.claude_pid, 4242, "M3: backward-compat alias must be present on the cache path");
+    assert.strictEqual(body.headless, true, "M3: headless derivation must run on the cache path");
+    assert.strictEqual(body.editor, "code");
+    assert.strictEqual(body.pid_chain, undefined, "cache-hit body must omit pid_chain (server MERGE keeps SessionStart's)");
+    assert.strictEqual(body.wt_hwnd, undefined);
+  });
+
+  it("M1: dead cached stablePid → falls back to a fresh resolve, never ships the dead pid", () => {
+    const sid = freshSid();
+    pidCache.writePidCache(sid, CWD, {
+      stablePid: DEAD_PID, agentPid: 4242, agentCommandLine: "claude", detectedEditor: "code",
+    });
+    let calls = 0;
+    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 1, "dead source_pid must trigger a fresh resolve");
+    assert.strictEqual(body.source_pid, process.pid, "ships the fresh pid, not the dead cached one");
+  });
+
+  it("M2: degraded resolve (snapshotOk false) is not cached", () => {
+    const sid = freshSid();
+    const degraded = { stablePid: 999, terminalPid: null, snapshotOk: false, agentPid: null, agentCommandLine: "", detectedEditor: null, pidChain: [], foregroundWtHwnd: null, tmuxSocket: null, tmuxClient: null };
+    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => degraded);
+    assert.strictEqual(body.source_pid, 999, "still reports the degraded pid for this one event");
+    assert.strictEqual(body.agent_pid, undefined);
+    assert.strictEqual(pidCache.readPidCache(sid, CWD), null, "a degraded snapshot must not poison the cache");
+  });
+
+  it("M2: snapshotOk true but no agentPid is not cached", () => {
+    const sid = freshSid();
+    const noAgent = goodResolved({ agentPid: null, agentCommandLine: "" });
+    buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => noAgent);
+    assert.strictEqual(pidCache.readPidCache(sid, CWD), null);
+  });
+
+  it("M2: a degraded fresh resolve does not overwrite an existing good cache", () => {
+    const sid = freshSid();
+    pidCache.writePidCache(sid, CWD, {
+      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude --print", detectedEditor: "code",
+    });
+    // UserPromptSubmit always re-resolves; feed it a degraded (snapshotOk:false) result.
+    const degraded = { stablePid: 999, terminalPid: null, snapshotOk: false, agentPid: null, agentCommandLine: "", detectedEditor: null, pidChain: [], foregroundWtHwnd: null, tmuxSocket: null, tmuxClient: null };
+    buildStateBody("UserPromptSubmit", { session_id: sid, cwd: CWD }, () => degraded);
+    const after = pidCache.readPidCache(sid, CWD);
+    assert.ok(after, "existing good cache must survive a degraded resolve");
+    assert.strictEqual(after.stablePid, process.pid, "stablePid untouched");
+    assert.strictEqual(after.agentPid, 4242, "agentPid untouched");
+  });
+
+  it("cache-hit path recomputes tmux_socket from the environment", () => {
+    const sid = freshSid();
+    pidCache.writePidCache(sid, CWD, {
+      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude", detectedEditor: "code",
+    });
+    const saved = process.env.TMUX;
+    process.env.TMUX = "/tmp/tmux-1000/win,200,5";
+    try {
+      const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => goodResolved());
+      assert.strictEqual(body.tmux_socket, "/tmp/tmux-1000/win");
+    } finally {
+      if (saved === undefined) delete process.env.TMUX;
+      else process.env.TMUX = saved;
+    }
+  });
+
+  it("M5: SessionEnd reads the cache, drops it, and does not resolve", () => {
+    const sid = freshSid();
+    pidCache.writePidCache(sid, CWD, {
+      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude", detectedEditor: "code",
+    });
+    let calls = 0;
+    const body = buildStateBody("SessionEnd", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 0, "SessionEnd hit uses the cache, no spawn");
+    assert.strictEqual(body.source_pid, process.pid);
+    assert.strictEqual(pidCache.readPidCache(sid, CWD), null, "SessionEnd must drop the cache");
+  });
+
+  it("M5: SessionEnd on a miss resolves for the body but never writes back", () => {
+    const sid = freshSid();
+    let calls = 0;
+    buildStateBody("SessionEnd", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(pidCache.readPidCache(sid, CWD), null, "SessionEnd must never write the cache");
+  });
+
+  it("UserPromptSubmit stays fresh: resolves, reports wt_hwnd, and refreshes the cache", () => {
+    const sid = freshSid();
+    let calls = 0;
+    const body = buildStateBody("UserPromptSubmit", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved({ foregroundWtHwnd: "987654" }); });
+    assert.strictEqual(calls, 1);
+    assert.strictEqual(body.wt_hwnd, "987654");
+    assert.ok(pidCache.readPidCache(sid, CWD), "UserPromptSubmit refreshes the cache");
+  });
+
+  it("caching disabled for session_id 'default' → always resolves, keeps pid_chain", () => {
+    let calls = 0;
+    const body = buildStateBody("PreToolUse", { session_id: "default", cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 1);
+    assert.deepStrictEqual(body.pid_chain, [111, 222]);
+  });
+});
+
+describe("buildStateBody pid cache — non-Windows", () => {
+  let buildStateBody, restore;
+  before(() => { ({ buildStateBody, restore } = loadClawdHook("linux")); });
+  after(() => restore());
+
+  it("never consults or writes the cache; always resolves with pid_chain", () => {
+    const sid = freshSid();
+    pidCache.writePidCache(sid, CWD, {
+      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude", detectedEditor: "code",
+    });
+    let calls = 0;
+    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 1, "non-Windows always resolves");
+    assert.deepStrictEqual(body.pid_chain, [111, 222], "fresh path includes pid_chain");
+  });
+});

--- a/test/clawd-hook-pid-cache.test.js
+++ b/test/clawd-hook-pid-cache.test.js
@@ -1,9 +1,10 @@
-// test/clawd-hook-pid-cache.test.js — #627 cache wiring in buildStateBody.
-// clawd-hook.js captures `isWin` at module load, so we force process.platform
-// and re-require it to exercise both the Windows (cache) and non-Windows paths
-// deterministically on any host.
+// test/clawd-hook-pid-cache.test.js — #627 cache wiring in buildStateBody
+// (bounded sliding TTL §8). clawd-hook.js captures `isWin` at module load, so we
+// force process.platform and re-require it to exercise both the Windows (cache)
+// and non-Windows paths deterministically on any host.
 const { describe, it, before, after, afterEach } = require("node:test");
 const assert = require("node:assert");
+const fs = require("node:fs");
 
 const pidCache = require("../hooks/pid-cache");
 
@@ -21,8 +22,10 @@ afterEach(() => {
   for (const sid of usedSids.splice(0)) pidCache.dropPidCache(sid, CWD);
 });
 
-// A healthy resolve() result. stablePid = this test process (guaranteed alive)
-// so the cache-hit liveness check passes.
+// A healthy resolve() result. stablePid = this test process (guaranteed alive).
+// agentPid = 4242 is a placeholder for the FRESH path (which does not
+// liveness-check agentPid); cache-HIT tests write their own subset with a LIVE
+// agentPid because the hit path now double-checks processAlive(agentPid).
 function goodResolved(extra = {}) {
   return {
     stablePid: process.pid,
@@ -35,6 +38,18 @@ function goodResolved(extra = {}) {
     foregroundWtHwnd: null,
     tmuxSocket: null,
     tmuxClient: null,
+    ...extra,
+  };
+}
+
+// A cached subset whose stablePid AND agentPid are both alive (this process),
+// so the hit path's double liveness check passes.
+function liveSubset(extra = {}) {
+  return {
+    stablePid: process.pid,
+    agentPid: process.pid,
+    agentCommandLine: "claude --print",
+    detectedEditor: "code",
     ...extra,
   };
 }
@@ -81,30 +96,51 @@ describe("buildStateBody pid cache — Windows", () => {
 
   it("cache hit → no resolve, replicates claude_pid + headless, omits pid_chain", () => {
     const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, {
-      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude --print", detectedEditor: "code",
-    });
+    pidCache.writePidCache(sid, CWD, liveSubset());
     let calls = 0;
     const body = buildStateBody("PostToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
     assert.strictEqual(calls, 0, "cache hit must not spawn a resolve");
     assert.strictEqual(body.source_pid, process.pid);
-    assert.strictEqual(body.agent_pid, 4242);
-    assert.strictEqual(body.claude_pid, 4242, "M3: backward-compat alias must be present on the cache path");
+    assert.strictEqual(body.agent_pid, process.pid);
+    assert.strictEqual(body.claude_pid, process.pid, "M3: backward-compat alias must be present on the cache path");
     assert.strictEqual(body.headless, true, "M3: headless derivation must run on the cache path");
     assert.strictEqual(body.editor, "code");
     assert.strictEqual(body.pid_chain, undefined, "cache-hit body must omit pid_chain (server MERGE keeps SessionStart's)");
     assert.strictEqual(body.wt_hwnd, undefined);
   });
 
-  it("M1: dead cached stablePid → falls back to a fresh resolve, never ships the dead pid", () => {
+  it("cache hit refreshes the idle TTL: touches mtime, keeps ts, no resolve (sliding TTL §8)", () => {
     const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, {
-      stablePid: DEAD_PID, agentPid: 4242, agentCommandLine: "claude", detectedEditor: "code",
-    });
+    pidCache.writePidCache(sid, CWD, liveSubset());
+    const file = pidCache.cacheFilePath(sid, CWD);
+    const tsBefore = JSON.parse(fs.readFileSync(file, "utf8")).ts;
+    // Age mtime toward idle expiry (but still within it) so the touch is observable.
+    const aged = (Date.now() - (pidCache.IDLE_TTL_MS - 2000)) / 1000;
+    fs.utimesSync(file, aged, aged);
+    const mtimeAged = fs.statSync(file).mtimeMs;
+    let calls = 0;
+    buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 0, "hit must not resolve");
+    assert.ok(fs.statSync(file).mtimeMs > mtimeAged, "hit must bump mtime = renew idle TTL");
+    assert.strictEqual(JSON.parse(fs.readFileSync(file, "utf8")).ts, tsBefore, "hit must not change ts (absolute-cap anchor)");
+  });
+
+  it("M1: dead cached stablePid → fresh resolve, never ships the dead pid", () => {
+    const sid = freshSid();
+    pidCache.writePidCache(sid, CWD, { stablePid: DEAD_PID, agentPid: process.pid, agentCommandLine: "claude", detectedEditor: "code" });
     let calls = 0;
     const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
     assert.strictEqual(calls, 1, "dead source_pid must trigger a fresh resolve");
     assert.strictEqual(body.source_pid, process.pid, "ships the fresh pid, not the dead cached one");
+  });
+
+  it("dead cached agentPid → fresh resolve (do not renew a dead session, sliding TTL §8)", () => {
+    const sid = freshSid();
+    pidCache.writePidCache(sid, CWD, { stablePid: process.pid, agentPid: DEAD_PID, agentCommandLine: "claude", detectedEditor: "code" });
+    let calls = 0;
+    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
+    assert.strictEqual(calls, 1, "dead agentPid must trigger a fresh resolve");
+    assert.strictEqual(body.source_pid, process.pid);
   });
 
   it("M2: degraded resolve (snapshotOk false) is not cached", () => {
@@ -125,23 +161,19 @@ describe("buildStateBody pid cache — Windows", () => {
 
   it("M2: a degraded fresh resolve does not overwrite an existing good cache", () => {
     const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, {
-      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude --print", detectedEditor: "code",
-    });
+    pidCache.writePidCache(sid, CWD, liveSubset());
     // UserPromptSubmit always re-resolves; feed it a degraded (snapshotOk:false) result.
     const degraded = { stablePid: 999, terminalPid: null, snapshotOk: false, agentPid: null, agentCommandLine: "", detectedEditor: null, pidChain: [], foregroundWtHwnd: null, tmuxSocket: null, tmuxClient: null };
     buildStateBody("UserPromptSubmit", { session_id: sid, cwd: CWD }, () => degraded);
     const after = pidCache.readPidCache(sid, CWD);
     assert.ok(after, "existing good cache must survive a degraded resolve");
     assert.strictEqual(after.stablePid, process.pid, "stablePid untouched");
-    assert.strictEqual(after.agentPid, 4242, "agentPid untouched");
+    assert.strictEqual(after.agentPid, process.pid, "agentPid untouched");
   });
 
   it("cache-hit path recomputes tmux_socket from the environment", () => {
     const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, {
-      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude", detectedEditor: "code",
-    });
+    pidCache.writePidCache(sid, CWD, liveSubset());
     const saved = process.env.TMUX;
     process.env.TMUX = "/tmp/tmux-1000/win,200,5";
     try {
@@ -155,9 +187,7 @@ describe("buildStateBody pid cache — Windows", () => {
 
   it("M5: SessionEnd reads the cache, drops it, and does not resolve", () => {
     const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, {
-      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude", detectedEditor: "code",
-    });
+    pidCache.writePidCache(sid, CWD, liveSubset());
     let calls = 0;
     const body = buildStateBody("SessionEnd", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
     assert.strictEqual(calls, 0, "SessionEnd hit uses the cache, no spawn");
@@ -197,9 +227,7 @@ describe("buildStateBody pid cache — non-Windows", () => {
 
   it("never consults or writes the cache; always resolves with pid_chain", () => {
     const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, {
-      stablePid: process.pid, agentPid: 4242, agentCommandLine: "claude", detectedEditor: "code",
-    });
+    pidCache.writePidCache(sid, CWD, liveSubset());
     let calls = 0;
     const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
     assert.strictEqual(calls, 1, "non-Windows always resolves");

--- a/test/pid-cache.test.js
+++ b/test/pid-cache.test.js
@@ -1,4 +1,5 @@
-// test/pid-cache.test.js — Unit tests for hooks/pid-cache.js (#627)
+// test/pid-cache.test.js — Unit tests for hooks/pid-cache.js
+// (#627, bounded sliding TTL §8)
 const { describe, it, afterEach } = require("node:test");
 const assert = require("node:assert");
 const fs = require("node:fs");
@@ -19,6 +20,8 @@ afterEach(() => {
   for (const sid of usedSids.splice(0)) pc.dropPidCache(sid, CWD);
 });
 
+// agentPid must be a positive integer: readPidCache now REQUIRES it (write
+// condition already needs snapshotOk && agentPid; the hit path liveness-checks it).
 const SUBSET = {
   stablePid: 1234,
   agentPid: 5678,
@@ -86,12 +89,8 @@ describe("pid-cache read/write/drop", () => {
     assert.doesNotThrow(() => pc.dropPidCache(freshSid(), CWD));
   });
 
-  it("readPidCache returns null past the TTL", () => {
-    const sid = freshSid();
-    const file = pc.cacheFilePath(sid, CWD);
-    // Write a file directly with a stale timestamp.
-    fs.writeFileSync(file, JSON.stringify({ ...SUBSET, cwd: CWD, ts: Date.now() - (pc.CACHE_TTL_MS + 1000) }));
-    assert.strictEqual(pc.readPidCache(sid, CWD), null);
+  it("readPidCache returns null on a missing file (no throw)", () => {
+    assert.strictEqual(pc.readPidCache(freshSid(), CWD), null);
   });
 
   it("readPidCache returns null when the stored cwd disagrees (second identity guard)", () => {
@@ -101,29 +100,106 @@ describe("pid-cache read/write/drop", () => {
     assert.strictEqual(pc.readPidCache(sid, CWD), null);
   });
 
-  it("readPidCache tolerates a corrupt file", () => {
+  it("readPidCache tolerates a corrupt file (null, no throw)", () => {
     const sid = freshSid();
     const file = pc.cacheFilePath(sid, CWD);
     fs.writeFileSync(file, "{ not json");
     assert.strictEqual(pc.readPidCache(sid, CWD), null);
   });
+
+  // agentPid shape tightened to REQUIRED positive integer (Codex NICE).
+  it("readPidCache returns null when agentPid is missing or non-positive", () => {
+    const sid = freshSid();
+    const file = pc.cacheFilePath(sid, CWD);
+    fs.writeFileSync(file, JSON.stringify({ stablePid: 1234, cwd: CWD, ts: Date.now() }));
+    assert.strictEqual(pc.readPidCache(sid, CWD), null, "missing agentPid → null");
+    fs.writeFileSync(file, JSON.stringify({ stablePid: 1234, agentPid: 0, cwd: CWD, ts: Date.now() }));
+    assert.strictEqual(pc.readPidCache(sid, CWD), null, "agentPid 0 → null");
+    fs.writeFileSync(file, JSON.stringify({ stablePid: 1234, agentPid: -5, cwd: CWD, ts: Date.now() }));
+    assert.strictEqual(pc.readPidCache(sid, CWD), null, "negative agentPid → null");
+  });
+});
+
+describe("pid-cache bounded sliding TTL (§8)", () => {
+  it("fresh mtime + fresh ts (within both clocks) → hit", () => {
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, SUBSET);
+    assert.ok(pc.readPidCache(sid, CWD));
+  });
+
+  it("idle-expired: mtime older than IDLE_TTL_MS → null (even with fresh ts)", () => {
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, SUBSET);
+    const file = pc.cacheFilePath(sid, CWD);
+    const old = (Date.now() - (pc.IDLE_TTL_MS + 1000)) / 1000;
+    fs.utimesSync(file, old, old); // age mtime; JSON ts stays fresh
+    assert.strictEqual(pc.readPidCache(sid, CWD), null);
+  });
+
+  it("absolute-cap-expired: ts older than ABSOLUTE_CAP_MS → null (even with fresh mtime)", () => {
+    const sid = freshSid();
+    const file = pc.cacheFilePath(sid, CWD);
+    // Stale ts, fresh mtime (writeFileSync stamps mtime = now).
+    fs.writeFileSync(file, JSON.stringify({ ...SUBSET, cwd: CWD, ts: Date.now() - (pc.ABSOLUTE_CAP_MS + 1000) }));
+    assert.strictEqual(pc.readPidCache(sid, CWD), null);
+  });
+
+  it("touchPidCache bumps mtime but leaves ts unchanged", () => {
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, SUBSET);
+    const file = pc.cacheFilePath(sid, CWD);
+    const tsBefore = JSON.parse(fs.readFileSync(file, "utf8")).ts;
+    const old = (Date.now() - (pc.IDLE_TTL_MS - 1000)) / 1000;
+    fs.utimesSync(file, old, old);
+    const mtimeAged = fs.statSync(file).mtimeMs;
+    pc.touchPidCache(sid, CWD);
+    assert.ok(fs.statSync(file).mtimeMs > mtimeAged, "touch must move mtime forward");
+    assert.strictEqual(JSON.parse(fs.readFileSync(file, "utf8")).ts, tsBefore, "touch must NOT change ts");
+  });
+
+  // NB: we deliberately do NOT test "touch revives an idle-expired file". Under
+  // utimesSync that mechanically works, but it is NOT the helper's contract:
+  // touch is only ever called ON A HIT (readPidCache already passed), so a
+  // genuinely-expired entry never reaches touch. Pinning revival as expected
+  // behavior would mislead future callers. The hit-path renewal contract is
+  // covered end-to-end in clawd-hook-pid-cache.test.js.
+
+  it("touchPidCache does not create a missing file (SessionEnd drop race)", () => {
+    const sid = freshSid();
+    const file = pc.cacheFilePath(sid, CWD);
+    assert.doesNotThrow(() => pc.touchPidCache(sid, CWD));
+    assert.strictEqual(fs.existsSync(file), false, "touch must not create a missing file");
+  });
+
+  it("touchPidCache is a no-op when caching is disabled", () => {
+    assert.doesNotThrow(() => pc.touchPidCache("default", CWD));
+    assert.doesNotThrow(() => pc.touchPidCache("sid", ""));
+  });
 });
 
 describe("pid-cache sweepStalePidCaches()", () => {
-  it("removes only our own prefix files older than 2x TTL, keeps fresh ones", () => {
+  it("removes only our prefix files idle past 2x IDLE_TTL_MS, keeps fresh ones", () => {
     const staleSid = freshSid();
     const freshSidId = freshSid();
     const staleFile = pc.cacheFilePath(staleSid, CWD);
     const freshFile = pc.cacheFilePath(freshSidId, CWD);
     pc.writePidCache(staleSid, CWD, SUBSET);
     pc.writePidCache(freshSidId, CWD, SUBSET);
-    // Age the stale one well past 2x TTL via mtime.
-    const old = (Date.now() - 3 * pc.CACHE_TTL_MS) / 1000;
+    const old = (Date.now() - 3 * pc.IDLE_TTL_MS) / 1000;
     fs.utimesSync(staleFile, old, old);
 
     pc.sweepStalePidCaches();
 
-    assert.strictEqual(fs.existsSync(staleFile), false, "stale file swept");
+    assert.strictEqual(fs.existsSync(staleFile), false, "stale (idle) file swept");
     assert.strictEqual(fs.existsSync(freshFile), true, "fresh file kept");
+  });
+
+  it("sweep keys off mtime, not ts: old ts + fresh mtime is kept", () => {
+    const sid = freshSid();
+    const file = pc.cacheFilePath(sid, CWD);
+    // Past absolute cap by ts, but mtime fresh (just written).
+    fs.writeFileSync(file, JSON.stringify({ ...SUBSET, cwd: CWD, ts: Date.now() - 10 * pc.ABSOLUTE_CAP_MS }));
+    pc.sweepStalePidCaches();
+    assert.strictEqual(fs.existsSync(file), true, "sweep must key off mtime, not ts");
   });
 });

--- a/test/pid-cache.test.js
+++ b/test/pid-cache.test.js
@@ -1,0 +1,129 @@
+// test/pid-cache.test.js — Unit tests for hooks/pid-cache.js (#627)
+const { describe, it, afterEach } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+
+const pc = require("../hooks/pid-cache");
+
+const CWD = "/repo/pidcache-under-test";
+let seq = 0;
+const usedSids = [];
+function freshSid() {
+  const sid = `pidcache-test-${process.pid}-${seq++}`;
+  usedSids.push(sid);
+  return sid;
+}
+
+afterEach(() => {
+  // Clean up any cache files these tests created.
+  for (const sid of usedSids.splice(0)) pc.dropPidCache(sid, CWD);
+});
+
+const SUBSET = {
+  stablePid: 1234,
+  agentPid: 5678,
+  agentCommandLine: "claude --print",
+  detectedEditor: "code",
+};
+
+describe("pid-cache canCache()", () => {
+  it("false for missing / default session id or empty cwd", () => {
+    assert.strictEqual(pc.canCache("", CWD), false);
+    assert.strictEqual(pc.canCache(null, CWD), false);
+    assert.strictEqual(pc.canCache("default", CWD), false);
+    assert.strictEqual(pc.canCache("real-sid", ""), false);
+  });
+
+  it("true for a real session id + cwd", () => {
+    assert.strictEqual(pc.canCache("real-sid", CWD), true);
+  });
+});
+
+describe("pid-cache cacheFilePath()", () => {
+  it("returns null when caching is disabled", () => {
+    assert.strictEqual(pc.cacheFilePath("default", CWD), null);
+    assert.strictEqual(pc.cacheFilePath("sid", ""), null);
+  });
+
+  it("is stable for the same (sid, cwd) and differs across sessions", () => {
+    const a = pc.cacheFilePath("sid-A", CWD);
+    const a2 = pc.cacheFilePath("sid-A", CWD);
+    const b = pc.cacheFilePath("sid-B", CWD);
+    assert.strictEqual(a, a2);
+    assert.notStrictEqual(a, b);
+    assert.ok(a.includes(pc.CACHE_PREFIX));
+  });
+});
+
+describe("pid-cache read/write/drop", () => {
+  it("round-trips the stable subset with cwd + ts stamped", () => {
+    const sid = freshSid();
+    assert.strictEqual(pc.writePidCache(sid, CWD, SUBSET), true);
+    const got = pc.readPidCache(sid, CWD);
+    assert.ok(got);
+    assert.strictEqual(got.stablePid, 1234);
+    assert.strictEqual(got.agentPid, 5678);
+    assert.strictEqual(got.agentCommandLine, "claude --print");
+    assert.strictEqual(got.detectedEditor, "code");
+    assert.strictEqual(got.cwd, CWD);
+    assert.strictEqual(typeof got.ts, "number");
+  });
+
+  it("writePidCache is a no-op (false) when caching is disabled", () => {
+    assert.strictEqual(pc.writePidCache("default", CWD, SUBSET), false);
+    assert.strictEqual(pc.writePidCache("sid", "", SUBSET), false);
+    assert.strictEqual(pc.readPidCache("default", CWD), null);
+  });
+
+  it("readPidCache returns null after drop", () => {
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, SUBSET);
+    pc.dropPidCache(sid, CWD);
+    assert.strictEqual(pc.readPidCache(sid, CWD), null);
+  });
+
+  it("dropPidCache on a missing file does not throw", () => {
+    assert.doesNotThrow(() => pc.dropPidCache(freshSid(), CWD));
+  });
+
+  it("readPidCache returns null past the TTL", () => {
+    const sid = freshSid();
+    const file = pc.cacheFilePath(sid, CWD);
+    // Write a file directly with a stale timestamp.
+    fs.writeFileSync(file, JSON.stringify({ ...SUBSET, cwd: CWD, ts: Date.now() - (pc.CACHE_TTL_MS + 1000) }));
+    assert.strictEqual(pc.readPidCache(sid, CWD), null);
+  });
+
+  it("readPidCache returns null when the stored cwd disagrees (second identity guard)", () => {
+    const sid = freshSid();
+    const file = pc.cacheFilePath(sid, CWD);
+    fs.writeFileSync(file, JSON.stringify({ ...SUBSET, cwd: "/some/other/cwd", ts: Date.now() }));
+    assert.strictEqual(pc.readPidCache(sid, CWD), null);
+  });
+
+  it("readPidCache tolerates a corrupt file", () => {
+    const sid = freshSid();
+    const file = pc.cacheFilePath(sid, CWD);
+    fs.writeFileSync(file, "{ not json");
+    assert.strictEqual(pc.readPidCache(sid, CWD), null);
+  });
+});
+
+describe("pid-cache sweepStalePidCaches()", () => {
+  it("removes only our own prefix files older than 2x TTL, keeps fresh ones", () => {
+    const staleSid = freshSid();
+    const freshSidId = freshSid();
+    const staleFile = pc.cacheFilePath(staleSid, CWD);
+    const freshFile = pc.cacheFilePath(freshSidId, CWD);
+    pc.writePidCache(staleSid, CWD, SUBSET);
+    pc.writePidCache(freshSidId, CWD, SUBSET);
+    // Age the stale one well past 2x TTL via mtime.
+    const old = (Date.now() - 3 * pc.CACHE_TTL_MS) / 1000;
+    fs.utimesSync(staleFile, old, old);
+
+    pc.sweepStalePidCaches();
+
+    assert.strictEqual(fs.existsSync(staleFile), false, "stale file swept");
+    assert.strictEqual(fs.existsSync(freshFile), true, "fresh file kept");
+  });
+});

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -10,6 +10,8 @@ const {
   readStdinJsonDetailed,
   DEFAULT_STDIN_READ_TIMEOUT_MS,
   buildElectronLaunchConfig,
+  tmuxSocketFromEnv,
+  processAlive,
 } = require("../hooks/shared-process");
 
 // ═════════════════════════════════════════════════════════════════════════════
@@ -602,5 +604,106 @@ describe("readStdinJsonDetailed()", () => {
     assert.strictEqual(result.payload.session_id, "big-sid");
     assert.strictEqual(result.bytes, Buffer.byteLength(big));
     assert.strictEqual(result.parseError, null);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// #627 provenance: snapshotOk / terminalPid — the fields the pid cache uses to
+// refuse caching a degraded Windows snapshot instead of reverse-inferring from
+// stablePid. Uses the mock loader so it runs on any platform.
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("createPidResolver() — snapshot provenance (#627, mocked win32)", () => {
+  const { loadSharedProcessWithMock } = require("./helpers/load-shared-process-with-mock");
+
+  function snapshotJson(procs) {
+    return JSON.stringify(procs.map((p) => ({
+      ProcessId: p.pid,
+      Name: p.name,
+      ParentProcessId: p.ppid,
+      CommandLine: typeof p.cmd === "string" ? p.cmd : null,
+    })));
+  }
+
+  it("snapshotOk true + terminalPid set when the walk reaches a terminal", () => {
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: () => snapshotJson([
+        { pid: 500, name: "node.exe", ppid: 600, cmd: "node C:/x/claude-code/cli.js" },
+        { pid: 600, name: "windowsterminal.exe", ppid: 0 },
+      ]),
+      platform: "win32",
+    });
+    try {
+      const cfg = mod.getPlatformConfig();
+      const r = mod.createPidResolver({
+        platformConfig: cfg,
+        startPid: 500,
+        agentNames: { win: new Set(["claude.exe"]), mac: new Set(["claude"]) },
+        agentCmdlineCheck: (c) => c.includes("claude-code"),
+      })();
+      assert.strictEqual(r.snapshotOk, true);
+      assert.strictEqual(r.terminalPid, 600);
+      assert.strictEqual(r.stablePid, 600);
+      assert.strictEqual(r.agentPid, 500);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("snapshotOk false + terminalPid null + stablePid decays to startPid on empty snapshot", () => {
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: () => "", // empty PS output → getWindowsProcessSnapshot yields an empty Map
+      platform: "win32",
+    });
+    try {
+      const cfg = mod.getPlatformConfig();
+      const r = mod.createPidResolver({ platformConfig: cfg, startPid: 4242 })();
+      assert.strictEqual(r.snapshotOk, false);
+      assert.strictEqual(r.terminalPid, null);
+      assert.strictEqual(r.stablePid, 4242, "decays to the ephemeral start pid — must not be cached");
+      assert.strictEqual(r.agentPid, null);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("tmuxSocketFromEnv()", () => {
+  it("parses the socket path from $TMUX", () => {
+    const saved = process.env.TMUX;
+    process.env.TMUX = "/tmp/tmux-1000/work,200,5";
+    try {
+      assert.strictEqual(tmuxSocketFromEnv(), "/tmp/tmux-1000/work");
+    } finally {
+      if (saved === undefined) delete process.env.TMUX;
+      else process.env.TMUX = saved;
+    }
+  });
+
+  it("returns null when $TMUX is unset", () => {
+    const saved = process.env.TMUX;
+    delete process.env.TMUX;
+    try {
+      assert.strictEqual(tmuxSocketFromEnv(), null);
+    } finally {
+      if (saved !== undefined) process.env.TMUX = saved;
+    }
+  });
+});
+
+describe("processAlive()", () => {
+  it("true for the current process", () => {
+    assert.strictEqual(processAlive(process.pid), true);
+  });
+
+  it("false for a pid that does not exist", () => {
+    assert.strictEqual(processAlive(2147483646), false);
+  });
+
+  it("false for non-positive / non-numeric input", () => {
+    assert.strictEqual(processAlive(0), false);
+    assert.strictEqual(processAlive(-1), false);
+    assert.strictEqual(processAlive(null), false);
+    assert.strictEqual(processAlive("nope"), false);
   });
 });

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -857,6 +857,42 @@ describe("updateSession()", () => {
     assert.strictEqual(api.sessions.get("new1").state, "working");
   });
 
+  // #627 safety net: the pid-snapshot cache omits pid_chain on cache-hit events,
+  // relying on updateSession MERGING (keeping the last pidChain) rather than
+  // OVERWRITING it to null. If a future refactor flips this to overwrite, the
+  // cache would blank out terminal-tab focus — this test pins the behavior.
+  it("update omitting pidChain keeps the previously stored pidChain (MERGE)", () => {
+    update(api, { id: "merge1", event: "SessionStart", state: "idle", pidChain: [700, 800, 900], sourcePid: 900 });
+    assert.deepStrictEqual(api.sessions.get("merge1").pidChain, [700, 800, 900]);
+
+    // A high-frequency event that carries no pid_chain must not clear it.
+    update(api, { id: "merge1", event: "PreToolUse", state: "working", pidChain: null, sourcePid: 900 });
+    assert.deepStrictEqual(
+      api.sessions.get("merge1").pidChain,
+      [700, 800, 900],
+      "omitting pidChain must merge (keep old), not overwrite with null",
+    );
+  });
+
+  // Same MERGE guarantee on the PermissionRequest persistence path (state.js:1367),
+  // which is a separate code branch from the main update path. #627 does not cache
+  // this path (PermissionRequest is an HTTP hook), but plan §6 asks both branches
+  // be pinned so a future refactor cannot flip either to overwrite-with-null.
+  it("PermissionRequest path also merges pidChain when a later request omits it", () => {
+    const sid = "codex:merge-perm";
+    update(api, { id: sid, event: "PermissionRequest", state: "notification", agentId: "codex", sourcePid: 456, agentPid: 456, pidChain: [321, 456] });
+    assert.deepStrictEqual(api.sessions.get(sid).pidChain, [321, 456]);
+
+    // A later codex PermissionRequest that still persists focus (sourcePid set)
+    // but omits pidChain must keep the old chain, not blank it.
+    update(api, { id: sid, event: "PermissionRequest", state: "notification", agentId: "codex", sourcePid: 456, agentPid: 456, pidChain: null });
+    assert.deepStrictEqual(
+      api.sessions.get(sid).pidChain,
+      [321, 456],
+      "PermissionRequest path must merge, not overwrite with null",
+    );
+  });
+
   it("existing session_id → updates state and timestamp", () => {
     update(api, { id: "s1", state: "working" });
     const t1 = api.sessions.get("s1").updatedAt;


### PR DESCRIPTION
## Problem

On Windows, every Claude Code hook event cold-starts a PowerShell to snapshot the process tree (`getWindowsProcessSnapshot` in `hooks/shared-process.js`). Under **Windows Terminal as the OS default terminal application**, that spawn flashes a visible console window despite `windowsHide: true`, because WT's console-host delegation does not honor `CREATE_NO_WINDOW`. Over a normal session that's one flash per tool call (PreToolUse + PostToolUse). Reported and diagnosed with a Windows 4688 process-creation audit in #627; also the ~270 ms cold-start cost tracked in #350.

## Fix

The resolved process tree is stable within a session, so snapshot **once** on the always-fresh events (SessionStart / UserPromptSubmit) and let the high-frequency events read a per-session cache instead of spawning.

- **`hooks/pid-cache.js`** (new): cross-process cache keyed by `hash(session_id + cwd)`, disabled when `session_id` is missing/`"default"` or `cwd` is empty; atomic writes via `writeJsonAtomic`; bounded sliding TTL + opportunistic sweep (see below).
- **`hooks/shared-process.js`**: `resolve()` now exposes `snapshotOk` / `terminalPid` provenance, so the cache refuses to store a degraded snapshot (an empty Windows snapshot decays `stablePid` to `process.ppid`) instead of reverse-inferring from `stablePid`. Adds `tmuxSocketFromEnv` and a zero-spawn `processAlive`.
- **`hooks/clawd-hook.js`**: cache-hit / fresh-resolve / SessionEnd branches. Only a non-degraded result (`snapshotOk && agentPid`) is cached. Cache-hit omits `pid_chain` (the server MERGEs a missing chain, keeping the SessionStart one) and validates the PID that actually becomes `source_pid`.
- **`scripts/remote-deploy.sh` + `src/remote-ssh-deploy.js`**: ship the new file (both deploy manifests, guarded by their existing consistency test).

Windows-only optimization; mac/linux keep the existing `ps`-per-ancestor path unchanged. `source_pid` / `agent_pid` are focus-only and never gate approval.

## Bounded sliding TTL (second commit)

With a plain fixed 5-min TTL, real-machine testing surfaced two residual flashes, both confirmed by Codex review:

1. **Periodic expiry on long turns** — only SessionStart / UserPromptSubmit refresh the cache, so a single prompt driving >5 min of tool calls lets the cache expire and re-snapshot once per 5-min window.
2. **Thundering herd** — when the cache is cold/expired, a batch of parallel hook events all miss and each spawns a resolve.

Both close by refreshing the entry **on every hit**, bounded by two clocks:

- **Idle TTL (5 min, file mtime = last use):** a hit calls `touchPidCache` (`utimesSync`, existing-file-only so it can't resurrect a SessionEnd-dropped file) to bump mtime, so an actively-used session never expires mid-turn.
- **Absolute cap (30 min, JSON `ts` = creation, never bumped):** backstops PID reuse — a reused `stablePid`/`agentPid` can't keep a dead session's cache alive forever, preserving the short-TTL reuse guard that "renew forever" would drop.
- On a hit, **both** `stablePid` and `agentPid` (the `claude.exe` that tracks session liveness) are `processAlive`-checked; a dead session falls back to a fresh resolve rather than renewing.

Net effect: an active long turn goes from one re-snapshot every 5 min to at most one at the 30-min cap; normal interactive use never flashes at all.

## Effect

PowerShell spawns drop from **one per tool call** to **one per session** (+ one per user turn), and with sliding TTL an active long turn no longer re-snapshots on a timer. The tool-call burst — the flash's main surface — no longer spawns at all.

## Real-machine verification

Verified on Windows 11 with Windows Terminal as the default terminal app, using an elevated ETW `Win32_ProcessStartTrace` watcher that correlates each snapshot `powershell.exe` back to its hook `node` parent (a name-only count would fold in unrelated system PowerShell):

- **Cache-hit path spawns zero real snapshots** — a warm cache serving a burst of ~30 parallel hook events produced no snapshot spawns beyond the single fixed one from the turn's UserPromptSubmit.
- **Sliding TTL holds** — on a real 9.5-min turn the cache stayed warm past the original 5-min idle deadline (idle anchor advanced on each hit, creation anchor pinned), so the every-5-min re-snapshot is gone.

Once this ships in a release, the reporter will run the before/after on their 4688 audit rig for the authoritative confirmation (issue kept open for that — see below).

## Tests

New `test/pid-cache.test.js` and `test/clawd-hook-pid-cache.test.js` (win32-forced loader, so the cache path runs on any host), including the bounded-sliding-TTL cases (idle vs absolute expiry, `touchPidCache` bumps mtime not `ts`, dead-`agentPid` fallback). Plus provenance / `processAlive` / `tmuxSocketFromEnv` cases in `test/shared-process.test.js` and a `pid_chain` MERGE regression in `test/state.test.js` (both the main and PermissionRequest persistence paths). Full suite: **4692 pass / 0 fail**.

Reviewed by Codex (plan v1→v4 including the sliding-TTL design, plus implementation) and a subagent; no security exposure surfaced.

---

Addresses #627 and #350. Intentionally **not** auto-closing #627 — leaving it open for the reporter's before/after verification on their 4688 audit rig once this ships in a release. Complemented by #628 (`-WindowStyle Hidden` on the remaining fresh spawns).
