### PR TITLE
fix(hooks): stop Antigravity wrapper leaking a UTF-8 BOM into hook stdin (#638)

### DIFF
--- a/hooks/antigravity-install.js
+++ b/hooks/antigravity-install.js
@@ -166,6 +166,18 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     ";",
     "$text=''",
     ";",
+    // #638: .NET Framework's Process.Start() eagerly creates the StandardInput
+    // StreamWriter on Console.InputEncoding with AutoFlush=true, which flushes
+    // the encoding's preamble into the pipe at Start() itself — under a
+    // CP-65001 console the hook's stdin starts with a 3-byte UTF-8 BOM that
+    // JSON.parse rejects (and an ANSI console mojibakes non-ASCII payloads
+    // written through that writer). Pre-set a BOM-less UTF-8 before Start()
+    // and restore right after; fail open where no console exists (ANSI has no
+    // preamble, so there is nothing to fix there).
+    "$origInputEncoding = $null",
+    ";",
+    "try { $origInputEncoding = [Console]::InputEncoding ; [Console]::InputEncoding = New-Object System.Text.UTF8Encoding($false) } catch { $origInputEncoding = $null }",
+    ";",
     "try {",
     "$psi = New-Object System.Diagnostics.ProcessStartInfo",
     ";",
@@ -191,6 +203,8 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     ";",
     "[void]$proc.Start()",
     ";",
+    "if ($null -ne $origInputEncoding) { try { [Console]::InputEncoding = $origInputEncoding } catch {} }",
+    ";",
     "$stdoutTask = $proc.StandardOutput.ReadToEndAsync()",
     ";",
     "$stderrTask = $proc.StandardError.ReadToEndAsync()",
@@ -204,9 +218,16 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     ";",
     `try { $stdinReader = New-Object System.IO.StreamReader([Console]::OpenStandardInput()) ; $stdinTask = $stdinReader.ReadToEndAsync() ; if ($stdinTask.Wait(${stdinTimeoutMs})) { $stdinText = $stdinTask.Result } } catch {}`,
     ";",
-    "$proc.StandardInput.Write($stdinText)",
+    // Write raw UTF-8 bytes through the base stream rather than the
+    // Console.InputEncoding StreamWriter, so this write stays correctly
+    // encoded even where the InputEncoding pre-set above failed (#638).
+    "$stdinBytes = [System.Text.Encoding]::UTF8.GetBytes($stdinText)",
     ";",
-    "$proc.StandardInput.Close()",
+    "$stdinStream = $proc.StandardInput.BaseStream",
+    ";",
+    "$stdinStream.Write($stdinBytes, 0, $stdinBytes.Length)",
+    ";",
+    "$stdinStream.Close()",
     ";",
     `if ($proc.WaitForExit(${timeoutMs})) {`,
     "$proc.WaitForExit()",
@@ -223,7 +244,7 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     ";",
     "$text=''",
     "}",
-    "} catch { $text='' }",
+    "} catch { $text='' ; if ($null -ne $origInputEncoding) { try { [Console]::InputEncoding = $origInputEncoding } catch {} } }",
     ";",
     "if ($text.Length -gt 0) { $trimmed=$text.Trim(); if (($trimmed.Length -lt 2) -or ($trimmed[0] -ne '{') -or ($trimmed[$trimmed.Length - 1] -ne '}')) { $text='' } else { try { $null = ($text | ConvertFrom-Json -ErrorAction Stop) } catch { $text='' } } }",
     ";",

--- a/hooks/antigravity-install.js
+++ b/hooks/antigravity-install.js
@@ -169,14 +169,15 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     // #638: .NET Framework's Process.Start() eagerly creates the StandardInput
     // StreamWriter on Console.InputEncoding with AutoFlush=true, which flushes
     // the encoding's preamble into the pipe at Start() itself — under a
-    // CP-65001 console the hook's stdin starts with a 3-byte UTF-8 BOM that
-    // JSON.parse rejects (and an ANSI console mojibakes non-ASCII payloads
-    // written through that writer). Pre-set a BOM-less UTF-8 before Start()
-    // and restore right after; fail open where no console exists (ANSI has no
-    // preamble, so there is nothing to fix there).
-    "$origInputEncoding = $null",
-    ";",
-    "try { $origInputEncoding = [Console]::InputEncoding ; [Console]::InputEncoding = New-Object System.Text.UTF8Encoding($false) } catch { $origInputEncoding = $null }",
+    // CP-65001 console the hook's stdin would start with a 3-byte UTF-8 BOM
+    // that JSON.parse rejects. Swap in a BOM-less UTF-8 before Start(), gated
+    // on the current encoding actually carrying a preamble: the swap then
+    // never changes the console codepage (65001 stays 65001), so there is no
+    // cross-process console state to restore — concurrent wrappers cannot
+    // race on it and a hard-killed wrapper leaves no residue. The swapped
+    // encoding object is process-local and dies with the wrapper. Fail open
+    // where no console exists (ANSI encodings carry no preamble anyway).
+    "try { if ([Console]::InputEncoding.GetPreamble().Length -gt 0) { [Console]::InputEncoding = New-Object System.Text.UTF8Encoding($false) } } catch {}",
     ";",
     "try {",
     "$psi = New-Object System.Diagnostics.ProcessStartInfo",
@@ -193,6 +194,14 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     ";",
     "$psi.RedirectStandardOutput = $true",
     ";",
+    // #638 read side: without this, the StandardOutput reader decodes the
+    // hook's UTF-8 stdout with Console.OutputEncoding — mojibake for any
+    // non-ASCII in the hook's response under an ANSI console. Available on
+    // .NET Framework 4.5+ (unlike StandardInputEncoding, which Framework
+    // never got, hence the InputEncoding swap above) and process-local by
+    // construction.
+    "$psi.StandardOutputEncoding = New-Object System.Text.UTF8Encoding($false)",
+    ";",
     "$psi.RedirectStandardError = $true",
     ";",
     "$psi.CreateNoWindow = $true",
@@ -202,8 +211,6 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     "$proc.StartInfo = $psi",
     ";",
     "[void]$proc.Start()",
-    ";",
-    "if ($null -ne $origInputEncoding) { try { [Console]::InputEncoding = $origInputEncoding } catch {} }",
     ";",
     "$stdoutTask = $proc.StandardOutput.ReadToEndAsync()",
     ";",
@@ -244,7 +251,7 @@ function buildWindowsEncodedFailOpenNodeHookCommand(nodeBin, hookScript, event, 
     ";",
     "$text=''",
     "}",
-    "} catch { $text='' ; if ($null -ne $origInputEncoding) { try { [Console]::InputEncoding = $origInputEncoding } catch {} } }",
+    "} catch { $text='' }",
     ";",
     "if ($text.Length -gt 0) { $trimmed=$text.Trim(); if (($trimmed.Length -lt 2) -or ($trimmed[0] -ne '{') -or ($trimmed[$trimmed.Length - 1] -ne '}')) { $text='' } else { try { $null = ($text | ConvertFrom-Json -ErrorAction Stop) } catch { $text='' } } }",
     ";",

--- a/hooks/codex-debug-hook.js
+++ b/hooks/codex-debug-hook.js
@@ -31,6 +31,9 @@ function readStdin() {
 
 function parsePayload(raw) {
   if (!raw || !raw.trim()) return null;
+  // A PowerShell/.NET intermediary can prefix the payload with a UTF-8 BOM
+  // (#638), which JSON.parse rejects.
+  if (raw.charCodeAt(0) === 0xFEFF) raw = raw.slice(1);
   try {
     return JSON.parse(raw);
   } catch {

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -424,7 +424,10 @@ function readStdinJsonDetailed(options = {}) {
       let payload = {};
       let parseError = null;
       try {
-        const text = raw.toString();
+        let text = raw.toString();
+        // A PowerShell/.NET intermediary can prefix the payload with a UTF-8
+        // BOM (#638); trim() below would hide it but JSON.parse rejects it.
+        if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
         if (text.trim()) payload = JSON.parse(text);
       } catch (err) {
         parseError = String((err && err.message) || "parse error").slice(0, 120);

--- a/test/antigravity-install.test.js
+++ b/test/antigravity-install.test.js
@@ -612,10 +612,15 @@ describe("Antigravity hook installer", () => {
     // other real-PowerShell tests must never observe the forced 65001.
     const before = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], { encoding: "utf8" });
     const cpMatch = (before.stdout || "").match(/\d+/);
+    assert.strictEqual(before.status, 0, "must be able to query the console codepage");
+    assert.ok(cpMatch, "must be able to parse the console codepage for restore");
     try {
+      // && (not &): if forcing 65001 fails, the wrapper must NOT run — under
+      // the original ANSI codepage this test would silently pass without ever
+      // exercising the BOM branch.
       const result = spawnSync(
         "cmd.exe",
-        ["/d", "/s", "/c", `chcp 65001>nul & ${command}`],
+        ["/d", "/s", "/c", `chcp 65001>nul && ${command}`],
         { input: payload, encoding: "utf8", timeout: 30000 }
       );
       assert.strictEqual(result.status, 0);
@@ -656,6 +661,15 @@ describe("Antigravity hook installer", () => {
     // stdin must be written as raw UTF-8 bytes, not through that writer.
     assert.ok(decoded.includes("[Console]::InputEncoding = New-Object System.Text.UTF8Encoding($false)"));
     assert.ok(decoded.indexOf("UTF8Encoding($false)") < decoded.indexOf("$proc.Start()"), "encoding pre-set must precede Start()");
+    // The swap must stay gated on the current encoding carrying a preamble and
+    // must NOT save/restore console state: gated, SetConsoleCP only ever
+    // receives the codepage the console already has, so concurrent wrappers
+    // cannot race and a hard-killed wrapper leaves no residue.
+    assert.ok(decoded.includes("if ([Console]::InputEncoding.GetPreamble().Length -gt 0)"));
+    assert.ok(!decoded.includes("$origInputEncoding"), "no console-state save/restore — the gated swap never changes the console CP");
+    // #638 read side: the hook's UTF-8 stdout must be decoded process-locally,
+    // not with the console-global OutputEncoding.
+    assert.ok(decoded.includes("$psi.StandardOutputEncoding = New-Object System.Text.UTF8Encoding($false)"));
     assert.ok(decoded.includes("[System.Text.Encoding]::UTF8.GetBytes($stdinText)"));
     assert.ok(!decoded.includes("$proc.StandardInput.Write"));
     assert.ok(decoded.includes("ConvertFrom-Json -ErrorAction Stop"));

--- a/test/antigravity-install.test.js
+++ b/test/antigravity-install.test.js
@@ -596,6 +596,40 @@ describe("Antigravity hook installer", () => {
     assert.ok(result.stdoutCloseElapsedMs < 10000, "stdout must reach EOF promptly after exit");
   });
 
+  it("delivers the stdin payload BOM-free under a CP-65001 console (#638)", windowsOnly, () => {
+    const scriptPath = writeEchoHook("clawd-antigravity-winbom-");
+    const command = __test.buildAntigravityHookCommand(
+      process.execPath,
+      scriptPath,
+      "PreInvocation",
+      { platform: "win32" }
+    );
+    // CJK in the payload also pins the encoding half of #638: the old
+    // Console.InputEncoding writer would mojibake non-ASCII under an ANSI
+    // console, the raw UTF-8 write must round-trip it byte-exact.
+    const payload = JSON.stringify({ session_id: "bom-check", cwd: "D:\\动画工作台" });
+    // chcp mutates the shared console's codepage, so capture and restore it —
+    // other real-PowerShell tests must never observe the forced 65001.
+    const before = spawnSync("cmd.exe", ["/d", "/s", "/c", "chcp"], { encoding: "utf8" });
+    const cpMatch = (before.stdout || "").match(/\d+/);
+    try {
+      const result = spawnSync(
+        "cmd.exe",
+        ["/d", "/s", "/c", `chcp 65001>nul & ${command}`],
+        { input: payload, encoding: "utf8", timeout: 30000 }
+      );
+      assert.strictEqual(result.status, 0);
+      const parsed = JSON.parse(result.stdout);
+      // Pre-#638 the .NET StandardInput writer flushed a UTF-8 BOM preamble
+      // under CP 65001, so the hook saw "\uFEFF" + payload (or a lone BOM on
+      // the empty watchdog path).
+      assert.strictEqual(parsed.got.charCodeAt(0) === 0xFEFF, false, "hook stdin must not carry a BOM");
+      assert.deepStrictEqual(parsed, { got: payload });
+    } finally {
+      if (cpMatch) spawnSync("cmd.exe", ["/d", "/s", "/c", `chcp ${cpMatch[0]}`], { encoding: "utf8" });
+    }
+  });
+
   it("builds Windows PowerShell bridge commands with fail-open fallback", () => {
     const command = __test.buildAntigravityHookCommand(
       "C:\\Program Files\\nodejs\\node.exe",
@@ -616,6 +650,14 @@ describe("Antigravity hook installer", () => {
     assert.ok(decoded.includes("New-Object System.IO.StreamReader([Console]::OpenStandardInput())"));
     assert.ok(decoded.includes("$stdinTask.Wait(2000)"));
     assert.ok(!decoded.includes("[Console]::In.ReadToEnd()"));
+    // #638: Console.InputEncoding must be swapped to BOM-less UTF-8 BEFORE
+    // Start() — .NET Framework creates the StandardInput writer eagerly there
+    // and AutoFlush pushes the encoding preamble into the pipe at once — and
+    // stdin must be written as raw UTF-8 bytes, not through that writer.
+    assert.ok(decoded.includes("[Console]::InputEncoding = New-Object System.Text.UTF8Encoding($false)"));
+    assert.ok(decoded.indexOf("UTF8Encoding($false)") < decoded.indexOf("$proc.Start()"), "encoding pre-set must precede Start()");
+    assert.ok(decoded.includes("[System.Text.Encoding]::UTF8.GetBytes($stdinText)"));
+    assert.ok(!decoded.includes("$proc.StandardInput.Write"));
     assert.ok(decoded.includes("ConvertFrom-Json -ErrorAction Stop"));
     assert.ok(decoded.includes("[Console]::Out.WriteLine( '{\"decision\":\"ask\"}' )"));
     assert.ok(decoded.endsWith("exit 0"));

--- a/test/shared-process.test.js
+++ b/test/shared-process.test.js
@@ -516,6 +516,26 @@ describe("readStdinJsonDetailed()", () => {
     assert.strictEqual(result.parseError, null);
   });
 
+  it("strips a leading UTF-8 BOM before parsing (#638)", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream });
+    stream.end('\uFEFF{"session_id":"bom-sid"}');
+
+    const result = await pending;
+    assert.strictEqual(result.payload.session_id, "bom-sid");
+    assert.strictEqual(result.parseError, null);
+  });
+
+  it("treats a lone UTF-8 BOM as an empty payload, not a parse error (#638)", async () => {
+    const stream = new PassThrough();
+    const pending = readStdinJsonDetailed({ stream });
+    stream.end("\uFEFF");
+
+    const result = await pending;
+    assert.deepStrictEqual(result.payload, {});
+    assert.strictEqual(result.parseError, null);
+  });
+
   it("concatenates chunked writes before parsing", async () => {
     const stream = new PassThrough();
     const pending = readStdinJsonDetailed({ stream });


### PR DESCRIPTION
## Problem

On CP-65001 consoles (Windows 11 "Beta: Use Unicode UTF-8", or any UTF-8 console such as pwsh 7 sessions), the Antigravity fail-open wrapper delivered the hook's stdin with a 3-byte UTF-8 BOM prefix. `readStdinJsonDetailed` passed the unstripped text to `JSON.parse`, which rejects a leading U+FEFF — the whole payload was silently dropped and the hook failed open with degraded data. Deterministic A/B repro in #638 (`chcp 437` → clean, `chcp 65001` → BOM); this is also why the #568 test was permanently red on UTF-8 consoles.

## Root cause

More subtle than the issue's original guess: **.NET Framework's `Process.Start()` eagerly creates the StandardInput `StreamWriter` on `Console.InputEncoding` with `AutoFlush = true`, and the AutoFlush setter flushes the encoding's preamble into the pipe at `Start()` itself** ([Process.cs](https://github.com/microsoft/referencesource/blob/main/System/services/monitoring/system/diagnosticts/Process.cs#L2153-L2163), [StreamWriter.cs](https://github.com/microsoft/referencesource/blob/main/mscorlib/system/io/streamwriter.cs#L300-L335)). So the issue's proposed "write through a BOM-less StreamWriter over BaseStream" cannot work — the BOM is in the pipe before any write. (.NET Core has the same eager writer but wraps the encoding in a preamble-suppressing `ConsoleEncoding`; Framework never got `ProcessStartInfo.StandardInputEncoding`.)

## Fix

**Wrapper (`hooks/antigravity-install.js`):**
- **Preamble-gated encoding swap before `Start()`** — `if ([Console]::InputEncoding.GetPreamble().Length -gt 0) { [Console]::InputEncoding = UTF8Encoding($false) }`. The gate is the load-bearing design choice: a preamble only exists when the console is already CP 65001, so the gated `SetConsoleCP` only ever receives the codepage the console already has. Console-observable state never changes → **no save/restore, and the shared-console race class (concurrent wrappers interleaving save/restore, hard-kill between set and restore leaving a mutated CP) is structurally impossible**, not merely mutex-guarded. Verified: `chcp` identical before/after a wrapper run under both 437 and 65001. Fail-open where no console exists (ANSI encodings carry no preamble anyway).
- **Raw UTF-8 stdin write** via `GetBytes` + `BaseStream` — also fixes the old writer encoding non-ASCII payloads as ANSI under CP-936-style consoles (mojibake for CJK `cwd`/`session` fields once decoded as UTF-8 by the hook).
- **`$psi.StandardOutputEncoding = UTF8Encoding($false)`** (Framework 4.5+, process-local): the wrapper now decodes the hook's UTF-8 stdout correctly under ANSI consoles instead of degrading non-ASCII responses to `{}` at the ConvertFrom-Json gate. The wrapper's *own* stdout (final hop to the IDE runner) intentionally keeps `Console.OutputEncoding` — changing it would reintroduce exactly the shared-console mutation this PR removes; hook responses on the registered events are ASCII-only JSON today.

**Generic defense (`hooks/shared-process.js`):** `readStdinJsonDetailed` strips one leading U+FEFF before `JSON.parse` — covers every agent hook against any BOM-emitting intermediary. Same guard added to `codex-debug-hook.js`, the one stdin JSON reader that bypasses it.

## Review

Deep-reviewed by Codex (44 min, reference-source-level): root cause and both fix directions confirmed; two blockers found in the v1 save/set/restore approach (cross-process interleave leaving a shared console at 65001, stale second restore in the outer catch) — both resolved by the gated no-restore design in the second commit, which supersedes the reviewer's named-mutex suggestion by removing the shared state instead of serializing access to it. Reviewer-confirmed alternatives (temp-file stdin, reflection, pwsh 7, raw CreateProcess) all rated worse trade-offs.

## Tests

- BOM / lone-BOM parse cases for `readStdinJsonDetailed`.
- Real-PowerShell round-trip forcing CP 65001 (`chcp 65001>nul && …`, codepage asserted and restored) with a byte-exact CJK payload — pins both the BOM and the encoding half.
- Bridge-shape assertions: the gated swap precedes `Start()`, no save/restore text present, `StandardOutputEncoding` set, stdin written via `GetBytes` and not the StandardInput writer.
- Antigravity suite green under both `chcp 437` and `chcp 65001`; full suite **4788 tests, 4773 pass / 0 fail** (the #568 test is no longer red on UTF-8 consoles).

Known non-goal: non-ASCII fidelity of the wrapper's final stdout hop under ANSI consoles (see above — would require mutating the shared console's output CP).

Fixes #638. Refs #568, #583.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
