### PR TITLE
test(bubble): reconcile family-card tests with the #704 terminal fallback

### DIFF
--- a/test/bubble-family-render.test.js
+++ b/test/bubble-family-render.test.js
@@ -158,12 +158,14 @@ describe("bubble-renderer family branch (executed)", () => {
     assert.strictEqual(r2.el("commandBlock").textContent, JSON.stringify({ weird: 1 }));
   });
 
-  it("shows the Always button only with candidates; tooltip carries the display name (twice, no {agent})", () => {
+  it("shows Always only with candidates (plus the #704 terminal fallback); tooltip carries the display name (twice, no {agent})", () => {
     const withAlways = makeRenderer();
     withAlways.show(familyPayload());
+    // #704 appends a Go-to-Terminal fallback after the Always action.
     const btns = withAlways.el("suggestions").children;
-    assert.strictEqual(btns.length, 1);
+    assert.strictEqual(btns.length, 2, "Always + Go-to-Terminal fallback");
     assert.strictEqual(btns[0].textContent, "Always Allow (blanket)");
+    assert.strictEqual(btns[1].textContent, "Go to Terminal");
     const occurrences = btns[0].title.split("OpenCode").length - 1;
     assert.strictEqual(occurrences, 2, `tooltip must name the product twice: ${btns[0].title}`);
     assert.strictEqual(btns[0].title.includes("{agent}"), false);
@@ -171,7 +173,9 @@ describe("bubble-renderer family branch (executed)", () => {
 
     const withoutAlways = makeRenderer();
     withoutAlways.show(familyPayload({ familyAlways: [] }));
-    assert.strictEqual(withoutAlways.el("suggestions").children.length, 0);
+    const fallbackOnly = withoutAlways.el("suggestions").children;
+    assert.strictEqual(fallbackOnly.length, 1, "no Always without candidates — fallback only");
+    assert.strictEqual(fallbackOnly[0].textContent, "Go to Terminal");
   });
 
   it("clicking Always emits the single family-always behavior and disables ALL buttons", () => {
@@ -183,6 +187,7 @@ describe("bubble-renderer family branch (executed)", () => {
     assert.strictEqual(r.el("btnAllow").disabled, true);
     assert.strictEqual(r.el("btnDeny").disabled, true);
     assert.strictEqual(alwaysBtn.disabled, true, "the clicked Always button itself must be disabled");
+    assert.strictEqual(r.el("suggestions").children[1].disabled, true, "the terminal fallback must be disabled too");
     // Double-click through the now-disabled button must not fire a second decide.
     alwaysBtn.click();
     assert.deepStrictEqual(r.decideCalls, ["family-always"]);

--- a/test/bubble-go-to-terminal.test.js
+++ b/test/bubble-go-to-terminal.test.js
@@ -142,12 +142,17 @@ describe("permission bubble terminal fallback (issue #689)", () => {
     assert.deepStrictEqual(harness.decisions, []);
   });
 
-  it("shows exactly one fallback for opencode and preserves its Always action", () => {
+  it("shows exactly one fallback for opencode-family cards and preserves the Always action", () => {
     const harness = createHarness();
+    // Family cards are selected by familyAgentId (the post-#706 payload
+    // vocabulary; buildPermissionBubblePayload no longer emits isOpencode /
+    // opencodeAlways for the renderer).
     harness.show({
       toolName: "bash",
-      isOpencode: true,
-      opencodeAlways: ["bash"],
+      familyAgentId: "opencode",
+      familyDisplayName: "OpenCode",
+      familyAlways: ["bash"],
+      familyPatterns: [],
       toolInput: { command: "pwd" },
     });
 


### PR DESCRIPTION
**main 现处红灯**:#704(前往终端 fallback)与 #706(opencode-family 渲染收编)同日合并,互相基于对方合并前的形状写测试,且无 PR CI:

- `bubble-go-to-terminal` 的 opencode 用例喂的是已退役的 `isOpencode`/`opencodeAlways` 词汇 → 选不中 family 分支,断言的 Always 按钮根本没渲染;
- `bubble-family-render` 把 suggestions 容器按 `[Always]` 计数 → #704 合法追加的 fallback 按钮把计数打破。

**渲染器行为本身两个功能都正确**(family 卡 = Always + 前往终端),本 PR 纯测试调和:夹具换新词汇、计数纳入 fallback、补「Always 点击后 fallback 同步禁用」断言。

变异确认:从 family 分支拆掉 `renderRegularTerminalFallback` → 两文件共 3 红。全量 **5281/0**。

顺带记录:两个 PR 各自绿、合并即红——PR CI 缺位的直接代价,test-ci 任务卡 +1。