### PR TITLE
fix: keep tray flash icon at a stable size (#722)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -121,6 +121,7 @@ const {
   getProportionalPixelSize,
 } = require("./size-utils");
 const { keepOutOfTaskbar } = require("./taskbar");
+const { loadTrayNormalIcon, loadTrayFlashIcon } = require("./tray-flash-icon");
 const createTopmostRuntime = require("./topmost-runtime");
 const { WIN_TOPMOST_LEVEL } = createTopmostRuntime;
 const createThemeFadeSequencer = require("./theme-fade-sequencer");
@@ -1167,27 +1168,24 @@ function flashTaskbar() {
 
   // Cache the normal icon on first call
   if (!trayFlashNormalIcon) {
-    if (process.platform === "darwin") {
-      trayFlashNormalIcon = nativeImage.createFromPath(
-        path.join(__dirname, "../assets/tray-iconTemplate.png")
-      );
-      trayFlashNormalIcon.setTemplateImage(true);
-    } else {
-      trayFlashNormalIcon = nativeImage.createFromPath(
-        path.join(__dirname, "../assets/tray-icon.png")
-      ).resize({ width: 32, height: 32 });
-    }
+    trayFlashNormalIcon = loadTrayNormalIcon({
+      nativeImage,
+      platform: process.platform,
+      templatePath: path.join(__dirname, "../assets/tray-iconTemplate.png"),
+      iconPath: path.join(__dirname, "../assets/tray-icon.png"),
+    });
   }
 
-  // Cache the highlight icon (orange circle) on first call
+  // Cache the highlight icon (orange dot) on first call. #722: it has to come
+  // back at the same point size as the normal icon, otherwise each blink
+  // resizes the tray icon and reflows the menu bar.
   if (!trayFlashHighlightIcon) {
-    const flashPath = path.join(__dirname, "../assets/tray-icon-flash.png");
-    if (fs.existsSync(flashPath)) {
-      const img = nativeImage.createFromPath(flashPath).resize({ width: 32, height: 32 });
-      if (!img.isEmpty()) {
-        trayFlashHighlightIcon = img;
-      }
-    }
+    trayFlashHighlightIcon = loadTrayFlashIcon({
+      nativeImage,
+      platform: process.platform,
+      flashPath: path.join(__dirname, "../assets/tray-icon-flash.png"),
+      fileExists: (p) => fs.existsSync(p),
+    });
   }
 
   if (!trayFlashHighlightIcon) return;

--- a/src/menu.js
+++ b/src/menu.js
@@ -3,6 +3,7 @@
 const { app, BrowserWindow, screen, Menu, Tray, nativeImage, dialog } = require("electron");
 const path = require("path");
 const { keepOutOfTaskbar } = require("./taskbar");
+const { loadTrayNormalIcon } = require("./tray-flash-icon");
 
 const isMac = process.platform === "darwin";
 const isWin = process.platform === "win32";
@@ -132,13 +133,13 @@ module.exports = function initMenu(ctx) {
   // ── System tray ──
   function createTray() {
     if (ctx.tray) return;
-    let icon;
-    if (isMac) {
-      icon = nativeImage.createFromPath(path.join(__dirname, "../assets/tray-iconTemplate.png"));
-      icon.setTemplateImage(true);
-    } else {
-      icon = nativeImage.createFromPath(path.join(__dirname, "../assets/tray-icon.png")).resize({ width: 32, height: 32 });
-    }
+    // Shared with the completion flash so both frames keep the same size (#722).
+    const icon = loadTrayNormalIcon({
+      nativeImage,
+      platform: process.platform,
+      templatePath: path.join(__dirname, "../assets/tray-iconTemplate.png"),
+      iconPath: path.join(__dirname, "../assets/tray-icon.png"),
+    });
     ctx.tray = new Tray(icon);
     ctx.tray.setToolTip("Clawd Desktop Pet");
     buildTrayMenu();

--- a/src/tray-flash-icon.js
+++ b/src/tray-flash-icon.js
@@ -1,0 +1,52 @@
+// Tray flash icons (#722).
+//
+// The completion flash blinks the menu bar / taskbar icon between the normal
+// icon and a highlight dot. The highlight asset is a 32×32 PNG, the macOS
+// normal icon is a 16pt template (16×16 plus an @2x sibling). Loading the
+// highlight as a plain 32×32 image therefore handed the menu bar an icon that
+// was logically twice as wide, so every blink resized the icon and shoved the
+// neighbouring status items sideways.
+//
+// On macOS the 32px asset is added as the @2x representation of a 16pt image
+// so both frames occupy the exact same slot. Windows / Linux trays work in
+// raw pixels and both assets are already normalised to 32×32 there.
+
+const TRAY_POINT_SIZE = 16; // macOS menu bar works in points
+const TRAY_PIXEL_SIZE = 32; // Windows / Linux trays work in pixels
+
+function loadTrayNormalIcon({ nativeImage, platform, templatePath, iconPath }) {
+  if (platform === "darwin") {
+    const icon = nativeImage.createFromPath(templatePath);
+    icon.setTemplateImage(true);
+    return icon;
+  }
+  return nativeImage
+    .createFromPath(iconPath)
+    .resize({ width: TRAY_PIXEL_SIZE, height: TRAY_PIXEL_SIZE });
+}
+
+function loadTrayFlashIcon({ nativeImage, platform, flashPath, fileExists }) {
+  if (!fileExists(flashPath)) return null;
+
+  const src = nativeImage.createFromPath(flashPath);
+  if (!src || src.isEmpty()) return null;
+
+  if (platform !== "darwin") {
+    return src.resize({ width: TRAY_PIXEL_SIZE, height: TRAY_PIXEL_SIZE });
+  }
+
+  // Point size = pixels / scaleFactor, so a 32px @2x representation renders in
+  // the same 16pt box as the template icon — no reflow while flashing.
+  const scaled = nativeImage.createEmpty();
+  try {
+    scaled.addRepresentation({ scaleFactor: 2, dataURL: src.toDataURL() });
+    if (!scaled.isEmpty()) return scaled;
+  } catch {
+    // addRepresentation is unavailable or rejected the payload — fall through.
+  }
+
+  // Fallback: downscale to the same point size. Softer, but still stable-width.
+  return src.resize({ width: TRAY_POINT_SIZE, height: TRAY_POINT_SIZE });
+}
+
+module.exports = { loadTrayNormalIcon, loadTrayFlashIcon, TRAY_POINT_SIZE, TRAY_PIXEL_SIZE };

--- a/test/tray-flash-icon.test.js
+++ b/test/tray-flash-icon.test.js
@@ -1,0 +1,116 @@
+const test = require("node:test");
+const assert = require("node:assert");
+
+const { loadTrayNormalIcon, loadTrayFlashIcon } = require("../src/tray-flash-icon");
+
+// Minimal nativeImage stand-in: records what was asked of it so the tests can
+// assert on the sizing decisions rather than on real pixels.
+function makeNativeImage({ empty = false, addRepresentationThrows = false } = {}) {
+  const calls = { created: [], representations: [], resizes: [] };
+
+  function makeImage({ isEmptyValue }) {
+    return {
+      isEmpty: () => isEmptyValue(),
+      setTemplateImage(value) { this.template = value; },
+      toDataURL: () => "data:image/png;base64,AAA",
+      resize(size) {
+        calls.resizes.push(size);
+        return { ...this, size };
+      },
+      addRepresentation(rep) {
+        if (addRepresentationThrows) throw new Error("unsupported");
+        calls.representations.push(rep);
+      },
+    };
+  }
+
+  return {
+    calls,
+    createFromPath(p) {
+      calls.created.push(p);
+      return makeImage({ isEmptyValue: () => empty });
+    },
+    createEmpty() {
+      return makeImage({ isEmptyValue: () => calls.representations.length === 0 });
+    },
+  };
+}
+
+const PATHS = {
+  templatePath: "/assets/tray-iconTemplate.png",
+  iconPath: "/assets/tray-icon.png",
+  flashPath: "/assets/tray-icon-flash.png",
+};
+
+test("mac normal icon is loaded as a template image at its natural point size", () => {
+  const nativeImage = makeNativeImage();
+  const icon = loadTrayNormalIcon({ nativeImage, platform: "darwin", ...PATHS });
+
+  assert.strictEqual(icon.template, true);
+  assert.deepStrictEqual(nativeImage.calls.created, [PATHS.templatePath]);
+  assert.deepStrictEqual(nativeImage.calls.resizes, [], "no resize — @2x sibling handles retina");
+});
+
+test("non-mac normal icon is normalised to 32px", () => {
+  const nativeImage = makeNativeImage();
+  loadTrayNormalIcon({ nativeImage, platform: "win32", ...PATHS });
+
+  assert.deepStrictEqual(nativeImage.calls.created, [PATHS.iconPath]);
+  assert.deepStrictEqual(nativeImage.calls.resizes, [{ width: 32, height: 32 }]);
+});
+
+// #722: the flash frame used to be a raw 32×32 image next to a 16pt normal
+// icon, so the menu bar reflowed on every blink.
+test("mac flash icon is added as an @2x representation, not a 32pt image", () => {
+  const nativeImage = makeNativeImage();
+  loadTrayFlashIcon({
+    nativeImage,
+    platform: "darwin",
+    flashPath: PATHS.flashPath,
+    fileExists: () => true,
+  });
+
+  assert.deepStrictEqual(nativeImage.calls.representations, [
+    { scaleFactor: 2, dataURL: "data:image/png;base64,AAA" },
+  ]);
+  assert.deepStrictEqual(nativeImage.calls.resizes, [], "no 32pt resize on mac");
+});
+
+test("mac flash icon falls back to a 16pt downscale when addRepresentation fails", () => {
+  const nativeImage = makeNativeImage({ addRepresentationThrows: true });
+  loadTrayFlashIcon({
+    nativeImage,
+    platform: "darwin",
+    flashPath: PATHS.flashPath,
+    fileExists: () => true,
+  });
+
+  assert.deepStrictEqual(nativeImage.calls.resizes, [{ width: 16, height: 16 }]);
+});
+
+test("non-mac flash icon matches the 32px normal icon", () => {
+  const nativeImage = makeNativeImage();
+  loadTrayFlashIcon({
+    nativeImage,
+    platform: "win32",
+    flashPath: PATHS.flashPath,
+    fileExists: () => true,
+  });
+
+  assert.deepStrictEqual(nativeImage.calls.resizes, [{ width: 32, height: 32 }]);
+});
+
+test("missing or unreadable flash asset yields no highlight icon", () => {
+  const absent = makeNativeImage();
+  assert.strictEqual(
+    loadTrayFlashIcon({ nativeImage: absent, platform: "darwin", flashPath: PATHS.flashPath, fileExists: () => false }),
+    null
+  );
+  assert.deepStrictEqual(absent.calls.created, []);
+
+  const emptyImage = makeNativeImage({ empty: true });
+  assert.strictEqual(
+    loadTrayFlashIcon({ nativeImage: emptyImage, platform: "darwin", flashPath: PATHS.flashPath, fileExists: () => true }),
+    null
+  );
+});


### PR DESCRIPTION
Fixes #722.

## Problem

When a task completes, `flashTaskbar()` blinks the tray icon between the normal icon and `assets/tray-icon-flash.png`. On macOS the two frames were not the same size:

| frame | asset | logical size |
| --- | --- | --- |
| normal | `tray-iconTemplate.png` (16×16) + `@2x` (32×32) | **16pt** |
| highlight | `tray-icon-flash.png` (32×32), loaded via `.resize({width: 32, height: 32})` at 1x | **32pt** |

The menu bar lays out in points, so the highlight rendered twice as wide as the normal icon. Every blink resized the icon and pushed the neighbouring status items sideways — the "big orange dot that shifts the icon position" in the issue.

## Fix

New `src/tray-flash-icon.js` owns tray icon loading:

- **macOS** — the 32px highlight is added as the `@2x` representation of a 16pt image (`addRepresentation({scaleFactor: 2, dataURL})`), so it occupies the exact same slot as the normal icon and stays crisp on retina. Falls back to a 16pt downscale if `addRepresentation` is unavailable.
- **Windows / Linux** — unchanged; those trays lay out in pixels and both assets are already normalised to 32×32.
- `menu.js`'s `createTray()` now uses the same normal-icon loader instead of its own copy, so the two paths can't drift apart again.

Asset paths stay on `path.join(__dirname, ...)`, and the artwork itself is untouched. The existing `flashTaskbarOnComplete` setting (Settings → General, default on) already covers the issue's "add an off switch" alternative, so no new preference was added.

## Verification

`AGENTS.md` asks for code-review-first notes on macOS-only paths and treats tray behaviour as manual-verification-first, so the status is spelled out below.

**Verified**

- `npm test` — 5625 tests, 0 failures (Node built-in runner).
- New `test/tray-flash-icon.test.js` covers the macOS `@2x` path, the `addRepresentation` fallback, the non-mac pixel path, and a missing / unreadable asset.
- `nativeImage` sizing measured under this repo's actual Electron (41.10.2), not just asserted against a stub:
  ```
  normal:       16×16 pt, scaleFactors [1, 2]
  flash before: 32×32 pt          ← the reflow
  flash after:  16×16 pt, scaleFactors [2]
  ```
- Manual QA on macOS 26.5.2 (Apple silicon), running from source: the tray icon keeps a constant width while flashing and no longer shifts neighbouring menu bar items.

**Not verified**

- Windows and Linux were not run. Those branches are a pure refactor — the same `createFromPath(...).resize({width: 32, height: 32})` as before, just moved into the shared module — so behaviour there is unchanged by inspection, not by execution.
- The `addRepresentation` fallback branch (16pt downscale) has not been exercised on a real runtime; it only triggers if `addRepresentation` throws, which it does not on Electron 41.

**Residual risk**

Low. The change is confined to how the two tray images are constructed; the flash timing, the `flashTaskbarOnComplete` gate, and the stop-on-click behaviour are all untouched.
