### PR TITLE
fix(kimi): re-surface passive permission cues for batched approvals (gate ledger)

### DIFF
--- a/hooks/kimi-hook.js
+++ b/hooks/kimi-hook.js
@@ -177,6 +177,35 @@ function readToolName(payload) {
   return "";
 }
 
+const PERMISSION_GATE_ID_MAX_CHARS = 100;
+
+// Legacy kimi-cli threads the same tool_call_id through PreToolUse /
+// PostToolUse / PostToolUseFailure (verified against 1.37 site-packages and
+// current upstream events.py/toolset.py), which lets state.js pair a gated
+// PreToolUse with the Post that settles it. Tolerate shape drift like the
+// other payload readers; null just downgrades that gate to FIFO matching.
+function readToolCallId(payload) {
+  if (!payload || typeof payload !== "object") return null;
+  const candidates = [
+    payload.tool_call_id,
+    payload.toolCallId,
+    payload.tool_call && typeof payload.tool_call === "object" ? payload.tool_call.id : undefined,
+    payload.toolCall && typeof payload.toolCall === "object" ? payload.toolCall.id : undefined,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim()) {
+      return candidate.trim().slice(0, PERMISSION_GATE_ID_MAX_CHARS);
+    }
+    if (typeof candidate === "number" && Number.isFinite(candidate)) return String(candidate);
+  }
+  return null;
+}
+
+function isGatedPostEvent(event, payload) {
+  if (event !== "PostToolUse" && event !== "PostToolUseFailure") return false;
+  return PERMISSION_TOOLS.has(normalizeToolName(readToolName(payload)));
+}
+
 const PERMISSION_TOOL_INPUT_MAX_CHARS = 500;
 
 // Whitelisted subset of a native PermissionRequest's structured tool_input,
@@ -319,6 +348,25 @@ function buildStateBody(event, payload, resolve) {
   if (permissionSuspect) body.permission_suspect = true;
   if (cwd) body.cwd = cwd;
 
+  // Gate-ledger markers (legacy kimi-cli heuristic only). state.js keeps a
+  // per-session ledger of outstanding permission-gated tool calls so batched
+  // approvals (kimi-cli fires every queued PreToolUse up front) re-surface
+  // the passive cue after each one is answered. Both classified PreToolUse
+  // shapes open a gate — the suspect path on its raw PreToolUse, the
+  // immediate path on the PermissionRequest it was rewritten into. Native
+  // Kimi Code PermissionRequests never take the rewrite branch, so they stay
+  // out of the ledger by construction. Gated PostToolUse/PostToolUseFailure
+  // close a gate again, paired by tool_call_id when present, FIFO otherwise.
+  if (classification === "suspect" || classification === "immediate") {
+    body.permission_gate_open = true;
+    const gateId = readToolCallId(payload);
+    if (gateId) body.permission_gate_id = gateId;
+  } else if (isGatedPostEvent(event, payload)) {
+    body.permission_gated = true;
+    const gateId = readToolCallId(payload);
+    if (gateId) body.permission_gate_id = gateId;
+  }
+
   // Permission context for the bubble. Native Kimi Code payloads carry a
   // human-readable action ("Running: echo hi") and a display block with the
   // real command; forward them so the bubble can show what actually needs
@@ -326,7 +374,10 @@ function buildStateBody(event, payload, resolve) {
   // synthesized PermissionRequest (rewritten PreToolUse) usually has neither
   // and degrades to tool_name only — but when its payload does carry
   // tool_input (immediate mode fires on the raw PreToolUse), the same
-  // whitelist applies and the cue stays accurate.
+  // whitelist applies and the cue stays accurate. A gated suspect PreToolUse
+  // forwards the same fields: state.js stores them in the gate ledger so the
+  // re-armed cue after a batched approval shows the NEXT pending tool rather
+  // than the generic line.
   //
   // Action/command/tool_name are clamped to the server's own limits
   // (trim().slice at 300/500, src/server-route-state.js): a heredoc Bash
@@ -338,7 +389,7 @@ function buildStateBody(event, payload, resolve) {
   // fitStateBodyToByteBudget instead, but that helper only sacrifices
   // assistant_last_output, which this body never has, so deterministic
   // clamps are the fit here.
-  if (event === "PermissionRequest" || event === "PermissionResult") {
+  if (event === "PermissionRequest" || event === "PermissionResult" || classification === "suspect") {
     const toolName = readToolName(payload).trim();
     if (toolName) body.tool_name = toolName.slice(0, 200);
     if (typeof payload.action === "string" && payload.action.trim()) {
@@ -350,9 +401,9 @@ function buildStateBody(event, payload, resolve) {
     ) {
       body.permission_command = payload.display.command.trim().slice(0, 500);
     }
-    // PermissionRequest only: a PermissionResult just clears the bubble —
-    // there is nothing left to render a cue for.
-    if (event === "PermissionRequest") {
+    // Not on PermissionResult: it just clears the bubble — there is nothing
+    // left to render a cue for.
+    if (event === "PermissionRequest" || classification === "suspect") {
       const permissionToolInput = extractPermissionToolInput(payload.tool_input);
       if (permissionToolInput) body.permission_tool_input = permissionToolInput;
     }
@@ -441,6 +492,9 @@ if (require.main === module) main();
 module.exports = {
   buildStateBody,
   extractPermissionToolInput,
+  readToolCallId,
+  isGatedPostEvent,
+  PERMISSION_GATE_ID_MAX_CHARS,
   PERMISSION_TOOLS,
   DEFAULT_PERMISSION_TOOLS,
   resolvePermissionTools,

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -222,6 +222,14 @@ function handleStatePost(req, res, options) {
       // re-run here at the trust boundary rather than trusted from the hook,
       // matching normalizeContextUsage.
       const permissionToolInput = extractPermissionToolInput(data.permission_tool_input);
+      // Kimi legacy gate-ledger markers (batched-approvals fix). Booleans plus
+      // a clamped opaque tool_call_id, re-validated at the trust boundary like
+      // permission_suspect above — the hook's word alone is not enough.
+      const permissionGateOpen = data.permission_gate_open === true;
+      const permissionGated = data.permission_gated === true;
+      const permissionGateId = typeof data.permission_gate_id === "string" && data.permission_gate_id.trim()
+        ? data.permission_gate_id.trim().slice(0, 100)
+        : null;
       const preserveState = data.preserve_state === true;
       // Statusline refresh POSTs are metadata, not lifecycle (#590 B2): they
       // may only annotate an existing session with quota/context and must
@@ -436,6 +444,9 @@ function handleStatePost(req, res, options) {
             permissionAction,
             permissionCommand,
             permissionToolInput,
+            permissionGateOpen,
+            permissionGated,
+            permissionGateId,
             preserveState,
             hookSource,
             backgroundTasksCount,

--- a/src/state.js
+++ b/src/state.js
@@ -248,6 +248,65 @@ let _lastKimiPulseAt = 0;
 //   4. If the timer fires, Kimi is probably still blocked on the TUI waiting
 //      for the user — promote to a real permission hold (notification state)
 const kimiPermissionSuspectTimers = new Map();
+
+// ── Kimi CLI permission gate ledger ──
+// Legacy kimi-cli fires the PreToolUse for EVERY queued tool call up front
+// (two calls in one assistant message arrive ~0.1s apart), then blocks on the
+// approval TUI one tool at a time. The hold/suspect slots above are
+// per-session booleans, so without extra bookkeeping only the FIRST approval
+// ever gets a cue — the second prompt sits invisible in the terminal.
+// The ledger tracks outstanding permission-gated tool calls per session:
+//   sessionId -> Array<{ id: string|null, detail: object|null }>
+// insertion-ordered (index 0 = oldest = what the terminal blocks on next).
+// Opened by gated PreToolUse / synthesized PermissionRequest (hook marks them
+// permission_gate_open), closed by gated PostToolUse/PostToolUseFailure —
+// exact match when a tool_call_id is present, FIFO across anonymous entries
+// otherwise. Native Kimi Code PermissionRequests carry no gate markers and
+// never touch the ledger.
+const kimiPermissionGateLedgers = new Map();
+
+function buildKimiGateDetail(toolName, permissionAction, permissionCommand, permissionToolInput) {
+  if (!toolName && !permissionAction && !permissionCommand && !permissionToolInput) return null;
+  return { toolName, permissionAction, permissionCommand, permissionToolInput };
+}
+
+function openKimiPermissionGate(sessionId, gateId, detail) {
+  if (!sessionId) return;
+  let gates = kimiPermissionGateLedgers.get(sessionId);
+  if (!gates) {
+    gates = [];
+    kimiPermissionGateLedgers.set(sessionId, gates);
+  }
+  const id = typeof gateId === "string" && gateId ? gateId : null;
+  if (id) {
+    // Idempotent refresh: a re-sent PreToolUse for the same call replaces its
+    // own entry instead of inflating the queue.
+    const dup = gates.findIndex((gate) => gate.id === id);
+    if (dup !== -1) gates.splice(dup, 1);
+  }
+  gates.push({ id, detail: detail || null });
+}
+
+function closeKimiPermissionGate(sessionId, gateId) {
+  const gates = kimiPermissionGateLedgers.get(sessionId);
+  if (!gates || !gates.length) return false;
+  const id = typeof gateId === "string" && gateId ? gateId : null;
+  let idx = -1;
+  if (id) {
+    // Exact pairing only. An unknown id is a no-op on purpose: a duplicate or
+    // out-of-order Post must not eat an anonymous entry it doesn't own.
+    idx = gates.findIndex((gate) => gate.id === id);
+  } else {
+    // Anonymous close (old hook / payload without tool_call_id): FIFO —
+    // settle the oldest anonymous gate.
+    idx = gates.findIndex((gate) => gate.id === null);
+  }
+  if (idx === -1) return false;
+  gates.splice(idx, 1);
+  if (!gates.length) kimiPermissionGateLedgers.delete(sessionId);
+  return true;
+}
+
 function parseSuspectDelay() {
   const raw = process.env.CLAWD_KIMI_PERMISSION_SUSPECT_MS;
   const n = Number.parseInt(raw, 10);
@@ -1313,6 +1372,9 @@ function updateSession(sessionId, state, event, opts = {}) {
     permissionAction = null,
     permissionCommand = null,
     permissionToolInput = null,
+    permissionGateOpen = false,
+    permissionGated = false,
+    permissionGateId = null,
     preserveState = false,
     hookSource = null,
     agentIdDefaulted = false,
@@ -1422,6 +1484,17 @@ function updateSession(sessionId, state, event, opts = {}) {
     }
     setState("notification", undefined, { muteNotificationSound: muteNotificationSound === true });
     if (permAgentId === "kimi-cli") {
+      // Synthesized PermissionRequest (rewritten gated PreToolUse) carries a
+      // gate marker — record it so the Post that settles it can re-arm the
+      // cue for the next queued approval. Native Kimi Code PermissionRequests
+      // have no marker and skip the ledger.
+      if (permissionGateOpen === true) {
+        openKimiPermissionGate(
+          sessionId,
+          permissionGateId,
+          buildKimiGateDetail(toolName, permissionAction, permissionCommand, permissionToolInput)
+        );
+      }
       startKimiPermissionPoll(sessionId, { toolName, permissionAction, permissionCommand, permissionToolInput });
     }
     return;
@@ -1625,7 +1698,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     sessions.delete(sessionId);
     debugSession(`session-end delete ${describeSession(sessionId, endingSession)}`);
     cleanStaleSessions();
-    if (srcAgentId === "kimi-cli") stopKimiPermissionPoll(sessionId);
+    if (srcAgentId === "kimi-cli") disposeKimiPermissionSession(sessionId);
     if (!endingSession || !endingSession.headless) {
       // /clear sends sweeping — play it even if other sessions are active
       // (sweeping is ONESHOT and auto-returns, so it won't interfere)
@@ -1707,14 +1780,38 @@ function updateSession(sessionId, state, event, opts = {}) {
     "PermissionResult",
     "Interrupt",
   ]);
-  const shouldClearKimiPermission = srcAgentId === "kimi-cli"
-    && KIMI_HOLD_CLEAR_EVENTS.has(event);
-  if (shouldClearKimiPermission) stopKimiPermissionPoll(sessionId);
+  if (srcAgentId === "kimi-cli" && KIMI_HOLD_CLEAR_EVENTS.has(event)) {
+    if (event === "PostToolUse" || event === "PostToolUseFailure") {
+      // A gated Post settles its ledger entry first (exact tool_call_id
+      // match, FIFO for anonymous entries). Non-gated Posts leave the
+      // ledger alone.
+      if (permissionGated === true) closeKimiPermissionGate(sessionId, permissionGateId);
+      // Cue-level clear only — the ledger survives. The user answered THIS
+      // tool, so the pet must leave notification now (sleep-30 rule above);
+      // but if the same assistant message queued more gated calls, re-arm
+      // the suspect window so the NEXT pending approval re-surfaces its own
+      // cue ~800ms later. Like any suspect it is cancelled if the next
+      // PostToolUse lands sooner (auto-approved chain → no flash). This also
+      // covers a non-gated tool finishing between two gated ones: its Post
+      // clears the cue, and the re-arm brings the pending approval back.
+      stopKimiPermissionPoll(sessionId);
+      const pendingGates = kimiPermissionGateLedgers.get(sessionId);
+      if (pendingGates && pendingGates.length) {
+        schedulePermissionSuspect(sessionId, pendingGates[0].detail);
+      }
+    } else {
+      // Turn-level / terminal events (Stop, UserPromptSubmit, PermissionResult,
+      // Interrupt, …): the whole approval context is gone — drop the ledger
+      // together with the cue.
+      disposeKimiPermissionSession(sessionId);
+    }
+  }
 
   // A brand-new PreToolUse for the same Kimi session starts a fresh approval
   // gate. Drop any leftover hold/suspect from the previous round so the new
   // suspect heuristic decides cleanly (and the animation doesn't carry over
-  // from the prior tool).
+  // from the prior tool). Cue-level only: the ledger is per-tool-call
+  // bookkeeping and an incoming gated Pre opens its own entry below.
   if (event === "PreToolUse" && srcAgentId === "kimi-cli") {
     if (kimiPermissionHolds.has(sessionId)) stopKimiPermissionPoll(sessionId);
     else cancelPermissionSuspect(sessionId);
@@ -1730,7 +1827,21 @@ function updateSession(sessionId, state, event, opts = {}) {
     && srcAgentId === "kimi-cli"
     && event === "PreToolUse"
   ) {
-    schedulePermissionSuspect(sessionId);
+    if (permissionGateOpen === true) {
+      openKimiPermissionGate(
+        sessionId,
+        permissionGateId,
+        buildKimiGateDetail(toolName, permissionAction, permissionCommand, permissionToolInput)
+      );
+    }
+    // The cue must describe what the terminal actually blocks on — the OLDEST
+    // outstanding gate — not the PreToolUse that happened to arrive last
+    // (batched Pres land back-to-back and each reschedules this timer).
+    const gates = kimiPermissionGateLedgers.get(sessionId);
+    const headDetail = gates && gates.length
+      ? gates[0].detail
+      : buildKimiGateDetail(toolName, permissionAction, permissionCommand, permissionToolInput);
+    schedulePermissionSuspect(sessionId, headDetail);
   }
 
   const suppressDuplicateCompletionVisual =
@@ -1863,6 +1974,7 @@ function cleanStaleSessions() {
 // Session removal helpers. Kimi has extra animation/bubble bookkeeping because
 // its approval prompt is terminal-driven rather than an HTTP permission roundtrip.
 function disposeKimiSessionState(id, reason) {
+  kimiPermissionGateLedgers.delete(id);
   const hadSuspect = cancelPermissionSuspect(id);
   const hold = kimiPermissionHolds.get(id);
   if (hold) {
@@ -2056,9 +2168,10 @@ function startKimiPermissionPoll(sessionId, permissionDetail = null) {
     // Last-resort safety cap. The primary release path is event-driven
     // (PostToolUse / Stop / UserPromptSubmit / new PreToolUse / SessionEnd /
     // cleanStaleSessions when the Kimi PID dies). The timer just prevents
-    // permanent stuck state if every other signal is somehow lost.
+    // permanent stuck state if every other signal is somehow lost — and in
+    // that lost-signal world the gate ledger is stale too, so drop it whole.
     timer = setTimeout(() => {
-      stopKimiPermissionPoll(sessionId);
+      disposeKimiPermissionSession(sessionId);
     }, maxMs);
   }
   kimiPermissionHolds.set(sessionId, {
@@ -2094,7 +2207,7 @@ function cancelPermissionSuspect(sessionId) {
   return true;
 }
 
-function schedulePermissionSuspect(sessionId) {
+function schedulePermissionSuspect(sessionId, permissionDetail = null) {
   if (!sessionId) return;
   const delay = parseSuspectDelay();
   // A zero delay disables the heuristic entirely (caller shouldn't reach
@@ -2116,14 +2229,24 @@ function schedulePermissionSuspect(sessionId) {
       typeof ctx.isAgentPermissionsEnabled === "function"
       && !ctx.isAgentPermissionsEnabled("kimi-cli")
     ) return;
-    startKimiPermissionPoll(sessionId);
+    // permissionDetail (queue head of the gate ledger, or null for a plain
+    // legacy suspect) makes the promoted cue name the tool that actually
+    // blocks the terminal; null degrades to the generic copy.
+    startKimiPermissionPoll(sessionId, permissionDetail);
     setState("notification");
   }, delay);
   kimiPermissionSuspectTimers.set(sessionId, { timer, scheduledAt: Date.now() });
 }
 
+// Cue-level clear: hold + suspect timer + visible card. The gate ledger is
+// deliberately PRESERVED — a Post that settles one of several batched
+// approvals must clear the current cue without forgetting the queued rest.
+// Full teardown (turn-level events, session disposal, safety cap) goes
+// through disposeKimiPermissionSession instead. The no-arg variant is the
+// global stop-everything path and drops the ledgers too.
 function stopKimiPermissionPoll(sessionId) {
   if (!sessionId) {
+    kimiPermissionGateLedgers.clear();
     const hadHold = kimiPermissionHolds.size > 0;
     const hadSuspect = kimiPermissionSuspectTimers.size > 0;
     if (!hadHold && !hadSuspect) return;
@@ -2148,6 +2271,16 @@ function stopKimiPermissionPoll(sessionId) {
     if (typeof ctx.clearKimiNotifyBubbles === "function") ctx.clearKimiNotifyBubbles(sessionId, "kimi-stop-suspect");
     applyResolvedDisplayState();
   }
+}
+
+// Full per-session teardown: cue + gate ledger. Used by turn-level events
+// (Stop/UserPromptSubmit/PermissionResult/Interrupt/…), SessionEnd, the
+// safety-cap timer, and session disposal — every path where the approval
+// context as a whole is gone and queued gates must not re-arm a cue later.
+function disposeKimiPermissionSession(sessionId) {
+  if (!sessionId) return;
+  kimiPermissionGateLedgers.delete(sessionId);
+  stopKimiPermissionPoll(sessionId);
 }
 
 function resolveDisplayState() {
@@ -2208,6 +2341,7 @@ function formatElapsed(ms) {
 // mid-transition and will resolve the visible state themselves. Returns
 // `true` if anything was cleared so callers can trigger their own resolve.
 function disposeAllKimiPermissionState() {
+  kimiPermissionGateLedgers.clear();
   const hadHold = kimiPermissionHolds.size > 0;
   const hadSuspect = kimiPermissionSuspectTimers.size > 0;
   if (!hadHold && !hadSuspect) return false;
@@ -2291,6 +2425,7 @@ function cleanup() {
   kimiPermissionHolds.clear();
   for (const { timer } of kimiPermissionSuspectTimers.values()) clearTimeout(timer);
   kimiPermissionSuspectTimers.clear();
+  kimiPermissionGateLedgers.clear();
   for (const id of [...codexExitProbes.keys()]) clearCodexExitProbe(id);
   stopStaleCleanup();
 }

--- a/src/state.js
+++ b/src/state.js
@@ -1494,8 +1494,22 @@ function updateSession(sessionId, state, event, opts = {}) {
           permissionGateId,
           buildKimiGateDetail(toolName, permissionAction, permissionCommand, permissionToolInput)
         );
+        // Same invariant as the suspect path: the cue must describe what the
+        // terminal actually blocks on — the OLDEST outstanding gate. Batched
+        // synthesized requests all land up front, so refreshing the card with
+        // the newest arrival would show a tool whose prompt hasn't appeared
+        // yet.
+        const gates = kimiPermissionGateLedgers.get(sessionId);
+        const headDetail = gates && gates.length
+          ? gates[0].detail
+          : buildKimiGateDetail(toolName, permissionAction, permissionCommand, permissionToolInput);
+        startKimiPermissionPoll(sessionId, headDetail);
+      } else {
+        // Native Kimi Code: a PermissionRequest fires when its prompt really
+        // is on screen, so the newest request IS what the terminal blocks on —
+        // refresh-to-newest stays correct here.
+        startKimiPermissionPoll(sessionId, { toolName, permissionAction, permissionCommand, permissionToolInput });
       }
-      startKimiPermissionPoll(sessionId, { toolName, permissionAction, permissionCommand, permissionToolInput });
     }
     return;
   }
@@ -2087,6 +2101,12 @@ function clearSessionsByAgent(agentId) {
         ctx.clearKimiNotifyBubbles(id, "kimi-orphan-suspect-cleared");
       }
     }
+    // Gate ledgers can hold the same orphans (immediate-mode sessions never
+    // enter the `sessions` Map either). Today's callers pair this function
+    // with dismissPermissionsByAgent → disposeAllKimiPermissionState, which
+    // would clear them anyway — but this function must not depend on that
+    // pairing to keep the ledger from re-arming a cue for a dead session.
+    kimiPermissionGateLedgers.clear();
   }
   if (removed > 0) {
     const resolved = resolveDisplayState();

--- a/test/kimi-hook.test.js
+++ b/test/kimi-hook.test.js
@@ -854,3 +854,157 @@ describe("Kimi Code native events (#563)", () => {
     assert.deepStrictEqual(body.permission_tool_input, { command: "npm test" });
   });
 });
+
+describe("Kimi gate-ledger markers", () => {
+  const resolve = () => ({ stablePid: 1, agentPid: null, detectedEditor: null, pidChain: [] });
+  const { readToolCallId, isGatedPostEvent, PERMISSION_GATE_ID_MAX_CHARS } = require("../hooks/kimi-hook");
+
+  const withSuspectMode = (fn) => {
+    const oldSuspect = process.env.CLAWD_KIMI_PERMISSION_SUSPECT;
+    const oldMode = process.env.CLAWD_KIMI_PERMISSION_MODE;
+    const oldImmediate = process.env.CLAWD_KIMI_PERMISSION_IMMEDIATE;
+    try {
+      process.env.CLAWD_KIMI_PERMISSION_SUSPECT = "1";
+      delete process.env.CLAWD_KIMI_PERMISSION_MODE;
+      delete process.env.CLAWD_KIMI_PERMISSION_IMMEDIATE;
+      fn();
+    } finally {
+      if (oldSuspect == null) delete process.env.CLAWD_KIMI_PERMISSION_SUSPECT;
+      else process.env.CLAWD_KIMI_PERMISSION_SUSPECT = oldSuspect;
+      if (oldMode == null) delete process.env.CLAWD_KIMI_PERMISSION_MODE;
+      else process.env.CLAWD_KIMI_PERMISSION_MODE = oldMode;
+      if (oldImmediate == null) delete process.env.CLAWD_KIMI_PERMISSION_IMMEDIATE;
+      else process.env.CLAWD_KIMI_PERMISSION_IMMEDIATE = oldImmediate;
+    }
+  };
+
+  it("gated suspect PreToolUse opens a gate and forwards the tool cue detail", () => {
+    withSuspectMode(() => {
+      const body = buildStateBody(
+        "PreToolUse",
+        {
+          session_id: "s1",
+          tool_name: "shell",
+          tool_call_id: "call_abc",
+          tool_input: { command: "Remove-Item kimi-cue-test.txt" },
+        },
+        resolve
+      );
+      assert.strictEqual(body.state, "working");
+      assert.strictEqual(body.event, "PreToolUse");
+      assert.strictEqual(body.permission_suspect, true);
+      assert.strictEqual(body.permission_gate_open, true);
+      assert.strictEqual(body.permission_gate_id, "call_abc");
+      assert.strictEqual(body.permission_gated, undefined);
+      assert.strictEqual(body.tool_name, "shell");
+      assert.deepStrictEqual(body.permission_tool_input, { command: "Remove-Item kimi-cue-test.txt" });
+    });
+  });
+
+  it("gated suspect PreToolUse without tool_call_id opens an anonymous gate", () => {
+    withSuspectMode(() => {
+      const body = buildStateBody(
+        "PreToolUse",
+        { session_id: "s1", tool_name: "write_file", tool_input: { path: "a.txt" } },
+        resolve
+      );
+      assert.strictEqual(body.permission_gate_open, true);
+      assert.strictEqual(body.permission_gate_id, undefined);
+      assert.deepStrictEqual(body.permission_tool_input, { file_path: "a.txt" });
+    });
+  });
+
+  it("synthesized immediate PermissionRequest carries the gate marker too", () => {
+    const body = buildStateBody(
+      "PreToolUse",
+      {
+        session_id: "s1",
+        tool_name: "shell",
+        tool_call_id: "call_now",
+        permission_required: true,
+        tool_input: { command: "npm install" },
+      },
+      resolve
+    );
+    assert.strictEqual(body.event, "PermissionRequest");
+    assert.strictEqual(body.state, "notification");
+    assert.strictEqual(body.permission_gate_open, true);
+    assert.strictEqual(body.permission_gate_id, "call_now");
+    assert.deepStrictEqual(body.permission_tool_input, { command: "npm install" });
+  });
+
+  it("gated PostToolUse and PostToolUseFailure close their gate; non-gated Posts carry no markers", () => {
+    const post = buildStateBody(
+      "PostToolUse",
+      { session_id: "s1", tool_name: "shell", tool_call_id: "call_abc" },
+      resolve
+    );
+    assert.strictEqual(post.permission_gated, true);
+    assert.strictEqual(post.permission_gate_id, "call_abc");
+    assert.strictEqual(post.permission_gate_open, undefined);
+
+    const failure = buildStateBody(
+      "PostToolUseFailure",
+      { session_id: "s1", tool_name: "write_file", tool_call_id: "call_w" },
+      resolve
+    );
+    assert.strictEqual(failure.permission_gated, true);
+    assert.strictEqual(failure.permission_gate_id, "call_w");
+
+    const nonGated = buildStateBody(
+      "PostToolUse",
+      { session_id: "s1", tool_name: "read_file", tool_call_id: "call_r" },
+      resolve
+    );
+    assert.strictEqual(nonGated.permission_gated, undefined);
+    assert.strictEqual(nonGated.permission_gate_id, undefined);
+  });
+
+  it("default explicit-only mode emits no gate markers at all", () => {
+    const oldSuspect = process.env.CLAWD_KIMI_PERMISSION_SUSPECT;
+    const oldMode = process.env.CLAWD_KIMI_PERMISSION_MODE;
+    try {
+      delete process.env.CLAWD_KIMI_PERMISSION_SUSPECT;
+      delete process.env.CLAWD_KIMI_PERMISSION_MODE;
+      const body = buildStateBody(
+        "PreToolUse",
+        { session_id: "s1", tool_name: "shell", tool_call_id: "call_abc" },
+        resolve
+      );
+      assert.strictEqual(body.state, "working");
+      assert.strictEqual(body.permission_suspect, undefined);
+      assert.strictEqual(body.permission_gate_open, undefined);
+      assert.strictEqual(body.permission_gate_id, undefined);
+      assert.strictEqual(body.tool_name, undefined);
+    } finally {
+      if (oldSuspect == null) delete process.env.CLAWD_KIMI_PERMISSION_SUSPECT;
+      else process.env.CLAWD_KIMI_PERMISSION_SUSPECT = oldSuspect;
+      if (oldMode == null) delete process.env.CLAWD_KIMI_PERMISSION_MODE;
+      else process.env.CLAWD_KIMI_PERMISSION_MODE = oldMode;
+    }
+  });
+
+  it("readToolCallId tolerates shape drift and clamps", () => {
+    assert.strictEqual(readToolCallId({ tool_call_id: " call_1 " }), "call_1");
+    assert.strictEqual(readToolCallId({ toolCallId: "call_2" }), "call_2");
+    assert.strictEqual(readToolCallId({ tool_call: { id: "call_3" } }), "call_3");
+    assert.strictEqual(readToolCallId({ toolCall: { id: "call_4" } }), "call_4");
+    assert.strictEqual(readToolCallId({ tool_call_id: 42 }), "42");
+    assert.strictEqual(
+      readToolCallId({ tool_call_id: "x".repeat(500) }),
+      "x".repeat(PERMISSION_GATE_ID_MAX_CHARS)
+    );
+    assert.strictEqual(readToolCallId({ tool_call_id: "   " }), null);
+    assert.strictEqual(readToolCallId({ tool_call_id: { nested: true } }), null);
+    assert.strictEqual(readToolCallId({}), null);
+    assert.strictEqual(readToolCallId(null), null);
+  });
+
+  it("isGatedPostEvent matches only gated tools on Post events", () => {
+    assert.strictEqual(isGatedPostEvent("PostToolUse", { tool_name: "shell" }), true);
+    assert.strictEqual(isGatedPostEvent("PostToolUseFailure", { tool_name: "WriteFile" }), true);
+    assert.strictEqual(isGatedPostEvent("PostToolUse", { tool_name: "read_file" }), false);
+    assert.strictEqual(isGatedPostEvent("PreToolUse", { tool_name: "shell" }), false);
+    assert.strictEqual(isGatedPostEvent("PostToolUse", {}), false);
+  });
+});

--- a/test/permission-notify-autoclose.test.js
+++ b/test/permission-notify-autoclose.test.js
@@ -493,3 +493,107 @@ describe("Kimi passive cue rebuild after dismissal (gate-ledger joint lifecycle)
     assert.ok(second.bubble && !second.bubble.destroyed);
   });
 });
+
+// Joint state ↔ permission coverage (codex review request): drive the REAL
+// state-machine scheduling into the REAL permission bubble layer and assert
+// what the user actually sees. Batched synthesized PermissionRequests must
+// keep the visible card on the queue head (t1) until Post(t1) settles it,
+// and only then advance to t2.
+describe("state ↔ permission joint: batched immediate cues stay on the queue head", () => {
+  afterEach(() => {
+    mock.timers.reset();
+    delete require.cache[PERMISSION_MODULE_PATH];
+    for (const logPath of tempLogPaths) {
+      try { fs.unlinkSync(logPath); } catch {}
+    }
+    tempLogPaths.clear();
+  });
+
+  it("visible card stays on t1 until Post(t1), then advances to t2", () => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    mock.timers.setTime(100_000);
+    const harness = createPermissionHarness();
+    const permApi = harness.api;
+
+    const themeLoader = require("../src/theme-loader");
+    themeLoader.init(path.join(__dirname, "..", "src"));
+    const { createTranslator } = require("../src/i18n");
+    const stateCtx = {
+      lang: "en",
+      theme: themeLoader.loadTheme("clawd"),
+      doNotDisturb: false,
+      miniTransitioning: false,
+      miniMode: false,
+      mouseOverPet: false,
+      idlePaused: false,
+      forceEyeResend: false,
+      eyePauseUntil: 0,
+      mouseStillSince: Date.now(),
+      miniSleepPeeked: false,
+      playSound: () => {},
+      sendToRenderer: () => {},
+      syncHitWin: () => {},
+      sendToHitWin: () => {},
+      miniPeekIn: () => {},
+      miniPeekOut: () => {},
+      buildContextMenu: () => {},
+      buildTrayMenu: () => {},
+      processKill: () => { const e = new Error("ESRCH"); e.code = "ESRCH"; throw e; },
+      getCursorScreenPoint: () => ({ x: 100, y: 100 }),
+      // The wiring under test: state's cue scheduling drives the real
+      // permission layer instead of a recording stub.
+      showKimiNotifyBubble: (entry) => permApi.showKimiNotifyBubble(entry),
+      clearKimiNotifyBubbles: (sessionId, reason) => permApi.clearKimiNotifyBubbles(sessionId, reason),
+    };
+    stateCtx.t = createTranslator(() => stateCtx.lang);
+    const stateApi = require("../src/state")(stateCtx);
+
+    try {
+      // Batched immediate mode: t1 and t2 land back-to-back while the
+      // terminal blocks on t1.
+      stateApi.updateSession("kimi-cli:s1", "notification", "PermissionRequest", {
+        agentId: "kimi-cli",
+        permissionGateOpen: true,
+        permissionGateId: "t1",
+        toolName: "shell",
+        permissionToolInput: { command: "npm install" },
+      });
+      stateApi.updateSession("kimi-cli:s1", "notification", "PermissionRequest", {
+        agentId: "kimi-cli",
+        permissionGateOpen: true,
+        permissionGateId: "t2",
+        toolName: "write_file",
+        permissionToolInput: { file_path: "b.txt" },
+      });
+      assert.strictEqual(permApi.pendingPermissions.length, 1);
+      assert.strictEqual(permApi.pendingPermissions[0].kimiToolName, "shell");
+      assert.deepStrictEqual(permApi.pendingPermissions[0].kimiToolInput, { command: "npm install" });
+
+      // User approves t1: the card drops with the settled gate...
+      stateApi.updateSession("kimi-cli:s1", "working", "PostToolUse", {
+        agentId: "kimi-cli",
+        permissionGated: true,
+        permissionGateId: "t1",
+      });
+      assert.strictEqual(permApi.pendingPermissions.length, 0);
+
+      // ...and the re-armed cue advances to t2.
+      mock.timers.tick(800);
+      assert.strictEqual(permApi.pendingPermissions.length, 1);
+      assert.strictEqual(permApi.pendingPermissions[0].isKimiNotify, true);
+      assert.strictEqual(permApi.pendingPermissions[0].kimiToolName, "write_file");
+      assert.deepStrictEqual(permApi.pendingPermissions[0].kimiToolInput, { file_path: "b.txt" });
+
+      // t2 answered: everything settles, nothing re-arms.
+      stateApi.updateSession("kimi-cli:s1", "working", "PostToolUse", {
+        agentId: "kimi-cli",
+        permissionGated: true,
+        permissionGateId: "t2",
+      });
+      mock.timers.tick(5000);
+      assert.strictEqual(permApi.pendingPermissions.length, 0);
+    } finally {
+      stateApi.cleanup();
+    }
+  });
+});

--- a/test/permission-notify-autoclose.test.js
+++ b/test/permission-notify-autoclose.test.js
@@ -80,7 +80,11 @@ function createPermissionHarness({ logPath = null } = {}) {
 
   const fakeElectron = {
     BrowserWindow: Object.assign(FakeBrowserWindow, {
-      fromWebContents() { return null; },
+      // Same convention as the codex-response harness: an ipc event whose
+      // sender carries __window resolves to that window, so handleDecide can
+      // pair the event with its bubble entry. Events without it keep the old
+      // null behavior.
+      fromWebContents(sender) { return (sender && sender.__window) || null; },
     }),
     globalShortcut: {
       register() { return true; },
@@ -406,5 +410,86 @@ describe("permission passive notify auto-close refresh", () => {
     assert.strictEqual(api.pendingPermissions.length, 1);
     mock.timers.tick(1);
     assert.strictEqual(api.pendingPermissions.length, 0);
+  });
+});
+
+// Gate-ledger joint lifecycle (batched approvals): after the FIRST cue is
+// gone — dismissed via the real ipc-decide path or auto-expired — state.js
+// re-arms a cue for the next queued approval by calling showKimiNotifyBubble
+// again. The permission layer must build a brand-new working card each time;
+// stale dedupe/bookkeeping from the dead entry must not swallow the re-show.
+describe("Kimi passive cue rebuild after dismissal (gate-ledger joint lifecycle)", () => {
+  afterEach(() => {
+    mock.timers.reset();
+    delete require.cache[PERMISSION_MODULE_PATH];
+    for (const logPath of tempLogPaths) {
+      try { fs.unlinkSync(logPath); } catch {}
+    }
+    tempLogPaths.clear();
+  });
+
+  it("rebuilds a fresh card after the previous cue was dismissed via Got it (ipc-decide)", () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"] });
+    mock.timers.setTime(100_000);
+    const harness = createPermissionHarness();
+    const { api } = harness;
+
+    api.showKimiNotifyBubble({
+      sessionId: "kimi-a",
+      toolName: "write_file",
+      permissionToolInput: { file_path: "a.txt" },
+    });
+    assert.strictEqual(api.pendingPermissions.length, 1);
+    const first = api.pendingPermissions[0];
+    assert.ok(first.bubble, "first cue should own a bubble window");
+
+    // "Got it" travels the production ipc-decide path.
+    api.handleDecide({ sender: { __window: first.bubble } }, "allow");
+    assert.strictEqual(api.pendingPermissions.length, 0);
+
+    // state.js re-arms ~800ms later with the next gate's detail.
+    mock.timers.tick(800);
+    api.showKimiNotifyBubble({
+      sessionId: "kimi-a",
+      toolName: "shell",
+      permissionToolInput: { command: "Remove-Item a.txt" },
+    });
+    assert.strictEqual(api.pendingPermissions.length, 1);
+    const second = api.pendingPermissions[0];
+    assert.notStrictEqual(second, first, "re-armed cue must be a fresh entry, not the dismissed one");
+    assert.strictEqual(second.isKimiNotify, true);
+    assert.strictEqual(second.kimiToolName, "shell");
+    assert.deepStrictEqual(second.kimiToolInput, { command: "Remove-Item a.txt" });
+    assert.ok(second.bubble && !second.bubble.destroyed, "re-armed cue should own a live bubble window");
+  });
+
+  it("rebuilds a fresh card after the previous cue auto-expired", () => {
+    mock.timers.enable({ apis: ["setTimeout", "Date"] });
+    mock.timers.setTime(100_000);
+    const harness = createPermissionHarness();
+    const { api } = harness;
+
+    api.showKimiNotifyBubble({
+      sessionId: "kimi-a",
+      toolName: "write_file",
+      permissionToolInput: { file_path: "a.txt" },
+    });
+    assert.strictEqual(api.pendingPermissions.length, 1);
+    const first = api.pendingPermissions[0];
+
+    // Default notification auto-close is 10s in this harness — let it expire.
+    mock.timers.tick(10_000);
+    assert.strictEqual(api.pendingPermissions.length, 0);
+
+    api.showKimiNotifyBubble({
+      sessionId: "kimi-a",
+      toolName: "shell",
+      permissionToolInput: { command: "Remove-Item a.txt" },
+    });
+    assert.strictEqual(api.pendingPermissions.length, 1);
+    const second = api.pendingPermissions[0];
+    assert.notStrictEqual(second, first);
+    assert.strictEqual(second.kimiToolName, "shell");
+    assert.ok(second.bubble && !second.bubble.destroyed);
   });
 });

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -167,6 +167,9 @@ describe("server-route-state POST", () => {
         permissionAction: null,
         permissionCommand: null,
         permissionToolInput: null,
+        permissionGateOpen: false,
+        permissionGated: false,
+        permissionGateId: null,
         preserveState: true,
         hookSource: "codex-official",
         backgroundTasksCount: 0,
@@ -195,6 +198,52 @@ describe("server-route-state POST", () => {
     assert.strictEqual(opts.permissionAction, "Running: echo hi");
     assert.strictEqual(opts.permissionCommand, "echo hi");
     assert.deepStrictEqual(opts.permissionToolInput, { command: "echo hi" });
+  });
+
+  it("forwards Kimi gate-ledger markers and re-validates their types", async () => {
+    const post = (extra) => callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "kimi-cli:session_abc",
+      event: "PreToolUse",
+      agent_id: "kimi-cli",
+      ...extra,
+    }));
+
+    // Well-formed markers pass through; the id is trimmed and clamped.
+    const open = await post({
+      permission_suspect: true,
+      permission_gate_open: true,
+      permission_gate_id: `  ${"g".repeat(150)}  `,
+    });
+    const openOpts = open.calls.updateSession[0][3];
+    assert.strictEqual(openOpts.permissionGateOpen, true);
+    assert.strictEqual(openOpts.permissionGated, false);
+    assert.strictEqual(openOpts.permissionGateId, "g".repeat(100));
+
+    const gated = await post({
+      event: "PostToolUse",
+      permission_gated: true,
+      permission_gate_id: "call_1",
+    });
+    const gatedOpts = gated.calls.updateSession[0][3];
+    assert.strictEqual(gatedOpts.permissionGated, true);
+    assert.strictEqual(gatedOpts.permissionGateOpen, false);
+    assert.strictEqual(gatedOpts.permissionGateId, "call_1");
+
+    // Wrong types are dropped at the trust boundary — truthiness is not enough.
+    const junk = await post({
+      permission_gate_open: "yes",
+      permission_gated: 1,
+      permission_gate_id: { id: "x" },
+    });
+    const junkOpts = junk.calls.updateSession[0][3];
+    assert.strictEqual(junkOpts.permissionGateOpen, false);
+    assert.strictEqual(junkOpts.permissionGated, false);
+    assert.strictEqual(junkOpts.permissionGateId, null);
+
+    // Whitespace-only id degrades to null, same as an absent field.
+    const blank = await post({ permission_gate_id: "   " });
+    assert.strictEqual(blank.calls.updateSession[0][3].permissionGateId, null);
   });
 
   it("re-validates permission_tool_input instead of trusting the hook", async () => {

--- a/test/state-kimi-permission.test.js
+++ b/test/state-kimi-permission.test.js
@@ -379,3 +379,264 @@ describe("Global permission animation lock", () => {
     assert.strictEqual(api.resolveDisplayState(), "working");
   });
 });
+
+// Batched approvals: legacy kimi-cli fires every queued PreToolUse up front,
+// then blocks on the approval TUI one tool at a time. The gate ledger must
+// re-surface a cue for each remaining approval after the previous one is
+// answered — without it only the FIRST prompt ever gets a card.
+describe("Kimi permission gate ledger (batched approvals)", () => {
+  let api;
+  let ctx;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    ctx = makeCtx();
+    api = require("../src/state")(ctx);
+  });
+
+  afterEach(() => {
+    api.cleanup();
+    mock.timers.reset();
+  });
+
+  const gatedPre = (sid, gateId, detail = {}) => api.updateSession(sid, "working", "PreToolUse", {
+    agentId: "kimi-cli",
+    permissionSuspect: true,
+    permissionGateOpen: true,
+    permissionGateId: gateId,
+    toolName: detail.toolName ?? null,
+    permissionAction: detail.permissionAction ?? null,
+    permissionCommand: detail.permissionCommand ?? null,
+    permissionToolInput: detail.permissionToolInput ?? null,
+  });
+
+  const gatedPost = (sid, gateId, event = "PostToolUse") => api.updateSession(
+    sid,
+    event === "PostToolUseFailure" ? "error" : "working",
+    event,
+    { agentId: "kimi-cli", permissionGated: true, permissionGateId: gateId }
+  );
+
+  it("re-arms a second cue with the next gate's detail after the first batched approval (core defect repro)", () => {
+    gatedPre("kimi-a", "t1", { toolName: "write_file", permissionToolInput: { file_path: "a.txt" } });
+    gatedPre("kimi-a", "t2", { toolName: "shell", permissionToolInput: { command: "Remove-Item a.txt" } });
+
+    // Suspect window expires -> first cue, described by the OLDEST gate (t1),
+    // not by the PreToolUse that happened to arrive last.
+    mock.timers.tick(1000);
+    assert.strictEqual(api.resolveDisplayState(), "notification");
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+    assert.strictEqual(ctx._kimiNotifyDetails[0].toolName, "write_file");
+
+    // User answers #1 in the terminal: cue drops instantly (no stuck
+    // notification), then the pending t2 re-arms its own cue ~800ms later.
+    gatedPost("kimi-a", "t1");
+    assert.strictEqual(api.resolveDisplayState(), "working");
+    mock.timers.tick(1000);
+    assert.strictEqual(api.resolveDisplayState(), "notification");
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+    assert.strictEqual(ctx._kimiNotifyDetails[1].toolName, "shell");
+    assert.deepStrictEqual(ctx._kimiNotifyDetails[1].permissionToolInput, { command: "Remove-Item a.txt" });
+
+    // Answering #2 settles everything — no third cue ever.
+    gatedPost("kimi-a", "t2");
+    assert.strictEqual(api.resolveDisplayState(), "working");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+  });
+
+  it("single gated call does not regress: one cue, no re-arm", () => {
+    gatedPre("kimi-a", "t1", { toolName: "shell" });
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+
+    gatedPost("kimi-a", "t1");
+    assert.strictEqual(api.resolveDisplayState(), "working");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+    assert.strictEqual(api.resolveDisplayState(), "working");
+  });
+
+  it("auto-approved chain never flashes: consecutive gated Posts inside the window cancel the re-arm", () => {
+    gatedPre("kimi-a", "t1");
+    gatedPre("kimi-a", "t2");
+    mock.timers.tick(100);
+    gatedPost("kimi-a", "t1");
+    mock.timers.tick(100);
+    gatedPost("kimi-a", "t2");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 0);
+    assert.notStrictEqual(api.getCurrentState(), "notification");
+  });
+
+  it("synthesized immediate PermissionRequests join the ledger and re-arm after each answer", () => {
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      permissionGateOpen: true,
+      permissionGateId: "t1",
+      toolName: "shell",
+      permissionCommand: "npm install",
+    });
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      permissionGateOpen: true,
+      permissionGateId: "t2",
+      toolName: "write_file",
+    });
+    // Immediate mode shows right away (dedupe/refresh is the bubble layer's
+    // job — here we just count show calls).
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+
+    gatedPost("kimi-a", "t1");
+    mock.timers.tick(1000);
+    // Re-armed cue carries the remaining gate's detail.
+    assert.strictEqual(ctx._kimiNotifyShown.length, 3);
+    assert.strictEqual(ctx._kimiNotifyDetails[2].toolName, "write_file");
+
+    gatedPost("kimi-a", "t2");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 3);
+  });
+
+  it("native Kimi Code PermissionRequests (no gate marker) stay out of the ledger", () => {
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      toolName: "Bash",
+      permissionCommand: "echo hi",
+    });
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+
+    // Non-gated Post (Kimi Code tool names never match the legacy gate set).
+    api.updateSession("kimi-a", "working", "PostToolUse", { agentId: "kimi-cli" });
+    mock.timers.tick(5000);
+    // No ledger entry -> no re-arm, exactly the pre-ledger behavior.
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+    assert.strictEqual(api.resolveDisplayState(), "working");
+  });
+
+  it("id semantics: unknown-id Post is a no-op on the ledger; duplicate opens refresh in place; out-of-order Posts pair exactly", () => {
+    gatedPre("kimi-a", "t1", { toolName: "write_file" });
+    gatedPre("kimi-a", "t1", { toolName: "write_file" }); // duplicate open refreshes, no queue inflation
+    gatedPre("kimi-a", "t2", { toolName: "shell" });
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+
+    // Out-of-order: t2 settles first — t1 must survive and drive the re-arm.
+    gatedPost("kimi-a", "t2");
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+    assert.strictEqual(ctx._kimiNotifyDetails[1].toolName, "write_file");
+
+    // Unknown id: ledger untouched (t1 still pending), cue re-arms again.
+    gatedPost("kimi-a", "t-unknown");
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 3);
+    assert.strictEqual(ctx._kimiNotifyDetails[2].toolName, "write_file");
+
+    gatedPost("kimi-a", "t1");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 3);
+  });
+
+  it("anonymous gates close FIFO and mixed queues keep exact-id pairing separate", () => {
+    gatedPre("kimi-a", null, { toolName: "write_file" }); // anon #1 (oldest)
+    gatedPre("kimi-a", "t2", { toolName: "shell" });
+    gatedPre("kimi-a", null, { toolName: "background" }); // anon #2
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+    assert.strictEqual(ctx._kimiNotifyDetails[0].toolName, "write_file");
+
+    // Anonymous Post settles the OLDEST anonymous gate (anon #1), never t2.
+    gatedPost("kimi-a", null);
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+    assert.strictEqual(ctx._kimiNotifyDetails[1].toolName, "shell");
+
+    gatedPost("kimi-a", "t2");
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 3);
+    assert.strictEqual(ctx._kimiNotifyDetails[2].toolName, "background");
+
+    gatedPost("kimi-a", null);
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 3);
+    assert.strictEqual(api.resolveDisplayState(), "working");
+  });
+
+  it("null detail (old hook without forwarding) degrades to the generic cue", () => {
+    gatedPre("kimi-a", "t1");
+    gatedPre("kimi-a", "t2");
+    mock.timers.tick(1000);
+    gatedPost("kimi-a", "t1");
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+    assert.strictEqual(ctx._kimiNotifyDetails[1].toolName, null);
+    assert.strictEqual(ctx._kimiNotifyDetails[1].permissionToolInput, null);
+  });
+
+  it("turn-level events drop the ledger: no re-arm after UserPromptSubmit", () => {
+    gatedPre("kimi-a", "t1");
+    gatedPre("kimi-a", "t2");
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+
+    // Reject-and-tell-model: the whole approval context is gone.
+    api.updateSession("kimi-a", "thinking", "UserPromptSubmit", { agentId: "kimi-cli" });
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+    assert.notStrictEqual(api.getCurrentState(), "notification");
+
+    // A later gated Post must not resurrect anything either.
+    gatedPost("kimi-a", "t1");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+  });
+
+  it("Stop and SessionEnd drop the ledger", () => {
+    gatedPre("kimi-a", "t1");
+    gatedPre("kimi-a", "t2");
+    mock.timers.tick(1000);
+    api.updateSession("kimi-a", "attention", "Stop", { agentId: "kimi-cli" });
+    gatedPost("kimi-a", "t1");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+
+    gatedPre("kimi-b", "u1");
+    gatedPre("kimi-b", "u2");
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+    api.updateSession("kimi-b", "sleeping", "SessionEnd", { agentId: "kimi-cli" });
+    gatedPost("kimi-b", "u1");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+  });
+
+  it("safety cap drops the ledger with the cue", () => {
+    gatedPre("kimi-a", "t1");
+    gatedPre("kimi-a", "t2");
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+
+    // Every release signal is lost; the 10-minute cap fires and must take the
+    // stale ledger with it.
+    mock.timers.tick(10 * 60 * 1000);
+    assert.notStrictEqual(api.getCurrentState(), "notification");
+
+    // A straggler Post can no longer re-arm anything.
+    gatedPost("kimi-a", "t1");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+  });
+
+  it("disposeAllKimiPermissionState (DND / permissions-off path) clears queued gates", () => {
+    gatedPre("kimi-a", "t1");
+    gatedPre("kimi-a", "t2");
+    mock.timers.tick(1000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+
+    api.disposeAllKimiPermissionState();
+    gatedPost("kimi-a", "t1");
+    mock.timers.tick(5000);
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+  });
+});

--- a/test/state-kimi-permission.test.js
+++ b/test/state-kimi-permission.test.js
@@ -469,7 +469,7 @@ describe("Kimi permission gate ledger (batched approvals)", () => {
     assert.notStrictEqual(api.getCurrentState(), "notification");
   });
 
-  it("synthesized immediate PermissionRequests join the ledger and re-arm after each answer", () => {
+  it("synthesized immediate PermissionRequests join the ledger, keep the cue on the queue head, and re-arm after each answer", () => {
     api.updateSession("kimi-a", "notification", "PermissionRequest", {
       agentId: "kimi-cli",
       permissionGateOpen: true,
@@ -477,25 +477,49 @@ describe("Kimi permission gate ledger (batched approvals)", () => {
       toolName: "shell",
       permissionCommand: "npm install",
     });
+    assert.strictEqual(ctx._kimiNotifyShown.length, 1);
+    assert.strictEqual(ctx._kimiNotifyDetails[0].toolName, "shell");
+
+    // Batched request #2 lands while the terminal still blocks on #1: the
+    // refreshed card must KEEP describing the queue head (t1), not flip to
+    // the newest arrival.
     api.updateSession("kimi-a", "notification", "PermissionRequest", {
       agentId: "kimi-cli",
       permissionGateOpen: true,
       permissionGateId: "t2",
       toolName: "write_file",
     });
-    // Immediate mode shows right away (dedupe/refresh is the bubble layer's
-    // job — here we just count show calls).
     assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+    assert.strictEqual(ctx._kimiNotifyDetails[1].toolName, "shell");
+    assert.strictEqual(ctx._kimiNotifyDetails[1].permissionCommand, "npm install");
 
     gatedPost("kimi-a", "t1");
     mock.timers.tick(1000);
-    // Re-armed cue carries the remaining gate's detail.
+    // Re-armed cue advances to the remaining gate's detail.
     assert.strictEqual(ctx._kimiNotifyShown.length, 3);
     assert.strictEqual(ctx._kimiNotifyDetails[2].toolName, "write_file");
 
     gatedPost("kimi-a", "t2");
     mock.timers.tick(5000);
     assert.strictEqual(ctx._kimiNotifyShown.length, 3);
+  });
+
+  it("native Kimi Code PermissionRequests keep refresh-to-newest semantics (no gate marker)", () => {
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      toolName: "Bash",
+      permissionCommand: "echo one",
+    });
+    // Native events fire when their prompt is really on screen — a second
+    // request means the terminal moved on, so the card follows the newest.
+    api.updateSession("kimi-a", "notification", "PermissionRequest", {
+      agentId: "kimi-cli",
+      toolName: "Write",
+      permissionAction: "Writing: b.txt",
+    });
+    assert.strictEqual(ctx._kimiNotifyShown.length, 2);
+    assert.strictEqual(ctx._kimiNotifyDetails[1].toolName, "Write");
+    assert.strictEqual(ctx._kimiNotifyDetails[1].permissionAction, "Writing: b.txt");
   });
 
   it("native Kimi Code PermissionRequests (no gate marker) stay out of the ledger", () => {


### PR DESCRIPTION
## Problem

The legacy (Python) kimi-cli fires the `PreToolUse` for **every queued tool call up front** — when one assistant message contains several tool calls, their PreToolUse events land ~0.1s apart — and then blocks on its approval TUI one tool at a time. The pet's passive-cue bookkeeping (hold + suspect timer) is a per-session single slot, so the batched events collapsed into a single cue: once the first approval was answered, the remaining prompts sat **invisible** in the terminal. No later event ever re-armed the heuristic.

Live repro (session logs, suspect mode enabled): two gated calls in one message → PreToolUse at `09:44:39.757` and `09:44:39.863` → one cue at `09:44:40.687` → first approval answered at `09:44:48` → terminal blocks on the second approval until `09:44:52` with **no cue ever shown** for it.

## Fix: a per-session gate ledger

- **`hooks/kimi-hook.js`** — gated suspect PreToolUse and synthesized PermissionRequests now carry `permission_gate_open` + `permission_gate_id` (`tool_call_id` is threaded through Pre/Post/Failure by kimi-cli, verified against 1.37 site-packages and current upstream); gated `PostToolUse`/`PostToolUseFailure` carry `permission_gated`. Gated suspect Pres also forward the tool cue detail (`tool_name` / whitelisted `permission_tool_input`, same clamps as the native path) so a re-armed cue can name the pending tool.
- **`src/server-route-state.js`** — the three new fields are re-validated at the trust boundary and passed through to `updateSession`.
- **`src/state.js`** — new insertion-ordered gate ledger per session: exact `tool_call_id` pairing, FIFO for anonymous (id-less) entries, unknown ids are deliberate no-ops. A gated Post settles its entry, clears the cue as before (the user answered *this* tool — the pet must not stay stuck on notification), then **re-arms the suspect window with the queue head's detail** when gates remain. Turn-level events (`Stop`/`UserPromptSubmit`/`PermissionResult`/`Interrupt`/…), `SessionEnd`, the safety cap, DND and session disposal go through the new `disposeKimiPermissionSession` and drop the ledger whole.
- The cue for batched **synthesized** requests always describes the ledger queue head (the tool the terminal actually blocks on), while **native Kimi Code** PermissionRequests keep refresh-to-newest semantics — native events fire when their prompt really is on screen, and they never touch the ledger (no gate marker by construction).

Compatibility: old hook + new main (and the reverse) degrade to the previous behavior — the markers are additive and re-validated server-side. Users who never enable the suspect/immediate heuristic see zero behavior change.

## Review trail

The design doc went through two external review rounds before implementation (8 blocking findings total, all incorporated). The implementation was then reviewed by two independent reviewers, which converged on the same single blocker (the synthesized-immediate cue used the newest arrival's detail instead of the queue head) — fixed in the second commit, with content-level assertions added so a count-only test can't mask it again.

## Verification

- **Tests**: 26 new cases — 13 ledger cases in `state-kimi-permission` (the core repro fails on the pre-fix state machine), hook marker/clamp cases, `/state` transport validation, permission-entry lifecycle cases (rebuild after Got-it dismissal and after auto-expire), and a joint state↔permission case driving the real scheduling into the real bubble layer. Full suite: **5249 tests, 0 fail**.
- **Live verification** (kimi-cli 1.37, Windows, suspect mode): two batched rounds. Round 1: cue → "Got it" dismissed → the first approval answered → **second cue re-armed ~0.8s later** with the pending tool's name/command → answered → clean stop. Round 2: same but with the first cue still open when the first approval was answered — the cue drops with the Post and the second one re-arms identically. Cards showed the concrete file/command (detail forwarding verified by eye).

## Known adjacent gaps (deliberately out of scope, tracked for follow-up)

- **Mixed gated/non-gated batches** (pre-existing on main, verified by experiment against the base commit): a non-gated PreToolUse arriving mid-batch cancels the suspect timer without re-arming and can swallow a pending gated cue. Needs a live repro of mixed batching before fixing.
- **Long-running first tool**: kimi-cli shows the second approval prompt immediately after the first is *approved* (before the first tool finishes), but the legacy event vocabulary has no hook event for the approval itself — `PostToolUse` is the earliest anchor, so the re-armed cue is late-but-correct in that case.
- **Default mode is still explicit-only**, which current kimi-cli versions never trigger (no explicit permission fields on PreToolUse, checked on 1.37 and upstream 1.49 source). Making the suspect heuristic the default for the legacy flavor (installer migration + Doctor check + docs) is the planned follow-up PR.

Composes with #680: the re-armed cue's "Got it" brings the terminal forward for each queued approval. Follow-up to the cue work introduced in #675.
