### PR TITLE
[codex] harden custom agent state isolation and settings sync

### DIFF
--- a/src/agent-installation-detector.js
+++ b/src/agent-installation-detector.js
@@ -399,6 +399,7 @@ function detectCustomTools(options = {}) {
 
 function detectCustomAgents(options = {}) {
   const fsImpl = options.fs || fs;
+  const platform = options.platform || process.platform;
   const applications = Array.isArray(options.snapshot && options.snapshot.customApplications)
     ? options.snapshot.customApplications
     : [];
@@ -408,13 +409,22 @@ function detectCustomAgents(options = {}) {
       ? application.executablePath
       : "";
     const kind = executablePath ? statPath(fsImpl, executablePath) : null;
+    let launchable = false;
+    if (kind === "file") {
+      try {
+        const stat = fsImpl.statSync(executablePath);
+        launchable = platform === "win32"
+          ? /\.(exe|cmd|bat|com)$/i.test(path.extname(executablePath))
+          : (stat.mode & 0o111) !== 0;
+      } catch {}
+    }
     return {
       agentId,
       executablePath,
-      detectedInstalled: !!kind,
-      confidence: kind ? "high" : LOW_CONFIDENCE,
-      reason: kind ? "registered-executable" : "not-found",
-      detail: kind
+      detectedInstalled: launchable,
+      confidence: launchable ? "high" : LOW_CONFIDENCE,
+      reason: launchable ? "registered-executable" : "not-found",
+      detail: launchable
         ? `Registered executable exists: ${executablePath} (${kind})`
         : `Registered executable was not found: ${executablePath}`,
     };

--- a/src/server-permission-utils.js
+++ b/src/server-permission-utils.js
@@ -153,7 +153,12 @@ function findPendingPermissionForStateEvent(pendingPermissions, options) {
     ? options.sessionId
     : "default";
   const sessionPending = pendingPermissions.filter((perm) => (
-    perm && perm.res && perm.sessionId === sessionId
+    perm
+      && perm.res
+      && perm.sessionId === sessionId
+      && (options.requireAgentOwnership === true
+        ? perm.agentId === options.agentId
+        : (!options.agentId || !perm.agentId || perm.agentId === options.agentId))
   ));
   if (!sessionPending.length) return null;
 

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -162,6 +162,31 @@ function handleStatePost(req, res, options) {
       const rawAgentPid = data.agent_pid ?? data.claude_pid ?? data.cursor_pid;
       const agentPid = Number.isFinite(rawAgentPid) && rawAgentPid > 0 ? Math.floor(rawAgentPid) : null;
       const agentId = agentIdentity.agentId;
+      const sid = session_id || "default";
+      const isCustomAgent = agentIdentity.source === "custom";
+      if (isCustomAgent && (typeof session_id !== "string" || !session_id.trim())) {
+        recordRequestHookEvent.droppedUnsupported();
+        res.writeHead(204, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
+        res.end();
+        return;
+      }
+      const existingSession = ctx.sessions && typeof ctx.sessions.get === "function"
+        ? ctx.sessions.get(sid)
+        : null;
+      // Custom agents are state-only and must not take over a session owned by
+      // another agent. Keep the legacy raw session key for built-in agents, but
+      // reject custom collisions before any permission/session side effects.
+      if (
+        isCustomAgent
+        && existingSession
+        && existingSession.agentId
+        && existingSession.agentId !== agentId
+      ) {
+        recordRequestHookEvent.droppedUnsupported();
+        res.writeHead(204, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
+        res.end();
+        return;
+      }
       const host = typeof data.host === "string" ? data.host : null;
       const wslDistro = typeof data.wsl_distro === "string" && data.wsl_distro.trim()
         ? data.wsl_distro.trim()
@@ -266,7 +291,6 @@ function handleStatePost(req, res, options) {
         return;
       }
       if (agentId === "codex" && codexUserInput) {
-        const sid = session_id || "default";
         if (codexUserInput.phase === "resolved") {
           if (typeof ctx.clearCodexUserInputBubbles === "function") {
             ctx.clearCodexUserInputBubbles(sid, codexUserInput.callId, "codex-user-input-resolved");
@@ -309,10 +333,11 @@ function handleStatePost(req, res, options) {
         // statusline script never reads the response, and "session unknown"
         // is the designed drop, not an error.
         if (typeof ctx.updateSessionMetadata === "function") {
-          ctx.updateSessionMetadata(session_id || "default", {
+          ctx.updateSessionMetadata(sid, {
             contextUsage,
             antigravityQuota,
             claudeQuota,
+            ...(isCustomAgent ? { agentId } : {}),
           });
         }
         res.writeHead(204, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
@@ -320,7 +345,6 @@ function handleStatePost(req, res, options) {
         return;
       }
       if (ctx.STATE_SVGS[state]) {
-        const sid = session_id || "default";
         const codexHookState = resolveCodexOfficialHookState(
           data,
           state,
@@ -409,6 +433,8 @@ function handleStatePost(req, res, options) {
         if (event === "PostToolUse" || event === "PostToolUseFailure" || event === "Stop") {
           const perm = findPendingPermissionForStateEvent(ctx.pendingPermissions, {
             sessionId: sid,
+            agentId,
+            requireAgentOwnership: isCustomAgent,
             toolName,
             toolUseId,
             toolInputFingerprint,
@@ -428,6 +454,7 @@ function handleStatePost(req, res, options) {
               stale !== perm
               && stale.res
               && stale.sessionId === sid
+              && (!isCustomAgent || stale.agentId === agentId)
               && (stale.isElicitation || stale.toolName === "ExitPlanMode")
             ) {
               ctx.resolvePermissionEntry(stale, "deny", "User answered in terminal");
@@ -448,6 +475,7 @@ function handleStatePost(req, res, options) {
               stale
               && stale.res
               && stale.sessionId === sid
+              && (!isCustomAgent || stale.agentId === agentId)
               && stale.toolName === "ExitPlanMode"
             ) {
               ctx.resolvePermissionEntry(stale, "deny", "Plan dialog dismissed in terminal");

--- a/src/settings-actions-agents.js
+++ b/src/settings-actions-agents.js
@@ -341,15 +341,35 @@ function setAgentCustomPermissionUrl(payload, deps = {}) {
   const current = snapshot.agents && snapshot.agents[payload.agentId];
   const currentValue = normalizeOptionalHttpUrl(current && current.customPermissionUrl);
   if (currentValue === value) return { status: "ok", noop: true };
+  const commit = buildAgentCommit(snapshot, payload.agentId, { customPermissionUrl: value });
+  const finishSync = (result) => {
+    if (
+      result === false
+      || (result && typeof result === "object" && (result.status === "error" || result.status === "skipped"))
+    ) {
+      return {
+        status: "error",
+        message: (result && (result.message || result.reason)) || "Failed to sync custom permission URL",
+      };
+    }
+    return { status: "ok", commit };
+  };
   try {
     if (
       isAgentIntegrationInstalled(snapshot, payload.agentId)
       && typeof deps.syncIntegrationForAgent === "function"
     ) {
-      deps.syncIntegrationForAgent(
+      const syncResult = deps.syncIntegrationForAgent(
         payload.agentId,
         buildAgentIntegrationOptionsWithPatch(snapshot, payload.agentId, { customPermissionUrl: value })
       );
+      if (syncResult && typeof syncResult.then === "function") {
+        return syncResult.then(finishSync, (err) => ({
+          status: "error",
+          message: `setAgentCustomPermissionUrl side effect threw: ${err && err.message}`,
+        }));
+      }
+      return finishSync(syncResult);
     }
   } catch (err) {
     return {
@@ -357,10 +377,7 @@ function setAgentCustomPermissionUrl(payload, deps = {}) {
       message: `setAgentCustomPermissionUrl side effect threw: ${err && err.message}`,
     };
   }
-  return {
-    status: "ok",
-    commit: buildAgentCommit(snapshot, payload.agentId, { customPermissionUrl: value }),
-  };
+  return { status: "ok", commit };
 }
 
 function setAgentCustomDiscoveryPaths(payload, deps = {}) {

--- a/src/state.js
+++ b/src/state.js
@@ -35,6 +35,7 @@ const {
   sessionSnapshotSignature,
 } = require("./state-session-snapshot");
 const { getAgentIconUrl } = require("./state-agent-icons");
+const { isCustomApplicationNamespace } = require("./custom-applications");
 const { normalizeTranscriptPath } = require("./transcript-path");
 const { normalizeQuotaGroup } = require("../hooks/quota-bucket");
 const { ANTIGRAVITY_QUOTA_FIELDS } = require("../hooks/antigravity-context-usage");
@@ -1190,6 +1191,14 @@ function updateSessionMetadata(sessionId, opts = {}) {
     debugSession(`metadata-only drop sid=${id} reason=no-session`);
     return false;
   }
+  if (
+    isCustomApplicationNamespace(opts.agentId)
+    && session.agentId
+    && session.agentId !== opts.agentId
+  ) {
+    debugSession(`metadata-only drop sid=${id} reason=agent-owner-mismatch`);
+    return false;
+  }
   const contextUsage = normalizeContextUsage(opts.contextUsage);
   const antigravityQuota = normalizeAntigravityQuota(opts.antigravityQuota);
   const claudeQuota = normalizeClaudeQuota(opts.claudeQuota);
@@ -1391,6 +1400,15 @@ function updateSession(sessionId, state, event, opts = {}) {
     stopHookActive = false,
     stdinDiag = null,
   } = opts;
+  if (
+    isCustomApplicationNamespace(agentId)
+    && sessions.has(sessionId)
+    && sessions.get(sessionId).agentId
+    && sessions.get(sessionId).agentId !== agentId
+  ) {
+    debugSession(`state drop sid=${sessionId} reason=agent-owner-mismatch incoming=${agentId}`);
+    return;
+  }
   if (startupRecoveryActive) {
     startupRecoveryActive = false;
     if (startupRecoveryTimer) { clearTimeout(startupRecoveryTimer); startupRecoveryTimer = null; }

--- a/test/agent-installation-detector.test.js
+++ b/test/agent-installation-detector.test.js
@@ -251,6 +251,7 @@ describe("agent installation detector", () => {
     const homeDir = makeHome();
     const executablePath = path.join(homeDir, "NovaAI.exe");
     writeText(executablePath, "");
+    if (process.platform !== "win32") fs.chmodSync(executablePath, 0o755);
     const application = {
       id: "custom-nova-ai-0123456789ab",
       executablePath,
@@ -273,6 +274,44 @@ describe("agent installation detector", () => {
       snapshot: { customApplications: [application], customToolDiscoveryPaths: [] },
     });
     assert.strictEqual(missing.customAgents[0].detectedInstalled, false);
+  });
+
+  it("does not treat a directory at a registered executable path as installed", () => {
+    const homeDir = makeHome();
+    const executablePath = path.join(homeDir, "NovaAI.exe");
+    mkdirp(executablePath);
+    const application = { id: "custom-nova-ai-0123456789ab", executablePath };
+    const report = detectAgentInstallations({
+      homeDir,
+      now: 1,
+      snapshot: { customApplications: [application], customToolDiscoveryPaths: [] },
+    });
+
+    assert.strictEqual(report.customAgents[0].detectedInstalled, false);
+  });
+
+  it("requires executable permissions for registered POSIX files", { skip: process.platform === "win32" }, () => {
+    const homeDir = makeHome();
+    const executablePath = path.join(homeDir, "NovaAI.bin");
+    writeText(executablePath, "");
+    fs.chmodSync(executablePath, 0o644);
+    const application = { id: "custom-nova-ai-0123456789ab", executablePath };
+    const missing = detectAgentInstallations({
+      homeDir,
+      platform: "linux",
+      now: 1,
+      snapshot: { customApplications: [application], customToolDiscoveryPaths: [] },
+    });
+    assert.strictEqual(missing.customAgents[0].detectedInstalled, false);
+
+    fs.chmodSync(executablePath, 0o755);
+    const present = detectAgentInstallations({
+      homeDir,
+      platform: "linux",
+      now: 2,
+      snapshot: { customApplications: [application], customToolDiscoveryPaths: [] },
+    });
+    assert.strictEqual(present.customAgents[0].detectedInstalled, true);
   });
 
   it("does not infer built-in agent installs from generic Windows app-name guesses", () => {

--- a/test/server-permission-state-cleanup.test.js
+++ b/test/server-permission-state-cleanup.test.js
@@ -166,6 +166,18 @@ describe("findPendingPermissionForStateEvent", () => {
     assert.strictEqual(match, null);
   });
 
+  it("requires exact ownership for custom state-event cleanup", () => {
+    const pending = [
+      { id: "claude", agentId: "claude-code", sessionId: "sid", toolName: "Bash", res: {} },
+    ];
+    assert.strictEqual(findPendingPermissionForStateEvent(pending, {
+      sessionId: "sid",
+      agentId: "custom-nova-ai-0123456789ab",
+      requireAgentOwnership: true,
+      allowSingletonFallback: true,
+    }), null);
+  });
+
   it("does not use singleton fallback for unrelated PostToolUse events", () => {
     const pending = [
       { id: "only", sessionId: "sid", toolName: "Bash", res: {} },

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -78,6 +78,7 @@ function callStatePost(body, overrides = {}) {
           droppedByDisabled: () => calls.recorder.push({ outcome: "disabled" }),
           droppedByDnd: () => calls.recorder.push({ outcome: "dnd" }),
           droppedInvalidAgent: () => calls.recorder.push({ outcome: "invalid-agent" }),
+          droppedUnsupported: () => calls.recorder.push({ outcome: "unsupported" }),
         };
       },
       shouldDropForDnd: () => false,
@@ -584,6 +585,43 @@ describe("server-route-state POST", () => {
     }), { ctx: { getCustomAgentIds: () => [id] } });
     assert.strictEqual(res.statusCode, 200);
     assert.strictEqual(res.calls.updateSession[0][3].agentId, id);
+  });
+
+  it("rejects custom events that collide with another agent session", async () => {
+    const id = "custom-nova-ai-0123456789ab";
+    const pending = { agentId: "claude-code", sessionId: "shared", toolName: "Bash", res: {} };
+    const res = await callStatePost(JSON.stringify({
+      state: "attention",
+      session_id: "shared",
+      event: "Stop",
+      agent_id: id,
+    }), {
+      ctx: {
+        getCustomAgentIds: () => [id],
+        sessions: new Map([["shared", { agentId: "claude-code" }]]),
+        pendingPermissions: [pending],
+      },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.calls.updateSession.length, 0);
+    assert.strictEqual(res.calls.resolved.length, 0);
+    assert.deepStrictEqual(
+      res.calls.recorder.map((entry) => entry.outcome).filter(Boolean),
+      ["unsupported"]
+    );
+  });
+
+  it("rejects custom events without a session id instead of using the shared default", async () => {
+    const id = "custom-nova-ai-0123456789ab";
+    const res = await callStatePost(JSON.stringify({
+      state: "working",
+      event: "PreToolUse",
+      agent_id: id,
+    }), { ctx: { getCustomAgentIds: () => [id] } });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.calls.updateSession.length, 0);
   });
 
   it("rejects stale custom ids before hook_source fallback", async () => {

--- a/test/settings-actions-agents.test.js
+++ b/test/settings-actions-agents.test.js
@@ -168,6 +168,41 @@ test("settings agent actions sync an installed custom permission URL change imme
   );
 });
 
+test("settings agent actions do not commit a custom permission URL when sync fails", () => {
+  const snapshot = prefs.getDefaults();
+  snapshot.agents.codebuddy.integrationInstalled = true;
+  snapshot.agents.codebuddy.customPermissionUrl = "https://old.example.test/permission";
+  const result = agentCommands.setAgentCustomPermissionUrl({
+    agentId: "codebuddy",
+    value: "https://new.example.test/permission",
+  }, {
+    snapshot,
+    syncIntegrationForAgent: () => ({ status: "error", message: "disk denied" }),
+  });
+
+  assert.strictEqual(result.status, "error");
+  assert.match(result.message, /disk denied/);
+  assert.strictEqual(result.commit, undefined);
+  assert.strictEqual(snapshot.agents.codebuddy.customPermissionUrl, "https://old.example.test/permission");
+});
+
+test("settings agent actions handle an async custom permission URL sync failure", async () => {
+  const snapshot = prefs.getDefaults();
+  snapshot.agents.codebuddy.integrationInstalled = true;
+  snapshot.agents.codebuddy.customPermissionUrl = "https://old.example.test/permission";
+  const result = await agentCommands.setAgentCustomPermissionUrl({
+    agentId: "codebuddy",
+    value: "https://new.example.test/permission",
+  }, {
+    snapshot,
+    syncIntegrationForAgent: async () => ({ status: "error", message: "async disk denied" }),
+  });
+
+  assert.strictEqual(result.status, "error");
+  assert.match(result.message, /async disk denied/);
+  assert.strictEqual(result.commit, undefined);
+});
+
 test("settings agent actions sync clearing an installed custom permission URL immediately", () => {
   const snapshot = prefs.getDefaults();
   snapshot.agents.codebuddy.integrationInstalled = true;

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -959,6 +959,24 @@ describe("updateSession()", () => {
     assert.strictEqual(api.sessions.get("shared-s1").agentId, "claude-code");
   });
 
+  it("custom attribution cannot replace or end another custom session owner", () => {
+    const sid = "custom-shared-s1";
+    api.updateSession(sid, "thinking", "UserPromptSubmit", {
+      agentId: "custom-nova-ai-0123456789ab",
+    });
+    api.updateSession(sid, "working", "PreToolUse", {
+      agentId: "custom-orbit-ai-0123456789ab",
+    });
+    assert.strictEqual(api.sessions.get(sid).agentId, "custom-nova-ai-0123456789ab");
+    assert.strictEqual(api.sessions.get(sid).state, "thinking");
+
+    api.updateSession(sid, "idle", "SessionEnd", {
+      agentId: "custom-orbit-ai-0123456789ab",
+    });
+    assert.ok(api.sessions.has(sid));
+    assert.strictEqual(api.sessions.get(sid).agentId, "custom-nova-ai-0123456789ab");
+  });
+
   it("defaulted Claude attribution is still used for new legacy sessions", () => {
     api.updateSession("legacy-s1", "working", "PreToolUse", {
       agentId: "claude-code",


### PR DESCRIPTION
## What changed

PR #652 is already merged. This follow-up fixes runtime gaps exposed after the merge:

- Isolate custom state and permission cleanup by requiring custom session ownership and rejecting blank or cross-agent session IDs.
- Prevent custom `customPermissionUrl` preferences from committing before CodeBuddy/integration sync succeeds, including async failures.
- Require registered custom executable paths to resolve to launchable files rather than directories or non-executable POSIX files.

## Why

Custom agents share the legacy raw session map key. A colliding `session_id` could otherwise update or delete another agent's session, resolve its pending permission, or sweep its ExitPlanMode entry. Settings could also report success while the integration file remained unchanged.

## Validation

- `node --test test/server-route-state.test.js test/server-permission-state-cleanup.test.js test/settings-actions-agents.test.js test/agent-installation-detector.test.js test/state.test.js test/prefs.test.js test/settings-controller.test.js test/settings-ipc.test.js`
- Result: 587 passed, 0 failed, 1 skipped on Node 22.22.3.
- Additional focused rerun after the final state regression test: 374 passed, 0 failed, 1 skipped.

The repository's `.nvmrc` requests Node 24.18.0; the full suite was not claimed clean on this Node 22 environment.
