### PR TITLE
Hide PowerShell process-query windows in remaining integrations

### DIFF
--- a/hooks/hermes-plugin/__init__.py
+++ b/hooks/hermes-plugin/__init__.py
@@ -437,7 +437,7 @@ def _query_windows_process_snapshot() -> Dict[int, Dict[str, Any]]:
         "Select-Object ProcessId,ParentProcessId,Name,ExecutablePath,CommandLine | "
         "ConvertTo-Json -Compress"
     )
-    result = _run_process_command(["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script], timeout=3.0)
+    result = _run_process_command(["powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", script], timeout=3.0)
     if not result or result.returncode != 0 or not result.stdout.strip():
         return {}
     try:
@@ -461,7 +461,7 @@ def _query_windows_process_info(pid: int, snapshot: Optional[Dict[int, Dict[str,
         f"$p=Get-CimInstance Win32_Process -Filter 'ProcessId={pid}' -ErrorAction SilentlyContinue; "
         "if ($p) { $p | Select-Object ProcessId,Name,ParentProcessId,ExecutablePath,CommandLine | ConvertTo-Json -Compress }"
     )
-    result = _run_process_command(["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script], timeout=3.0)
+    result = _run_process_command(["powershell.exe", "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", script], timeout=3.0)
     if result and result.returncode == 0 and result.stdout.strip():
         try:
             row = json.loads(result.stdout)
@@ -487,7 +487,7 @@ def _query_windows_process_info(pid: int, snapshot: Optional[Dict[int, Dict[str,
         "}"
     )
     for shell in ("pwsh.exe", "powershell.exe"):
-        result = _run_process_command([shell, "-NoProfile", "-NonInteractive", "-Command", get_process_script], timeout=2.5)
+        result = _run_process_command([shell, "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command", get_process_script], timeout=2.5)
         if not result or result.returncode != 0 or not result.stdout.strip():
             continue
         try:

--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -94,7 +94,7 @@ function getWindowsProcessSnapshot() {
     const out = execFileSync(
       "powershell.exe",
       [
-        "-NoProfile", "-NonInteractive", "-Command",
+        "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command",
         "Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, Name | ConvertTo-Json -Compress",
       ],
       { encoding: "utf8", timeout: 3000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 }

--- a/hooks/pi-extension.ts
+++ b/hooks/pi-extension.ts
@@ -202,7 +202,7 @@ function getWindowsProcessSnapshot(): Map<number, WinProcessRecord> {
     const raw = childProcess.execFileSync(
       "powershell.exe",
       [
-        "-NoProfile", "-NonInteractive", "-Command",
+        "-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-Command",
         "Get-CimInstance Win32_Process | Select-Object ProcessId, ParentProcessId, Name | ConvertTo-Json -Compress",
       ],
       { encoding: "utf8", timeout: 3000, windowsHide: true, maxBuffer: 8 * 1024 * 1024 }


### PR DESCRIPTION
## Summary

- add `-WindowStyle Hidden` to the Pi and shared opencode-family PowerShell process snapshots; the shared core covers both opencode and MiMo Code
- add the same flag to Hermes snapshot, per-PID CIM, and `Get-Process` fallback queries
- keep the existing `windowsHide` / `CREATE_NO_WINDOW` protection in place

## Root cause

These process-query paths do not use the shared resolver fixed in #628. Since the opencode-family refactor in `eb5fc10`, opencode and MiMo Code share the same family core and receive the mitigation together. When Windows Terminal is the default terminal, its console delegation can ignore `CREATE_NO_WINDOW`, allowing a brief PowerShell window flash.

## User impact

Background process-tree detection in Pi, opencode, MiMo Code, and Hermes now asks both Windows PowerShell and PowerShell 7 to stay hidden.

## Validation

- `node --test test/shared-process.test.js test/pi-install.test.js test/opencode-plugin-session.test.js test/hermes-plugin.test.js` (90 passed)
- `node --test test/opencode-family-bridge.test.js` (6 passed)
- `node --check hooks/opencode-family-plugin/core.mjs`
- `node --check hooks/opencode-plugin/index.mjs`
- Python compile check for `hooks/hermes-plugin/__init__.py`
- Windows PowerShell 5.1 and PowerShell 7 smoke tests with `-WindowStyle Hidden`

Fixes #639
