### PR TITLE
Validate nested hook integrations per event in Doctor

### DIFF
--- a/src/doctor-detectors/agent-descriptors.js
+++ b/src/doctor-detectors/agent-descriptors.js
@@ -237,6 +237,7 @@ const AGENT_DESCRIPTORS = Object.freeze([
     marker: qoder.MARKER,
     nested: true,
     hookEvents: qoder.QODER_HOOK_EVENTS,
+    hookGroupId: "clawd",
   }),
   Object.freeze({
     agentId: "reasonix",
@@ -261,6 +262,7 @@ const AGENT_DESCRIPTORS = Object.freeze([
     marker: qoderwork.MARKER,
     nested: true,
     hookEvents: qoderwork.QODERWORK_HOOK_EVENTS,
+    hookGroupId: "clawd",
   }),
 ]);
 

--- a/src/doctor-detectors/agent-integrations.js
+++ b/src/doctor-detectors/agent-integrations.js
@@ -12,7 +12,6 @@ const { getAgent } = require("../../agents/registry");
 const { commandMatchesMarker, findHookCommands } = require("../../hooks/json-utils");
 const { GEMINI_HOOK_EVENTS } = require("../../hooks/gemini-install");
 const { ANTIGRAVITY_HOOK_EVENTS, HOOK_GROUP_ID: ANTIGRAVITY_HOOK_GROUP_ID } = require("../../hooks/antigravity-install");
-const { QWEN_CODE_HOOK_EVENTS } = require("../../hooks/qwen-code-install");
 const {
   hasUserPermissionHookInOtherFiles,
   hasUserPermissionHookInSettingsJson,
@@ -109,6 +108,7 @@ function withClaudeHookGuardNotice(detail, descriptor, options) {
 
 function withAgentFixAction(detail, descriptor) {
   if (!descriptor.autoInstall || !REPAIRABLE_AGENT_STATUSES.has(detail.status)) return detail;
+  if (detail.supplementary && detail.supplementary.key === "hook_group") return detail;
   if (
     descriptor.agentId === "gemini-cli"
     && detail.supplementary
@@ -337,8 +337,11 @@ function validateGeminiHookEvents(descriptor, settings, options) {
   });
 }
 
-function validateQwenHookEvents(descriptor, settings, options) {
-  const events = Array.isArray(descriptor.hookEvents) ? descriptor.hookEvents : QWEN_CODE_HOOK_EVENTS;
+function validateFileHookEvents(descriptor, settings, options) {
+  const events = descriptor.hookEvents;
+  const agentName = descriptor.agentName || descriptor.agentId;
+  const missingKey = descriptor.agentId === "qwen-code" ? "missingQwenHookEvents" : "missingHookEvents";
+  const brokenKey = descriptor.agentId === "qwen-code" ? "brokenQwenHookEvent" : "brokenHookEvent";
   const missingEvents = [];
   let commandCount = 0;
   let firstOk = null;
@@ -373,9 +376,9 @@ function validateQwenHookEvents(descriptor, settings, options) {
   if (missingEvents.length) {
     return makeDetail(descriptor, "not-connected", {
       level: "warning",
-      detail: `${descriptor.configPath} missing Qwen Code hook event(s): ${missingEvents.join(", ")}`,
+      detail: `${descriptor.configPath} missing ${agentName} hook event(s): ${missingEvents.join(", ")}`,
       commandCount,
-      missingQwenHookEvents: missingEvents,
+      [missingKey]: missingEvents,
     });
   }
 
@@ -383,19 +386,19 @@ function validateQwenHookEvents(descriptor, settings, options) {
     const first = firstFailure.result;
     return makeDetail(descriptor, "broken-path", {
       level: "warning",
-      detail: `Qwen Code hook command failed validation for ${firstFailure.eventName}: ${first.issue || "parse-failed"}`,
+      detail: `${agentName} hook command failed validation for ${firstFailure.eventName}: ${first.issue || "parse-failed"}`,
       commandCount,
       hookCommandIssue: first.issue || "parse-failed",
       nodeBin: first.nodeBin || null,
       scriptPath: first.scriptPath || null,
       commandFragment: first.fragment || String(firstFailure.command || "").slice(0, 128),
-      brokenQwenHookEvent: firstFailure.eventName,
+      [brokenKey]: firstFailure.eventName,
     });
   }
 
   return makeDetail(descriptor, "ok", {
     level: null,
-    detail: `${descriptor.configPath} Qwen Code hooks registered for ${events.length} events, scriptPath verified`,
+    detail: `${descriptor.configPath} ${agentName} hooks registered for ${events.length} events, scriptPath verified`,
     commandCount,
     scriptPath: firstOk && firstOk.scriptPath ? firstOk.scriptPath : null,
   });
@@ -741,6 +744,35 @@ function applyGeminiSupplementary(detail, descriptor, settings) {
   };
 }
 
+function applyDisabledHookGroup(detail, descriptor, settings) {
+  if (!descriptor.hookGroupId) return detail;
+  const hooksConfig = settings && typeof settings === "object" ? settings.hooksConfig : null;
+  if (!hooksConfig || typeof hooksConfig !== "object") return detail;
+
+  let supplementary = null;
+  if (hooksConfig.enabled === false) {
+    supplementary = {
+      key: "hook_group",
+      value: "disabled-global",
+      detail: "hooksConfig.enabled is false",
+    };
+  } else if (Array.isArray(hooksConfig.disabled) && hooksConfig.disabled.includes(descriptor.hookGroupId)) {
+    supplementary = {
+      key: "hook_group",
+      value: `disabled-${descriptor.hookGroupId}`,
+      detail: `hooksConfig.disabled includes "${descriptor.hookGroupId}"`,
+    };
+  }
+  if (!supplementary) return detail;
+  return {
+    ...detail,
+    status: "not-connected",
+    level: "warning",
+    detail: `${descriptor.agentName} hooks are disabled in settings.json; Clawd preserves this user setting and will not receive hook events`,
+    supplementary,
+  };
+}
+
 function getQwenHooksSupplementary(settings) {
   if (settings && typeof settings === "object" && settings.disableAllHooks === true) {
     return {
@@ -841,8 +873,8 @@ function checkFileMode(descriptor, options) {
   let detail;
   if (descriptor.agentId === "gemini-cli") {
     detail = validateGeminiHookEvents(descriptor, settings, options);
-  } else if (descriptor.agentId === "qwen-code") {
-    detail = validateQwenHookEvents(descriptor, settings, options);
+  } else if (Array.isArray(descriptor.hookEvents) && descriptor.hookEvents.length) {
+    detail = validateFileHookEvents(descriptor, settings, options);
   } else if (descriptor.agentId === "codex") {
     detail = validateCommandList(
       descriptor,
@@ -863,6 +895,7 @@ function checkFileMode(descriptor, options) {
     configPath: descriptor.configPath,
   };
   detail = applyCodexSupplementary(detail, descriptor, options, settings);
+  detail = applyDisabledHookGroup(detail, descriptor, settings);
   detail = applyGeminiSupplementary(detail, descriptor, settings);
   return applyQwenSupplementary(detail, descriptor, settings);
 }

--- a/test/doctor-agent-integrations.test.js
+++ b/test/doctor-agent-integrations.test.js
@@ -9,6 +9,7 @@ const {
   findOpenClawPluginEntry,
   findOpencodePluginEntry,
 } = require("../src/doctor-detectors/agent-integrations");
+const { getAgentDescriptor } = require("../src/doctor-detectors/agent-descriptors");
 const { GEMINI_HOOK_EVENTS } = require("../hooks/gemini-install");
 const { ANTIGRAVITY_HOOK_EVENTS, __test: antigravityInstallTest } = require("../hooks/antigravity-install");
 const { QWEN_CODE_HOOK_EVENTS, buildQwenCodeHookCommand } = require("../hooks/qwen-code-install");
@@ -134,30 +135,48 @@ function qwenDescriptor() {
   });
 }
 
-function qoderDescriptor() {
+function managedFileDescriptor(agentId, dirName) {
   const root = makeTempDir();
-  const parentDir = path.join(root, ".qoder");
-  return baseDescriptor({
-    agentId: "qoder",
-    agentName: "Qoder",
-    marker: "qoder-hook.js",
+  const parentDir = path.join(root, dirName);
+  return {
+    ...getAgentDescriptor(agentId),
     parentDir,
     configPath: path.join(parentDir, "settings.json"),
-    configMode: "file",
-    nested: true,
-    hookEvents: QODER_HOOK_EVENTS,
-  });
+  };
 }
 
-function qoderHooksConfig(commandForEvent = (event) => `"/node" "/app/hooks/qoder-hook.js" ${event}`) {
+function qoderDescriptor() {
+  return managedFileDescriptor("qoder", ".qoder");
+}
+
+function nestedHooksConfig(events, marker, commandForEvent = (event) => `"/node" "/app/hooks/${marker}" ${event}`) {
   const hooks = {};
-  for (const event of QODER_HOOK_EVENTS) {
+  for (const event of events) {
     hooks[event] = [{
       matcher: "*",
       hooks: [{ name: "clawd", type: "command", command: commandForEvent(event) }],
     }];
   }
   return hooks;
+}
+
+function qoderHooksConfig(commandForEvent) {
+  return nestedHooksConfig(QODER_HOOK_EVENTS, "qoder-hook.js", commandForEvent);
+}
+
+function reasonixDescriptor() {
+  return managedFileDescriptor("reasonix", ".reasonix");
+}
+
+function qoderWorkDescriptor() {
+  return managedFileDescriptor("qoderwork", ".qoderwork");
+}
+
+function flatHooksConfig(events, marker) {
+  return Object.fromEntries(events.map((event) => [
+    event,
+    [{ match: "*", command: `"/node" "/app/hooks/${marker}" ${event}` }],
+  ]));
 }
 
 function codewhaleDescriptor() {
@@ -866,8 +885,75 @@ describe("checkAgentIntegrations", () => {
 
     const detail = runOne(descriptor);
     assert.strictEqual(detail.status, "not-connected");
-    assert.match(detail.detail, /has no qoder-hook\.js command/);
+    assert.deepStrictEqual(detail.missingHookEvents, QODER_HOOK_EVENTS);
     assert.deepStrictEqual(detail.fixAction, { type: "agent-integration", agentId: "qoder" });
+  });
+
+  it("warns and offers repair when required file-mode hook events are missing", () => {
+    for (const descriptor of [qoderDescriptor(), reasonixDescriptor(), qoderWorkDescriptor()]) {
+      const hooks = descriptor.agentId === "reasonix"
+        ? flatHooksConfig(descriptor.hookEvents, descriptor.marker)
+        : nestedHooksConfig(descriptor.hookEvents, descriptor.marker);
+      const firstEvent = descriptor.hookEvents[0];
+      writeJson(descriptor.configPath, { hooks: { [firstEvent]: hooks[firstEvent] } });
+
+      const detail = runOne(descriptor);
+      assert.strictEqual(detail.status, "not-connected", descriptor.agentId);
+      assert.strictEqual(detail.commandCount, 1, descriptor.agentId);
+      assert.deepStrictEqual(detail.missingHookEvents, descriptor.hookEvents.slice(1), descriptor.agentId);
+      assert.deepStrictEqual(detail.fixAction, {
+        type: "agent-integration",
+        agentId: descriptor.agentId,
+      });
+    }
+  });
+
+  it("does not offer repair when a managed hook group is disabled", () => {
+    for (const descriptor of [qoderDescriptor(), qoderWorkDescriptor()]) {
+      writeJson(descriptor.configPath, {
+        hooks: nestedHooksConfig(descriptor.hookEvents, descriptor.marker),
+        hooksConfig: { disabled: ["clawd"] },
+      });
+
+      const detail = runOne(descriptor);
+      assert.strictEqual(detail.status, "not-connected", descriptor.agentId);
+      assert.strictEqual(detail.level, "warning", descriptor.agentId);
+      assert.deepStrictEqual(detail.supplementary, {
+        key: "hook_group",
+        value: "disabled-clawd",
+        detail: 'hooksConfig.disabled includes "clawd"',
+      });
+      assert.strictEqual(detail.fixAction, undefined, descriptor.agentId);
+    }
+  });
+
+  it("does not offer repair when hooksConfig is globally disabled", () => {
+    const descriptor = qoderDescriptor();
+    writeJson(descriptor.configPath, {
+      hooks: qoderHooksConfig(),
+      hooksConfig: { enabled: false },
+    });
+
+    const detail = runOne(descriptor);
+    assert.strictEqual(detail.status, "not-connected");
+    assert.deepStrictEqual(detail.supplementary, {
+      key: "hook_group",
+      value: "disabled-global",
+      detail: "hooksConfig.enabled is false",
+    });
+    assert.strictEqual(detail.fixAction, undefined);
+  });
+
+  it("ignores unrelated disabled hook groups", () => {
+    const descriptor = qoderDescriptor();
+    writeJson(descriptor.configPath, {
+      hooks: qoderHooksConfig(),
+      hooksConfig: { disabled: ["other"] },
+    });
+
+    const detail = runOne(descriptor);
+    assert.strictEqual(detail.status, "ok");
+    assert.strictEqual(detail.supplementary, undefined);
   });
 
   it("validates CodeWhale TOML hooks", () => {


### PR DESCRIPTION
## Summary

- validate every required hook event for file-based integrations that declare `hookEvents`
- report partial Qoder, Reasonix, and QoderWork installs instead of treating one surviving command as healthy
- detect disabled Qoder/QoderWork hook groups and preserve that user intent without offering a misleading Fix action

## Root cause

Doctor's generic file-mode path validated all matching commands as one list and returned healthy when any command passed. It did not use the required event lists already present on the affected descriptors, and it ignored Qoder-family `hooksConfig.enabled` / `hooksConfig.disabled` settings.

## User impact

Doctor now identifies exactly which required events are missing. A complete but explicitly disabled hook group is shown as disabled rather than healthy, and Clawd does not offer an automatic repair that would contradict the user's setting.

## Validation

- `node --test test/doctor*.test.js` (166 passed)
- `git diff --check`
- existing Qwen/Gemini compatibility tests remain unchanged and passing

Fixes #599
