### PR TITLE
feat(kimi): tool-aware cues on the passive Kimi Code permission bubble

### DIFF
--- a/hooks/kimi-hook.js
+++ b/hooks/kimi-hook.js
@@ -177,6 +177,39 @@ function readToolName(payload) {
   return "";
 }
 
+const PERMISSION_TOOL_INPUT_MAX_CHARS = 500;
+
+// Whitelisted subset of a native PermissionRequest's structured tool_input,
+// forwarded so the bubble can render tool-aware cues (command for Bash, file
+// path for Write/Edit) through the same formatter Claude bubbles use. Kimi
+// Code's file tools say `path` where Claude says `file_path` (captured from
+// kimi-code 0.14.3, unchanged in the 0.23.6 bundle's Write/Edit schemas);
+// map it so the formatter finds it. src/server-route-state.js re-runs this
+// exact function at the trust boundary rather than trusting the hook.
+// Everything else is dropped by construction: content / old_string /
+// new_string can be arbitrarily large (an oversized /state body is rejected
+// whole), and Bash's optional `description` is model-authored text that
+// formatDetail would show instead of the real command — the card must show
+// what actually runs, not what the model says about it.
+function extractPermissionToolInput(raw) {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const out = {};
+  const take = (target, value) => {
+    // First writer wins: an explicit file_path beats the mapped `path` alias.
+    if (typeof value !== "string" || out[target] !== undefined) return;
+    // Trim first, matching the server's trim-then-clamp order: a value with
+    // ≥500 chars of leading whitespace would otherwise clamp to whitespace
+    // only and be dropped server-side.
+    const trimmed = value.trim();
+    if (trimmed) out[target] = trimmed.slice(0, PERMISSION_TOOL_INPUT_MAX_CHARS);
+  };
+  take("command", raw.command);
+  take("file_path", raw.file_path);
+  take("file_path", raw.path);
+  take("pattern", raw.pattern);
+  return Object.keys(out).length ? out : null;
+}
+
 function isExplicitPermissionSignal(payload) {
   if (!payload || typeof payload !== "object") return false;
   const topLevelFlags = [
@@ -289,20 +322,39 @@ function buildStateBody(event, payload, resolve) {
   // Permission context for the bubble. Native Kimi Code payloads carry a
   // human-readable action ("Running: echo hi") and a display block with the
   // real command; forward them so the bubble can show what actually needs
-  // approval instead of the generic "check the Kimi terminal" line. The
-  // legacy synthesized PermissionRequest (rewritten PreToolUse) has none of
-  // these fields, so it degrades to tool_name only — same behavior as before.
+  // approval instead of the generic "check the Kimi terminal" line. A
+  // synthesized PermissionRequest (rewritten PreToolUse) usually has neither
+  // and degrades to tool_name only — but when its payload does carry
+  // tool_input (immediate mode fires on the raw PreToolUse), the same
+  // whitelist applies and the cue stays accurate.
+  //
+  // Action/command/tool_name are clamped to the server's own limits
+  // (trim().slice at 300/500, src/server-route-state.js): a heredoc Bash
+  // call embeds the command in both action and display.command, and
+  // unclamped they could push the body past the 16KB /state cap — that 413
+  // is headerless and silently drops the whole notification. Clamps keep
+  // realistic bodies well under the cap. The hooks that carry
+  // assistant_last_output (clawd, codex) byte-fit via
+  // fitStateBodyToByteBudget instead, but that helper only sacrifices
+  // assistant_last_output, which this body never has, so deterministic
+  // clamps are the fit here.
   if (event === "PermissionRequest" || event === "PermissionResult") {
-    const toolName = readToolName(payload);
-    if (toolName) body.tool_name = toolName;
-    if (typeof payload.action === "string" && payload.action) {
-      body.permission_action = payload.action;
+    const toolName = readToolName(payload).trim();
+    if (toolName) body.tool_name = toolName.slice(0, 200);
+    if (typeof payload.action === "string" && payload.action.trim()) {
+      body.permission_action = payload.action.trim().slice(0, 300);
     }
     if (
       payload.display && typeof payload.display === "object"
-      && typeof payload.display.command === "string" && payload.display.command
+      && typeof payload.display.command === "string" && payload.display.command.trim()
     ) {
-      body.permission_command = payload.display.command;
+      body.permission_command = payload.display.command.trim().slice(0, 500);
+    }
+    // PermissionRequest only: a PermissionResult just clears the bubble —
+    // there is nothing left to render a cue for.
+    if (event === "PermissionRequest") {
+      const permissionToolInput = extractPermissionToolInput(payload.tool_input);
+      if (permissionToolInput) body.permission_tool_input = permissionToolInput;
     }
     if (typeof payload.decision === "string" && payload.decision) {
       body.permission_decision = payload.decision;
@@ -388,6 +440,7 @@ function main() {
 if (require.main === module) main();
 module.exports = {
   buildStateBody,
+  extractPermissionToolInput,
   PERMISSION_TOOLS,
   DEFAULT_PERMISSION_TOOLS,
   resolvePermissionTools,

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -814,10 +814,35 @@ function show(data) {
   // Kimi notify mode — informational bubble with Dismiss button only
   if (data.toolName === "KimiPermission") {
     headerTitle.textContent = bubbleText(data.lang, "kimiPermission");
-    toolPillText.textContent = "KIMI";
-    toolPill.setAttribute("data-tool", "KimiPermission");
+    // A native Kimi Code request forwards the real tool name plus a
+    // whitelisted tool_input subset. When both are present, reuse the
+    // standard cue path (formatDetail / detectIrreversible / real tool pill)
+    // — display-only, the card stays dismiss-only. Without them (legacy
+    // Python CLI, shape drift) this renders exactly the old generic card.
+    const kimiTool = typeof data.kimiToolName === "string" && data.kimiToolName ? data.kimiToolName : null;
+    const kimiInput = data.kimiToolInput && typeof data.kimiToolInput === "object" ? data.kimiToolInput : null;
+    if (kimiTool && kimiInput) {
+      const kimiMcp = parseMcpToolName(kimiTool);
+      toolPillText.textContent = kimiMcp ? kimiMcp.display : kimiTool;
+      toolPill.setAttribute("data-tool", kimiTool);
+      // The fallbacks are defense-in-depth only: formatDetail's generic
+      // last-resort loop returns non-empty for any server-normalized input.
+      commandBlock.textContent = formatDetail(kimiTool, kimiInput)
+        || (data.toolInput && data.toolInput.command)
+        || bubbleText(data.lang, "checkKimiTerminal");
+      const kimiIrreversible = detectIrreversible(kimiTool, kimiInput);
+      if (kimiIrreversible) {
+        irreversibleBadge.textContent = "\u26A0 " + bubbleText(data.lang, "irreversibleHint");
+        irreversibleBadge.setAttribute("data-reason", kimiIrreversible.tag);
+        irreversibleBadge.style.display = "";
+      }
+      // No else branch: resetBubbleContent() above already hid the badge.
+    } else {
+      toolPillText.textContent = "KIMI";
+      toolPill.setAttribute("data-tool", "KimiPermission");
+      commandBlock.textContent = (data.toolInput && data.toolInput.command) || bubbleText(data.lang, "checkKimiTerminal");
+    }
     toolPill.style.display = "";
-    commandBlock.textContent = (data.toolInput && data.toolInput.command) || bubbleText(data.lang, "checkKimiTerminal");
     btnAllow.textContent = bubbleText(data.lang, "gotIt");
     btnAllow.disabled = false;
     btnDeny.style.display = "none";

--- a/src/permission.js
+++ b/src/permission.js
@@ -909,6 +909,11 @@ function buildPermissionBubblePayload(permEntry) {
     // Provenance for the renderer: lets the bubble relabel Codex MCP tool calls
     // (issue #445) without touching approval semantics. Mirrors the flags above.
     isCodex: permEntry.isCodex || false,
+    // Display-only detail for the passive Kimi notify card: the real tool
+    // name plus the whitelisted tool_input subset let the renderer reuse the
+    // standard cue path (formatDetail) while the card stays dismiss-only.
+    kimiToolName: permEntry.kimiToolName || null,
+    kimiToolInput: permEntry.kimiToolInput || null,
     opencodeAlways: permEntry.opencodeAlwaysCandidates || [],
     opencodePatterns: permEntry.opencodePatterns || [],
     sessionFolder,
@@ -2066,7 +2071,7 @@ function showCodexNotifyBubble({ sessionId, command }) {
   schedulePassiveNotifyAutoExpire(permEntry, policy.autoCloseMs);
 }
 
-function showKimiNotifyBubble({ sessionId, command, toolName, permissionAction, permissionCommand }) {
+function showKimiNotifyBubble({ sessionId, command, toolName, permissionAction, permissionCommand, permissionToolInput }) {
   if (shouldSuppressKimiNotifyBubble(ctx)) {
     const policy = getPolicy(ctx, "notification");
     permLog(`kimi notify suppressed: session=${sessionId} dnd=${ctx.doNotDisturb} notificationEnabled=${policy.enabled}`);
@@ -2078,6 +2083,24 @@ function showKimiNotifyBubble({ sessionId, command, toolName, permissionAction, 
   // requests carry neither and keep the generic copy.
   const bubbleCommand = permissionCommand || permissionAction || command
     || "Approve or reject in Kimi terminal.";
+  // A newer request for the same session replaces the stale cue in place
+  // (codex idiom above): the terminal now blocks on the NEW command, and
+  // keeping request #1's pill/command/badge would show a wrong answer with
+  // authority. A legacy-shaped refresh downgrades to the generic copy — the
+  // generic line can't be wrong.
+  const existing = findKimiNotifyEntryBySession(sessionId);
+  if (existing) {
+    existing.toolInput = { command: bubbleCommand };
+    existing.kimiToolName = typeof toolName === "string" && toolName ? toolName : null;
+    existing.kimiToolInput = permissionToolInput && typeof permissionToolInput === "object"
+      ? permissionToolInput
+      : null;
+    existing.createdAt = Date.now();
+    permLog(`passive notify refresh: agent=kimi-cli session=${sessionId} autoCloseMs=${policy.autoCloseMs}`);
+    syncPermissionBubbleContent(existing);
+    schedulePassiveNotifyAutoExpire(existing, policy.autoCloseMs);
+    return;
+  }
   const permEntry = {
     res: null,
     abortHandler: null, suggestions: [],
@@ -2085,6 +2108,13 @@ function showKimiNotifyBubble({ sessionId, command, toolName, permissionAction, 
     toolName: "KimiPermission",
     toolInput: { command: bubbleCommand },
     kimiToolName: typeof toolName === "string" && toolName ? toolName : null,
+    // Whitelisted subset of the native request's tool_input (see
+    // extractPermissionToolInput in hooks/kimi-hook.js — the server re-runs
+    // it at the trust boundary). Display-only: it feeds the bubble's
+    // tool-aware cue and never touches approval semantics.
+    kimiToolInput: permissionToolInput && typeof permissionToolInput === "object"
+      ? permissionToolInput
+      : null,
     resolvedSuggestion: null, createdAt: Date.now(),
     isElicitation: false, isKimiNotify: true,
     agentId: "kimi-cli",
@@ -2105,6 +2135,11 @@ function getPassiveNotifyAgentId(permEntry) {
 function findCodexNotifyEntryBySession(sessionId) {
   if (!sessionId) return null;
   return pendingPermissions.find((permEntry) => permEntry && permEntry.isCodexNotify && permEntry.sessionId === sessionId) || null;
+}
+
+function findKimiNotifyEntryBySession(sessionId) {
+  if (!sessionId) return null;
+  return pendingPermissions.find((permEntry) => permEntry && permEntry.isKimiNotify && permEntry.sessionId === sessionId) || null;
 }
 
 function dismissPassiveNotify(permEntry, reason = "unknown") {

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -15,6 +15,7 @@ const { normalizeTranscriptPath } = require("./transcript-path");
 const { normalizeQuotaGroup } = require("../hooks/quota-bucket");
 const { ANTIGRAVITY_QUOTA_FIELDS } = require("../hooks/antigravity-context-usage");
 const { CLAUDE_QUOTA_FIELDS } = require("../hooks/claude-rate-limits");
+const { extractPermissionToolInput } = require("../hooks/kimi-hook");
 
 // /state POST body size cap. Raised 1024 → 4096 → 16384: a CJK
 // assistant_last_output (3 UTF-8 bytes/char) on a Stop completion blew past
@@ -216,6 +217,11 @@ function handleStatePost(req, res, options) {
       const permissionCommand = typeof data.permission_command === "string" && data.permission_command.trim()
         ? data.permission_command.trim().slice(0, 500)
         : null;
+      // Whitelisted tool_input subset from a Kimi Code native
+      // PermissionRequest. Same validator the hook runs before POSTing —
+      // re-run here at the trust boundary rather than trusted from the hook,
+      // matching normalizeContextUsage.
+      const permissionToolInput = extractPermissionToolInput(data.permission_tool_input);
       const preserveState = data.preserve_state === true;
       // Statusline refresh POSTs are metadata, not lifecycle (#590 B2): they
       // may only annotate an existing session with quota/context and must
@@ -429,6 +435,7 @@ function handleStatePost(req, res, options) {
             permissionSuspect,
             permissionAction,
             permissionCommand,
+            permissionToolInput,
             preserveState,
             hookSource,
             backgroundTasksCount,

--- a/src/state.js
+++ b/src/state.js
@@ -1312,6 +1312,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     permissionSuspect = false,
     permissionAction = null,
     permissionCommand = null,
+    permissionToolInput = null,
     preserveState = false,
     hookSource = null,
     agentIdDefaulted = false,
@@ -1421,7 +1422,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     }
     setState("notification", undefined, { muteNotificationSound: muteNotificationSound === true });
     if (permAgentId === "kimi-cli") {
-      startKimiPermissionPoll(sessionId, { toolName, permissionAction, permissionCommand });
+      startKimiPermissionPoll(sessionId, { toolName, permissionAction, permissionCommand, permissionToolInput });
     }
     return;
   }
@@ -2064,9 +2065,13 @@ function startKimiPermissionPoll(sessionId, permissionDetail = null) {
     timer,
     until: maxMs > 0 ? Date.now() + maxMs : null,
   });
-  // Avoid stacking duplicate passive bubbles for the same pending request.
-  // Refreshing the hold timer should not create extra UI noise.
-  if (!existing && typeof ctx.showKimiNotifyBubble === "function") {
+  // Refreshing the hold must still forward fresh detail: with the rich cue,
+  // showing request #1's command while the terminal blocks on request #2
+  // would be authoritatively wrong. showKimiNotifyBubble dedupes per session
+  // and refreshes the existing card in place (codex idiom), so no bubble
+  // stacking. Suspect promotions carry no detail object and skip the
+  // refresh — a heuristic re-affirmation must not downgrade a rich card.
+  if (typeof ctx.showKimiNotifyBubble === "function" && (!existing || permissionDetail)) {
     // #563: Kimi Code native PermissionRequest carries what actually needs
     // approval; the bubble shows the real command instead of generic copy.
     // Legacy synthesized requests pass null detail and keep the old text.
@@ -2075,6 +2080,7 @@ function startKimiPermissionPoll(sessionId, permissionDetail = null) {
       toolName: permissionDetail && permissionDetail.toolName ? permissionDetail.toolName : null,
       permissionAction: permissionDetail && permissionDetail.permissionAction ? permissionDetail.permissionAction : null,
       permissionCommand: permissionDetail && permissionDetail.permissionCommand ? permissionDetail.permissionCommand : null,
+      permissionToolInput: permissionDetail && permissionDetail.permissionToolInput ? permissionDetail.permissionToolInput : null,
     });
   }
 }

--- a/test/bubble-kimi-cue.test.js
+++ b/test/bubble-kimi-cue.test.js
@@ -1,0 +1,104 @@
+"use strict";
+
+// Follow-up to #563 — the passive Kimi Code permission card renders
+// tool-aware cues (real tool pill, command / file-path detail, irreversible
+// hint) when the native PermissionRequest forwarded structured tool_input.
+// bubble-renderer.js pulls in DOM globals at load time, so (per this repo's
+// convention) we assert the relevant logic against the source string instead
+// of instantiating it.
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const RENDERER_SRC = fs.readFileSync(
+  path.join(__dirname, "..", "src", "bubble-renderer.js"),
+  "utf8"
+);
+
+function kimiBranch() {
+  const start = RENDERER_SRC.indexOf('if (data.toolName === "KimiPermission")');
+  assert.notStrictEqual(start, -1, "Kimi notify branch not found");
+  const end = RENDERER_SRC.indexOf("return;", start);
+  return RENDERER_SRC.slice(start, end);
+}
+
+describe("bubble-renderer Kimi tool-aware cue", () => {
+  it("keeps KimiPermission as the branch discriminator", () => {
+    // The literal keeps the passive card unreachable from the actionable
+    // Allow/Deny path; the real tool name travels in separate display fields.
+    assert.match(RENDERER_SRC, /if \(data\.toolName === "KimiPermission"\) \{/);
+  });
+
+  it("renders the rich cue only when BOTH the real tool name and structured input arrived", () => {
+    const branch = kimiBranch();
+    assert.match(
+      branch,
+      /const kimiTool = typeof data\.kimiToolName === "string" && data\.kimiToolName \? data\.kimiToolName : null;/
+    );
+    assert.match(
+      branch,
+      /const kimiInput = data\.kimiToolInput && typeof data\.kimiToolInput === "object" \? data\.kimiToolInput : null;/
+    );
+    assert.match(branch, /if \(kimiTool && kimiInput\) \{/);
+  });
+
+  it("reuses the standard cue path: formatDetail, MCP relabel, irreversible hint", () => {
+    const branch = kimiBranch();
+    assert.match(branch, /formatDetail\(kimiTool, kimiInput\)/);
+    assert.match(branch, /parseMcpToolName\(kimiTool\)/);
+    assert.match(branch, /detectIrreversible\(kimiTool, kimiInput\)/);
+    // The pill shows the real tool so per-tool CSS (data-tool="Bash" etc.)
+    // applies, exactly like Claude bubbles.
+    assert.match(branch, /toolPill\.setAttribute\("data-tool", kimiTool\);/);
+  });
+
+  it("shows the irreversible badge when the cue's detection fires", () => {
+    // Not just the detectIrreversible call — the badge render itself, so the
+    // safety payoff can't be deleted without failing a test.
+    const branch = kimiBranch();
+    assert.match(branch, /if \(kimiIrreversible\) \{/);
+    assert.match(branch, /irreversibleBadge\.setAttribute\("data-reason", kimiIrreversible\.tag\);/);
+    assert.match(branch, /irreversibleBadge\.style\.display = "";/);
+  });
+
+  it("degrades to the old generic card when structured input is absent", () => {
+    const branch = kimiBranch();
+    // Legacy Python-CLI pulses and shape drift keep the exact pre-existing
+    // rendering: KIMI pill + forwarded command or the generic terminal line.
+    assert.match(branch, /toolPillText\.textContent = "KIMI";/);
+    assert.match(branch, /toolPill\.setAttribute\("data-tool", "KimiPermission"\);/);
+    const fallback = /\(data\.toolInput && data\.toolInput\.command\) \|\| bubbleText\(data\.lang, "checkKimiTerminal"\)/;
+    assert.match(branch, fallback);
+    // The rich path falls back through the same chain if formatDetail
+    // returns nothing.
+    assert.match(
+      branch,
+      /formatDetail\(kimiTool, kimiInput\)\s*\|\| \(data\.toolInput && data\.toolInput\.command\)\s*\|\| bubbleText\(data\.lang, "checkKimiTerminal"\)/
+    );
+  });
+
+  it("stays passive: dismiss-only button set, no Deny, no suggestions", () => {
+    const branch = kimiBranch();
+    assert.match(branch, /btnAllow\.textContent = bubbleText\(data\.lang, "gotIt"\);/);
+    assert.match(branch, /btnDeny\.style\.display = "none";/);
+    assert.match(branch, /suggestionsContainer\.innerHTML = "";/);
+    // No decision wiring inside the branch — display only.
+    assert.doesNotMatch(branch, /bubbleAPI\.decide/);
+  });
+
+  it("writes cue text via textContent only", () => {
+    const branch = kimiBranch();
+    // The suggestions clear is the only innerHTML touch allowed.
+    assert.doesNotMatch(
+      branch.replace('suggestionsContainer.innerHTML = "";', ""),
+      /innerHTML/
+    );
+    assert.match(branch, /commandBlock\.textContent = formatDetail/);
+  });
+});
+
+// permission.js entry + payload plumbing is covered behaviorally in
+// test/permission-notify-autoclose.test.js (entry fields, and the
+// permission-show payload recorded off the fake window on refresh).

--- a/test/kimi-hook.test.js
+++ b/test/kimi-hook.test.js
@@ -593,6 +593,167 @@ describe("Kimi Code native events (#563)", () => {
     assert.strictEqual(body.tool_name, "Bash");
     assert.strictEqual(body.permission_action, "Running: echo test-approve");
     assert.strictEqual(body.permission_command, "echo test-approve");
+    assert.deepStrictEqual(body.permission_tool_input, { command: "echo test-approve" });
+  });
+
+  it("forwards a whitelisted tool_input subset for file tools (path → file_path)", () => {
+    // Real tool_input shapes captured on-machine from kimi-code 0.14.3:
+    // Write sends { path, content }, Edit sends { path, old_string, new_string }.
+    // The 0.23.6 bundle's Write/Edit input schemas are unchanged (`path`,
+    // not `file_path`).
+    const write = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        cwd: "D:/proj",
+        tool_call_id: "Write_0",
+        tool_name: "Write",
+        action: "Writing: cue-probe.txt",
+        tool_input: { path: "cue-probe.txt", content: "hello cue" },
+      },
+      resolve
+    );
+    assert.deepStrictEqual(write.permission_tool_input, { file_path: "cue-probe.txt" });
+
+    const edit = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        tool_name: "Edit",
+        tool_input: { path: "cue-probe.txt", old_string: "hello", new_string: "goodbye" },
+      },
+      resolve
+    );
+    assert.deepStrictEqual(edit.permission_tool_input, { file_path: "cue-probe.txt" });
+
+    // An explicit Claude-style file_path wins over path.
+    const explicit = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        tool_name: "Write",
+        tool_input: { file_path: "D:/proj/a.txt", path: "b.txt" },
+      },
+      resolve
+    );
+    assert.deepStrictEqual(explicit.permission_tool_input, { file_path: "D:/proj/a.txt" });
+  });
+
+  it("clamps forwarded tool_input strings and drops empty or non-string values", () => {
+    const body = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        tool_name: "Bash",
+        tool_input: { command: "x".repeat(10000), file_path: 42, pattern: "" },
+      },
+      resolve
+    );
+    assert.strictEqual(body.permission_tool_input.command.length, 500);
+    assert.strictEqual(body.permission_tool_input.file_path, undefined);
+    assert.strictEqual(body.permission_tool_input.pattern, undefined);
+
+    const empty = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        tool_name: "Write",
+        tool_input: { content: "only heavy fields" },
+      },
+      resolve
+    );
+    assert.strictEqual(empty.permission_tool_input, undefined);
+  });
+
+  it("trims tool_input values before clamping so padded content survives", () => {
+    // Slice-before-trim would clamp 600 chars of leading whitespace down to
+    // whitespace only, and the server's own trim would then drop the field.
+    const body = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        tool_name: "Bash",
+        tool_input: { command: " ".repeat(600) + "rm -rf build" },
+      },
+      resolve
+    );
+    assert.strictEqual(body.permission_tool_input.command, "rm -rf build");
+  });
+
+  it("never forwards description — model-authored text would mask the real command", () => {
+    // kimi-code 0.23.6's Bash schema has an optional model-written
+    // `description`, and formatDetail prefers it over `command`; forwarding
+    // it would let generated text replace the ground truth on the card.
+    const body = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        tool_name: "Bash",
+        tool_input: { command: "rm -rf build", description: "Tidy workspace" },
+      },
+      resolve
+    );
+    assert.deepStrictEqual(body.permission_tool_input, { command: "rm -rf build" });
+  });
+
+  it("forwards pattern for search tools", () => {
+    const body = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        tool_name: "Grep",
+        tool_input: { pattern: "TODO(kimi)", path: "src" },
+      },
+      resolve
+    );
+    assert.deepStrictEqual(body.permission_tool_input, { file_path: "src", pattern: "TODO(kimi)" });
+  });
+
+  it("clamps action, display.command and tool_name so a huge command can't 413 the /state POST", () => {
+    // A heredoc-sized Bash command embeds itself in action AND display.command;
+    // unclamped, the body blows the server's 16KB cap and the headerless 413
+    // silently drops the whole notification.
+    const big = "x".repeat(20000);
+    const body = buildStateBody(
+      "PermissionRequest",
+      {
+        hook_event_name: "PermissionRequest",
+        session_id: "session_abc",
+        tool_name: `Bash${big}`,
+        action: `Running: ${big}`,
+        display: { command: big },
+        tool_input: { command: big },
+      },
+      resolve
+    );
+    assert.strictEqual(body.permission_action.length, 300);
+    assert.strictEqual(body.permission_command.length, 500);
+    assert.strictEqual(body.tool_name.length, 200);
+    assert.ok(Buffer.byteLength(JSON.stringify(body), "utf8") < 14 * 1024);
+  });
+
+  it("ignores garbage tool_input shapes at the hook layer", () => {
+    for (const garbage of ["text", [1, 2], 7, true, null]) {
+      const body = buildStateBody(
+        "PermissionRequest",
+        {
+          hook_event_name: "PermissionRequest",
+          session_id: "session_abc",
+          tool_name: "Bash",
+          tool_input: garbage,
+        },
+        resolve
+      );
+      assert.strictEqual(body.permission_tool_input, undefined, `shape: ${JSON.stringify(garbage)}`);
+    }
   });
 
   it("maps native PermissionResult to working and forwards the decision", () => {
@@ -605,6 +766,7 @@ describe("Kimi Code native events (#563)", () => {
           tool_call_id: "Bash_0",
           tool_name: "Bash",
           action: "Running: echo hi",
+          tool_input: { command: "echo hi" },
           decision,
         },
         resolve
@@ -612,6 +774,7 @@ describe("Kimi Code native events (#563)", () => {
       assert.strictEqual(body.state, "working", `decision ${decision}`);
       assert.strictEqual(body.event, "PermissionResult");
       assert.strictEqual(body.permission_decision, decision);
+      assert.strictEqual(body.permission_tool_input, undefined);
     }
   });
 
@@ -655,6 +818,7 @@ describe("Kimi Code native events (#563)", () => {
     assert.strictEqual(body.permission_action, undefined);
     assert.strictEqual(body.permission_command, undefined);
     assert.strictEqual(body.permission_decision, undefined);
+    assert.strictEqual(body.permission_tool_input, undefined);
   });
 
   it("legacy synthesized PermissionRequest still carries tool_name but no action", () => {
@@ -667,5 +831,26 @@ describe("Kimi Code native events (#563)", () => {
     assert.strictEqual(body.tool_name, "shell");
     assert.strictEqual(body.permission_action, undefined);
     assert.strictEqual(body.permission_command, undefined);
+    assert.strictEqual(body.permission_tool_input, undefined);
+  });
+
+  it("synthesized PermissionRequest forwards the cue when the PreToolUse payload carries tool_input", () => {
+    // The PreToolUse→PermissionRequest rewrite happens before cue extraction
+    // on purpose: immediate mode fires on the raw PreToolUse, whose payload
+    // has the real tool_input, and the same whitelist/clamps apply — an
+    // accurate cue, not a trust change.
+    const body = buildStateBody(
+      "PreToolUse",
+      {
+        session_id: "s",
+        tool_name: "shell",
+        permission_required: true,
+        tool_input: { command: "npm test" },
+      },
+      resolve
+    );
+    assert.strictEqual(body.event, "PermissionRequest");
+    assert.strictEqual(body.state, "notification");
+    assert.deepStrictEqual(body.permission_tool_input, { command: "npm test" });
   });
 });

--- a/test/permission-notify-autoclose.test.js
+++ b/test/permission-notify-autoclose.test.js
@@ -42,7 +42,13 @@ function createPermissionHarness({ logPath = null } = {}) {
       this._didFinishLoad = null;
       this.webContents = {
         once: (event, cb) => {
-          if (event === "did-finish-load") this._didFinishLoad = cb;
+          if (event === "did-finish-load") {
+            // permission.js registers this after calling loadFile; fire
+            // immediately in that case so bubbleReady is set and
+            // syncPermissionBubbleContent really sends.
+            if (this._loadFileCalled) { cb(); return; }
+            this._didFinishLoad = cb;
+          }
         },
         on: (event, cb) => {
           if (event === "render-process-gone") this._renderGoneHandler = cb;
@@ -57,6 +63,7 @@ function createPermissionHarness({ logPath = null } = {}) {
     setAlwaysOnTop() {}
     setBounds(bounds) { this.bounds = bounds; }
     loadFile() {
+      this._loadFileCalled = true;
       if (typeof this._didFinishLoad === "function") this._didFinishLoad();
     }
     showInactive() {}
@@ -308,6 +315,95 @@ describe("permission passive notify auto-close refresh", () => {
     mock.timers.tick(9_999);
     assert.strictEqual(api.pendingPermissions.length, 1);
 
+    mock.timers.tick(1);
+    assert.strictEqual(api.pendingPermissions.length, 0);
+  });
+
+  it("Kimi passive entry carries the display-only tool cue fields", () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"] });
+    mock.timers.setTime(100_000);
+    const harness = createPermissionHarness();
+    const { api } = harness;
+
+    api.showKimiNotifyBubble({
+      sessionId: "kimi-a",
+      toolName: "Write",
+      permissionAction: "Writing: cue-probe.txt",
+      permissionToolInput: { file_path: "cue-probe.txt" },
+    });
+    assert.strictEqual(api.pendingPermissions.length, 1);
+    const entry = api.pendingPermissions[0];
+    // Passive identity untouched — the cue fields are display-only extras.
+    assert.strictEqual(entry.toolName, "KimiPermission");
+    assert.strictEqual(entry.isKimiNotify, true);
+    assert.strictEqual(entry.kimiToolName, "Write");
+    assert.deepStrictEqual(entry.kimiToolInput, { file_path: "cue-probe.txt" });
+
+    // Legacy pulse: no structured input -> null cue fields, generic copy.
+    api.clearKimiNotifyBubbles("kimi-a", "test-reset");
+    assert.strictEqual(api.pendingPermissions.length, 0);
+    api.showKimiNotifyBubble({ sessionId: "kimi-b", toolName: "shell" });
+    const legacy = api.pendingPermissions[0];
+    assert.strictEqual(legacy.kimiToolName, "shell");
+    assert.strictEqual(legacy.kimiToolInput, null);
+    assert.strictEqual(legacy.toolInput.command, "Approve or reject in Kimi terminal.");
+  });
+
+  it("deduplicates Kimi passive notifications by session and refreshes the cue in place", () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"] });
+    mock.timers.setTime(100_000);
+    const harness = createPermissionHarness();
+    const { api } = harness;
+
+    api.showKimiNotifyBubble({
+      sessionId: "kimi-a",
+      toolName: "Bash",
+      permissionCommand: "ls -la",
+      permissionToolInput: { command: "ls -la" },
+    });
+    assert.strictEqual(api.pendingPermissions.length, 1);
+    const existing = api.pendingPermissions[0];
+    const originalBubble = existing.bubble;
+    const firstCreatedAt = existing.createdAt;
+
+    // Request #2 for the same session: the stale cue must be replaced, not
+    // kept (the terminal now blocks on the NEW command) and not stacked.
+    mock.timers.tick(500);
+    api.showKimiNotifyBubble({
+      sessionId: "kimi-a",
+      toolName: "Bash",
+      permissionCommand: "rm -rf build",
+      permissionToolInput: { command: "rm -rf build" },
+    });
+
+    assert.strictEqual(api.pendingPermissions.length, 1);
+    assert.strictEqual(api.pendingPermissions[0], existing);
+    assert.strictEqual(existing.bubble, originalBubble);
+    assert.strictEqual(existing.toolInput.command, "rm -rf build");
+    assert.strictEqual(existing.kimiToolName, "Bash");
+    assert.deepStrictEqual(existing.kimiToolInput, { command: "rm -rf build" });
+    assert.ok(existing.createdAt > firstCreatedAt);
+
+    // The refresh reaches the renderer: the last permission-show payload
+    // carries the new cue fields.
+    const shows = originalBubble.sentEvents.filter(([channel]) => channel === "permission-show");
+    assert.ok(shows.length >= 2, "refresh should re-send permission-show");
+    const lastShow = shows[shows.length - 1];
+    const payload = lastShow[1];
+    assert.strictEqual(payload.toolName, "KimiPermission");
+    assert.strictEqual(payload.kimiToolName, "Bash");
+    assert.deepStrictEqual(payload.kimiToolInput, { command: "rm -rf build" });
+
+    // A legacy-shaped refresh downgrades to the generic copy — the generic
+    // line can't be wrong; a stale rich cue can.
+    api.showKimiNotifyBubble({ sessionId: "kimi-a", toolName: "shell" });
+    assert.strictEqual(api.pendingPermissions.length, 1);
+    assert.strictEqual(existing.kimiToolInput, null);
+    assert.strictEqual(existing.toolInput.command, "Approve or reject in Kimi terminal.");
+
+    // The refresh re-arms auto-expire from the last request.
+    mock.timers.tick(9_999);
+    assert.strictEqual(api.pendingPermissions.length, 1);
     mock.timers.tick(1);
     assert.strictEqual(api.pendingPermissions.length, 0);
   });

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -166,6 +166,7 @@ describe("server-route-state POST", () => {
         permissionSuspect: true,
         permissionAction: null,
         permissionCommand: null,
+        permissionToolInput: null,
         preserveState: true,
         hookSource: "codex-official",
         backgroundTasksCount: 0,
@@ -185,6 +186,7 @@ describe("server-route-state POST", () => {
       tool_name: "Bash",
       permission_action: "Running: echo hi",
       permission_command: "echo hi",
+      permission_tool_input: { command: "echo hi" },
     }), { ctx: { STATE_SVGS: { notification: "x.svg" } } });
 
     assert.strictEqual(res.statusCode, 200);
@@ -192,6 +194,48 @@ describe("server-route-state POST", () => {
     assert.strictEqual(opts.toolName, "Bash");
     assert.strictEqual(opts.permissionAction, "Running: echo hi");
     assert.strictEqual(opts.permissionCommand, "echo hi");
+    assert.deepStrictEqual(opts.permissionToolInput, { command: "echo hi" });
+  });
+
+  it("re-validates permission_tool_input instead of trusting the hook", async () => {
+    const post = (permissionToolInput) => callStatePost(JSON.stringify({
+      state: "notification",
+      session_id: "kimi-cli:session_abc",
+      event: "PermissionRequest",
+      agent_id: "kimi-cli",
+      tool_name: "Write",
+      permission_tool_input: permissionToolInput,
+    }), { ctx: { STATE_SVGS: { notification: "x.svg" } } });
+
+    // Non-whitelisted and non-string fields are dropped; strings re-clamped.
+    const mixed = await post({
+      file_path: ` ${"p".repeat(600)} `,
+      content: "never forwarded",
+      command: 42,
+    });
+    const forwarded = mixed.calls.updateSession[0][3].permissionToolInput;
+    assert.deepStrictEqual(Object.keys(forwarded), ["file_path"]);
+    assert.strictEqual(forwarded.file_path.length, 500);
+
+    // description is deliberately outside the whitelist: formatDetail prefers
+    // it over command, so a model-authored string could mask the real command.
+    const masked = await post({ command: "rm -rf /tmp/x", description: "Tidy workspace" });
+    assert.deepStrictEqual(
+      masked.calls.updateSession[0][3].permissionToolInput,
+      { command: "rm -rf /tmp/x" }
+    );
+
+    const pattern = await post({ pattern: "TODO(kimi)" });
+    assert.deepStrictEqual(
+      pattern.calls.updateSession[0][3].permissionToolInput,
+      { pattern: "TODO(kimi)" }
+    );
+
+    // Nothing whitelisted survives -> null, same as an absent field.
+    for (const garbage of [{ content: "x" }, "text", [1, 2], 7]) {
+      const res = await post(garbage);
+      assert.strictEqual(res.calls.updateSession[0][3].permissionToolInput, null);
+    }
   });
 
   it("passes assistant last output metadata to updateSession", async () => {

--- a/test/state-kimi-permission.test.js
+++ b/test/state-kimi-permission.test.js
@@ -9,6 +9,7 @@ const defaultTheme = themeLoader.loadTheme("clawd");
 
 function makeCtx() {
   const kimiNotifyShown = [];
+  const kimiNotifyDetails = [];
   const kimiNotifyCleared = [];
   const ctx = {
     lang: "en",
@@ -33,12 +34,16 @@ function makeCtx() {
     pendingPermissions: [],
     resolvePermissionEntry: () => {},
     focusTerminalWindow: () => {},
-    showKimiNotifyBubble: ({ sessionId }) => { kimiNotifyShown.push(sessionId); },
+    showKimiNotifyBubble: (entry) => {
+      kimiNotifyShown.push(entry.sessionId);
+      kimiNotifyDetails.push(entry);
+    },
     clearKimiNotifyBubbles: (sessionId) => { kimiNotifyCleared.push(sessionId || "__all__"); },
     processKill: () => { const e = new Error("ESRCH"); e.code = "ESRCH"; throw e; },
     getCursorScreenPoint: () => ({ x: 100, y: 100 }),
   };
   ctx._kimiNotifyShown = kimiNotifyShown;
+  ctx._kimiNotifyDetails = kimiNotifyDetails;
   ctx._kimiNotifyCleared = kimiNotifyCleared;
   ctx.t = createTranslator(() => ctx.lang);
   return ctx;
@@ -149,10 +154,55 @@ describe("Kimi permission hold by session", () => {
     assert.deepStrictEqual(ctx._kimiNotifyCleared, ["kimi-a"]);
   });
 
-  it("does not show duplicate Kimi notify bubble for repeated permission pulses", () => {
+  it("forwards repeated permission pulses so the bubble layer can refresh in place", () => {
+    // Anti-stacking lives in showKimiNotifyBubble (per-session refresh, codex
+    // idiom) — the state layer must keep forwarding so request #2's detail
+    // replaces request #1's stale cue.
     api.updateSession("kimi-a", "notification", "PermissionRequest", { agentId: "kimi-cli" });
     api.updateSession("kimi-a", "notification", "PermissionRequest", { agentId: "kimi-cli" });
-    assert.deepStrictEqual(ctx._kimiNotifyShown, ["kimi-a"]);
+    assert.deepStrictEqual(ctx._kimiNotifyShown, ["kimi-a", "kimi-a"]);
+  });
+
+  it("forwards fresh detail while a hold is active so the cue never goes stale", () => {
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      toolName: "Bash",
+      permissionCommand: "ls -la",
+      permissionToolInput: { command: "ls -la" },
+    });
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      toolName: "Bash",
+      permissionCommand: "rm -rf build",
+      permissionToolInput: { command: "rm -rf build" },
+    });
+    assert.strictEqual(ctx._kimiNotifyDetails.length, 2);
+    const second = ctx._kimiNotifyDetails[1];
+    assert.strictEqual(second.permissionCommand, "rm -rf build");
+    assert.deepStrictEqual(second.permissionToolInput, { command: "rm -rf build" });
+  });
+
+  it("forwards native permission detail incl. structured tool_input to the notify bubble", () => {
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      toolName: "Write",
+      permissionAction: "Writing: cue-probe.txt",
+      permissionToolInput: { file_path: "cue-probe.txt" },
+    });
+    assert.strictEqual(ctx._kimiNotifyDetails.length, 1);
+    const detail = ctx._kimiNotifyDetails[0];
+    assert.strictEqual(detail.toolName, "Write");
+    assert.strictEqual(detail.permissionAction, "Writing: cue-probe.txt");
+    assert.deepStrictEqual(detail.permissionToolInput, { file_path: "cue-probe.txt" });
+  });
+
+  it("legacy permission pulses pass null tool_input to the notify bubble", () => {
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      toolName: "shell",
+    });
+    assert.strictEqual(ctx._kimiNotifyDetails.length, 1);
+    assert.strictEqual(ctx._kimiNotifyDetails[0].permissionToolInput, null);
   });
 
   it("clears Kimi notify bubble when clearSessionsByAgent disposes the hold", () => {


### PR DESCRIPTION
Follow-up invited in the #504 closing comment: the permission cue for Kimi Code's
Claude-style tool names (Write / Bash / Edit), building on the native
PermissionRequest events from #593.

## What it does

The passive Kimi permission card previously only said "check the Kimi terminal".
The hook now forwards a whitelisted, clamped subset of the native
PermissionRequest's structured `tool_input` (`command` / `file_path` / `pattern`),
and the bubble reuses the standard cue path Claude bubbles use: real tool pill,
`formatDetail` detail line, irreversible-action badge. The card stays
dismiss-only — approval semantics are untouched.

When no structured input arrives (legacy Python CLI, shape drift), the card
renders byte-identical to the old generic one.

## Validation

- Double validation: the hook whitelists + clamps before POSTing, and the server
  re-runs the same validator (`extractPermissionToolInput`) at the trust
  boundary — the `normalizeQuotaGroup` idiom.
- Heavy fields (`content`, `old_string`, `new_string`) are dropped by
  construction; `action` / `display.command` / `tool_name` are clamped so a
  heredoc-sized command can't 413 the /state POST and silently lose the
  notification.
- Bash's model-authored `description` is deliberately not forwarded:
  `formatDetail` prefers it over `command`, so generated text could mask what
  actually runs.
- Kimi's `path` maps to Claude's `file_path` (verified unchanged in the
  kimi-code 0.23.6 bundle).
- A repeat request for the same session refreshes the card in place (the Codex
  notify idiom) instead of leaving a stale cue for a command the terminal is no
  longer blocking on.
- Rendering is textContent/setAttribute only; remote surfaces (Telegram/mobile)
  are excluded.

## Deliberate trade-offs (open to changing)

- The detail line truncates at 120 chars (Claude-bubble parity) where the old
  card showed up to 500 raw chars, and the irreversible badge scans the 500-char
  clamped command (the Claude path scans 4096). Both are wire-budget choices —
  happy to raise the clamps if you prefer.
- The rich pill makes the passive card resemble an actionable bubble; the header
  title and the single "Got it" button remain the passive markers.
- The MCP relabel on the pill (`parseMcpToolName`) is a small separable hunk —
  say the word if you'd like it dropped for tighter scope.
- Legacy immediate-mode requests (lowercase `shell`) get an unstyled pill —
  accepted as cosmetic on a legacy-only path.

## Testing

- Full suite green: 4901 tests / 4885 pass / 0 fail / 16 skipped.
- Every hop is behaviorally tested: hook extraction (incl. clamp, trim-order,
  garbage-shape and description negatives), server re-validation, state
  threading, permission entry + renderer payload, refresh-in-place at both
  layers; the renderer branch follows the repo's source-string test convention.
- Live-verified against kimi-code 0.23.6 interactively (Bash / Write / Edit
  approvals: pill, detail line and badge render; PermissionResult
  auto-dismisses; legacy-shaped payloads keep the generic card), plus payload
  shapes verified from the npm bundle source.
