### PR TITLE
feat(win): DWM cloak self-heal — probe, un-cloak primitive, watchdog/power wiring (#525)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -4079,9 +4079,8 @@ if (!gotTheLock) {
   app.on("before-quit", () => {
     isQuitting = true;
     if (systemWakeRecovery) systemWakeRecovery.dispose();
-    // #525: release the IVirtualDesktopManager COM ref. (CoUninitialize is
-    // deliberately NOT called — the main thread's COM lifetime belongs to
-    // Chromium; see win-cloak-recovery.js.)
+    // #525: release the IVirtualDesktopManager COM ref and pay back our own
+    // CoInitializeEx count (see win-cloak-recovery.js dispose()).
     _cloakInspector.dispose();
     try { stopUpdateScheduler(); } catch {}
     releasePowerSaveBlocker();

--- a/src/main.js
+++ b/src/main.js
@@ -170,6 +170,15 @@ const _isForegroundFullscreen = createForegroundFullscreenProbe({
   onError: (err) => console.warn("Clawd: win-fullscreen-detect not available:", err && err.message),
 });
 
+// ── Windows: DWM cloak inspection + un-cloak (#525 self-heal) ──
+// Best-effort; degrades to "never cloaked / recovery no-op" when koffi/dwmapi
+// or the virtual-desktop COM manager is unavailable.
+const { createCloakInspector } = require("./win-cloak-recovery");
+const _cloakInspector = createCloakInspector({
+  isWin,
+  log: (line) => console.warn(`Clawd: ${line}`),
+});
+
 // ── Windows: foreground Windows Terminal probe (server-side wt_hwnd sample,
 // #627 residual) ──
 // Best-effort; degrades to "never sampled" (always null) if koffi/user32 is
@@ -745,6 +754,8 @@ const petWindowRuntime = createPetWindowRuntime({
   reapplyMacVisibility: () => reapplyMacVisibility(),
   reassertWinTopmost: () => reassertWinTopmost(),
   scheduleHwndRecovery: () => scheduleHwndRecovery(),
+  cloakInspector: _cloakInspector,
+  isMiniAnimating: () => _mini.getIsAnimating(),
   isNearWorkAreaEdge: (bounds) => isNearWorkAreaEdge(bounds),
   flushRuntimeStateToPrefs: () => flushRuntimeStateToPrefs(),
   handleMiniDisplayChange: () => _mini.handleDisplayChange(),
@@ -1297,6 +1308,7 @@ const topmostRuntime = createTopmostRuntime({
   isMac,
   getWin: () => win,
   getHitWin: () => hitWin,
+  recoverCloakedPet: () => petWindowRuntime.recoverIfCloaked(),
   getPendingPermissions: () => pendingPermissions,
   getUpdateBubbleWindow: () => _updateBubble.getBubbleWindow(),
   getSessionHudWindow: () => getSessionHudWindow(),
@@ -3866,6 +3878,10 @@ if (!gotTheLock) {
         hitWin.showInactive();
         keepOutOfTaskbar(hitWin);
       }
+      // #525: relaunching while the pet is nominally visible is a "where is my
+      // pet?" signal — showInactive() alone cannot clear a DWM cloak, so run
+      // the cloak recovery path too.
+      petWindowRuntime.recoverIfCloaked();
     }
     if (shouldOpenSettingsWindowFromArgv(commandLine)) {
       settingsWindowRuntime.openWhenReady();
@@ -3988,6 +4004,16 @@ if (!gotTheLock) {
       ),
     });
     systemWakeRecovery.start();
+    // #525: sleep/wake and lock/unlock are prime DWM-cloak moments. Hang the
+    // cloak recovery directly on powerMonitor rather than onRecovered above:
+    // onRecovered only fires after a renderer round-trip and is skipped on
+    // timeout (system-wake-recovery.js finishWithTimeout), while un-cloaking is
+    // a main-process concern that must not depend on renderer health. The two
+    // paths coexist; recoverIfCloaked() is a no-op when nothing is cloaked.
+    if (isWin) {
+      powerMonitor.on("resume", () => petWindowRuntime.recoverIfCloaked());
+      powerMonitor.on("unlock-screen", () => petWindowRuntime.recoverIfCloaked());
+    }
     // macOS: bridge the OS app-hidden state (⌘H / Dock right-click → 隐藏) to the
     // pet. Pet windows are setCanHide:NO, so the OS marks the app hidden but the
     // windows refuse to vanish, and an inactive-app Dock Hide fires no

--- a/src/main.js
+++ b/src/main.js
@@ -4079,6 +4079,10 @@ if (!gotTheLock) {
   app.on("before-quit", () => {
     isQuitting = true;
     if (systemWakeRecovery) systemWakeRecovery.dispose();
+    // #525: release the IVirtualDesktopManager COM ref. (CoUninitialize is
+    // deliberately NOT called — the main thread's COM lifetime belongs to
+    // Chromium; see win-cloak-recovery.js.)
+    _cloakInspector.dispose();
     try { stopUpdateScheduler(); } catch {}
     releasePowerSaveBlocker();
     flushRuntimeStateToPrefs();

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -350,6 +350,7 @@ function createPetWindowRuntime(options = {}) {
     if (!targets.length) return "no-window";
 
     let attempted = false;
+    let touched = false;
     let stillCloaked = false;
     for (const win of targets) {
       const flag = cloakInspector.readCloakState(win);
@@ -368,6 +369,7 @@ function createPetWindowRuntime(options = {}) {
       }
       win.showInactive();
       keepOutOfTaskbar(win);
+      touched = true;
       if (cloakInspector.readCloakState(win) !== 0) stillCloaked = true;
     }
     if (!attempted) {
@@ -379,7 +381,10 @@ function createPetWindowRuntime(options = {}) {
       return "clean";
     }
 
-    reassertWinTopmost();
+    // Same fail-open contract as above, second exit: a round where every
+    // un-cloak call failed must not re-assert topmost either — that would
+    // setAlwaysOnTop both windows on a path where native calls are failing.
+    if (touched) reassertWinTopmost();
     if (!stillCloaked) {
       cloakFailStreak = 0;
       cloakCooldownUntil = 0;

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -21,6 +21,7 @@ const {
   needsFinalClampAdjustment: needsFinalClampAdjustmentRaw,
   materializeVirtualBounds: materializeVirtualBoundsRaw,
 } = require("./drag-position");
+const { classifyCloakState } = require("./win-cloak-recovery");
 
 const noop = () => {};
 const DEFAULT_CRASH_RELOAD_LIMIT = 5;
@@ -133,6 +134,11 @@ function createPetWindowRuntime(options = {}) {
   const syncImeEditingPetDodge = options.syncImeEditingPetDodge || noop;
   const reassertWinTopmost = options.reassertWinTopmost || noop;
   const scheduleHwndRecovery = options.scheduleHwndRecovery || noop;
+  // #525: DWM cloak probe + un-cloak primitives (win-cloak-recovery.js).
+  // Absent/unavailable inspector degrades every cloak path to a no-op.
+  const cloakInspector = options.cloakInspector || null;
+  const isMiniAnimating = options.isMiniAnimating || (() => false);
+  const now = options.now || (() => Date.now());
   const isNearWorkAreaEdge = options.isNearWorkAreaEdge || (() => false);
   const flushRuntimeStateToPrefs = options.flushRuntimeStateToPrefs || noop;
   const handleMiniDisplayChange = options.handleMiniDisplayChange || noop;
@@ -251,14 +257,28 @@ function createPetWindowRuntime(options = {}) {
     return petHidden;
   }
 
+  // #525: clear an abnormal DWM cloak before showing. showInactive() alone
+  // does NOT un-cloak (hide/show cycling is unreliable for that — plan §1.2-B);
+  // DwmSetWindowAttribute(DWMWA_CLOAK, FALSE) is the direct primitive. Windows
+  // parked on another virtual desktop are deliberately left alone.
+  function uncloakIfAbnormal(win) {
+    if (!cloakInspector || !cloakInspector.available || !isLiveWindow(win)) return false;
+    const flag = cloakInspector.readCloakState(win);
+    const verdict = classifyCloakState(flag, flag === 0 ? true : cloakInspector.isOnCurrentVirtualDesktop(win));
+    if (verdict !== "recover") return false;
+    return cloakInspector.uncloak(win);
+  }
+
   function showPetWindows() {
     const win = getRenderWindow();
     if (isLiveWindow(win)) {
+      uncloakIfAbnormal(win);
       win.showInactive();
       keepOutOfTaskbar(win);
     }
     const hitWin = getHitWindow();
     if (isLiveWindow(hitWin)) {
+      uncloakIfAbnormal(hitWin);
       hitWin.showInactive();
       keepOutOfTaskbar(hitWin);
     }
@@ -303,6 +323,61 @@ function createPetWindowRuntime(options = {}) {
 
   function togglePetVisibility() {
     return setPetHidden(!petHidden);
+  }
+
+  // ── #525: self-healing for cloaked-yet-supposedly-visible windows ──
+  //
+  // Called from the 5s topmost watchdog, powerMonitor resume/unlock, and the
+  // second-instance handler. Deliberately NOT wired into togglePetVisibility:
+  // hide must always mean hide (a cloak-aware toggle polarity degenerates into
+  // "can never hide" on machines whose cloak flag reads permanently non-zero —
+  // the exact regression review round 2026-07-16 blocked in the external
+  // patch). Recovery failures back off exponentially so a stubborn cloak never
+  // turns the watchdog into a 5s hide/show strobe.
+  const CLOAK_BACKOFF_BASE_MS = 5_000;
+  const CLOAK_BACKOFF_MAX_MS = 300_000;
+  let cloakFailStreak = 0;
+  let cloakCooldownUntil = 0;
+
+  function recoverIfCloaked() {
+    if (!cloakInspector || !cloakInspector.available) return "unavailable";
+    if (petHidden) return "hidden";
+    if (getMiniTransitioning() || isMiniAnimating() || dragLocked) return "busy";
+    if (settingsSizePreviewSyncFrozen) return "frozen";
+    if (now() < cloakCooldownUntil) return "backoff";
+
+    const targets = [getRenderWindow(), getHitWindow()].filter(isLiveWindow);
+    if (!targets.length) return "no-window";
+
+    let attempted = false;
+    let stillCloaked = false;
+    for (const win of targets) {
+      const flag = cloakInspector.readCloakState(win);
+      if (flag === 0) continue;
+      const verdict = classifyCloakState(flag, cloakInspector.isOnCurrentVirtualDesktop(win));
+      if (verdict !== "recover") continue;
+      attempted = true;
+      cloakInspector.uncloak(win);
+      win.showInactive();
+      keepOutOfTaskbar(win);
+      if (cloakInspector.readCloakState(win) !== 0) stillCloaked = true;
+    }
+    if (!attempted) return "clean";
+
+    reassertWinTopmost();
+    if (!stillCloaked) {
+      cloakFailStreak = 0;
+      cloakCooldownUntil = 0;
+      scheduleHwndRecovery();
+      return "recovered";
+    }
+    cloakFailStreak += 1;
+    const backoff = Math.min(
+      CLOAK_BACKOFF_BASE_MS * 2 ** cloakFailStreak,
+      CLOAK_BACKOFF_MAX_MS
+    );
+    cloakCooldownUntil = now() + backoff;
+    return "failed";
   }
 
   function bringPetToPrimaryDisplay() {
@@ -886,6 +961,7 @@ function createPetWindowRuntime(options = {}) {
     isPetHidden,
     setPetHidden,
     togglePetVisibility,
+    recoverIfCloaked,
     bringPetToPrimaryDisplay,
     getViewportOffsetY,
     setViewportOffsetY,

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -357,12 +357,27 @@ function createPetWindowRuntime(options = {}) {
       const verdict = classifyCloakState(flag, cloakInspector.isOnCurrentVirtualDesktop(win));
       if (verdict !== "recover") continue;
       attempted = true;
-      cloakInspector.uncloak(win);
+      // Fail-open contract: if the DWM un-cloak call itself fails, do NOT go
+      // on to touch the window (show/taskbar/topmost would be a behavior
+      // change over the pre-#525 no-op, and a fail-open re-read of 0 could
+      // then mislabel the round "recovered"). Count it as a failure and let
+      // the backoff decide when to try again.
+      if (!cloakInspector.uncloak(win)) {
+        stillCloaked = true;
+        continue;
+      }
       win.showInactive();
       keepOutOfTaskbar(win);
       if (cloakInspector.readCloakState(win) !== 0) stillCloaked = true;
     }
-    if (!attempted) return "clean";
+    if (!attempted) {
+      // Nothing abnormal this round: the previous fault (if any) resolved on
+      // its own, so the NEXT independent fault must start from a fresh 10s
+      // backoff instead of inheriting an escalated cooldown.
+      cloakFailStreak = 0;
+      cloakCooldownUntil = 0;
+      return "clean";
+    }
 
     reassertWinTopmost();
     if (!stillCloaked) {

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -98,6 +98,11 @@ function createTopmostRuntime(options = {}) {
   // fullscreen ends because dragging needs it (#545). No-op off Windows / when
   // unset. (#538 drag focus-steal)
   const setHitWinFocusable = options.setHitWinFocusable || (() => {});
+  // #525: cloak self-heal hook, run at the tail of each watchdog tick. The
+  // callee (pet-window-runtime recoverIfCloaked) carries its own guards and
+  // exponential backoff; the watchdog only decides WHEN it's appropriate to
+  // try at all (see the fullscreen stand-down at the call site).
+  const recoverCloakedPet = options.recoverCloakedPet || (() => {});
   const setForceEyeResend = options.setForceEyeResend || (() => {});
   const applyPetWindowPosition = options.applyPetWindowPosition || (() => {});
   const syncHitWin = options.syncHitWin || (() => {});
@@ -406,6 +411,11 @@ function createTopmostRuntime(options = {}) {
       const skipTopmost = fsForeground && !getFullscreenOverlay();
       reassertWindowAndTaskbar(getWin(), { skipTopmost });
       reassertWindowAndTaskbar(getHitWin(), { skipTopmost });
+
+      // #525: periodic cloak self-heal. Skipped while standing down for a
+      // fullscreen app — recovery calls showInactive()/setAlwaysOnTop, exactly
+      // the interference stand-down exists to avoid (§8.3).
+      if (!skipTopmost) recoverCloakedPet();
 
       for (const perm of getPendingPermissions()) {
         const bubble = perm && perm.bubble;

--- a/src/win-cloak-recovery.js
+++ b/src/win-cloak-recovery.js
@@ -1,0 +1,209 @@
+"use strict";
+
+// ── Windows DWM cloak inspection + recovery primitives (#525) ──
+//
+// DWM can "cloak" a window: it stays logically visible (isVisible()=true,
+// WS_VISIBLE set) but the compositor stops drawing it. Sources: app suspension,
+// virtual-desktop membership, shell decisions, sleep/wake, RDP reconnects.
+// Electron has no API for any of this, so the pet can vanish while every
+// JS-visible signal stays green.
+//
+// This module is the production distillation of the three-round diagnostic
+// probe (win-cloak-diagnostic.js, kept in history at d8d308a) whose FFI paths
+// were verified on real machines during the #496/#525 investigation:
+//   • DwmGetWindowAttribute(DWMWA_CLOAKED=14) reads the cloak flag
+//     (0 none / 1 APP / 2 SHELL / 4 INHERITED).
+//   • DwmSetWindowAttribute(DWMWA_CLOAK=13, FALSE) un-cloaks a window the
+//     process cloaked itself — the direct primitive; hide()/show() cycling is
+//     NOT a reliable un-cloak (plan §1.2-B).
+//   • IVirtualDesktopManager::IsWindowOnCurrentVirtualDesktop distinguishes
+//     "cloaked because the user parked it on another virtual desktop"
+//     (legitimate — leave it alone) from "cloaked on the CURRENT desktop"
+//     (broken — recover). SHELL=2 alone cannot make that call (plan §1.2-D):
+//     the SDK guarantees flag values, not "SHELL ⇔ virtual desktop".
+//
+// Degradation ladder (every rung fail-open — a probe failure must never make
+// the pet WORSE than the pre-#525 no-op behavior):
+//   koffi/dwmapi unavailable        → available=false, callers skip entirely
+//   COM manager unavailable         → isOnCurrentVirtualDesktop returns null;
+//                                     callers must then only treat APP=1 as
+//                                     abnormal and leave SHELL/INHERITED alone
+//   any per-call throw / bad handle → "not cloaked" / no-op
+//
+// COM lifetime: CoInitializeEx may report S_OK, S_FALSE, or RPC_E_CHANGED_MODE
+// depending on what Chromium already did on this thread — none of those block
+// CoCreateInstance, so success is judged solely by CoCreateInstance. We Release
+// the manager on dispose() but deliberately never CoUninitialize: the main
+// thread's COM lifetime belongs to Chromium.
+
+const DWMWA_CLOAK = 13;
+const DWMWA_CLOAKED = 14;
+
+const CLOAK_NONE = 0;
+const CLOAK_APP = 1;
+const CLOAK_SHELL = 2;
+const CLOAK_INHERITED = 4;
+
+// Pure decision core, exported for tests: given a cloak flag and the
+// virtual-desktop answer (true/false/null=unknown), should recovery act?
+//   flag 0                → "clean"        (nothing to do)
+//   on another desktop    → "other-desktop" (user choice — never touch)
+//   on current desktop    → "recover"      (cloaked yet supposedly in view)
+//   desktop unknown (COM down): only APP=1 is safely attributable to a broken
+//   state; SHELL/INHERITED could be legitimate desktop parking → "skip".
+function classifyCloakState(flag, onCurrentDesktop) {
+  if (!Number.isInteger(flag) || flag === CLOAK_NONE) return "clean";
+  if (onCurrentDesktop === false) return "other-desktop";
+  if (onCurrentDesktop === true) return "recover";
+  return (flag & CLOAK_APP) ? "recover" : "skip";
+}
+
+function createCloakInspector(options = {}) {
+  const isWin = options.isWin != null ? !!options.isWin : process.platform === "win32";
+  const log = typeof options.log === "function" ? options.log : () => {};
+
+  const unavailable = {
+    available: false,
+    readCloakState: () => CLOAK_NONE,
+    isOnCurrentVirtualDesktop: () => null,
+    uncloak: () => false,
+    dispose: () => {},
+  };
+  if (!isWin) return unavailable;
+
+  let koffi;
+  let dwmGet;
+  let dwmSet;
+  let ptrSize;
+  try {
+    koffi = require("koffi");
+    const dwmapi = koffi.load("dwmapi.dll");
+    dwmGet = dwmapi.func("int __stdcall DwmGetWindowAttribute(void *hwnd, uint dwAttribute, void *pvAttribute, uint cbAttribute)");
+    dwmSet = dwmapi.func("int __stdcall DwmSetWindowAttribute(void *hwnd, uint dwAttribute, void *pvAttribute, uint cbAttribute)");
+    ptrSize = koffi.sizeof("void *");
+  } catch (err) {
+    log(`cloak-recovery init failed (probe disabled): ${err && err.message}`);
+    return unavailable;
+  }
+
+  // IVirtualDesktopManager via manual vtable dispatch (koffi has no COM layer):
+  // *iface is the vtable; slots 0-2 are IUnknown, slot 3 is
+  // IsWindowOnCurrentVirtualDesktop. Verified on real machines by the round-3
+  // probe (reporter logs show "vdesk probe ready" + per-window vdesk=CURRENT).
+  let vdeskQuery = null;
+  let vdeskRelease = null;
+  try {
+    const ole32 = koffi.load("ole32.dll");
+    const CoInitializeEx = ole32.func("int __stdcall CoInitializeEx(void *pvReserved, uint dwCoInit)");
+    const CoCreateInstance = ole32.func(
+      "int __stdcall CoCreateInstance(void *rclsid, void *pUnkOuter, uint dwClsContext, void *riid, _Out_ void **ppv)"
+    );
+    // GUID memory layout: Data1(u32 LE) Data2(u16 LE) Data3(u16 LE) Data4(8 bytes)
+    const guidBuf = (g) => {
+      const [d1, d2, d3, d4, d5] = g.split("-");
+      const b = Buffer.alloc(16);
+      b.writeUInt32LE(parseInt(d1, 16), 0);
+      b.writeUInt16LE(parseInt(d2, 16), 4);
+      b.writeUInt16LE(parseInt(d3, 16), 6);
+      Buffer.from(d4 + d5, "hex").copy(b, 8);
+      return b;
+    };
+    const coInitHr = CoInitializeEx(null, 0x2 /* COINIT_APARTMENTTHREADED */);
+    const ppv = [null];
+    const ccHr = CoCreateInstance(
+      guidBuf("AA509086-5CA9-4C25-8F95-589D3C07B48A"), // CLSID_VirtualDesktopManager
+      null,
+      0x17 /* CLSCTX_ALL */,
+      guidBuf("A5CD92FF-29BE-454C-8D04-D82879FB3F1B"), // IID_IVirtualDesktopManager
+      ppv
+    );
+    if (ccHr === 0 && ppv[0]) {
+      const mgr = ppv[0];
+      const vtbl = koffi.decode(mgr, "void *");
+      const fnIsOnCurrent = koffi.decode(vtbl, 3 * ptrSize, "void *");
+      const IsOnCurrentProto = koffi.proto(
+        "int __stdcall CloakIsWindowOnCurrentVirtualDesktop(void *self, void *hwnd, _Out_ int *onCurrent)"
+      );
+      vdeskQuery = (hwnd) => {
+        const out = [0];
+        const hr = koffi.call(fnIsOnCurrent, IsOnCurrentProto, mgr, hwnd, out);
+        return hr === 0 ? !!out[0] : null;
+      };
+      const fnRelease = koffi.decode(vtbl, 2 * ptrSize, "void *");
+      const ReleaseProto = koffi.proto("uint __stdcall CloakIUnknownRelease(void *self)");
+      vdeskRelease = () => { try { koffi.call(fnRelease, ReleaseProto, mgr); } catch {} };
+    } else {
+      log(`cloak-recovery vdesk unavailable (CoCreateInstance=0x${(ccHr >>> 0).toString(16)}, CoInitializeEx=0x${(coInitHr >>> 0).toString(16)}) — degrading to APP-only recovery`);
+    }
+  } catch (err) {
+    log(`cloak-recovery vdesk init failed — degrading to APP-only recovery: ${err && err.message}`);
+  }
+
+  function hwndOf(win) {
+    try {
+      if (!win || typeof win.isDestroyed !== "function" || win.isDestroyed()) return null;
+      const buf = win.getNativeWindowHandle();
+      if (!buf || buf.length < ptrSize) return null;
+      return koffi.decode(buf, "void *");
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    available: true,
+
+    // 0 when not cloaked OR when anything fails (fail-open).
+    readCloakState(win) {
+      const hwnd = hwndOf(win);
+      if (!hwnd) return CLOAK_NONE;
+      try {
+        const out = Buffer.alloc(4);
+        const hr = dwmGet(hwnd, DWMWA_CLOAKED, out, 4);
+        return hr === 0 ? out.readUInt32LE(0) : CLOAK_NONE;
+      } catch {
+        return CLOAK_NONE;
+      }
+    },
+
+    // true/false, or null when the COM manager is unavailable or the call fails.
+    isOnCurrentVirtualDesktop(win) {
+      if (!vdeskQuery) return null;
+      const hwnd = hwndOf(win);
+      if (!hwnd) return null;
+      try {
+        return vdeskQuery(hwnd);
+      } catch {
+        return null;
+      }
+    },
+
+    // Clear a self-inflicted (APP) cloak. Returns whether the DWM call
+    // reported success; the caller re-reads the flag to confirm.
+    uncloak(win) {
+      const hwnd = hwndOf(win);
+      if (!hwnd) return false;
+      try {
+        const f = Buffer.alloc(4); // BOOL FALSE
+        return dwmSet(hwnd, DWMWA_CLOAK, f, 4) === 0;
+      } catch {
+        return false;
+      }
+    },
+
+    dispose() {
+      if (vdeskRelease) vdeskRelease();
+      vdeskQuery = null;
+      vdeskRelease = null;
+    },
+  };
+}
+
+module.exports = {
+  createCloakInspector,
+  classifyCloakState,
+  CLOAK_NONE,
+  CLOAK_APP,
+  CLOAK_SHELL,
+  CLOAK_INHERITED,
+};

--- a/src/win-cloak-recovery.js
+++ b/src/win-cloak-recovery.js
@@ -32,9 +32,11 @@
 //
 // COM lifetime: CoInitializeEx may report S_OK, S_FALSE, or RPC_E_CHANGED_MODE
 // depending on what Chromium already did on this thread — none of those block
-// CoCreateInstance, so success is judged solely by CoCreateInstance. We Release
-// the manager on dispose() but deliberately never CoUninitialize: the main
-// thread's COM lifetime belongs to Chromium.
+// CoCreateInstance, so success is judged solely by CoCreateInstance. dispose()
+// Releases the manager and then pays back OUR CoInitializeEx count (S_OK and
+// S_FALSE both add one; RPC_E_CHANGED_MODE adds none) — balancing our own
+// count is required by the CoInitializeEx contract and never disturbs
+// Chromium's own counts on the thread.
 
 const DWMWA_CLOAK = 13;
 const DWMWA_CLOAKED = 14;
@@ -92,9 +94,17 @@ function createCloakInspector(options = {}) {
   // probe (reporter logs show "vdesk probe ready" + per-window vdesk=CURRENT).
   let vdeskQuery = null;
   let vdeskRelease = null;
+  let coUninitialize = null;
+  // COM init is reference-counted per thread: our CoInitializeEx adds exactly
+  // one count that dispose() pays back with one CoUninitialize (same thread —
+  // module load and before-quit both run on the main thread). Balancing our
+  // own count never disturbs Chromium's. RPC_E_CHANGED_MODE adds no count, so
+  // nothing is owed in that case.
+  let owesCoUninitialize = false;
   try {
     const ole32 = koffi.load("ole32.dll");
     const CoInitializeEx = ole32.func("int __stdcall CoInitializeEx(void *pvReserved, uint dwCoInit)");
+    coUninitialize = ole32.func("void __stdcall CoUninitialize()");
     const CoCreateInstance = ole32.func(
       "int __stdcall CoCreateInstance(void *rclsid, void *pUnkOuter, uint dwClsContext, void *riid, _Out_ void **ppv)"
     );
@@ -109,6 +119,7 @@ function createCloakInspector(options = {}) {
       return b;
     };
     const coInitHr = CoInitializeEx(null, 0x2 /* COINIT_APARTMENTTHREADED */);
+    owesCoUninitialize = coInitHr === 0 || coInitHr === 1; // S_OK / S_FALSE
     const ppv = [null];
     const ccHr = CoCreateInstance(
       guidBuf("AA509086-5CA9-4C25-8F95-589D3C07B48A"), // CLSID_VirtualDesktopManager
@@ -192,9 +203,15 @@ function createCloakInspector(options = {}) {
     },
 
     dispose() {
+      // Order matters: release the COM object before paying back the COM
+      // init count that keeps its apartment alive.
       if (vdeskRelease) vdeskRelease();
       vdeskQuery = null;
       vdeskRelease = null;
+      if (owesCoUninitialize && coUninitialize) {
+        try { coUninitialize(); } catch {}
+        owesCoUninitialize = false;
+      }
     },
   };
 }

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -625,16 +625,22 @@ function makeCloakInspector(overrides = {}) {
   const inspector = {
     calls: [],
     available: overrides.available ?? true,
+    // number, or (win) => number for per-window flags (mixed-verdict tests).
     flag: overrides.flag ?? 0,
     // "onCurrent: null" must survive as null (= COM probe down), so ?? is wrong here.
     onCurrent: "onCurrent" in overrides ? overrides.onCurrent : true,
     uncloakClears: overrides.uncloakClears ?? true,
-    readCloakState() { inspector.calls.push("read"); return inspector.flag; },
+    uncloakResult: overrides.uncloakResult ?? true,
+    flagFor(win) {
+      return typeof inspector.flag === "function" ? inspector.flag(win) : inspector.flag;
+    },
+    readCloakState(win) { inspector.calls.push("read"); return inspector.flagFor(win); },
     isOnCurrentVirtualDesktop() { inspector.calls.push("vdesk"); return inspector.onCurrent; },
-    uncloak() {
+    uncloak(win) {
       inspector.calls.push("uncloak");
-      if (inspector.uncloakClears) inspector.flag = 0;
-      return true;
+      if (overrides.onUncloak) return overrides.onUncloak(win);
+      if (inspector.uncloakClears && typeof inspector.flag !== "function") inspector.flag = 0;
+      return inspector.uncloakResult;
     },
     dispose() {},
   };
@@ -746,15 +752,64 @@ describe("pet-window-runtime cloak self-heal (#525)", () => {
     assert.equal(down.runtime.recoverIfCloaked(), "unavailable");
   });
 
-  it("showPetWindows un-cloaks an abnormally cloaked window before showing", () => {
-    const inspector = makeCloakInspector({ flag: 1, onCurrent: true });
-    const h = createRuntime({ cloakInspector: inspector });
+  it("showPetWindows un-cloaks an abnormally cloaked window BEFORE showInactive (order-sensitive)", () => {
+    // Shared timeline so the uncloak/showInactive relative order is provable —
+    // a swapped implementation must fail this test.
+    const timeline = [];
+    const renderWin = makeWindow();
+    const origShowInactive = renderWin.showInactive;
+    renderWin.showInactive = () => { timeline.push("showInactive"); origShowInactive(); };
+    const inspector = makeCloakInspector({ flag: 1, onCurrent: true, onUncloak: () => { timeline.push("uncloak"); return true; } });
+    const h = createRuntime({ cloakInspector: inspector, renderWin });
     h.runtime.setPetHidden(true);
-    inspector.calls.length = 0;
+    timeline.length = 0;
     h.runtime.setPetHidden(false);
+    const uncloakIdx = timeline.indexOf("uncloak");
+    const showIdx = timeline.indexOf("showInactive");
+    assert.ok(uncloakIdx >= 0 && showIdx >= 0);
+    assert.ok(uncloakIdx < showIdx, `expected uncloak before showInactive, got ${JSON.stringify(timeline)}`);
+  });
+
+  it("recoverIfCloaked fails the round when one window recovers and the other stays cloaked", () => {
+    const flags = new Map();
+    const renderWin = makeWindow();
+    const hitWin = makeWindow();
+    flags.set(renderWin, 1); // recovers on uncloak
+    flags.set(hitWin, 1);    // stays cloaked forever
+    const inspector = makeCloakInspector({
+      flag: (win) => flags.get(win) ?? 0,
+      onUncloak: (win) => { if (win === renderWin) flags.set(renderWin, 0); return true; },
+    });
+    const h = createRuntime({ cloakInspector: inspector, renderWin, hitWin });
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");
+    // Shared cooldown: the healthy window's success must not clear the streak.
+    assert.equal(h.runtime.recoverIfCloaked(), "backoff");
+  });
+
+  it("recoverIfCloaked does not touch the window when the un-cloak call itself fails (fail-open)", () => {
+    const inspector = makeCloakInspector({ flag: 1, uncloakResult: false, uncloakClears: false });
+    const renderWin = makeWindow();
+    const h = createRuntime({ cloakInspector: inspector, renderWin });
+    const before = renderWin.calls.length;
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");
     assert.ok(inspector.calls.includes("uncloak"));
-    const win = h.renderWin;
-    const uncloakBeforeShow = win.calls.findIndex(([n]) => n === "showInactive") >= 0;
-    assert.ok(uncloakBeforeShow);
+    // No showInactive/keepOutOfTaskbar on the window after a failed native call.
+    assert.deepStrictEqual(renderWin.calls.slice(before), []);
+    assert.ok(!h.calls.some(([name]) => name === "keepOutOfTaskbar"));
+  });
+
+  it("a clean round resets the backoff so the next independent fault starts fresh", () => {
+    let clock = 1_000_000;
+    const inspector = makeCloakInspector({ flag: 1, uncloakClears: false });
+    const h = createRuntime({ cloakInspector: inspector, now: () => clock });
+
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");   // streak=1, cooldown 10s
+    clock += 10_001;
+    inspector.flag = 0;                                      // fault resolves on its own
+    assert.equal(h.runtime.recoverIfCloaked(), "clean");     // must reset the streak
+    inspector.flag = 1;                                      // NEW independent fault
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");    // streak must restart at 1
+    clock += 10_001;                                         // fresh 10s window, not 20s
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");
   });
 });

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -117,6 +117,9 @@ function createRuntime(overrides = {}) {
       : {}),
     reassertWinTopmost: () => calls.push(["reassertWinTopmost"]),
     scheduleHwndRecovery: () => calls.push(["scheduleHwndRecovery"]),
+    ...(overrides.cloakInspector ? { cloakInspector: overrides.cloakInspector } : {}),
+    ...(overrides.isMiniAnimating ? { isMiniAnimating: overrides.isMiniAnimating } : {}),
+    ...(overrides.now ? { now: overrides.now } : {}),
     isNearWorkAreaEdge: () => overrides.nearEdge || false,
     flushRuntimeStateToPrefs: () => calls.push(["flushRuntimeStateToPrefs"]),
     handleMiniDisplayChange: () => calls.push(["handleMiniDisplayChange"]),
@@ -606,5 +609,152 @@ describe("pet-window-runtime setPetHidden contract (#416)", () => {
     assert.equal(h.runtime.isPetHidden(), true);
     h.runtime.togglePetVisibility();
     assert.equal(h.runtime.isPetHidden(), false);
+  });
+});
+
+// ── #525: DWM cloak self-heal ──
+//
+// The review of the external cef717d patch (2026-07-16, three independent
+// reviewers) blocked a cloak-aware toggle polarity: on a machine whose cloak
+// flag reads permanently non-zero (the #496 reporter's machine did, SHELL=2
+// while visibly fine), "toggle by actual visibility" degenerates into
+// setPetHidden(false) forever — tray/context-menu/shortcut all lose the
+// ability to hide. These tests pin the survivors: hide always means hide;
+// recovery lives on its own path with guards and backoff.
+function makeCloakInspector(overrides = {}) {
+  const inspector = {
+    calls: [],
+    available: overrides.available ?? true,
+    flag: overrides.flag ?? 0,
+    // "onCurrent: null" must survive as null (= COM probe down), so ?? is wrong here.
+    onCurrent: "onCurrent" in overrides ? overrides.onCurrent : true,
+    uncloakClears: overrides.uncloakClears ?? true,
+    readCloakState() { inspector.calls.push("read"); return inspector.flag; },
+    isOnCurrentVirtualDesktop() { inspector.calls.push("vdesk"); return inspector.onCurrent; },
+    uncloak() {
+      inspector.calls.push("uncloak");
+      if (inspector.uncloakClears) inspector.flag = 0;
+      return true;
+    },
+    dispose() {},
+  };
+  return inspector;
+}
+
+describe("pet-window-runtime cloak self-heal (#525)", () => {
+  it("toggle hides on the FIRST press even when the cloak flag reads permanently non-zero", () => {
+    const inspector = makeCloakInspector({ flag: 2, uncloakClears: false });
+    const h = createRuntime({ cloakInspector: inspector });
+    assert.equal(h.runtime.isPetHidden(), false);
+    h.runtime.togglePetVisibility();
+    // The blocked external patch returned false here (show-forever). Hide must win.
+    assert.equal(h.runtime.isPetHidden(), true);
+    h.runtime.togglePetVisibility();
+    assert.equal(h.runtime.isPetHidden(), false);
+  });
+
+  it("recoverIfCloaked un-cloaks a cloaked window on the current desktop and reports recovered", () => {
+    const inspector = makeCloakInspector({ flag: 1, onCurrent: true });
+    const h = createRuntime({ cloakInspector: inspector });
+    const res = h.runtime.recoverIfCloaked();
+    assert.equal(res, "recovered");
+    assert.ok(inspector.calls.includes("uncloak"));
+    assert.ok(h.calls.some(([name]) => name === "reassertWinTopmost"));
+    assert.ok(h.calls.some(([name]) => name === "scheduleHwndRecovery"));
+  });
+
+  it("recoverIfCloaked leaves a window parked on another virtual desktop alone", () => {
+    const inspector = makeCloakInspector({ flag: 2, onCurrent: false });
+    const h = createRuntime({ cloakInspector: inspector });
+    const res = h.runtime.recoverIfCloaked();
+    assert.equal(res, "clean");
+    assert.ok(!inspector.calls.includes("uncloak"));
+  });
+
+  it("recoverIfCloaked degrades to APP-only when the virtual-desktop probe is down", () => {
+    const shell = makeCloakInspector({ flag: 2, onCurrent: null });
+    const hShell = createRuntime({ cloakInspector: shell });
+    assert.equal(hShell.runtime.recoverIfCloaked(), "clean");
+    assert.ok(!shell.calls.includes("uncloak"));
+
+    const app = makeCloakInspector({ flag: 1, onCurrent: null });
+    const hApp = createRuntime({ cloakInspector: app });
+    assert.equal(hApp.runtime.recoverIfCloaked(), "recovered");
+    assert.ok(app.calls.includes("uncloak"));
+  });
+
+  it("recoverIfCloaked guard matrix: hidden/mini/drag/preview each stand down before probing", () => {
+    const mkH = (overrides) => {
+      const inspector = makeCloakInspector({ flag: 1 });
+      return { inspector, h: createRuntime({ cloakInspector: inspector, ...overrides }) };
+    };
+
+    const hidden = mkH({});
+    hidden.h.runtime.setPetHidden(true);
+    hidden.inspector.calls.length = 0;
+    assert.equal(hidden.h.runtime.recoverIfCloaked(), "hidden");
+    assert.equal(hidden.inspector.calls.length, 0);
+
+    const mini = mkH({ miniTransitioning: true });
+    assert.equal(mini.h.runtime.recoverIfCloaked(), "busy");
+    assert.equal(mini.inspector.calls.length, 0);
+
+    const anim = mkH({ isMiniAnimating: () => true });
+    assert.equal(anim.h.runtime.recoverIfCloaked(), "busy");
+    assert.equal(anim.inspector.calls.length, 0);
+
+    const drag = mkH({});
+    drag.h.runtime.setDragLocked(true);
+    assert.equal(drag.h.runtime.recoverIfCloaked(), "busy");
+    assert.equal(drag.inspector.calls.length, 0);
+
+    const preview = mkH({});
+    preview.h.runtime.beginSettingsSizePreviewProtection();
+    assert.equal(preview.h.runtime.recoverIfCloaked(), "frozen");
+    assert.equal(preview.inspector.calls.length, 0);
+  });
+
+  it("recoverIfCloaked backs off exponentially after a failed recovery and resets on success", () => {
+    let clock = 1_000_000;
+    const inspector = makeCloakInspector({ flag: 1, uncloakClears: false });
+    const h = createRuntime({ cloakInspector: inspector, now: () => clock });
+
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");
+    // Cooldown = 5000 * 2^1 = 10s: immediate retry must be suppressed.
+    assert.equal(h.runtime.recoverIfCloaked(), "backoff");
+    clock += 9_999;
+    assert.equal(h.runtime.recoverIfCloaked(), "backoff");
+    clock += 2;
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");
+    // Second failure doubles the cooldown window (20s).
+    clock += 10_001;
+    assert.equal(h.runtime.recoverIfCloaked(), "backoff");
+    clock += 10_000;
+    // Un-cloak starts working: recovery succeeds and the streak resets.
+    inspector.uncloakClears = true;
+    assert.equal(h.runtime.recoverIfCloaked(), "recovered");
+    inspector.flag = 1;
+    inspector.uncloakClears = false;
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");
+    assert.equal(h.runtime.recoverIfCloaked(), "backoff");
+  });
+
+  it("recoverIfCloaked reports unavailable without an inspector (non-Windows / FFI down)", () => {
+    const none = createRuntime();
+    assert.equal(none.runtime.recoverIfCloaked(), "unavailable");
+    const down = createRuntime({ cloakInspector: makeCloakInspector({ available: false }) });
+    assert.equal(down.runtime.recoverIfCloaked(), "unavailable");
+  });
+
+  it("showPetWindows un-cloaks an abnormally cloaked window before showing", () => {
+    const inspector = makeCloakInspector({ flag: 1, onCurrent: true });
+    const h = createRuntime({ cloakInspector: inspector });
+    h.runtime.setPetHidden(true);
+    inspector.calls.length = 0;
+    h.runtime.setPetHidden(false);
+    assert.ok(inspector.calls.includes("uncloak"));
+    const win = h.renderWin;
+    const uncloakBeforeShow = win.calls.findIndex(([n]) => n === "showInactive") >= 0;
+    assert.ok(uncloakBeforeShow);
   });
 });

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -793,9 +793,32 @@ describe("pet-window-runtime cloak self-heal (#525)", () => {
     const before = renderWin.calls.length;
     assert.equal(h.runtime.recoverIfCloaked(), "failed");
     assert.ok(inspector.calls.includes("uncloak"));
-    // No showInactive/keepOutOfTaskbar on the window after a failed native call.
+    // No showInactive/keepOutOfTaskbar on the window after a failed native call...
     assert.deepStrictEqual(renderWin.calls.slice(before), []);
     assert.ok(!h.calls.some(([name]) => name === "keepOutOfTaskbar"));
+    // ...and no global topmost re-assert either — an all-failed round must be
+    // a complete no-op on the windows (codex round-3 finding).
+    assert.ok(!h.calls.some(([name]) => name === "reassertWinTopmost"));
+  });
+
+  it("recoverIfCloaked still re-asserts topmost in a mixed round where one window did recover", () => {
+    const flags = new Map();
+    const renderWin = makeWindow();
+    const hitWin = makeWindow();
+    flags.set(renderWin, 1);
+    flags.set(hitWin, 1);
+    const inspector = makeCloakInspector({
+      flag: (win) => flags.get(win) ?? 0,
+      onUncloak: (win) => {
+        if (win === renderWin) { flags.set(renderWin, 0); return true; }
+        return false; // hit window's native un-cloak fails
+      },
+    });
+    const h = createRuntime({ cloakInspector: inspector, renderWin, hitWin });
+    assert.equal(h.runtime.recoverIfCloaked(), "failed");
+    // The recovered window was shown, so the topmost re-assert must run.
+    assert.ok(renderWin.calls.some(([n]) => n === "showInactive"));
+    assert.ok(h.calls.some(([name]) => name === "reassertWinTopmost"));
   });
 
   it("a clean round resets the backoff so the next independent fault starts fresh", () => {

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -468,6 +468,51 @@ describe("topmost runtime Windows recovery", () => {
     assert.deepStrictEqual(hitWin.calls, [["setAlwaysOnTop", true, createTopmostRuntime.WIN_TOPMOST_LEVEL]]);
   });
 
+  it("watchdog tick runs the cloak self-heal hook on every normal tick (#525)", () => {
+    const timers = makeTimers();
+    const recoveries = [];
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => new FakeWindow(),
+      getHitWin: () => new FakeWindow(),
+      isForegroundFullscreen: () => false,
+      recoverCloakedPet: () => recoveries.push("tick"),
+      setInterval: timers.setInterval,
+      clearInterval: timers.clearInterval,
+    });
+
+    runtime.startTopmostWatchdog();
+    timers.intervals[0].fn();
+    timers.intervals[0].fn();
+
+    assert.equal(recoveries.length, 2);
+  });
+
+  it("watchdog skips the cloak self-heal while standing down for a fullscreen app (#525/§8.3)", () => {
+    const timers = makeTimers();
+    const recoveries = [];
+    let overlay = false;
+    const runtime = createTopmostRuntime({
+      isWin: true,
+      getWin: () => new FakeWindow(),
+      getHitWin: () => new FakeWindow(),
+      isForegroundFullscreen: () => true,
+      getFullscreenOverlay: () => overlay,
+      recoverCloakedPet: () => recoveries.push("tick"),
+      setInterval: timers.setInterval,
+      clearInterval: timers.clearInterval,
+    });
+
+    runtime.startTopmostWatchdog();
+    // Stand-down (fullscreen + overlay off): recovery must not fire.
+    timers.intervals[0].fn();
+    assert.equal(recoveries.length, 0);
+    // Overlay mode keeps re-asserting, so recovery may run again.
+    overlay = true;
+    timers.intervals[0].fn();
+    assert.equal(recoveries.length, 1);
+  });
+
   it("focusable poll drops hit-window activation under fullscreen and restores it otherwise (#538/#562)", () => {
     const timers = makeTimers();
     const win = new FakeWindow();

--- a/test/win-cloak-recovery.test.js
+++ b/test/win-cloak-recovery.test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  createCloakInspector,
+  classifyCloakState,
+  CLOAK_NONE,
+  CLOAK_APP,
+  CLOAK_SHELL,
+  CLOAK_INHERITED,
+} = require("../src/win-cloak-recovery");
+
+describe("win-cloak-recovery classifyCloakState", () => {
+  it("treats flag 0 and malformed flags as clean", () => {
+    assert.equal(classifyCloakState(CLOAK_NONE, true), "clean");
+    assert.equal(classifyCloakState(CLOAK_NONE, null), "clean");
+    assert.equal(classifyCloakState(undefined, true), "clean");
+    assert.equal(classifyCloakState(NaN, true), "clean");
+    assert.equal(classifyCloakState("2", true), "clean");
+  });
+
+  it("never touches a window parked on another virtual desktop", () => {
+    assert.equal(classifyCloakState(CLOAK_APP, false), "other-desktop");
+    assert.equal(classifyCloakState(CLOAK_SHELL, false), "other-desktop");
+    assert.equal(classifyCloakState(CLOAK_INHERITED, false), "other-desktop");
+  });
+
+  it("recovers any cloak kind confirmed on the current desktop", () => {
+    assert.equal(classifyCloakState(CLOAK_APP, true), "recover");
+    assert.equal(classifyCloakState(CLOAK_SHELL, true), "recover");
+    assert.equal(classifyCloakState(CLOAK_INHERITED, true), "recover");
+  });
+
+  it("degrades to APP-only when the desktop answer is unknown (COM down)", () => {
+    assert.equal(classifyCloakState(CLOAK_APP, null), "recover");
+    assert.equal(classifyCloakState(CLOAK_SHELL, null), "skip");
+    assert.equal(classifyCloakState(CLOAK_INHERITED, null), "skip");
+    // Combined flags containing the APP bit still recover.
+    assert.equal(classifyCloakState(CLOAK_APP | CLOAK_SHELL, null), "recover");
+  });
+});
+
+describe("win-cloak-recovery createCloakInspector off Windows", () => {
+  it("returns the unavailable inspector whose methods are safe no-ops", () => {
+    const inspector = createCloakInspector({ isWin: false });
+    assert.equal(inspector.available, false);
+    assert.equal(inspector.readCloakState({}), CLOAK_NONE);
+    assert.equal(inspector.isOnCurrentVirtualDesktop({}), null);
+    assert.equal(inspector.uncloak({}), false);
+    assert.doesNotThrow(() => inspector.dispose());
+  });
+});


### PR DESCRIPTION
## Summary

Closes #525.

Windows DWM can "cloak" a window: it stays logically visible (`isVisible()` true, `WS_VISIBLE` set) while the compositor stops drawing it — the pet vanishes with every JS-observable signal green. This PR adds detection and **self-healing** for that state, distilled from the three-round remote diagnostic run in #496 (probe FFI paths were verified on real machines during that investigation) and from the internal redesign plan that followed.

Credit where due: the probe approach originates from @Git-creat7's work on #496; all commits carry co-authorship.

## What it does

- **`src/win-cloak-recovery.js`** (new): `DwmGetWindowAttribute(DWMWA_CLOAKED)` probe, `DwmSetWindowAttribute(DWMWA_CLOAK, FALSE)` un-cloak primitive (hide/show cycling is *not* a reliable un-cloak), and an `IVirtualDesktopManager` COM query so windows parked on another virtual desktop are left alone. Pure decision core (`classifyCloakState`) is unit-testable.
- **`pet-window-runtime.js`**: `recoverIfCloaked()` — guarded (manual hide / mini transitions / drag / settings preview all stand down) with exponential backoff (10s → 5min cap) so a stubborn cloak can never turn the watchdog into a strobe. `showPetWindows()` un-cloaks abnormally cloaked windows before `showInactive()`.
- **Wiring**: 5s topmost watchdog tail (skipped during fullscreen stand-down), `powerMonitor` resume/unlock-screen (renderer-independent), and the second-instance handler.

## Key design decisions

- **`togglePetVisibility` is untouched — hide always means hide.** A cloak-aware toggle polarity degenerates into "show forever, can never hide" on machines whose cloak flag reads permanently non-zero (a real, observed machine state in #496). Recovery lives exclusively on its own guarded path.
- **Fail-open everywhere**: probe/FFI/COM failure degrades to the pre-#525 no-op. A round where the native un-cloak call fails touches nothing — no show, no taskbar, no topmost re-assert.
- **Virtual-desktop aware**: SHELL-cloak on another desktop is a legitimate user choice, never overridden. When the COM manager is unavailable, recovery degrades to APP-cloak only (conservative).
- `renderWin.setFocusable(false)` is unchanged.

## Verification

- Unit: 5225 tests green, including two-press toggle pinning, guard matrix, backoff/reset, mixed two-window rounds, fail-open exits.
- Three codex review rounds; all findings addressed (backoff reset on clean rounds, both fail-open exits, CoInitializeEx count balanced on dispose).
- Real-machine (Windows 11): FFI+COM load clean, lock/unlock, sleep/wake, virtual-desktop A/B against main (tool windows are visible on all desktops by design — baseline-identical), shortcut double-press, drag/click-through/focus regression, 5-minute idle with zero flicker, clean quit smoke (exit 0, no leftover processes).

## Scope note

This heals *cloak-class* invisibility. The #496 reporter's "all-green yet invisible" state showed flag=0 in the latest probe round, so this is expected to be a strong mitigation there (the recovery kick is what their manual toggling effectively did), **not** a confirmed root-cause fix — that investigation stays open in #496.
