### PR TITLE
fix(win): stop treating the desktop shell as a fullscreen app

### DIFF
--- a/src/win-fullscreen-detect.js
+++ b/src/win-fullscreen-detect.js
@@ -24,6 +24,25 @@ const FULLSCREEN_TOLERANCE_PX = 2;
 
 const MONITOR_DEFAULTTONEAREST = 2;
 
+// #719: the desktop itself passes the geometry test. Clicking the desktop
+// makes the shell window the foreground window — Progman, or one of
+// explorer's WorkerW siblings when a wallpaper host re-parents the icon view —
+// and its rect covers the whole monitor, so geometry alone classifies the
+// bare desktop as a fullscreen app. That made the hit window go non-activating
+// ~1s after any desktop click (startFocusablePoll), and Electron's
+// setFocusable(false) on Windows ends in Focus(false), which deactivates —
+// cancelling e.g. an in-place file rename on the desktop. Excluding the shell
+// window classes keeps "fullscreen" meaning an actual app.
+const DESKTOP_SHELL_WINDOW_CLASSES = new Set(["progman", "workerw"]);
+// Ample for real class names; matches win-foreground-terminal.js.
+const CLASS_NAME_BUF_LEN = 256;
+
+// Win32 class-name comparison is case-insensitive.
+function isDesktopShellWindowClass(className) {
+  return typeof className === "string"
+    && DESKTOP_SHELL_WINDOW_CLASSES.has(className.toLowerCase());
+}
+
 // Pure geometry: does the window rect cover the entire monitor rect (not just
 // the work area)? Exported so the decision logic is unit-testable without FFI.
 function rectCoversMonitor(winRect, monitorRect, tolerance = FULLSCREEN_TOLERANCE_PX) {
@@ -48,6 +67,7 @@ function createForegroundFullscreenProbe(options = {}) {
   let GetWindowRect;
   let MonitorFromWindow;
   let GetMonitorInfoW;
+  let GetClassNameW;
   let monitorInfoSize;
   try {
     const koffi = options.koffi || require("koffi");
@@ -65,6 +85,7 @@ function createForegroundFullscreenProbe(options = {}) {
     GetWindowRect = user32.func("bool __stdcall GetWindowRect(void* hWnd, _Out_ ClawdRECT* lpRect)");
     MonitorFromWindow = user32.func("void* __stdcall MonitorFromWindow(void* hWnd, uint32 dwFlags)");
     GetMonitorInfoW = user32.func("bool __stdcall GetMonitorInfoW(void* hMonitor, _Inout_ ClawdMONITORINFO* lpmi)");
+    GetClassNameW = user32.func("int __stdcall GetClassNameW(void* hWnd, _Out_ uint16_t* lpClassName, int nMaxCount)");
   } catch (err) {
     if (typeof options.onError === "function") options.onError(err);
     return noop;
@@ -84,7 +105,20 @@ function createForegroundFullscreenProbe(options = {}) {
       const info = { cbSize: monitorInfoSize, rcMonitor: {}, rcWork: {}, dwFlags: 0 };
       if (!GetMonitorInfoW(hMonitor, info)) return false;
 
-      return rectCoversMonitor(winRect, info.rcMonitor);
+      if (!rectCoversMonitor(winRect, info.rcMonitor)) return false;
+
+      // Geometry matched — rule out the desktop shell (#719). Only reached in
+      // the rare covers-monitor case, so the extra FFI call is off the common
+      // path. A failed class read (0 length) keeps the geometric answer: the
+      // pre-#719 behavior, erring toward "fullscreen" for a covering window.
+      const classBuf = new Uint16Array(CLASS_NAME_BUF_LEN);
+      const classLen = GetClassNameW(hwnd, classBuf, CLASS_NAME_BUF_LEN);
+      if (classLen > 0) {
+        let className = "";
+        for (let i = 0; i < classLen; i++) className += String.fromCharCode(classBuf[i]);
+        if (isDesktopShellWindowClass(className)) return false;
+      }
+      return true;
     } catch {
       // Any FFI hiccup at call time: behave as "not fullscreen" so the
       // watchdog keeps the pet visible rather than hiding it on an error.
@@ -96,5 +130,6 @@ function createForegroundFullscreenProbe(options = {}) {
 module.exports = {
   createForegroundFullscreenProbe,
   rectCoversMonitor,
+  isDesktopShellWindowClass,
   FULLSCREEN_TOLERANCE_PX,
 };

--- a/test/win-fullscreen-detect.test.js
+++ b/test/win-fullscreen-detect.test.js
@@ -6,6 +6,7 @@ const assert = require("node:assert");
 const {
   createForegroundFullscreenProbe,
   rectCoversMonitor,
+  isDesktopShellWindowClass,
   FULLSCREEN_TOLERANCE_PX,
 } = require("../src/win-fullscreen-detect");
 
@@ -33,6 +34,14 @@ function fakeKoffi(behavior) {
             return (_h, infoOut) => {
               if (behavior.monitorRect) infoOut.rcMonitor = behavior.monitorRect;
               return behavior.getMonitorInfo !== false;
+            };
+          }
+          if (signature.includes("GetClassNameW")) {
+            return (_hwnd, bufOut, _maxLen) => {
+              const name = behavior.className === undefined ? "FakeApp" : behavior.className;
+              if (name === null) return 0;
+              for (let i = 0; i < name.length; i++) bufOut[i] = name.charCodeAt(i);
+              return name.length;
             };
           }
           throw new Error(`unexpected func: ${signature}`);
@@ -73,6 +82,24 @@ describe("rectCoversMonitor", () => {
   it("returns false for missing rects", () => {
     assert.strictEqual(rectCoversMonitor(null, MONITOR), false);
     assert.strictEqual(rectCoversMonitor(FULLSCREEN_RECT, null), false);
+  });
+});
+
+describe("isDesktopShellWindowClass", () => {
+  it("matches the desktop shell window classes", () => {
+    assert.strictEqual(isDesktopShellWindowClass("Progman"), true);
+    assert.strictEqual(isDesktopShellWindowClass("WorkerW"), true);
+  });
+
+  it("compares case-insensitively (Win32 class names are case-insensitive)", () => {
+    assert.strictEqual(isDesktopShellWindowClass("progman"), true);
+    assert.strictEqual(isDesktopShellWindowClass("WORKERW"), true);
+  });
+
+  it("rejects normal app classes and empty input", () => {
+    assert.strictEqual(isDesktopShellWindowClass("Chrome_WidgetWin_1"), false);
+    assert.strictEqual(isDesktopShellWindowClass(""), false);
+    assert.strictEqual(isDesktopShellWindowClass(null), false);
   });
 });
 
@@ -124,5 +151,52 @@ describe("createForegroundFullscreenProbe", () => {
       koffi: fakeKoffi({ hwnd: {}, getWindowRect: false }),
     });
     assert.strictEqual(probe(), false);
+  });
+
+  // #719: clicking the desktop makes the shell window (Progman, or a WorkerW
+  // when a wallpaper host re-parents the icon view) the foreground window, and
+  // its rect covers the whole monitor — geometry alone says "fullscreen app".
+  it("does not treat the desktop shell (Progman) as a fullscreen app", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "Progman",
+      }),
+    });
+    assert.strictEqual(probe(), false);
+  });
+
+  it("does not treat a monitor-covering WorkerW as a fullscreen app", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "WorkerW",
+      }),
+    });
+    assert.strictEqual(probe(), false);
+  });
+
+  it("still reports fullscreen for a normal app class covering the monitor", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "Chrome_WidgetWin_1",
+      }),
+    });
+    assert.strictEqual(probe(), true);
+  });
+
+  it("falls back to geometry when GetClassNameW fails", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: null,
+      }),
+    });
+    assert.strictEqual(probe(), true);
   });
 });


### PR DESCRIPTION
Fixes #719.

Root cause: win-fullscreen-detect.js judges "fullscreen app in foreground" by geometry alone. Clicking the bare desktop makes the shell window (Progman, or a WorkerW when a wallpaper host re-parents the icon view) the foreground window, and its rect covers the whole monitor — so the probe reported a fullscreen app. The ~1s focusable poll then set the hit window non-focusable, and Electron's setFocusable(false) on Windows ends in Focus(false) → Deactivate(), which hands the foreground away — cancelling an in-place rename on the desktop. It also silently made the topmost watchdog stand down whenever the desktop had focus. This matches every isolation result in the issue: the ~1s delay is the poll interval, an Explorer window doesn't cover the monitor, and quitting Clawd kills the poll.

Fix: after the geometry match, read the foreground window's class via GetClassNameW (same koffi idiom as win-foreground-terminal.js) and exclude Progman/WorkerW (case-insensitive). The class read only happens in the rare covers-monitor case; a failed read keeps the old geometric answer.

Evidence (100ms foreground watcher on Windows 11 build 26200, comparing the old geometry-only verdict vs the new one):

```
12:08:37.800 class=CASCADIA_HOSTING_WINDOW_CLASS coversMonitor=false oldProbe=normal newProbe=normal
12:08:43.556 class=Chrome_WidgetWin_0     coversMonitor=false oldProbe=normal newProbe=normal
12:08:43.968 class=Progman                coversMonitor=true oldProbe=FULLSCREEN newProbe=normal   <-- MISDETECT (old code flips Clawd's hit window here)
12:08:44.932 class=CASCADIA_HOSTING_WINDOW_CLASS coversMonitor=false oldProbe=normal newProbe=normal
12:08:49.925 class=Chrome_WidgetWin_0     coversMonitor=false oldProbe=normal newProbe=normal
12:08:50.338 class=Progman                coversMonitor=true oldProbe=FULLSCREEN newProbe=normal   <-- MISDETECT (old code flips Clawd's hit window here)
12:08:50.447 class=XamlExplorerHostIslandWindow_WASDK coversMonitor=false oldProbe=normal newProbe=normal
12:08:52.753 class=Progman                coversMonitor=true oldProbe=FULLSCREEN newProbe=normal   <-- MISDETECT (old code flips Clawd's hit window here)
12:08:55.690 class=CASCADIA_HOSTING_WINDOW_CLASS coversMonitor=false oldProbe=normal newProbe=normal

14:58:06.743 class=Chrome_WidgetWin_1     coversMonitor=true oldProbe=FULLSCREEN newProbe=FULLSCREEN
```

Desktop clicks stop being classified as fullscreen; a real fullscreen app (browser video, last line) is classified identically before and after.

Note on reproducing: the misdetection fires on every machine (watcher above), but whether the rename visibly cancels depends on Windows' foreground lock allowing the background process to deactivate the foreground — it reproduces on some machines (as in the issue report) while others block the yank and only suffer the silent watchdog stand-down.

Tests: 5 new cases in test/win-fullscreen-detect.test.js (Progman/WorkerW excluded, normal class still fullscreen, class-read failure falls back to geometry, plus unit cases for the new helper); the fake koffi gained a GetClassNameW stub. File passes 17/17.

Verified live: desktop rename survives, pet drag works, fullscreen video still classified fullscreen (overlay behavior unchanged).
