### PR TITLE
fix(mobile): 使用 lastPong 判断定时轮换时的活跃客户端

### DIFF
--- a/src/network/mobile-preview-server.js
+++ b/src/network/mobile-preview-server.js
@@ -90,6 +90,10 @@ function initMobilePreviewServer(ctx) {
   const clientTimeoutMs = ctx && typeof ctx.clientTimeoutMs === "number"
     ? ctx.clientTimeoutMs
     : CLIENT_TIMEOUT_MS;
+  const rotationProbeMs = ctx && typeof ctx.rotationProbeMs === "number"
+    ? ctx.rotationProbeMs
+    : 5000;
+  const requestedPort = ctx && Number.isInteger(ctx.port) ? ctx.port : null;
   const writeTokenState = ctx && typeof ctx.writeTokenState === "function"
     ? ctx.writeTokenState
     : atomicWrite;
@@ -102,6 +106,7 @@ function initMobilePreviewServer(ctx) {
   let activePort = null;
   let heartbeatTimer = null;
   let rotationTimer = null;
+  let rotationProbeCancel = null;
   let closed = false;
 
   // ── Token rotation ──
@@ -151,12 +156,40 @@ function initMobilePreviewServer(ctx) {
     return true;
   }
 
-  function hasActiveClients() {
-    const nowMs = Date.now();
-    for (const meta of clientMeta.values()) {
-      if (nowMs - meta.lastPong < clientTimeoutMs) return true;
-    }
-    return false;
+  function probeClientsBeforeRotation() {
+    const candidates = [...clients].filter((c) => c.readyState === WebSocket.OPEN);
+    if (candidates.length === 0) return Promise.resolve(false);
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const responders = new Set();
+      const handlers = new Map();
+      const finish = (allResponded) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        for (const [client, handler] of handlers) client.removeListener("pong", handler);
+        rotationProbeCancel = null;
+        resolve(allResponded && responders.size === candidates.length);
+      };
+      const timer = setTimeout(() => finish(false), rotationProbeMs);
+      rotationProbeCancel = () => finish(false);
+      const probePayload = Buffer.from(`rotation-probe:${crypto.randomBytes(8).toString("hex")}`);
+
+      for (const client of candidates) {
+        const handler = (data) => {
+          const pongPayload = Buffer.isBuffer(data) ? data : Buffer.from(data || "");
+          if (!pongPayload.equals(probePayload)) return;
+          responders.add(client);
+          if (responders.size === candidates.length) finish(true);
+        };
+        handlers.set(client, handler);
+        client.once("pong", handler);
+      }
+      for (const client of candidates) {
+        try { client.ping(probePayload); } catch { finish(false); }
+      }
+    });
   }
 
   function scheduleRotation() {
@@ -165,11 +198,25 @@ function initMobilePreviewServer(ctx) {
     const msUntilRotate = Math.max(0, (tokenState.rotatedAt + ROTATION_INTERVAL_MS) - now());
     rotationTimer = setTimeout(() => {
       rotationTimer = null;
-      if (hasActiveClients()) {
-        if (!performRotation()) {
-          scheduleRotationRetry();
-          return;
-        }
+      if (clients.size > 0) {
+        probeClientsBeforeRotation().then((allResponded) => {
+          if (closed) return;
+          if (allResponded) {
+            if (!performRotation()) {
+              scheduleRotationRetry();
+              return;
+            }
+          } else {
+            const nextState = { ...tokenState, rotationPending: true };
+            if (!persistTokenState(nextState)) {
+              console.error("[mobile-preview] pending token rotation skipped: failed to persist token state");
+              scheduleRotationRetry();
+              return;
+            }
+          }
+          scheduleRotation();
+        });
+        return;
       } else {
         const nextState = { ...tokenState, rotationPending: true };
         if (!persistTokenState(nextState)) {
@@ -472,8 +519,10 @@ function initMobilePreviewServer(ctx) {
   function start() {
     closed = false;
     createServers();
-    const ports = [];
-    for (let i = 0; i < PORT_RANGE; i++) ports.push(DEFAULT_PORT + i);
+    const ports = requestedPort === null ? [] : [requestedPort];
+    if (requestedPort === null) {
+      for (let i = 0; i < PORT_RANGE; i++) ports.push(DEFAULT_PORT + i);
+    }
     let idx = 0;
 
     const ready = new Promise((resolve, reject) => {
@@ -489,7 +538,7 @@ function initMobilePreviewServer(ctx) {
         reject(err);
       };
       const onListening = () => {
-        activePort = ports[idx];
+        activePort = ports[idx] === 0 ? httpServer.address().port : ports[idx];
         console.log(`[mobile-preview] started on 0.0.0.0:${activePort}`);
         httpServer.removeListener("error", onError);
         httpServer.removeListener("listening", onListening);
@@ -510,6 +559,7 @@ function initMobilePreviewServer(ctx) {
     sessionCache.clear();
     stopHeartbeat();
     if (rotationTimer) { clearTimeout(rotationTimer); rotationTimer = null; }
+    if (rotationProbeCancel) rotationProbeCancel();
     for (const c of clients) { try { c.close(1001, "Server shutting down"); } catch {} }
     clients.clear();
     clientMeta.clear();

--- a/src/network/mobile-preview-server.js
+++ b/src/network/mobile-preview-server.js
@@ -90,6 +90,9 @@ function initMobilePreviewServer(ctx) {
   const clientTimeoutMs = ctx && typeof ctx.clientTimeoutMs === "number"
     ? ctx.clientTimeoutMs
     : CLIENT_TIMEOUT_MS;
+  const heartbeatMs = ctx && typeof ctx.heartbeatMs === "number"
+    ? ctx.heartbeatMs
+    : HEARTBEAT_MS;
   const rotationProbeMs = ctx && typeof ctx.rotationProbeMs === "number"
     ? ctx.rotationProbeMs
     : 5000;
@@ -157,39 +160,78 @@ function initMobilePreviewServer(ctx) {
   }
 
   function probeClientsBeforeRotation() {
-    const candidates = [...clients].filter((c) => c.readyState === WebSocket.OPEN);
-    if (candidates.length === 0) return Promise.resolve(false);
+    const probeToken = tokenState.token;
+    const initialCandidates = [...clients].filter((c) => c.readyState === WebSocket.OPEN);
+    if (initialCandidates.length === 0) return Promise.resolve({ allResponded: false, probeToken });
 
     return new Promise((resolve) => {
       let settled = false;
+      const candidates = new Set();
       const responders = new Set();
       const handlers = new Map();
+      const probePayload = Buffer.from(`rotation-probe:${crypto.randomBytes(8).toString("hex")}`);
       const finish = (allResponded) => {
         if (settled) return;
         settled = true;
         clearTimeout(timer);
-        for (const [client, handler] of handlers) client.removeListener("pong", handler);
+        for (const [client, listener] of handlers) {
+          client.removeListener("pong", listener.onPong);
+          client.removeListener("close", listener.onLeave);
+          client.removeListener("error", listener.onLeave);
+        }
         rotationProbeCancel = null;
-        resolve(allResponded && responders.size === candidates.length);
+        resolve({ allResponded, probeToken });
       };
-      const timer = setTimeout(() => finish(false), rotationProbeMs);
-      rotationProbeCancel = () => finish(false);
-      const probePayload = Buffer.from(`rotation-probe:${crypto.randomBytes(8).toString("hex")}`);
-
-      for (const client of candidates) {
-        const handler = (data) => {
+      const check = () => {
+        if (candidates.size === 0) return finish(false);
+        for (const client of candidates) {
+          if (!responders.has(client)) return;
+        }
+        finish(true);
+      };
+      const removeCandidate = (client) => {
+        const listener = handlers.get(client);
+        if (!listener) return;
+        client.removeListener("pong", listener.onPong);
+        client.removeListener("close", listener.onLeave);
+        client.removeListener("error", listener.onLeave);
+        handlers.delete(client);
+        candidates.delete(client);
+        responders.delete(client);
+        check();
+      };
+      const addCandidate = (client, sendPing) => {
+        if (settled || candidates.has(client) || client.readyState !== WebSocket.OPEN) return;
+        const onPong = (data) => {
           const pongPayload = Buffer.isBuffer(data) ? data : Buffer.from(data || "");
           if (!pongPayload.equals(probePayload)) return;
           responders.add(client);
-          if (responders.size === candidates.length) finish(true);
+          check();
         };
-        handlers.set(client, handler);
-        client.once("pong", handler);
+        const onLeave = () => removeCandidate(client);
+        candidates.add(client);
+        handlers.set(client, { onPong, onLeave });
+        client.on("pong", onPong);
+        client.once("close", onLeave);
+        client.once("error", onLeave);
+        if (!sendPing) return;
+        try { client.ping(probePayload); } catch { removeCandidate(client); }
+      };
+      const timer = setTimeout(() => finish(false), rotationProbeMs);
+      rotationProbeCancel = () => finish(false);
+      rotationProbeCancel.addClient = (client) => addCandidate(client, true);
+
+      for (const client of initialCandidates) addCandidate(client, false);
+      for (const client of [...candidates]) {
+        if (settled) break;
+        try { client.ping(probePayload); } catch { removeCandidate(client); }
       }
-      for (const client of candidates) {
-        try { client.ping(probePayload); } catch { finish(false); }
-      }
+      check();
     });
+  }
+
+  function addClientToRotationProbe(client) {
+    if (rotationProbeCancel && rotationProbeCancel.addClient) rotationProbeCancel.addClient(client);
   }
 
   function scheduleRotation() {
@@ -199,8 +241,8 @@ function initMobilePreviewServer(ctx) {
     rotationTimer = setTimeout(() => {
       rotationTimer = null;
       if (clients.size > 0) {
-        probeClientsBeforeRotation().then((allResponded) => {
-          if (closed) return;
+        probeClientsBeforeRotation().then(({ allResponded, probeToken }) => {
+          if (closed || tokenState.token !== probeToken) return;
           if (allResponded) {
             if (!performRotation()) {
               scheduleRotationRetry();
@@ -242,6 +284,7 @@ function initMobilePreviewServer(ctx) {
     if (!persistTokenState(nextState)) {
       throw new Error("Failed to persist mobile token state");
     }
+    if (rotationProbeCancel) rotationProbeCancel();
     // Kick all connected clients (they have stale tokens)
     for (const c of clients) {
       try { c.close(1008, "Token regenerated"); } catch {}
@@ -379,6 +422,7 @@ function initMobilePreviewServer(ctx) {
         const meta = clientMeta.get(ws);
         if (meta) meta.lastPong = Date.now();
       });
+      addClientToRotationProbe(ws);
 
       ws.on("message", (data) => {
         if (closed) return;
@@ -440,7 +484,7 @@ function initMobilePreviewServer(ctx) {
         try { c.ping(); } catch {}
       }
       if (clients.size === 0) stopHeartbeat();
-    }, HEARTBEAT_MS);
+    }, heartbeatMs);
   }
 
   function stopHeartbeat() {

--- a/src/network/mobile-preview-server.js
+++ b/src/network/mobile-preview-server.js
@@ -87,6 +87,9 @@ function isPathInside(parent, child) {
 function initMobilePreviewServer(ctx) {
   const tokenPath = (ctx && ctx.tokenPath) || TOKEN_PATH;
   const now = () => (ctx && ctx.now && ctx.now()) || Date.now();
+  const clientTimeoutMs = ctx && typeof ctx.clientTimeoutMs === "number"
+    ? ctx.clientTimeoutMs
+    : CLIENT_TIMEOUT_MS;
   const writeTokenState = ctx && typeof ctx.writeTokenState === "function"
     ? ctx.writeTokenState
     : atomicWrite;
@@ -148,13 +151,21 @@ function initMobilePreviewServer(ctx) {
     return true;
   }
 
+  function hasActiveClients() {
+    const nowMs = Date.now();
+    for (const meta of clientMeta.values()) {
+      if (nowMs - meta.lastPong < clientTimeoutMs) return true;
+    }
+    return false;
+  }
+
   function scheduleRotation() {
     if (tokenState.rotationPending) return;
     if (rotationTimer) clearTimeout(rotationTimer);
     const msUntilRotate = Math.max(0, (tokenState.rotatedAt + ROTATION_INTERVAL_MS) - now());
     rotationTimer = setTimeout(() => {
       rotationTimer = null;
-      if (clients.size > 0) {
+      if (hasActiveClients()) {
         if (!performRotation()) {
           scheduleRotationRetry();
           return;
@@ -356,7 +367,7 @@ function initMobilePreviewServer(ctx) {
       const nowMs = Date.now();
       for (const c of clients) {
         const meta = clientMeta.get(c);
-        if (c.isAlive === false || (meta && nowMs - meta.lastPong > CLIENT_TIMEOUT_MS)) {
+        if (c.isAlive === false || (meta && nowMs - meta.lastPong > clientTimeoutMs)) {
           c.terminate();
           clients.delete(c);
           clientMeta.delete(c);

--- a/test/mobile-preview-server.test.js
+++ b/test/mobile-preview-server.test.js
@@ -746,7 +746,7 @@ describe("Rotate-on-use", () => {
       token: testToken,
       previous: null,
       graceUntil: null,
-      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 250,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 1000,
       rotationPending: false,
     }, null, 2));
 
@@ -761,8 +761,10 @@ describe("Rotate-on-use", () => {
     try {
       const port = await server.start();
       client = connectClient(port, testToken);
+      const probe = new Promise((resolve) => client.ws.once("ping", resolve));
       await waitForOpen(client.ws);
-      await new Promise((r) => setTimeout(r, 350));
+      await probe;
+      await new Promise((r) => setTimeout(r, 50));
 
       const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
       assert.strictEqual(persisted.rotationPending, false);
@@ -844,6 +846,143 @@ describe("Rotate-on-use", () => {
         client.ws._socket.resume();
         client.ws.terminate();
       }
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  it("probe ignores an unrelated pong before its matching pong", async () => {
+    const testToken = "13579bdf".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 450,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({
+      sessions,
+      tokenPath: tokenFile,
+      heartbeatMs: 100,
+      rotationProbeMs: 200,
+      port: 0,
+    });
+    let client;
+    try {
+      const port = await server.start();
+      client = new WebSocket(`ws://127.0.0.1:${port}/ws?token=${testToken}`, { autoPong: false });
+      await waitForOpen(client);
+      client.on("ping", (payload) => setTimeout(() => client.pong(payload), 60));
+      await new Promise((r) => setTimeout(r, 900));
+
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(persisted.rotationPending, false);
+      assert.notStrictEqual(persisted.token, testToken);
+    } finally {
+      if (client) client.terminate();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  it("probe does not defer rotation when a silent client closes mid-probe", async () => {
+    const testToken = "2468ace0".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 150,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile, rotationProbeMs: 150, port: 0 });
+    let healthy;
+    let leaver;
+    try {
+      const port = await server.start();
+      healthy = connectClient(port, testToken);
+      leaver = new WebSocket(`ws://127.0.0.1:${port}/ws?token=${testToken}`, { autoPong: false });
+      await waitForOpen(healthy.ws);
+      await waitForOpen(leaver);
+      leaver.on("ping", () => leaver.close());
+      await new Promise((r) => setTimeout(r, 500));
+
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(persisted.rotationPending, false);
+      assert.notStrictEqual(persisted.token, testToken);
+    } finally {
+      if (healthy) healthy.close();
+      if (leaver) leaver.terminate();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  it("probe includes a client that connects during the probe window", async () => {
+    const testToken = "89abcdef".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 150,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile, rotationProbeMs: 200, port: 0 });
+    let first;
+    let joiner;
+    try {
+      const port = await server.start();
+      first = new WebSocket(`ws://127.0.0.1:${port}/ws?token=${testToken}`, { autoPong: false });
+      await waitForOpen(first);
+      const probeStarted = new Promise((resolve) => {
+        first.once("ping", (payload) => {
+          setTimeout(() => first.pong(payload), 100);
+          resolve();
+        });
+      });
+      await probeStarted;
+      joiner = new WebSocket(`ws://127.0.0.1:${port}/ws?token=${testToken}`, { autoPong: false });
+      await waitForOpen(joiner);
+      await new Promise((r) => setTimeout(r, 350));
+
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(persisted.rotationPending, true);
+      assert.strictEqual(persisted.token, testToken);
+    } finally {
+      if (first) first.terminate();
+      if (joiner) joiner.terminate();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  it("regenerating a token invalidates an in-flight probe", async () => {
+    const testToken = "deadbeef".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 100,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile, rotationProbeMs: 200, port: 0 });
+    let frozen;
+    try {
+      const port = await server.start();
+      frozen = new WebSocket(`ws://127.0.0.1:${port}/ws?token=${testToken}`, { autoPong: false });
+      await waitForOpen(frozen);
+      await new Promise((r) => setTimeout(r, 150));
+      const regenerated = server.regenerateToken();
+      await new Promise((r) => setTimeout(r, 300));
+
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(persisted.token, regenerated);
+      assert.strictEqual(persisted.rotationPending, false);
+    } finally {
+      if (frozen) frozen.terminate();
       server.cleanup();
       await new Promise((r) => setTimeout(r, 200));
     }

--- a/test/mobile-preview-server.test.js
+++ b/test/mobile-preview-server.test.js
@@ -740,7 +740,7 @@ describe("Rotate-on-use", () => {
     await new Promise((r) => setTimeout(r, 200));
   });
 
-  it("24h timer with a stale client → defers rotation until the client reconnects", async () => {
+  it("24h timer with a stale lastPong but responsive client → rotates after probe", async () => {
     const testToken = "aabbccdd".repeat(4);
     fs.writeFileSync(tokenFile, JSON.stringify({
       token: testToken,
@@ -754,6 +754,8 @@ describe("Rotate-on-use", () => {
       sessions,
       tokenPath: tokenFile,
       clientTimeoutMs: 100,
+      rotationProbeMs: 50,
+      port: 0,
     });
     let client;
     try {
@@ -763,10 +765,85 @@ describe("Rotate-on-use", () => {
       await new Promise((r) => setTimeout(r, 350));
 
       const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(persisted.rotationPending, false);
+      assert.notStrictEqual(persisted.token, testToken);
+    } finally {
+      if (client) client.close();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  it("24h timer with a frozen client → probes before rotating", async () => {
+    const testToken = "fedcba98".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 200,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({
+      sessions,
+      tokenPath: tokenFile,
+      clientTimeoutMs: 90000,
+      rotationProbeMs: 50,
+      port: 0,
+    });
+    let client;
+    try {
+      const port = await server.start();
+      client = connectClient(port, testToken);
+      await waitForOpen(client.ws);
+      // Keep the TCP connection open but stop the client from answering ping.
+      client.ws._socket.pause();
+      await new Promise((r) => setTimeout(r, 350));
+
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
       assert.strictEqual(persisted.rotationPending, true);
       assert.strictEqual(persisted.token, testToken);
     } finally {
-      if (client) client.close();
+      if (client) {
+        client.ws._socket.resume();
+        client.ws.terminate();
+      }
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  it("production defaults defer rotation for a frozen client", async () => {
+    const testToken = "01234567".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 200,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({
+      sessions,
+      tokenPath: tokenFile,
+      port: 0,
+    });
+    let client;
+    try {
+      const port = await server.start();
+      client = connectClient(port, testToken);
+      await waitForOpen(client.ws);
+      client.ws._socket.pause();
+      await new Promise((r) => setTimeout(r, 6200));
+
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(persisted.rotationPending, true);
+      assert.strictEqual(persisted.token, testToken);
+    } finally {
+      if (client) {
+        client.ws._socket.resume();
+        client.ws.terminate();
+      }
       server.cleanup();
       await new Promise((r) => setTimeout(r, 200));
     }
@@ -786,6 +863,7 @@ describe("Rotate-on-use", () => {
       sessions,
       tokenPath: tokenFile,
       clientTimeoutMs: 1000,
+      port: 0,
     });
     let client;
     try {

--- a/test/mobile-preview-server.test.js
+++ b/test/mobile-preview-server.test.js
@@ -740,6 +740,98 @@ describe("Rotate-on-use", () => {
     await new Promise((r) => setTimeout(r, 200));
   });
 
+  it("24h timer with a stale client → defers rotation until the client reconnects", async () => {
+    const testToken = "aabbccdd".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 250,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({
+      sessions,
+      tokenPath: tokenFile,
+      clientTimeoutMs: 100,
+    });
+    let client;
+    try {
+      const port = await server.start();
+      client = connectClient(port, testToken);
+      await waitForOpen(client.ws);
+      await new Promise((r) => setTimeout(r, 350));
+
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(persisted.rotationPending, true);
+      assert.strictEqual(persisted.token, testToken);
+    } finally {
+      if (client) client.close();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  it("24h timer with an active client → rotates immediately", async () => {
+    const testToken = "bbccddee".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now() - (24 * 60 * 60 * 1000) + 250,
+      rotationPending: false,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({
+      sessions,
+      tokenPath: tokenFile,
+      clientTimeoutMs: 1000,
+    });
+    let client;
+    try {
+      const port = await server.start();
+      client = connectClient(port, testToken);
+      await waitForOpen(client.ws);
+
+      const rotateMsg = await client.waitFor("token_rotate");
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.notStrictEqual(rotateMsg.newToken, testToken);
+      assert.strictEqual(persisted.rotationPending, false);
+      assert.strictEqual(persisted.token, rotateMsg.newToken);
+    } finally {
+      if (client) client.close();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
+  it("rotationPending=true + invalid token connection leaves pending unchanged", async () => {
+    const testToken = "ccddeeff".repeat(4);
+    fs.writeFileSync(tokenFile, JSON.stringify({
+      token: testToken,
+      previous: null,
+      graceUntil: null,
+      rotatedAt: Date.now(),
+      rotationPending: true,
+    }, null, 2));
+
+    const server = initMobilePreviewServer({ sessions, tokenPath: tokenFile });
+    let client;
+    try {
+      const port = await server.start();
+      client = connectClient(port, "deadbeef".repeat(4));
+      assert.strictEqual(await waitForClose(client.ws), 1008);
+
+      const persisted = JSON.parse(fs.readFileSync(tokenFile, "utf8"));
+      assert.strictEqual(persisted.rotationPending, true);
+      assert.strictEqual(persisted.token, testToken);
+    } finally {
+      if (client) client.close();
+      server.cleanup();
+      await new Promise((r) => setTimeout(r, 200));
+    }
+  });
+
   it("rotationPending=true + client connects → receives token_rotate", async () => {
     const testToken = "11223344".repeat(4);
     const setupRotatedAt = Date.now();


### PR DESCRIPTION
修复 #487  
替代 #494

## 问题

`scheduleRotation()` 当前通过 `clients.size > 0` 判断是否存在在线客户端。

iOS PWA 进入后台冻结后，WebSocket/TCP 连接可能仍暂时保留，但客户端已经无法处理 `token_rotate`。服务端此时仍会立即轮换 token；如果手机冻结超过 5 分钟宽限期，恢复后会继续使用旧 token，导致连接被拒绝并需要重新配对。

## 修复

- 新增 `hasActiveClients()`，通过 `clientMeta.lastPong` 判断客户端是否活跃；
- 只有存在最近收到 pong 的客户端时才立即轮换；
- 所有连接的 `lastPong` 均超过 `CLIENT_TIMEOUT_MS` 时，将轮换挂起为 `rotationPending`；
- 客户端重新连接后复用现有 rotate-on-use 流程完成轮换；
- 通过 `ctx.clientTimeoutMs` 注入客户端超时时间，供轮换判断、heartbeat 和测试使用；
- 保留现有 token 持久化与失败重试逻辑，不做其他重构。

## 测试

- [x] 定时器到点、客户端 `lastPong` 已过期：持久化 `rotationPending`，不立即更换 token；
- [x] 定时器到点、存在活跃客户端：正常执行 `performRotation`；
- [x] `rotationPending=true` 时使用无效 token 连接：pending 状态保持不变；
- [x] `node --test test/mobile-preview-server.test.js`：33/33 通过；
- [x] `npm test`：4,793 通过，0 失败，18 跳过；
- [x] `git diff --check` 通过。

## 改动范围

这是 #494 基于当前 `main` 重做的干净版本，仅包含：

- `hasActiveClients`
- `clientTimeoutMs` 注入
- 3 个针对性测试

没有 formatter 产生的大范围格式化，也没有无关重构。

## 已知边界

刚进入冻结状态的客户端，其最后一次 pong 可能仍处于超时窗口内，因此会暂时被判断为活跃。

触发该残余场景需要同时满足：

1. 手机在每日 token 轮换点前约 30–90 秒内进入冻结；
2. 冻结持续超过 5 分钟宽限期；
3. 手机未能处理并保存 `token_rotate` 中的新 token。

目前给不出精确概率，粗略假设前后台切换时间均匀分布，单次切换与每日轮换点碰撞的理论概率约为 `0.03%–0.1%`，对实际影响极小。

彻底消除这一窗口需要应用层 prepare/ack 或 per-device token，超出本次小范围修复的目标，可后续单独讨论。