### PR TITLE
fix: honor Linux Electron override fallback

### DIFF
--- a/docs/guides/setup-guide.md
+++ b/docs/guides/setup-guide.md
@@ -28,6 +28,13 @@ Remove-Item -Recurse -Force node_modules/electron
 npm install
 ```
 
+For custom development distributions, a Linux launch with
+`ELECTRON_OVERRIDE_DIST_PATH` mirrors Electron's resolver and falls back to the
+`electron` executable at the override root when `path.txt` is absent. macOS and
+Windows overrides must retain Electron's exact standard `path.txt` because
+their supported executable layouts use an app bundle and `electron.exe` rather
+than the Linux root executable.
+
 ## Agent Setup
 
 Fresh installs enable and install only Claude Code and Codex by default. For other local agents, open **Settings → Agents** and click **Install** for that agent first; after that, Clawd keeps the hook/plugin/extension synced on launch while the agent remains enabled. Turning an enabled agent off stops event intake but does not uninstall files. **Uninstall** removes only Clawd-managed hook/plugin/extension entries and also disables that agent.

--- a/scripts/verify-electron-install.js
+++ b/scripts/verify-electron-install.js
@@ -108,9 +108,16 @@ function verifyElectronInstall(options = {}) {
 
   if (platformPath && isExistingDirectory(fsModule, packageRoot)) {
     const pathFile = pathModule.join(packageRoot, "path.txt");
-    if (!existingFileStat(fsModule, pathFile)) {
+    // Electron's resolver falls back to `<override>/electron` when path.txt is
+    // absent. That filename matches the shipped Linux launcher. macOS and
+    // Windows keep the exact path.txt requirement because their supported
+    // executable layouts use an app bundle and electron.exe, respectively.
+    const allowLinuxOverrideFallback =
+      context === "launch" && platform === "linux" && Boolean(env.ELECTRON_OVERRIDE_DIST_PATH);
+    const pathFileStat = existingFileStat(fsModule, pathFile);
+    if (!pathFileStat && !allowLinuxOverrideFallback) {
       missing.push(pathFile);
-    } else {
+    } else if (pathFileStat) {
       const actualPath = fsModule.readFileSync(pathFile, "utf8");
       if (actualPath !== platformPath) {
         invalid.push({

--- a/test/verify-electron-install.test.js
+++ b/test/verify-electron-install.test.js
@@ -233,6 +233,73 @@ test("launch validates the effective ELECTRON_OVERRIDE_DIST_PATH", () => {
   assert.ok(failing.missing.includes(frameworksRoot));
 });
 
+test("Linux launch override mirrors Electron's path.txt-free executable fallback", () => {
+  const fixture = createFixture("linux");
+  const overrideRoot = path.join(fixture.rootDir, "custom-electron");
+  fs.renameSync(fixture.distRoot, overrideRoot);
+  fs.rmSync(path.join(fixture.packageRoot, "path.txt"));
+
+  const result = verifyFixture(fixture, "linux", {
+    context: "launch",
+    env: { ELECTRON_OVERRIDE_DIST_PATH: overrideRoot },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.executablePath, path.join(overrideRoot, "electron"));
+});
+
+test("Linux launch override reports the exact fallback executable when it is missing", () => {
+  const fixture = createFixture("linux");
+  const overrideRoot = path.join(fixture.rootDir, "custom-electron");
+  fs.renameSync(fixture.distRoot, overrideRoot);
+  fs.rmSync(path.join(fixture.packageRoot, "path.txt"));
+  const executablePath = path.join(overrideRoot, "electron");
+  fs.rmSync(executablePath);
+
+  const result = verifyFixture(fixture, "linux", {
+    context: "launch",
+    env: { ELECTRON_OVERRIDE_DIST_PATH: overrideRoot },
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.missing.includes(executablePath));
+  assert.ok(!result.missing.includes(path.join(fixture.packageRoot, "path.txt")));
+});
+
+test("Linux override fallback applies only to launch context", () => {
+  const fixture = createFixture("linux");
+  const overrideRoot = path.join(fixture.rootDir, "custom-electron");
+  fs.renameSync(fixture.distRoot, overrideRoot);
+  const pathFile = path.join(fixture.packageRoot, "path.txt");
+  fs.rmSync(pathFile);
+
+  const result = verifyFixture(fixture, "linux", {
+    context: "verify",
+    env: { ELECTRON_OVERRIDE_DIST_PATH: overrideRoot },
+  });
+
+  assert.equal(result.ok, false);
+  assert.ok(result.missing.includes(pathFile));
+});
+
+test("macOS and Windows overrides retain their exact path.txt requirement", () => {
+  for (const platform of ["darwin", "win32"]) {
+    const fixture = createFixture(platform);
+    const overrideRoot = path.join(fixture.rootDir, `custom-electron-${platform}`);
+    fs.renameSync(fixture.distRoot, overrideRoot);
+    const pathFile = path.join(fixture.packageRoot, "path.txt");
+    fs.rmSync(pathFile);
+
+    const result = verifyFixture(fixture, platform, {
+      context: "launch",
+      env: { ELECTRON_OVERRIDE_DIST_PATH: overrideRoot },
+    });
+
+    assert.equal(result.ok, false, platform);
+    assert.ok(result.missing.includes(pathFile), platform);
+  }
+});
+
 test("failure output explains the false green and safe recovery", () => {
   const fixture = createFixture("darwin");
   fs.rmSync(path.join(fixture.distRoot, "Electron.app", "Contents", "Frameworks"), {


### PR DESCRIPTION
## Summary

- allow a Linux development launch with `ELECTRON_OVERRIDE_DIST_PATH` to use Electron's `<override>/electron` fallback when the package `path.txt` is absent
- keep standard installs, non-launch verification, macOS overrides, and Windows overrides on the existing exact `path.txt` contract
- validate the effective fallback executable and report its exact path when missing
- document the platform boundary for custom development distributions

## Why Linux-only

Electron's resolver uses the literal fallback name `electron`. That matches the shipped Linux launcher, while the supported macOS and Windows layouts use `Electron.app/Contents/MacOS/Electron` and `electron.exe`. Keeping those platforms strict avoids weakening the macOS bundle integrity checks introduced in #710.

## Verification

- targeted verifier suite: 28 passed, 0 failed
- full `npm test`: 5,363 tests; 5,345 passed; 0 failed; 18 skipped
- standard local `npm run verify:electron`: passed with Electron 41.10.2

Closes #711
