### PR TITLE
fix(bubble): let permission bubbles return to the terminal without deciding

### DIFF
--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -938,7 +938,10 @@ function show(data) {
         suggestionsContainer.appendChild(btn);
       });
     }
-    renderRegularTerminalFallback(data.lang);
+    // Hermes cards get no terminal fallback: its protocol can't express
+    // "no decision, user answers in the terminal" — our 204 fails open
+    // (= allow) past the plugin's permission gate. See handleDecide/isHermes.
+    if (!data.isHermes) renderRegularTerminalFallback(data.lang);
   }
   // Re-enable buttons
   btnAllow.disabled = false;

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -660,6 +660,17 @@ function renderElicitationTerminalFallback() {
   suggestionsContainer.appendChild(btn);
 }
 
+function renderRegularTerminalFallback(lang) {
+  const btn = document.createElement("button");
+  btn.className = "btn-suggestion";
+  btn.textContent = bubbleText(lang, "goToTerminal");
+  btn.addEventListener("click", () => {
+    disableAll();
+    window.bubbleAPI.decide("deny-and-focus");
+  });
+  suggestionsContainer.appendChild(btn);
+}
+
 function renderElicitationStep() {
   const total = elicitationQuestions.length;
   if (total === 0) {
@@ -780,7 +791,7 @@ function show(data) {
       });
       suggestionsContainer.appendChild(btn);
     }
-
+    renderRegularTerminalFallback(data.lang);
     revealCard();
     return;
   }
@@ -910,21 +921,24 @@ function show(data) {
       window.bubbleAPI.decide("deny-and-focus");
     });
     suggestionsContainer.appendChild(btn);
-  } else if (Array.isArray(data.suggestions)) {
-    const seenLabels = new Set();
-    data.suggestions.forEach((s, i) => {
-      const label = getSuggestionLabel(s, data.lang);
-      if (seenLabels.has(label)) return;
-      seenLabels.add(label);
-      const btn = document.createElement("button");
-      btn.className = "btn-suggestion";
-      btn.textContent = label;
-      btn.addEventListener("click", () => {
-        disableAll();
-        window.bubbleAPI.decide("suggestion:" + i);
+  } else {
+    if (Array.isArray(data.suggestions)) {
+      const seenLabels = new Set();
+      data.suggestions.forEach((s, i) => {
+        const label = getSuggestionLabel(s, data.lang);
+        if (seenLabels.has(label)) return;
+        seenLabels.add(label);
+        const btn = document.createElement("button");
+        btn.className = "btn-suggestion";
+        btn.textContent = label;
+        btn.addEventListener("click", () => {
+          disableAll();
+          window.bubbleAPI.decide("suggestion:" + i);
+        });
+        suggestionsContainer.appendChild(btn);
       });
-      suggestionsContainer.appendChild(btn);
-    });
+    }
+    renderRegularTerminalFallback(data.lang);
   }
   // Re-enable buttons
   btnAllow.disabled = false;

--- a/src/permission.js
+++ b/src/permission.js
@@ -909,6 +909,11 @@ function buildPermissionBubblePayload(permEntry) {
     // Provenance for the renderer: lets the bubble relabel Codex MCP tool calls
     // (issue #445) without touching approval semantics. Mirrors the flags above.
     isCodex: permEntry.isCodex || false,
+    // Hermes must NOT get the go-to-terminal fallback: its wire protocol has
+    // no "no decision, user answers in the terminal" shape — the plugin treats
+    // our 204 no-decision exactly like allow (fail-open past the opt-in
+    // CLAWD_HERMES_PERMISSION_TOOLS gate). See handleDecide's isHermes branch.
+    isHermes: permEntry.isHermes || false,
     // Display-only detail for the passive Kimi notify card: the real tool
     // name plus the whitelisted tool_input subset let the renderer reuse the
     // standard cue path (formatDetail) while the card stays dismiss-only.
@@ -1232,14 +1237,17 @@ function cancelRemoteApproval(permEntry, options = {}) {
 }
 
 // "Go to terminal" path: drop the bubble, abort any in-flight Telegram prompt,
-// hand focus back to the agent terminal. The HTTP res is intentionally NOT
-// answered here — the original socket-close abortHandler stays registered so
-// the agent's own disconnect drives final cleanup. That assumption only holds
-// when there's a desktop bubble the user is looking at; a remote-only entry
-// (bubbles disabled, decided over Feishu/Telegram) has no local UI to fall
-// back on, so leaving res unanswered would hang the hook until its own
-// timeout. Route those through the same no-decision/destroy path the other
-// remote-only "go to terminal" branches already use.
+// destroy the hook socket WITHOUT writing a decision, hand focus back to the
+// agent terminal. The destroy is what actually frees the terminal: CC and
+// CodeBuddy block on the PermissionRequest HTTP hook (600s) and show nothing
+// in the terminal until it finishes — a dropped connection is a non-blocking
+// hook error, so they immediately fall back to their native chat prompt
+// without treating it as a deny (same mechanism as the autoclose no-decision
+// path and the bypass gate in server-route-permission.js). For opencode the
+// destroy is a no-op behind the writableEnded guard: its fire-and-forget POST
+// was 200-ACKed on arrival and the native TUI prompt owns the request.
+// A remote-only entry (bubbles disabled, decided over Feishu/Telegram) has no
+// desktop bubble to drop — route it through the shared no-decision path.
 function dismissPermissionForTerminal(perm) {
   if (!perm) return;
   if (perm.remoteOnly) {
@@ -1263,6 +1271,13 @@ function dismissPermissionForTerminal(perm) {
     pendingPermissions.splice(idx, 1);
     notifyPermissionsChanged("deny-and-focus");
     notifyPermissionResolved(perm, "deny-and-focus");
+  }
+  const { res, abortHandler } = perm;
+  if (res && abortHandler) {
+    try { res.removeListener("close", abortHandler); } catch {}
+  }
+  if (res && !res.writableEnded && !res.destroyed) {
+    try { res.destroy(); } catch {}
   }
   if (perm.bubble && !perm.bubble.isDestroyed()) {
     perm.bubble.webContents.send("permission-hide");
@@ -1989,6 +2004,13 @@ function handleDecide(event, behavior) {
       resolvePermissionEntry(perm, "allow");
       return;
     }
+    // ⚠ Hermes no-decision is NOT neutral: the plugin maps our 204 to None,
+    // which its pre_tool_call gate treats exactly like allow — the tool runs
+    // (fail-open past CLAWD_HERMES_PERMISSION_TOOLS). The renderer therefore
+    // never offers deny-and-focus on Hermes cards (isHermes in the bubble
+    // payload); this branch only backstops unknown/legacy actions. Do not add
+    // a Hermes UI entry point for deny-and-focus until the plugin protocol
+    // grows a real "hand back to terminal" answer.
     resolvePermissionEntry(perm, "no-decision", `Unsupported Hermes bubble action: ${String(behavior)}`);
     if (behavior === "deny-and-focus") {
       ctx.focusTerminalForSession(perm.sessionId, { fallbackEntry: buildPermissionFocusEntry(perm) });
@@ -2339,6 +2361,9 @@ return {
   addPendingPermission, removePendingPermission,
   maybeStartRemoteApproval,
   dismissPermissionForTerminal,
+  // Test seam: lets wire-level tests pin which provenance flags reach the
+  // renderer (isHermes suppresses the go-to-terminal action — issue #689).
+  buildPermissionBubblePayload,
   handleBubbleHeight, handleDecide, handleImeEditing, handleBubbleRendererGone, cleanup,
   showCodexNotifyBubble, clearCodexNotifyBubbles,
   showKimiNotifyBubble, clearKimiNotifyBubbles,

--- a/test/bubble-go-to-terminal.test.js
+++ b/test/bubble-go-to-terminal.test.js
@@ -114,13 +114,13 @@ function createHarness() {
 }
 
 describe("permission bubble terminal fallback (issue #689)", () => {
+  // The bubble payload (buildPermissionBubblePayload) only forwards the
+  // provenance flags isElicitation/isOpencode/isAntigravity/isCodex/isHermes.
+  // Claude Code, CodeBuddy, Qwen, Copilot and other CC-protocol forks all
+  // reach the renderer as a flagless default card — one case covers them.
   for (const [name, data] of [
-    ["Claude Code", { toolName: "Bash" }],
-    ["CodeBuddy", { toolName: "Bash" }],
-    ["Codex", { toolName: "Bash", isCodex: true }],
-    ["Qwen", { toolName: "Bash", isQwenCode: true }],
-    ["Copilot", { toolName: "Bash", isCopilotCli: true }],
-    ["Hermes", { toolName: "Bash", isHermes: true }],
+    ["default cards (Claude Code / CC-protocol forks)", { toolName: "Bash" }],
+    ["Codex interactive", { toolName: "Bash", isCodex: true }],
   ]) {
     it(`shows exactly one fallback for ${name} and emits only deny-and-focus`, () => {
       const harness = createHarness();
@@ -133,6 +133,14 @@ describe("permission bubble terminal fallback (issue #689)", () => {
       assert.deepStrictEqual(harness.decisions, ["deny-and-focus"]);
     });
   }
+
+  it("does not offer the fallback on Hermes cards (204 no-decision fails open = allow)", () => {
+    const harness = createHarness();
+    harness.show({ toolName: "Bash", isHermes: true });
+
+    assert.strictEqual(harness.terminalButtons().length, 0);
+    assert.deepStrictEqual(harness.decisions, []);
+  });
 
   it("shows exactly one fallback for opencode and preserves its Always action", () => {
     const harness = createHarness();

--- a/test/bubble-go-to-terminal.test.js
+++ b/test/bubble-go-to-terminal.test.js
@@ -1,0 +1,179 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const SOURCE = fs.readFileSync(path.join(__dirname, "..", "src", "bubble-renderer.js"), "utf8");
+
+class ClassList {
+  constructor() { this.values = new Set(); }
+  add(...names) { names.forEach((name) => this.values.add(name)); }
+  remove(...names) { names.forEach((name) => this.values.delete(name)); }
+  contains(name) { return this.values.has(name); }
+  toggle(name, force) {
+    const enabled = force === undefined ? !this.contains(name) : !!force;
+    if (enabled) this.add(name); else this.remove(name);
+    return enabled;
+  }
+}
+
+class FakeElement {
+  constructor(tagName = "div") {
+    this.tagName = tagName.toUpperCase();
+    this.children = [];
+    this.listeners = new Map();
+    this.classList = new ClassList();
+    this.style = { removeProperty(name) { delete this[name]; }, setProperty(name, value) { this[name] = value; } };
+    this.attributes = new Map();
+    this.textContent = "";
+    this.disabled = false;
+    this.value = "";
+    this.offsetHeight = 100;
+    this.scrollHeight = 100;
+    this.scrollWidth = 0;
+    this.clientWidth = 0;
+  }
+  set innerHTML(value) { this.children = []; this.textContent = String(value); }
+  get innerHTML() { return this.textContent; }
+  appendChild(child) { this.children.push(child); child.parentElement = this; return child; }
+  addEventListener(type, listener) {
+    const listeners = this.listeners.get(type) || [];
+    listeners.push(listener);
+    this.listeners.set(type, listeners);
+  }
+  click() {
+    if (this.disabled) return;
+    for (const listener of this.listeners.get("click") || []) listener({ target: this, preventDefault() {} });
+  }
+  focus() {}
+  setAttribute(name, value) { this.attributes.set(name, String(value)); }
+  getAttribute(name) { return this.attributes.get(name) || null; }
+  removeAttribute(name) { this.attributes.delete(name); }
+  querySelector() { return null; }
+  querySelectorAll() { return []; }
+}
+
+function createHarness() {
+  const elements = new Map();
+  for (const id of [
+    "card", "toolPill", "toolPillText", "commandBlock", "irreversibleBadge",
+    "elicitationForm", "elicitationProgress", "planFeedbackForm", "planFeedbackTextarea",
+    "planFeedbackBack", "planFeedbackSubmit", "btnAllow", "btnDeny", "suggestions", "sessionTag",
+  ]) elements.set(id, new FakeElement(id.includes("Textarea") ? "textarea" : "div"));
+  elements.set("btnAllow", new FakeElement("button"));
+  elements.set("btnDeny", new FakeElement("button"));
+  elements.set("planFeedbackBack", new FakeElement("button"));
+  elements.set("planFeedbackSubmit", new FakeElement("button"));
+  const headerTitle = new FakeElement("span");
+  const decisions = [];
+  let showPermission;
+
+  const document = {
+    activeElement: null,
+    getElementById: (id) => elements.get(id),
+    querySelector: (selector) => selector === ".header-title" ? headerTitle : null,
+    createElement: (tagName) => new FakeElement(tagName),
+    addEventListener() {},
+  };
+  const bubbleAPI = {
+    decide: (decision) => decisions.push(decision),
+    reportHeight() {},
+    onPermissionShow: (callback) => { showPermission = callback; },
+    onPermissionHide() {},
+  };
+  const context = {
+    window: {
+      ClawdBubbleFormat: {
+        formatDetail: () => "detail",
+        truncate: (value) => String(value),
+        parseMcpToolName: () => null,
+        detectIrreversible: () => null,
+      },
+      bubbleAPI,
+      addEventListener() {},
+    },
+    document,
+    requestAnimationFrame(callback) { callback(); return 1; },
+    cancelAnimationFrame() {},
+    console,
+  };
+  context.globalThis = context;
+  vm.runInNewContext(SOURCE, context);
+
+  return {
+    show(data) { showPermission({ lang: "en", toolInput: {}, suggestions: [], ...data }); },
+    decisions,
+    terminalButtons() {
+      return elements.get("suggestions").children.filter((button) => button.textContent === "Go to Terminal");
+    },
+    actionTexts() { return elements.get("suggestions").children.map((button) => button.textContent); },
+  };
+}
+
+describe("permission bubble terminal fallback (issue #689)", () => {
+  for (const [name, data] of [
+    ["Claude Code", { toolName: "Bash" }],
+    ["CodeBuddy", { toolName: "Bash" }],
+    ["Codex", { toolName: "Bash", isCodex: true }],
+    ["Qwen", { toolName: "Bash", isQwenCode: true }],
+    ["Copilot", { toolName: "Bash", isCopilotCli: true }],
+    ["Hermes", { toolName: "Bash", isHermes: true }],
+  ]) {
+    it(`shows exactly one fallback for ${name} and emits only deny-and-focus`, () => {
+      const harness = createHarness();
+      harness.show(data);
+      const buttons = harness.terminalButtons();
+
+      assert.strictEqual(buttons.length, 1);
+      buttons[0].click();
+      buttons[0].click();
+      assert.deepStrictEqual(harness.decisions, ["deny-and-focus"]);
+    });
+  }
+
+  it("shows exactly one fallback for opencode and preserves its Always action", () => {
+    const harness = createHarness();
+    harness.show({
+      toolName: "bash",
+      isOpencode: true,
+      opencodeAlways: ["bash"],
+      toolInput: { command: "pwd" },
+    });
+
+    assert.ok(harness.actionTexts().includes("Always Allow (blanket)"));
+    assert.strictEqual(harness.terminalButtons().length, 1);
+    harness.terminalButtons()[0].click();
+    assert.deepStrictEqual(harness.decisions, ["deny-and-focus"]);
+  });
+
+  for (const toolName of ["CodexExec", "KimiPermission"]) {
+    it(`does not add a terminal fallback to passive ${toolName} notifications`, () => {
+      const harness = createHarness();
+      harness.show({ toolName });
+      assert.strictEqual(harness.terminalButtons().length, 0);
+    });
+  }
+
+  it("keeps elicitation's single terminal action and deny semantics", () => {
+    const harness = createHarness();
+    harness.show({ isElicitation: true, toolName: "AskUserQuestion", toolInput: { questions: [] } });
+
+    const buttons = harness.terminalButtons();
+    assert.strictEqual(buttons.length, 1);
+    buttons[0].click();
+    assert.deepStrictEqual(harness.decisions, ["deny"]);
+  });
+
+  it("keeps plan review's single terminal action and deny-and-focus semantics", () => {
+    const harness = createHarness();
+    harness.show({ toolName: "ExitPlanMode" });
+
+    const buttons = harness.terminalButtons();
+    assert.strictEqual(buttons.length, 1);
+    buttons[0].click();
+    assert.deepStrictEqual(harness.decisions, ["deny-and-focus"]);
+  });
+});

--- a/test/permission-go-to-terminal-wire.test.js
+++ b/test/permission-go-to-terminal-wire.test.js
@@ -1,0 +1,242 @@
+// Wire-level tests for the "Go to Terminal" (deny-and-focus) action on
+// regular permission cards (issue #689). The renderer DOM half of the chain
+// is covered by bubble-go-to-terminal.test.js; these tests pin the backend
+// half: handleDecide → per-protocol wire outcome. They guard the two P0s
+// found in the first cut of the fix:
+//   1. CC/CodeBuddy block on the PermissionRequest HTTP hook (600s) and show
+//      nothing in the terminal while it is pending. The socket must be
+//      DESTROYED (dropped connection = non-blocking hook error → native
+//      prompt takes over immediately), never parked until the hook timeout,
+//      and never answered with a deny on the user's behalf.
+//   2. The hermes plugin treats a 204 no-decision exactly like allow
+//      (fail-open past its CLAWD_HERMES_PERMISSION_TOOLS gate), so the bubble
+//      payload must forward isHermes for the renderer to suppress the action,
+//      and the defensive handleDecide branch must still never emit a deny.
+
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const Module = require("node:module");
+
+// ── Mock electron before requiring permission.js (same seam as
+// permission-plan-feedback.test.js) ──
+const __electronMock = {
+  BrowserWindow: { fromWebContents: (sender) => (sender && sender.__win) || null },
+  globalShortcut: {
+    register: () => {}, unregister: () => {}, unregisterAll: () => {}, isRegistered: () => false,
+  },
+};
+const __origModuleLoad = Module._load;
+Module._load = function (request) {
+  if (request === "electron") return __electronMock;
+  return __origModuleLoad.apply(this, arguments);
+};
+const initPermission = require("../src/permission");
+Module._load = __origModuleLoad;
+
+function createMockResponse() {
+  const captured = {
+    statusCode: null,
+    headers: {},
+    body: null,
+    ended: false,
+    listeners: {},
+  };
+  return {
+    captured,
+    writableEnded: false,
+    destroyed: false,
+    headersSent: false,
+    setHeader(key, value) { captured.headers[key] = value; },
+    writeHead(status, headers) {
+      captured.statusCode = status;
+      this.headersSent = true;
+      if (headers) Object.assign(captured.headers, headers);
+    },
+    write(chunk) { captured.body = (captured.body || "") + String(chunk); },
+    end(chunk) {
+      if (chunk !== undefined) captured.body = (captured.body || "") + String(chunk);
+      captured.ended = true;
+      this.writableEnded = true;
+    },
+    on(evt, fn) {
+      (captured.listeners[evt] = captured.listeners[evt] || []).push(fn);
+    },
+    removeListener(evt, fn) {
+      const arr = captured.listeners[evt] || [];
+      const idx = arr.indexOf(fn);
+      if (idx !== -1) arr.splice(idx, 1);
+    },
+    destroy() { this.destroyed = true; },
+  };
+}
+
+function makeCtx(overrides = {}) {
+  return {
+    focusTerminalCalls: [],
+    focusTerminalForSession(sessionId, opts) {
+      this.focusTerminalCalls.push({ sessionId, opts });
+    },
+    getSettingsSnapshot: () => ({}),
+    isAgentPermissionsEnabled: () => true,
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
+    getPetWindowBounds: () => ({ x: 0, y: 0, width: 100, height: 100 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop: () => {},
+    reapplyMacVisibility: () => {},
+    permDebugLog: null,
+    updateDebugLog: null,
+    sessionDebugLog: null,
+    repositionUpdateBubble: () => {},
+    win: null,
+    bubbleFollowPet: false,
+    petHidden: false,
+    doNotDisturb: false,
+    hideBubbles: false,
+    sessions: new Map(),
+    pendingPermissions: [],
+    subscribeShortcuts: () => () => {},
+    reportShortcutFailure: () => {},
+    clearShortcutFailure: () => {},
+    onPermissionsChanged: () => {},
+    onPermissionResolved: () => {},
+    STATE_SVGS: {},
+    setState: () => {},
+    updateSession: () => {},
+    ...overrides,
+  };
+}
+
+function makeFakeBubble() {
+  return { isDestroyed: () => false, webContents: { send: () => {} }, destroy: () => {} };
+}
+function makeEventFor(bubble) {
+  return { sender: { __win: bubble } };
+}
+
+function makePermEntry(res, overrides = {}) {
+  const entry = {
+    res,
+    abortHandler: () => {},
+    suggestions: [],
+    sessionId: "wire-session-1",
+    bubble: null,
+    hideTimer: null,
+    toolName: "Bash",
+    toolInput: { command: "rm -rf build" },
+    resolvedSuggestion: null,
+    createdAt: Date.now() - 5000,
+    ...overrides,
+  };
+  // Mirror the server route: the abort handler is registered on the socket.
+  res.on("close", entry.abortHandler);
+  return entry;
+}
+
+describe("go-to-terminal wire semantics (issue #689)", () => {
+  it("destroys the CC hook socket without a decision and focuses the terminal", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const { pendingPermissions, handleDecide } = perm;
+
+    const res = createMockResponse();
+    const bubble = makeFakeBubble();
+    const permEntry = makePermEntry(res, { bubble });
+    pendingPermissions.push(permEntry);
+
+    handleDecide(makeEventFor(bubble), "deny-and-focus");
+
+    // Dropped, not parked; empty, not denied.
+    assert.strictEqual(res.destroyed, true, "hook socket must be destroyed immediately");
+    assert.strictEqual(res.captured.ended, false, "no response may be written");
+    assert.strictEqual(res.captured.body, null, "no decision body may be written");
+    // Abort handler detached before destroy — the close event can't
+    // double-resolve the removed entry.
+    assert.deepStrictEqual(res.captured.listeners.close, [], "close listener must be detached");
+    assert.strictEqual(pendingPermissions.indexOf(permEntry), -1, "entry must be removed");
+    assert.strictEqual(ctx.focusTerminalCalls.length, 1);
+    assert.strictEqual(ctx.focusTerminalCalls[0].sessionId, "wire-session-1");
+  });
+
+  it("treats a repeated deny-and-focus for the same bubble as a no-op", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const { pendingPermissions, handleDecide } = perm;
+
+    const res = createMockResponse();
+    const bubble = makeFakeBubble();
+    const permEntry = makePermEntry(res, { bubble });
+    pendingPermissions.push(permEntry);
+
+    handleDecide(makeEventFor(bubble), "deny-and-focus");
+    handleDecide(makeEventFor(bubble), "deny-and-focus");
+
+    assert.strictEqual(ctx.focusTerminalCalls.length, 1, "second IPC must not focus again");
+    assert.strictEqual(pendingPermissions.length, 0);
+  });
+
+  it("opencode: leaves the already-ACKed bridge response untouched", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const { pendingPermissions, handleDecide } = perm;
+
+    // The opencode plugin's POST is 200-ACKed on arrival — by the time the
+    // bubble is up, res is already finished. The destroy guard must not touch
+    // it, and no bridge reply is owed (native TUI owns the request).
+    const res = createMockResponse();
+    res.end();
+    const bubble = makeFakeBubble();
+    const permEntry = makePermEntry(res, {
+      bubble,
+      isOpencode: true,
+      toolName: "bash",
+    });
+    pendingPermissions.push(permEntry);
+
+    handleDecide(makeEventFor(bubble), "deny-and-focus");
+
+    assert.strictEqual(res.destroyed, false, "finished ACK socket must not be destroyed");
+    assert.strictEqual(pendingPermissions.indexOf(permEntry), -1, "entry must be removed");
+    assert.strictEqual(ctx.focusTerminalCalls.length, 1);
+  });
+
+  it("forwards isHermes in the bubble payload so the renderer suppresses the action", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+
+    const hermesPayload = perm.buildPermissionBubblePayload(
+      makePermEntry(createMockResponse(), { isHermes: true })
+    );
+    assert.strictEqual(hermesPayload.isHermes, true);
+
+    const defaultPayload = perm.buildPermissionBubblePayload(
+      makePermEntry(createMockResponse())
+    );
+    assert.strictEqual(defaultPayload.isHermes, false);
+  });
+
+  it("Hermes defensive branch: deny-and-focus still answers no-decision, never deny", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const { pendingPermissions, handleDecide } = perm;
+
+    const res = createMockResponse();
+    const bubble = makeFakeBubble();
+    const permEntry = makePermEntry(res, { bubble, isHermes: true });
+    pendingPermissions.push(permEntry);
+
+    // No UI offers this on Hermes cards anymore; if it ever arrives anyway
+    // (legacy renderer, future regression), the answer must stay a bodyless
+    // no-decision — a deny here would decide on the user's behalf.
+    handleDecide(makeEventFor(bubble), "deny-and-focus");
+
+    assert.strictEqual(res.captured.statusCode, 204, "must answer 204 no-decision");
+    const body = res.captured.body || "";
+    assert.ok(!body.includes("deny"), "must not carry a deny decision");
+    assert.strictEqual(pendingPermissions.indexOf(permEntry), -1, "entry must be removed");
+    assert.strictEqual(ctx.focusTerminalCalls.length, 1, "terminal still gets focus");
+  });
+});

--- a/test/permission-plan-feedback.test.js
+++ b/test/permission-plan-feedback.test.js
@@ -174,7 +174,7 @@ describe("permission plan-feedback handleDecide", () => {
     );
   });
 
-  it("empty feedback results in dismiss-for-terminal (no HTTP response written)", () => {
+  it("empty feedback dismisses for terminal: destroys the socket without writing a decision", () => {
     const ctx = makeCtx();
     const perm = initPermission(ctx);
     const { pendingPermissions, handleDecide } = perm;
@@ -186,6 +186,9 @@ describe("permission plan-feedback handleDecide", () => {
       destroy: () => {},
     };
     const permEntry = makePlanPermEntry(res, { bubble: fakeBubble });
+    // Mirror the server route: the abort handler is registered on the socket,
+    // so the detach assertion below exercises the real cleanup path.
+    res.on("close", permEntry.abortHandler);
     pendingPermissions.push(permEntry);
 
     // Simulate handleDecide being called with plan-feedback but empty feedback
@@ -195,9 +198,17 @@ describe("permission plan-feedback handleDecide", () => {
     // directly through the exported dismissPermissionForTerminal:
     perm.dismissPermissionForTerminal(permEntry);
 
-    // Should NOT have written an HTTP response (dismissPermissionForTerminal
-    // leaves the HTTP connection open for CC to detect socket close)
-    assert.strictEqual(res.captured.ended, false, "HTTP response should NOT be ended by dismiss-for-terminal");
+    // No decision may be written — but the socket MUST be destroyed, not left
+    // parked: CC blocks on the PermissionRequest hook (600s) with nothing in
+    // the terminal until the connection dies, and a dropped connection is a
+    // non-blocking hook error that sends CC to its native prompt (issue #689).
+    assert.strictEqual(res.captured.ended, false, "No decision body may be written by dismiss-for-terminal");
+    assert.strictEqual(res.captured.body, null, "Response body must stay empty");
+    assert.strictEqual(res.destroyed, true, "Hook socket must be destroyed so CC falls back to its native prompt");
+
+    // The socket-close abort handler must be detached before the destroy so
+    // the close event can't double-resolve the already-removed entry.
+    assert.deepStrictEqual(res.captured.listeners.close || [], [], "close listener should be removed");
 
     // Entry should be removed
     assert.strictEqual(


### PR DESCRIPTION
## Summary

Adds a "Go to Terminal" action to regular interactive permission bubbles (and opencode cards) so users can dismiss a bubble **without deciding** — the undecided request is handed back to the agent's own terminal flow. Supersedes #697, keeping its commit as the base and fixing two blocking issues found in review.

## What was wrong in the original cut (#697)

1. **Claude Code / CodeBuddy hung for up to 600s.** The action routed to `dismissPermissionForTerminal()`, which hid the bubble but left the blocking PermissionRequest HTTP hook parked — CC shows nothing in the terminal until that connection dies (hook registered with `timeout: 600`). "Go to Terminal" sent users to a blank terminal for up to 10 minutes.
2. **Hermes failed open.** `handleDecide` answers the action with a 204 no-decision, but the hermes plugin maps 204 to `None`, which its `pre_tool_call` gate treats exactly like **allow** — clicking "Go to Terminal" would have executed the tool the user meant to defer, straight past the opt-in `CLAWD_HERMES_PERMISSION_TOOLS` gate.

## The fix

- `dismissPermissionForTerminal()` now detaches the socket-close abort handler and **destroys the hook socket**: a dropped connection is a non-blocking hook error, so CC/CodeBuddy fall back to their native terminal prompt immediately (same mechanism as the autoclose no-decision path and the DND bypass gate). opencode is unaffected (its fire-and-forget POST is already ACKed; the `writableEnded` guard makes the destroy a no-op). The plan-review "Go to Terminal" button shares this path and is fixed by the same change.
- The bubble payload now forwards `isHermes`, and the renderer suppresses the go-to-terminal action on Hermes cards — the protocol has no way to express "no decision, user answers in the terminal", so the button is not offered. The `handleDecide` Hermes branch carries a warning comment against re-adding a UI entry point.

## Validation

- New wire-level suite (`test/permission-go-to-terminal-wire.test.js`) pins the destroy semantics, `isHermes` forwarding, opencode no-op, and repeat-click no-op; mutation-checked (reverting the fix turns 3 tests red).
- The stale plan-feedback assertion that pinned the parked-socket behavior is flipped to assert the destroy.
- Full suite: 5219 tests, 0 failures.
- Real-machine verification on live Claude Code sessions: regular Bash approval and the plan-review path both drop back to the native terminal prompt within ~2s of the click (previously a blank wait).

Fixes #689

Co-authored-by: drulu <yanqilu1997@126.com>
