### PR TITLE
feat(discord): ship the official Clawd on Desk Application ID as default (#215)

### DIFF
--- a/src/discord-presence-settings.js
+++ b/src/discord-presence-settings.js
@@ -3,8 +3,10 @@
 // Non-secret config: the Application ID is a public ID (not a token), stored in
 // clawd-prefs.json. Privacy fields default off.
 
-// Empty upstream = bring-your-own. Maintainer fills in the published ID.
-const DEFAULT_CLAWD_DISCORD_APP_ID = "";
+// Official "Clawd on Desk" Discord application (public ID, not a secret) —
+// the zero-friction default from #215. Users can still bring their own App ID
+// in Settings; a saved ID always wins over this default.
+const DEFAULT_CLAWD_DISCORD_APP_ID = "1525141423328854179";
 
 const DEFAULT_DISCORD_PRESENCE = Object.freeze({
   enabled: false,

--- a/test/discord-presence-settings.test.js
+++ b/test/discord-presence-settings.test.js
@@ -7,6 +7,7 @@ const {
   validateDiscordPresence,
   readiness,
   DEFAULT_DISCORD_PRESENCE,
+  DEFAULT_CLAWD_DISCORD_APP_ID,
 } = require("../src/discord-presence-settings");
 
 test("normalizeDiscordPresence coerces types and strips non-digits from the App ID", () => {
@@ -40,13 +41,25 @@ test("readiness gates on enabled + an effective App ID", () => {
   assert.strictEqual(off.ready, false);
   assert.strictEqual(off.reason, "disabled");
 
-  const noId = readiness({ enabled: true, applicationId: "" });
+  // Inject an empty default: the shipped constant is non-empty now, and this
+  // case guards the no-App-ID-at-all branch.
+  const noId = readiness({ enabled: true, applicationId: "" }, "");
   assert.strictEqual(noId.ready, false);
   assert.strictEqual(noId.reason, "no-app-id");
 
   const ok = readiness({ enabled: true, applicationId: "123456789012345678" });
   assert.strictEqual(ok.ready, true);
   assert.strictEqual(ok.appId, "123456789012345678");
+});
+
+test("shipped default App ID makes an empty config ready out of the box (#215)", () => {
+  assert.match(DEFAULT_CLAWD_DISCORD_APP_ID, /^[0-9]{17,20}$/, "shipped default must be a valid snowflake");
+  const r = readiness({ enabled: true, applicationId: "" });
+  assert.strictEqual(r.ready, true);
+  assert.strictEqual(r.appId, DEFAULT_CLAWD_DISCORD_APP_ID);
+  // A user-saved App ID still wins over the shipped default.
+  const saved = readiness({ enabled: true, applicationId: "111111111111111111" });
+  assert.strictEqual(saved.appId, "111111111111111111");
 });
 
 test("readiness honors an injected default App ID (the BYO handoff seam)", () => {


### PR DESCRIPTION
Fills the `DEFAULT_CLAWD_DISCORD_APP_ID` handoff seam from #508 with the official **Clawd on Desk** Discord application, completing the zero-friction default requested in #215: a fresh install can flip the presence switch with no Developer Portal trip. The ID is a public identifier, not a secret; a user-saved App ID still wins over the default.

Tests: the `no-app-id` readiness branch now injects an empty default to stay covered; a new case guards that the shipped constant is a valid snowflake and that an empty config is ready out of the box (plus saved-ID precedence).

Live-verified end to end: with `applicationId` cleared from prefs, the bridge resolves the shipped default, handshakes, and the Discord profile card shows "Playing **Clawd on Desk**" (owner-confirmed on the real client). Full suite 4773/4773.
