### PR TITLE
feat(hooks): sink pid cache + lifecycle into the shared resolver (#634 Slice 1)

### DIFF
--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -8,10 +8,10 @@ const fs = require("fs");
 const { postStateToRunningServer, readHostPrefix, resolveWslDistro } = require("./server-config");
 const { fitStateBodyToByteBudget } = require("./state-payload-size");
 const { extractClaudeContextUsageFromEntries } = require("./context-usage");
-const { createPidResolver, readStdinJsonDetailed, getPlatformConfig, tmuxSocketFromEnv, processAlive } = require("./shared-process");
-const pidCache = require("./pid-cache");
-
-const isWin = process.platform === "win32";
+const { createPidResolver, readStdinJsonDetailed, getPlatformConfig } = require("./shared-process");
+// #634: the pid cache + lifecycle orchestration is owned by the shared resolver
+// now (hooks/shared-process.js); this adapter no longer touches pid-cache,
+// processAlive, or isWin directly.
 
 const TRANSCRIPT_TAIL_BYTES = 262144; // 256 KB
 // #583: claude-code registers this hook with async:true and a 5s timeout
@@ -330,6 +330,18 @@ const EVENT_TO_STATE = {
   WorktreeCreate: "carrying",
 };
 
+// #634: maps a Claude hook event to a shared-resolver cache lifecycle. Only the
+// three boundary events are special; every other state event is an ordinary
+// `event` (cache hit = zero spawn, miss = one fresh). Stop is deliberately NOT
+// end — it is turn completion, and dropping the cache on it would force a
+// re-resolve (flash) on the next event. SessionEnd with source=clear still maps
+// to end, so the cache is dropped on /clear too (matrix §5.0).
+const EVENT_TO_LIFECYCLE = {
+  SessionStart: "start",
+  UserPromptSubmit: "prompt",
+  SessionEnd: "end",
+};
+
 function isTaskToolStart(event, payload) {
   // Claude Code may report subagent launches as PreToolUse(Task) without a
   // matching SubagentStart. Keep PostToolUse(Task) as a normal working update:
@@ -353,10 +365,19 @@ function applyAgentPidFields(body, agentPid, agentCommandLine) {
   }
 }
 
-// Fresh-resolve path: preserves the exact pre-cache field output (#627).
+// Applies the shared resolver's process metadata to the body. Works for all
+// three resolver result shapes (#634):
+//   - fresh          → full fields, including pid_chain and (on SessionStart)
+//     the foreground WT handle;
+//   - cache hit / v1→v2 promotion → the stable subset only (pidChain is [],
+//     foregroundWtHwnd/tmuxClient are null in the returned object, so they are
+//     naturally omitted — the server MERGE keeps the SessionStart pid_chain);
+//   - empty (prompt/end miss) → every pid field is null/[], so source_pid,
+//     agent_pid, pid_chain, etc. are all left off (never a degraded
+//     process.ppid). source_pid is guarded so an empty result ships no null pid.
 function applyResolvedFields(body, resolved, event) {
   const { stablePid, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient } = resolved;
-  body.source_pid = stablePid;
+  if (stablePid) body.source_pid = stablePid;
   if (detectedEditor) body.editor = detectedEditor;
   applyAgentPidFields(body, agentPid, agentCommandLine);
   if (pidChain && pidChain.length) body.pid_chain = pidChain;
@@ -365,19 +386,6 @@ function applyResolvedFields(body, resolved, event) {
   if (shouldReportForegroundWtHwnd(event) && foregroundWtHwnd) {
     body.wt_hwnd = String(foregroundWtHwnd);
   }
-}
-
-// Cache-hit path (#627): stable subset only. Deliberately omits pid_chain — the
-// server MERGEs a missing pid_chain and keeps the SessionStart one, whereas the
-// cached chain's head would be a dead per-event PowerShell — and wt_hwnd, which
-// is only reported on the always-fresh SessionStart/UserPromptSubmit events.
-// tmux_socket is a pure-env value, recomputed so a tmux user still gets it.
-function applyCachedFields(body, cached) {
-  body.source_pid = cached.stablePid;
-  if (cached.detectedEditor) body.editor = cached.detectedEditor;
-  applyAgentPidFields(body, cached.agentPid, cached.agentCommandLine);
-  const tmuxSocket = tmuxSocketFromEnv();
-  if (tmuxSocket) body.tmux_socket = tmuxSocket;
 }
 
 function buildStateBody(event, payload, resolve) {
@@ -476,101 +484,36 @@ function buildStateBody(event, payload, resolve) {
     body.host = readHostPrefix();
     if (wslDistro) body.wsl_distro = wslDistro;
   } else {
-    // #627: on Windows every hook event otherwise cold-starts a PowerShell to
-    // snapshot the process tree, flashing a console window under Windows
-    // Terminal. The tree is stable within a session, so snapshot once on
-    // SessionStart; every other event reads a per-session cache instead of
-    // spawning. Ordinary high-frequency events (PreToolUse/PostToolUse/Stop/
-    // etc.) keep #630's original miss behavior: a miss still falls back to
-    // one fresh resolve (and may repopulate the cache) — that fallback is
-    // what gets the cache warm again after a PID dies mid-session, and it's
-    // rare in steady state once SessionStart has populated the cache.
-    //
-    // #627 residual: two events get a STRICTER "miss = zero spawn, no
-    // fallback" contract instead:
-    //   - UserPromptSubmit used to be an always-fresh event (it needed a live
-    //     foreground WT window handle). That handle is now sampled
-    //     server-side (src/main.js's koffi probe, wired through
-    //     src/server-route-state.js), so UserPromptSubmit no longer has any
-    //     reason to spawn — cache hit or miss, it never calls resolve().
-    //   - SessionEnd reads the cache to fill the final body, then drops it;
-    //     a miss no longer falls back to a fresh resolve either (see below).
-    // A miss on either ships a body with no process-metadata fields; the
-    // server's MERGE (state.js) keeps whatever the session already had.
-    // See docs/plans/plan-issue-627-residual-userprompt-flash.md §4.3.
-    const canCacheSession = isWin && pidCache.canCache(sessionId, cwd);
-    const wantsFresh = event === "SessionStart";
-    // The no-fallback contract is a WINDOWS contract, not a cache-availability
-    // one: it must hold even when caching is disabled (session_id "default" /
-    // empty cwd, #583) — otherwise those degenerate sessions keep flashing a
-    // console once per prompt, which is the exact symptom this fix removes.
-    // Non-Windows keeps resolving fresh on every event (the ps path neither
-    // flashes nor pays a cold start), unchanged.
-    const cacheOnlyNoFallback = isWin && (event === "UserPromptSubmit" || event === "SessionEnd");
-
-    let cached = null;
-    if (canCacheSession && event === "SessionEnd") {
-      // Cache-only + drop: read the last-known subset for the final body (if
-      // any), then drop — and, per the #627 residual plan, a MISS no longer
-      // falls back to a fresh resolve. That resolve was itself the
-      // console-flashing spawn this cache exists to avoid, and by SessionEnd
-      // the session is already ending: an incomplete final body (server
-      // MERGE keeps whatever the session already had) beats a guaranteed
-      // flash. This reverses the #630-shipped SessionEnd-miss fallback (630
-      // plan §3.2) — test/clawd-hook-pid-cache.test.js's "SessionEnd on a
-      // miss" case is inverted to match.
-      cached = pidCache.readPidCache(sessionId, cwd);
-      pidCache.dropPidCache(sessionId, cwd);
-    } else if (canCacheSession && !wantsFresh) {
-      const c = pidCache.readPidCache(sessionId, cwd);
-      // M1 (630 plan §5) + lease rewrite (#627 residual §4.4): the PID that
-      // becomes source_pid (stablePid) must be alive — session-focus.js only
-      // checks source_pid's existence, so a dead stablePid must trigger a
-      // fresh resolve. agentPid (claude.exe) must ALSO be alive: it tracks
-      // session liveness, so a dead agentPid means the session ended and the
-      // cache must NOT be treated as a hit. Both alive → hit, no clock
-      // consulted (pid-cache.js's readPidCache no longer expires by time).
-      if (c && c.cwd === cwd && processAlive(c.stablePid) && processAlive(c.agentPid)) {
-        pidCache.touchPidCache(sessionId, cwd);
-        cached = c;
-      }
-    }
-
-    if (cached) {
-      applyCachedFields(body, cached);
-    } else if (!cacheOnlyNoFallback) {
-      // Fresh resolve: non-Windows (always resolves on every event,
-      // unchanged), SessionStart (still the one event that spawns once,
-      // prewarmed during stdin buffering — see main() below), or an ordinary
-      // cache-only event (PreToolUse/PostToolUse/Stop/etc.) on a miss or with
-      // caching unavailable — #630's original repopulate fallback, unchanged.
-      // On Windows, UserPromptSubmit/SessionEnd can NEVER reach this branch,
-      // cacheable session or not (see cacheOnlyNoFallback above).
-      if (event === "SessionStart" && canCacheSession) {
-        pidCache.sweepStalePidCaches({ isProcessAlive: processAlive });
-      }
-      const resolved = resolve();
-      applyResolvedFields(body, resolved, event);
-      // M2 (630 plan §5): only cache a non-degraded result. An empty Windows
-      // snapshot decays stablePid to process.ppid (a per-event ephemeral
-      // PID); snapshotOk rules that out, and a found agentPid proves the walk
-      // reached a real ancestor. Never write on SessionEnd (unreachable here
-      // since SessionEnd never takes this branch, but keep the guard as
-      // defense in depth).
-      if (canCacheSession && event !== "SessionEnd" && resolved.snapshotOk && resolved.agentPid) {
-        pidCache.writePidCache(sessionId, cwd, {
-          stablePid: resolved.stablePid,
-          agentPid: resolved.agentPid,
-          agentCommandLine: resolved.agentCommandLine,
-          detectedEditor: resolved.detectedEditor,
-        });
-      }
-    }
-    // else: Windows UserPromptSubmit/SessionEnd with no usable cache entry
-    // (cacheable miss OR caching unavailable) — zero spawn, no fallback. Body
-    // gets no source_pid/agent_pid/etc.; server MERGE keeps whatever the
-    // session already had. Never degrade to process.ppid — that would ship a
-    // wrong-but-plausible-looking pid (#627 residual plan §4.3).
+    // #627/#634: the per-session pid cache + lifecycle orchestration now lives
+    // in the shared resolver (hooks/shared-process.js). This hook is the Claude
+    // adapter — it maps the event to a resolver lifecycle, declares the cache
+    // identity, and applies whatever process metadata the resolver returns:
+    //   - SessionStart → start (fresh once, prewarmed during stdin buffering;
+    //     writes the v2 cache),
+    //   - UserPromptSubmit → prompt (cache-only, NEVER spawns — even for a
+    //     non-cacheable session; the foreground WT handle it used to fresh for
+    //     is sampled server-side now, src/server-route-state.js),
+    //   - SessionEnd → end (cache-only, fills the final body then drops; never
+    //     spawns, never writes back),
+    //   - everything else → event (cache hit = zero spawn; a miss falls back to
+    //     one fresh resolve and repopulates).
+    // The Windows zero-spawn contracts, the double-PID liveness check, and the
+    // v1→v2 promotion all live in the resolver; mac/linux keep the
+    // fresh-every-event runtime behavior. The cache identity is Claude's raw
+    // session id + payload cwd (matrix §5.0): a "default" session id (#583) or
+    // an empty cwd is non-cacheable, which the resolver honors WITHOUT relaxing
+    // the prompt/end no-spawn contract. A miss ships a body with no
+    // process-metadata fields; the server MERGE (state.js) keeps whatever the
+    // session already had — never a degraded process.ppid.
+    const cacheCwd = cwd;
+    const resolved = resolve({
+      namespace: "claude-code",
+      sessionId,
+      cacheCwd,
+      lifecycle: EVENT_TO_LIFECYCLE[event] || "event",
+      cacheable: sessionId !== "default" && !!cacheCwd,
+    });
+    applyResolvedFields(body, resolved, event);
 
     if (wslDistro) {
       body.wsl_distro = wslDistro;

--- a/hooks/pid-cache.js
+++ b/hooks/pid-cache.js
@@ -38,22 +38,38 @@
 // swept out from under it.
 //
 // Liveness for the sweep is dependency-injected (isProcessAlive) rather than
-// required from shared-process.js: PR2 (#634) will have shared-process.js
-// require this module for its shared resolver cache, and a reverse require
-// here would create a cycle. clawd-hook.js injects processAlive from
-// shared-process.js; tests inject a fake.
+// required from shared-process.js: PR2 (#634) has shared-process.js require this
+// module for its shared resolver cache, and a reverse require here would create a
+// cycle. The shared resolver (PR2) / clawd-hook.js (PR1) injects processAlive
+// from shared-process.js; tests inject a fake.
 //
-// Design constraints (see docs/plans/plan-issue-627-residual-userprompt-flash.md §4.4,
+// Cache v2 (#634): PR2 sinks the per-session cache into the shared resolver and
+// namespaces it by agent. v2 lives ALONGSIDE v1 (untouched) for at least one
+// release cycle so a session already running across the upgrade keeps hitting
+// its v1 file until it is promoted (hooks/shared-process.js). The two schemes
+// differ only in prefix, key input, and shape:
+//   - v1: prefix `clawd-pidcache-`, key sha1(sessionId\0cwd), no version/namespace.
+//   - v2: prefix `clawd-pidcache2-`, key sha1("2\0namespace\0sessionId\0cwd"),
+//     shape adds `version` + `namespace`. The two prefixes are deliberately
+//     non-overlapping under startsWith() ("clawd-pidcache2-" does NOT start with
+//     "clawd-pidcache-": index 14 is "2" vs "-"), so the sweep classifies every
+//     file with a single startsWith() and never double-counts (plan §5.2/§5.4).
+// The lease read semantics (no clock, double-PID liveness by the caller) are
+// identical for both.
+//
+// Design constraints (see docs/plans/plan-issue-627-residual-userprompt-flash.md §4.4/§5,
 // and docs/plans/plan-issue-627-hook-snapshot-flash-cache.md for the original shape):
 //   - Cache ONLY the stable subset: stablePid, agentPid, agentCommandLine,
 //     detectedEditor. NOT pidChain (its head is the per-event ephemeral hook
 //     PowerShell; server MERGEs a missing pid_chain, keeping the SessionStart one).
-//   - Key by session_id + cwd; disabled entirely when session_id is missing/
-//     "default" or cwd is empty (a shared "default" cache would cross sessions).
+//   - v1 keys by session_id + cwd; v2 keys by namespace + session_id + cacheCwd.
+//     Both are disabled when an identity ingredient is missing (a shared cache
+//     would cross sessions); the CALLER declares cacheability (an agent's
+//     "default" session id / empty cwd is non-cacheable).
 //   - Reuse json-utils.writeJsonAtomic (tmp + rename) so a concurrent reader
-//     never sees a half-written file.
-//   - File format/prefix unchanged in this PR (still v1, `clawd-pidcache-`) —
-//     namespacing + a v2 shape/prefix + v1→v2 promotion are PR2 (#634) scope.
+//     never sees a half-written file. The promotion no-clobber path additionally
+//     uses tmp + linkSync (atomic create-if-absent) so a stale v1→v2 promotion
+//     never overwrites a concurrent fresh v2 (plan §5.5/§6.10).
 //   - Zero third-party deps. Zero require of ./shared-process.js (see above).
 
 const fs = require("fs");
@@ -63,6 +79,11 @@ const crypto = require("crypto");
 const { writeJsonAtomic } = require("./json-utils");
 
 const CACHE_PREFIX = "clawd-pidcache-";
+// v2 (#634): a DISTINCT, non-overlapping prefix (see module doc). CACHE_PREFIX_V2
+// deliberately does not startsWith CACHE_PREFIX and vice versa, so sweep
+// classification is unambiguous.
+const CACHE_PREFIX_V2 = "clawd-pidcache2-";
+const CACHE_VERSION_V2 = 2;
 // Sweep-only age floor: a file must be idle (mtime) at least this long before
 // it is even considered for cleanup. This is NOT a read-validity clock (see
 // module doc above) — it only bounds how eagerly the low-frequency
@@ -70,6 +91,21 @@ const CACHE_PREFIX = "clawd-pidcache-";
 // enough that no realistically long-running session's cache is a candidate
 // while it is still being touched (every cache HIT calls touchPidCache).
 const SWEEP_AGE_MS = 24 * 60 * 60 * 1000;
+
+// The directory every cache file lives in. Production always uses os.tmpdir().
+// Tests inject an isolated directory (__setCacheDirForTests) so a fake-liveness
+// sweep can never scan the real temp dir — which would both interfere with
+// concurrently-running test PROCESSES and delete a developer's genuine >24h
+// session caches (the sweep does not spawn, so it happily walks everything under
+// the shared prefix). No production env surface: the override is an in-process
+// test seam only.
+let _cacheDirOverride = null;
+function cacheDir() {
+  return _cacheDirOverride || os.tmpdir();
+}
+function __setCacheDirForTests(dir) {
+  _cacheDirOverride = dir || null;
+}
 
 // A session_id of "default" is the placeholder clawd-hook.js falls back to when
 // the agent's stdin JSON lacked one (#583): caching under it would let unrelated
@@ -89,32 +125,62 @@ function cacheFilePath(sessionId, cwd) {
     .update(`${sessionId}\0${cwd}`)
     .digest("hex")
     .slice(0, 16);
-  return path.join(os.tmpdir(), `${CACHE_PREFIX}${hash}.json`);
+  return path.join(cacheDir(), `${CACHE_PREFIX}${hash}.json`);
+}
+
+// The v1 shape guard, shared by readPidCache and readPidCacheEntry so they can
+// never drift. NO clock participates (lease rewrite, §4.4). Liveness of the
+// cached PIDs is the CALLER's job — it must check BOTH the PID that becomes
+// source_pid (stablePid) AND agentPid are alive before treating this as a hit.
+// agentPid is REQUIRED (the write condition needs snapshotOk && agentPid, and
+// the hit path liveness-checks it), so both are pinned to positive integers and
+// a corrupt/hand-edited file can't ship a bad PID.
+function isValidV1Shape(obj, cwd) {
+  return !!obj && typeof obj === "object"
+    && typeof obj.ts === "number" // ts itself is debug-only, but its presence is a shape guard
+    && obj.cwd === cwd
+    && isPositivePid(obj.stablePid)
+    && isPositivePid(obj.agentPid);
 }
 
 // Returns the cached subset, or null on: caching disabled, no file,
-// unreadable/unparseable file, shape guard failure, or cwd mismatch. NO clock
-// participates in this decision (lease rewrite, §4.4). Liveness of the cached
-// PIDs is entirely the caller's job: it must check that BOTH the PID that
-// becomes source_pid (stablePid) AND agentPid are alive before treating this
-// as a real hit.
+// unreadable/unparseable file, shape guard failure, or cwd mismatch.
 function readPidCache(sessionId, cwd) {
   const file = cacheFilePath(sessionId, cwd);
   if (!file) return null;
   try {
     const obj = JSON.parse(fs.readFileSync(file, "utf8"));
-    if (!obj || typeof obj !== "object") return null;
-    if (typeof obj.ts !== "number") return null; // shape guard; ts itself is debug-only
-    if (obj.cwd !== cwd) return null;
-    // Shape guard. Liveness is re-validated by the caller. agentPid is
-    // REQUIRED (the write condition needs snapshotOk && agentPid, and the hit
-    // path does its own processAlive(agentPid)) — pin both to positive
-    // integers so a corrupt/hand-edited file can't ship a bad PID.
-    if (!isPositivePid(obj.stablePid)) return null;
-    if (!isPositivePid(obj.agentPid)) return null;
-    return obj;
+    return isValidV1Shape(obj, cwd) ? obj : null;
   } catch {
     return null;
+  }
+}
+
+// Read the v1 file in a SINGLE observation and return BOTH the validated subset
+// AND the file identity (mtimeMs + size + raw content) from that same read. A
+// caller that later conditionally deletes the file (promotion / end) MUST bind
+// its delete-guard to this identity so it never deletes bytes it did not read
+// (plan §5.5). This closes the race where readPidCache and a separate identity
+// read straddle a concurrent replacement — the parsed subset and the identity
+// then describe different files, and the fresh replacement gets promoted-over
+// and deleted. Using ONE fd means the fstat and the read see the same inode even
+// if a concurrent writer renames a replacement over the path mid-call. Returns
+// null on caching disabled / missing / unreadable / shape-invalid.
+function readPidCacheEntry(sessionId, cwd) {
+  const file = cacheFilePath(sessionId, cwd);
+  if (!file) return null;
+  let fd;
+  try {
+    fd = fs.openSync(file, "r");
+    const st = fs.fstatSync(fd);
+    const raw = fs.readFileSync(fd).toString("utf8"); // same inode as the fstat above
+    const obj = JSON.parse(raw);
+    if (!isValidV1Shape(obj, cwd)) return null;
+    return { subset: obj, identity: { mtimeMs: st.mtimeMs, size: st.size, raw } };
+  } catch {
+    return null;
+  } finally {
+    if (fd !== undefined) { try { fs.closeSync(fd); } catch {} }
   }
 }
 
@@ -162,13 +228,160 @@ function dropPidCache(sessionId, cwd) {
   }
 }
 
+// ── Cache v2 (#634): namespaced + versioned ────────────────────────────────────
+// The v2 surface mirrors v1 read/write/touch/drop but keys by
+// namespace + sessionId + cacheCwd and stamps version + namespace into the file.
+// Read validity is the same lease model as v1: NO clock, shape + identity only;
+// liveness (double processAlive) stays the caller's job.
+
+// v2 key input pins version + namespace + sessionId + cacheCwd with NUL
+// separators (so "a"+"bc" and "ab"+"c" can't collide) before the same 16-char
+// SHA-1 truncation v1 uses. namespace MUST be in the key so two agents that
+// happen to share a session_id + cwd never read each other's cache. Returns null
+// (caching off) when any identity ingredient is empty.
+function cacheFilePathV2(namespace, sessionId, cacheCwd) {
+  if (!namespace || !sessionId || !cacheCwd) return null;
+  const hash = crypto
+    .createHash("sha1")
+    .update(`2\0${namespace}\0${sessionId}\0${cacheCwd}`)
+    .digest("hex")
+    .slice(0, 16);
+  return path.join(cacheDir(), `${CACHE_PREFIX_V2}${hash}.json`);
+}
+
+// The v2 on-disk shape. `cwd` stores the cacheCwd (not necessarily an adapter's
+// body cwd). pidChain / foregroundWtHwnd / tmuxClient are deliberately NOT
+// cached (a cache hit must never fake them); tmuxSocket is recomputed from env
+// by the resolver, zero spawn.
+function v2Payload(namespace, cacheCwd, subset) {
+  return {
+    version: CACHE_VERSION_V2,
+    namespace,
+    cwd: cacheCwd,
+    stablePid: subset.stablePid,
+    agentPid: subset.agentPid,
+    agentCommandLine: subset.agentCommandLine,
+    detectedEditor: subset.detectedEditor,
+    ts: Date.now(),
+  };
+}
+
+// Returns the cached v2 subset, or null on: caching disabled, no file,
+// unreadable/unparseable, version/namespace/cwd mismatch, or a non-positive
+// stablePid/agentPid. NO clock participates (lease model, §4.4). The caller
+// re-validates liveness of BOTH cached PIDs before treating this as a hit.
+function readPidCacheV2(namespace, sessionId, cacheCwd) {
+  const file = cacheFilePathV2(namespace, sessionId, cacheCwd);
+  if (!file) return null;
+  try {
+    const obj = JSON.parse(fs.readFileSync(file, "utf8"));
+    if (!obj || typeof obj !== "object") return null;
+    if (obj.version !== CACHE_VERSION_V2) return null;
+    if (obj.namespace !== namespace) return null; // defense-in-depth; key already encodes it
+    if (typeof obj.ts !== "number") return null; // shape guard, mirrors v1; ts is debug-only
+    if (obj.cwd !== cacheCwd) return null;
+    if (!isPositivePid(obj.stablePid)) return null;
+    if (!isPositivePid(obj.agentPid)) return null;
+    return obj;
+  } catch {
+    return null;
+  }
+}
+
+// Overwriting atomic write (tmp + rename), for the authoritative `start`/`event`
+// fresh path. Callers MUST only pass a non-degraded subset (snapshotOk &&
+// agentPid). Returns false when caching is disabled or the write fails.
+function writePidCacheV2(namespace, sessionId, cacheCwd, subset) {
+  const file = cacheFilePathV2(namespace, sessionId, cacheCwd);
+  if (!file) return false;
+  try {
+    writeJsonAtomic(file, v2Payload(namespace, cacheCwd, subset));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Atomic create-if-absent v2 write for v1→v2 promotion (plan §5.5/§6.10).
+// Returns:
+//   "created" — we wrote the v2 (we won the race);
+//   "exists"  — a concurrent writer already placed a v2 here. This is NOT a
+//               failure: the caller prefers that (fresher) file and must not
+//               overwrite it. This is exactly what keeps a stale promotion from
+//               clobbering a concurrent fresh SessionStart v2 — the documented
+//               recheck-is-not-CAS residual (plan §6.10) is closed by it;
+//   false     — the write/link failed for another reason (e.g. a filesystem
+//               without hard-link support). The caller falls back to returning
+//               the validated v1 WITHOUT deleting it, and never spawns.
+// Uses a sibling temp + linkSync: link is an atomic O_EXCL-style create, so a
+// concurrent fresh v2 (written via writePidCacheV2's tmp+rename) is never
+// overwritten. Never throws.
+function writePidCacheV2IfAbsent(namespace, sessionId, cacheCwd, subset) {
+  const file = cacheFilePathV2(namespace, sessionId, cacheCwd);
+  if (!file) return false;
+  const dir = path.dirname(file);
+  const base = path.basename(file);
+  const tmpPath = path.join(
+    dir,
+    `.${base}.${process.pid}.${Date.now()}.${crypto.randomBytes(4).toString("hex")}.nc.tmp`
+  );
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(v2Payload(namespace, cacheCwd, subset), null, 2), "utf-8");
+  } catch {
+    try { fs.unlinkSync(tmpPath); } catch {}
+    return false;
+  }
+  try {
+    fs.linkSync(tmpPath, file); // atomic create-if-absent; throws EEXIST if file exists
+    return "created";
+  } catch (err) {
+    return err && err.code === "EEXIST" ? "exists" : false;
+  } finally {
+    // On success the inode survives via `file`; on any failure this removes the
+    // orphan temp. Either way the temp name never lingers.
+    try { fs.unlinkSync(tmpPath); } catch {}
+  }
+}
+
+function touchPidCacheV2(namespace, sessionId, cacheCwd) {
+  const file = cacheFilePathV2(namespace, sessionId, cacheCwd);
+  if (!file) return;
+  try {
+    const now = new Date();
+    fs.utimesSync(file, now, now);
+  } catch {
+    /* file gone (SessionEnd drop) / race — fine */
+  }
+}
+
+function dropPidCacheV2(namespace, sessionId, cacheCwd) {
+  const file = cacheFilePathV2(namespace, sessionId, cacheCwd);
+  if (!file) return;
+  try {
+    fs.unlinkSync(file);
+  } catch {
+    /* already gone / race — fine */
+  }
+}
+
+// Classify a temp-dir entry as a v1/v2 cache file or neither. The prefixes are
+// non-overlapping under startsWith (see module doc), so this is unambiguous.
+function classifyPidCacheName(name) {
+  if (!name.endsWith(".json")) return null;
+  if (name.startsWith(CACHE_PREFIX_V2)) return "v2";
+  if (name.startsWith(CACHE_PREFIX)) return "v1";
+  return null;
+}
+
 // Best-effort sweep of orphaned cache files (sessions that crashed without a
-// SessionEnd). Deletes a file only when BOTH hold:
+// SessionEnd). Scans BOTH the v1 and v2 prefixes (#634, plan §5.4) so v1 files
+// keep getting collected for at least one release cycle after PR2. Deletes a
+// file only when BOTH hold:
 //   1. age floor:  now - mtime > SWEEP_AGE_MS (mtime is bumped by every hit,
 //      so an actively-used session's file is never even considered), AND
-//   2. death proof: the file's shape is corrupt, OR either cached PID
-//      (stablePid / agentPid) is no longer alive per the injected
-//      isProcessAlive.
+//   2. death proof: the file's shape is corrupt (a v2-prefixed file must also
+//      carry version === 2), OR either cached PID (stablePid / agentPid) is no
+//      longer alive per the injected isProcessAlive.
 // Age alone NEVER deletes — a long-idle-but-still-alive session's cache
 // survives indefinitely, by design (the read-side lease has no clock either;
 // see module doc above).
@@ -176,12 +389,12 @@ function dropPidCache(sessionId, cwd) {
 // isProcessAlive is dependency-injected (kill(pid,0) semantics, e.g.
 // hooks/shared-process.js processAlive) rather than required directly, to
 // avoid a reverse-require cycle once PR2 makes shared-process.js depend on
-// this module. Called once per session from SessionStart (low frequency);
-// silent on any error.
+// this module. Called at low frequency from the shared resolver (SessionStart
+// for adapters that have one); silent on any error.
 function sweepStalePidCaches(options = {}) {
   const now = Number.isFinite(options.nowMs) ? options.nowMs : Date.now();
   const checkAlive = typeof options.isProcessAlive === "function" ? options.isProcessAlive : () => true;
-  const dir = os.tmpdir();
+  const dir = cacheDir();
   let names;
   try {
     names = fs.readdirSync(dir);
@@ -189,7 +402,8 @@ function sweepStalePidCaches(options = {}) {
     return;
   }
   for (const name of names) {
-    if (!name.startsWith(CACHE_PREFIX) || !name.endsWith(".json")) continue;
+    const kind = classifyPidCacheName(name);
+    if (!kind) continue;
     const full = path.join(dir, name);
     try {
       const st = fs.statSync(full);
@@ -198,8 +412,17 @@ function sweepStalePidCaches(options = {}) {
       let dead;
       try {
         const obj = JSON.parse(fs.readFileSync(full, "utf8"));
-        const shapeOk = !!obj && typeof obj === "object"
+        let shapeOk = !!obj && typeof obj === "object"
           && isPositivePid(obj.stablePid) && isPositivePid(obj.agentPid);
+        // A v2-prefixed file must carry the full v2 shape (version + namespace +
+        // cwd + ts); any missing/malformed field is corrupt → dead. (A normal
+        // atomic write never produces this; a hand-edited/partial file can.)
+        if (shapeOk && kind === "v2") {
+          shapeOk = obj.version === CACHE_VERSION_V2
+            && typeof obj.namespace === "string" && obj.namespace.length > 0
+            && typeof obj.cwd === "string" && obj.cwd.length > 0
+            && typeof obj.ts === "number";
+        }
         dead = !shapeOk || !checkAlive(obj.stablePid) || !checkAlive(obj.agentPid);
       } catch {
         dead = true; // unreadable/corrupt — treated as a damaged shape
@@ -231,10 +454,22 @@ module.exports = {
   canCache,
   cacheFilePath,
   readPidCache,
+  readPidCacheEntry,
   writePidCache,
   touchPidCache,
   dropPidCache,
   sweepStalePidCaches,
   SWEEP_AGE_MS,
   CACHE_PREFIX,
+  // v2 (#634) — namespaced, versioned; lives alongside v1 for the migration.
+  CACHE_PREFIX_V2,
+  CACHE_VERSION_V2,
+  cacheFilePathV2,
+  readPidCacheV2,
+  writePidCacheV2,
+  writePidCacheV2IfAbsent,
+  touchPidCacheV2,
+  dropPidCacheV2,
+  // Test-only seam (no production env surface); see cacheDir() above.
+  __setCacheDirForTests,
 };

--- a/hooks/shared-process.js
+++ b/hooks/shared-process.js
@@ -226,6 +226,128 @@ function getWindowsProcessSnapshot(execFileSync) {
   }
 }
 
+// ── PR2 (#634) lifecycle-context helpers ──────────────────────────────────────
+// These service the resolve({ namespace, sessionId, cacheCwd, lifecycle,
+// cacheable }) overload. They are module-level (they need neither the walk nor
+// the per-resolver closure state) and are NEVER reached by the compatibility
+// no-arg resolve() path, so the 12 not-yet-migrated adapters are untouched.
+//
+// A cache-HIT / promotion / empty-MISS result must never carry pidChain,
+// foregroundWtHwnd, or tmuxClient — none are cached, and faking them would ship
+// a dead per-event PID or a stale window handle (plan §6.1). tmuxSocket is a
+// pure-env value recomputed on a hit. `cacheSource` (fresh|v2|v1|none) is
+// observability only; the compatibility no-arg shape never gains it.
+
+function emptyMetadata() {
+  return {
+    stablePid: null, terminalPid: null, snapshotOk: false, agentPid: null,
+    agentCommandLine: "", detectedEditor: null, pidChain: [], foregroundWtHwnd: null,
+    tmuxSocket: null, tmuxClient: null, cacheSource: "none",
+  };
+}
+
+function cacheHitMetadata(cached, source) {
+  return {
+    stablePid: cached.stablePid, terminalPid: null, snapshotOk: true,
+    agentPid: cached.agentPid, agentCommandLine: cached.agentCommandLine || "",
+    detectedEditor: cached.detectedEditor || null, pidChain: [], foregroundWtHwnd: null,
+    tmuxSocket: tmuxSocketFromEnv(), tmuxClient: null, cacheSource: source,
+  };
+}
+
+// A cached v2 entry is a HIT only when BOTH cached PIDs are still alive: the
+// stablePid that becomes source_pid AND the agentPid that tracks session
+// liveness. This double check is the ONLY defense against a dead session's
+// cache lingering — no clock participates.
+function readLiveV2(pidCache, namespace, sessionId, cacheCwd) {
+  const c = pidCache.readPidCacheV2(namespace, sessionId, cacheCwd);
+  if (c && processAlive(c.stablePid) && processAlive(c.agentPid)) return c;
+  return null;
+}
+
+// v1 was Claude-only, so only the claude-code namespace ever reads it. The v1
+// key uses Claude's RAW session id + RAW payload cwd — which for Claude ARE the
+// sessionId + cacheCwd passed here, so we reuse them directly (never a prefixed
+// or renormalized value). Returns the SINGLE-observation entry ({ subset,
+// identity }) so a caller that conditionally deletes the file binds its
+// delete-guard to exactly the bytes it consumed — never a version a concurrent
+// writer swapped in between two reads (plan §5.5). null when absent/dead/shape-
+// invalid or not the Claude namespace.
+function claudeReadLiveV1Entry(pidCache, namespace, sessionId, cacheCwd) {
+  if (namespace !== "claude-code") return null;
+  const entry = pidCache.readPidCacheEntry(sessionId, cacheCwd);
+  if (!entry) return null;
+  const v1 = entry.subset;
+  if (!processAlive(v1.stablePid) || !processAlive(v1.agentPid)) return null;
+  return entry;
+}
+
+function claudeDropV1SameKey(pidCache, namespace, sessionId, cacheCwd) {
+  if (namespace !== "claude-code") return;
+  pidCache.dropPidCache(sessionId, cacheCwd);
+}
+
+// Delete a v1 file ONLY if its mtimeMs + size + raw content are all unchanged
+// since `identity` was taken (plan §5.5). Any change means a concurrent
+// SessionStart replaced it; leave it for the sweep rather than strand a live
+// cache. No identity recorded → never delete.
+function deleteV1IfUnchanged(v1File, identity) {
+  if (!identity) return;
+  const fs = require("fs");
+  try {
+    const st = fs.statSync(v1File);
+    if (st.mtimeMs !== identity.mtimeMs || st.size !== identity.size) return;
+    if (fs.readFileSync(v1File, "utf8") !== identity.raw) return;
+    fs.unlinkSync(v1File);
+  } catch {
+    /* gone / raced — fine */
+  }
+}
+
+// v1→v2 in-place promotion on a v2 miss (Claude only). Returns cache-hit
+// metadata (ZERO spawn) on success, or null to fall through to the lifecycle's
+// normal miss handling. Failure ordering is pinned (plan §5.5):
+//   - a v2 write failure still returns the validated v1, never fresh-spawns, and
+//     never deletes v1;
+//   - v1 is deleted only AFTER a confirmed v2 write, and only when its
+//     mtimeMs + size + raw content are all unchanged (deleteV1IfUnchanged);
+//   - recheck v2 first, then write no-clobber, so a concurrent fresh
+//     SessionStart v2 is preferred and never overwritten (recheck-is-not-CAS
+//     residual closed, plan §6.10).
+function claudePromote(pidCache, namespace, sessionId, cacheCwd) {
+  // The subset we promote AND the identity we later delete-guard on both come
+  // from this ONE read, so a v1 a concurrent writer swaps in after we read is
+  // never promoted-over and deleted (High: identity must bind the read).
+  const entry = claudeReadLiveV1Entry(pidCache, namespace, sessionId, cacheCwd);
+  if (!entry) return null;
+  const v1 = entry.subset;
+  const v1File = pidCache.cacheFilePath(sessionId, cacheCwd);
+
+  // A concurrent SessionStart may already have written a fresher v2.
+  const existing = readLiveV2(pidCache, namespace, sessionId, cacheCwd);
+  if (existing) return cacheHitMetadata(existing, "v2");
+
+  const subset = {
+    stablePid: v1.stablePid, agentPid: v1.agentPid,
+    agentCommandLine: v1.agentCommandLine, detectedEditor: v1.detectedEditor,
+  };
+  const writeResult = pidCache.writePidCacheV2IfAbsent(namespace, sessionId, cacheCwd, subset);
+  if (writeResult === "exists") {
+    // A concurrent writer won: prefer their live v2, else fall back to our
+    // validated v1 (still zero spawn). Either way, do NOT delete v1.
+    const raced = readLiveV2(pidCache, namespace, sessionId, cacheCwd);
+    return raced ? cacheHitMetadata(raced, "v2") : cacheHitMetadata(v1, "v1");
+  }
+  if (writeResult === "created") {
+    // Delete ONLY the exact v1 we read+promoted; a concurrently-replaced file
+    // has a different identity and is kept (deleteV1IfUnchanged).
+    deleteV1IfUnchanged(v1File, entry.identity);
+  }
+  // "created" or false (write failed) → return the validated v1 metadata, zero
+  // spawn. On false we deliberately keep v1 for a later attempt / the sweep.
+  return cacheHitMetadata(v1, "v1");
+}
+
 function createPidResolver(options) {
   const { platformConfig } = options;
   const { terminalNames, systemBoundary, editorMap, editorPathChecks } = platformConfig;
@@ -242,9 +364,12 @@ function createPidResolver(options) {
 
   let _cached = null;
 
-  return function resolve() {
-    if (_cached) return _cached;
-
+  // The platform process-tree snapshot. Extracted so the compatibility no-arg
+  // resolve() and the PR2 lifecycle context share ONE implementation and ONE
+  // spawn. Returns the exact 5c2b1f0 10-field shape (NO cacheSource): the no-arg
+  // path must stay byte-for-byte, so this object is what the 12 not-yet-migrated
+  // adapters keep destructuring.
+  function computeFreshSnapshot() {
     const { execFileSync } = require("child_process");
     const winSnapshotResult = isWin ? getWindowsProcessSnapshot(execFileSync) : null;
     const winSnapshot = winSnapshotResult ? winSnapshotResult.processes : null;
@@ -372,8 +497,167 @@ function createPidResolver(options) {
     // silently decays to process.ppid) instead of reverse-inferring from
     // stablePid. Non-Windows has no snapshot step, so snapshotOk is trivially true.
     const snapshotOk = isWin ? !!(winSnapshot && winSnapshot.size > 0) : true;
-    _cached = { stablePid: terminalPid || lastGoodPid, terminalPid, snapshotOk, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient };
+    return { stablePid: terminalPid || lastGoodPid, terminalPid, snapshotOk, agentPid, agentCommandLine, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient };
+  }
+
+  // Compatibility no-arg path (SessionStart prewarm + the 12 not-yet-migrated
+  // adapters): byte-for-byte with 5c2b1f0 — first call snapshots, later calls
+  // return the SAME cached object. It performs ZERO cache
+  // read/write/touch/drop/promotion/sweep and never produces a clawd-pidcache2-*
+  // file; all disk-cache orchestration lives behind the context overload below.
+  function freshResolve() {
+    if (_cached) return _cached;
+    _cached = computeFreshSnapshot();
     return _cached;
+  }
+
+  // ── PR2 (#634) lifecycle context ──
+  // Reuses the prewarmed in-process _cached (SessionStart) so a `start` context
+  // after a no-arg prewarm never spawns a second time. Spreads into a NEW object
+  // (never mutates _cached) so the no-arg shape stays pristine.
+  function freshMetadata() {
+    return { ...freshResolve(), cacheSource: "fresh" };
+  }
+
+  // Low-frequency orphan sweep, AT MOST ONCE per resolver instance = per hook
+  // process (plan §5.4). Triggered by `start`, or — for adapters that have no
+  // start (Antigravity etc., later slices) — by the first successful `event`
+  // fresh→v2 population, so every adapter has a cleanup entry point. Zero spawn
+  // (kill(pid,0) liveness).
+  let _swept = false;
+  function maybeSweep(pidCache) {
+    if (_swept) return;
+    _swept = true;
+    pidCache.sweepStalePidCaches({ isProcessAlive: processAlive });
+  }
+
+  // start: fresh snapshot (reusing the prewarm), write v2 only when the walk is
+  // non-degraded (snapshotOk && agentPid). Low-frequency orphan sweep first,
+  // gated on cacheability (matching PR1: SessionStart only swept a cacheable
+  // session). Cleans a stale same-key v1 ONLY after a CONFIRMED v2 write — a
+  // failed write must keep v1 so the next prompt/event can still promote it
+  // (else the session loses its cache and re-freshes, i.e. flashes). No extra
+  // fresh for the cleanup.
+  function startLifecycle(pidCache, namespace, sessionId, cacheCwd, canDisk) {
+    if (canDisk) maybeSweep(pidCache);
+    const meta = freshMetadata();
+    if (canDisk && meta.snapshotOk && meta.agentPid) {
+      if (pidCache.writePidCacheV2(namespace, sessionId, cacheCwd, {
+        stablePid: meta.stablePid, agentPid: meta.agentPid,
+        agentCommandLine: meta.agentCommandLine, detectedEditor: meta.detectedEditor,
+      }) === true) {
+        claudeDropV1SameKey(pidCache, namespace, sessionId, cacheCwd);
+      }
+    }
+    return meta;
+  }
+
+  // prompt: cache-only, NO fallback. A hit (or a v1→v2 promotion) returns the
+  // stable subset; a miss/corrupt/dead/non-cacheable prompt returns empty
+  // metadata and NEVER spawns — even when caching is disabled. The foreground WT
+  // handle it used to fresh-resolve for is sampled server-side now.
+  function promptLifecycle(pidCache, namespace, sessionId, cacheCwd, canDisk) {
+    if (canDisk) {
+      const hit = readLiveV2(pidCache, namespace, sessionId, cacheCwd);
+      if (hit) {
+        pidCache.touchPidCacheV2(namespace, sessionId, cacheCwd);
+        return cacheHitMetadata(hit, "v2");
+      }
+      const promoted = claudePromote(pidCache, namespace, sessionId, cacheCwd);
+      if (promoted) return promoted;
+    }
+    return emptyMetadata();
+  }
+
+  // event: a hit (or promotion) is zero spawn; a miss is at most ONE fresh, then
+  // repopulate v2 if the walk was usable. Non-cacheable events may fresh (the
+  // no-fallback contract is prompt/end only).
+  function eventLifecycle(pidCache, namespace, sessionId, cacheCwd, canDisk) {
+    if (canDisk) {
+      const hit = readLiveV2(pidCache, namespace, sessionId, cacheCwd);
+      if (hit) {
+        pidCache.touchPidCacheV2(namespace, sessionId, cacheCwd);
+        return cacheHitMetadata(hit, "v2");
+      }
+      const promoted = claudePromote(pidCache, namespace, sessionId, cacheCwd);
+      if (promoted) return promoted;
+    }
+    const meta = freshMetadata();
+    if (canDisk && meta.snapshotOk && meta.agentPid) {
+      if (pidCache.writePidCacheV2(namespace, sessionId, cacheCwd, {
+        stablePid: meta.stablePid, agentPid: meta.agentPid,
+        agentCommandLine: meta.agentCommandLine, detectedEditor: meta.detectedEditor,
+      }) === true) {
+        claudeDropV1SameKey(pidCache, namespace, sessionId, cacheCwd);
+        // First successful population is a sweep entry point for no-start
+        // adapters (§5.4); the once-per-process guard makes it a no-op when
+        // `start` already swept.
+        maybeSweep(pidCache);
+      }
+    }
+    return meta;
+  }
+
+  // end: cache-only. Fill the final body from a live v2 (or a valid v1 — used to
+  // construct the body but NOT re-promoted into a short-lived v2), then drop the
+  // cache for this ending session. v2 is dropped defensively (Claude's own key);
+  // a VALID v1 is deleted ONLY via its own read-identity so a v1 a concurrent
+  // writer swapped in after we read is not blindly deleted (Medium). An
+  // absent/dead/corrupt v1 is defensively cleaned. NEVER fresh, NEVER write back.
+  function endLifecycle(pidCache, namespace, sessionId, cacheCwd, canDisk) {
+    let meta = emptyMetadata();
+    if (canDisk) {
+      const hit = readLiveV2(pidCache, namespace, sessionId, cacheCwd);
+      const v1Entry = claudeReadLiveV1Entry(pidCache, namespace, sessionId, cacheCwd);
+      if (hit) meta = cacheHitMetadata(hit, "v2");
+      else if (v1Entry) meta = cacheHitMetadata(v1Entry.subset, "v1");
+
+      pidCache.dropPidCacheV2(namespace, sessionId, cacheCwd);
+      if (v1Entry) {
+        // Delete only the exact v1 we read; a concurrently-replaced one survives.
+        deleteV1IfUnchanged(pidCache.cacheFilePath(sessionId, cacheCwd), v1Entry.identity);
+      } else {
+        // No valid v1 (absent/dead/corrupt) → defensive cleanup of any garbage.
+        claudeDropV1SameKey(pidCache, namespace, sessionId, cacheCwd);
+      }
+    }
+    return meta;
+  }
+
+  function resolveWithContext(ctx) {
+    const namespace = ctx.namespace;
+    const sessionId = ctx.sessionId;
+    const cacheCwd = ctx.cacheCwd;
+    const lifecycle = ctx.lifecycle;
+    const cacheable = ctx.cacheable === true;
+
+    // Non-Windows: runtime behavior unchanged — every lifecycle does a fresh
+    // (in-process cached) snapshot and no disk cache is ever consulted. Keeps
+    // the ps-based path identical to 5c2b1f0 for mac/linux.
+    if (!isWin) return { ...freshResolve(), cacheSource: "fresh" };
+
+    // Lazy require: the no-arg path never loads pid-cache. pid-cache never
+    // requires shared-process, so there is no cycle.
+    const pidCache = require("./pid-cache");
+    // canDisk gates every disk read/write/touch/drop/promotion/sweep. cacheable
+    // is the adapter's declaration; the path check guards a stray empty
+    // ingredient. It never relaxes the prompt/end no-fallback contract below.
+    const canDisk = cacheable && !!pidCache.cacheFilePathV2(namespace, sessionId, cacheCwd);
+
+    switch (lifecycle) {
+      case "start":  return startLifecycle(pidCache, namespace, sessionId, cacheCwd, canDisk);
+      case "prompt": return promptLifecycle(pidCache, namespace, sessionId, cacheCwd, canDisk);
+      case "end":    return endLifecycle(pidCache, namespace, sessionId, cacheCwd, canDisk);
+      case "event":
+      default:       return eventLifecycle(pidCache, namespace, sessionId, cacheCwd, canDisk);
+    }
+  }
+
+  // Single entry point. No argument → the strict compatibility path. A context
+  // object → the PR2 lifecycle path. Nothing else changes for existing callers.
+  return function resolve(ctx) {
+    if (ctx === undefined || ctx === null) return freshResolve();
+    return resolveWithContext(ctx);
   };
 }
 

--- a/test/clawd-hook-pid-cache.test.js
+++ b/test/clawd-hook-pid-cache.test.js
@@ -1,355 +1,400 @@
-// test/clawd-hook-pid-cache.test.js — #627 cache wiring in buildStateBody
-// (bounded sliding TTL §8). clawd-hook.js captures `isWin` at module load, so we
-// force process.platform and re-require it to exercise both the Windows (cache)
-// and non-Windows paths deterministically on any host.
+// test/clawd-hook-pid-cache.test.js — #634: the Claude adapter side of the
+// shared-resolver migration.
+//
+// Two layers:
+//  1. Adapter mapping — buildStateBody maps event→lifecycle, declares the cache
+//     identity (namespace/sessionId/cacheCwd/cacheable), bypasses on remote, and
+//     applies whatever metadata the resolver returns. A context-capturing fake
+//     resolver pins the mapping without exercising the cache.
+//  2. End-to-end Claude regression — buildStateBody wired to the REAL shared
+//     resolver (mock-loaded shared-process for a counting execFileSync + forced
+//     platform, real pid-cache on real temp files). This nails the §3.5 zero-
+//     spawn guarantees through the actual integration, not a stand-in.
 const { describe, it, before, after, afterEach } = require("node:test");
 const assert = require("node:assert");
 const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
 
 const pidCache = require("../hooks/pid-cache");
 
+const NS = "claude-code";
 const CWD = "/repo/clawd-hook-cache-test";
 const DEAD_PID = 2147483646;
 
-let seq = 0;
-const usedSids = [];
-function freshSid() {
-  const sid = `clawd-hook-cache-${process.pid}-${seq++}`;
-  usedSids.push(sid);
-  return sid;
-}
-afterEach(() => {
-  for (const sid of usedSids.splice(0)) pidCache.dropPidCache(sid, CWD);
+// Isolate the cache directory (#634): the end-to-end SessionStart tests drive the
+// real resolver, which sweeps the shared os.tmpdir() unless redirected. See
+// pid-cache.js cacheDir(). The resolver reaches pid-cache through this same
+// module object, so the override covers both layers.
+let ISO_DIR;
+before(() => {
+  ISO_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-hook-cache-iso-"));
+  pidCache.__setCacheDirForTests(ISO_DIR);
+});
+after(() => {
+  pidCache.__setCacheDirForTests(null);
+  try { fs.rmSync(ISO_DIR, { recursive: true, force: true }); } catch {}
 });
 
-// A healthy resolve() result. stablePid = this test process (guaranteed alive).
-// agentPid = 4242 is a placeholder for the FRESH path (which does not
-// liveness-check agentPid); cache-HIT tests write their own subset with a LIVE
-// agentPid because the hit path now double-checks processAlive(agentPid).
-function goodResolved(extra = {}) {
-  return {
-    stablePid: process.pid,
-    terminalPid: process.pid,
-    snapshotOk: true,
-    agentPid: 4242,
-    agentCommandLine: "claude --print",
-    detectedEditor: "code",
-    pidChain: [111, 222],
-    foregroundWtHwnd: null,
-    tmuxSocket: null,
-    tmuxClient: null,
-    ...extra,
-  };
-}
+let seq = 0;
+const usedV1 = [];
+const usedV2 = [];
+function freshSid() { const s = `clawd-hook-cache-${process.pid}-${seq++}`; usedV1.push(s); usedV2.push(s); return s; }
+afterEach(() => {
+  for (const s of usedV1.splice(0)) pidCache.dropPidCache(s, CWD);
+  for (const s of usedV2.splice(0)) pidCache.dropPidCacheV2(NS, s, CWD);
+});
 
-// A cached subset whose stablePid AND agentPid are both alive (this process),
-// so the hit path's double liveness check passes.
-function liveSubset(extra = {}) {
-  return {
-    stablePid: process.pid,
-    agentPid: process.pid,
-    agentCommandLine: "claude --print",
-    detectedEditor: "code",
-    ...extra,
-  };
-}
+// ═══════════════════════════════════════════════════════════════════════════
+// Layer 1 — adapter mapping (context-capturing fake resolver)
+// ═══════════════════════════════════════════════════════════════════════════
+describe("buildStateBody adapter → shared resolver context (#634)", () => {
+  const { buildStateBody } = require("../hooks/clawd-hook.js");
 
-function loadClawdHook(platform) {
-  const key = require.resolve("../hooks/clawd-hook.js");
-  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
-  const hadRemote = process.env.CLAWD_REMOTE;
-  delete process.env.CLAWD_REMOTE;
-  Object.defineProperty(process, "platform", { ...origPlatform, value: platform });
-  delete require.cache[key];
-  const mod = require("../hooks/clawd-hook.js");
-  const restore = () => {
-    Object.defineProperty(process, "platform", origPlatform);
-    if (hadRemote !== undefined) process.env.CLAWD_REMOTE = hadRemote;
-    delete require.cache[key];
-    require("../hooks/clawd-hook.js"); // put a natively-loaded instance back
-  };
-  return { buildStateBody: mod.buildStateBody, restore };
-}
+  // Captures every resolver context and returns a preset metadata object.
+  function capture(returns = emptyMeta()) {
+    const calls = [];
+    const fn = (ctx) => { calls.push(ctx); return returns; };
+    fn.calls = calls;
+    return fn;
+  }
+  function emptyMeta() {
+    return { stablePid: null, terminalPid: null, snapshotOk: false, agentPid: null, agentCommandLine: "", detectedEditor: null, pidChain: [], foregroundWtHwnd: null, tmuxSocket: null, tmuxClient: null, cacheSource: "none" };
+  }
 
-describe("buildStateBody pid cache — Windows", () => {
-  let buildStateBody, restore;
-  before(() => { ({ buildStateBody, restore } = loadClawdHook("win32")); });
-  after(() => restore());
-
-  it("cache miss → resolves once, writes cache, fresh body carries pid_chain", () => {
-    const sid = freshSid();
-    let calls = 0;
-    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 1);
-    assert.strictEqual(body.source_pid, process.pid);
-    assert.strictEqual(body.agent_pid, 4242);
-    assert.strictEqual(body.claude_pid, 4242);
-    assert.strictEqual(body.headless, true);
-    assert.strictEqual(body.editor, "code");
-    assert.deepStrictEqual(body.pid_chain, [111, 222]);
-
-    const cached = pidCache.readPidCache(sid, CWD);
-    assert.ok(cached, "miss must populate the cache");
-    assert.strictEqual(cached.stablePid, process.pid);
-    assert.strictEqual(cached.agentPid, 4242);
-  });
-
-  it("cache hit → no resolve, replicates claude_pid + headless, omits pid_chain", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    let calls = 0;
-    const body = buildStateBody("PostToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "cache hit must not spawn a resolve");
-    assert.strictEqual(body.source_pid, process.pid);
-    assert.strictEqual(body.agent_pid, process.pid);
-    assert.strictEqual(body.claude_pid, process.pid, "M3: backward-compat alias must be present on the cache path");
-    assert.strictEqual(body.headless, true, "M3: headless derivation must run on the cache path");
-    assert.strictEqual(body.editor, "code");
-    assert.strictEqual(body.pid_chain, undefined, "cache-hit body must omit pid_chain (server MERGE keeps SessionStart's)");
-    assert.strictEqual(body.wt_hwnd, undefined);
-  });
-
-  it("cache hit touches mtime (feeds the sweep age floor), keeps ts, no resolve (lease rewrite §4.4)", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    const file = pidCache.cacheFilePath(sid, CWD);
-    const tsBefore = JSON.parse(fs.readFileSync(file, "utf8")).ts;
-    // Age mtime arbitrarily (the lease read no longer consults it at all —
-    // this only proves the touch-on-hit mechanism itself still works).
-    const aged = new Date(Date.now() - 10_000);
-    fs.utimesSync(file, aged, aged);
-    const mtimeAged = fs.statSync(file).mtimeMs;
-    let calls = 0;
-    buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "hit must not resolve");
-    assert.ok(fs.statSync(file).mtimeMs > mtimeAged, "hit must bump mtime (feeds sweepStalePidCaches' age floor)");
-    assert.strictEqual(JSON.parse(fs.readFileSync(file, "utf8")).ts, tsBefore, "hit must not change ts (debug-only field, not a validity clock)");
-  });
-
-  it("an ancient file (mtime/ts far in the past) is still a hit when both cached PIDs are alive (lease has no clock)", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    const file = pidCache.cacheFilePath(sid, CWD);
-    // Push both the JSON ts AND the file mtime absurdly far into the past —
-    // under the old TTL/cap design this would be a double-expired miss.
-    const obj = JSON.parse(fs.readFileSync(file, "utf8"));
-    obj.ts = Date.now() - 365 * 24 * 60 * 60 * 1000; // ~1 year old
-    fs.writeFileSync(file, JSON.stringify(obj));
-    const ancientTime = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
-    fs.utimesSync(file, ancientTime, ancientTime);
-    let calls = 0;
-    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "an ancient-but-alive cache must still hit — no clock participates in read validity");
-    assert.strictEqual(body.source_pid, process.pid);
-  });
-
-  it("M1: dead cached stablePid → fresh resolve, never ships the dead pid", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, { stablePid: DEAD_PID, agentPid: process.pid, agentCommandLine: "claude", detectedEditor: "code" });
-    let calls = 0;
-    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 1, "dead source_pid must trigger a fresh resolve");
-    assert.strictEqual(body.source_pid, process.pid, "ships the fresh pid, not the dead cached one");
-  });
-
-  it("dead cached agentPid → fresh resolve (do not renew a dead session, sliding TTL §8)", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, { stablePid: process.pid, agentPid: DEAD_PID, agentCommandLine: "claude", detectedEditor: "code" });
-    let calls = 0;
-    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 1, "dead agentPid must trigger a fresh resolve");
-    assert.strictEqual(body.source_pid, process.pid);
-  });
-
-  it("M2: degraded resolve (snapshotOk false) is not cached", () => {
-    const sid = freshSid();
-    const degraded = { stablePid: 999, terminalPid: null, snapshotOk: false, agentPid: null, agentCommandLine: "", detectedEditor: null, pidChain: [], foregroundWtHwnd: null, tmuxSocket: null, tmuxClient: null };
-    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => degraded);
-    assert.strictEqual(body.source_pid, 999, "still reports the degraded pid for this one event");
-    assert.strictEqual(body.agent_pid, undefined);
-    assert.strictEqual(pidCache.readPidCache(sid, CWD), null, "a degraded snapshot must not poison the cache");
-  });
-
-  it("M2: snapshotOk true but no agentPid is not cached", () => {
-    const sid = freshSid();
-    const noAgent = goodResolved({ agentPid: null, agentCommandLine: "" });
-    buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => noAgent);
-    assert.strictEqual(pidCache.readPidCache(sid, CWD), null);
-  });
-
-  it("M2: a degraded fresh resolve does not overwrite an existing good cache", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    // SessionStart is the only event that still always re-resolves
-    // (wantsFresh, #627 residual §4.3 — UserPromptSubmit no longer does).
-    // Feed it a degraded (snapshotOk:false) result.
-    const degraded = { stablePid: 999, terminalPid: null, snapshotOk: false, agentPid: null, agentCommandLine: "", detectedEditor: null, pidChain: [], foregroundWtHwnd: null, tmuxSocket: null, tmuxClient: null };
-    buildStateBody("SessionStart", { session_id: sid, cwd: CWD }, () => degraded);
-    const after = pidCache.readPidCache(sid, CWD);
-    assert.ok(after, "existing good cache must survive a degraded resolve");
-    assert.strictEqual(after.stablePid, process.pid, "stablePid untouched");
-    assert.strictEqual(after.agentPid, process.pid, "agentPid untouched");
-  });
-
-  it("wantsFresh is narrowed to SessionStart only: SessionStart always resolves even with a valid cache present", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    let calls = 0;
-    const freshEditor = "code"; // goodResolved()'s editor, distinguishable from liveSubset()'s
-    const body = buildStateBody("SessionStart", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved({ agentPid: 55555, stablePid: process.pid, detectedEditor: freshEditor }); });
-    assert.strictEqual(calls, 1, "SessionStart must always resolve, regardless of an existing valid cache");
-    assert.strictEqual(body.agent_pid, 55555, "body reflects the fresh resolve, not the stale cache");
-    const after = pidCache.readPidCache(sid, CWD);
-    assert.strictEqual(after.agentPid, 55555, "a non-degraded SessionStart resolve overwrites the cache");
-  });
-
-  it("cache-hit path recomputes tmux_socket from the environment", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    const saved = process.env.TMUX;
-    process.env.TMUX = "/tmp/tmux-1000/win,200,5";
-    try {
-      const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => goodResolved());
-      assert.strictEqual(body.tmux_socket, "/tmp/tmux-1000/win");
-    } finally {
-      if (saved === undefined) delete process.env.TMUX;
-      else process.env.TMUX = saved;
+  it("maps SessionStart→start, UserPromptSubmit→prompt, SessionEnd→end, everything else→event", () => {
+    for (const [event, lifecycle] of [
+      ["SessionStart", "start"],
+      ["UserPromptSubmit", "prompt"],
+      ["SessionEnd", "end"],
+      ["PreToolUse", "event"],
+      ["PostToolUse", "event"],
+      ["Stop", "event"],
+      ["Notification", "event"],
+      ["SubagentStop", "event"],
+    ]) {
+      const r = capture();
+      buildStateBody(event, { session_id: "s", cwd: CWD }, r);
+      assert.strictEqual(r.calls.length, 1, `${event} calls the resolver once`);
+      assert.strictEqual(r.calls[0].lifecycle, lifecycle, `${event} → ${lifecycle}`);
     }
   });
 
-  it("M5: SessionEnd reads the cache, drops it, and does not resolve", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    let calls = 0;
-    const body = buildStateBody("SessionEnd", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "SessionEnd hit uses the cache, no spawn");
-    assert.strictEqual(body.source_pid, process.pid);
-    assert.strictEqual(pidCache.readPidCache(sid, CWD), null, "SessionEnd must drop the cache");
+  it("Stop maps to event, NOT end (turn completion must not drop the cache)", () => {
+    const r = capture();
+    buildStateBody("Stop", { session_id: "s", cwd: CWD }, r);
+    assert.strictEqual(r.calls[0].lifecycle, "event");
+    assert.notStrictEqual(r.calls[0].lifecycle, "end");
   });
 
-  // #627 residual §4.3: this inverts the #630-shipped behavior (630 plan
-  // §3.2), which deliberately let a SessionEnd miss fall back to one fresh
-  // resolve to fill out the final body. That fallback was itself a
-  // console-flashing spawn — by the time SessionEnd fires the session is
-  // already ending, so an incomplete final body (server MERGE keeps whatever
-  // the session already had) now wins over a guaranteed flash.
-  it("M5 (reversed): SessionEnd on a miss does NOT resolve and ships no PID fields", () => {
-    const sid = freshSid();
-    let calls = 0;
-    const body = buildStateBody("SessionEnd", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "SessionEnd miss must never spawn");
-    assert.strictEqual(body.source_pid, undefined);
-    assert.strictEqual(body.agent_pid, undefined);
-    assert.strictEqual(body.claude_pid, undefined);
-    assert.strictEqual(pidCache.readPidCache(sid, CWD), null, "SessionEnd must never write the cache");
+  it("declares namespace=claude-code and cacheCwd=payload.cwd", () => {
+    const r = capture();
+    buildStateBody("PreToolUse", { session_id: "s", cwd: "/some/where" }, r);
+    assert.strictEqual(r.calls[0].namespace, "claude-code");
+    assert.strictEqual(r.calls[0].cacheCwd, "/some/where");
+    assert.strictEqual(r.calls[0].sessionId, "s");
   });
 
-  // #627 residual §4.3: UserPromptSubmit is no longer an always-fresh event —
-  // the foreground WT window handle it used to carry is now sampled
-  // server-side (src/win-foreground-terminal.js via src/server-route-state.js),
-  // so the hook itself never needs a live snapshot for it anymore. It behaves
-  // exactly like every other cache-only high-frequency event: a HIT applies
-  // the cached subset with zero spawn; a MISS also spawns nothing (unlike
-  // PreToolUse/PostToolUse/etc., which still fall back to one fresh resolve —
-  // see the "cacheOnlyNoFallback" comment in clawd-hook.js).
-  it("UserPromptSubmit cache HIT: zero spawn, applies cached fields, never reports wt_hwnd", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    let calls = 0;
-    const body = buildStateBody("UserPromptSubmit", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved({ foregroundWtHwnd: "987654" }); });
-    assert.strictEqual(calls, 0, "UserPromptSubmit hit must not resolve");
-    assert.strictEqual(body.source_pid, process.pid);
-    assert.strictEqual(body.agent_pid, process.pid);
-    assert.strictEqual(body.wt_hwnd, undefined, "wt_hwnd is no longer the hook's job on UserPromptSubmit");
+  it("cacheable is true only for a real session id AND a non-empty cwd", () => {
+    const real = capture();
+    buildStateBody("PreToolUse", { session_id: "sid", cwd: CWD }, real);
+    assert.strictEqual(real.calls[0].cacheable, true);
+
+    const def = capture();
+    buildStateBody("PreToolUse", { session_id: "default", cwd: CWD }, def);
+    assert.strictEqual(def.calls[0].cacheable, false, "session_id 'default' (#583) is non-cacheable");
+
+    const noCwd = capture();
+    buildStateBody("PreToolUse", { session_id: "sid" }, noCwd);
+    assert.strictEqual(noCwd.calls[0].cacheable, false, "empty cwd is non-cacheable");
+
+    const missingSid = capture();
+    buildStateBody("PreToolUse", { cwd: CWD }, missingSid);
+    assert.strictEqual(missingSid.calls[0].sessionId, "default", "missing session_id falls back to 'default'");
+    assert.strictEqual(missingSid.calls[0].cacheable, false);
   });
 
-  it("UserPromptSubmit cache MISS: zero spawn, ships no PID fields (never degrades to process.ppid)", () => {
-    const sid = freshSid();
-    let calls = 0;
-    const body = buildStateBody("UserPromptSubmit", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "UserPromptSubmit miss must never spawn");
-    assert.strictEqual(body.source_pid, undefined);
-    assert.strictEqual(body.agent_pid, undefined);
-    assert.strictEqual(body.claude_pid, undefined);
-    assert.strictEqual(body.editor, undefined);
-    assert.strictEqual(body.pid_chain, undefined);
-    assert.strictEqual(body.wt_hwnd, undefined);
-    assert.strictEqual(pidCache.readPidCache(sid, CWD), null, "a miss must never write the cache either");
+  it("remote mode (CLAWD_REMOTE) bypasses the resolver entirely (zero context calls)", () => {
+    const hadRemote = process.env.CLAWD_REMOTE;
+    process.env.CLAWD_REMOTE = "1";
+    try {
+      const r = capture();
+      const body = buildStateBody("PreToolUse", { session_id: "s", cwd: CWD }, r);
+      assert.strictEqual(r.calls.length, 0, "remote must not call the resolver context");
+      assert.ok(!("source_pid" in body), "remote body carries no local pid");
+      assert.strictEqual(typeof body.host, "string");
+    } finally {
+      if (hadRemote === undefined) delete process.env.CLAWD_REMOTE;
+      else process.env.CLAWD_REMOTE = hadRemote;
+    }
   });
 
-  it("UserPromptSubmit cache MISS with a dead cached PID: still zero spawn (no fallback, unlike ordinary events)", () => {
-    const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, { stablePid: DEAD_PID, agentPid: process.pid, agentCommandLine: "claude", detectedEditor: "code" });
-    let calls = 0;
-    const body = buildStateBody("UserPromptSubmit", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "a dead-PID miss on UserPromptSubmit must still not fall back to a fresh resolve");
-    assert.strictEqual(body.source_pid, undefined, "must never ship the dead cached pid, and must never degrade to process.ppid either");
+  it("applies a hit's stable subset (source_pid/agent_pid/headless/editor), omitting pid_chain", () => {
+    const hit = { stablePid: 4242, terminalPid: null, snapshotOk: true, agentPid: 4242, agentCommandLine: "node claude-code --print", detectedEditor: "code", pidChain: [], foregroundWtHwnd: null, tmuxSocket: null, tmuxClient: null, cacheSource: "v2" };
+    const body = buildStateBody("PostToolUse", { session_id: "s", cwd: CWD }, capture(hit));
+    assert.strictEqual(body.source_pid, 4242);
+    assert.strictEqual(body.agent_pid, 4242);
+    assert.strictEqual(body.claude_pid, 4242, "backward-compat alias");
+    assert.strictEqual(body.headless, true);
+    assert.strictEqual(body.editor, "code");
+    assert.ok(!("pid_chain" in body), "a hit omits pid_chain (server MERGE keeps the SessionStart one)");
   });
 
-  it("caching disabled for session_id 'default' → always resolves, keeps pid_chain", () => {
-    let calls = 0;
-    const body = buildStateBody("PreToolUse", { session_id: "default", cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 1);
-    assert.deepStrictEqual(body.pid_chain, [111, 222]);
+  it("empty metadata (prompt/end miss) applies NO pid fields — never a degraded process.ppid", () => {
+    const body = buildStateBody("UserPromptSubmit", { session_id: "s", cwd: CWD }, capture(emptyMeta()));
+    assert.ok(!("source_pid" in body));
+    assert.ok(!("agent_pid" in body));
+    assert.ok(!("claude_pid" in body));
+    assert.ok(!("editor" in body));
+    assert.ok(!("pid_chain" in body));
+    assert.ok(!("wt_hwnd" in body));
   });
 
-  // P1 (codex review): the no-fallback contract is a Windows contract, not a
-  // cache-availability one. Even when caching is disabled (session_id
-  // "default" per #583, or an empty cwd), UserPromptSubmit/SessionEnd must
-  // never spawn — otherwise those degenerate sessions keep flashing once per
-  // prompt, the exact symptom this fix removes. Ordinary events (PreToolUse,
-  // above) still resolve fresh for them, which is what keeps their server-side
-  // fields populated.
-  it("P1: UserPromptSubmit with session_id 'default' (caching disabled) never resolves", () => {
-    let calls = 0;
-    const body = buildStateBody("UserPromptSubmit", { session_id: "default", cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "non-cacheable UserPromptSubmit must not spawn on Windows");
-    assert.strictEqual(body.source_pid, undefined);
-  });
-
-  it("P1: UserPromptSubmit with an empty cwd (caching disabled) never resolves", () => {
-    const sid = freshSid();
-    let calls = 0;
-    const body = buildStateBody("UserPromptSubmit", { session_id: sid, cwd: "" }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "non-cacheable UserPromptSubmit must not spawn on Windows");
-    assert.strictEqual(body.source_pid, undefined);
-  });
-
-  it("P1: SessionEnd with session_id 'default' (caching disabled) never resolves", () => {
-    let calls = 0;
-    const body = buildStateBody("SessionEnd", { session_id: "default", cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "non-cacheable SessionEnd must not spawn on Windows");
-    assert.strictEqual(body.source_pid, undefined);
-  });
-
-  it("P1: SessionEnd with an empty cwd (caching disabled) never resolves", () => {
-    const sid = freshSid();
-    let calls = 0;
-    const body = buildStateBody("SessionEnd", { session_id: sid, cwd: "" }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 0, "non-cacheable SessionEnd must not spawn on Windows");
-    assert.strictEqual(body.source_pid, undefined);
+  it("applies wt_hwnd on a foreground-safe start, but never on a prompt", () => {
+    const withHwnd = (extra) => ({ stablePid: 1, terminalPid: null, snapshotOk: true, agentPid: null, agentCommandLine: "", detectedEditor: null, pidChain: [], foregroundWtHwnd: "987654", tmuxSocket: null, tmuxClient: null, cacheSource: "fresh", ...extra });
+    const startBody = buildStateBody("SessionStart", { session_id: "s", cwd: CWD }, capture(withHwnd()));
+    assert.strictEqual(startBody.wt_hwnd, "987654");
+    // Even if a (misbehaving) resolver surfaced a handle on prompt, the event
+    // is foreground-safe so it *would* apply — but the real resolver returns
+    // null foregroundWtHwnd for prompt, so model that here.
+    const promptBody = buildStateBody("UserPromptSubmit", { session_id: "s", cwd: CWD }, capture(withHwnd({ foregroundWtHwnd: null })));
+    assert.ok(!("wt_hwnd" in promptBody));
   });
 });
 
-describe("buildStateBody pid cache — non-Windows", () => {
-  let buildStateBody, restore;
-  before(() => { ({ buildStateBody, restore } = loadClawdHook("linux")); });
-  after(() => restore());
+// ═══════════════════════════════════════════════════════════════════════════
+// Layer 2 — end-to-end Claude regression (REAL resolver)
+// ═══════════════════════════════════════════════════════════════════════════
 
-  it("never consults or writes the cache; always resolves with pid_chain", () => {
+function snapshotJson(procs) {
+  return JSON.stringify(procs.map((p) => ({
+    ProcessId: p.pid, Name: p.name, ParentProcessId: p.ppid,
+    CommandLine: typeof p.cmd === "string" ? p.cmd : null,
+  })));
+}
+// The resolver walks from process.ppid by default (main() passes no startPid),
+// so the mock snapshot anchors the agent node.exe at process.ppid (alive: it's
+// this process's parent), headless claude-code, under WindowsTerminal.
+const PPID = process.ppid;
+const HEADLESS_PROCS = [
+  { pid: PPID, name: "node.exe", ppid: 600, cmd: "node C:/x/claude-code/cli.js --print" },
+  { pid: 600, name: "windowsterminal.exe", ppid: 0 },
+];
+function liveSubset(extra = {}) {
+  return { stablePid: process.pid, agentPid: process.pid, agentCommandLine: "node claude-code --print", detectedEditor: "code", ...extra };
+}
+
+// Loads clawd-hook wired to the REAL shared resolver: patches child_process for a
+// counting execFileSync, forces process.platform, reloads shared-process then
+// clawd-hook. Exposes the shared-process module so each test builds a FRESH
+// resolver (clean in-process _cached).
+function loadRealResolver({ platform }) {
+  const cpKey = require.resolve("child_process");
+  const spKey = require.resolve("../hooks/shared-process");
+  const chKey = require.resolve("../hooks/clawd-hook");
+  const origCp = require.cache[cpKey];
+  const origSp = require.cache[spKey];
+  const origCh = require.cache[chKey];
+  const origPlatform = Object.getOwnPropertyDescriptor(process, "platform");
+  const hadRemote = process.env.CLAWD_REMOTE;
+  delete process.env.CLAWD_REMOTE;
+
+  const state = { snapshot: snapshotJson(HEADLESS_PROCS), spawns: 0 };
+  const execFileSyncMock = (cmd, args) => {
+    state.spawns++;
+    if (cmd === "powershell.exe") return state.snapshot;
+    const key = `${cmd} ${(args || []).join(" ")}`;
+    if (key.includes("ppid=")) return "1\n";
+    return "bash\n";
+  };
+
+  const realCp = require("child_process");
+  require.cache[cpKey] = { id: cpKey, filename: cpKey, loaded: true, exports: { ...realCp, execFileSync: execFileSyncMock } };
+  Object.defineProperty(process, "platform", { ...origPlatform, value: platform });
+
+  delete require.cache[spKey];
+  const sp = require("../hooks/shared-process");
+  delete require.cache[chKey];
+  const ch = require("../hooks/clawd-hook");
+
+  const CLAUDE_OPTS = {
+    agentNames: { win: new Set(["claude.exe"]), mac: new Set(["claude"]) },
+    agentCmdlineCheck: (cmd) => cmd.includes("claude-code") || cmd.includes("@anthropic-ai"),
+  };
+  const makeResolve = () => sp.createPidResolver({ ...CLAUDE_OPTS, platformConfig: sp.getPlatformConfig() });
+
+  const restore = () => {
+    Object.defineProperty(process, "platform", origPlatform);
+    if (hadRemote !== undefined) process.env.CLAWD_REMOTE = hadRemote;
+    if (origCp) require.cache[cpKey] = origCp; else delete require.cache[cpKey];
+    if (origSp) require.cache[spKey] = origSp; else delete require.cache[spKey];
+    if (origCh) require.cache[chKey] = origCh; else delete require.cache[chKey];
+    require("../hooks/shared-process");
+    require("../hooks/clawd-hook"); // put natively-loaded instances back
+  };
+  return { buildStateBody: ch.buildStateBody, makeResolve, state, restore };
+}
+
+describe("clawd-hook end-to-end with the real resolver — Windows", () => {
+  let env;
+  before(() => { env = loadRealResolver({ platform: "win32" }); });
+  after(() => env.restore());
+
+  function run(event, payload) {
+    env.state.spawns = 0;
+    const resolve = env.makeResolve();
+    const body = buildStateBodyPrewarmAware(env, event, payload, resolve);
+    return { body, spawns: env.state.spawns };
+  }
+  // Mirrors main(): prewarm no-arg resolve() on SessionStart before build.
+  function buildStateBodyPrewarmAware(env, event, payload, resolve) {
+    if (event === "SessionStart" && !process.env.CLAWD_REMOTE) resolve();
+    return env.buildStateBody(event, payload, resolve);
+  }
+
+  it("SessionStart prewarm resolves exactly once (build reuses the prewarmed snapshot)", () => {
     const sid = freshSid();
-    pidCache.writePidCache(sid, CWD, liveSubset());
-    let calls = 0;
-    const body = buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 1, "non-Windows always resolves");
-    assert.deepStrictEqual(body.pid_chain, [111, 222], "fresh path includes pid_chain");
+    const { body, spawns } = run("SessionStart", { session_id: sid, cwd: CWD });
+    assert.strictEqual(spawns, 1, "prewarm + start build = ONE snapshot");
+    assert.strictEqual(body.source_pid, 600);
+    assert.strictEqual(body.agent_pid, PPID);
+    assert.ok(pidCache.readPidCacheV2(NS, sid, CWD), "SessionStart wrote v2");
   });
 
-  it("UserPromptSubmit and SessionEnd still resolve fresh (the no-fallback contract is Windows-only)", () => {
+  it("UserPromptSubmit HIT: zero spawn, applies subset, no hook-side wt_hwnd", () => {
     const sid = freshSid();
-    let calls = 0;
-    buildStateBody("UserPromptSubmit", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    buildStateBody("SessionEnd", { session_id: sid, cwd: CWD }, () => { calls++; return goodResolved(); });
-    assert.strictEqual(calls, 2, "the ps path neither flashes nor pays a cold start — semantics unchanged");
+    pidCache.writePidCacheV2(NS, sid, CWD, liveSubset());
+    const { body, spawns } = run("UserPromptSubmit", { session_id: sid, cwd: CWD });
+    assert.strictEqual(spawns, 0, "prompt hit never spawns");
+    assert.strictEqual(body.source_pid, process.pid);
+    assert.strictEqual(body.agent_pid, process.pid);
+    assert.strictEqual(body.headless, true, "headless derives from the cached agentCommandLine");
+    assert.ok(!("wt_hwnd" in body), "prompt body never carries a hook-side wt_hwnd (server samples it)");
+  });
+
+  it("UserPromptSubmit MISS: zero spawn, ships no pid fields, writes nothing", () => {
+    const sid = freshSid();
+    const { body, spawns } = run("UserPromptSubmit", { session_id: sid, cwd: CWD });
+    assert.strictEqual(spawns, 0, "prompt miss never spawns");
+    assert.ok(!("source_pid" in body));
+    assert.ok(!("agent_pid" in body));
+    assert.strictEqual(pidCache.readPidCacheV2(NS, sid, CWD), null, "a prompt miss must never write a v2");
+  });
+
+  it("UserPromptSubmit MISS with a dead cached PID: still zero spawn (no fallback)", () => {
+    const sid = freshSid();
+    pidCache.writePidCacheV2(NS, sid, CWD, { stablePid: DEAD_PID, agentPid: process.pid, agentCommandLine: "x", detectedEditor: "code" });
+    const { body, spawns } = run("UserPromptSubmit", { session_id: sid, cwd: CWD });
+    assert.strictEqual(spawns, 0);
+    assert.ok(!("source_pid" in body), "never ship the dead cached pid, never degrade to process.ppid");
+  });
+
+  it("SessionEnd HIT: zero spawn, fills the final body, drops the cache", () => {
+    const sid = freshSid();
+    pidCache.writePidCacheV2(NS, sid, CWD, liveSubset());
+    const { body, spawns } = run("SessionEnd", { session_id: sid, cwd: CWD });
+    assert.strictEqual(spawns, 0);
+    assert.strictEqual(body.source_pid, process.pid);
+    assert.strictEqual(pidCache.readPidCacheV2(NS, sid, CWD), null, "SessionEnd dropped the cache");
+  });
+
+  it("SessionEnd MISS: zero spawn, no pid fields, never writes (reversed #630 fallback)", () => {
+    const sid = freshSid();
+    const { body, spawns } = run("SessionEnd", { session_id: sid, cwd: CWD });
+    assert.strictEqual(spawns, 0, "SessionEnd miss must never spawn");
+    assert.ok(!("source_pid" in body));
+    assert.strictEqual(pidCache.readPidCacheV2(NS, sid, CWD), null);
+  });
+
+  it("Windows prompt/end with session_id 'default' (non-cacheable) still zero spawn", () => {
+    const p = run("UserPromptSubmit", { session_id: "default", cwd: CWD });
+    assert.strictEqual(p.spawns, 0);
+    assert.ok(!("source_pid" in p.body));
+    const e = run("SessionEnd", { session_id: "default", cwd: CWD });
+    assert.strictEqual(e.spawns, 0);
+  });
+
+  it("Windows prompt/end with an empty cwd (non-cacheable) still zero spawn", () => {
+    const p = run("UserPromptSubmit", { session_id: freshSid(), cwd: "" });
+    assert.strictEqual(p.spawns, 0);
+    const e = run("SessionEnd", { session_id: freshSid(), cwd: "" });
+    assert.strictEqual(e.spawns, 0);
+  });
+
+  it("Stop does NOT drop the cache (turn completion is not SessionEnd)", () => {
+    const sid = freshSid();
+    pidCache.writePidCacheV2(NS, sid, CWD, liveSubset());
+    const { spawns } = run("Stop", { session_id: sid, cwd: CWD });
+    assert.strictEqual(spawns, 0, "Stop hits the cache, no spawn");
+    assert.ok(pidCache.readPidCacheV2(NS, sid, CWD), "Stop must NOT drop the cache");
+  });
+
+  it("ordinary event MISS falls back to one fresh resolve and repopulates", () => {
+    const sid = freshSid();
+    const { body, spawns } = run("PreToolUse", { session_id: sid, cwd: CWD });
+    assert.strictEqual(spawns, 1, "an ordinary event miss resolves fresh once");
+    assert.strictEqual(body.source_pid, 600);
+    assert.deepStrictEqual(body.pid_chain, [PPID, 600], "the fresh path ships pid_chain");
+    assert.ok(pidCache.readPidCacheV2(NS, sid, CWD), "event miss repopulated the cache");
+  });
+
+  it("agentCommandLine / headless are preserved on the fresh path", () => {
+    const sid = freshSid();
+    const { body } = run("PreToolUse", { session_id: sid, cwd: CWD });
+    assert.strictEqual(body.headless, true, "the --print cmdline sets headless");
+    assert.strictEqual(body.agent_pid, PPID);
+  });
+
+  it("tmux_socket is recomputed from the environment on a cache hit", () => {
+    const sid = freshSid();
+    pidCache.writePidCacheV2(NS, sid, CWD, liveSubset());
+    const saved = process.env.TMUX;
+    process.env.TMUX = "/tmp/tmux-1000/win,200,5";
+    try {
+      const { body } = run("PreToolUse", { session_id: sid, cwd: CWD });
+      assert.strictEqual(body.tmux_socket, "/tmp/tmux-1000/win");
+    } finally {
+      if (saved === undefined) delete process.env.TMUX; else process.env.TMUX = saved;
+    }
+  });
+
+  it("remote mode never resolves a local PID (bypass before the resolver)", () => {
+    const hadRemote = process.env.CLAWD_REMOTE;
+    process.env.CLAWD_REMOTE = "1";
+    env.state.spawns = 0;
+    try {
+      const resolve = env.makeResolve();
+      const body = env.buildStateBody("UserPromptSubmit", { session_id: freshSid(), cwd: CWD }, resolve);
+      assert.strictEqual(env.state.spawns, 0, "remote must not spawn");
+      assert.ok(!("source_pid" in body));
+      assert.strictEqual(typeof body.host, "string");
+    } finally {
+      if (hadRemote === undefined) delete process.env.CLAWD_REMOTE;
+      else process.env.CLAWD_REMOTE = hadRemote;
+    }
+  });
+});
+
+describe("clawd-hook end-to-end with the real resolver — non-Windows", () => {
+  let env;
+  before(() => { env = loadRealResolver({ platform: "linux" }); });
+  after(() => env.restore());
+
+  it("UserPromptSubmit and SessionEnd still resolve fresh (no-fallback is Windows-only)", () => {
+    env.state.spawns = 0;
+    const r1 = env.makeResolve();
+    env.buildStateBody("UserPromptSubmit", { session_id: freshSid(), cwd: CWD }, r1);
+    const afterPrompt = env.state.spawns;
+    const r2 = env.makeResolve();
+    env.buildStateBody("SessionEnd", { session_id: freshSid(), cwd: CWD }, r2);
+    assert.ok(afterPrompt >= 1, "non-Windows prompt resolves fresh");
+    assert.ok(env.state.spawns > afterPrompt, "non-Windows SessionEnd resolves fresh too");
+  });
+
+  it("never creates a v2 cache file on non-Windows", () => {
+    const sid = freshSid();
+    const resolve = env.makeResolve();
+    env.buildStateBody("PreToolUse", { session_id: sid, cwd: CWD }, resolve);
+    assert.strictEqual(pidCache.readPidCacheV2(NS, sid, CWD), null, "non-Windows must not disk-cache");
   });
 });

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -236,32 +236,30 @@ describe("buildStateBody", () => {
     assert.ok(!("pid_chain" in body));
   });
 
-  it("includes foreground WT HWND only on foreground-safe events", () => {
-    const resolveWithWtHwnd = () => ({
+  it("applies the foreground WT HWND only on foreground-safe events, and only when the resolver surfaces one", () => {
+    // #634: buildStateBody is now the Claude adapter — the shared resolver
+    // decides whether a foreground WT handle exists (only a fresh SessionStart
+    // snapshot carries one; a prompt is cache-only and never does, the server
+    // samples it), and buildStateBody applies it only on a foreground-safe
+    // event. The fake models the resolver contract: null foregroundWtHwnd for
+    // the prompt lifecycle. This is now platform-independent — the resolver
+    // owns the Windows/non-Windows behavior; deterministic both-platform
+    // coverage lives in test/clawd-hook-pid-cache.test.js (forced reloads).
+    const resolveByLifecycle = (ctx) => ({
       stablePid: 1,
       agentPid: null,
       detectedEditor: null,
       pidChain: [],
-      foregroundWtHwnd: "123456",
+      foregroundWtHwnd: ctx && ctx.lifecycle === "prompt" ? null : "123456",
     });
 
-    const startBody = buildStateBody("SessionStart", { session_id: "s" }, resolveWithWtHwnd);
-    const promptBody = buildStateBody("UserPromptSubmit", { session_id: "s" }, resolveWithWtHwnd);
-    const stopBody = buildStateBody("Stop", { session_id: "s" }, resolveWithWtHwnd);
+    const startBody = buildStateBody("SessionStart", { session_id: "s" }, resolveByLifecycle);
+    const promptBody = buildStateBody("UserPromptSubmit", { session_id: "s" }, resolveByLifecycle);
+    const stopBody = buildStateBody("Stop", { session_id: "s" }, resolveByLifecycle);
 
-    assert.strictEqual(startBody.wt_hwnd, "123456");
-    // This file loads clawd-hook natively (host platform). On Windows,
-    // UserPromptSubmit is cache-only/no-fallback (#627 residual) — it never
-    // resolves, so the hook no longer reports wt_hwnd (the server samples it
-    // instead, src/server-route-state.js). Off Windows the prompt still
-    // resolves fresh and reports it. Deterministic both-platform coverage
-    // lives in test/clawd-hook-pid-cache.test.js (platform-forced reloads).
-    if (process.platform === "win32") {
-      assert.ok(!("wt_hwnd" in promptBody), "Windows prompt is zero-spawn; wt_hwnd is the server's job now");
-    } else {
-      assert.strictEqual(promptBody.wt_hwnd, "123456");
-    }
-    assert.ok(!("wt_hwnd" in stopBody));
+    assert.strictEqual(startBody.wt_hwnd, "123456", "SessionStart (start) surfaces the fresh handle");
+    assert.ok(!("wt_hwnd" in promptBody), "prompt is cache-only; the hook never reports wt_hwnd (server samples it)");
+    assert.ok(!("wt_hwnd" in stopBody), "Stop is not a foreground-safe event even when a handle is present");
   });
 
   describe("agentPid and headless detection", () => {

--- a/test/pid-cache.test.js
+++ b/test/pid-cache.test.js
@@ -1,11 +1,26 @@
 // test/pid-cache.test.js — Unit tests for hooks/pid-cache.js
-// (#627; lease rewrite #627-residual §4.4)
-const { describe, it, afterEach } = require("node:test");
+// (#627; lease rewrite #627-residual §4.4; v2 #634)
+const { describe, it, before, after, afterEach } = require("node:test");
 const assert = require("node:assert");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
 
 const pc = require("../hooks/pid-cache");
+
+// Isolate the cache directory for this whole file (#634): the sweep and its
+// fake-liveness tests would otherwise scan the shared os.tmpdir() — interfering
+// with concurrently-running test PROCESSES and deleting a developer's real >24h
+// caches. With an isolated dir, each sweep only ever sees this file's own files.
+let ISO_DIR;
+before(() => {
+  ISO_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "pidcache-test-iso-"));
+  pc.__setCacheDirForTests(ISO_DIR);
+});
+after(() => {
+  pc.__setCacheDirForTests(null);
+  try { fs.rmSync(ISO_DIR, { recursive: true, force: true }); } catch {}
+});
 
 const CWD = "/repo/pidcache-under-test";
 let seq = 0;
@@ -118,6 +133,41 @@ describe("pid-cache read/write/drop", () => {
     assert.strictEqual(pc.readPidCache(sid, CWD), null, "agentPid 0 → null");
     fs.writeFileSync(file, JSON.stringify({ stablePid: 1234, agentPid: -5, cwd: CWD, ts: Date.now() }));
     assert.strictEqual(pc.readPidCache(sid, CWD), null, "negative agentPid → null");
+  });
+});
+
+describe("pid-cache readPidCacheEntry — single-observation subset + identity (#634 §5.5)", () => {
+  it("returns a subset and identity read from the SAME bytes", () => {
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, SUBSET);
+    const entry = pc.readPidCacheEntry(sid, CWD);
+    assert.ok(entry);
+    // The whole point: the parsed subset and the delete-guard identity are the
+    // same observation, so identity.raw must parse back to the subset exactly.
+    assert.deepStrictEqual(JSON.parse(entry.identity.raw), entry.subset);
+    assert.strictEqual(entry.subset.stablePid, 1234);
+    assert.strictEqual(entry.subset.agentPid, 5678);
+    assert.strictEqual(entry.identity.size, Buffer.byteLength(entry.identity.raw));
+    assert.strictEqual(typeof entry.identity.mtimeMs, "number");
+  });
+
+  it("returns null when caching is disabled / file missing / shape invalid", () => {
+    assert.strictEqual(pc.readPidCacheEntry("default", CWD), null, "caching disabled");
+    assert.strictEqual(pc.readPidCacheEntry(freshSid(), CWD), null, "missing file");
+    const sid = freshSid();
+    const file = pc.cacheFilePath(sid, CWD);
+    fs.writeFileSync(file, "{ not json");
+    assert.strictEqual(pc.readPidCacheEntry(sid, CWD), null, "corrupt file");
+    fs.writeFileSync(file, JSON.stringify({ stablePid: 1, cwd: CWD, ts: Date.now() }));
+    assert.strictEqual(pc.readPidCacheEntry(sid, CWD), null, "missing agentPid → shape invalid");
+    fs.writeFileSync(file, JSON.stringify({ ...SUBSET, cwd: "/other", ts: Date.now() }));
+    assert.strictEqual(pc.readPidCacheEntry(sid, CWD), null, "cwd mismatch");
+  });
+
+  it("readPidCache and readPidCacheEntry agree on the same file", () => {
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, SUBSET);
+    assert.deepStrictEqual(pc.readPidCacheEntry(sid, CWD).subset, pc.readPidCache(sid, CWD));
   });
 });
 
@@ -292,7 +342,7 @@ describe("pid-cache sweepStalePidCaches() — age floor + injected liveness (§4
   });
 
   it("ignores files outside our prefix", () => {
-    const dir = require("os").tmpdir();
+    const dir = ISO_DIR; // the sweep/cache scan this isolated dir, not the real temp dir
     const foreignFile = path.join(dir, `not-clawd-${process.pid}-${seq++}.json`);
     fs.writeFileSync(foreignFile, "{}");
     const old = new Date(Date.now() - (pc.SWEEP_AGE_MS + 60_000));
@@ -334,5 +384,233 @@ describe("pid-cache module boundary (#627 residual §4.4)", () => {
       !loadedChildren.includes(sharedProcessKey),
       "pid-cache.js's module.children must not include shared-process.js"
     );
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Cache v2 (#634): namespaced, versioned, non-overlapping prefix.
+// ═══════════════════════════════════════════════════════════════════════════
+
+const NS = "claude-code";
+const usedV2 = [];
+function freshSidV2() {
+  const sid = `pidcache2-test-${process.pid}-${seq++}`;
+  usedV2.push(sid);
+  return sid;
+}
+afterEach(() => {
+  for (const sid of usedV2.splice(0)) pc.dropPidCacheV2(NS, sid, CWD);
+});
+
+const SUBSET_V2 = {
+  stablePid: 4321,
+  agentPid: 8765,
+  agentCommandLine: "claude --print",
+  detectedEditor: "code",
+};
+
+describe("pid-cache v2 — path + key (§5.2)", () => {
+  it("v1 and v2 prefixes are mutually exclusive under startsWith (clean sweep classification)", () => {
+    assert.strictEqual(pc.CACHE_PREFIX_V2.startsWith(pc.CACHE_PREFIX), false);
+    assert.strictEqual(pc.CACHE_PREFIX.startsWith(pc.CACHE_PREFIX_V2), false);
+    assert.strictEqual(pc.CACHE_PREFIX_V2, "clawd-pidcache2-");
+    assert.strictEqual(pc.CACHE_VERSION_V2, 2);
+  });
+
+  it("cacheFilePathV2 returns null when any identity ingredient is empty", () => {
+    assert.strictEqual(pc.cacheFilePathV2("", "sid", CWD), null);
+    assert.strictEqual(pc.cacheFilePathV2(NS, "", CWD), null);
+    assert.strictEqual(pc.cacheFilePathV2(NS, "sid", ""), null);
+  });
+
+  it("v2 path uses the clawd-pidcache2- prefix and is stable per (namespace, sid, cwd)", () => {
+    const a = pc.cacheFilePathV2(NS, "sid-A", CWD);
+    const a2 = pc.cacheFilePathV2(NS, "sid-A", CWD);
+    assert.strictEqual(a, a2);
+    assert.ok(path.basename(a).startsWith(pc.CACHE_PREFIX_V2));
+  });
+
+  it("the key varies with version+namespace+sessionId+cacheCwd (NUL-separated, no cross-field collision)", () => {
+    // namespace is in the key: two agents that share a sid+cwd never collide.
+    assert.notStrictEqual(pc.cacheFilePathV2("gemini", "sid", CWD), pc.cacheFilePathV2("qoder", "sid", CWD));
+    // sessionId and cacheCwd both participate.
+    assert.notStrictEqual(pc.cacheFilePathV2(NS, "sid-A", CWD), pc.cacheFilePathV2(NS, "sid-B", CWD));
+    assert.notStrictEqual(pc.cacheFilePathV2(NS, "sid", "/a"), pc.cacheFilePathV2(NS, "sid", "/b"));
+    // NUL separators mean "a"+"bc" and "ab"+"c" cannot alias.
+    assert.notStrictEqual(pc.cacheFilePathV2(NS, "a", "bc"), pc.cacheFilePathV2(NS, "ab", "c"));
+    // v1 and v2 of the same (sid, cwd) never share a file.
+    assert.notStrictEqual(pc.cacheFilePath("sid", CWD), pc.cacheFilePathV2(NS, "sid", CWD));
+  });
+});
+
+describe("pid-cache v2 — read/write/shape", () => {
+  it("round-trips the v2 shape: version + namespace + cwd + ts, and NO pidChain/foregroundWtHwnd/tmuxClient", () => {
+    const sid = freshSidV2();
+    assert.strictEqual(pc.writePidCacheV2(NS, sid, CWD, SUBSET_V2), true);
+    const got = pc.readPidCacheV2(NS, sid, CWD);
+    assert.ok(got);
+    assert.strictEqual(got.version, 2);
+    assert.strictEqual(got.namespace, NS);
+    assert.strictEqual(got.cwd, CWD);
+    assert.strictEqual(got.stablePid, 4321);
+    assert.strictEqual(got.agentPid, 8765);
+    assert.strictEqual(got.agentCommandLine, "claude --print");
+    assert.strictEqual(got.detectedEditor, "code");
+    assert.strictEqual(typeof got.ts, "number");
+    // Only the stable subset is cached — the volatile fields never touch disk.
+    assert.ok(!("pidChain" in got), "pidChain must never be cached");
+    assert.ok(!("foregroundWtHwnd" in got), "foregroundWtHwnd must never be cached");
+    assert.ok(!("tmuxClient" in got), "tmuxClient must never be cached");
+  });
+
+  it("different namespaces never read each other's cache (even at the same sid+cwd)", () => {
+    const sid = freshSidV2();
+    pc.writePidCacheV2(NS, sid, CWD, SUBSET_V2);
+    assert.ok(pc.readPidCacheV2(NS, sid, CWD), "own namespace hits");
+    assert.strictEqual(pc.readPidCacheV2("gemini", sid, CWD), null, "another namespace must miss");
+    pc.dropPidCacheV2("gemini", sid, CWD); // no-op cleanup
+  });
+
+  it("readPidCacheV2 rejects version / namespace / cwd mismatch and non-positive pids", () => {
+    const sid = freshSidV2();
+    const file = pc.cacheFilePathV2(NS, sid, CWD);
+    const base = { namespace: NS, cwd: CWD, stablePid: 1, agentPid: 2, ts: Date.now() };
+    fs.writeFileSync(file, JSON.stringify({ ...base, version: 1 }));
+    assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "wrong version → null");
+    fs.writeFileSync(file, JSON.stringify({ ...base, version: 2, namespace: "gemini" }));
+    assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "stored namespace mismatch → null");
+    fs.writeFileSync(file, JSON.stringify({ ...base, version: 2, cwd: "/other" }));
+    assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "cwd mismatch → null");
+    fs.writeFileSync(file, JSON.stringify({ ...base, version: 2, agentPid: 0 }));
+    assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "non-positive agentPid → null");
+    fs.writeFileSync(file, JSON.stringify({ ...base, version: 2, stablePid: -1 }));
+    assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "negative stablePid → null");
+    fs.writeFileSync(file, JSON.stringify({ ...base, version: 2, ts: "not-a-number" }));
+    assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "non-number ts → null (mirrors v1 shape guard)");
+  });
+
+  it("v2 read consults NO clock (ancient mtime + ts is still a hit)", () => {
+    const sid = freshSidV2();
+    const file = pc.cacheFilePathV2(NS, sid, CWD);
+    fs.writeFileSync(file, JSON.stringify({ version: 2, namespace: NS, cwd: CWD, stablePid: 1, agentPid: 2, ts: Date.now() - 365 * 24 * 60 * 60 * 1000 }));
+    const ancient = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000);
+    fs.utimesSync(file, ancient, ancient);
+    assert.ok(pc.readPidCacheV2(NS, sid, CWD), "age must never expire a v2 read under the lease model");
+  });
+
+  it("touch/drop v2 behave like v1 (touch bumps mtime, never creates; drop removes)", () => {
+    const sid = freshSidV2();
+    const file = pc.cacheFilePathV2(NS, sid, CWD);
+    assert.doesNotThrow(() => pc.touchPidCacheV2(NS, sid, CWD)); // missing file: no-op, no create
+    assert.strictEqual(fs.existsSync(file), false);
+    pc.writePidCacheV2(NS, sid, CWD, SUBSET_V2);
+    const old = new Date(Date.now() - 10_000);
+    fs.utimesSync(file, old, old);
+    const aged = fs.statSync(file).mtimeMs;
+    pc.touchPidCacheV2(NS, sid, CWD);
+    assert.ok(fs.statSync(file).mtimeMs > aged, "touch bumps mtime");
+    pc.dropPidCacheV2(NS, sid, CWD);
+    assert.strictEqual(fs.existsSync(file), false);
+  });
+});
+
+describe("pid-cache v2 — writePidCacheV2IfAbsent (no-clobber promotion, §5.5/§6.10)", () => {
+  it("returns 'created' and writes the file when absent", () => {
+    const sid = freshSidV2();
+    assert.strictEqual(pc.writePidCacheV2IfAbsent(NS, sid, CWD, SUBSET_V2), "created");
+    assert.ok(pc.readPidCacheV2(NS, sid, CWD));
+  });
+
+  it("returns 'exists' and NEVER overwrites an already-present file", () => {
+    const sid = freshSidV2();
+    pc.writePidCacheV2(NS, sid, CWD, SUBSET_V2); // pre-existing (the 'fresh' one)
+    const result = pc.writePidCacheV2IfAbsent(NS, sid, CWD, {
+      stablePid: 111, agentPid: 222, agentCommandLine: "STALE", detectedEditor: "vim",
+    });
+    assert.strictEqual(result, "exists", "must report the file already exists");
+    const got = pc.readPidCacheV2(NS, sid, CWD);
+    assert.strictEqual(got.agentCommandLine, "claude --print", "the pre-existing file must NOT be overwritten");
+    assert.strictEqual(got.agentPid, 8765);
+  });
+
+  it("returns false (no throw) when caching is disabled", () => {
+    assert.strictEqual(pc.writePidCacheV2IfAbsent(NS, "sid", "", SUBSET_V2), false);
+    assert.strictEqual(pc.writePidCacheV2IfAbsent("", "sid", CWD, SUBSET_V2), false);
+  });
+
+  it("leaves no leftover temp files after a successful create", () => {
+    const sid = freshSidV2();
+    pc.writePidCacheV2IfAbsent(NS, sid, CWD, SUBSET_V2);
+    const dir = ISO_DIR; // the sweep/cache scan this isolated dir, not the real temp dir
+    const leftovers = fs.readdirSync(dir).filter((n) => n.includes(".nc.tmp"));
+    assert.deepStrictEqual(leftovers, [], "the sibling temp must be unlinked after linking");
+  });
+});
+
+describe("pid-cache sweep — dual prefix v1 + v2 (§5.4)", () => {
+  function neverAlive() { return false; }
+  function alwaysAlive() { return true; }
+
+  it("sweeps an old dead v2 file", () => {
+    const sid = freshSidV2();
+    const file = pc.cacheFilePathV2(NS, sid, CWD);
+    pc.writePidCacheV2(NS, sid, CWD, SUBSET_V2);
+    const old = new Date(Date.now() - (pc.SWEEP_AGE_MS + 60_000));
+    fs.utimesSync(file, old, old);
+    pc.sweepStalePidCaches({ isProcessAlive: neverAlive });
+    assert.strictEqual(fs.existsSync(file), false, "old + dead v2 must be swept");
+  });
+
+  it("keeps an old but alive v2 file (age alone never deletes)", () => {
+    const sid = freshSidV2();
+    const file = pc.cacheFilePathV2(NS, sid, CWD);
+    pc.writePidCacheV2(NS, sid, CWD, SUBSET_V2);
+    const old = new Date(Date.now() - (pc.SWEEP_AGE_MS + 60_000));
+    fs.utimesSync(file, old, old);
+    pc.sweepStalePidCaches({ isProcessAlive: alwaysAlive });
+    assert.strictEqual(fs.existsSync(file), true, "old-but-alive v2 must survive");
+  });
+
+  it("classifies v1 and v2 independently in one pass (both dead → both swept)", () => {
+    const sid1 = freshSid(); // v1 uses the v1 cleanup list
+    const sid2 = freshSidV2();
+    const v1File = pc.cacheFilePath(sid1, CWD);
+    const v2File = pc.cacheFilePathV2(NS, sid2, CWD);
+    pc.writePidCache(sid1, CWD, SUBSET);
+    pc.writePidCacheV2(NS, sid2, CWD, SUBSET_V2);
+    const old = new Date(Date.now() - (pc.SWEEP_AGE_MS + 60_000));
+    fs.utimesSync(v1File, old, old);
+    fs.utimesSync(v2File, old, old);
+    pc.sweepStalePidCaches({ isProcessAlive: neverAlive });
+    assert.strictEqual(fs.existsSync(v1File), false, "dead v1 swept");
+    assert.strictEqual(fs.existsSync(v2File), false, "dead v2 swept");
+  });
+
+  it("a v2-prefixed file missing version:2 is corrupt → swept when old, even if PIDs report alive", () => {
+    const sid = freshSidV2();
+    const file = pc.cacheFilePathV2(NS, sid, CWD);
+    // shape looks alive but lacks the v2 version tag → corrupt for a v2 file.
+    fs.writeFileSync(file, JSON.stringify({ namespace: NS, cwd: CWD, stablePid: 1, agentPid: 2, ts: Date.now() }));
+    const old = new Date(Date.now() - (pc.SWEEP_AGE_MS + 60_000));
+    fs.utimesSync(file, old, old);
+    pc.sweepStalePidCaches({ isProcessAlive: alwaysAlive });
+    assert.strictEqual(fs.existsSync(file), false, "a v2 file without version:2 is treated as dead");
+  });
+
+  it("a v2 file with a malformed namespace/cwd/ts is corrupt → swept when old (full v2 shape)", () => {
+    const old = new Date(Date.now() - (pc.SWEEP_AGE_MS + 60_000));
+    for (const bad of [
+      { version: 2, cwd: CWD, stablePid: 1, agentPid: 2, ts: Date.now() },              // missing namespace
+      { version: 2, namespace: NS, stablePid: 1, agentPid: 2, ts: Date.now() },          // missing cwd
+      { version: 2, namespace: NS, cwd: CWD, stablePid: 1, agentPid: 2 },                // missing ts
+      { version: 2, namespace: "", cwd: CWD, stablePid: 1, agentPid: 2, ts: Date.now() },// empty namespace
+    ]) {
+      const sid = freshSidV2();
+      const file = pc.cacheFilePathV2(NS, sid, CWD);
+      fs.writeFileSync(file, JSON.stringify(bad));
+      fs.utimesSync(file, old, old);
+      pc.sweepStalePidCaches({ isProcessAlive: alwaysAlive });
+      assert.strictEqual(fs.existsSync(file), false, `malformed v2 shape must be swept: ${JSON.stringify(bad)}`);
+    }
   });
 });

--- a/test/pid-resolver-context.test.js
+++ b/test/pid-resolver-context.test.js
@@ -1,0 +1,685 @@
+// test/pid-resolver-context.test.js — PR2 (#634) shared resolver lifecycle
+// context + v1→v2 promotion + the Slice 1 no-arg compatibility red line.
+//
+// The resolver's fresh path re-requires child_process at call time, so
+// loadSharedProcessWithMock injects a counting execFileSync (spawn counter) and
+// forces process.platform. The cache side uses the REAL pid-cache with real temp
+// files (like clawd-hook-pid-cache.test.js), and node:test's t.mock.method spies
+// on the pid-cache module object to assert call counts / inject failures.
+const { describe, it, before, after, afterEach } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { loadSharedProcessWithMock } = require("./helpers/load-shared-process-with-mock");
+const pc = require("../hooks/pid-cache");
+
+// Isolate the cache directory (#634): startLifecycle triggers a real sweep, and
+// without isolation it would scan the shared os.tmpdir() — deleting other test
+// processes' fixtures and a developer's real >24h caches. The resolver reaches
+// pid-cache through the SAME module object, so this override covers it too.
+let ISO_DIR;
+before(() => {
+  ISO_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "resolver-test-iso-"));
+  pc.__setCacheDirForTests(ISO_DIR);
+});
+after(() => {
+  pc.__setCacheDirForTests(null);
+  try { fs.rmSync(ISO_DIR, { recursive: true, force: true }); } catch {}
+});
+
+const NS = "claude-code";
+const CWD = "/repo/resolver-under-test";
+const DEAD_PID = 2147483646;
+const AGENT_OPTS = {
+  agentNames: { win: new Set(["claude.exe"]), mac: new Set(["claude"]) },
+  agentCmdlineCheck: (c) => c.includes("claude-code"),
+};
+
+let seq = 0;
+const usedV1 = [];
+const usedV2 = [];
+function freshSid() { const s = `res-${process.pid}-${seq++}`; usedV1.push(s); usedV2.push(s); return s; }
+afterEach(() => {
+  for (const s of usedV1.splice(0)) pc.dropPidCache(s, CWD);
+  for (const s of usedV2.splice(0)) pc.dropPidCacheV2(NS, s, CWD);
+});
+
+function snapshotJson(procs) {
+  return JSON.stringify(procs.map((p) => ({
+    ProcessId: p.pid, Name: p.name, ParentProcessId: p.ppid,
+    CommandLine: typeof p.cmd === "string" ? p.cmd : null,
+  })));
+}
+// A live agent tree: node.exe (this process → alive) under windowsterminal.exe.
+// agentPid resolves to process.pid, so `start`/`event` meet the write condition.
+function liveProcs() {
+  return [
+    { pid: process.pid, name: "node.exe", ppid: 600, cmd: "node C:/x/claude-code/cli.js" },
+    { pid: 600, name: "windowsterminal.exe", ppid: 0 },
+  ];
+}
+// A cached subset whose BOTH pids are this (alive) process, so the resolver's
+// double-liveness check treats it as a hit.
+function liveSubset(extra = {}) {
+  return { stablePid: process.pid, agentPid: process.pid, agentCommandLine: "claude --print", detectedEditor: "code", ...extra };
+}
+
+// Build a resolver over a mock-loaded shared-process. `snapshot` is returned by
+// every execFileSync (the Windows snapshot); `spawns()` counts calls.
+function mkResolver({ platform = "win32", procs, startPid, snapshot } = {}) {
+  let spawns = 0;
+  const out = snapshot !== undefined ? snapshot : snapshotJson(procs || liveProcs());
+  const { mod, cleanup } = loadSharedProcessWithMock({
+    execFileSyncMock: () => { spawns++; return out; },
+    platform,
+  });
+  const cfg = mod.getPlatformConfig();
+  const resolve = mod.createPidResolver({ platformConfig: cfg, startPid: startPid || process.pid, ...AGENT_OPTS });
+  return { mod, resolve, cleanup, spawns: () => spawns };
+}
+
+function ctx(sessionId, lifecycle, cacheable = true, extra = {}) {
+  return { namespace: NS, sessionId, cacheCwd: CWD, lifecycle, cacheable, ...extra };
+}
+
+const NO_ARG_FIELDS = [
+  "agentCommandLine", "agentPid", "detectedEditor", "foregroundWtHwnd", "pidChain",
+  "snapshotOk", "stablePid", "terminalPid", "tmuxClient", "tmuxSocket",
+].sort();
+
+const ALL_CACHE_METHODS = [
+  "readPidCache", "writePidCache", "touchPidCache", "dropPidCache",
+  "readPidCacheV2", "writePidCacheV2", "writePidCacheV2IfAbsent", "touchPidCacheV2", "dropPidCacheV2",
+  "sweepStalePidCaches", "cacheFilePath", "cacheFilePathV2",
+];
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Slice 1 no-arg compatibility red line (§5.1)
+// ═══════════════════════════════════════════════════════════════════════════
+describe("resolver no-arg compatibility (§5.1 red line)", () => {
+  it("first + second no-arg call: identical full object, same ref, exactly one snapshot", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    try {
+      const r1 = resolve();
+      const r2 = resolve();
+      assert.strictEqual(spawns(), 1, "no-arg: exactly one snapshot across two calls");
+      assert.strictEqual(r1, r2, "no-arg: subsequent call returns the SAME cached object");
+      assert.deepStrictEqual(Object.keys(r1).sort(), NO_ARG_FIELDS, "exact 5c2b1f0 field set");
+      assert.ok(!("cacheSource" in r1), "no-arg result must NOT carry the context-only cacheSource field");
+      assert.strictEqual(r1.agentPid, process.pid);
+      assert.strictEqual(r1.stablePid, 600);
+    } finally { cleanup(); }
+  });
+
+  it("no-arg path performs ZERO cache read/write/touch/drop/promotion/sweep", (t) => {
+    const { resolve, cleanup } = mkResolver();
+    const spies = ALL_CACHE_METHODS.map((m) => [m, t.mock.method(pc, m)]);
+    try {
+      resolve();
+      resolve();
+      for (const [name, spy] of spies) {
+        assert.strictEqual(spy.mock.calls.length, 0, `no-arg path must never call pidCache.${name}`);
+      }
+    } finally { cleanup(); }
+  });
+
+  it("no-arg path produces no clawd-pidcache2-* file (never calls a v2 write)", (t) => {
+    // Asserted via the write mechanism rather than a global tmpdir scan: the
+    // temp dir is shared with concurrently-running tests that legitimately
+    // create v2 files, so a before/after directory diff is racy. Zero calls to
+    // either v2 write path deterministically means no clawd-pidcache2-* file can
+    // be produced from here.
+    const { resolve, cleanup } = mkResolver();
+    const wrote = t.mock.method(pc, "writePidCacheV2");
+    const wroteNoClobber = t.mock.method(pc, "writePidCacheV2IfAbsent");
+    try {
+      resolve();
+      resolve();
+      assert.strictEqual(wrote.mock.calls.length, 0, "no-arg must never write a v2 file");
+      assert.strictEqual(wroteNoClobber.mock.calls.length, 0, "no-arg must never no-clobber-write a v2 file");
+    } finally { cleanup(); }
+  });
+
+  it("an unmigrated adapter (Gemini-shaped resolver) is unaffected: same fields + spawn count, zero cache files", (t) => {
+    // Slice 1 migrates only Claude. Any other adapter keeps calling resolve()
+    // no-arg; its behavior must be byte-for-byte with 5c2b1f0.
+    let spawns = 0;
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: () => { spawns++; return snapshotJson([
+        { pid: process.pid, name: "node.exe", ppid: 700, cmd: "node C:/x/gemini/cli.js" },
+        { pid: 700, name: "windowsterminal.exe", ppid: 0 },
+      ]); },
+      platform: "win32",
+    });
+    const spies = ALL_CACHE_METHODS.map((m) => t.mock.method(pc, m));
+    try {
+      const cfg = mod.getPlatformConfig();
+      const resolve = mod.createPidResolver({
+        platformConfig: cfg, startPid: process.pid,
+        agentNames: { win: new Set(["node.exe"]), mac: new Set(["node"]) },
+        agentCmdlineCheck: (c) => c.includes("gemini"),
+      });
+      const r1 = resolve();
+      const r2 = resolve();
+      assert.strictEqual(spawns, 1);
+      assert.strictEqual(r1, r2);
+      assert.deepStrictEqual(Object.keys(r1).sort(), NO_ARG_FIELDS);
+      for (const spy of spies) assert.strictEqual(spy.mock.calls.length, 0, "unmigrated adapter must not touch pid-cache");
+    } finally { cleanup(); }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Lifecycle matrix (Windows) (§5.1)
+// ═══════════════════════════════════════════════════════════════════════════
+describe("resolver lifecycle — start", () => {
+  it("reuses a no-arg prewarm: the start context does NOT spawn a second time", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    try {
+      resolve();                          // prewarm (no-arg)
+      assert.strictEqual(spawns(), 1);
+      const meta = resolve(ctx(sid, "start"));
+      assert.strictEqual(spawns(), 1, "start must reuse the prewarmed snapshot, not spawn again");
+      assert.strictEqual(meta.cacheSource, "fresh");
+      assert.ok(pc.readPidCacheV2(NS, sid, CWD), "start wrote v2");
+    } finally { cleanup(); }
+  });
+
+  it("writes v2 only when snapshotOk && agentPid; a degraded snapshot writes nothing", () => {
+    // agentless tree: no claude-code cmd → agentPid null → no write.
+    const { resolve, cleanup } = mkResolver({ procs: [
+      { pid: process.pid, name: "node.exe", ppid: 600, cmd: "node other.js" },
+      { pid: 600, name: "windowsterminal.exe", ppid: 0 },
+    ]});
+    const sid = freshSid();
+    try {
+      const meta = resolve(ctx(sid, "start"));
+      assert.strictEqual(meta.agentPid, null);
+      assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "no agentPid → no v2 write");
+    } finally { cleanup(); }
+  });
+
+  it("triggers a low-frequency sweep (cacheable start only)", (t) => {
+    const { resolve, cleanup } = mkResolver();
+    const spy = t.mock.method(pc, "sweepStalePidCaches");
+    const sid = freshSid();
+    try {
+      resolve(ctx(sid, "start"));
+      assert.strictEqual(spy.mock.calls.length, 1, "cacheable start sweeps once");
+      resolve.call(null); // no-op to be safe
+    } finally { cleanup(); }
+  });
+
+  it("non-cacheable start still resolves fresh but writes nothing and does not sweep", (t) => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const spy = t.mock.method(pc, "sweepStalePidCaches");
+    try {
+      const meta = resolve(ctx("default", "start", false, { cacheCwd: "" }));
+      assert.strictEqual(meta.cacheSource, "fresh");
+      assert.strictEqual(spawns(), 1, "start may fresh");
+      assert.strictEqual(spy.mock.calls.length, 0, "non-cacheable start does not sweep");
+    } finally { cleanup(); }
+  });
+});
+
+describe("resolver lifecycle — prompt (cache-only, no fallback)", () => {
+  it("hit: zero spawn, stable subset, never fakes pidChain/foregroundWtHwnd/tmuxClient", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCacheV2(NS, sid, CWD, liveSubset());
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(spawns(), 0, "prompt hit must not spawn");
+      assert.strictEqual(meta.cacheSource, "v2");
+      assert.strictEqual(meta.stablePid, process.pid);
+      assert.deepStrictEqual(meta.pidChain, []);
+      assert.strictEqual(meta.foregroundWtHwnd, null);
+      assert.strictEqual(meta.tmuxClient, null);
+    } finally { cleanup(); }
+  });
+
+  it("miss / corrupt / dead-PID / cacheable=false: all zero spawn + empty metadata", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    try {
+      // plain miss
+      let m = resolve(ctx(freshSid(), "prompt"));
+      assert.strictEqual(m.cacheSource, "none");
+      assert.strictEqual(m.stablePid, null);
+      // corrupt file
+      const sidC = freshSid();
+      fs.writeFileSync(pc.cacheFilePathV2(NS, sidC, CWD), "{ not json");
+      m = resolve(ctx(sidC, "prompt"));
+      assert.strictEqual(m.cacheSource, "none");
+      // dead cached PID
+      const sidD = freshSid();
+      pc.writePidCacheV2(NS, sidD, CWD, { stablePid: DEAD_PID, agentPid: process.pid, agentCommandLine: "x", detectedEditor: "code" });
+      m = resolve(ctx(sidD, "prompt"));
+      assert.strictEqual(m.cacheSource, "none", "dead cached stablePid is not a hit");
+      // cacheable=false (default sid / empty cwd)
+      m = resolve(ctx("default", "prompt", false, { cacheCwd: "" }));
+      assert.strictEqual(m.cacheSource, "none");
+      assert.strictEqual(spawns(), 0, "NONE of the prompt paths may spawn");
+    } finally { cleanup(); }
+  });
+});
+
+describe("resolver lifecycle — event", () => {
+  it("hit: zero spawn", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCacheV2(NS, sid, CWD, liveSubset());
+    try {
+      const meta = resolve(ctx(sid, "event"));
+      assert.strictEqual(spawns(), 0, "event hit must not spawn");
+      assert.strictEqual(meta.cacheSource, "v2");
+    } finally { cleanup(); }
+  });
+
+  it("miss: at most one fresh, then repopulates v2", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    try {
+      const meta = resolve(ctx(sid, "event"));
+      assert.strictEqual(spawns(), 1, "event miss: exactly one fresh");
+      assert.strictEqual(meta.cacheSource, "fresh");
+      assert.ok(pc.readPidCacheV2(NS, sid, CWD), "event miss repopulated v2");
+    } finally { cleanup(); }
+  });
+
+  it("non-cacheable event may fresh (no-fallback is prompt/end only)", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    try {
+      const meta = resolve(ctx("default", "event", false, { cacheCwd: "" }));
+      assert.strictEqual(spawns(), 1, "non-cacheable event resolves fresh");
+      assert.strictEqual(meta.cacheSource, "fresh");
+    } finally { cleanup(); }
+  });
+});
+
+describe("resolver lifecycle — end (cache-only, drop, no write-back)", () => {
+  it("hit: zero spawn, fills body from cache, drops it, never writes back", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCacheV2(NS, sid, CWD, liveSubset());
+    try {
+      const meta = resolve(ctx(sid, "end"));
+      assert.strictEqual(spawns(), 0, "end hit must not spawn");
+      assert.strictEqual(meta.stablePid, process.pid, "end used the cache for the final body");
+      assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "end dropped v2");
+    } finally { cleanup(); }
+  });
+
+  it("miss: zero spawn, empty metadata, still drops (idempotent), never writes", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    try {
+      const meta = resolve(ctx(sid, "end"));
+      assert.strictEqual(spawns(), 0, "end miss must not spawn");
+      assert.strictEqual(meta.cacheSource, "none");
+      assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "end miss never wrote a v2");
+    } finally { cleanup(); }
+  });
+});
+
+describe("resolver lifecycle — non-Windows keeps fresh runtime behavior", () => {
+  it("every lifecycle resolves fresh and touches no disk cache", (t) => {
+    // ps mock: ppid=1 stops the walk immediately; comm=bash.
+    let spawns = 0;
+    const { mod, cleanup } = loadSharedProcessWithMock({
+      execFileSyncMock: (cmd, args) => {
+        spawns++;
+        const key = `${cmd} ${(args || []).join(" ")}`;
+        if (key.includes("ppid=")) return "1\n";
+        return "bash\n";
+      },
+      platform: "linux",
+    });
+    const spies = ALL_CACHE_METHODS.map((m) => t.mock.method(pc, m));
+    try {
+      const cfg = mod.getPlatformConfig();
+      const resolve = mod.createPidResolver({ platformConfig: cfg, startPid: 4242, ...AGENT_OPTS });
+      for (const lifecycle of ["start", "prompt", "event", "end"]) {
+        const meta = resolve(ctx(freshSid(), lifecycle));
+        assert.strictEqual(meta.cacheSource, "fresh", `${lifecycle} is fresh on non-Windows`);
+      }
+      // One resolver instance reuses its in-process snapshot across calls (same
+      // as 5c2b1f0); each real hook event is a fresh process. What matters here:
+      // the ps walk ran and NO disk cache was consulted on any lifecycle.
+      assert.ok(spawns >= 1, "the fresh ps walk ran");
+      for (const spy of spies) assert.strictEqual(spy.mock.calls.length, 0, "non-Windows must not touch the disk cache");
+    } finally { cleanup(); }
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
+// v1 → v2 promotion (§5.5)
+// ═══════════════════════════════════════════════════════════════════════════
+describe("resolver v1→v2 promotion (Claude only)", () => {
+  it("normal promotion: zero spawn, writes v2, deletes the (unchanged) v1", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(spawns(), 0, "promotion is zero spawn");
+      assert.strictEqual(meta.cacheSource, "v1");
+      assert.strictEqual(meta.stablePid, process.pid);
+      assert.ok(pc.readPidCacheV2(NS, sid, CWD), "promotion wrote v2");
+      assert.strictEqual(pc.readPidCache(sid, CWD), null, "unchanged v1 deleted after a confirmed v2 write");
+    } finally { cleanup(); }
+  });
+
+  it("a v1 with a dead PID is not promoted and prompt falls through to empty", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, { stablePid: DEAD_PID, agentPid: process.pid, agentCommandLine: "claude", detectedEditor: "code" });
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(spawns(), 0);
+      assert.strictEqual(meta.cacheSource, "none", "dead v1 is not promoted");
+      assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "no v2 from a dead v1");
+      assert.ok(pc.readPidCache(sid, CWD), "dead v1 is left for the sweep, not deleted");
+    } finally { cleanup(); }
+  });
+
+  it("v2 write FAILURE: returns the validated v1, does NOT spawn, does NOT delete v1", (t) => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    t.mock.method(pc, "writePidCacheV2IfAbsent", () => false); // simulate a write/link failure
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(spawns(), 0, "a v2 write failure must not trigger a fresh resolve");
+      assert.strictEqual(meta.cacheSource, "v1", "still returns the validated v1 metadata");
+      assert.strictEqual(meta.stablePid, process.pid);
+      assert.ok(pc.readPidCache(sid, CWD), "v1 must NOT be deleted when the v2 write failed");
+    } finally { cleanup(); }
+  });
+
+  it("v1 identity changed between read and delete: v1 is kept (deleted only when unchanged)", (t) => {
+    const { resolve, cleanup } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    const v1File = pc.cacheFilePath(sid, CWD);
+    const realIfAbsent = pc.writePidCacheV2IfAbsent;
+    t.mock.method(pc, "writePidCacheV2IfAbsent", (...a) => {
+      // A concurrent SessionStart atomically replaces the v1 right before our
+      // post-write delete check — same key, different content/size.
+      fs.writeFileSync(v1File, JSON.stringify({ ...liveSubset({ agentCommandLine: "claude --REPLACED" }), cwd: CWD, ts: Date.now() }));
+      return realIfAbsent(...a);
+    });
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(meta.cacheSource, "v1");
+      assert.ok(pc.readPidCache(sid, CWD), "a replaced v1 must NOT be deleted (left for the sweep)");
+      assert.match(pc.readPidCache(sid, CWD).agentCommandLine, /REPLACED/);
+    } finally { cleanup(); }
+  });
+
+  it("recheck finds a concurrent v2 already present: prefer it, do not overwrite", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    pc.writePidCacheV2(NS, sid, CWD, liveSubset({ agentCommandLine: "claude --FRESH-V2" }));
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(spawns(), 0);
+      assert.strictEqual(meta.cacheSource, "v2", "recheck prefers the existing v2");
+      assert.strictEqual(meta.agentCommandLine, "claude --FRESH-V2");
+    } finally { cleanup(); }
+  });
+
+  it("no-clobber closes the recheck-is-not-CAS race: a fresh v2 written mid-promotion survives", (t) => {
+    // A concurrent SessionStart writes a FRESH v2 AFTER promotion's recheck saw
+    // none, right before promotion's no-clobber link. The link then fails EEXIST
+    // ("exists"), so promotion uses the fresh v2 and the stale v1 never
+    // overwrites it (plan §6.10).
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset({ agentCommandLine: "claude --STALE-V1" }));
+    const realIfAbsent = pc.writePidCacheV2IfAbsent;
+    t.mock.method(pc, "writePidCacheV2IfAbsent", (...a) => {
+      pc.writePidCacheV2(NS, sid, CWD, liveSubset({ agentCommandLine: "claude --FRESH-CONCURRENT" }));
+      return realIfAbsent(...a); // real no-clobber now sees the fresh v2 → "exists"
+    });
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(spawns(), 0, "no fresh spawn");
+      assert.strictEqual(meta.cacheSource, "v2", "promotion yields to the concurrent fresh v2");
+      const surviving = pc.readPidCacheV2(NS, sid, CWD);
+      assert.strictEqual(surviving.agentCommandLine, "claude --FRESH-CONCURRENT", "the fresh v2 must NOT be overwritten by the stale v1");
+    } finally { cleanup(); }
+  });
+
+  it("end first-sees-v1: uses it for the final body, drops it, creates NO short-lived v2", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    try {
+      const meta = resolve(ctx(sid, "end"));
+      assert.strictEqual(spawns(), 0);
+      assert.strictEqual(meta.cacheSource, "v1", "end used the v1 for the final body");
+      assert.strictEqual(meta.stablePid, process.pid);
+      assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "end must NOT create a v2");
+      assert.strictEqual(pc.readPidCache(sid, CWD), null, "end dropped the v1");
+    } finally { cleanup(); }
+  });
+
+  it("start writes v2 then best-effort cleans a pre-existing v1, with no extra fresh", () => {
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());   // leftover v1 from before the upgrade
+    try {
+      resolve();                                 // prewarm
+      const meta = resolve(ctx(sid, "start"));
+      assert.strictEqual(spawns(), 1, "start reuses prewarm — no extra fresh for the v1 cleanup");
+      assert.strictEqual(meta.cacheSource, "fresh");
+      assert.ok(pc.readPidCacheV2(NS, sid, CWD), "start wrote v2");
+      assert.strictEqual(pc.readPidCache(sid, CWD), null, "start cleaned the stale v1");
+    } finally { cleanup(); }
+  });
+
+  it("start v2 write FAILURE keeps a pre-existing v1 (never drops it on a failed write)", (t) => {
+    // Regression for the High finding: a failed start v2 write must NOT delete
+    // the valid v1 — else the session loses its only cache and the next event
+    // re-freshes (flashes). v1 stays promotable on the next prompt/event.
+    const { resolve, cleanup } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    t.mock.method(pc, "writePidCacheV2", () => false); // simulate a write failure
+    try {
+      resolve(ctx(sid, "start"));
+      assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "the v2 write failed, so no v2 exists");
+      assert.ok(pc.readPidCache(sid, CWD), "a failed start v2 write must KEEP the valid v1");
+    } finally { cleanup(); }
+  });
+
+  it("a non-Claude namespace never reads v1", () => {
+    const { resolve, cleanup } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    try {
+      const meta = resolve({ namespace: "gemini", sessionId: sid, cacheCwd: CWD, lifecycle: "prompt", cacheable: true });
+      assert.strictEqual(meta.cacheSource, "none", "non-Claude prompt miss stays empty (no v1 read)");
+      assert.ok(pc.readPidCache(sid, CWD), "the v1 is untouched by a non-Claude namespace");
+    } finally { cleanup(); }
+  });
+
+  it("promotion interleaved with a concurrent end/drop leaves at most a sweepable orphan, never a spawn", (t) => {
+    // The accepted residual (plan §7.3): a promotion that writes v2 while a
+    // concurrent SessionEnd drops it may leave an orphan. It must never spawn.
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    const realIfAbsent = pc.writePidCacheV2IfAbsent;
+    t.mock.method(pc, "writePidCacheV2IfAbsent", (...a) => {
+      const r = realIfAbsent(...a);
+      pc.dropPidCacheV2(NS, sid, CWD); // concurrent SessionEnd drop, right after our write
+      return r;
+    });
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(spawns(), 0, "the interleave must never fall back to a spawn");
+      assert.strictEqual(meta.cacheSource, "v1", "still returns the validated v1 metadata");
+      // Whether a v2 orphan remains is unspecified (accepted residual); the
+      // read-side double-liveness + sweep bound the consequence.
+    } finally { cleanup(); }
+  });
+
+  it("event fresh write FAILURE: writes exactly once (false), does NOT sweep, produces no v2", (t) => {
+    // A clean miss (no v1, no v2) reaches the event fresh→write path. On a failed
+    // write the population is incomplete, so it must NOT count as a sweep entry
+    // point and must leave no v2. (The previous version disabled the promotion
+    // no-clobber write with a v1 present, so it returned the promoted v1 and
+    // never reached this fresh write at all — it did not cover this branch.)
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    const writeSpy = t.mock.method(pc, "writePidCacheV2", () => false);
+    const sweepSpy = t.mock.method(pc, "sweepStalePidCaches");
+    try {
+      resolve(ctx(sid, "event"));
+      assert.strictEqual(spawns(), 1, "the event miss still resolves fresh once");
+      assert.strictEqual(writeSpy.mock.calls.length, 1, "the fresh v2 write is attempted exactly once");
+      assert.strictEqual(writeSpy.mock.calls[0].result, false, "and it reports failure");
+      assert.strictEqual(sweepSpy.mock.calls.length, 0, "a FAILED population is not a sweep entry point");
+      assert.strictEqual(pc.readPidCacheV2(NS, sid, CWD), null, "no v2 is produced");
+    } finally { cleanup(); }
+  });
+
+  it("event fresh write FAILURE keeps a pre-existing (dead) v1 — the v1 drop is gated on write success", (t) => {
+    // A DEAD v1 is skipped by promotion, so the event reaches the fresh path with
+    // a v1 still on disk. A failed write must NOT drop it (gated on === true).
+    const { resolve, cleanup } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, { stablePid: DEAD_PID, agentPid: DEAD_PID, agentCommandLine: "x", detectedEditor: "code" });
+    t.mock.method(pc, "writePidCacheV2", () => false);
+    try {
+      resolve(ctx(sid, "event"));
+      assert.ok(pc.readPidCache(sid, CWD), "a failed event write must not drop the (dead) v1");
+    } finally { cleanup(); }
+  });
+});
+
+describe("resolver v1→v2 promotion — identity binds the exact bytes read (High, §5.5)", () => {
+  it("promotion reads the v1 through the SINGLE-observation readPidCacheEntry, never the legacy split read", (t) => {
+    // The structural guard for Codex's between-reads race: the bug required a
+    // separate readPidCache (content) + identity read that a concurrent write
+    // could straddle. If the resolver ever regresses to that split, this fails.
+    const { resolve, cleanup } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    const entrySpy = t.mock.method(pc, "readPidCacheEntry");
+    const legacySpy = t.mock.method(pc, "readPidCache");
+    try {
+      resolve(ctx(sid, "prompt")); // v2 miss → promotion
+      assert.ok(entrySpy.mock.calls.length >= 1, "promotion uses readPidCacheEntry (one observation)");
+      assert.strictEqual(legacySpy.mock.calls.length, 0, "and NEVER the legacy separate readPidCache");
+    } finally { cleanup(); }
+  });
+
+  it("a v1 replaced after the read (before the delete-guard) survives; the content read is promoted", (t) => {
+    // Codex's deterministic repro: a concurrent writer replaces the v1 after the
+    // resolver read it. Pre-fix, the separate identity read captured the NEW file
+    // and the delete-guard then deleted it while promoting the OLD content
+    // ({returned:OLD, survivingV1:null}). Now the subset AND identity come from
+    // ONE observation, so the NEW v1 survives and the OLD is promoted.
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset({ agentCommandLine: "claude --OLD" }));
+    const realIfAbsent = pc.writePidCacheV2IfAbsent;
+    t.mock.method(pc, "writePidCacheV2IfAbsent", (...a) => {
+      // fires AFTER the single-observation read, BEFORE the delete-guard.
+      pc.writePidCache(sid, CWD, liveSubset({ agentCommandLine: "claude --NEW" }));
+      return realIfAbsent(...a);
+    });
+    try {
+      const meta = resolve(ctx(sid, "prompt"));
+      assert.strictEqual(spawns(), 0);
+      assert.match(meta.agentCommandLine, /OLD/, "promoted the content it actually read");
+      const surviving = pc.readPidCache(sid, CWD);
+      assert.ok(surviving, "the concurrently-written NEW v1 must SURVIVE");
+      assert.match(surviving.agentCommandLine, /NEW/, "and it is the NEW content, not deleted");
+    } finally { cleanup(); }
+  });
+});
+
+describe("resolver end — v1 delete is identity-verified, not blind (Medium, §5.5)", () => {
+  it("a v1 replaced DURING end survives; end used the v1 it actually read", (t) => {
+    // Codex's repro: end read the OLD v1, a concurrent writer wrote a NEW v1,
+    // and the blind drop deleted it ({returned:OLD-END, survivingV1:null}). Now
+    // the valid v1 is deleted only via its own read-identity.
+    const { resolve, cleanup, spawns } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset({ agentCommandLine: "claude --OLD-END" }));
+    const realDropV2 = pc.dropPidCacheV2;
+    t.mock.method(pc, "dropPidCacheV2", (...a) => {
+      // end reads the v1 entry, then drops v2, then delete-guards v1 — replace in
+      // the drop-v2 step so it lands between the v1 read and the v1 delete.
+      pc.writePidCache(sid, CWD, liveSubset({ agentCommandLine: "claude --NEW-END" }));
+      return realDropV2(...a);
+    });
+    try {
+      const meta = resolve(ctx(sid, "end"));
+      assert.strictEqual(spawns(), 0);
+      assert.match(meta.agentCommandLine, /OLD-END/, "end used the v1 it read for the final body");
+      const surviving = pc.readPidCache(sid, CWD);
+      assert.ok(surviving, "the concurrently-written NEW v1 must SURVIVE end's identity-verified delete");
+      assert.match(surviving.agentCommandLine, /NEW-END/);
+    } finally { cleanup(); }
+  });
+
+  it("end still deletes the v1 it read when unchanged (no concurrent writer)", () => {
+    const { resolve, cleanup } = mkResolver();
+    const sid = freshSid();
+    pc.writePidCache(sid, CWD, liveSubset());
+    try {
+      const meta = resolve(ctx(sid, "end"));
+      assert.strictEqual(meta.cacheSource, "v1");
+      assert.strictEqual(pc.readPidCache(sid, CWD), null, "an unchanged v1 is dropped on end");
+    } finally { cleanup(); }
+  });
+});
+
+describe("resolver sweep triggering (§5.4: once per process)", () => {
+  it("no-start adapter path: the first successful event population triggers a sweep", (t) => {
+    const { resolve, cleanup } = mkResolver();
+    const spy = t.mock.method(pc, "sweepStalePidCaches");
+    try {
+      resolve(ctx(freshSid(), "event")); // miss → fresh → write → sweep
+      assert.strictEqual(spy.mock.calls.length, 1, "first event population sweeps once");
+    } finally { cleanup(); }
+  });
+
+  it("sweeps AT MOST once per resolver instance (a second event does not re-sweep)", (t) => {
+    const { resolve, cleanup } = mkResolver();
+    const spy = t.mock.method(pc, "sweepStalePidCaches");
+    try {
+      resolve(ctx(freshSid(), "event"));
+      resolve(ctx(freshSid(), "event"));
+      assert.strictEqual(spy.mock.calls.length, 1, "the once-per-process guard holds across events");
+    } finally { cleanup(); }
+  });
+
+  it("start sweeps; a later event in the same process does not sweep again", (t) => {
+    const { resolve, cleanup } = mkResolver();
+    const spy = t.mock.method(pc, "sweepStalePidCaches");
+    try {
+      resolve(); // prewarm
+      resolve(ctx(freshSid(), "start"));
+      resolve(ctx(freshSid(), "event"));
+      assert.strictEqual(spy.mock.calls.length, 1, "start already swept; the event must not re-sweep");
+    } finally { cleanup(); }
+  });
+
+  it("a prompt (cache-only) never triggers a sweep", (t) => {
+    const { resolve, cleanup } = mkResolver();
+    const spy = t.mock.method(pc, "sweepStalePidCaches");
+    try {
+      resolve(ctx(freshSid(), "prompt"));
+      assert.strictEqual(spy.mock.calls.length, 0, "prompt is cache-only; no sweep");
+    } finally { cleanup(); }
+  });
+});


### PR DESCRIPTION
Slice 1 of #634: move the per-session pid-cache orchestration out of the Claude hook and into the shared resolver, so the other 12 agent hooks can adopt it in later slices. Sequential follow-up to #672 (now on `main`).

## What this changes

Only Claude is migrated here — the other 12 adapters keep calling the no-arg `resolve()` unchanged.

**`hooks/shared-process.js`** — `createPidResolver` gains a lifecycle context overload:

- `resolve({ namespace, sessionId, cacheCwd, lifecycle, cacheable })` with `start` / `prompt` / `event` / `end` lifecycles.
- The no-arg `resolve()` stays byte-for-byte with the #672 baseline (same 10-field shape, SessionStart prewarm reuse, zero cache interaction) — verified with an A/B against the baseline source. `pid-cache` is lazy-required only in the context path, so there is no require cycle and unmigrated adapters never load it.
- Windows zero-spawn contracts: `prompt`/`end` never spawn (even for a non-cacheable session); `event` hit is zero spawn, miss is one fresh; `start` reuses the prewarm. macOS/Linux keep the fresh-every-event runtime behavior.
- Claude v1→v2 cache promotion, so a session already running across the upgrade does not take a one-off re-resolve (flash). The promoted content and its delete-guard come from a single file observation, and the write is no-clobber, so a concurrently-written fresh entry is never overwritten or deleted.

**`hooks/pid-cache.js`** — cache v2 alongside the untouched v1:

- Namespaced + versioned, with a non-overlapping prefix (`clawd-pidcache2-`) so a dual-prefix sweep classifies every file unambiguously and drops only on age-floor + death-proof.
- Reads consult no clock (lease model); liveness is a double-PID check by the caller.
- `readPidCacheEntry()` returns the subset and its file identity from one fd observation (so a promotion never promotes one version and deletes another).

**`hooks/clawd-hook.js`** — `buildStateBody` is now a thin Claude adapter: event→lifecycle map (`Stop` is not `end`), cache identity, remote bypass before the resolver, and apply the returned metadata (an empty result ships no degraded pid).

## Compatibility / safety

- The 12 unmigrated adapters (Codex, Cursor, Gemini, Copilot, Kimi, Kiro, Qoder, QoderWork, Qwen, Reasonix, CodeBuddy, Antigravity) are untouched: same fields, same spawn count, zero cache interaction — regression-tested.
- No public protocol or event-name changes. No permission-behavior changes.

## Testing

`node --test test/*.test.js` — all green. Coverage:

- Full lifecycle matrix (start / prompt / event / end, cacheable and not, Windows and non-Windows).
- v1→v2 promotion: success, write-failure keeps v1, dead PID, concurrent replacement, and end/drop interleave.
- The Slice-1 no-arg compatibility red line: field set + first/second spawn count + zero cache interaction, plus an unmigrated-adapter regression.
- The Claude end-to-end regression through the real resolver.

Two review rounds surfaced and fixed: a v1 drop on a failed start/event write, a missing event-population sweep entry point for no-start adapters, cache-test directory isolation (so the sweep tests never scan the real temp dir), and a promotion identity race (the promoted bytes and the delete-guard must come from the same read).

## Follow-ups

- Real-machine 4688/ETW spawn audit under Windows Terminal as the default terminal app — pending; not reproducible in a VS Code terminal.
- Later slices migrate the remaining adapters one at a time.
