### PR TITLE
feat(kimi): focus the terminal when the passive Kimi cue is dismissed

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -1929,6 +1929,13 @@ function handleDecide(event, behavior) {
   if (!perm) return;
   if (perm.isCodexNotify || perm.isKimiNotify) {
     dismissPassiveNotify(perm, "ipc-decide");
+    // Kimi Code's cue is a heads-up that its terminal is blocking on a native
+    // approve/reject prompt, so "Got it" doubles as "take me there": focus the
+    // originating terminal after dismissing. Codex's passive notify is
+    // informational-only, so it stays a plain acknowledge.
+    if (perm.isKimiNotify) {
+      ctx.focusTerminalForSession(perm.sessionId, { fallbackEntry: buildPermissionFocusEntry(perm) });
+    }
     return;
   }
   if (perm.isCodex) {

--- a/test/permission-codex-response.test.js
+++ b/test/permission-codex-response.test.js
@@ -270,6 +270,64 @@ describe("Codex permission response sanitizer", () => {
     assert.strictEqual(api.pendingPermissions.length, 0);
   });
 
+  it("focuses the originating terminal when the Kimi cue's Got it button is clicked", () => {
+    const { api, focusCalls } = createCodexDecisionHarness();
+    const bubble = createFakeBubble();
+    const permEntry = {
+      res: null,
+      abortHandler: null,
+      suggestions: [],
+      sessionId: "kimi-cli:s1",
+      bubble,
+      hideTimer: null,
+      toolName: "KimiPermission",
+      toolInput: { command: "rm -rf build" },
+      createdAt: Date.now(),
+      agentId: "kimi-cli",
+      isKimiNotify: true,
+    };
+    api.pendingPermissions.push(permEntry);
+
+    // The renderer sends "allow" for the relabeled "Got it" button; the passive
+    // branch dismisses regardless of the behavior value, and Kimi additionally
+    // brings the terminal forward so the native approve/reject prompt is in view.
+    api.handleDecide({ sender: { __window: bubble } }, "allow");
+
+    assert.deepStrictEqual(focusCalls, [[
+      "kimi-cli:s1",
+      { fallbackEntry: { id: "kimi-cli:s1", agentId: "kimi-cli" } },
+    ]]);
+    assert.strictEqual(bubble.hidden, true);
+    assert.strictEqual(api.pendingPermissions.length, 0);
+  });
+
+  it("dismisses a Codex passive notify without focusing the terminal", () => {
+    const { api, focusCalls } = createCodexDecisionHarness();
+    const bubble = createFakeBubble();
+    api.pendingPermissions.push({
+      res: null,
+      abortHandler: null,
+      suggestions: [],
+      sessionId: "codex:s1",
+      bubble,
+      hideTimer: null,
+      toolName: "CodexExec",
+      toolInput: { command: "npm test" },
+      createdAt: Date.now(),
+      agentId: "codex",
+      isCodexNotify: true,
+    });
+
+    api.handleDecide({ sender: { __window: bubble } }, "allow");
+
+    // The focus-on-dismiss affordance is Kimi-only: Codex notify stays a plain
+    // acknowledge. Pins the shared passive-notify branch against accidental
+    // scope creep.
+    assert.deepStrictEqual(focusCalls, []);
+    assert.strictEqual(bubble.hidden, true);
+    assert.strictEqual(api.pendingPermissions.length, 0);
+  });
+
   it("does not let Codex take suggestion or opencode-only decision paths", () => {
     for (const behavior of ["suggestion:0", "opencode-always"]) {
       const { api } = createCodexDecisionHarness();


### PR DESCRIPTION
Follow-up to #675, implementing the non-blocking UX note from your review:

> "Got it" currently dismisses the cue but does not focus the corresponding terminal.

### What changed
Clicking the passive Kimi Code cue's **"Got it"** button now brings the originating
terminal forward in addition to dismissing the bubble — so you land where Kimi Code's
native approve/reject prompt is waiting instead of hunting for the terminal.

The dismiss path in `handleDecide` routes through the existing
`ctx.focusTerminalForSession(sessionId, { fallbackEntry })` — the same helper the
interactive "Go to Terminal" / `deny-and-focus` buttons already use. No renderer change:
the cue's button already sends `decide`, and the main process owns the Kimi-notify dismiss.

### Scope
Kimi-only. Codex's passive notify is informational-only and has no native prompt to
return to, so it stays a plain acknowledge — pinned by a regression test so the shared
passive-notify branch can't silently gain the behavior.

### Testing
- New tests in `test/permission-codex-response.test.js`: (1) the Kimi cue's "Got it"
  focuses the terminal; (2) Codex notify dismiss does not focus. The feature test was
  confirmed to fail before the change.
- Full suite green: 4997 tests, 4981 pass, 0 fail, 16 skipped.
- Live-verified on a real Kimi Code session: clicking "Got it" brings the Kimi terminal
  to the foreground.