### PR TITLE
refactor(codex): extract hook runner and reuse runtime port

### DIFF
--- a/hooks/codex-hook.js
+++ b/hooks/codex-hook.js
@@ -10,6 +10,7 @@ const {
   postPermissionToRunningServer,
   postStateToRunningServer,
   readHostPrefix,
+  readRuntimeIdentity,
   applyWslSourceFields,
 } = require("./server-config");
 const { createPidResolver, readStdinJson, getPlatformConfig } = require("./shared-process");
@@ -391,49 +392,81 @@ function buildStateBody(payload, resolve) {
   return body;
 }
 
-function requestCodexPermission(body, callback) {
-  postPermissionToRunningServer(
+function requestCodexPermission(body, callback, options = {}) {
+  const postPermission = options.postPermission || postPermissionToRunningServer;
+  const requestOptions = {
+    timeoutMs: getCodexPermissionTimeoutMs(),
+    probeTimeoutMs: 100,
+  };
+  if (options.preferredPort) {
+    requestOptions.preferredPort = options.preferredPort;
+    requestOptions.runtimePort = options.preferredPort;
+  }
+  postPermission(
     JSON.stringify(body),
-    {
-      timeoutMs: getCodexPermissionTimeoutMs(),
-      probeTimeoutMs: 100,
-    },
-    (ok, _port, responseBody) => {
-      callback(ok ? sanitizeCodexPermissionOutput(responseBody) : buildCodexNoDecisionOutput());
+    requestOptions,
+    (ok, port, responseBody) => {
+      callback(ok ? sanitizeCodexPermissionOutput(responseBody) : buildCodexNoDecisionOutput(), ok, port);
     }
   );
 }
 
-function main() {
+async function runCodexHook(payload, options = {}) {
   const config = getPlatformConfig();
-  const resolve = createPidResolver({
+  let preferredPort = options.preferredPort || null;
+  const readIdentity = options.readRuntimeIdentity || readRuntimeIdentity;
+  const resolverOptions = {
     agentNames: { win: new Set(["codex.exe"]), mac: new Set(["codex"]), linux: new Set(["codex"]) },
     platformConfig: config,
+    readRuntimeIdentity() {
+      const identity = readIdentity();
+      if (!preferredPort && identity && identity.port) preferredPort = identity.port;
+      return identity;
+    },
+  };
+  const resolve = options.resolvePid || (options.createPidResolver
+    ? options.createPidResolver(resolverOptions)
+    : createPidResolver(resolverOptions));
+
+  const permissionBody = buildPermissionBody(payload || {}, resolve);
+  if (permissionBody) {
+    return new Promise((resolveRun) => {
+      requestCodexPermission(permissionBody, (stdout, posted, port) => {
+        resolveRun({ body: permissionBody, posted: !!posted, port: port || null, stdout });
+      }, { ...options, preferredPort });
+    });
+  }
+
+  const body = buildStateBody(payload || {}, resolve);
+  if (!body) return { body: null, posted: false, stdout: "" };
+  // Byte-fit before POST so a long CJK assistant_last_output can't trip the
+  // server's headerless 413 (read back as posted=false). See
+  // hooks/state-payload-size.js.
+  const fitted = fitStateBodyToByteBudget(body);
+  const postState = options.postState || postStateToRunningServer;
+  const postOptions = { timeoutMs: 100 };
+  if (preferredPort) {
+    postOptions.preferredPort = preferredPort;
+    postOptions.runtimePort = preferredPort;
+  }
+  return new Promise((resolveRun) => {
+    postState(
+      JSON.stringify(fitted.body),
+      postOptions,
+      (posted, port) => resolveRun({ body: fitted.body, posted: !!posted, port: port || null, stdout: "" })
+    );
   });
-
-  readStdinJson()
-    .then((payload) => {
-      const permissionBody = buildPermissionBody(payload || {}, resolve);
-      if (permissionBody) {
-        requestCodexPermission(permissionBody, (output) => {
-          process.stdout.write(`${output}\n`);
-          process.exit(0);
-        });
-        return;
-      }
-
-      const body = buildStateBody(payload || {}, resolve);
-      if (!body) process.exit(0);
-      // Byte-fit before POST so a long CJK assistant_last_output can't trip the
-      // server's headerless 413 (read back as posted=false). See
-      // hooks/state-payload-size.js.
-      const fitted = fitStateBodyToByteBudget(body);
-      postStateToRunningServer(JSON.stringify(fitted.body), { timeoutMs: 100 }, () => process.exit(0));
-    })
-    .catch(() => process.exit(0));
 }
 
-if (require.main === module) main();
+async function main() {
+  const payload = await readStdinJson();
+  const result = await runCodexHook(payload || {});
+  if (result.stdout) process.stdout.write(`${result.stdout}\n`);
+}
+
+if (require.main === module) {
+  main().then(() => process.exit(0), () => process.exit(0));
+}
 
 module.exports = {
   EVENT_TO_STATE,
@@ -449,6 +482,7 @@ module.exports = {
   isCodexDesktopSession,
   normalizeCodexSessionId,
   readFirstSessionMeta,
+  runCodexHook,
   sanitizeCodexPermissionDecision,
   sanitizeCodexPermissionOutput,
 };

--- a/test/codex-hook.test.js
+++ b/test/codex-hook.test.js
@@ -14,6 +14,7 @@ const {
   extractCodexSessionIdFromTranscriptPath,
   normalizeCodexSessionId,
   readFirstSessionMeta,
+  runCodexHook,
   sanitizeCodexPermissionOutput,
 } = require("../hooks/codex-hook");
 const { readCodexThreadName } = require("../hooks/codex-session-index");
@@ -507,6 +508,51 @@ describe("Codex official hook", () => {
 
     assert.strictEqual(result.status, 0);
     assert.strictEqual(result.stdout, "");
+  });
+
+  it("reuses the runtime port for state and permission hooks", async () => {
+    let resolveCalls = 0;
+    let identityReads = 0;
+    const options = {
+      readRuntimeIdentity() {
+        identityReads += 1;
+        return { ok: true, reason: null, port: 23335, ownerPid: process.pid };
+      },
+      createPidResolver(resolverOptions) {
+        return () => {
+          resolveCalls += 1;
+          resolverOptions.readRuntimeIdentity();
+          return mockResolve();
+        };
+      },
+      postState(_body, options, callback) {
+        assert.strictEqual(options.preferredPort, 23335);
+        assert.strictEqual(options.runtimePort, 23335);
+        callback(true, 23335);
+      },
+      postPermission(_body, requestOptions, callback) {
+        assert.strictEqual(requestOptions.preferredPort, 23335);
+        assert.strictEqual(requestOptions.runtimePort, 23335);
+        callback(true, 23335, JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PermissionRequest",
+            decision: { behavior: "allow" },
+          },
+        }));
+      },
+    };
+    const stateResult = await runCodexHook({ hook_event_name: "SessionStart", session_id: "s1" }, options);
+    const permissionResult = await runCodexHook({
+      hook_event_name: "PermissionRequest",
+      session_id: "s1",
+    }, options);
+
+    assert.strictEqual(resolveCalls, 2);
+    assert.strictEqual(identityReads, 2);
+    assert.strictEqual(stateResult.posted, true);
+    assert.strictEqual(stateResult.port, 23335);
+    assert.strictEqual(permissionResult.posted, true);
+    assert.strictEqual(permissionResult.port, 23335);
   });
 
   describe("remote mode", () => {


### PR DESCRIPTION
## Summary
- extract an awaitable, injectable runCodexHook from the bare main entrypoint
- reuse the port already read by the shared Windows resolver for state and permission routing
- preserve the existing permission discovery probe and full fallback behavior without adding a second preflight

## Context
Rebased onto 2179fac from #687. The redundant Codex-only offline gate and its extra 100 ms probe have been removed; offline process-scan gating remains owned by the shared resolver.

## Testing
- node --test test/hook-adapter-offline-contract.test.js test/codex-hook.test.js (64 passed)
- npm test (5186 passed, 18 skipped, 0 failed)