### PR TITLE
fix(pet): drop the pet behind text-input bubbles via native SkyLight de-delegation (#640 Phase 2)

### DIFF
--- a/src/mac-window.js
+++ b/src/mac-window.js
@@ -91,6 +91,9 @@ function initSkyLight() {
     "void *",
     "int",
   ]);
+  // #640 Phase 2: pulling a window back OUT of the private space (de-delegation).
+  const SLSRemoveWindowsFromSpaces = lib.func("SLSRemoveWindowsFromSpaces", "int", ["int", "void *", "void *"]);
+  const SLSGetActiveSpace = lib.func("SLSGetActiveSpace", "uint64", ["int"]);
 
   const connection = SLSMainConnectionID();
   const space = SLSSpaceCreate(connection, 1, 0);
@@ -99,6 +102,8 @@ function initSkyLight() {
     connection,
     space,
     SLSSpaceAddWindowsAndRemoveFromSpaces,
+    SLSRemoveWindowsFromSpaces,
+    SLSGetActiveSpace,
   };
 
   // Same strategy as Masko Code: create an absolute-level system Space that is
@@ -190,6 +195,60 @@ function applyStationaryCollectionBehavior(browserWindow) {
   }
 }
 
+// #640 Phase 2 — reverse of applyStationaryCollectionBehavior's space delegation.
+// While a text field is focused the editing bubble drops to the normal window
+// level (#626), but the pet stays in the private absolute-level-100 space and
+// keeps covering — and eating clicks over — that bubble. This pulls the given
+// window OUT of the private space so its normal window level applies again and
+// it sits BEHIND the bubble. Restore by re-running applyStationaryCollectionBehavior
+// (idempotent: re-adds to the private space and restores the assistive-tech level).
+//
+// Two non-obvious points, both confirmed by real-machine probing:
+//  - Adding the window to the active space is NOT enough; it stays a member of
+//    the private space (whose absolute level dominates) until it is explicitly
+//    removed via SLSRemoveWindowsFromSpaces.
+//  - The SkyLight calls return a non-zero status (6619136) even on success, so
+//    the return code is deliberately ignored.
+function deDelegateWindowFromStationarySpace(browserWindow, level = 0) {
+  if (!isMac || !browserWindow || browserWindow.isDestroyed()) return false;
+  try {
+    const { msgPtr, msgLong, msgVoidLong } = initObjc();
+    const nsView = nativeHandleToPointer(browserWindow.getNativeWindowHandle());
+    if (!nsView) return false;
+    const nsWindow = msgPtr(nsView, selWindow);
+    if (!nsWindow) return false;
+    const windowNumber = Number(msgLong(nsWindow, selWindowNumber)) || 0;
+    if (!windowNumber) return false;
+
+    const {
+      connection,
+      space,
+      SLSRemoveWindowsFromSpaces,
+      SLSSpaceAddWindowsAndRemoveFromSpaces,
+      SLSGetActiveSpace,
+    } = initSkyLight();
+
+    // 1. Explicitly leave the private absolute-level space.
+    SLSRemoveWindowsFromSpaces(connection, makeNSNumberArray(windowNumber), makeNSNumberArray(space));
+    // 2. Land in the current user space so the window keeps a valid on-screen home.
+    const activeSpace = Number(BigInt(SLSGetActiveSpace(connection))) || 0;
+    if (activeSpace) {
+      SLSSpaceAddWindowsAndRemoveFromSpaces(connection, activeSpace, makeNSNumberArray(windowNumber), 7);
+    }
+    // 3. Drop the native level applyStationaryCollectionBehavior raised to
+    //    CGAssistiveTechHighWindowLevel (Electron's setAlwaysOnTop can't undo it).
+    msgVoidLong(nsWindow, selSetLevel, level);
+    return true;
+  } catch (err) {
+    if (!warnedSkyLightFailure) {
+      console.warn("Clawd: failed to de-delegate window from stationary SkyLight space:", err.message);
+      warnedSkyLightFailure = true;
+    }
+    return false;
+  }
+}
+
 module.exports = {
   applyStationaryCollectionBehavior,
+  deDelegateWindowFromStationarySpace,
 };

--- a/src/mac-window.js
+++ b/src/mac-window.js
@@ -195,6 +195,36 @@ function applyStationaryCollectionBehavior(browserWindow) {
   }
 }
 
+function runDeDelegateTransaction({
+  activeSpace,
+  level,
+  addToActiveSpace,
+  removeFromPrivateSpace,
+  setNativeLevel,
+  restoreStationary,
+  onFailure,
+}) {
+  if (!activeSpace) return false;
+
+  try {
+    // Give the window a valid user-Space home before removing its only known
+    // private-Space membership. Reversing these calls can strand the window
+    // off-screen when the active Space cannot be resolved.
+    addToActiveSpace();
+    removeFromPrivateSpace();
+    setNativeLevel(level);
+    return true;
+  } catch (err) {
+    // The add/remove/level sequence is one transaction from the caller's point
+    // of view. If any step fails, make the original stationary configuration
+    // visible and clickable again as far as the remaining native calls allow.
+    try { restoreStationary(); } catch {}
+    try { setNativeLevel(CGAssistiveTechHighWindowLevel); } catch {}
+    try { if (onFailure) onFailure(err); } catch {}
+    return false;
+  }
+}
+
 // #640 Phase 2 — reverse of applyStationaryCollectionBehavior's space delegation.
 // While a text field is focused the editing bubble drops to the normal window
 // level (#626), but the pet stays in the private absolute-level-100 space and
@@ -228,17 +258,36 @@ function deDelegateWindowFromStationarySpace(browserWindow, level = 0) {
       SLSGetActiveSpace,
     } = initSkyLight();
 
-    // 1. Explicitly leave the private absolute-level space.
-    SLSRemoveWindowsFromSpaces(connection, makeNSNumberArray(windowNumber), makeNSNumberArray(space));
-    // 2. Land in the current user space so the window keeps a valid on-screen home.
+    // Resolve the landing Space before mutating any window membership. If the
+    // lookup fails or returns 0, leave the stationary setup untouched so the
+    // caller can safely use the visible 18% fade fallback.
     const activeSpace = Number(BigInt(SLSGetActiveSpace(connection))) || 0;
-    if (activeSpace) {
-      SLSSpaceAddWindowsAndRemoveFromSpaces(connection, activeSpace, makeNSNumberArray(windowNumber), 7);
-    }
-    // 3. Drop the native level applyStationaryCollectionBehavior raised to
-    //    CGAssistiveTechHighWindowLevel (Electron's setAlwaysOnTop can't undo it).
-    msgVoidLong(nsWindow, selSetLevel, level);
-    return true;
+    if (!activeSpace) return false;
+
+    const windows = makeNSNumberArray(windowNumber);
+    const privateSpaces = makeNSNumberArray(space);
+    return runDeDelegateTransaction({
+      activeSpace,
+      level,
+      addToActiveSpace: () => {
+        SLSSpaceAddWindowsAndRemoveFromSpaces(connection, activeSpace, windows, 7);
+      },
+      removeFromPrivateSpace: () => {
+        SLSRemoveWindowsFromSpaces(connection, windows, privateSpaces);
+      },
+      setNativeLevel: (nextLevel) => {
+        msgVoidLong(nsWindow, selSetLevel, nextLevel);
+      },
+      restoreStationary: () => {
+        delegateWindowToStationarySpace(nsWindow);
+      },
+      onFailure: (err) => {
+        if (!warnedSkyLightFailure) {
+          console.warn("Clawd: failed to de-delegate window from stationary SkyLight space:", err.message);
+          warnedSkyLightFailure = true;
+        }
+      },
+    });
   } catch (err) {
     if (!warnedSkyLightFailure) {
       console.warn("Clawd: failed to de-delegate window from stationary SkyLight space:", err.message);
@@ -251,4 +300,7 @@ function deDelegateWindowFromStationarySpace(browserWindow, level = 0) {
 module.exports = {
   applyStationaryCollectionBehavior,
   deDelegateWindowFromStationarySpace,
+  __test: {
+    runDeDelegateTransaction,
+  },
 };

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -2,6 +2,7 @@
 
 const {
   applyStationaryCollectionBehavior: defaultApplyStationaryCollectionBehavior,
+  deDelegateWindowFromStationarySpace: defaultDeDelegateWindowFromStationarySpace,
 } = require("./mac-window");
 const { animateWindowOpacity } = require("./window-opacity-transition");
 
@@ -77,6 +78,11 @@ function createTopmostRuntime(options = {}) {
   const isMiniTransitioning = options.isMiniTransitioning || (() => false);
   const applyStationaryCollectionBehavior = options.applyStationaryCollectionBehavior
     || defaultApplyStationaryCollectionBehavior;
+  // #640 phase 2: pulls a pet window OUT of the SkyLight private space so it
+  // drops to a normal window level and sits BEHIND the editing bubble instead
+  // of merely fading. Restore is applyStationaryCollectionBehavior (idempotent).
+  const deDelegateWindowFromStationarySpace = options.deDelegateWindowFromStationarySpace
+    || defaultDeDelegateWindowFromStationarySpace;
   const keepOutOfTaskbar = options.keepOutOfTaskbar || (() => {});
   // Windows-only: when a fullscreen app/game owns the foreground, the watchdog
   // and always-on-top guard stand down so we stop clawing the pet back over it
@@ -117,9 +123,15 @@ function createTopmostRuntime(options = {}) {
   let focusablePoll = null;
   let hwndRecoveryTimer = null;
   let pendingNudgeRestore = null;
-  // #640 editing-overlap dodge state: true while the pet is faded +
-  // click-through because it overlaps the bubble being typed into.
+  // #640 editing-overlap dodge state: true while the pet is stepped back
+  // (de-delegated behind, or faded as fallback) + click-through because it
+  // overlaps the bubble being typed into.
   let imeEditingPetDodge = false;
+  // #640 phase 2: true only while the dodge is active AND native de-delegation
+  // was unavailable, so we're falling back to fading the pet rather than
+  // dropping it behind the bubble. Drives getPetTargetOpacity so external
+  // opacity writers (theme-switch fade) restore the right baseline.
+  let imeEditingFadeFallback = false;
   // Tracked separately from the dodge boolean: the hit window's click-through
   // write is deferred while a drag is in flight (see syncImeEditingPetDodge),
   // so "what we want" and "what we last wrote" can legitimately differ.
@@ -144,6 +156,34 @@ function createTopmostRuntime(options = {}) {
     if (isLiveWindow(hitWin)) hitWin.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
   }
 
+  // The pet is drawn by two stacked windows: the render window (getWin) and the
+  // transparent hit window above it (getHitWin). The #640 dodge acts on both.
+  function isPetWindow(win) {
+    return win === getWin() || win === getHitWin();
+  }
+
+  // #640 phase 2: pull both pet windows out of the SkyLight private space so
+  // they fall to a normal level and sit behind the editing bubble. Success is
+  // judged by the render window (that's what determines visibility / whether the
+  // fade fallback is needed); the hit window is de-delegated for click ordering.
+  function applyPetDeDelegate() {
+    const win = getWin();
+    const hitWin = getHitWin();
+    let renderDeDelegated = false;
+    if (isLiveWindow(win)) renderDeDelegated = deDelegateWindowFromStationarySpace(win, 0);
+    if (isLiveWindow(hitWin)) deDelegateWindowFromStationarySpace(hitWin, 0);
+    return renderDeDelegated;
+  }
+
+  // #640 phase 2: reverse of applyPetDeDelegate — re-delegate both pet windows
+  // back into the private space at the assistive-tech level (idempotent).
+  function restorePetDelegate() {
+    const win = getWin();
+    const hitWin = getHitWin();
+    if (isLiveWindow(win)) applyStationaryCollectionBehavior(win);
+    if (isLiveWindow(hitWin)) applyStationaryCollectionBehavior(hitWin);
+  }
+
   function reapplyMacVisibility() {
     if (!isMac) return;
     const applyElectronCrossSpace = (win) => {
@@ -166,6 +206,16 @@ function createTopmostRuntime(options = {}) {
       if (win.__clawdMacImeEditing) {
         win.setAlwaysOnTop(false);
         if (win.__clawdMacTextInputBubble) applyElectronCrossSpace(win);
+        return;
+      }
+      // #640 phase 2: while the editing-overlap dodge is active, the pet's
+      // render + hit windows must stay OUT of the private space so they sit
+      // behind the bubble. Re-running applyStationaryCollectionBehavior below
+      // would re-delegate them to the absolute-level space (back on top) every
+      // pass; syncImeEditingPetDodge is edge-triggered and wouldn't undo that
+      // until the overlap state changed. deDelegate is idempotent, so re-run it.
+      if (imeEditingPetDodge && !imeEditingFadeFallback && isPetWindow(win)) {
+        deDelegateWindowFromStationarySpace(win, 0);
         return;
       }
       win.setAlwaysOnTop(true, MAC_TOPMOST_LEVEL);
@@ -197,12 +247,36 @@ function createTopmostRuntime(options = {}) {
     syncImeEditingPetDodge();
   }
 
-  function findImeEditingBubble() {
+  // #640 Phase 2: the dodge triggers on the pet OVERLAPPING a text-input bubble
+  // (permission.js flags elicitation / ExitPlanMode bubbles __clawdMacTextInputBubble
+  // at creation) — NOT merely on a focused text field (__clawdMacImeEditing).
+  // Why: #626 deliberately keeps text-input bubbles OUT of the SkyLight private
+  // space so the OS IME candidate window can surface, but that same treatment
+  // leaves the pet (private space, assistive-tech level) sitting ON TOP of them
+  // from the moment they appear — covering the options and the input box before
+  // the user ever focuses it. #626 unified both bubble kinds under one model, so
+  // the pet must step back for the whole overlapping bubble, not just while
+  // typing. (A focused field is a strict subset: those bubbles are text-input
+  // bubbles too.) Permission (options-only) bubbles get the same private-space
+  // treatment as the pet, so they coexist in one level band and are unaffected.
+  function petOverlapsTextInputBubble() {
+    let petRect = null;
+    let petRectComputed = false;
     for (const perm of getPendingPermissions() || []) {
       const bubble = perm && perm.bubble;
-      if (isLiveWindow(bubble) && bubble.__clawdMacImeEditing) return bubble;
+      if (!isLiveWindow(bubble) || !bubble.__clawdMacTextInputBubble) continue;
+      if (typeof bubble.getBounds !== "function") continue;
+      if (!petRectComputed) {
+        const petBounds = getPetWindowBounds();
+        try { petRect = getHitRectScreen(petBounds); } catch { petRect = null; }
+        if (!petRect) petRect = petBounds;
+        petRectComputed = true;
+      }
+      let bubbleRect = null;
+      try { bubbleRect = bubble.getBounds(); } catch { bubbleRect = null; }
+      if (rectsIntersect(petRect, bubbleRect)) return true;
     }
-    return null;
+    return false;
   }
 
   function fadePetWindow(targetOpacity) {
@@ -219,14 +293,17 @@ function createTopmostRuntime(options = {}) {
     });
   }
 
-  // #640: while a bubble text field is focused (permission.js handleImeEditing,
-  // macOS only) AND the pet sprite overlaps that bubble, the pet politely steps
-  // back: its render window fades to IME_EDIT_PET_FADE_OPACITY and the hit
-  // window stops intercepting clicks, so the box being typed into stays
-  // readable and clickable underneath. The pet stays in the SkyLight private
-  // space — always above the editing bubble, which #626 drops to the normal
-  // level — so until a native space de-delegation exists (#640 phase 2) this
-  // fade is the mitigation. Edge-triggered on the overlap state; every
+  // #640: while the pet sprite overlaps a text-input bubble (macOS; see
+  // petOverlapsTextInputBubble for why the trigger is overlap, not focus) the
+  // pet politely steps back so the bubble — its options AND the box being typed
+  // into — stays readable and clickable underneath.
+  // Phase 2 (#640): the primary path pulls both pet windows OUT of the SkyLight
+  // private space (deDelegateWindowFromStationarySpace) so they drop to a normal
+  // level and sit genuinely BEHIND the bubble — fully opaque, just behind. The
+  // fade to IME_EDIT_PET_FADE_OPACITY is kept only as a FALLBACK for when native
+  // de-delegation is unavailable (FFI load failure returns false). Either way
+  // the hit window stops intercepting clicks. Edge-triggered on the overlap
+  // state; every
   // transition path funnels here: handleImeEditing calls reapplyMacVisibility,
   // pet moves call this directly (main.js), and every pendingPermissions
   // add/remove calls this via notifyPermissionsChanged (permission.js) — that
@@ -241,20 +318,20 @@ function createTopmostRuntime(options = {}) {
   // faded value rather than snapping the pet opaque over the input box.
   function syncImeEditingPetDodge() {
     if (!isMac) return;
-    const editingBubble = findImeEditingBubble();
-    let overlap = false;
-    if (editingBubble && typeof editingBubble.getBounds === "function") {
-      const petBounds = getPetWindowBounds();
-      let petRect = null;
-      try { petRect = getHitRectScreen(petBounds); } catch { petRect = null; }
-      if (!petRect) petRect = petBounds;
-      let bubbleRect = null;
-      try { bubbleRect = editingBubble.getBounds(); } catch { bubbleRect = null; }
-      overlap = rectsIntersect(petRect, bubbleRect);
-    }
+    const overlap = petOverlapsTextInputBubble();
     if (overlap !== imeEditingPetDodge) {
       imeEditingPetDodge = overlap;
-      fadePetWindow(overlap ? IME_EDIT_PET_FADE_OPACITY : 1);
+      if (overlap) {
+        // Native path: drop the pet behind the bubble. If it works the pet stays
+        // opaque (it's simply behind now); only fall back to fading when
+        // de-delegation is unavailable.
+        imeEditingFadeFallback = !applyPetDeDelegate();
+      } else {
+        // Restore the pet to the private space + assistive-tech level.
+        restorePetDelegate();
+        imeEditingFadeFallback = false;
+      }
+      fadePetWindow(imeEditingFadeFallback ? IME_EDIT_PET_FADE_OPACITY : 1);
     }
     // The click-through write is deferred while a drag is in flight: an
     // established macOS mouse-tracking session keeps delivering the drag's
@@ -275,9 +352,11 @@ function createTopmostRuntime(options = {}) {
 
   // #640: the render window's baseline opacity as far as the dodge is
   // concerned. External opacity writers that restore "full" opacity (the
-  // theme-switch fade) must ask this instead of hardcoding 1.
+  // theme-switch fade) must ask this instead of hardcoding 1. Phase 2: only the
+  // fade FALLBACK lowers opacity; when the pet is de-delegated behind the bubble
+  // it stays fully opaque, so the baseline is 1.
   function getPetTargetOpacity() {
-    return imeEditingPetDodge ? IME_EDIT_PET_FADE_OPACITY : 1;
+    return imeEditingFadeFallback ? IME_EDIT_PET_FADE_OPACITY : 1;
   }
 
   function isNearWorkAreaEdge(bounds, tolerance = 2) {

--- a/test/mac-window.test.js
+++ b/test/mac-window.test.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+const { __test } = require("../src/mac-window");
+
+function makeTransaction(overrides = {}) {
+  const calls = [];
+  const transaction = {
+    activeSpace: 42,
+    level: 0,
+    addToActiveSpace: () => calls.push("add-active"),
+    removeFromPrivateSpace: () => calls.push("remove-private"),
+    setNativeLevel: (level) => calls.push(`level:${level}`),
+    restoreStationary: () => calls.push("restore-stationary"),
+    onFailure: () => calls.push("failure"),
+    ...overrides,
+  };
+  return { calls, transaction };
+}
+
+describe("macOS stationary Space de-delegation transaction", () => {
+  it("does not mutate Space membership or level without a valid active Space", () => {
+    const { calls, transaction } = makeTransaction({ activeSpace: 0 });
+
+    assert.strictEqual(__test.runDeDelegateTransaction(transaction), false);
+    assert.deepStrictEqual(calls, []);
+  });
+
+  it("adds to the active Space before removing the private Space and lowering the level", () => {
+    const { calls, transaction } = makeTransaction();
+
+    assert.strictEqual(__test.runDeDelegateTransaction(transaction), true);
+    assert.deepStrictEqual(calls, ["add-active", "remove-private", "level:0"]);
+  });
+
+  for (const failedStep of ["add-active", "remove-private", "level:0"]) {
+    it(`rolls back the stationary Space and level when ${failedStep} fails`, () => {
+      const { calls, transaction } = makeTransaction();
+      if (failedStep === "add-active") {
+        transaction.addToActiveSpace = () => {
+          calls.push("add-active");
+          throw new Error("add failed");
+        };
+      } else if (failedStep === "remove-private") {
+        transaction.removeFromPrivateSpace = () => {
+          calls.push("remove-private");
+          throw new Error("remove failed");
+        };
+      } else {
+        transaction.setNativeLevel = (level) => {
+          calls.push(`level:${level}`);
+          if (level === 0) throw new Error("level failed");
+        };
+      }
+
+      assert.strictEqual(__test.runDeDelegateTransaction(transaction), false);
+      const rollbackAt = calls.indexOf("restore-stationary");
+      assert.notStrictEqual(rollbackAt, -1);
+      assert.deepStrictEqual(calls.slice(rollbackAt), ["restore-stationary", "level:1500", "failure"]);
+    });
+  }
+
+  it("still restores the native level when the stationary rollback itself fails", () => {
+    const { calls, transaction } = makeTransaction({
+      addToActiveSpace: () => {
+        throw new Error("add failed");
+      },
+      restoreStationary: () => {
+        calls.push("restore-stationary");
+        throw new Error("restore failed");
+      },
+    });
+
+    assert.strictEqual(__test.runDeDelegateTransaction(transaction), false);
+    assert.deepStrictEqual(calls, ["restore-stationary", "level:1500", "failure"]);
+  });
+});

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -834,11 +834,14 @@ describe("topmost runtime macOS visibility", () => {
 });
 
 describe("IME editing pet dodge (#640)", () => {
-  function makeDodgeSetup(overrides = {}) {
+  function makeDodgeSetup({ deDelegateResult = true, ...overrides } = {}) {
     const pet = new FakeWindow();
     const hit = new FakeWindow();
     const bubble = new FakeWindow({ bounds: { x: 100, y: 100, width: 300, height: 200 } });
-    bubble.__clawdMacImeEditing = true;
+    // #640 phase 2: the dodge triggers on overlapping a TEXT-INPUT bubble, set
+    // at bubble creation — NOT on a focused field (__clawdMacImeEditing). No ime
+    // flag here on purpose: the pet must step back the moment the bubble appears,
+    // before the user ever clicks into the box.
     bubble.__clawdMacTextInputBubble = true;
     const runtime = createTopmostRuntime({
       isMac: true,
@@ -850,21 +853,31 @@ describe("IME editing pet dodge (#640)", () => {
       // exactly what the first real-machine run caught the arbiter mishandling.
       getHitRectScreen: () => ({ left: 320, top: 240, right: 440, bottom: 360 }),
       imeEditingFadeMs: 0,
-      applyStationaryCollectionBehavior: () => true,
+      // Record which native primitive ran on each window: applyStationary
+      // re-delegates into the private space (on top); deDelegate pulls it out
+      // (behind). deDelegateResult toggles the fade-fallback path (#640 phase 2).
+      applyStationaryCollectionBehavior: (window) => {
+        window.calls.push(["applyStationary"]);
+        return true;
+      },
+      deDelegateWindowFromStationarySpace: (window, level) => {
+        window.calls.push(["deDelegate", level]);
+        return deDelegateResult;
+      },
       ...overrides,
     });
     return { pet, hit, bubble, runtime };
   }
 
-  it("fades the pet and lets clicks through while the editing bubble overlaps the sprite", () => {
+  it("drops the pet behind the bubble and lets clicks through while it overlaps the sprite", () => {
     const { pet, hit, runtime } = makeDodgeSetup();
 
     runtime.syncImeEditingPetDodge();
 
-    assert.deepStrictEqual(pet.calls, [
-      ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
-    ]);
-    assert.deepStrictEqual(hit.calls, [["setIgnoreMouseEvents", true]]);
+    // Native path: both pet windows de-delegated out of the private space
+    // (behind the bubble); the render window stays fully opaque.
+    assert.deepStrictEqual(pet.calls, [["deDelegate", 0], ["setOpacity", 1]]);
+    assert.deepStrictEqual(hit.calls, [["deDelegate", 0], ["setIgnoreMouseEvents", true]]);
   });
 
   it("is edge-triggered: repeated syncs while overlapping do not repeat window calls", () => {
@@ -874,24 +887,39 @@ describe("IME editing pet dodge (#640)", () => {
     runtime.syncImeEditingPetDodge();
     runtime.syncImeEditingPetDodge();
 
-    assert.strictEqual(pet.calls.length, 1);
-    assert.strictEqual(hit.calls.length, 1);
+    assert.strictEqual(pet.calls.length, 2, "deDelegate + setOpacity, once");
+    assert.strictEqual(hit.calls.length, 2, "deDelegate + ignore-mouse, once");
   });
 
-  it("restores the pet when the text field blurs (flag cleared)", () => {
+  it("stays behind while the bubble is up regardless of field focus (blur does NOT restore)", () => {
+    const { pet, hit, bubble, runtime } = makeDodgeSetup();
+
+    runtime.syncImeEditingPetDodge();          // bubble overlaps → pet drops behind
+    bubble.__clawdMacImeEditing = true;        // user focuses the field
+    runtime.syncImeEditingPetDodge();
+    delete bubble.__clawdMacImeEditing;         // user blurs the field, bubble still up
+    runtime.syncImeEditingPetDodge();
+
+    // Focus/blur must not retrigger anything — the trigger is overlap, not focus.
+    // The pet stepped back exactly once and stays there while the bubble is up.
+    assert.deepStrictEqual(pet.calls, [["deDelegate", 0], ["setOpacity", 1]]);
+    assert.deepStrictEqual(hit.calls, [["deDelegate", 0], ["setIgnoreMouseEvents", true]]);
+  });
+
+  it("restores the pet when the text-input bubble goes away (flag cleared)", () => {
     const { pet, hit, bubble, runtime } = makeDodgeSetup();
 
     runtime.syncImeEditingPetDodge();
-    delete bubble.__clawdMacImeEditing;
+    delete bubble.__clawdMacTextInputBubble;
     runtime.syncImeEditingPetDodge();
 
     assert.deepStrictEqual(pet.calls, [
-      ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
-      ["setOpacity", 1],
+      ["deDelegate", 0], ["setOpacity", 1],
+      ["applyStationary"], ["setOpacity", 1],
     ]);
     assert.deepStrictEqual(hit.calls, [
-      ["setIgnoreMouseEvents", true],
-      ["setIgnoreMouseEvents", false],
+      ["deDelegate", 0], ["setIgnoreMouseEvents", true],
+      ["applyStationary"], ["setIgnoreMouseEvents", false],
     ]);
   });
 
@@ -906,9 +934,12 @@ describe("IME editing pet dodge (#640)", () => {
     perms.length = 0;
     runtime.syncImeEditingPetDodge();
 
-    assert.deepStrictEqual(pet.calls.map((c) => c[0]), ["setOpacity", "setOpacity"]);
-    assert.deepStrictEqual(pet.calls[1], ["setOpacity", 1]);
-    assert.deepStrictEqual(hit.calls[1], ["setIgnoreMouseEvents", false]);
+    assert.deepStrictEqual(
+      pet.calls.map((c) => c[0]),
+      ["deDelegate", "setOpacity", "applyStationary", "setOpacity"]
+    );
+    assert.deepStrictEqual(pet.calls[pet.calls.length - 1], ["setOpacity", 1]);
+    assert.deepStrictEqual(hit.calls[hit.calls.length - 1], ["setIgnoreMouseEvents", false]);
   });
 
   it("does nothing while editing without geometric overlap", () => {
@@ -930,9 +961,7 @@ describe("IME editing pet dodge (#640)", () => {
 
     runtime.syncImeEditingPetDodge();
 
-    assert.deepStrictEqual(pet.calls, [
-      ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
-    ]);
+    assert.deepStrictEqual(pet.calls, [["deDelegate", 0], ["setOpacity", 1]]);
   });
 
   it("does nothing off macOS", () => {
@@ -949,9 +978,15 @@ describe("IME editing pet dodge (#640)", () => {
 
     runtime.reapplyMacVisibility();
 
+    // The dodge fires at the end of the pass: the pet is de-delegated behind the
+    // bubble and left fully opaque, and the hit window goes click-through.
+    assert.deepStrictEqual(
+      pet.calls.filter((c) => c[0] === "deDelegate"),
+      [["deDelegate", 0]]
+    );
     assert.deepStrictEqual(
       pet.calls.filter((c) => c[0] === "setOpacity"),
-      [["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY]]
+      [["setOpacity", 1]]
     );
     assert.deepStrictEqual(
       hit.calls.filter((c) => c[0] === "setIgnoreMouseEvents"),
@@ -959,21 +994,36 @@ describe("IME editing pet dodge (#640)", () => {
     );
   });
 
+  it("keeps the pet de-delegated on later passes instead of re-delegating it on top", () => {
+    const { pet, hit, runtime } = makeDodgeSetup();
+
+    runtime.reapplyMacVisibility();  // establishes the overlap + de-delegation
+    pet.calls.length = 0;
+    hit.calls.length = 0;
+    runtime.reapplyMacVisibility();  // second pass while still overlapping
+
+    // apply() must re-de-delegate the pet windows, NOT re-run applyStationary
+    // (which would re-insert them into the private absolute-level space on top).
+    assert.deepStrictEqual(pet.calls, [["deDelegate", 0]]);
+    assert.deepStrictEqual(hit.calls, [["deDelegate", 0]]);
+  });
+
   // #640/F3: Electron's setIgnoreMouseEvents makes no promise about toggling
   // mid-gesture, so the click-through write is deferred while a drag is in
-  // flight; the fade is not (the mid-drag fade transition is the hands-on-
-  // verified experience). Drag-lock release re-runs the sync to apply it.
+  // flight; the space moves (de-delegate / applyStationary) are not — they are
+  // the same class of setLevel/space op the visibility pass already runs on
+  // these windows mid-drag, and dropping the pet behind is the hands-on-verified
+  // mid-drag experience. Drag-lock release re-runs the sync to apply the write.
   describe("drag-lock deferral", () => {
-    it("fades mid-drag but defers the click-through write", () => {
+    it("drops the pet behind mid-drag but defers the click-through write", () => {
       const { pet, hit, runtime } = makeDodgeSetup({ isDragLocked: () => true });
 
       runtime.syncImeEditingPetDodge();
 
-      assert.deepStrictEqual(pet.calls, [
-        ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
-      ], "the fade still runs mid-drag");
-      assert.deepStrictEqual(hit.calls, [],
-        "the ignore-mouse write must wait until the drag ends");
+      assert.deepStrictEqual(pet.calls, [["deDelegate", 0], ["setOpacity", 1]],
+        "the render window steps back mid-drag");
+      assert.deepStrictEqual(hit.calls, [["deDelegate", 0]],
+        "the hit window drops behind, but the ignore-mouse write waits for drag end");
     });
 
     it("applies the deferred click-through on the first sync after the drag ends", () => {
@@ -984,51 +1034,92 @@ describe("IME editing pet dodge (#640)", () => {
       dragging = false;
       runtime.syncImeEditingPetDodge();
 
-      assert.deepStrictEqual(hit.calls, [["setIgnoreMouseEvents", true]]);
-      assert.strictEqual(pet.calls.length, 1,
-        "the fade already ran mid-drag; the post-drag sync only applies the write");
+      assert.deepStrictEqual(hit.calls, [["deDelegate", 0], ["setIgnoreMouseEvents", true]]);
+      assert.strictEqual(pet.calls.length, 2,
+        "the render step already ran mid-drag; the post-drag sync only applies the write");
 
       runtime.syncImeEditingPetDodge();
-      assert.strictEqual(hit.calls.length, 1, "the applied write is edge-triggered");
+      assert.strictEqual(hit.calls.length, 2, "the applied write is edge-triggered");
     });
 
     it("skips the write entirely when the overlap ended before the drag did", () => {
       let dragging = true;
       const { pet, hit, bubble, runtime } = makeDodgeSetup({ isDragLocked: () => dragging });
 
-      runtime.syncImeEditingPetDodge();       // overlap while dragging → fade only
-      delete bubble.__clawdMacImeEditing;     // edit ends mid-drag
-      runtime.syncImeEditingPetDodge();       // fade back, still no write
+      runtime.syncImeEditingPetDodge();       // overlap while dragging → step back
+      delete bubble.__clawdMacTextInputBubble; // bubble closes mid-drag
+      runtime.syncImeEditingPetDodge();       // restore, still no write
       dragging = false;
       runtime.syncImeEditingPetDodge();       // drag ends: nothing left to apply
 
-      assert.deepStrictEqual(pet.calls.map((c) => c[1]), [
-        createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY, 1,
-      ]);
-      assert.deepStrictEqual(hit.calls, [],
+      assert.deepStrictEqual(pet.calls.map((c) => c[0]),
+        ["deDelegate", "setOpacity", "applyStationary", "setOpacity"]);
+      assert.ok(!hit.calls.some((c) => c[0] === "setIgnoreMouseEvents"),
         "never went click-through, so nothing to undo");
     });
   });
 
-  // #640: external opacity writers (theme-switch fade) restore to this value
-  // instead of a hardcoded 1, so a theme reload mid-edit lands back on the
-  // dodge baseline rather than planting an opaque pet over the input box.
-  it("getPetTargetOpacity tracks the dodge state", () => {
+  // #640 phase 2: when native de-delegation is unavailable (FFI load failure
+  // returns false) the pet falls back to fading in place instead of dropping
+  // behind, and stays in the private space (on top) so apply() keeps
+  // re-delegating rather than de-delegating it.
+  describe("fade fallback when native de-delegation is unavailable", () => {
+    it("fades the pet instead of dropping it behind when de-delegation returns false", () => {
+      const { pet, hit, runtime } = makeDodgeSetup({ deDelegateResult: false });
+
+      runtime.syncImeEditingPetDodge();
+
+      assert.deepStrictEqual(pet.calls, [
+        ["deDelegate", 0],
+        ["setOpacity", createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY],
+      ]);
+      assert.deepStrictEqual(hit.calls, [["deDelegate", 0], ["setIgnoreMouseEvents", true]]);
+    });
+
+    it("does not de-delegate pet windows on later passes in fallback mode", () => {
+      const { pet, runtime } = makeDodgeSetup({ deDelegateResult: false });
+
+      runtime.reapplyMacVisibility();
+      pet.calls.length = 0;
+      runtime.reapplyMacVisibility();
+
+      // Faded-in-place → the pet must stay in the private space, so apply()
+      // re-delegates it and never de-delegates.
+      assert.ok(!pet.calls.some((c) => c[0] === "deDelegate"));
+      assert.ok(pet.calls.some((c) => c[0] === "applyStationary"));
+    });
+
+    it("getPetTargetOpacity reports the faded baseline in fallback mode", () => {
+      const { bubble, runtime } = makeDodgeSetup({ deDelegateResult: false });
+
+      runtime.syncImeEditingPetDodge();
+      assert.strictEqual(
+        runtime.getPetTargetOpacity(),
+        createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY,
+        "while fading in place, the baseline is the faded value"
+      );
+
+      delete bubble.__clawdMacTextInputBubble;
+      runtime.syncImeEditingPetDodge();
+      assert.strictEqual(runtime.getPetTargetOpacity(), 1);
+    });
+  });
+
+  // #640 phase 2: external opacity writers (theme-switch fade) restore to this
+  // value instead of a hardcoded 1. On the native path the de-delegated pet is
+  // fully opaque (just behind), so the baseline stays 1 throughout.
+  it("getPetTargetOpacity stays 1 when the pet is de-delegated behind the bubble", () => {
     const { bubble, runtime } = makeDodgeSetup();
 
     assert.strictEqual(runtime.getPetTargetOpacity(), 1,
       "before any sync the baseline is full opacity");
 
     runtime.syncImeEditingPetDodge();
-    assert.strictEqual(
-      runtime.getPetTargetOpacity(),
-      createTopmostRuntime.IME_EDIT_PET_FADE_OPACITY,
-      "while dodging, the baseline is the faded value"
-    );
-
-    delete bubble.__clawdMacImeEditing;
-    runtime.syncImeEditingPetDodge();
     assert.strictEqual(runtime.getPetTargetOpacity(), 1,
-      "after the edit ends the baseline returns to full opacity");
+      "de-delegated behind the bubble, the pet is fully opaque");
+
+    delete bubble.__clawdMacTextInputBubble;
+    runtime.syncImeEditingPetDodge();
+    assert.strictEqual(runtime.getPetTargetOpacity(), 1);
   });
 });


### PR DESCRIPTION
> Re-opened against `main` at the maintainer's request — supersedes #654, which was auto-closed when its base branch (`fix/640-pet-dodge-while-typing`) was deleted on merge.

Follows up #642 (Phase 0/1, the fade mitigation), now merged into `main`. While #642 *fades* the pet to 18% when a text field is focused, this replaces that with a **native SkyLight de-delegation** that drops the pet **genuinely behind** the bubble — fully opaque — and broadens the trigger so it steps back the moment a text-input bubble appears, not only while you are typing. The fade is kept as a fallback.

## How we validated it (before touching the integration)

The hard part of #640 was the SkyLight mechanism itself — the same one that looked "stuck" earlier (the `rc=6619136` "move failed"). So we nailed it down in isolation first, then end-to-end:

1. **Isolated SkyLight probe.** A throwaway Electron script creates two overlapping windows — a "pet" P given the real shipping `applyStationaryCollectionBehavior`, and a "bubble" B — then reads actual z-order back from `CGWindowListCopyWindowInfo`. Findings:
   - De-delegating P pulls it behind B and back on `applyStationaryCollectionBehavior`, cleanly, across repeated round-trips.
   - `rc=6619136` is a **benign** status — the calls succeed; judge by space membership / z-order, not the return code.
   - Just adding the window to the active space is **not** enough — it stays a member of the private absolute-level space until explicitly removed via `SLSRemoveWindowsFromSpaces`.

2. **Production z-order, not a rigged one.** The first probe put B at `screen-saver` level, so level dominance trivially won. We re-ran it with **B at normal level 0 and focused** — exactly what #626 leaves the editing bubble at while you type. Result: the de-delegated pet (level 0) still lands **behind** the focused bubble at the *same* level, because the bubble is the key window. So no defensive "level −1" is needed; level 0 is correct. (We tested −1 too — also works, but unnecessary.)

3. **Real machine, real elicitation.** Triggered an actual text-input elicitation bubble and confirmed, hands-on:
   - the pet drops behind the **instant the bubble appears** — before focusing anything;
   - options are clickable, the input box is clickable, **CJK input works** (candidate window no longer occluded);
   - the pet **restores to top-most the moment the bubble closes**.

4. **Unit tests.** The `#640` block (48 assertions) covers: de-delegate-on-overlap, edge-triggering, focus-independence (blur does *not* restore while the bubble is up), restore on bubble removal, the drag-lock deferral, and the fade fallback path. Full suite green (**4805 pass / 0 fail**).

## What changed

**`src/mac-window.js` — the primitive.**
`deDelegateWindowFromStationarySpace(win, level = 0)`: `SLSRemoveWindowsFromSpaces` out of the private space → land in the active user space → drop the native window level (`applyStationaryCollectionBehavior` raised it to `CGAssistiveTechHighWindowLevel`, which Electron's `setAlwaysOnTop(false)` cannot undo). Restore is just `applyStationaryCollectionBehavior` (idempotent). The two SkyLight gotchas above are documented inline.

**`src/topmost-runtime.js` — the integration.**
- On overlap, the pet's **render + hit** windows are de-delegated behind the bubble; `fadePetWindow(1)` keeps them opaque. If de-delegation is unavailable (FFI load failure → `false`), we fall back to the #642 fade.
- `reapplyMacVisibility`'s `apply()` now **respects** the de-delegated state for the pet windows — it re-de-delegates each pass instead of re-running `applyStationaryCollectionBehavior` (which would re-insert them on top).
- Only `setIgnoreMouseEvents` stays drag-deferred (Electron's mid-gesture contract); the space moves ride the same class of `setLevel`/space ops the visibility pass already runs on these windows.
- `getPetTargetOpacity` keys off the fade-fallback flag (native path stays fully opaque).

**Trigger broadened: overlap, not focus.** The dodge now fires when the pet overlaps any `__clawdMacTextInputBubble` (set at bubble creation), not only when a field is focused (`__clawdMacImeEditing`). Rationale below.

## Why the trigger is "overlap a text-input bubble", not "field focused"

#626 (which introduced the two-bubble split) deliberately keeps **text-input** bubbles *out* of the SkyLight private space so the OS IME candidate window can surface — but that same treatment means the pet (private space, assistive-tech level) sits **on top of them from the moment they appear**, covering the options and the input box before you ever click in. #626 unified both bubble kinds under one model, so to keep the effect consistent the pet must step back for the **whole** overlapping text-input bubble, not just while typing.

**Permission (options-only) bubbles are unaffected** — they get the same private-space treatment as the pet, so they coexist in one level band and were never occluded by it.

## Scope / non-goals
- No change to permission-bubble behavior, Windows paths, or the bubble's own IME-editing level handling (#626).
- The fade path is retained purely as a graceful fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
