### PR TITLE
fix: elicitation agent attribution + codebuddy installer ownership test

### DIFF
--- a/hooks/codebuddy-install.js
+++ b/hooks/codebuddy-install.js
@@ -8,10 +8,9 @@ const os = require("os");
 const {
   resolveNodeBin,
   buildPermissionUrl,
+  isManagedPermissionUrl,
   DEFAULT_SERVER_PORT,
-  PERMISSION_PATH,
   readRuntimePort,
-  SERVER_PORTS,
 } = require("./server-config");
 const {
   readJsonFile,
@@ -24,7 +23,6 @@ const {
   removeMatchingHttpHooks,
 } = require("./json-utils");
 const MARKER = "codebuddy-hook.js";
-const HTTP_MARKER = "/permission";
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".codebuddy");
 const DEFAULT_CONFIG_PATH = path.join(DEFAULT_PARENT_DIR, "settings.json");
 
@@ -39,22 +37,6 @@ const CODEBUDDY_HOOK_EVENTS = [
   "Notification",
   "PreCompact",
 ];
-
-function isManagedPermissionUrl(value) {
-  if (typeof value !== "string") return false;
-  try {
-    const parsed = new URL(value);
-    const port = Number(parsed.port);
-    return parsed.protocol === "http:"
-      && parsed.hostname === "127.0.0.1"
-      && parsed.pathname === PERMISSION_PATH
-      && parsed.search === ""
-      && parsed.hash === ""
-      && SERVER_PORTS.includes(port);
-  } catch {
-    return false;
-  }
-}
 
 /**
  * Register Clawd hooks into ~/.codebuddy/settings.json
@@ -170,13 +152,15 @@ function registerCodeBuddyHooks(options = {}) {
     if (Array.isArray(innerHooks)) {
       for (const h of innerHooks) {
         if (!h || h.type !== "http" || typeof h.url !== "string") continue;
-        if (!h.url.includes(HTTP_MARKER)) continue;
+        // Only URLs we wrote ourselves are eligible for the in-place port
+        // refresh; foreign endpoints are skipped and we append our own entry.
+        if (!isManagedPermissionUrl(h.url)) continue;
         permFound = true;
         if (h.url !== permissionUrl) { h.url = permissionUrl; updated++; changed = true; }
         break;
       }
     }
-    if (!permFound && entry.type === "http" && typeof entry.url === "string" && entry.url.includes(HTTP_MARKER)) {
+    if (!permFound && entry.type === "http" && typeof entry.url === "string" && isManagedPermissionUrl(entry.url)) {
       permFound = true;
       if (entry.url !== permissionUrl) { entry.url = permissionUrl; updated++; changed = true; }
     }

--- a/hooks/server-config.js
+++ b/hooks/server-config.js
@@ -162,6 +162,27 @@ function buildPermissionUrl(port) {
   return `http://127.0.0.1:${safePort}${PERMISSION_PATH}`;
 }
 
+// Ownership test for PermissionRequest HTTP hooks: true only for URLs that
+// buildPermissionUrl could have written (any bindable server port). Installers
+// must gate every update/remove of an HTTP hook on this — a user's own
+// approval endpoint (e.g. https://approval.corp.example/permission) merely
+// contains "/permission" and must never be rewritten or deleted.
+function isManagedPermissionUrl(value) {
+  if (typeof value !== "string") return false;
+  try {
+    const parsed = new URL(value);
+    const port = Number(parsed.port);
+    return parsed.protocol === "http:"
+      && parsed.hostname === "127.0.0.1"
+      && parsed.pathname === PERMISSION_PATH
+      && parsed.search === ""
+      && parsed.hash === ""
+      && SERVER_PORTS.includes(port);
+  } catch {
+    return false;
+  }
+}
+
 function readHeader(res, headerName) {
   const value = res.headers && res.headers[headerName];
   return Array.isArray(value) ? value[0] : value;
@@ -875,6 +896,7 @@ module.exports = {
   STATE_PATH,
   buildPermissionUrl,
   clearRuntimeConfig,
+  isManagedPermissionUrl,
   discoverClawdPort,
   getPortCandidates,
   getPermissionProbeTimeoutMs,

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -1146,7 +1146,7 @@ function handlePermissionPost(req, res, options) {
       if (toolName === "AskUserQuestion") {
         const elicitationInput = normalizeElicitationToolInput(toolInput);
         ctx.permLog(`ELICITATION: tool=${toolName} session=${sessionId}`);
-        ctx.updateSession(sessionId, "notification", "Elicitation", { agentId: "claude-code" });
+        ctx.updateSession(sessionId, "notification", "Elicitation", { agentId: permAgentId });
 
         const permEntry = {
           res,

--- a/test/codebuddy-install.test.js
+++ b/test/codebuddy-install.test.js
@@ -161,12 +161,16 @@ describe("CodeBuddy hook installer", () => {
     assert.ok(settings.hooks.PostToolUse[0].command.includes("/home/user/.volta/bin/node"));
   });
 
-  it("updates stale PermissionRequest HTTP URL", () => {
+  it("updates a stale managed PermissionRequest HTTP URL in place", () => {
+    // 23337 is inside SERVER_PORTS, so this is a URL an older install could
+    // have written — eligible for the in-place refresh. Anything outside the
+    // managed set is foreign (see the zero-destruction tests below).
+    const stale = "http://127.0.0.1:23337/permission";
     const settingsPath = makeTempSettingsFile({
       hooks: {
         PermissionRequest: [{
           matcher: "",
-          hooks: [{ type: "http", url: "http://127.0.0.1:99999/permission", timeout: 600 }],
+          hooks: [{ type: "http", url: stale, timeout: 600 }],
         }],
       },
     });
@@ -177,12 +181,58 @@ describe("CodeBuddy hook installer", () => {
       nodeBin: "/usr/local/bin/node",
     });
 
-    assert.ok(result.updated >= 1);
     const settings = readJson(settingsPath);
     const permHook = settings.hooks.PermissionRequest[0].hooks[0];
-    assert.ok(permHook.url.includes("/permission"));
-    assert.ok(permHook.url.includes("127.0.0.1"));
-    assert.notStrictEqual(permHook.url, "http://127.0.0.1:99999/permission");
+    assert.ok(__test.isManagedPermissionUrl(permHook.url));
+    assert.strictEqual(settings.hooks.PermissionRequest.length, 1);
+    if (permHook.url !== stale) assert.ok(result.updated >= 1);
+  });
+
+  it("leaves foreign PermissionRequest URLs untouched and appends the managed hook", () => {
+    const foreign = { type: "http", url: "https://approval.corp.example/permission", timeout: 30 };
+    const settingsPath = makeTempSettingsFile({
+      hooks: {
+        PermissionRequest: [{ matcher: "", hooks: [{ ...foreign }] }],
+      },
+    });
+
+    const result = registerCodeBuddyHooks({
+      silent: true,
+      settingsPath,
+      nodeBin: "/usr/local/bin/node",
+    });
+
+    // 8 command hooks + appended managed HTTP hook
+    assert.strictEqual(result.added, 9);
+    const settings = readJson(settingsPath);
+    assert.deepStrictEqual(settings.hooks.PermissionRequest[0].hooks, [foreign]);
+    const managed = settings.hooks.PermissionRequest
+      .flatMap((entry) => entry.hooks || [])
+      .filter((hook) => __test.isManagedPermissionUrl(hook.url));
+    assert.strictEqual(managed.length, 1);
+
+    // Second run must not churn: managed entry matched, foreign still intact.
+    const contentBefore = fs.readFileSync(settingsPath, "utf8");
+    const again = registerCodeBuddyHooks({ silent: true, settingsPath, nodeBin: "/usr/local/bin/node" });
+    assert.strictEqual(again.added, 0);
+    assert.strictEqual(again.updated, 0);
+    assert.strictEqual(fs.readFileSync(settingsPath, "utf8"), contentBefore);
+  });
+
+  it("leaves a foreign flat-format PermissionRequest URL untouched", () => {
+    const settingsPath = makeTempSettingsFile({
+      hooks: {
+        PermissionRequest: [{ type: "http", url: "http://localhost:23333/permission", timeout: 600 }],
+      },
+    });
+
+    registerCodeBuddyHooks({ silent: true, settingsPath, nodeBin: "/usr/local/bin/node" });
+
+    const settings = readJson(settingsPath);
+    assert.strictEqual(settings.hooks.PermissionRequest[0].url, "http://localhost:23333/permission");
+    const nested = settings.hooks.PermissionRequest.filter((entry) => Array.isArray(entry.hooks));
+    assert.strictEqual(nested.length, 1);
+    assert.ok(__test.isManagedPermissionUrl(nested[0].hooks[0].url));
   });
 
   it("unregister removes only managed command hooks and managed PermissionRequest URLs", () => {

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -697,6 +697,30 @@ describe("server-route-permission POST", () => {
     assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, [entry]);
   });
 
+  it("stamps elicitation session updates with the resolved agent id", async () => {
+    // The shared CC path also serves codebuddy (and future CC-compatible
+    // agents). The Elicitation session update must carry the resolved agent
+    // id, not a hardcoded claude-code, or the session gets relabeled.
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "codebuddy",
+      session_id: "cb-elicit",
+      tool_name: "AskUserQuestion",
+      tool_input: { questions: [{ question: "Continue?" }] },
+    }));
+
+    assert.strictEqual(res.statusCode, null);
+    assert.strictEqual(res.ctx.pendingPermissions.length, 1);
+    const entry = res.ctx.pendingPermissions[0];
+    assert.strictEqual(entry.isElicitation, true);
+    assert.strictEqual(entry.agentId, "codebuddy");
+    assert.deepStrictEqual(res.ctx.calls.updateSession, [[
+      "cb-elicit",
+      "notification",
+      "Elicitation",
+      { agentId: "codebuddy" },
+    ]]);
+  });
+
   it("keeps local Claude permission pending if remote approval startup throws", async () => {
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "claude-code",


### PR DESCRIPTION
## Summary

Two shared-path bugs surfaced by the second-round review of #618 (WorkBuddy integration). Both predate that PR and affect CodeBuddy today, so they are fixed in main directly instead of being pushed onto the PR author.

1. **Elicitation session attribution** — the AskUserQuestion branch in `src/server-route-permission.js` hardcoded `{ agentId: "claude-code" }` in its `updateSession` call while the `permEntry` right below already used the resolved `permAgentId`. Any CC-compatible agent routing an elicitation through the shared path had its session relabeled as Claude Code (dashboard label, per-agent cleanup, terminal focus attribution). Now stamps the resolved agent id; behavior for Claude Code itself is unchanged (the default resolution is `claude-code`, including the subagent-uuid case).

2. **Installer ownership test** — `registerCodeBuddyHooks` matched existing PermissionRequest HTTP hooks with `url.includes("/permission")`, so a user's own approval endpoint (e.g. `https://approval.corp.example/permission`) was silently rewritten to our localhost URL on install and on every startup sync — and the rewritten entry then matched the strict managed-URL check, so uninstall deleted it. Register now uses the same strict ownership test as unregister (`isManagedPermissionUrl`): only URLs Clawd itself could have written are refreshed in place; foreign entries are preserved and the managed entry is appended alongside.

`isManagedPermissionUrl` moves to `hooks/server-config.js` as a shared export so the WorkBuddy installer in #618 can reuse it instead of growing a third copy.

## Tests

- New regression test: codebuddy elicitation → session stamped `codebuddy` (fails on pre-fix code).
- New zero-destruction tests: foreign nested + flat PermissionRequest URLs preserved, managed entry appended, second run byte-identical (both fail on pre-fix code).
- Stale-URL test reworked: fixture moved from port 99999 (now correctly foreign) to 23337 (managed range). Behavior change: a URL outside `SERVER_PORTS` is now treated as foreign and preserved instead of hijacked — Clawd has never written such a URL.
- Full suite: 4758 pass / 0 fail / 18 pre-existing skips.

## Review

Adversarial subagent review verified the regression tests genuinely fail on pre-fix sources, no repo-wide stale references, no managed-entry accumulation across port changes, and no upgrade risk for settings files written by the old installer.
