### PR TITLE
Count concurrent Codex Desktop sessions separately

### DIFF
--- a/src/state-session-dedupe.js
+++ b/src/state-session-dedupe.js
@@ -14,6 +14,10 @@ function normalizePositiveInteger(value) {
 
 function getLocalCodexProcessKey(session) {
   if (!session || session.agentId !== "codex" || session.host || session.headless) return null;
+  // Codex Desktop multiplexes independent threads through one process, so its
+  // stable session IDs must remain distinct in the HUD (#581).
+  if (typeof session.codexOriginator === "string"
+    && session.codexOriginator.trim().toLowerCase() === "codex desktop") return null;
   const agentPid = normalizePositiveInteger(session.agentPid);
   return agentPid ? `codex-agent:${agentPid}` : null;
 }

--- a/test/state-priority.test.js
+++ b/test/state-priority.test.js
@@ -102,6 +102,23 @@ describe("state-priority display selection", () => {
     ])), "working");
   });
 
+  it("keeps concurrent Codex Desktop sessions separate when they share one agent process", () => {
+    assert.strictEqual(resolveDominantSessionState(new Map([
+      ["codex:desktop-a", session("working", {
+        agentId: "codex",
+        agentPid: 4242,
+        codexOriginator: " Codex Desktop ",
+        updatedAt: 1000,
+      })],
+      ["codex:desktop-b", session("thinking", {
+        agentId: "codex",
+        agentPid: 4242,
+        codexOriginator: "codex desktop",
+        updatedAt: 2000,
+      })],
+    ])), "working");
+  });
+
   it("does not dedupe Codex sessions without a local agent pid", () => {
     assert.strictEqual(resolveDominantSessionState(new Map([
       ["codex:old", session("working", {

--- a/test/state-session-snapshot.test.js
+++ b/test/state-session-snapshot.test.js
@@ -537,6 +537,33 @@ describe("state-session-snapshot builder", () => {
     assert.deepStrictEqual(snapshot.groups, [{ host: "", ids: ["codex:new", "codex:old"], displayHost: "" }]);
   });
 
+  it("keeps Codex Desktop sessions that share one agent process visible in HUD", () => {
+    const snapshot = buildSessionSnapshot(new Map([
+      ["codex:desktop-a", session("working", {
+        agentId: "codex",
+        agentPid: 4242,
+        codexOriginator: "Codex Desktop",
+        updatedAt: 1000,
+        cwd: "/repo/a",
+      })],
+      ["codex:desktop-b", session("thinking", {
+        agentId: "codex",
+        agentPid: 4242,
+        codexOriginator: "Codex Desktop",
+        updatedAt: 2000,
+        cwd: "/repo/b",
+      })],
+    ]), {
+      statePriority: STATE_PRIORITY,
+      getAgentIconUrl: () => null,
+    });
+
+    assert.strictEqual(snapshot.sessions.find((entry) => entry.id === "codex:desktop-a").hiddenFromHud, false);
+    assert.strictEqual(snapshot.sessions.find((entry) => entry.id === "codex:desktop-b").hiddenFromHud, false);
+    assert.strictEqual(snapshot.hudTotalNonIdle, 2);
+    assert.strictEqual(snapshot.hudLastSessionId, "codex:desktop-b");
+  });
+
   it("snapshot signatures include visible fields but ignore icon URL churn", () => {
     const base = buildSessionSnapshot(new Map([
       ["s1", session("working", {


### PR DESCRIPTION
## Summary

- keep independent Codex Desktop threads separate in HUD/work count even when they share one `agentPid`
- retain existing PID-based ghost dedupe for CLI/unknown local Codex sessions
- cover both dominant display-state selection and HUD visibility

## Root cause

Codex Desktop multiplexes multiple stable thread/session IDs through one process. The shared dedupe keyed every local Codex session by `agentPid`, so only the newest Desktop thread remained visible.

## User impact

Concurrent Codex Desktop threads now contribute independently to the HUD and display-state selection. Sessions without a confirmed Desktop originator continue using the existing conservative PID dedupe.

## Validation

- `node --test test/state-priority.test.js test/state-session-snapshot.test.js test/state.test.js` (282 passed)
- `git diff --check`
- existing #427 generic/local same-PID regression remains passing

Fixes #581
