### PR TITLE
fix(permission): 客户端断线的 abort 按 no-decision 收尾,不再记成 deny

### DIFF
--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -1169,7 +1169,12 @@ function handlePermissionPost(req, res, options) {
         const abortHandler = () => {
           if (res.writableFinished) return;
           ctx.permLog("abortHandler fired (elicitation)");
-          ctx.resolvePermissionEntry(permEntry, "deny", "Client disconnected");
+          // A dropped connection is not a user decision (CC's HTTP hook gives
+          // up after its 600s timeout and re-prompts in the terminal) — settle
+          // without one, like the codex/qwen/copilot abort paths. A "deny"
+          // here would stamp a refusal nobody made on the log and on any
+          // still-live remote approval card.
+          ctx.resolvePermissionEntry(permEntry, "no-decision", "Client disconnected");
         };
         permEntry.abortHandler = abortHandler;
         res.on("close", abortHandler);
@@ -1216,7 +1221,8 @@ function handlePermissionPost(req, res, options) {
       const abortHandler = () => {
         if (res.writableFinished) return;
         ctx.permLog("abortHandler fired");
-        ctx.resolvePermissionEntry(permEntry, "deny", "Client disconnected");
+        // Same rationale as the elicitation abort above: disconnect ≠ deny.
+        ctx.resolvePermissionEntry(permEntry, "no-decision", "Client disconnected");
       };
       permEntry.abortHandler = abortHandler;
       res.on("close", abortHandler);

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -697,6 +697,42 @@ describe("server-route-permission POST", () => {
     assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, [entry]);
   });
 
+  it("resolves Claude elicitation abort as no-decision (NOT deny) when the connection closes", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "sid",
+      tool_name: "AskUserQuestion",
+      tool_input: { questions: [{ question: "Continue?" }] },
+    }));
+
+    assert.strictEqual(res.ctx.pendingPermissions.length, 1);
+    const entry = res.ctx.pendingPermissions[0];
+    res.emit("close");
+
+    assert.strictEqual(res.ctx.calls.resolved.length, 1);
+    assert.strictEqual(res.ctx.calls.resolved[0].entry, entry);
+    assert.strictEqual(res.ctx.calls.resolved[0].behavior, "no-decision");
+    assert.strictEqual(res.ctx.calls.resolved[0].message, "Client disconnected");
+  });
+
+  it("resolves Claude permission abort as no-decision (NOT deny) when the connection closes", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "sid",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+    }));
+
+    assert.strictEqual(res.ctx.pendingPermissions.length, 1);
+    const entry = res.ctx.pendingPermissions[0];
+    res.emit("close");
+
+    assert.strictEqual(res.ctx.calls.resolved.length, 1);
+    assert.strictEqual(res.ctx.calls.resolved[0].entry, entry);
+    assert.strictEqual(res.ctx.calls.resolved[0].behavior, "no-decision");
+    assert.strictEqual(res.ctx.calls.resolved[0].message, "Client disconnected");
+  });
+
   it("keeps local Claude permission pending if remote approval startup throws", async () => {
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "claude-code",


### PR DESCRIPTION
## 背景

调查「注入 elicitation 气泡 60-120s 被静默 deny 收走」时发现:CC 的 permission/elicitation 请求方断开连接时(CC 的 PermissionRequest HTTP hook 600s 超时挂断、或注入测试的 curl 被杀),`res.on("close")` 的 abortHandler 会把条目 resolve 成 **`deny`**。

但断线不是任何人的决定:socket 已死,这个 deny 从未真正送达谁——它只会把日志和(将来)还活着的远程审批卡片的结局错标成「已拒绝」。codex/qwen/copilot/hermes 四个分支的同款 abort 路径**本来就是 no-decision**(测试名都写着 "NOT deny"),CC 这两处是仅存的旧写法。

## 改动

- `src/server-route-permission.js`:CC elicitation + CC generic 两处 abortHandler `deny` → `no-decision`,message 保留 `Client disconnected` 作排查线索
- 新增 2 个测试锁住契约(镜像既有 Copilot/Hermes 断线测试)

## 行为影响

**零线上行为差异**——resolvePermissionEntry 的 res 存活守卫在断线时早于一切响应分支返回,deny/no-decision 都不会写出任何响应、不会抢焦点。变化仅:日志语义诚实化 + 远程卡片结局标签(对齐 `maybeFallBackRemoteOnlyEntry` 的设计注释:"answering deny here would decide on the user's behalf")。

## 验证

- 全量测试 4785 / 0 fail(新增 2 个含在内)
- 调查期活体复现(改动前基线):注入的 elicitation 气泡无人碰静置 310s 安然无恙(不存在 60-120s 自动收割器);杀掉注入端 curl 的**同一秒** `abortHandler fired (elicitation)` 收走气泡、无响应写出。真实场景同路径:log 中 3 例真实会话在精确 600.0s(CC hook 超时)被同样收走
- 附带定论:当天观察到的 6 笔无 message deny 全部是 `IPC permission-decide`(气泡「前往终端」按钮的真实点击,与 #640 点击穿透测试同窗),与远程无关;本机 TG 审批从未配置,mobile 通道不参与 permission