### PR TITLE
fix: let permission bubbles return to terminal

### DIFF
--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -660,6 +660,17 @@ function renderElicitationTerminalFallback() {
   suggestionsContainer.appendChild(btn);
 }
 
+function renderRegularTerminalFallback(lang) {
+  const btn = document.createElement("button");
+  btn.className = "btn-suggestion";
+  btn.textContent = bubbleText(lang, "goToTerminal");
+  btn.addEventListener("click", () => {
+    disableAll();
+    window.bubbleAPI.decide("deny-and-focus");
+  });
+  suggestionsContainer.appendChild(btn);
+}
+
 function renderElicitationStep() {
   const total = elicitationQuestions.length;
   if (total === 0) {
@@ -780,7 +791,7 @@ function show(data) {
       });
       suggestionsContainer.appendChild(btn);
     }
-
+    renderRegularTerminalFallback(data.lang);
     revealCard();
     return;
   }
@@ -910,21 +921,24 @@ function show(data) {
       window.bubbleAPI.decide("deny-and-focus");
     });
     suggestionsContainer.appendChild(btn);
-  } else if (Array.isArray(data.suggestions)) {
-    const seenLabels = new Set();
-    data.suggestions.forEach((s, i) => {
-      const label = getSuggestionLabel(s, data.lang);
-      if (seenLabels.has(label)) return;
-      seenLabels.add(label);
-      const btn = document.createElement("button");
-      btn.className = "btn-suggestion";
-      btn.textContent = label;
-      btn.addEventListener("click", () => {
-        disableAll();
-        window.bubbleAPI.decide("suggestion:" + i);
+  } else {
+    if (Array.isArray(data.suggestions)) {
+      const seenLabels = new Set();
+      data.suggestions.forEach((s, i) => {
+        const label = getSuggestionLabel(s, data.lang);
+        if (seenLabels.has(label)) return;
+        seenLabels.add(label);
+        const btn = document.createElement("button");
+        btn.className = "btn-suggestion";
+        btn.textContent = label;
+        btn.addEventListener("click", () => {
+          disableAll();
+          window.bubbleAPI.decide("suggestion:" + i);
+        });
+        suggestionsContainer.appendChild(btn);
       });
-      suggestionsContainer.appendChild(btn);
-    });
+    }
+    renderRegularTerminalFallback(data.lang);
   }
   // Re-enable buttons
   btnAllow.disabled = false;

--- a/test/bubble-go-to-terminal.test.js
+++ b/test/bubble-go-to-terminal.test.js
@@ -1,0 +1,179 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const SOURCE = fs.readFileSync(path.join(__dirname, "..", "src", "bubble-renderer.js"), "utf8");
+
+class ClassList {
+  constructor() { this.values = new Set(); }
+  add(...names) { names.forEach((name) => this.values.add(name)); }
+  remove(...names) { names.forEach((name) => this.values.delete(name)); }
+  contains(name) { return this.values.has(name); }
+  toggle(name, force) {
+    const enabled = force === undefined ? !this.contains(name) : !!force;
+    if (enabled) this.add(name); else this.remove(name);
+    return enabled;
+  }
+}
+
+class FakeElement {
+  constructor(tagName = "div") {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.listeners = new Map();
+    this.classList = new ClassList();
+    this.style = { removeProperty(name) { delete this[name]; }, setProperty(name, value) { this[name] = value; } };
+    this.attributes = new Map();
+    this.textContent = "";
+    this.disabled = false;
+    this.value = "";
+    this.offsetHeight = 100;
+    this.scrollHeight = 100;
+    this.scrollWidth = 0;
+    this.clientWidth = 0;
+  }
+  set innerHTML(value) { this.children = []; this.textContent = String(value); }
+  get innerHTML() { return this.textContent; }
+  appendChild(child) { this.children.push(child); child.parentElement = this; return child; }
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+  click() {
+    if (this.disabled) return;
+    for (const listener of this.listeners.get("click") || []) listener({ target: this, preventDefault() {} });
+  }
+  focus() {}
+  setAttribute(name, value) { this.attributes.set(name, String(value)); }
+  getAttribute(name) { return this.attributes.get(name) || null; }
+  removeAttribute(name) { this.attributes.delete(name); }
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
+}
+
+function createHarness() {
+  const elements = new Map();
+  for (const id of [
+    "card", "toolPill", "toolPillText", "commandBlock", "irreversibleBadge",
+    "elicitationForm", "elicitationProgress", "planFeedbackForm", "planFeedbackTextarea",
+    "planFeedbackBack", "planFeedbackSubmit", "btnAllow", "btnDeny", "suggestions", "sessionTag",
+  ]) elements.set(id, new FakeElement(id.includes("Textarea") ? "textarea" : "div"));
+  elements.set("btnAllow", new FakeElement("button"));
+  elements.set("btnDeny", new FakeElement("button"));
+  elements.set("planFeedbackBack", new FakeElement("button"));
+  elements.set("planFeedbackSubmit", new FakeElement("button"));
+  const headerTitle = new FakeElement("span");
+  const decisions = [];
+  let showPermission;
+
+  const document = {
+    activeElement: null,
+    getElementById: (id) => elements.get(id),
+    querySelector: (selector) => selector === ".header-title" ? headerTitle : null,
+    createElement: (tagName) => new FakeElement(tagName),
+    addEventListener() {},
+  };
+  const bubbleAPI = {
+    decide: (decision) => decisions.push(decision),
+    reportHeight() {},
+    onPermissionShow: (callback) => { showPermission = callback; },
+    onPermissionHide() {},
+  };
+  const context = {
+    window: {
+      ClawdBubbleFormat: {
+        formatDetail: () => "detail",
+        truncate: (value) => String(value),
+        parseMcpToolName: () => null,
+        detectIrreversible: () => null,
+      },
+      bubbleAPI,
+      addEventListener() {},
+    },
+    document,
+    requestAnimationFrame(callback) { callback(); return 1; },
+    cancelAnimationFrame() {},
+    console,
+  };
+  context.globalThis = context;
+  vm.runInNewContext(SOURCE, context);
+
+  return {
+    show(data) { showPermission({ lang: "en", toolInput: {}, suggestions: [], ...data }); },
+    decisions,
+    terminalButtons() {
+      return elements.get("suggestions").children.filter((button) => button.textContent === "Go to Terminal");
+    },
+    actionTexts() { return elements.get("suggestions").children.map((button) => button.textContent); },
+  };
+}
+
+describe("permission bubble terminal fallback (issue #689)", () => {
+  for (const [name, data] of [
+    ["Claude Code", { toolName: "Bash" }],
+    ["CodeBuddy", { toolName: "Bash" }],
+    ["Codex", { toolName: "Bash", isCodex: true }],
+    ["Qwen", { toolName: "Bash", isQwenCode: true }],
+    ["Copilot", { toolName: "Bash", isCopilotCli: true }],
+    ["Hermes", { toolName: "Bash", isHermes: true }],
+  ]) {
+    it(`shows exactly one fallback for ${name} and emits only deny-and-focus`, () => {
+      const harness = createHarness();
+      harness.show(data);
+      const buttons = harness.terminalButtons();
+
+      assert.strictEqual(buttons.length, 1);
+      buttons[0].click();
+      buttons[0].click();
+      assert.deepStrictEqual(harness.decisions, ["deny-and-focus"]);
+    });
+  }
+
+  it("shows exactly one fallback for opencode and preserves its Always action", () => {
+    const harness = createHarness();
+    harness.show({
+      toolName: "bash",
+      isOpencode: true,
+      opencodeAlways: ["bash"],
+      toolInput: { command: "pwd" },
+    });
+
+    assert.ok(harness.actionTexts().includes("Always Allow (blanket)"));
+    assert.strictEqual(harness.terminalButtons().length, 1);
+    harness.terminalButtons()[0].click();
+    assert.deepStrictEqual(harness.decisions, ["deny-and-focus"]);
+  });
+
+  for (const toolName of ["CodexExec", "KimiPermission"]) {
+    it(`does not add a terminal fallback to passive ${toolName} notifications`, () => {
+      const harness = createHarness();
+      harness.show({ toolName });
+      assert.strictEqual(harness.terminalButtons().length, 0);
+    });
+  }
+
+  it("keeps elicitation's single terminal action and deny semantics", () => {
+    const harness = createHarness();
+    harness.show({ isElicitation: true, toolName: "AskUserQuestion", toolInput: { questions: [] } });
+
+    const buttons = harness.terminalButtons();
+    assert.strictEqual(buttons.length, 1);
+    buttons[0].click();
+    assert.deepStrictEqual(harness.decisions, ["deny"]);
+  });
+
+  it("keeps plan review's single terminal action and deny-and-focus semantics", () => {
+    const harness = createHarness();
+    harness.show({ toolName: "ExitPlanMode" });
+
+    const buttons = harness.terminalButtons();
+    assert.strictEqual(buttons.length, 1);
+    buttons[0].click();
+    assert.deepStrictEqual(harness.decisions, ["deny-and-focus"]);
+  });
+});


### PR DESCRIPTION
## Summary

- add a Go to Terminal action to regular interactive permission bubbles
- reuse the existing deny-and-focus fallback without approving or denying on the user's behalf
- keep passive notifications, elicitation, and plan-review flows on their existing specialized paths
- add renderer-level DOM behavior coverage across supported permission sources

## Root cause

Regular permission bubbles exposed only Allow and Deny even though the backend already supported handing the undecided request back to the native terminal. Users therefore had no safe way to dismiss the Clawd bubble without making a decision.

## Validation

- targeted permission/bubble tests: 76 passed
- full suite: 5167 tests, 5149 passed, 0 failed, 18 skipped
- independent code review: approved

Fixes #689