### PR TITLE
fix(pet): freeze the editing bubble, pause roam, and fade + click-through the pet while it overlaps the box being typed into (#640 phases 0+1)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1217,6 +1217,10 @@ let getSessionHudWindow = () => null;
 const themeFadeSequencer = createThemeFadeSequencer({
   getRenderWindow: () => win,
   getHitWindow: () => hitWin,
+  // #640: while the pet dodges an editing bubble its baseline opacity is the
+  // faded value, not 1 — restoring to 1 mid-edit would plant an opaque pet on
+  // top of the box being typed into. (Lazy: topmostRuntime is defined below.)
+  getRestoreOpacity: () => topmostRuntime.getPetTargetOpacity(),
   fadeOutMs: THEME_SWITCH_FADE_OUT_MS,
   fadeInMs: THEME_SWITCH_FADE_IN_MS,
   fallbackMs: THEME_SWITCH_FADE_FALLBACK_MS,
@@ -1334,6 +1338,10 @@ const _permCtx = {
   getTextScale: () => getTextScaleForPetWindows(),
   guardAlwaysOnTop,
   reapplyMacVisibility,
+  // #640: permission.js re-runs the editing-overlap dodge scan whenever the
+  // pendingPermissions list changes (notifyPermissionsChanged), so a bubble
+  // that leaves the list mid-edit can't strand the pet faded + click-through.
+  syncImeEditingPetDodge: () => topmostRuntime.syncImeEditingPetDodge(),
   isAgentPermissionsEnabled: (agentId) =>
     _isAgentPermissionsEnabled({ agents: _settingsController.get("agents") }, agentId),
   // DANGER "auto-pilot": when true, showPermissionBubble auto-approves every

--- a/src/main.js
+++ b/src/main.js
@@ -1283,6 +1283,8 @@ const topmostRuntime = createTopmostRuntime({
   getContextMenuOwner: () => contextMenuOwner,
   getNearestWorkArea,
   getPetWindowBounds,
+  // #640: tight sprite rect for the editing-overlap dodge test
+  getHitRectScreen: (bounds) => getHitRectScreen(bounds),
   getShowDock: () => showDock,
   isDragLocked: () => petWindowRuntime.isDragLocked(),
   isMiniAnimating: () => _mini.getIsAnimating(),
@@ -1437,7 +1439,12 @@ function repositionFloatingBubbles() {
 }
 
 function repositionAnchoredFloatingSurfaces() {
-  return floatingWindowRuntime.repositionAnchoredSurfaces();
+  const result = floatingWindowRuntime.repositionAnchoredSurfaces();
+  // #640: pet bounds changed — re-evaluate the editing-overlap dodge (a drag
+  // can slide the pet over the bubble being typed into; the bubble itself is
+  // frozen while editing, and roam is paused, so the pet is the mover here).
+  topmostRuntime.syncImeEditingPetDodge();
+  return result;
 }
 
 function syncSessionHudVisibilityAndBubbles() {
@@ -3967,6 +3974,10 @@ const _roamCtx = {
   applyState: (state, svgOverride, opts) => _state.applyState(state, svgOverride, opts),
   setState: (state, svgOverride, opts) => _state.setState(state, svgOverride, opts),
   setRoamHeading: (headingLeft) => sendToRenderer("roam-heading", !!headingLeft),
+  // #640: hold still while the user types into a bubble text field (macOS)
+  isImeEditingActive: () => pendingPermissions.some(
+    (p) => p && p.bubble && !p.bubble.isDestroyed() && p.bubble.__clawdMacImeEditing
+  ),
 };
 const _roam = require("./roam")(_roamCtx);
 

--- a/src/main.js
+++ b/src/main.js
@@ -719,6 +719,9 @@ const petWindowRuntime = createPetWindowRuntime({
   keepOutOfTaskbar,
   repositionSessionHud: () => repositionSessionHud(),
   repositionAnchoredSurfaces: () => repositionAnchoredFloatingSurfaces(),
+  // #640: hitbox changes without a window move (state switch, theme reload)
+  // must re-answer the editing-overlap question. (Lazy — defined below.)
+  syncImeEditingPetDodge: () => topmostRuntime.syncImeEditingPetDodge(),
   repositionFloatingBubbles: () => repositionFloatingBubbles(),
   showFloatingSurfacesForPet: () => floatingWindowRuntime.showFloatingSurfacesForPet(),
   hideFloatingSurfacesForPet: () => floatingWindowRuntime.hideFloatingSurfacesForPet(),
@@ -3772,6 +3775,7 @@ function createWindow() {
     beginDragSnapshot: () => beginDragSnapshot(),
     clearDragSnapshot: () => clearDragSnapshot(),
     syncHitWin: () => syncHitWin(),
+    syncImeEditingPetDodge: () => topmostRuntime.syncImeEditingPetDodge(),
     isMiniMode: () => _mini.getMiniMode(),
     checkMiniModeSnap: () => checkMiniModeSnap(),
     getDisableMiniMode: () => disableMiniModeCached,

--- a/src/permission.js
+++ b/src/permission.js
@@ -826,6 +826,20 @@ function dismissPermissionWithoutDecision(permEntry, message) {
 }
 
 function notifyPermissionsChanged(reason) {
+  // #640: every path that adds or removes a pendingPermissions entry funnels
+  // through here — including resolvePermissionEntry's inline splice, which is
+  // what Allow/Deny clicks, Enter submits, and the auto-close timer all use.
+  // A bubble can leave the list while its text field still holds focus (no
+  // blur ever fires, and handleImeEditing can't match a spliced entry), so
+  // this is the one reliable place to re-run the editing-overlap dodge scan
+  // and restore the pet. Cheap + edge-triggered; platform gate lives inside.
+  if (typeof ctx.syncImeEditingPetDodge === "function") {
+    try {
+      ctx.syncImeEditingPetDodge();
+    } catch (err) {
+      permLog(`syncImeEditingPetDodge failed: ${err && err.message ? err.message : err}`);
+    }
+  }
   if (typeof ctx.onPermissionsChanged !== "function") return;
   try {
     ctx.onPermissionsChanged(reason);
@@ -864,14 +878,6 @@ function removePendingPermission(permEntry, reason = "removed") {
   if (idx === -1) return false;
   pendingPermissions.splice(idx, 1);
   notifyPermissionsChanged(reason);
-  // #640: if this bubble closed while its text field was still focused, the
-  // pet may be faded + click-through (syncImeEditingPetDodge) with no blur
-  // event coming to undo it. Re-run the visibility pass — it re-scans
-  // pendingPermissions and restores the pet once no editing bubble remains.
-  if (isMac && permEntry.bubble && permEntry.bubble.__clawdMacImeEditing
-      && typeof ctx.reapplyMacVisibility === "function") {
-    ctx.reapplyMacVisibility();
-  }
   return true;
 }
 

--- a/src/permission.js
+++ b/src/permission.js
@@ -624,6 +624,11 @@ function repositionBubbles() {
       // with a different textScale (applyZoomToWindow memoizes, so this is
       // a no-op when nothing changed).
       applyZoomToWindow(perm.bubble, scale);
+      // #640: a bubble whose text field is being typed into holds its
+      // position — followPet anchoring must not yank the input box around
+      // mid-composition (pet drag; roam is separately paused while editing).
+      // Fresh bubbles never carry the flag, so they still get placed.
+      if (perm.bubble.__clawdMacImeEditing) continue;
       perm.bubble.setBounds(bounds[i]);
     }
   }
@@ -859,6 +864,14 @@ function removePendingPermission(permEntry, reason = "removed") {
   if (idx === -1) return false;
   pendingPermissions.splice(idx, 1);
   notifyPermissionsChanged(reason);
+  // #640: if this bubble closed while its text field was still focused, the
+  // pet may be faded + click-through (syncImeEditingPetDodge) with no blur
+  // event coming to undo it. Re-run the visibility pass — it re-scans
+  // pendingPermissions and restores the pet once no editing bubble remains.
+  if (isMac && permEntry.bubble && permEntry.bubble.__clawdMacImeEditing
+      && typeof ctx.reapplyMacVisibility === "function") {
+    ctx.reapplyMacVisibility();
+  }
   return true;
 }
 

--- a/src/permission.js
+++ b/src/permission.js
@@ -788,6 +788,12 @@ function showPermissionBubble(permEntry) {
     }
   });
 
+  // #640: a dead renderer can never send the focusout/window-blur IPC that
+  // clears the editing flag — without this, a crash while a text field was
+  // focused leaves the flag stuck and the pet faded + click-through for as
+  // long as the entry lives.
+  bub.webContents.on("render-process-gone", () => handleBubbleRendererGone(bub));
+
   ctx.guardAlwaysOnTop(bub);
   syncPermissionShortcuts();
   armPermissionAutoCloseTimer(permEntry);
@@ -1909,6 +1915,16 @@ function handleImeEditing(event, editing) {
   if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
 }
 
+// #640: the editing flag is normally cleared by renderer focusout/window-blur
+// IPC (see handleImeEditing) — a crashed renderer can't send either, so the
+// flag would stay stuck and keep the pet faded + click-through. Called from
+// the bubble's render-process-gone listener.
+function handleBubbleRendererGone(bubble) {
+  if (!bubble || !bubble.__clawdMacImeEditing) return;
+  delete bubble.__clawdMacImeEditing;
+  if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
+}
+
 function handleDecide(event, behavior) {
   // Identify which permission this bubble belongs to via sender webContents
   const senderWin = BrowserWindow.fromWebContents(event.sender);
@@ -2297,7 +2313,7 @@ return {
   addPendingPermission, removePendingPermission,
   maybeStartRemoteApproval,
   dismissPermissionForTerminal,
-  handleBubbleHeight, handleDecide, handleImeEditing, cleanup,
+  handleBubbleHeight, handleDecide, handleImeEditing, handleBubbleRendererGone, cleanup,
   showCodexNotifyBubble, clearCodexNotifyBubbles,
   showKimiNotifyBubble, clearKimiNotifyBubbles,
   refreshPassiveNotifyAutoClose,

--- a/src/pet-interaction-ipc.js
+++ b/src/pet-interaction-ipc.js
@@ -55,6 +55,10 @@ function registerPetInteractionIpc(options = {}) {
     options.setLowPowerIdlePaused,
     "setLowPowerIdlePaused"
   );
+  // #640: the editing-overlap dodge defers its hit-window click-through write
+  // while a drag is in flight; drag-lock release must re-run the sync so the
+  // state the drag ended in (overlapping or not) gets applied.
+  const syncImeEditingPetDodge = options.syncImeEditingPetDodge || (() => {});
   const statPath = requiredDependency(options.statPath, "statPath");
   const openTerminalAt = requiredDependency(options.openTerminalAt, "openTerminalAt");
   const dropLog = options.dropLog || (() => {});
@@ -91,6 +95,7 @@ function registerPetInteractionIpc(options = {}) {
     } else {
       clearDragSnapshot();
       syncHitWin();
+      syncImeEditingPetDodge();
     }
   });
 
@@ -124,6 +129,11 @@ function registerPetInteractionIpc(options = {}) {
     } finally {
       setDragLocked(false);
       clearDragSnapshot();
+      // Normally the preceding drag-lock(false) already re-ran the dodge, but
+      // this handler also releases the lock defensively — mirror the re-run so
+      // a drag-end without a paired drag-lock(false) can't strand the deferred
+      // click-through write.
+      syncImeEditingPetDodge();
     }
   });
 

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -632,7 +632,10 @@ function createPetWindowRuntime(options = {}) {
     // setShape: native hit region, no per-pixel alpha dependency.
     // hitWin has no visual content, so clipping is irrelevant.
     hitWin.setShape([{ x: 0, y: 0, width: initialHitWindowBounds.width, height: initialHitWindowBounds.height }]);
-    hitWin.setIgnoreMouseEvents(false); // PERMANENT: never toggle outside settings preview protection.
+    // Baseline: interactive. Only two writers may toggle this — the Windows
+    // settings-size-preview protection (below) and the macOS editing-overlap
+    // dodge (#640, topmost-runtime.js). They are platform-disjoint.
+    hitWin.setIgnoreMouseEvents(false);
     if (isMac) hitWin.setFocusable(false);
     hitWin.showInactive();
     keepOutOfTaskbar(hitWin);

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -127,6 +127,10 @@ function createPetWindowRuntime(options = {}) {
   const buildTrayMenu = options.buildTrayMenu || noop;
   const buildContextMenu = options.buildContextMenu || noop;
   const reapplyMacVisibility = options.reapplyMacVisibility || noop;
+  // #640: re-run the editing-overlap dodge whenever the hit geometry syncs —
+  // the hitbox can change without the window moving (state switches between
+  // hitboxes, theme reload), which changes the overlap answer.
+  const syncImeEditingPetDodge = options.syncImeEditingPetDodge || noop;
   const reassertWinTopmost = options.reassertWinTopmost || noop;
   const scheduleHwndRecovery = options.scheduleHwndRecovery || noop;
   const isNearWorkAreaEdge = options.isNearWorkAreaEdge || (() => false);
@@ -488,6 +492,10 @@ function createPetWindowRuntime(options = {}) {
       hitWin.setShape([{ x: 0, y: 0, width: w, height: h }]);
     }
     repositionSessionHud();
+    // #640: the hit rect just (re)resolved — state switches and theme reloads
+    // change hitboxes without moving the window, so the overlap answer can
+    // flip right here. Cheap + edge-triggered inside.
+    syncImeEditingPetDodge();
   }
 
   function getInitialHitWindowBounds(renderBounds = getPetWindowBounds()) {

--- a/src/roam.js
+++ b/src/roam.js
@@ -44,6 +44,12 @@ module.exports = function initRoam(ctx) {
     // Allow roaming when idle (about to start) or already roaming (mid-animation)
     if (state !== "idle" && state !== "roam") return false;
     if (ctx.miniTransitioning) return false;
+    // #640: while the user is typing into a bubble's text field (macOS IME
+    // editing), the pet must hold still — a wandering pet either drags the
+    // bubble along (followPet anchoring) or walks over the box being typed
+    // into. Checked per-frame like the state gate, so an editing start
+    // cancels a walk mid-stride.
+    if (typeof ctx.isImeEditingActive === "function" && ctx.isImeEditingActive()) return false;
     return true;
   }
 
@@ -155,10 +161,12 @@ module.exports = function initRoam(ctx) {
       // Re-check state on every frame: if the pet is no longer idle/roam (e.g. a
       // working/notification event arrived), stop the animation immediately.
       if (!isRoamAllowed()) {
-        roamActive = false;
-        cleanupTimers();
-        // State changed away from idle/roam — next idle entry should wait full delay
+        // Next idle entry should wait the full delay again
         firstRoam = true;
+        // cancelRoam also restores "idle" when the state is still "roam" —
+        // gates with no incoming state of their own (IME editing #640, mini
+        // mode) would otherwise strand the pet frozen in its walk pose.
+        cancelRoam();
         return;
       }
 

--- a/src/theme-fade-sequencer.js
+++ b/src/theme-fade-sequencer.js
@@ -12,6 +12,11 @@ function isLiveWindow(win) {
 function createThemeFadeSequencer(options = {}) {
   const getRenderWindow = options.getRenderWindow || (() => null);
   const getHitWindow = options.getHitWindow || (() => null);
+  // #640: "full" opacity is not always 1 — while the pet dodges an editing
+  // bubble it sits at a faded value owned by topmost-runtime. Every restore
+  // path below asks this at restore time instead of hardcoding 1, so a theme
+  // reload mid-edit doesn't snap the pet opaque over the box being typed into.
+  const getRestoreOpacity = options.getRestoreOpacity || (() => 1);
   const animateWindowOpacity = options.animateWindowOpacity || defaultAnimateWindowOpacity;
   const setWindowOpacity = options.setWindowOpacity || defaultSetWindowOpacity;
   const setTimeoutFn = options.setTimeout || setTimeout;
@@ -27,6 +32,12 @@ function createThemeFadeSequencer(options = {}) {
 
   function isCurrent(seq) {
     return seq === sequenceId;
+  }
+
+  function restoreOpacity() {
+    let value = 1;
+    try { value = Number(getRestoreOpacity()); } catch { value = 1; }
+    return Number.isFinite(value) ? Math.max(0, Math.min(1, value)) : 1;
   }
 
   function clearFadeFallback() {
@@ -58,7 +69,7 @@ function createThemeFadeSequencer(options = {}) {
       if (typeof onFallback === "function") {
         onFallback();
       } else {
-        setWindowOpacity(getRenderWindow(), 1);
+        setWindowOpacity(getRenderWindow(), restoreOpacity());
       }
     }, fallbackMs);
   }
@@ -81,8 +92,9 @@ function createThemeFadeSequencer(options = {}) {
   function fadeIn(seq) {
     if (!isCurrent(seq)) return;
     clearFadeFallback();
-    animateOpacity(seq, 1, fadeInMs).then((ok) => {
-      if (!ok && isCurrent(seq)) setWindowOpacity(getRenderWindow(), 1);
+    const target = restoreOpacity();
+    animateOpacity(seq, target, fadeInMs).then((ok) => {
+      if (!ok && isCurrent(seq)) setWindowOpacity(getRenderWindow(), restoreOpacity());
     });
   }
 
@@ -92,7 +104,7 @@ function createThemeFadeSequencer(options = {}) {
     const hitWin = getHitWindow();
     if (!isLiveWindow(renderWin) || !isLiveWindow(hitWin)) {
       if (typeof onFallback === "function") onFallback();
-      else setWindowOpacity(renderWin, 1);
+      else setWindowOpacity(renderWin, restoreOpacity());
       return;
     }
 

--- a/src/theme-fade-sequencer.js
+++ b/src/theme-fade-sequencer.js
@@ -94,7 +94,18 @@ function createThemeFadeSequencer(options = {}) {
     clearFadeFallback();
     const target = restoreOpacity();
     animateOpacity(seq, target, fadeInMs).then((ok) => {
-      if (!ok && isCurrent(seq)) setWindowOpacity(getRenderWindow(), restoreOpacity());
+      if (!isCurrent(seq)) return;
+      if (!ok) {
+        setWindowOpacity(getRenderWindow(), restoreOpacity());
+        return;
+      }
+      // #640: the baseline can move WHILE this fade-in runs (the dodge engages
+      // or releases mid-animation, racing this loop with its own independent
+      // one — separate cancel signals, last writer wins). Whoever finishes
+      // last must land on the CURRENT baseline, so re-read it at completion
+      // and converge instead of trusting the target chosen at start.
+      const finalTarget = restoreOpacity();
+      if (finalTarget !== target) setWindowOpacity(getRenderWindow(), finalTarget);
     });
   }
 

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -223,11 +223,18 @@ function createTopmostRuntime(options = {}) {
   // space — always above the editing bubble, which #626 drops to the normal
   // level — so until a native space de-delegation exists (#640 phase 2) this
   // fade is the mitigation. Edge-triggered on the overlap state; every
-  // transition path funnels here: handleImeEditing and bubble teardown call
-  // reapplyMacVisibility, and pet moves call this directly (main.js).
+  // transition path funnels here: handleImeEditing calls reapplyMacVisibility,
+  // pet moves call this directly (main.js), and every pendingPermissions
+  // add/remove calls this via notifyPermissionsChanged (permission.js) — that
+  // last one covers bubbles that leave the list while their text field still
+  // holds focus (Enter submit, auto-close), where no blur ever fires.
   // The hit window's ignore-mouse has exactly one other writer — the Windows
   // settings-size-preview protection (pet-window-runtime.js) — which is
   // platform-disjoint with this macOS-only path, so the two never fight.
+  // The render window's opacity has one other writer, the theme-switch fade
+  // (theme-fade-sequencer.js): its restore target asks getPetTargetOpacity()
+  // below instead of assuming 1, so a mid-edit theme reload lands back on the
+  // faded value rather than snapping the pet opaque over the input box.
   function syncImeEditingPetDodge() {
     if (!isMac) return;
     const editingBubble = findImeEditingBubble();
@@ -248,6 +255,13 @@ function createTopmostRuntime(options = {}) {
     if (isLiveWindow(hitWin) && typeof hitWin.setIgnoreMouseEvents === "function") {
       hitWin.setIgnoreMouseEvents(overlap);
     }
+  }
+
+  // #640: the render window's baseline opacity as far as the dodge is
+  // concerned. External opacity writers that restore "full" opacity (the
+  // theme-switch fade) must ask this instead of hardcoding 1.
+  function getPetTargetOpacity() {
+    return imeEditingPetDodge ? IME_EDIT_PET_FADE_OPACITY : 1;
   }
 
   function isNearWorkAreaEdge(bounds, tolerance = 2) {
@@ -457,6 +471,7 @@ function createTopmostRuntime(options = {}) {
     reassertWinTopmost,
     reapplyMacVisibility,
     syncImeEditingPetDodge,
+    getPetTargetOpacity,
     isNearWorkAreaEdge,
     scheduleHwndRecovery,
     guardAlwaysOnTop,

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -3,6 +3,7 @@
 const {
   applyStationaryCollectionBehavior: defaultApplyStationaryCollectionBehavior,
 } = require("./mac-window");
+const { animateWindowOpacity } = require("./window-opacity-transition");
 
 const WIN_TOPMOST_LEVEL = "pop-up-menu";  // above taskbar-level UI
 const MAC_TOPMOST_LEVEL = "screen-saver"; // above fullscreen apps on macOS
@@ -14,6 +15,13 @@ const TOPMOST_WATCHDOG_MS = 5_000;
 // this polls ~1s instead of riding the slow watchdog (which left a ~5s window).
 const FOCUSABLE_POLL_MS = 1_000;
 const HWND_RECOVERY_DELAY_MS = 1000;
+// #640: while a bubble text field is focused AND the pet visually overlaps that
+// bubble, the pet fades to this opacity and its hit window goes click-through.
+// The pet lives in the SkyLight private space (always above the editing bubble,
+// which drops to the normal level — #626), so until a native de-delegation
+// exists this is the polite way to keep the input box readable and clickable.
+const IME_EDIT_PET_FADE_OPACITY = 0.18;
+const IME_EDIT_PET_FADE_MS = 160;
 
 function isLiveWindow(win) {
   return !!(win && typeof win.isDestroyed === "function" && !win.isDestroyed());
@@ -21,6 +29,16 @@ function isLiveWindow(win) {
 
 function defaultGetter(value) {
   return typeof value === "function" ? value : () => value;
+}
+
+function rectsIntersect(a, b) {
+  if (!a || !b) return false;
+  const aw = Number(a.width) || 0;
+  const ah = Number(a.height) || 0;
+  const bw = Number(b.width) || 0;
+  const bh = Number(b.height) || 0;
+  if (aw <= 0 || ah <= 0 || bw <= 0 || bh <= 0) return false;
+  return a.x < b.x + bw && b.x < a.x + aw && a.y < b.y + bh && b.y < a.y + ah;
 }
 
 function createTopmostRuntime(options = {}) {
@@ -34,6 +52,13 @@ function createTopmostRuntime(options = {}) {
   const getContextMenuOwner = options.getContextMenuOwner || (() => null);
   const getNearestWorkArea = options.getNearestWorkArea || (() => null);
   const getPetWindowBounds = options.getPetWindowBounds || (() => null);
+  // #640: tight screen-space rect of the visible pet sprite (the pet window
+  // frame is much larger than what's drawn). Falls back to the window bounds
+  // when unset, which only makes the overlap test more conservative.
+  const getHitRectScreen = options.getHitRectScreen || (() => null);
+  const imeEditingFadeMs = Number.isFinite(options.imeEditingFadeMs)
+    ? options.imeEditingFadeMs
+    : IME_EDIT_PET_FADE_MS;
   const getShowDock = options.getShowDock || (() => true);
   const isDragLocked = options.isDragLocked || (() => false);
   const isMiniAnimating = options.isMiniAnimating || (() => false);
@@ -80,6 +105,10 @@ function createTopmostRuntime(options = {}) {
   let focusablePoll = null;
   let hwndRecoveryTimer = null;
   let pendingNudgeRestore = null;
+  // #640 editing-overlap dodge state: true while the pet is faded +
+  // click-through because it overlaps the bubble being typed into.
+  let imeEditingPetDodge = false;
+  let imeEditingFadeCancel = null;
 
   function reassertWinTopmost() {
     if (!isWin) return;
@@ -149,6 +178,64 @@ function createTopmostRuntime(options = {}) {
     apply(getUpdateBubbleWindow());
     apply(getSessionHudWindow());
     apply(getContextMenuOwner());
+    syncImeEditingPetDodge();
+  }
+
+  function findImeEditingBubble() {
+    for (const perm of getPendingPermissions() || []) {
+      const bubble = perm && perm.bubble;
+      if (isLiveWindow(bubble) && bubble.__clawdMacImeEditing) return bubble;
+    }
+    return null;
+  }
+
+  function fadePetWindow(targetOpacity) {
+    if (imeEditingFadeCancel) imeEditingFadeCancel.cancelled = true;
+    const signal = { cancelled: false };
+    imeEditingFadeCancel = signal;
+    const win = getWin();
+    if (!isLiveWindow(win) || typeof win.setOpacity !== "function") return;
+    animateWindowOpacity(win, targetOpacity, {
+      durationMs: imeEditingFadeMs,
+      cancelSignal: signal,
+      setTimeout: setTimeoutFn,
+      clearTimeout: clearTimeoutFn,
+    });
+  }
+
+  // #640: while a bubble text field is focused (permission.js handleImeEditing,
+  // macOS only) AND the pet sprite overlaps that bubble, the pet politely steps
+  // back: its render window fades to IME_EDIT_PET_FADE_OPACITY and the hit
+  // window stops intercepting clicks, so the box being typed into stays
+  // readable and clickable underneath. The pet stays in the SkyLight private
+  // space — always above the editing bubble, which #626 drops to the normal
+  // level — so until a native space de-delegation exists (#640 phase 2) this
+  // fade is the mitigation. Edge-triggered on the overlap state; every
+  // transition path funnels here: handleImeEditing and bubble teardown call
+  // reapplyMacVisibility, and pet moves call this directly (main.js).
+  // The hit window's ignore-mouse has exactly one other writer — the Windows
+  // settings-size-preview protection (pet-window-runtime.js) — which is
+  // platform-disjoint with this macOS-only path, so the two never fight.
+  function syncImeEditingPetDodge() {
+    if (!isMac) return;
+    const editingBubble = findImeEditingBubble();
+    let overlap = false;
+    if (editingBubble && typeof editingBubble.getBounds === "function") {
+      const petBounds = getPetWindowBounds();
+      let petRect = null;
+      try { petRect = getHitRectScreen(petBounds); } catch { petRect = null; }
+      if (!petRect) petRect = petBounds;
+      let bubbleRect = null;
+      try { bubbleRect = editingBubble.getBounds(); } catch { bubbleRect = null; }
+      overlap = rectsIntersect(petRect, bubbleRect);
+    }
+    if (overlap === imeEditingPetDodge) return;
+    imeEditingPetDodge = overlap;
+    fadePetWindow(overlap ? IME_EDIT_PET_FADE_OPACITY : 1);
+    const hitWin = getHitWin();
+    if (isLiveWindow(hitWin) && typeof hitWin.setIgnoreMouseEvents === "function") {
+      hitWin.setIgnoreMouseEvents(overlap);
+    }
   }
 
   function isNearWorkAreaEdge(bounds, tolerance = 2) {
@@ -348,11 +435,16 @@ function createTopmostRuntime(options = {}) {
       hwndRecoveryTimer = null;
     }
     pendingNudgeRestore = null;
+    if (imeEditingFadeCancel) {
+      imeEditingFadeCancel.cancelled = true;
+      imeEditingFadeCancel = null;
+    }
   }
 
   return {
     reassertWinTopmost,
     reapplyMacVisibility,
+    syncImeEditingPetDodge,
     isNearWorkAreaEdge,
     scheduleHwndRecovery,
     guardAlwaysOnTop,
@@ -366,6 +458,7 @@ function createTopmostRuntime(options = {}) {
 
 createTopmostRuntime.WIN_TOPMOST_LEVEL = WIN_TOPMOST_LEVEL;
 createTopmostRuntime.MAC_TOPMOST_LEVEL = MAC_TOPMOST_LEVEL;
+createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY = IME_EDIT_PET_FADE_OPACITY;
 createTopmostRuntime.TOPMOST_WATCHDOG_MS = TOPMOST_WATCHDOG_MS;
 createTopmostRuntime.FOCUSABLE_POLL_MS = FOCUSABLE_POLL_MS;
 createTopmostRuntime.HWND_RECOVERY_DELAY_MS = HWND_RECOVERY_DELAY_MS;

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -31,14 +31,26 @@ function defaultGetter(value) {
   return typeof value === "function" ? value : () => value;
 }
 
-function rectsIntersect(a, b) {
+// Accepts both rect shapes in use across the codebase: window bounds are
+// { x, y, width, height } while hit-geometry rects (getHitRectScreen) are
+// { left, top, right, bottom }.
+function normalizeRect(rect) {
+  if (!rect) return null;
+  if (Number.isFinite(rect.x) && Number.isFinite(rect.width)) {
+    return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+  }
+  if (Number.isFinite(rect.left) && Number.isFinite(rect.right)) {
+    return { x: rect.left, y: rect.top, width: rect.right - rect.left, height: rect.bottom - rect.top };
+  }
+  return null;
+}
+
+function rectsIntersect(rawA, rawB) {
+  const a = normalizeRect(rawA);
+  const b = normalizeRect(rawB);
   if (!a || !b) return false;
-  const aw = Number(a.width) || 0;
-  const ah = Number(a.height) || 0;
-  const bw = Number(b.width) || 0;
-  const bh = Number(b.height) || 0;
-  if (aw <= 0 || ah <= 0 || bw <= 0 || bh <= 0) return false;
-  return a.x < b.x + bw && b.x < a.x + aw && a.y < b.y + bh && b.y < a.y + ah;
+  if (a.width <= 0 || a.height <= 0 || b.width <= 0 || b.height <= 0) return false;
+  return a.x < b.x + b.width && b.x < a.x + a.width && a.y < b.y + b.height && b.y < a.y + a.height;
 }
 
 function createTopmostRuntime(options = {}) {

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -120,6 +120,10 @@ function createTopmostRuntime(options = {}) {
   // #640 editing-overlap dodge state: true while the pet is faded +
   // click-through because it overlaps the bubble being typed into.
   let imeEditingPetDodge = false;
+  // Tracked separately from the dodge boolean: the hit window's click-through
+  // write is deferred while a drag is in flight (see syncImeEditingPetDodge),
+  // so "what we want" and "what we last wrote" can legitimately differ.
+  let imeEditingHitIgnoreApplied = false;
   let imeEditingFadeCancel = null;
 
   function reassertWinTopmost() {
@@ -248,12 +252,24 @@ function createTopmostRuntime(options = {}) {
       try { bubbleRect = editingBubble.getBounds(); } catch { bubbleRect = null; }
       overlap = rectsIntersect(petRect, bubbleRect);
     }
-    if (overlap === imeEditingPetDodge) return;
-    imeEditingPetDodge = overlap;
-    fadePetWindow(overlap ? IME_EDIT_PET_FADE_OPACITY : 1);
+    if (overlap !== imeEditingPetDodge) {
+      imeEditingPetDodge = overlap;
+      fadePetWindow(overlap ? IME_EDIT_PET_FADE_OPACITY : 1);
+    }
+    // The click-through write is deferred while a drag is in flight: an
+    // established macOS mouse-tracking session keeps delivering the drag's
+    // events, but Electron's setIgnoreMouseEvents contract makes no promise
+    // about toggling mid-gesture — flipping it here could strand the drag
+    // with dragLocked stuck true. The fade above still runs mid-drag (that
+    // transition is the hands-on-verified experience); the ignore-mouse state
+    // is applied on the next sync after the drag ends (pet-interaction-ipc
+    // re-runs this on drag-lock release).
+    if (isDragLocked()) return;
+    if (imeEditingHitIgnoreApplied === imeEditingPetDodge) return;
     const hitWin = getHitWin();
     if (isLiveWindow(hitWin) && typeof hitWin.setIgnoreMouseEvents === "function") {
-      hitWin.setIgnoreMouseEvents(overlap);
+      hitWin.setIgnoreMouseEvents(imeEditingPetDodge);
+      imeEditingHitIgnoreApplied = imeEditingPetDodge;
     }
   }
 

--- a/test/permission-640-editing-freeze.test.js
+++ b/test/permission-640-editing-freeze.test.js
@@ -1,0 +1,132 @@
+"use strict";
+
+const assert = require("node:assert");
+const Module = require("node:module");
+const { describe, it } = require("node:test");
+
+// ── Mock electron before requiring permission.js (same pattern as
+// permission-ime-editing.test.js): handleImeEditing and friends resolve IPC
+// senders via BrowserWindow.fromWebContents, and the test runtime's
+// require("electron") returns a path string.
+const __electronMock = {
+  BrowserWindow: { fromWebContents: (sender) => (sender && sender.__win) || null },
+  globalShortcut: {
+    register: () => {}, unregister: () => {}, unregisterAll: () => {}, isRegistered: () => false,
+  },
+};
+const __origModuleLoad = Module._load;
+Module._load = function (request) {
+  if (request === "electron") return __electronMock;
+  return __origModuleLoad.apply(this, arguments);
+};
+const initPermission = require("../src/permission");
+Module._load = __origModuleLoad;
+
+const macOnly = { skip: process.platform !== "darwin" ? "macOS-only" : false };
+
+function makeCtx(overrides = {}) {
+  return {
+    reapplyMacVisibility: () => {},
+    getSettingsSnapshot: () => ({}),
+    isAgentPermissionsEnabled: () => true,
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
+    getPetWindowBounds: () => ({ x: 200, y: 200, width: 120, height: 120 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => ({ x: 200, y: 200, width: 120, height: 120 }),
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop: () => {},
+    focusTerminalForSession: () => {},
+    win: { isDestroyed: () => false },
+    bubbleFollowPet: true,
+    doNotDisturb: false,
+    hideBubbles: false,
+    sessions: new Map(),
+    pendingPermissions: [],
+    subscribeShortcuts: () => () => {},
+    onPermissionsChanged: () => {},
+    onPermissionResolved: () => {},
+    STATE_SVGS: {},
+    setState: () => {},
+    updateSession: () => {},
+    ...overrides,
+  };
+}
+
+function makeBubble(overrides = {}) {
+  return {
+    isDestroyed: () => false,
+    setBoundsCalls: [],
+    setBounds(bounds) { this.setBoundsCalls.push(bounds); },
+    getBounds: () => ({ x: 0, y: 0, width: 300, height: 200 }),
+    ...overrides,
+  };
+}
+
+describe("repositionBubbles freeze while editing (#640)", () => {
+  it("skips the bubble being typed into and still places the others", () => {
+    const ctx = makeCtx();
+    const { repositionBubbles, pendingPermissions } = initPermission(ctx);
+
+    const frozen = makeBubble();
+    frozen.__clawdMacImeEditing = true;
+    const normal = makeBubble();
+    pendingPermissions.push(
+      { bubble: frozen, suggestions: [], measuredHeight: 120 },
+      { bubble: normal, suggestions: [], measuredHeight: 120 },
+    );
+
+    repositionBubbles();
+
+    assert.strictEqual(frozen.setBoundsCalls.length, 0,
+      "the editing bubble must hold its position");
+    assert.strictEqual(normal.setBoundsCalls.length, 1,
+      "non-editing bubbles still get placed");
+  });
+
+  it("places every bubble again once editing ends", () => {
+    const ctx = makeCtx();
+    const { repositionBubbles, pendingPermissions } = initPermission(ctx);
+
+    const bubble = makeBubble();
+    bubble.__clawdMacImeEditing = true;
+    pendingPermissions.push({ bubble, suggestions: [], measuredHeight: 120 });
+
+    repositionBubbles();
+    assert.strictEqual(bubble.setBoundsCalls.length, 0);
+
+    delete bubble.__clawdMacImeEditing;
+    repositionBubbles();
+    assert.strictEqual(bubble.setBoundsCalls.length, 1);
+  });
+});
+
+describe("removePendingPermission editing cleanup (#640)", () => {
+  it("re-runs the mac visibility pass when the removed bubble was mid-edit", macOnly, () => {
+    const reapply = [];
+    const ctx = makeCtx({ reapplyMacVisibility: () => reapply.push(true) });
+    const { removePendingPermission, pendingPermissions } = initPermission(ctx);
+
+    const bubble = makeBubble();
+    bubble.__clawdMacImeEditing = true;
+    const perm = { bubble, suggestions: [] };
+    pendingPermissions.push(perm);
+
+    removePendingPermission(perm, "test");
+
+    assert.strictEqual(reapply.length, 1,
+      "closing an editing bubble must restore the pet via reapplyMacVisibility");
+  });
+
+  it("does not run the visibility pass for a non-editing bubble", macOnly, () => {
+    const reapply = [];
+    const ctx = makeCtx({ reapplyMacVisibility: () => reapply.push(true) });
+    const { removePendingPermission, pendingPermissions } = initPermission(ctx);
+
+    const perm = { bubble: makeBubble(), suggestions: [] };
+    pendingPermissions.push(perm);
+
+    removePendingPermission(perm, "test");
+
+    assert.strictEqual(reapply.length, 0);
+  });
+});

--- a/test/permission-640-editing-freeze.test.js
+++ b/test/permission-640-editing-freeze.test.js
@@ -22,11 +22,10 @@ Module._load = function (request) {
 const initPermission = require("../src/permission");
 Module._load = __origModuleLoad;
 
-const macOnly = { skip: process.platform !== "darwin" ? "macOS-only" : false };
-
 function makeCtx(overrides = {}) {
   return {
     reapplyMacVisibility: () => {},
+    syncImeEditingPetDodge: () => {},
     getSettingsSnapshot: () => ({}),
     isAgentPermissionsEnabled: () => true,
     getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
@@ -100,10 +99,17 @@ describe("repositionBubbles freeze while editing (#640)", () => {
   });
 });
 
-describe("removePendingPermission editing cleanup (#640)", () => {
-  it("re-runs the mac visibility pass when the removed bubble was mid-edit", macOnly, () => {
-    const reapply = [];
-    const ctx = makeCtx({ reapplyMacVisibility: () => reapply.push(true) });
+// #640: the dodge re-scan is funneled through notifyPermissionsChanged, so it
+// fires on EVERY pendingPermissions change regardless of platform or editing
+// state — the platform gate and the edge-trigger live in topmost-runtime.js
+// (covered by topmost-runtime.test.js). What matters here is that every
+// production removal path reaches the scan, because a bubble can leave the
+// list while its text field still holds focus (Enter submit, auto-close) and
+// no blur will ever fire to restore the pet.
+describe("pendingPermissions changes re-run the dodge scan (#640)", () => {
+  it("fires when removePendingPermission drops a mid-edit bubble", () => {
+    const syncs = [];
+    const ctx = makeCtx({ syncImeEditingPetDodge: () => syncs.push(true) });
     const { removePendingPermission, pendingPermissions } = initPermission(ctx);
 
     const bubble = makeBubble();
@@ -113,20 +119,43 @@ describe("removePendingPermission editing cleanup (#640)", () => {
 
     removePendingPermission(perm, "test");
 
-    assert.strictEqual(reapply.length, 1,
-      "closing an editing bubble must restore the pet via reapplyMacVisibility");
+    assert.strictEqual(syncs.length, 1,
+      "removing an editing bubble must re-run the dodge scan");
   });
 
-  it("does not run the visibility pass for a non-editing bubble", macOnly, () => {
-    const reapply = [];
-    const ctx = makeCtx({ reapplyMacVisibility: () => reapply.push(true) });
+  it("fires on resolvePermissionEntry — the path Allow/Deny, Enter submit, and auto-close use", () => {
+    const syncs = [];
+    const ctx = makeCtx({ syncImeEditingPetDodge: () => syncs.push(true) });
+    const { resolvePermissionEntry, pendingPermissions } = initPermission(ctx);
+
+    const bubble = makeBubble({ webContents: { send: () => {} } });
+    bubble.__clawdMacImeEditing = true;
+    const perm = {
+      bubble,
+      suggestions: [],
+      createdAt: Date.now(),
+      res: null, // client gone — resolve still must splice and re-scan
+    };
+    pendingPermissions.push(perm);
+
+    resolvePermissionEntry(perm, "no-decision", "Auto-closed");
+
+    assert.strictEqual(pendingPermissions.length, 0,
+      "entry must be spliced by resolvePermissionEntry");
+    assert.strictEqual(syncs.length, 1,
+      "resolving an editing bubble must re-run the dodge scan — this is the "
+      + "production close path, which never goes through removePendingPermission");
+    if (perm.hideTimer) clearTimeout(perm.hideTimer);
+  });
+
+  it("survives a throwing sync without breaking the removal", () => {
+    const ctx = makeCtx({ syncImeEditingPetDodge: () => { throw new Error("boom"); } });
     const { removePendingPermission, pendingPermissions } = initPermission(ctx);
 
     const perm = { bubble: makeBubble(), suggestions: [] };
     pendingPermissions.push(perm);
 
-    removePendingPermission(perm, "test");
-
-    assert.strictEqual(reapply.length, 0);
+    assert.strictEqual(removePendingPermission(perm, "test"), true);
+    assert.strictEqual(pendingPermissions.length, 0);
   });
 });

--- a/test/permission-640-editing-freeze.test.js
+++ b/test/permission-640-editing-freeze.test.js
@@ -159,3 +159,33 @@ describe("pendingPermissions changes re-run the dodge scan (#640)", () => {
     assert.strictEqual(pendingPermissions.length, 0);
   });
 });
+
+// #640: a crashed bubble renderer can never send the focusout/window-blur IPC
+// that clears the editing flag — the render-process-gone listener routes here.
+describe("handleBubbleRendererGone (#640)", () => {
+  it("clears a stuck editing flag and re-runs the visibility pass", () => {
+    const reapply = [];
+    const ctx = makeCtx({ reapplyMacVisibility: () => reapply.push(true) });
+    const { handleBubbleRendererGone } = initPermission(ctx);
+
+    const bubble = makeBubble();
+    bubble.__clawdMacImeEditing = true;
+
+    handleBubbleRendererGone(bubble);
+
+    assert.strictEqual(bubble.__clawdMacImeEditing, undefined,
+      "a dead renderer can't clear the flag itself — this must");
+    assert.strictEqual(reapply.length, 1);
+  });
+
+  it("does nothing for a bubble that was not mid-edit", () => {
+    const reapply = [];
+    const ctx = makeCtx({ reapplyMacVisibility: () => reapply.push(true) });
+    const { handleBubbleRendererGone } = initPermission(ctx);
+
+    handleBubbleRendererGone(makeBubble());
+    handleBubbleRendererGone(null);
+
+    assert.strictEqual(reapply.length, 0);
+  });
+});

--- a/test/permission-notify-autoclose.test.js
+++ b/test/permission-notify-autoclose.test.js
@@ -44,6 +44,9 @@ function createPermissionHarness({ logPath = null } = {}) {
         once: (event, cb) => {
           if (event === "did-finish-load") this._didFinishLoad = cb;
         },
+        on: (event, cb) => {
+          if (event === "render-process-gone") this._renderGoneHandler = cb;
+        },
         send: (...args) => {
           this.sentEvents.push(args);
         },

--- a/test/pet-interaction-ipc.test.js
+++ b/test/pet-interaction-ipc.test.js
@@ -60,6 +60,7 @@ function createHarness(overrides = {}) {
     beginDragSnapshot: () => calls.push(["beginDragSnapshot"]),
     clearDragSnapshot: () => calls.push(["clearDragSnapshot"]),
     syncHitWin: () => calls.push(["syncHitWin"]),
+    syncImeEditingPetDodge: () => calls.push(["syncImeEditingPetDodge"]),
     isMiniMode: () => state.miniMode,
     checkMiniModeSnap: overrides.checkMiniModeSnap
       ? () => overrides.checkMiniModeSnap({ calls, state })
@@ -205,6 +206,9 @@ test("pet interaction IPC preserves drag lock lifecycle", () => {
     ["setDragLocked", false],
     ["clearDragSnapshot"],
     ["syncHitWin"],
+    // #640: the dodge defers its hit-window click-through write while a drag
+    // is in flight — releasing the lock must re-run the sync.
+    ["syncImeEditingPetDodge"],
   ]);
 });
 
@@ -226,6 +230,7 @@ test("pet interaction IPC finalizes drag end and always clears drag state", () =
     ["repositionFloatingBubbles"],
     ["setDragLocked", false],
     ["clearDragSnapshot"],
+    ["syncImeEditingPetDodge"],
     ["checkMiniModeSnap"],
     ["computeDragEndBounds", state.petWindowBounds, state.effectivePixelSize],
     ["applyPetWindowBounds", state.clampedBounds],
@@ -236,6 +241,7 @@ test("pet interaction IPC finalizes drag end and always clears drag state", () =
     ["repositionFloatingBubbles"],
     ["setDragLocked", false],
     ["clearDragSnapshot"],
+    ["syncImeEditingPetDodge"],
   ]);
 });
 
@@ -253,6 +259,7 @@ test("pet interaction IPC skips drag-end clamp when mini snap starts", () => {
     ["checkMiniModeSnap"],
     ["setDragLocked", false],
     ["clearDragSnapshot"],
+    ["syncImeEditingPetDodge"],
   ]);
 });
 
@@ -272,6 +279,7 @@ test("pet interaction IPC does not persist when drag-end has no clamped bounds",
     ["repositionFloatingBubbles"],
     ["setDragLocked", false],
     ["clearDragSnapshot"],
+    ["syncImeEditingPetDodge"],
   ]);
 });
 
@@ -292,6 +300,7 @@ test("pet interaction IPC disables mini snap without skipping drag-end cleanup",
     ["repositionFloatingBubbles"],
     ["setDragLocked", false],
     ["clearDragSnapshot"],
+    ["syncImeEditingPetDodge"],
   ]);
 });
 
@@ -306,6 +315,7 @@ test("pet interaction IPC still clears drag state when drag end has no live pet 
     ["checkMiniModeSnap"],
     ["setDragLocked", false],
     ["clearDragSnapshot"],
+    ["syncImeEditingPetDodge"],
   ]);
 });
 

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -112,6 +112,9 @@ function createRuntime(overrides = {}) {
     buildTrayMenu: () => calls.push(["buildTrayMenu"]),
     buildContextMenu: () => calls.push(["buildContextMenu"]),
     reapplyMacVisibility: () => calls.push(["reapplyMacVisibility"]),
+    ...(overrides.syncImeEditingPetDodge
+      ? { syncImeEditingPetDodge: overrides.syncImeEditingPetDodge }
+      : {}),
     reassertWinTopmost: () => calls.push(["reassertWinTopmost"]),
     scheduleHwndRecovery: () => calls.push(["scheduleHwndRecovery"]),
     isNearWorkAreaEdge: () => overrides.nearEdge || false,
@@ -361,6 +364,20 @@ describe("pet-window-runtime", () => {
     harness.runtime.syncHitWin();
 
     assert.deepStrictEqual(harness.hitWin.calls, []);
+  });
+
+  it("re-answers the editing overlap after each hit geometry sync (#640)", () => {
+    const dodgeSyncs = [];
+    const harness = createRuntime({ syncImeEditingPetDodge: () => dodgeSyncs.push(true) });
+
+    harness.runtime.syncHitWin();
+    assert.strictEqual(dodgeSyncs.length, 1,
+      "hitbox changes without a window move (state switch, theme reload) must re-run the dodge");
+
+    harness.runtime.setDragLocked(true);
+    harness.runtime.syncHitWin();
+    assert.strictEqual(dodgeSyncs.length, 1,
+      "the drag-locked early-return precedes the hook; drag unlock re-runs it via pet-interaction-ipc");
   });
 
   it("clips the hit window to a right-side internal monitor seam", () => {

--- a/test/roam.test.js
+++ b/test/roam.test.js
@@ -644,3 +644,59 @@ describe("roam module", () => {
     assert.deepEqual(headings, [], "vertical walk must not change the heading");
   });
 });
+
+describe("roam pauses during IME editing (#640)", () => {
+  beforeEach(() => {
+    const randomValues = [0.9, 0.9, 0.9, 0.1];
+    let randomIndex = 0;
+    mock.method(Math, "random", () => randomValues[randomIndex++ % randomValues.length]);
+    mock.timers.enable({ apis: ["setTimeout", "Date"] });
+  });
+
+  afterEach(() => {
+    mock.timers.reset();
+    mock.reset();
+  });
+
+  it("does not start a roam while a bubble text field is being edited", () => {
+    const ctx = makeCtx({ isImeEditingActive: () => true });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000);
+    mock.timers.tick(200);
+
+    assert.equal(ctx._realBounds.x, 400, "pet must hold still while editing");
+    assert.equal(ctx._realBounds.y, 300, "pet must hold still while editing");
+    assert.equal(ctx._stateLog.length, 0, "no roam state change while editing");
+  });
+
+  it("cancels a roam mid-walk when editing starts and restores idle", () => {
+    let editing = false;
+    const ctx = makeCtx({ isImeEditingActive: () => editing });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000); // pause timer fires, walk starts
+    mock.timers.tick(160);  // a few frames in
+    const midWalk = { x: ctx._realBounds.x, y: ctx._realBounds.y };
+    assert.ok(midWalk.x !== 400 || midWalk.y !== 300, "walk should be underway");
+
+    editing = true;
+    mock.timers.tick(64); // next frame hits the gate
+
+    assert.ok(
+      ctx._stateLog.some((e) => e.type === "setState" && e.state === "idle"),
+      "gate with no incoming state must restore idle instead of freezing the walk pose"
+    );
+    const stopped = { x: ctx._realBounds.x, y: ctx._realBounds.y };
+    mock.timers.tick(320);
+    assert.deepEqual(
+      { x: ctx._realBounds.x, y: ctx._realBounds.y },
+      stopped,
+      "no further movement after the editing gate cancels the walk"
+    );
+  });
+});

--- a/test/theme-fade-sequencer.test.js
+++ b/test/theme-fade-sequencer.test.js
@@ -64,6 +64,7 @@ function createHarness(options = {}) {
   const sequencer = createThemeFadeSequencer({
     getRenderWindow: () => renderWin,
     getHitWindow: () => hitWin,
+    ...(options.getRestoreOpacity ? { getRestoreOpacity: options.getRestoreOpacity } : {}),
     fadeOutMs: 10,
     fadeInMs: 20,
     fallbackMs: 30,
@@ -229,5 +230,68 @@ describe("theme fade sequencer", () => {
     sequencer.cleanup();
 
     assert.strictEqual(animations[0].options.cancelSignal.cancelled, true);
+  });
+});
+
+// #640: while the pet dodges an editing bubble, its baseline opacity is the
+// faded dodge value — a theme reload finishing mid-edit must not snap the pet
+// back to 1 on top of the box being typed into.
+describe("theme fade sequencer restore opacity (#640)", () => {
+  it("fades back in to getRestoreOpacity instead of a hardcoded 1", async () => {
+    const { animations, hitWin, renderWin, sequencer } = createHarness({
+      getRestoreOpacity: () => 0.18,
+    });
+
+    sequencer.run();
+    await flushMicrotasks();
+    renderWin.webContents.emit("did-finish-load");
+    hitWin.webContents.emit("did-finish-load");
+    await flushMicrotasks();
+
+    assert.strictEqual(animations[1].targetOpacity, 0.18,
+      "fade-in must land on the dodge baseline, not full opacity");
+  });
+
+  it("fallback fade-in also lands on getRestoreOpacity", async () => {
+    const { animations, sequencer, timers } = createHarness({
+      autoResolveAnimation: false,
+      getRestoreOpacity: () => 0.18,
+    });
+
+    sequencer.run();
+    activeTimeout(timers).fn();
+    await flushMicrotasks();
+
+    assert.strictEqual(animations[1].targetOpacity, 0.18);
+  });
+
+  it("reads the restore value at restore time, not at run() time", async () => {
+    let base = 1;
+    const { animations, hitWin, renderWin, sequencer } = createHarness({
+      getRestoreOpacity: () => base,
+    });
+
+    sequencer.run();
+    await flushMicrotasks();
+    base = 0.18; // dodge engaged while the reload was in flight
+    renderWin.webContents.emit("did-finish-load");
+    hitWin.webContents.emit("did-finish-load");
+    await flushMicrotasks();
+
+    assert.strictEqual(animations[1].targetOpacity, 0.18);
+  });
+
+  it("clamps garbage restore values back to 1", async () => {
+    const { animations, hitWin, renderWin, sequencer } = createHarness({
+      getRestoreOpacity: () => { throw new Error("boom"); },
+    });
+
+    sequencer.run();
+    await flushMicrotasks();
+    renderWin.webContents.emit("did-finish-load");
+    hitWin.webContents.emit("did-finish-load");
+    await flushMicrotasks();
+
+    assert.strictEqual(animations[1].targetOpacity, 1);
   });
 });

--- a/test/theme-fade-sequencer.test.js
+++ b/test/theme-fade-sequencer.test.js
@@ -281,6 +281,53 @@ describe("theme fade sequencer restore opacity (#640)", () => {
     assert.strictEqual(animations[1].targetOpacity, 0.18);
   });
 
+  it("converges on the current baseline when the dodge flips during the fade-in", async () => {
+    // The dodge runs its own animateWindowOpacity loop with a separate cancel
+    // signal — last writer wins. Whoever finishes last must land on the
+    // CURRENT baseline, so fade-in completion re-reads it.
+    let base = 1;
+    const { animations, hitWin, renderWin, sequencer } = createHarness({
+      autoResolveAnimation: false,
+      getRestoreOpacity: () => base,
+    });
+
+    sequencer.run();
+    animations[0].resolve(true); // fade-out done → reload starts
+    await flushMicrotasks();
+    renderWin.webContents.emit("did-finish-load");
+    hitWin.webContents.emit("did-finish-load");
+    await flushMicrotasks();
+
+    assert.strictEqual(animations[1].targetOpacity, 1,
+      "fade-in starts toward the baseline read at start");
+
+    base = 0.18;                 // dodge engages while the fade-in is running
+    animations[1].resolve(true); // fade-in loop finishes (has written 1)
+    await flushMicrotasks();
+
+    assert.deepStrictEqual(renderWin.opacityWrites, [0.18],
+      "completion must re-read the baseline and converge");
+  });
+
+  it("does not double-write when the baseline held still through the fade-in", async () => {
+    const { animations, hitWin, renderWin, sequencer } = createHarness({
+      autoResolveAnimation: false,
+      getRestoreOpacity: () => 0.18,
+    });
+
+    sequencer.run();
+    animations[0].resolve(true);
+    await flushMicrotasks();
+    renderWin.webContents.emit("did-finish-load");
+    hitWin.webContents.emit("did-finish-load");
+    await flushMicrotasks();
+    animations[1].resolve(true);
+    await flushMicrotasks();
+
+    assert.deepStrictEqual(renderWin.opacityWrites, [],
+      "an unchanged baseline needs no converge write");
+  });
+
   it("clamps garbage restore values back to 1", async () => {
     const { animations, hitWin, renderWin, sequencer } = createHarness({
       getRestoreOpacity: () => { throw new Error("boom"); },

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -958,4 +958,26 @@ describe("IME editing pet dodge (#640)", () => {
       [["setIgnoreMouseEvents", true]]
     );
   });
+
+  // #640: external opacity writers (theme-switch fade) restore to this value
+  // instead of a hardcoded 1, so a theme reload mid-edit lands back on the
+  // dodge baseline rather than planting an opaque pet over the input box.
+  it("getPetTargetOpacity tracks the dodge state", () => {
+    const { bubble, runtime } = makeDodgeSetup();
+
+    assert.strictEqual(runtime.getPetTargetOpacity(), 1,
+      "before any sync the baseline is full opacity");
+
+    runtime.syncImeEditingPetDodge();
+    assert.strictEqual(
+      runtime.getPetTargetOpacity(),
+      createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY,
+      "while dodging, the baseline is the faded value"
+    );
+
+    delete bubble.__clawdMacImeEditing;
+    runtime.syncImeEditingPetDodge();
+    assert.strictEqual(runtime.getPetTargetOpacity(), 1,
+      "after the edit ends the baseline returns to full opacity");
+  });
 });

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -11,6 +11,7 @@ class FakeWindow extends EventEmitter {
     super();
     this.destroyed = !!options.destroyed;
     this.visible = options.visible !== false;
+    this.bounds = options.bounds || null;
     this.calls = [];
   }
 
@@ -28,6 +29,18 @@ class FakeWindow extends EventEmitter {
 
   setVisibleOnAllWorkspaces(...args) {
     this.calls.push(["setVisibleOnAllWorkspaces", ...args]);
+  }
+
+  getBounds() {
+    return this.bounds ? { ...this.bounds } : { x: 0, y: 0, width: 0, height: 0 };
+  }
+
+  setOpacity(value) {
+    this.calls.push(["setOpacity", value]);
+  }
+
+  setIgnoreMouseEvents(...args) {
+    this.calls.push(["setIgnoreMouseEvents", ...args]);
   }
 }
 
@@ -817,5 +830,130 @@ describe("topmost runtime macOS visibility", () => {
       ["setVisibleOnAllWorkspaces", true, { visibleOnFullScreen: true, skipTransformProcessType: true }],
     ]);
     assert.deepStrictEqual(stationaryCalls, []);
+  });
+});
+
+describe("IME editing pet dodge (#640)", () => {
+  function makeDodgeSetup(overrides = {}) {
+    const pet = new FakeWindow();
+    const hit = new FakeWindow();
+    const bubble = new FakeWindow({ bounds: { x: 100, y: 100, width: 300, height: 200 } });
+    bubble.__clawdMacImeEditing = true;
+    bubble.__clawdMacTextInputBubble = true;
+    const runtime = createTopmostRuntime({
+      isMac: true,
+      getWin: () => pet,
+      getHitWin: () => hit,
+      getPendingPermissions: () => [{ bubble }],
+      // Sprite rect intersecting the bubble unless overridden
+      getHitRectScreen: () => ({ x: 320, y: 240, width: 120, height: 120 }),
+      imeEditingFadeMs: 0,
+      applyStationaryCollectionBehavior: () => true,
+      ...overrides,
+    });
+    return { pet, hit, bubble, runtime };
+  }
+
+  it("fades the pet and lets clicks through while the editing bubble overlaps the sprite", () => {
+    const { pet, hit, runtime } = makeDodgeSetup();
+
+    runtime.syncImeEditingPetDodge();
+
+    assert.deepStrictEqual(pet.calls, [
+      ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
+    ]);
+    assert.deepStrictEqual(hit.calls, [["setIgnoreMouseEvents", true]]);
+  });
+
+  it("is edge-triggered: repeated syncs while overlapping do not repeat window calls", () => {
+    const { pet, hit, runtime } = makeDodgeSetup();
+
+    runtime.syncImeEditingPetDodge();
+    runtime.syncImeEditingPetDodge();
+    runtime.syncImeEditingPetDodge();
+
+    assert.strictEqual(pet.calls.length, 1);
+    assert.strictEqual(hit.calls.length, 1);
+  });
+
+  it("restores the pet when the text field blurs (flag cleared)", () => {
+    const { pet, hit, bubble, runtime } = makeDodgeSetup();
+
+    runtime.syncImeEditingPetDodge();
+    delete bubble.__clawdMacImeEditing;
+    runtime.syncImeEditingPetDodge();
+
+    assert.deepStrictEqual(pet.calls, [
+      ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
+      ["setOpacity", 1],
+    ]);
+    assert.deepStrictEqual(hit.calls, [
+      ["setIgnoreMouseEvents", true],
+      ["setIgnoreMouseEvents", false],
+    ]);
+  });
+
+  it("restores the pet when the editing bubble is removed (closed mid-edit)", () => {
+    const perms = [];
+    const { pet, hit, bubble, runtime } = makeDodgeSetup({
+      getPendingPermissions: () => perms,
+    });
+    perms.push({ bubble });
+
+    runtime.syncImeEditingPetDodge();
+    perms.length = 0;
+    runtime.syncImeEditingPetDodge();
+
+    assert.deepStrictEqual(pet.calls.map((c) => c[0]), ["setOpacity", "setOpacity"]);
+    assert.deepStrictEqual(pet.calls[1], ["setOpacity", 1]);
+    assert.deepStrictEqual(hit.calls[1], ["setIgnoreMouseEvents", false]);
+  });
+
+  it("does nothing while editing without geometric overlap", () => {
+    const { pet, hit, runtime } = makeDodgeSetup({
+      getHitRectScreen: () => ({ x: 900, y: 900, width: 120, height: 120 }),
+    });
+
+    runtime.syncImeEditingPetDodge();
+
+    assert.deepStrictEqual(pet.calls, []);
+    assert.deepStrictEqual(hit.calls, []);
+  });
+
+  it("falls back to the pet window bounds when no sprite rect is available", () => {
+    const { pet, runtime } = makeDodgeSetup({
+      getHitRectScreen: () => null,
+      getPetWindowBounds: () => ({ x: 150, y: 150, width: 200, height: 200 }),
+    });
+
+    runtime.syncImeEditingPetDodge();
+
+    assert.deepStrictEqual(pet.calls, [
+      ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
+    ]);
+  });
+
+  it("does nothing off macOS", () => {
+    const { pet, hit, runtime } = makeDodgeSetup({ isMac: false });
+
+    runtime.syncImeEditingPetDodge();
+
+    assert.deepStrictEqual(pet.calls, []);
+    assert.deepStrictEqual(hit.calls, []);
+  });
+
+  it("runs as part of reapplyMacVisibility so every visibility pass self-heals", () => {
+    const { pet, hit, runtime } = makeDodgeSetup();
+
+    runtime.reapplyMacVisibility();
+
+    assert.deepStrictEqual(
+      pet.calls.filter((c) => c[0] === "setOpacity"),
+      [["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY]]
+    );
+    assert.deepStrictEqual(
+      hit.calls.filter((c) => c[0] === "setIgnoreMouseEvents"),
+      [["setIgnoreMouseEvents", true]]
+    );
   });
 });

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -845,8 +845,10 @@ describe("IME editing pet dodge (#640)", () => {
       getWin: () => pet,
       getHitWin: () => hit,
       getPendingPermissions: () => [{ bubble }],
-      // Sprite rect intersecting the bubble unless overridden
-      getHitRectScreen: () => ({ x: 320, y: 240, width: 120, height: 120 }),
+      // Sprite rect intersecting the bubble unless overridden — in the
+      // production { left, top, right, bottom } hit-geometry shape, which is
+      // exactly what the first real-machine run caught the arbiter mishandling.
+      getHitRectScreen: () => ({ left: 320, top: 240, right: 440, bottom: 360 }),
       imeEditingFadeMs: 0,
       applyStationaryCollectionBehavior: () => true,
       ...overrides,
@@ -911,7 +913,7 @@ describe("IME editing pet dodge (#640)", () => {
 
   it("does nothing while editing without geometric overlap", () => {
     const { pet, hit, runtime } = makeDodgeSetup({
-      getHitRectScreen: () => ({ x: 900, y: 900, width: 120, height: 120 }),
+      getHitRectScreen: () => ({ left: 900, top: 900, right: 1020, bottom: 1020 }),
     });
 
     runtime.syncImeEditingPetDodge();

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -959,6 +959,57 @@ describe("IME editing pet dodge (#640)", () => {
     );
   });
 
+  // #640/F3: Electron's setIgnoreMouseEvents makes no promise about toggling
+  // mid-gesture, so the click-through write is deferred while a drag is in
+  // flight; the fade is not (the mid-drag fade transition is the hands-on-
+  // verified experience). Drag-lock release re-runs the sync to apply it.
+  describe("drag-lock deferral", () => {
+    it("fades mid-drag but defers the click-through write", () => {
+      const { pet, hit, runtime } = makeDodgeSetup({ isDragLocked: () => true });
+
+      runtime.syncImeEditingPetDodge();
+
+      assert.deepStrictEqual(pet.calls, [
+        ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
+      ], "the fade still runs mid-drag");
+      assert.deepStrictEqual(hit.calls, [],
+        "the ignore-mouse write must wait until the drag ends");
+    });
+
+    it("applies the deferred click-through on the first sync after the drag ends", () => {
+      let dragging = true;
+      const { pet, hit, runtime } = makeDodgeSetup({ isDragLocked: () => dragging });
+
+      runtime.syncImeEditingPetDodge();
+      dragging = false;
+      runtime.syncImeEditingPetDodge();
+
+      assert.deepStrictEqual(hit.calls, [["setIgnoreMouseEvents", true]]);
+      assert.strictEqual(pet.calls.length, 1,
+        "the fade already ran mid-drag; the post-drag sync only applies the write");
+
+      runtime.syncImeEditingPetDodge();
+      assert.strictEqual(hit.calls.length, 1, "the applied write is edge-triggered");
+    });
+
+    it("skips the write entirely when the overlap ended before the drag did", () => {
+      let dragging = true;
+      const { pet, hit, bubble, runtime } = makeDodgeSetup({ isDragLocked: () => dragging });
+
+      runtime.syncImeEditingPetDodge();       // overlap while dragging → fade only
+      delete bubble.__clawdMacImeEditing;     // edit ends mid-drag
+      runtime.syncImeEditingPetDodge();       // fade back, still no write
+      dragging = false;
+      runtime.syncImeEditingPetDodge();       // drag ends: nothing left to apply
+
+      assert.deepStrictEqual(pet.calls.map((c) => c[1]), [
+        createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY, 1,
+      ]);
+      assert.deepStrictEqual(hit.calls, [],
+        "never went click-through, so nothing to undo");
+    });
+  });
+
   // #640: external opacity writers (theme-switch fade) restore to this value
   // instead of a hardcoded 1, so a theme reload mid-edit lands back on the
   // dodge baseline rather than planting an opaque pet over the input box.


### PR DESCRIPTION
> **中文摘要**:#640 的 Phase 0+1。打字进气泡输入框时:①气泡钉住不动(不再被 followPet 拖着跑)+ 自由漫游暂停 ②桌宠若正好叠在这个气泡上,淡化到 18% 并放行鼠标点击(点得到它身后的输入框和按钮),失焦/气泡关闭/移开重叠即恢复。全部 mac-only,复用 #626 的 editing 信号。三层验证全过:4780/0 全量、仪器化真机(透明度 1→0.18→1 全链路)、真人上手(淡化+点穿生效、拖拽穿越不断手)。

Phases 0+1 of #640 — the pure-Electron mitigation for "the pet covers (and eats clicks over) the bubble being typed into". All behavior keys off the `__clawdMacImeEditing` signal #626 introduced, macOS only; Windows/Linux untouched.

## Phase 0 — hold still while typing

- **The bubble being typed into freezes**: `repositionBubbles` skips applying bounds to a bubble whose text field is focused, so `followPet` anchoring can't yank the input box around mid-composition (pet drag, mini crabwalk, display churn). Fresh bubbles never carry the flag and still get placed.
- **Free roam pauses**: `isRoamAllowed()` gains a per-frame `isImeEditingActive` gate — an editing start cancels a walk mid-stride within one frame. The cancel path now funnels through `cancelRoam()`, which also fixes a pre-existing nit: a gate with no incoming state of its own used to strand the pet frozen in its walk pose (the walk-state SVG kept showing); now it restores `idle`.

## Phase 1 — step back when overlapping

`syncImeEditingPetDodge()` in `topmost-runtime.js`, running at the end of every `reapplyMacVisibility` pass (the #626 single-source-of-truth hook point) and on pet moves via `repositionAnchoredFloatingSurfaces`:

- While an editing bubble exists AND the pet sprite (`getHitRectScreen`, falling back to window bounds) intersects it: the pet render window fades to **0.18** (160 ms, via the existing `animateWindowOpacity` helper) and the hit window goes **click-through**, so the box being typed into stays readable and clickable underneath.
- Edge-triggered, with every transition path funneled: text-field blur (`handleImeEditing`), bubble teardown (`removePendingPermission` now re-runs the visibility pass), and overlap changes from pet movement.
- The hit window's ignore-mouse keeps exactly two writers, **platform-disjoint** (Windows settings-size-preview protection vs this macOS-only dodge), so they can never fight — the old "PERMANENT" comment's intent is preserved and documented at the arbiter.

## A bug the test suite missed — caught by instrumented real-machine verification

The first instrumented run showed `ime: true` with obvious geometric overlap and **no fade**: `getHitRectScreen` returns hit-geometry rects as `{ left, top, right, bottom }`, while the intersect test read `{ x, y, width, height }` — width coerced to 0, overlap never detected. The unit fixtures had encoded the same wrong assumption, so they were green. Fixed with a shape-normalizing `rectsIntersect`, and the fixtures now feed the production shape.

## Verification

- `npm test`: **4780 pass / 0 fail** (14 new cases: 8 dodge, 4 freeze/teardown, 2 roam).
- Instrumented real machine (dev app + injected elicitation + main-process inspector): focus → opacity 0.18, blur → 1, refocus → 0.18; bubble bounds frozen throughout; an editing bubble torn down mid-edit (remote-approval dismissal) restored cleanly.
- Hands-on (maintainer, real mouse + real IME): fade + click-through confirmed working; **dragging the pet across the editing bubble stays smooth through the mid-drag fade/restore transitions**; "pet is fully click-through while overlapped mid-edit — click anywhere to blur first, then grab it" reviewed and accepted as designed behavior (a hover-wake alternative was considered and rejected: it re-introduces click stealing over the overlapped region).

Phases 2 (native SkyLight de-delegation) and 3 (mini-mode tuck-behind, @Yike-Ye's idea) remain open on #640 — this is the stopgap that makes typing usable today.

Part of #640.
