### PR TITLE
feat(hooks): wire the 12 remaining adapters into the shared pid cache (#634)

### DIFF
--- a/hooks/antigravity-hook.js
+++ b/hooks/antigravity-hook.js
@@ -161,6 +161,25 @@ function resolveCwd(payload) {
   return "";
 }
 
+// #634: cross-process pid cache context for the shared resolver. Antigravity
+// has no session-start hook (earliest event is PreInvocation), so every event
+// uses the "event" lifecycle — first resolve populates the cache, later ones
+// hit it (zero snapshot spawns). cacheable compares against the exact
+// normalizeSessionId fallback so an id-less payload ("antigravity:default",
+// cf. #583) never keys a shared entry; the transcript-dirname fallback is a
+// real per-conversation id and stays cacheable.
+function pidCacheContext(payload) {
+  const sessionId = normalizeSessionId(payload && payload.conversationId, payload);
+  const cwd = resolveCwd(payload);
+  return {
+    namespace: "antigravity-cli",
+    sessionId,
+    cacheCwd: cwd,
+    lifecycle: "event",
+    cacheable: sessionId !== "antigravity:default" && !!cwd,
+  };
+}
+
 function normalizeToolInputValue(value, depth = 0) {
   if (depth > TOOL_INPUT_DEPTH_MAX) return null;
   if (Array.isArray(value)) {
@@ -403,7 +422,7 @@ async function sendHookEvent(payload, argvEvent, deps = {}) {
   const outLine = stdoutForEvent(hookName);
   const remote = !!env.CLAWD_REMOTE;
   const pidMeta = shouldResolvePid(hookName, env)
-    ? (deps.resolvePid ? deps.resolvePid() : undefined)
+    ? (deps.resolvePid ? deps.resolvePid(pidCacheContext(payload)) : undefined)
     : undefined;
   const body = buildStateBody(hookName, payload || {}, {
     remote,

--- a/hooks/antigravity-hook.js
+++ b/hooks/antigravity-hook.js
@@ -164,10 +164,11 @@ function resolveCwd(payload) {
 // #634: cross-process pid cache context for the shared resolver. Antigravity
 // has no session-start hook (earliest event is PreInvocation), so every event
 // uses the "event" lifecycle — first resolve populates the cache, later ones
-// hit it (zero snapshot spawns). cacheable compares against the exact
-// normalizeSessionId fallback so an id-less payload ("antigravity:default",
-// cf. #583) never keys a shared entry; the transcript-dirname fallback is a
-// real per-conversation id and stays cacheable.
+// hit it (zero snapshot spawns). Only an explicit conversationId may key the
+// cache. normalizeSessionId still keeps the historic transcript-dirname
+// fallback for the state body, but that dirname is not proven session-unique
+// (for example, multiple transcript files may share a `jetski` directory), so
+// using it on disk could pin one conversation to another's live terminal PID.
 //
 // The cache key deliberately does NOT use resolveCwd(): that helper prefers
 // toolCall.args.Cwd, which varies per tool call (subdirs, slash spelling) and
@@ -183,14 +184,19 @@ function stableWorkspaceCwd(payload) {
 }
 
 function pidCacheContext(payload) {
-  const sessionId = normalizeSessionId(payload && payload.conversationId, payload);
+  const conversationId = payload && payload.conversationId;
+  const rawConversationId = conversationId != null ? String(conversationId).trim() : "";
+  const sessionId = normalizeSessionId(conversationId, payload);
   const cacheCwd = stableWorkspaceCwd(payload);
   return {
     namespace: "antigravity-cli",
     sessionId,
     cacheCwd,
     lifecycle: "event",
-    cacheable: sessionId !== "antigravity:default" && !!cacheCwd,
+    cacheable: !!rawConversationId
+      && rawConversationId !== "default"
+      && rawConversationId !== "antigravity:default"
+      && !!cacheCwd,
   };
 }
 

--- a/hooks/antigravity-hook.js
+++ b/hooks/antigravity-hook.js
@@ -168,15 +168,29 @@ function resolveCwd(payload) {
 // normalizeSessionId fallback so an id-less payload ("antigravity:default",
 // cf. #583) never keys a shared entry; the transcript-dirname fallback is a
 // real per-conversation id and stays cacheable.
+//
+// The cache key deliberately does NOT use resolveCwd(): that helper prefers
+// toolCall.args.Cwd, which varies per tool call (subdirs, slash spelling) and
+// would fragment one conversation across many v2 cache files — each a miss
+// that can spawn another snapshot. The key needs a per-SESSION constant, so it
+// uses workspacePaths[0] only; the event/body cwd keeps resolveCwd() behavior.
+function stableWorkspaceCwd(payload) {
+  if (payload && Array.isArray(payload.workspacePaths)) {
+    const first = payload.workspacePaths.find((entry) => typeof entry === "string" && entry);
+    if (first) return first;
+  }
+  return "";
+}
+
 function pidCacheContext(payload) {
   const sessionId = normalizeSessionId(payload && payload.conversationId, payload);
-  const cwd = resolveCwd(payload);
+  const cacheCwd = stableWorkspaceCwd(payload);
   return {
     namespace: "antigravity-cli",
     sessionId,
-    cacheCwd: cwd,
+    cacheCwd,
     lifecycle: "event",
-    cacheable: sessionId !== "antigravity:default" && !!cwd,
+    cacheable: sessionId !== "antigravity:default" && !!cacheCwd,
   };
 }
 

--- a/hooks/codebuddy-hook.js
+++ b/hooks/codebuddy-hook.js
@@ -19,6 +19,15 @@ const HOOK_MAP = {
   PreCompact:       { state: "sweeping",     event: "PreCompact" },
 };
 
+// #634: lifecycle for the shared resolver's cross-process pid cache. Stop is
+// deliberately NOT "end" (turn completion, not session end — dropping the
+// cache there would force a fresh snapshot flash on the next tool event).
+const EVENT_TO_LIFECYCLE = {
+  SessionStart: "start",
+  UserPromptSubmit: "prompt",
+  SessionEnd: "end",
+};
+
 const config = getPlatformConfig({
   extraTerminals: { win: ["codebuddy.exe"] },
   extraEditors: {
@@ -83,7 +92,13 @@ readStdinJson()
     const sessionId = (payload && payload.session_id) || "default";
     const cwd = (payload && payload.cwd) || "";
 
-    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve({
+      namespace: "codebuddy",
+      sessionId,
+      cacheCwd: cwd,
+      lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
+      cacheable: sessionId !== "default" && !!cwd,
+    });
 
     const body = { state, session_id: sessionId, event };
     body.agent_id = "codebuddy";

--- a/hooks/codex-hook.js
+++ b/hooks/codex-hook.js
@@ -200,7 +200,22 @@ function shouldReportForegroundWtHwnd(event) {
 }
 
 function applyLocalProcessFields(body, resolve, options = {}) {
-  const { stablePid, agentPid, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient } = resolve();
+  // #634: cross-process pid cache via the shared resolver. Lifecycle keys off
+  // the state event (permission bodies carry no event → "event"); codex has no
+  // SessionEnd hook and Stop is deliberately NOT "end" (turn completion). The
+  // cacheable guard compares against the exact normalizeCodexSessionId
+  // fallback, so an id-less payload (raw "default", cf. #583) never keys a
+  // shared cache entry.
+  const lifecycle = options.event === "SessionStart" ? "start"
+    : options.event === "UserPromptSubmit" ? "prompt"
+    : "event";
+  const { stablePid, agentPid, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient } = resolve({
+    namespace: "codex",
+    sessionId: body.session_id,
+    cacheCwd: body.cwd || "",
+    lifecycle,
+    cacheable: body.session_id !== "codex:default" && !!body.cwd,
+  });
   const sourcePid = options.preferAgentPid && agentPid ? agentPid : stablePid;
   body.source_pid = sourcePid;
   if (detectedEditor) body.editor = detectedEditor;

--- a/hooks/copilot-hook.js
+++ b/hooks/copilot-hook.js
@@ -163,6 +163,26 @@ const EVENT_TO_STATE = {
   preCompact: "sweeping",
 };
 
+// #634: lifecycle for the shared resolver's cross-process pid cache, keyed on
+// Copilot's camelCase hook names. agentStop is deliberately NOT "end" (turn
+// completion — dropping the cache there would force a snapshot flash on the
+// next tool event).
+const EVENT_TO_LIFECYCLE = {
+  sessionStart: "start",
+  userPromptSubmitted: "prompt",
+  sessionEnd: "end",
+};
+
+function pidCacheContext(event, sessionId, cwd) {
+  return {
+    namespace: "copilot-cli",
+    sessionId,
+    cacheCwd: cwd,
+    lifecycle: EVENT_TO_LIFECYCLE[event] || "event",
+    cacheable: sessionId !== "default" && !!cwd,
+  };
+}
+
 // Hook-side caps for permission payload. `src/server-route-permission.js`
 // rejects bodies >512KB *before* it can route by agent_id, so an
 // unbounded payload (e.g. an `edit` tool's full git-style diff for a
@@ -288,7 +308,8 @@ function buildPermissionBody(payload, resolve, options = {}) {
     body.host = readHost();
     applyWslSourceFields(body, { remote: true });
   } else if (typeof resolve === "function") {
-    const { stablePid, agentPid, pidChain, tmuxSocket, tmuxClient } = resolve();
+    const { stablePid, agentPid, pidChain, tmuxSocket, tmuxClient } =
+      resolve(pidCacheContext("permissionRequest", sessionId, cwd));
     if (stablePid) body.source_pid = stablePid;
     if (agentPid) body.agent_pid = agentPid;
     if (Array.isArray(pidChain) && pidChain.length) body.pid_chain = pidChain;
@@ -379,7 +400,8 @@ function buildStateBody(event, payload, resolve, options = {}) {
     applyWslSourceFields(body, { remote: true });
   } else {
     applyWslSourceFields(body);
-    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } =
+      resolve(pidCacheContext(event, sessionId, cwd));
     body.source_pid = stablePid;
     if (detectedEditor) body.editor = detectedEditor;
     if (agentPid) body.agent_pid = agentPid;

--- a/hooks/cursor-hook.js
+++ b/hooks/cursor-hook.js
@@ -18,6 +18,15 @@ const HOOK_TO_STATE = {
   afterAgentThought: { state: "thinking", event: "AfterAgentThought" },
 };
 
+// #634: lifecycle for the shared resolver's cross-process pid cache. Raw
+// Cursor hook names (pre-mapping). sessionEnd drops the cache; everything
+// unlisted is "event" (cache hit = zero snapshot spawns).
+const EVENT_TO_LIFECYCLE = {
+  sessionStart: "start",
+  beforeSubmitPrompt: "prompt",
+  sessionEnd: "end",
+};
+
 const config = getPlatformConfig({ extraTerminals: { win: ["cursor.exe"] } });
 const resolve = createPidResolver({
   agentNames: { win: new Set(["cursor.exe"]), mac: new Set(["cursor"]), linux: new Set(["cursor"]) },
@@ -101,7 +110,13 @@ readStdinJson()
       cwd = payload.workspace_roots[0];
     }
 
-    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve({
+      namespace: "cursor-agent",
+      sessionId,
+      cacheCwd: cwd,
+      lifecycle: EVENT_TO_LIFECYCLE[hookNameResolved] || "event",
+      cacheable: sessionId !== "default" && !!cwd,
+    });
 
     const body = { state, session_id: sessionId, event };
     body.agent_id = "cursor-agent";

--- a/hooks/gemini-hook.js
+++ b/hooks/gemini-hook.js
@@ -54,6 +54,28 @@ function normalizeSessionId(value) {
   return raw.startsWith("gemini:") ? raw : `gemini:${raw}`;
 }
 
+// #634: lifecycle for the shared resolver's cross-process pid cache, keyed on
+// Gemini's RAW hook names (BeforeAgent = the UserPromptSubmit equivalent).
+// cacheable compares against the exact normalizeSessionId fallback so an
+// id-less payload ("gemini:default", cf. #583) never keys a shared entry.
+const EVENT_TO_LIFECYCLE = {
+  SessionStart: "start",
+  BeforeAgent: "prompt",
+  SessionEnd: "end",
+};
+
+function pidCacheContext(hookName, payload) {
+  const sessionId = normalizeSessionId(payload && payload.session_id);
+  const cwd = (payload && payload.cwd) || "";
+  return {
+    namespace: "gemini-cli",
+    sessionId,
+    cacheCwd: cwd,
+    lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
+    cacheable: sessionId !== "gemini:default" && !!cwd,
+  };
+}
+
 function hasToolResponseError(payload) {
   const response = payload && payload.tool_response;
   if (!response || typeof response !== "object") return false;
@@ -121,7 +143,7 @@ function sendHookEvent(payload, argvEvent, deps = {}) {
     remote,
     host: remote && deps.readHostPrefix ? deps.readHostPrefix() : undefined,
     pidMeta: shouldResolvePid(hookName, env)
-      ? (deps.resolvePid ? deps.resolvePid() : undefined)
+      ? (deps.resolvePid ? deps.resolvePid(pidCacheContext(hookName, payload)) : undefined)
       : undefined,
   });
 

--- a/hooks/kimi-hook.js
+++ b/hooks/kimi-hook.js
@@ -381,6 +381,16 @@ function shouldRemapPreToolToPermission(event, payload) {
   return classifyPreTool(event, payload) === "immediate";
 }
 
+// #634: lifecycle for the shared resolver's cross-process pid cache. Keyed on
+// the incoming hook event; Stop/StopFailure are deliberately NOT "end" (turn
+// completion — dropping the cache there would force a snapshot flash on the
+// next tool event).
+const EVENT_TO_LIFECYCLE = {
+  SessionStart: "start",
+  UserPromptSubmit: "prompt",
+  SessionEnd: "end",
+};
+
 function buildStateBody(event, payload, resolve) {
   const state = EVENT_TO_STATE[event];
   if (!state) return null;
@@ -493,7 +503,16 @@ function buildStateBody(event, payload, resolve) {
     applyWslSourceFields(body, { remote: true });
   } else {
     applyWslSourceFields(body);
-    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve();
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve({
+      namespace: "kimi-cli",
+      sessionId,
+      cacheCwd: cwd,
+      // `event` may have been remapped to PermissionRequest above; both it and
+      // the original PreToolUse fall through to "event" here, so the remap
+      // cannot change the lifecycle.
+      lifecycle: EVENT_TO_LIFECYCLE[event] || "event",
+      cacheable: rawSessionId !== "default" && !!cwd,
+    });
     body.source_pid = stablePid;
     if (detectedEditor) body.editor = detectedEditor;
     if (agentPid) {

--- a/hooks/kiro-hook.js
+++ b/hooks/kiro-hook.js
@@ -39,8 +39,9 @@ readStdinJson()
     // #634: no stable session id → cacheable stays false (never key a
     // cross-process cache under the shared "default" sid, cf. #583) and no
     // "prompt" mapping (cache-only would ship empty fields where today's
-    // per-event fresh snapshot ships real ones). agentSpawn→"start" keeps the
-    // sweep + v1-drop hygiene; everything else stays a plain fresh snapshot.
+    // per-event fresh snapshot ships real ones). agentSpawn→"start" still
+    // reuses the existing in-process prewarm; with cacheable:false it does no
+    // disk sweep/write/drop. Everything else stays a plain fresh snapshot.
     const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve({
       namespace: "kiro-cli",
       sessionId,

--- a/hooks/kiro-hook.js
+++ b/hooks/kiro-hook.js
@@ -36,7 +36,18 @@ readStdinJson()
     const sessionId = "default";
     const cwd = (payload && payload.cwd) || "";
 
-    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve();
+    // #634: no stable session id → cacheable stays false (never key a
+    // cross-process cache under the shared "default" sid, cf. #583) and no
+    // "prompt" mapping (cache-only would ship empty fields where today's
+    // per-event fresh snapshot ships real ones). agentSpawn→"start" keeps the
+    // sweep + v1-drop hygiene; everything else stays a plain fresh snapshot.
+    const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve({
+      namespace: "kiro-cli",
+      sessionId,
+      cacheCwd: cwd,
+      lifecycle: hookName === "agentSpawn" ? "start" : "event",
+      cacheable: false,
+    });
 
     const body = { state, session_id: sessionId, event };
     body.agent_id = "kiro-cli";

--- a/hooks/qoder-hook.js
+++ b/hooks/qoder-hook.js
@@ -137,6 +137,29 @@ const TOOL_METADATA_EVENTS = new Set([
   "PermissionDenied",
 ]);
 
+// #634: lifecycle for the shared resolver's cross-process pid cache. Qoder has
+// no SessionEnd hook; Stop is deliberately NOT "end" (turn completion).
+// cacheable keys off the RAW session id — normalizeSessionId prefixes, so its
+// "qoder:default" fallback would defeat the #583 same-key guard.
+const EVENT_TO_LIFECYCLE = {
+  SessionStart: "start",
+  UserPromptSubmit: "prompt",
+};
+
+function pidCacheContext(hookName, payload) {
+  const raw = payload && payload.session_id != null && payload.session_id !== ""
+    ? String(payload.session_id)
+    : "";
+  const cwd = payload && typeof payload.cwd === "string" ? payload.cwd : "";
+  return {
+    namespace: "qoder",
+    sessionId: normalizeSessionId(payload && payload.session_id),
+    cacheCwd: cwd,
+    lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
+    cacheable: !!raw && !!cwd,
+  };
+}
+
 function maybeAddToolMetadata(body, payload) {
   const toolName = typeof payload.tool_name === "string" && payload.tool_name ? payload.tool_name : null;
   const toolUseId = normalizeToolUseId(payload.tool_use_id ?? payload.toolUseId ?? payload.toolUseID);
@@ -189,7 +212,7 @@ function sendHookEvent(payload, argvEvent, deps = {}) {
     remote,
     host: remote && deps.readHostPrefix ? deps.readHostPrefix() : undefined,
     pidMeta: shouldResolvePid(hookName, env)
-      ? (deps.resolvePid ? deps.resolvePid() : undefined)
+      ? (deps.resolvePid ? deps.resolvePid(pidCacheContext(hookName, payload)) : undefined)
       : undefined,
   });
 

--- a/hooks/qoder-hook.js
+++ b/hooks/qoder-hook.js
@@ -137,13 +137,16 @@ const TOOL_METADATA_EVENTS = new Set([
   "PermissionDenied",
 ]);
 
-// #634: lifecycle for the shared resolver's cross-process pid cache. Qoder has
-// no SessionEnd hook; Stop is deliberately NOT "end" (turn completion).
-// cacheable keys off the RAW session id — normalizeSessionId prefixes, so its
-// "qoder:default" fallback would defeat the #583 same-key guard.
+// #634: lifecycle for the shared resolver's cross-process pid cache. Stop is
+// deliberately NOT "end" (turn completion); SessionEnd IS a true session end
+// (registered by qoder-install.js) and drops the cache. cacheable keys off the
+// RAW session id — normalizeSessionId prefixes, so its "qoder:default"
+// fallback would defeat the #583 same-key guard — and rejects a literal
+// "default" id for the same reason.
 const EVENT_TO_LIFECYCLE = {
   SessionStart: "start",
   UserPromptSubmit: "prompt",
+  SessionEnd: "end",
 };
 
 function pidCacheContext(hookName, payload) {
@@ -156,7 +159,7 @@ function pidCacheContext(hookName, payload) {
     sessionId: normalizeSessionId(payload && payload.session_id),
     cacheCwd: cwd,
     lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
-    cacheable: !!raw && !!cwd,
+    cacheable: !!raw && raw !== "default" && !!cwd,
   };
 }
 

--- a/hooks/qoderwork-hook.js
+++ b/hooks/qoderwork-hook.js
@@ -144,13 +144,16 @@ const TOOL_METADATA_EVENTS = new Set([
   "PermissionDenied",
 ]);
 
-// #634: lifecycle for the shared resolver's cross-process pid cache. QoderWork
-// has no SessionEnd hook; Stop is deliberately NOT "end" (turn completion).
-// cacheable keys off the RAW session id — normalizeSessionId prefixes, so its
-// "qoderwork:default" fallback would defeat the #583 same-key guard.
+// #634: lifecycle for the shared resolver's cross-process pid cache. Stop is
+// deliberately NOT "end" (turn completion); SessionEnd IS a true session end
+// (registered by qoderwork-install.js) and drops the cache. cacheable keys off
+// the RAW session id — normalizeSessionId prefixes, so its "qoderwork:default"
+// fallback would defeat the #583 same-key guard — and rejects a literal
+// "default" id for the same reason.
 const EVENT_TO_LIFECYCLE = {
   SessionStart: "start",
   UserPromptSubmit: "prompt",
+  SessionEnd: "end",
 };
 
 function pidCacheContext(hookName, payload) {
@@ -163,7 +166,7 @@ function pidCacheContext(hookName, payload) {
     sessionId: normalizeSessionId(payload && payload.session_id),
     cacheCwd: cwd,
     lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
-    cacheable: !!raw && !!cwd,
+    cacheable: !!raw && raw !== "default" && !!cwd,
   };
 }
 

--- a/hooks/qoderwork-hook.js
+++ b/hooks/qoderwork-hook.js
@@ -144,6 +144,29 @@ const TOOL_METADATA_EVENTS = new Set([
   "PermissionDenied",
 ]);
 
+// #634: lifecycle for the shared resolver's cross-process pid cache. QoderWork
+// has no SessionEnd hook; Stop is deliberately NOT "end" (turn completion).
+// cacheable keys off the RAW session id — normalizeSessionId prefixes, so its
+// "qoderwork:default" fallback would defeat the #583 same-key guard.
+const EVENT_TO_LIFECYCLE = {
+  SessionStart: "start",
+  UserPromptSubmit: "prompt",
+};
+
+function pidCacheContext(hookName, payload) {
+  const raw = payload && payload.session_id != null && payload.session_id !== ""
+    ? String(payload.session_id)
+    : "";
+  const cwd = payload && typeof payload.cwd === "string" ? payload.cwd : "";
+  return {
+    namespace: "qoderwork",
+    sessionId: normalizeSessionId(payload && payload.session_id),
+    cacheCwd: cwd,
+    lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
+    cacheable: !!raw && !!cwd,
+  };
+}
+
 function maybeAddToolMetadata(body, payload) {
   const toolName = typeof payload.tool_name === "string" && payload.tool_name ? payload.tool_name : null;
   const toolUseId = normalizeToolUseId(payload.tool_use_id ?? payload.toolUseId ?? payload.toolUseID);
@@ -225,7 +248,7 @@ function sendHookEvent(payload, argvEvent, deps = {}) {
     remote,
     host: remote && deps.readHostPrefix ? deps.readHostPrefix() : undefined,
     pidMeta: shouldResolvePid(hookName, env)
-      ? (deps.resolvePid ? deps.resolvePid() : undefined)
+      ? (deps.resolvePid ? deps.resolvePid(pidCacheContext(hookName, payload)) : undefined)
       : undefined,
   });
 

--- a/hooks/qwen-code-hook.js
+++ b/hooks/qwen-code-hook.js
@@ -134,7 +134,8 @@ const EVENT_TO_LIFECYCLE = {
 };
 
 // cacheable keys off the RAW session id: normalizeQwenSessionId prefixes, so
-// its "qwen-code:default" fallback would defeat the #583 same-key guard.
+// its "qwen-code:default" fallback would defeat the #583 same-key guard; a
+// literal raw "default" is rejected for the same reason.
 function pidCacheContext(hookName, payload, body) {
   const raw = payload && payload.session_id != null && payload.session_id !== ""
     ? String(payload.session_id)
@@ -144,7 +145,7 @@ function pidCacheContext(hookName, payload, body) {
     sessionId: body.session_id,
     cacheCwd: body.cwd || "",
     lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
-    cacheable: !!raw && !!body.cwd,
+    cacheable: !!raw && raw !== "default" && !!body.cwd,
   };
 }
 

--- a/hooks/qwen-code-hook.js
+++ b/hooks/qwen-code-hook.js
@@ -124,8 +124,32 @@ function isQwenAgentCommandLine(cmd) {
     || /(^|[\s"'/])qwen(\.js)?($|[\s"'/])/.test(normalized);
 }
 
-function applyLocalProcessFields(body, resolve) {
-  const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve();
+// #634: lifecycle for the shared resolver's cross-process pid cache. Stop is
+// deliberately NOT "end" (turn completion, not session end). PermissionRequest
+// falls through to "event" like any other mid-session hook.
+const EVENT_TO_LIFECYCLE = {
+  SessionStart: "start",
+  UserPromptSubmit: "prompt",
+  SessionEnd: "end",
+};
+
+// cacheable keys off the RAW session id: normalizeQwenSessionId prefixes, so
+// its "qwen-code:default" fallback would defeat the #583 same-key guard.
+function pidCacheContext(hookName, payload, body) {
+  const raw = payload && payload.session_id != null && payload.session_id !== ""
+    ? String(payload.session_id)
+    : "";
+  return {
+    namespace: "qwen-code",
+    sessionId: body.session_id,
+    cacheCwd: body.cwd || "",
+    lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
+    cacheable: !!raw && !!body.cwd,
+  };
+}
+
+function applyLocalProcessFields(body, resolve, ctx) {
+  const { stablePid, agentPid, detectedEditor, pidChain, tmuxSocket, tmuxClient } = resolve(ctx);
   if (Number.isFinite(stablePid) && stablePid > 0) body.source_pid = Math.floor(stablePid);
   if (detectedEditor) body.editor = detectedEditor;
   if (Number.isFinite(agentPid) && agentPid > 0) body.agent_pid = Math.floor(agentPid);
@@ -171,7 +195,7 @@ function buildStateBody(hookName, payload, resolve, options = {}) {
     applyWslSourceFields(body, { remote: true });
   } else {
     applyWslSourceFields(body);
-    applyLocalProcessFields(body, resolve);
+    applyLocalProcessFields(body, resolve, pidCacheContext(hookName, payload, body));
   }
 
   return body;
@@ -255,7 +279,7 @@ function buildPermissionBody(hookName, payload, resolve, options = {}) {
     applyWslSourceFields(body, { remote: true });
   } else {
     applyWslSourceFields(body);
-    applyLocalProcessFields(body, resolve);
+    applyLocalProcessFields(body, resolve, pidCacheContext(hookName, payload, body));
   }
   return body;
 }

--- a/hooks/reasonix-hook.js
+++ b/hooks/reasonix-hook.js
@@ -21,6 +21,14 @@ const EVENT_TO_STATE = {
   PreCompact: "sweeping",
 };
 
+// #634: lifecycle for the shared resolver's cross-process pid cache. Stop is
+// deliberately NOT "end" (turn completion; Reasonix even delays its Stop POST).
+const EVENT_TO_LIFECYCLE = {
+  SessionStart: "start",
+  UserPromptSubmit: "prompt",
+  SessionEnd: "end",
+};
+
 const config = getPlatformConfig();
 const resolve = createPidResolver({
   agentNames: {
@@ -99,7 +107,16 @@ readStdinJson()
       applyWslSourceFields(body, { remote: true });
     } else {
       applyWslSourceFields(body);
-      const { stablePid, agentPid, detectedEditor, pidChain } = resolve();
+      // #634: cacheable keys off the RAW session id — the normalized value is
+      // prefixed, so its "reasonix:default" fallback would defeat the #583 guard.
+      const rawSessionId = (payload && payload.session_id) || "";
+      const { stablePid, agentPid, detectedEditor, pidChain } = resolve({
+        namespace: "reasonix",
+        sessionId: body.session_id,
+        cacheCwd: body.cwd || "",
+        lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
+        cacheable: !!rawSessionId && !!body.cwd,
+      });
       if (Number.isFinite(stablePid) && stablePid > 0) body.source_pid = Math.floor(stablePid);
       if (detectedEditor) body.editor = detectedEditor;
       if (Number.isFinite(agentPid) && agentPid > 0) body.agent_pid = Math.floor(agentPid);

--- a/hooks/reasonix-hook.js
+++ b/hooks/reasonix-hook.js
@@ -108,14 +108,15 @@ readStdinJson()
     } else {
       applyWslSourceFields(body);
       // #634: cacheable keys off the RAW session id — the normalized value is
-      // prefixed, so its "reasonix:default" fallback would defeat the #583 guard.
+      // prefixed, so its "reasonix:default" fallback would defeat the #583
+      // guard; a literal raw "default" is rejected for the same reason.
       const rawSessionId = (payload && payload.session_id) || "";
       const { stablePid, agentPid, detectedEditor, pidChain } = resolve({
         namespace: "reasonix",
         sessionId: body.session_id,
         cacheCwd: body.cwd || "",
         lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
-        cacheable: !!rawSessionId && !!body.cwd,
+        cacheable: !!rawSessionId && rawSessionId !== "default" && !!body.cwd,
       });
       if (Number.isFinite(stablePid) && stablePid > 0) body.source_pid = Math.floor(stablePid);
       if (detectedEditor) body.editor = detectedEditor;

--- a/test/hook-adapter-offline-contract.test.js
+++ b/test/hook-adapter-offline-contract.test.js
@@ -54,7 +54,11 @@ const ADAPTERS = [
   { name: "clawd-hook.js", argv: ["PreToolUse"], payload: { hook_event_name: "PreToolUse", session_id: "s-681", cwd: "D:/repo" }, stdout: "" },
   { name: "codex-hook.js", payload: { hook_event_name: "PreToolUse", session_id: "s-681", cwd: "D:/repo" }, stdout: "" },
   { name: "copilot-hook.js", argv: ["sessionStart"], payload: { hook_event_name: "sessionStart", session_id: "s-681", cwd: "D:/repo" }, stdout: "" },
-  { name: "cursor-hook.js", payload: { hook_event_name: "beforeSubmitPrompt", cwd: "D:/repo" }, stdout: `${JSON.stringify({ continue: true })}\n` },
+  // #634: cursor's beforeSubmitPrompt now maps to the "prompt" lifecycle,
+  // which is cache-only and deliberately spawn-free — it can no longer anchor
+  // the one-spawn vacuity guard. preToolUse ("event" lifecycle: fresh on cache
+  // miss) keeps the guard meaningful, matching the other adapters' rows.
+  { name: "cursor-hook.js", payload: { hook_event_name: "preToolUse", cwd: "D:/repo" }, stdout: "{}\n" },
   { name: "gemini-hook.js", payload: { hook_event_name: "SessionStart", cwd: "D:/repo" }, stdout: null },
   { name: "kimi-hook.js", payload: { hook_event_name: "PreToolUse", session_id: "s-681", cwd: "D:/repo" }, stdout: "" },
   { name: "kiro-hook.js", payload: { hook_event_name: "preToolUse", cwd: "D:/repo" }, stdout: "" },

--- a/test/hook-pid-cache-contexts.test.js
+++ b/test/hook-pid-cache-contexts.test.js
@@ -185,7 +185,7 @@ describe("#634 ctx contract — sendHookEvent seams", () => {
     });
   }
 
-  it("antigravity: every event uses the event lifecycle; transcript-dirname id is cacheable", async () => {
+  it("antigravity: every event uses the event lifecycle; only an explicit conversation id is cacheable", async () => {
     const mod = require("../hooks/antigravity-hook.js");
     const send = mod.sendHookEvent || (mod.__test && mod.__test.sendHookEvent);
     assert.strictEqual(typeof send, "function", "sendHookEvent seam");
@@ -199,15 +199,35 @@ describe("#634 ctx contract — sendHookEvent seams", () => {
       { namespace: "antigravity-cli", sessionId: "antigravity:ag1", cacheCwd: "D:/repo", lifecycle: "event", cacheable: true }
     );
 
-    const capDirname = capture();
-    await send({ hookEventName: "PreToolUse", transcriptPath: "C:/t/conv-77/rollout.json", workspacePaths: ["D:/repo"] }, "", deps(capDirname));
-    assert.strictEqual(capDirname.calls[0].sessionId, "antigravity:conv-77");
-    assert.strictEqual(capDirname.calls[0].cacheable, true, "transcript-dirname fallback is a real per-conversation id");
+    const fallbackContexts = [];
+    for (const transcriptPath of [
+      "D:/repo/.gemini/jetski/transcript-A.jsonl",
+      "D:/repo/.gemini/jetski/transcript-B.jsonl",
+    ]) {
+      const capFallback = capture();
+      await send({ hookEventName: "PostToolUse", transcriptPath, workspacePaths: ["D:/repo"] }, "", deps(capFallback));
+      fallbackContexts.push(capFallback.calls[0]);
+    }
+    assert.deepStrictEqual(
+      fallbackContexts.map(({ sessionId, cacheable }) => ({ sessionId, cacheable })),
+      [
+        { sessionId: "antigravity:jetski", cacheable: false },
+        { sessionId: "antigravity:jetski", cacheable: false },
+      ],
+      "a transcript parent may be shared by multiple conversations, so the fallback must not key a pid cache"
+    );
 
     const capNone = capture();
     await send({ hookEventName: "PreToolUse", workspacePaths: ["D:/repo"] }, "", deps(capNone));
     assert.strictEqual(capNone.calls[0].sessionId, "antigravity:default");
     assert.strictEqual(capNone.calls[0].cacheable, false, "antigravity:default must not key a shared cache entry");
+
+    for (const conversationId of ["default", "antigravity:default", "   "]) {
+      const capPlaceholder = capture();
+      await send({ hookEventName: "PostToolUse", conversationId, workspacePaths: ["D:/repo"] }, "", deps(capPlaceholder));
+      assert.strictEqual(capPlaceholder.calls[0].cacheable, false,
+        `placeholder conversationId ${JSON.stringify(conversationId)} must not key a shared cache entry`);
+    }
   });
 
   it("antigravity: cache key stays stable while toolCall.args.Cwd varies within one conversation", async () => {
@@ -279,7 +299,7 @@ describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully
     });
     let spawns = null;
     try { spawns = JSON.parse(fs.readFileSync(probeOut, "utf8")); } catch {}
-    return { spawns, stderr: result.stderr };
+    return { spawns, stderr: result.stderr, stdout: result.stdout, status: result.status };
   }
 
   const sid = (p) => `${p}-634-${process.pid}`;
@@ -318,6 +338,22 @@ describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully
     });
     assert.ok(Array.isArray(r.spawns), `cursor did not report — stderr=${r.stderr}`);
     assert.deepStrictEqual(r.spawns, [], "prompt is cache-only: no snapshot spawn, hit or miss");
+    assert.strictEqual(r.status, 0, `cursor must exit cleanly — stderr=${r.stderr}`);
+    assert.strictEqual(r.stdout, `${JSON.stringify({ continue: true })}\n`,
+      "cache-only prompt metadata must not degrade Cursor's gating stdout");
+  });
+
+  it("antigravity-hook.js: transcript fallback cannot read another conversation's seeded cache", () => {
+    seedLiveCache("antigravity-cli", "antigravity:jetski", "D:/repo");
+    const r = runHook("antigravity-hook.js", {
+      hookEventName: "PostToolUse",
+      transcriptPath: "D:/repo/.gemini/jetski/transcript-B.jsonl",
+      workspacePaths: ["D:/repo"],
+    });
+    assert.ok(Array.isArray(r.spawns), `antigravity did not report — stderr=${r.stderr}`);
+    assert.strictEqual(r.spawns.length, 1,
+      "without an explicit conversationId the shared transcript fallback must be ignored and resolved fresh");
+    assert.match(r.spawns[0], /powershell/i);
   });
 
   it("qoder-hook.js: SessionEnd drops the live cache entry without spawning", () => {

--- a/test/hook-pid-cache-contexts.test.js
+++ b/test/hook-pid-cache-contexts.test.js
@@ -124,6 +124,9 @@ describe("#634 ctx contract — buildStateBody seams", () => {
     const capNoSid = capture();
     mod.buildStateBody("PreToolUse", { cwd: "D:/repo" }, capNoSid, {});
     assert.strictEqual(capNoSid.calls[0].cacheable, false, "qwen-code:default must not be cacheable");
+    const capLiteral = capture();
+    mod.buildStateBody("PreToolUse", { session_id: "default", cwd: "D:/repo" }, capLiteral, {});
+    assert.strictEqual(capLiteral.calls[0].cacheable, false, "a literal raw \"default\" id must not be cacheable either");
     const capPerm = capture();
     mod.buildPermissionBody("PermissionRequest", { session_id: "qw1", cwd: "D:/repo", tool_name: "bash" }, capPerm, {});
     assert.strictEqual(capPerm.calls[0].lifecycle, "event", "permission bodies use the event lifecycle");
@@ -159,10 +162,11 @@ describe("#634 ctx contract — sendHookEvent seams", () => {
   });
 
   for (const [file, ns] of [["qoder-hook.js", "qoder"], ["qoderwork-hook.js", "qoderwork"]]) {
-    it(`${ns}: SessionStart/UserPromptSubmit map; prefixed default not cacheable`, async () => {
+    it(`${ns}: SessionStart/UserPromptSubmit/SessionEnd map; default ids not cacheable`, async () => {
       const mod = require(`../hooks/${file}`);
       for (const [event, lifecycle] of [
-        ["SessionStart", "start"], ["UserPromptSubmit", "prompt"], ["PreToolUse", "event"], ["Stop", "event"],
+        ["SessionStart", "start"], ["UserPromptSubmit", "prompt"], ["SessionEnd", "end"],
+        ["PreToolUse", "event"], ["Stop", "event"],
       ]) {
         const cap = capture();
         await mod.sendHookEvent({ hook_event_name: event, session_id: "q1", cwd: "D:/repo" }, "", { env: {}, resolvePid: cap, postState: stubPost });
@@ -175,6 +179,9 @@ describe("#634 ctx contract — sendHookEvent seams", () => {
       const cap = capture();
       await mod.sendHookEvent({ hook_event_name: "PreToolUse", cwd: "D:/repo" }, "", { env: {}, resolvePid: cap, postState: stubPost });
       assert.strictEqual(cap.calls[0].cacheable, false, `${ns}:default must not key a shared cache entry`);
+      const capLiteral = capture();
+      await mod.sendHookEvent({ hook_event_name: "PreToolUse", session_id: "default", cwd: "D:/repo" }, "", { env: {}, resolvePid: capLiteral, postState: stubPost });
+      assert.strictEqual(capLiteral.calls[0].cacheable, false, "a literal raw \"default\" id must not be cacheable either");
     });
   }
 
@@ -201,6 +208,29 @@ describe("#634 ctx contract — sendHookEvent seams", () => {
     await send({ hookEventName: "PreToolUse", workspacePaths: ["D:/repo"] }, "", deps(capNone));
     assert.strictEqual(capNone.calls[0].sessionId, "antigravity:default");
     assert.strictEqual(capNone.calls[0].cacheable, false, "antigravity:default must not key a shared cache entry");
+  });
+
+  it("antigravity: cache key stays stable while toolCall.args.Cwd varies within one conversation", async () => {
+    const mod = require("../hooks/antigravity-hook.js");
+    const send = mod.sendHookEvent || (mod.__test && mod.__test.sendHookEvent);
+    const deps = (cap) => ({ env: {}, resolvePid: cap, postState: stubPost, postPermission: stubPost });
+
+    // Same conversation + workspace; the per-tool cwd wanders across subdirs
+    // and slash spellings. resolveCwd() legitimately follows it for the event
+    // body, but the CACHE key must not — each drift would be a fresh v2 file
+    // and a snapshot-spawning miss.
+    const toolCwds = ["D:/repo", "D:\\repo", "D:/repo/src", undefined];
+    const seen = [];
+    for (const toolCwd of toolCwds) {
+      const cap = capture();
+      const payload = { hookEventName: "PreToolUse", conversationId: "ag-stable", workspacePaths: ["D:/repo"] };
+      if (toolCwd !== undefined) payload.toolCall = { args: { Cwd: toolCwd } };
+      await send(payload, "", deps(cap));
+      seen.push(cap.calls[0].cacheCwd);
+      assert.strictEqual(cap.calls[0].cacheable, true, String(toolCwd));
+    }
+    assert.deepStrictEqual(seen, ["D:/repo", "D:/repo", "D:/repo", "D:/repo"],
+      "cacheCwd must be the stable workspacePaths[0], never the per-tool cwd");
   });
 });
 
@@ -288,5 +318,69 @@ describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully
     });
     assert.ok(Array.isArray(r.spawns), `cursor did not report — stderr=${r.stderr}`);
     assert.deepStrictEqual(r.spawns, [], "prompt is cache-only: no snapshot spawn, hit or miss");
+  });
+
+  it("qoder-hook.js: SessionEnd drops the live cache entry without spawning", () => {
+    const raw = sid("qd-end");
+    const cacheSid = `qoder:${raw}`;
+    seedLiveCache("qoder", cacheSid, "D:/repo");
+    const file = pc.cacheFilePathV2("qoder", cacheSid, "D:/repo");
+    assert.ok(fs.existsSync(file), "seeded entry exists before SessionEnd");
+    const r = runHook("qoder-hook.js", { hook_event_name: "SessionEnd", session_id: raw, cwd: "D:/repo" });
+    assert.ok(Array.isArray(r.spawns), `qoder did not report — stderr=${r.stderr}`);
+    assert.deepStrictEqual(r.spawns, [], "end is cache-only: no snapshot spawn");
+    assert.strictEqual(fs.existsSync(file), false, "SessionEnd must delete the session's v2 cache entry");
+  });
+
+  it("qoder-hook.js: SessionEnd on a cache miss stays spawn-free", () => {
+    const r = runHook("qoder-hook.js", { hook_event_name: "SessionEnd", session_id: sid("qd-end-miss"), cwd: "D:/repo" });
+    assert.ok(Array.isArray(r.spawns), `qoder did not report — stderr=${r.stderr}`);
+    assert.deepStrictEqual(r.spawns, [], "the end contract never takes a fresh snapshot, hit or miss");
+  });
+
+  it("reasonix-hook.js: a literal \"default\" session id ignores a seeded entry and stays fresh", () => {
+    seedLiveCache("reasonix", "reasonix:default", "D:/repo");
+    const r = runHook("reasonix-hook.js", { event: "PreToolUse", session_id: "default", cwd: "D:/repo", toolName: "bash" });
+    assert.ok(Array.isArray(r.spawns), `reasonix did not report — stderr=${r.stderr}`);
+    assert.strictEqual(r.spawns.length, 1, "literal default must not be cacheable: per-event fresh snapshot, like kiro");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// C. Consumer contract — no adapter silently stays on the bare (uncached) path
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("#634 consumer contract — ctx or explicit exemption", () => {
+  // The offline-contract test locks the consumer COUNT; this locks the cache
+  // MIGRATION: a createPidResolver consumer must build a cache context
+  // (recognized by its `namespace: "` literal) or be exempted here on purpose.
+  // Prewarm-style bare resolve() calls are fine — this only catches files with
+  // no context anywhere.
+  const EXEMPT = new Set([
+    // #634 scopes exactly 12 adapters; WorkBuddy joined the resolver later
+    // (#618) and is tracked as an explicit follow-up on the issue — remove
+    // this exemption when it migrates.
+    "workbuddy-hook.js",
+  ]);
+
+  it("every createPidResolver consumer passes a cache context or is exempted", () => {
+    const consumers = fs.readdirSync(HOOKS_DIR)
+      .filter((f) => f.endsWith("-hook.js"))
+      .filter((f) => fs.readFileSync(path.join(HOOKS_DIR, f), "utf8").includes("createPidResolver("));
+    assert.ok(consumers.length >= 14, "sanity: the resolver consumers are all visible to this scan");
+    const bare = consumers.filter((f) => {
+      if (EXEMPT.has(f)) return false;
+      return !fs.readFileSync(path.join(HOOKS_DIR, f), "utf8").includes('namespace: "');
+    });
+    assert.deepStrictEqual(bare, [],
+      "these adapters call createPidResolver but never build a cache context — migrate them or add an explicit exemption with a reason");
+  });
+
+  it("exemptions stay honest — an exempted file must still be a consumer", () => {
+    for (const f of EXEMPT) {
+      const p = path.join(HOOKS_DIR, f);
+      assert.ok(fs.existsSync(p), `${f} exempted but missing`);
+      assert.ok(fs.readFileSync(p, "utf8").includes("createPidResolver("), `${f} exempted but no longer a consumer — drop the exemption`);
+    }
   });
 });

--- a/test/hook-pid-cache-contexts.test.js
+++ b/test/hook-pid-cache-contexts.test.js
@@ -1,0 +1,292 @@
+"use strict";
+// test/hook-pid-cache-contexts.test.js — #634: every migrated adapter passes a
+// correct lifecycle context to the shared resolver's cross-process pid cache.
+//
+// Two layers, mirroring the repo's split for this area:
+//   A. In-process ctx capture (all platforms) — a fake resolve records the ctx
+//      each adapter builds, pinning namespace / lifecycle mapping / the
+//      RAW-session-id cacheable guard (a prefixed "<agent>:default" fallback
+//      must NOT count as cacheable, cf. #583).
+//   B. Real-subprocess cache behavior (win32) — the offline-probe pattern from
+//      test/hook-adapter-offline-contract.test.js, plus a seeded live v2 cache
+//      entry in the real tmpdir: a cache hit must attempt ZERO snapshot spawns
+//      (#634 acceptance), kiro (no stable session id) must keep its per-event
+//      fresh snapshot (graceful degrade), and a prompt-lifecycle event must be
+//      spawn-free even on a cache miss.
+
+const { describe, it, before, after, afterEach } = require("node:test");
+const assert = require("node:assert");
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const HOOKS_DIR = path.join(__dirname, "..", "hooks");
+const PROBE = path.join(__dirname, "helpers", "hook-offline-probe.js");
+const pc = require("../hooks/pid-cache");
+
+// Full public metadata shape the resolver returns — adapters destructure all of
+// these, so the capture stub must provide every field.
+function fakeMeta() {
+  return {
+    stablePid: 4321, terminalPid: 4321, snapshotOk: true, agentPid: 8765,
+    agentCommandLine: "", detectedEditor: null, pidChain: [],
+    foregroundWtHwnd: null, tmuxSocket: null, tmuxClient: null, headless: false,
+  };
+}
+
+function capture() {
+  const calls = [];
+  const fn = (ctx) => { calls.push(ctx); return fakeMeta(); };
+  fn.calls = calls;
+  return fn;
+}
+
+const stubPost = (body, opts, cb) => cb(false, null);
+
+// ═════════════════════════════════════════════════════════════════════════════
+// A. ctx capture — buildStateBody seams (kimi / codex / copilot / qwen)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("#634 ctx contract — buildStateBody seams", () => {
+  let hadRemote;
+  before(() => { hadRemote = process.env.CLAWD_REMOTE; delete process.env.CLAWD_REMOTE; });
+  after(() => { if (hadRemote !== undefined) process.env.CLAWD_REMOTE = hadRemote; });
+
+  it("kimi: lifecycle map + prefixed-default is not cacheable", () => {
+    const mod = require("../hooks/kimi-hook.js");
+    for (const [event, lifecycle] of [
+      ["SessionStart", "start"], ["UserPromptSubmit", "prompt"],
+      ["SessionEnd", "end"], ["PreToolUse", "event"], ["Stop", "event"],
+    ]) {
+      const cap = capture();
+      mod.buildStateBody(event, { session_id: "k1", cwd: "D:/repo" }, cap);
+      assert.strictEqual(cap.calls.length, 1, event);
+      assert.deepStrictEqual(
+        { ...cap.calls[0] },
+        { namespace: "kimi-cli", sessionId: "kimi-cli:k1", cacheCwd: "D:/repo", lifecycle, cacheable: true },
+        event
+      );
+    }
+    const cap = capture();
+    mod.buildStateBody("PreToolUse", { cwd: "D:/repo" }, cap); // no session_id
+    assert.strictEqual(cap.calls[0].sessionId, "kimi-cli:default");
+    assert.strictEqual(cap.calls[0].cacheable, false, "kimi-cli:default must not key a shared cache entry");
+  });
+
+  it("codex: state + permission bodies share the guard; Stop is not end", () => {
+    const mod = require("../hooks/codex-hook.js");
+    for (const [event, lifecycle] of [
+      ["SessionStart", "start"], ["UserPromptSubmit", "prompt"], ["Stop", "event"], ["PreToolUse", "event"],
+    ]) {
+      const cap = capture();
+      mod.buildStateBody({ hook_event_name: event, session_id: "cx1", cwd: "D:/repo" }, cap);
+      assert.strictEqual(cap.calls[0].namespace, "codex", event);
+      assert.strictEqual(cap.calls[0].lifecycle, lifecycle, event);
+      assert.strictEqual(cap.calls[0].sessionId, "codex:cx1", event);
+      assert.strictEqual(cap.calls[0].cacheable, true, event);
+    }
+    const cap = capture();
+    mod.buildStateBody({ hook_event_name: "PreToolUse", cwd: "D:/repo" }, cap);
+    assert.strictEqual(cap.calls[0].sessionId, "codex:default");
+    assert.strictEqual(cap.calls[0].cacheable, false, "codex:default must not key a shared cache entry");
+  });
+
+  it("copilot: camelCase lifecycle map; permission body uses the event lifecycle", () => {
+    const mod = require("../hooks/copilot-hook.js");
+    for (const [event, lifecycle] of [
+      ["sessionStart", "start"], ["userPromptSubmitted", "prompt"],
+      ["sessionEnd", "end"], ["preToolUse", "event"], ["agentStop", "event"],
+    ]) {
+      const cap = capture();
+      mod.buildStateBody(event, { sessionId: "cp1", cwd: "D:/repo" }, cap);
+      assert.strictEqual(cap.calls[0].namespace, "copilot-cli", event);
+      assert.strictEqual(cap.calls[0].lifecycle, lifecycle, event);
+      assert.strictEqual(cap.calls[0].cacheable, true, event);
+    }
+    const cap = capture();
+    mod.buildStateBody("preToolUse", { cwd: "D:/repo" }, cap); // no session id → "default"
+    assert.strictEqual(cap.calls[0].cacheable, false);
+  });
+
+  it("qwen-code: state + permission bodies; raw-id guard beats the prefixed fallback", () => {
+    const mod = require("../hooks/qwen-code-hook.js");
+    for (const [event, lifecycle] of [
+      ["SessionStart", "start"], ["UserPromptSubmit", "prompt"], ["SessionEnd", "end"], ["PreToolUse", "event"],
+    ]) {
+      const cap = capture();
+      mod.buildStateBody(event, { session_id: "qw1", cwd: "D:/repo" }, cap, {});
+      assert.strictEqual(cap.calls[0].namespace, "qwen-code", event);
+      assert.strictEqual(cap.calls[0].lifecycle, lifecycle, event);
+      assert.strictEqual(cap.calls[0].sessionId, "qwen-code:qw1", event);
+      assert.strictEqual(cap.calls[0].cacheable, true, event);
+    }
+    const capNoSid = capture();
+    mod.buildStateBody("PreToolUse", { cwd: "D:/repo" }, capNoSid, {});
+    assert.strictEqual(capNoSid.calls[0].cacheable, false, "qwen-code:default must not be cacheable");
+    const capPerm = capture();
+    mod.buildPermissionBody("PermissionRequest", { session_id: "qw1", cwd: "D:/repo", tool_name: "bash" }, capPerm, {});
+    assert.strictEqual(capPerm.calls[0].lifecycle, "event", "permission bodies use the event lifecycle");
+    assert.strictEqual(capPerm.calls[0].cacheable, true);
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// A (cont.) — sendHookEvent deps.resolvePid seams (gemini / qoder / qoderwork /
+// antigravity)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("#634 ctx contract — sendHookEvent seams", () => {
+  it("gemini: BeforeAgent is the prompt equivalent; gemini:default not cacheable", async () => {
+    const mod = require("../hooks/gemini-hook.js");
+    const send = mod.sendHookEvent || mod.__test.sendHookEvent;
+    for (const [event, lifecycle] of [
+      ["SessionStart", "start"], ["BeforeAgent", "prompt"], ["SessionEnd", "end"], ["BeforeTool", "event"],
+    ]) {
+      const cap = capture();
+      await send({ hook_event_name: event, session_id: "g1", cwd: "D:/repo" }, "", { env: {}, resolvePid: cap, postState: stubPost });
+      assert.strictEqual(cap.calls.length, 1, event);
+      assert.deepStrictEqual(
+        { ...cap.calls[0] },
+        { namespace: "gemini-cli", sessionId: "gemini:g1", cacheCwd: "D:/repo", lifecycle, cacheable: true },
+        event
+      );
+    }
+    const cap = capture();
+    await send({ hook_event_name: "BeforeTool", cwd: "D:/repo" }, "", { env: {}, resolvePid: cap, postState: stubPost });
+    assert.strictEqual(cap.calls[0].sessionId, "gemini:default");
+    assert.strictEqual(cap.calls[0].cacheable, false, "gemini:default must not key a shared cache entry");
+  });
+
+  for (const [file, ns] of [["qoder-hook.js", "qoder"], ["qoderwork-hook.js", "qoderwork"]]) {
+    it(`${ns}: SessionStart/UserPromptSubmit map; prefixed default not cacheable`, async () => {
+      const mod = require(`../hooks/${file}`);
+      for (const [event, lifecycle] of [
+        ["SessionStart", "start"], ["UserPromptSubmit", "prompt"], ["PreToolUse", "event"], ["Stop", "event"],
+      ]) {
+        const cap = capture();
+        await mod.sendHookEvent({ hook_event_name: event, session_id: "q1", cwd: "D:/repo" }, "", { env: {}, resolvePid: cap, postState: stubPost });
+        assert.strictEqual(cap.calls.length, 1, event);
+        assert.strictEqual(cap.calls[0].namespace, ns, event);
+        assert.strictEqual(cap.calls[0].lifecycle, lifecycle, event);
+        assert.strictEqual(cap.calls[0].sessionId, `${ns}:q1`, event);
+        assert.strictEqual(cap.calls[0].cacheable, true, event);
+      }
+      const cap = capture();
+      await mod.sendHookEvent({ hook_event_name: "PreToolUse", cwd: "D:/repo" }, "", { env: {}, resolvePid: cap, postState: stubPost });
+      assert.strictEqual(cap.calls[0].cacheable, false, `${ns}:default must not key a shared cache entry`);
+    });
+  }
+
+  it("antigravity: every event uses the event lifecycle; transcript-dirname id is cacheable", async () => {
+    const mod = require("../hooks/antigravity-hook.js");
+    const send = mod.sendHookEvent || (mod.__test && mod.__test.sendHookEvent);
+    assert.strictEqual(typeof send, "function", "sendHookEvent seam");
+    const deps = (cap) => ({ env: {}, resolvePid: cap, postState: stubPost, postPermission: stubPost });
+
+    const cap = capture();
+    await send({ hookEventName: "PreToolUse", conversationId: "ag1", workspacePaths: ["D:/repo"] }, "", deps(cap));
+    assert.strictEqual(cap.calls.length, 1);
+    assert.deepStrictEqual(
+      { ...cap.calls[0] },
+      { namespace: "antigravity-cli", sessionId: "antigravity:ag1", cacheCwd: "D:/repo", lifecycle: "event", cacheable: true }
+    );
+
+    const capDirname = capture();
+    await send({ hookEventName: "PreToolUse", transcriptPath: "C:/t/conv-77/rollout.json", workspacePaths: ["D:/repo"] }, "", deps(capDirname));
+    assert.strictEqual(capDirname.calls[0].sessionId, "antigravity:conv-77");
+    assert.strictEqual(capDirname.calls[0].cacheable, true, "transcript-dirname fallback is a real per-conversation id");
+
+    const capNone = capture();
+    await send({ hookEventName: "PreToolUse", workspacePaths: ["D:/repo"] }, "", deps(capNone));
+    assert.strictEqual(capNone.calls[0].sessionId, "antigravity:default");
+    assert.strictEqual(capNone.calls[0].cacheable, false, "antigravity:default must not key a shared cache entry");
+  });
+});
+
+// ═════════════════════════════════════════════════════════════════════════════
+// B. Real subprocess — seeded v2 cache hit ⇒ zero snapshot spawns (win32)
+// ═════════════════════════════════════════════════════════════════════════════
+
+describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully", { skip: process.platform !== "win32" }, () => {
+  let fakeHome;
+  let probeOut;
+  const seeded = [];
+
+  before(() => {
+    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-634-ctx-home-"));
+    probeOut = path.join(fakeHome, "spawns.json");
+  });
+  after(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
+  afterEach(() => {
+    for (const [ns, sid, cwd] of seeded.splice(0)) pc.dropPidCacheV2(ns, sid, cwd);
+  });
+
+  // The parent and the child hook share the real os.tmpdir() (TEMP is not
+  // remapped — only USERPROFILE/HOME are), so a v2 entry seeded here is exactly
+  // what the child's resolver reads. Both pids are this test process — alive
+  // from the child's perspective, so the double-liveness check passes.
+  function seedLiveCache(ns, sid, cwd) {
+    const ok = pc.writePidCacheV2(ns, sid, cwd, {
+      stablePid: process.pid, agentPid: process.pid, headless: false, detectedEditor: null,
+    });
+    assert.ok(ok, `seed ${ns}`);
+    seeded.push([ns, sid, cwd]);
+  }
+
+  const LIVE_RUNTIME = () => ({ app: "clawd-on-desk", port: 23333, ownerPid: process.pid });
+
+  function runHook(name, payload) {
+    const clawdDir = path.join(fakeHome, ".clawd");
+    fs.mkdirSync(clawdDir, { recursive: true });
+    fs.writeFileSync(path.join(clawdDir, "runtime.json"), JSON.stringify(LIVE_RUNTIME()));
+    try { fs.unlinkSync(probeOut); } catch {}
+    const env = { ...process.env, USERPROFILE: fakeHome, HOME: fakeHome, CLAWD_PROBE_OUT: probeOut };
+    delete env.CLAWD_REMOTE;
+    const result = spawnSync(process.execPath, ["--require", PROBE, path.join(HOOKS_DIR, name)], {
+      input: `${JSON.stringify(payload)}\n`,
+      encoding: "utf8", windowsHide: true, timeout: 20000, env,
+    });
+    let spawns = null;
+    try { spawns = JSON.parse(fs.readFileSync(probeOut, "utf8")); } catch {}
+    return { spawns, stderr: result.stderr };
+  }
+
+  const sid = (p) => `${p}-634-${process.pid}`;
+
+  // Script-style adapters (no unit seam) — a live v2 hit must spawn nothing.
+  const HIT_ROWS = [
+    { name: "cursor-hook.js", ns: "cursor-agent", raw: sid("cur"), cacheSid: sid("cur"),
+      payload: { hook_event_name: "preToolUse", conversation_id: sid("cur"), cwd: "D:/repo" } },
+    { name: "codebuddy-hook.js", ns: "codebuddy", raw: sid("cb"), cacheSid: sid("cb"),
+      payload: { hook_event_name: "PreToolUse", session_id: sid("cb"), cwd: "D:/repo" } },
+    { name: "reasonix-hook.js", ns: "reasonix", raw: sid("rx"), cacheSid: `reasonix:${sid("rx")}`,
+      payload: { event: "PreToolUse", session_id: sid("rx"), cwd: "D:/repo", toolName: "bash" } },
+  ];
+
+  for (const row of HIT_ROWS) {
+    it(`${row.name}: live v2 cache hit ⇒ zero snapshot spawns`, () => {
+      seedLiveCache(row.ns, row.cacheSid, "D:/repo");
+      const r = runHook(row.name, row.payload);
+      assert.ok(Array.isArray(r.spawns), `${row.name} did not report — stderr=${r.stderr}`);
+      assert.deepStrictEqual(r.spawns, [], `${row.name} must resolve from the cache without spawning`);
+    });
+  }
+
+  it("kiro-hook.js: no stable session id ⇒ cache disabled, still one fresh snapshot per event", () => {
+    // Even a seeded entry under its would-be key must be ignored (cacheable:false).
+    seedLiveCache("kiro-cli", "default", "D:/repo");
+    const r = runHook("kiro-hook.js", { hook_event_name: "preToolUse", cwd: "D:/repo" });
+    assert.ok(Array.isArray(r.spawns), `kiro did not report — stderr=${r.stderr}`);
+    assert.strictEqual(r.spawns.length, 1, "kiro must keep today's per-event fresh snapshot (graceful degrade)");
+    assert.match(r.spawns[0], /powershell/i);
+  });
+
+  it("cursor-hook.js: prompt lifecycle is spawn-free even on a cache miss", () => {
+    const r = runHook("cursor-hook.js", {
+      hook_event_name: "beforeSubmitPrompt", conversation_id: sid("cur-miss"), cwd: "D:/repo",
+    });
+    assert.ok(Array.isArray(r.spawns), `cursor did not report — stderr=${r.stderr}`);
+    assert.deepStrictEqual(r.spawns, [], "prompt is cache-only: no snapshot spawn, hit or miss");
+  });
+});

--- a/test/hook-pid-cache-contexts.test.js
+++ b/test/hook-pid-cache-contexts.test.js
@@ -9,7 +9,7 @@
 //      must NOT count as cacheable, cf. #583).
 //   B. Real-subprocess cache behavior (win32) — the offline-probe pattern from
 //      test/hook-adapter-offline-contract.test.js, plus a seeded live v2 cache
-//      entry in the real tmpdir: a cache hit must attempt ZERO snapshot spawns
+//      entry in an isolated tmpdir: a cache hit must attempt ZERO snapshot spawns
 //      (#634 acceptance), kiro (no stable session id) must keep its per-event
 //      fresh snapshot (graceful degrade), and a prompt-lifecycle event must be
 //      spawn-free even on a cache miss.
@@ -201,8 +201,8 @@ describe("#634 ctx contract — sendHookEvent seams", () => {
 
     const fallbackContexts = [];
     for (const transcriptPath of [
-      "D:/repo/.gemini/jetski/transcript-A.jsonl",
-      "D:/repo/.gemini/jetski/transcript-B.jsonl",
+      "D:/home/.gemini/antigravity-cli/brain/conversation-A/.system_generated/logs/transcript.jsonl",
+      "D:/home/.gemini/antigravity-cli/brain/conversation-B/.system_generated/logs/transcript.jsonl",
     ]) {
       const capFallback = capture();
       await send({ hookEventName: "PostToolUse", transcriptPath, workspacePaths: ["D:/repo"] }, "", deps(capFallback));
@@ -211,10 +211,10 @@ describe("#634 ctx contract — sendHookEvent seams", () => {
     assert.deepStrictEqual(
       fallbackContexts.map(({ sessionId, cacheable }) => ({ sessionId, cacheable })),
       [
-        { sessionId: "antigravity:jetski", cacheable: false },
-        { sessionId: "antigravity:jetski", cacheable: false },
+        { sessionId: "antigravity:logs", cacheable: false },
+        { sessionId: "antigravity:logs", cacheable: false },
       ],
-      "a transcript parent may be shared by multiple conversations, so the fallback must not key a pid cache"
+      "the official transcript shape has a shared `logs` parent, so the fallback must not key a pid cache"
     );
 
     const capNone = capture();
@@ -260,22 +260,30 @@ describe("#634 ctx contract — sendHookEvent seams", () => {
 
 describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully", { skip: process.platform !== "win32" }, () => {
   let fakeHome;
+  let isolatedTemp;
   let probeOut;
   const seeded = [];
 
   before(() => {
     fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-634-ctx-home-"));
+    isolatedTemp = path.join(fakeHome, "tmp");
+    fs.mkdirSync(isolatedTemp, { recursive: true });
+    pc.__setCacheDirForTests(isolatedTemp);
     probeOut = path.join(fakeHome, "spawns.json");
   });
-  after(() => { try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {} });
+  after(() => {
+    pc.__setCacheDirForTests(null);
+    try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch {}
+  });
   afterEach(() => {
     for (const [ns, sid, cwd] of seeded.splice(0)) pc.dropPidCacheV2(ns, sid, cwd);
   });
 
-  // The parent and the child hook share the real os.tmpdir() (TEMP is not
-  // remapped — only USERPROFILE/HOME are), so a v2 entry seeded here is exactly
-  // what the child's resolver reads. Both pids are this test process — alive
-  // from the child's perspective, so the double-liveness check passes.
+  // The parent uses pid-cache's test-only override and the child receives the
+  // same directory via TEMP/TMP. This keeps every seeded tuple away from the
+  // developer's real cache while still exercising cross-process file I/O.
+  // Both pids are this test process — alive from the child's perspective, so
+  // the double-liveness check passes.
   function seedLiveCache(ns, sid, cwd) {
     const ok = pc.writePidCacheV2(ns, sid, cwd, {
       stablePid: process.pid, agentPid: process.pid, headless: false, detectedEditor: null,
@@ -291,7 +299,14 @@ describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully
     fs.mkdirSync(clawdDir, { recursive: true });
     fs.writeFileSync(path.join(clawdDir, "runtime.json"), JSON.stringify(LIVE_RUNTIME()));
     try { fs.unlinkSync(probeOut); } catch {}
-    const env = { ...process.env, USERPROFILE: fakeHome, HOME: fakeHome, CLAWD_PROBE_OUT: probeOut };
+    const env = {
+      ...process.env,
+      USERPROFILE: fakeHome,
+      HOME: fakeHome,
+      TEMP: isolatedTemp,
+      TMP: isolatedTemp,
+      CLAWD_PROBE_OUT: probeOut,
+    };
     delete env.CLAWD_REMOTE;
     const result = spawnSync(process.execPath, ["--require", PROBE, path.join(HOOKS_DIR, name)], {
       input: `${JSON.stringify(payload)}\n`,
@@ -344,16 +359,50 @@ describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully
   });
 
   it("antigravity-hook.js: transcript fallback cannot read another conversation's seeded cache", () => {
-    seedLiveCache("antigravity-cli", "antigravity:jetski", "D:/repo");
+    seedLiveCache("antigravity-cli", "antigravity:logs", "D:/repo");
     const r = runHook("antigravity-hook.js", {
       hookEventName: "PostToolUse",
-      transcriptPath: "D:/repo/.gemini/jetski/transcript-B.jsonl",
+      transcriptPath: "D:/home/.gemini/antigravity-cli/brain/conversation-B/.system_generated/logs/transcript.jsonl",
       workspacePaths: ["D:/repo"],
     });
     assert.ok(Array.isArray(r.spawns), `antigravity did not report — stderr=${r.stderr}`);
     assert.strictEqual(r.spawns.length, 1,
       "without an explicit conversationId the shared transcript fallback must be ignored and resolved fresh");
     assert.match(r.spawns[0], /powershell/i);
+    assert.strictEqual(r.status, 0, `antigravity must exit cleanly — stderr=${r.stderr}`);
+    assert.strictEqual(r.stdout, "{}\n", "PostToolUse must keep Antigravity's empty-object stdout contract");
+  });
+
+  it("antigravity-hook.js: explicit conversationId reads its live cache without spawning", () => {
+    const raw = sid("ag-hit");
+    seedLiveCache("antigravity-cli", `antigravity:${raw}`, "D:/repo");
+    const r = runHook("antigravity-hook.js", {
+      hookEventName: "PostToolUse",
+      conversationId: raw,
+      transcriptPath: `D:/home/.gemini/antigravity-cli/brain/${raw}/.system_generated/logs/transcript.jsonl`,
+      workspacePaths: ["D:/repo"],
+    });
+    assert.ok(Array.isArray(r.spawns), `antigravity did not report — stderr=${r.stderr}`);
+    assert.deepStrictEqual(r.spawns, [], "an explicit conversationId must resolve from its live cache");
+    assert.strictEqual(r.status, 0, `antigravity must exit cleanly — stderr=${r.stderr}`);
+    assert.strictEqual(r.stdout, "{}\n", "PostToolUse must keep Antigravity's empty-object stdout contract");
+  });
+
+  it("antigravity-hook.js: Stop cache hit stays spawn-free and preserves gating stdout", () => {
+    const raw = sid("ag-stop");
+    seedLiveCache("antigravity-cli", `antigravity:${raw}`, "D:/repo");
+    const r = runHook("antigravity-hook.js", {
+      hookEventName: "Stop",
+      conversationId: raw,
+      transcriptPath: `D:/home/.gemini/antigravity-cli/brain/${raw}/.system_generated/logs/transcript.jsonl`,
+      workspacePaths: ["D:/repo"],
+      fullyIdle: true,
+    });
+    assert.ok(Array.isArray(r.spawns), `antigravity did not report — stderr=${r.stderr}`);
+    assert.deepStrictEqual(r.spawns, [], "Stop must resolve from the live event cache without spawning");
+    assert.strictEqual(r.status, 0, `antigravity must exit cleanly — stderr=${r.stderr}`);
+    assert.strictEqual(r.stdout, `${JSON.stringify({ decision: "allow" })}\n`,
+      "Stop must preserve Antigravity's gating stdout");
   });
 
   it("qoder-hook.js: SessionEnd drops the live cache entry without spawning", () => {


### PR DESCRIPTION
## What

The #634 resolver mechanism (lifecycle `resolve(ctx)` + namespaced v2 disk cache) already lives in `shared-process.js`, with `clawd-hook.js` as its first consumer. This wires the **12 not-yet-migrated adapters** into it: each now passes `{ namespace, sessionId, cacheCwd, lifecycle, cacheable }` at its existing `resolve()` / `deps.resolvePid()` call sites, mirroring the clawd-hook pattern.

There are **no resolver-core changes**. The returned shape remains field-compatible, so body building is untouched. The disk-cache behavior is Windows-only; the context path remains a no-op elsewhere.

## Per-adapter mapping

| Adapter | namespace | start | prompt | end | cacheable |
|---|---|---|---|---|---|
| cursor | `cursor-agent` | `sessionStart` | `beforeSubmitPrompt` | `sessionEnd` | `sid !== "default" && cwd` |
| copilot | `copilot-cli` | `sessionStart` | `userPromptSubmitted` | `sessionEnd` | same |
| codex | `codex` | `SessionStart` | `UserPromptSubmit` | — | `!== "codex:default"` (raw-id guard) |
| gemini | `gemini-cli` | `SessionStart` | `BeforeAgent` | `SessionEnd` | `!== "gemini:default"` |
| kimi | `kimi-cli` | `SessionStart` | `UserPromptSubmit` | `SessionEnd` | raw id ≠ default |
| qwen-code | `qwen-code` | `SessionStart` | `UserPromptSubmit` | `SessionEnd` | raw id truthy ≠ `"default"` |
| qoder / qoderwork | `qoder` / `qoderwork` | `SessionStart` | `UserPromptSubmit` | `SessionEnd` | raw id truthy ≠ `"default"` |
| codebuddy | `codebuddy` | `SessionStart` | `UserPromptSubmit` | `SessionEnd` | `sid !== "default"` |
| reasonix | `reasonix` | `SessionStart` | `UserPromptSubmit` | `SessionEnd` | raw id truthy ≠ `"default"` |
| antigravity | `antigravity-cli` | — (no start hook) | — | — | explicit non-default `conversationId` + `workspacePaths[0]` only |
| kiro | `kiro-cli` | `agentSpawn` | **none** | — | **always false** |

## Design notes

- **Raw-session-id guard:** eight adapters prefix their ids, so a Claude-style `!== "default"` check would let an `<agent>:default` fallback key one shared cache entry across id-less sessions. The guard keys off the raw payload id and also rejects a literal raw `"default"`.
- **Antigravity requires an explicit cache identity:** `normalizeSessionId()` retains the historic transcript-dirname fallback for state compatibility, but that fallback never keys the disk cache. The [official payload shape](https://antigravity.google/docs/hooks#common-input-fields) ends in `.system_generated/logs/transcript.jsonl`, so the immediate parent is the shared name `logs`, not a conversation identity. Only the explicit per-conversation UUID is cacheable.
- **Antigravity's cache cwd is the stable workspace:** `resolveCwd()` prefers per-tool `toolCall.args.Cwd`, which can drift within one conversation and fragment the cache. The cache key uses `workspacePaths[0]`; the event/body cwd keeps the existing `resolveCwd()` behavior.
- **Kiro degrades gracefully:** it has no stable session id, so `cacheable:false` keeps the existing per-event fresh snapshot rather than returning empty cache-only metadata.
- **Stop/agentStop remain `"event"`:** they are turn-completion events, not session teardown. **SessionEnd maps to `"end"`** everywhere that hook exists, including Qoder and QoderWork.
- The offline-contract Cursor row moves `beforeSubmitPrompt` to `preToolUse`: prompt is deliberately spawn-free and can no longer anchor the one-spawn vacuity guard. A separate subprocess assertion preserves Cursor's exact prompt stdout.

## Acceptance mapping

- **Cache hits do not spawn snapshots:** win32 subprocess rows run the real hook entrypoints as fresh processes against live v2 entries and assert zero snapshot attempts for Cursor, CodeBuddy, Reasonix, and explicit-id Antigravity. Test cache files are isolated under a per-test `TEMP` / `TMP`; the suite never seeds or deletes the developer's real cache.
- **Prompt/end miss paths remain spawn-free:** Cursor prompt and Qoder SessionEnd are asserted on cache misses. Qoder SessionEnd also deletes only its matching live entry.
- **Unstable identities degrade safely:** Kiro and literal/default-id cases ignore seeded entries and resolve fresh. Antigravity transcript fallback paths are explicitly non-cacheable.
- **No cross-session PID bleed:** all prefixed/default guards are pinned, and the Antigravity regression uses the official transcript shape where distinct conversations share the parent name `logs`.
- **Consumer contract:** every `createPidResolver` consumer must pass a cache context or remain in the explicit WorkBuddy exemption.

## Windows smoke (2026-07-31)

- **Real Qoder CLI + administrator `Win32_ProcessStartTrace`:** SessionStart produced one snapshot; subsequent prompt events and SessionEnd produced zero. Two concurrent sessions in the same cwd created distinct cache files, and ending either session deleted only its own entry.
- **Antigravity authenticated CLI:** Google OAuth token exchange failed before a session or hook could start, so this run does not claim an authenticated CLI-layer result.
- **Antigravity Windows process-chain fallback:** two isolated `agy.exe` parent processes ran the real hook against official-shape payloads. Each first `PreInvocation` produced one real PowerShell snapshot; `PostInvocation` and `Stop` produced zero. Same-cwd conversations produced distinct cache files, all hook exits were status 0, and Stop preserved `{"decision":"allow"}` stdout. This is a process-tree/cache validation, not a substitute for the blocked authenticated CLI smoke.

## Out of scope, tracked

`workbuddy-hook.js` is the only remaining bare `resolve()` consumer. It is the sole contract-test exemption and should move in a small follow-up. This PR intentionally leaves #634 open because WorkBuddy and the remaining authenticated/CLI acceptance work stay outstanding.

## Testing

- `node --test test/hook-pid-cache-contexts.test.js` — **22/22 passed** on the final PR head.
- Merge-state full suite against current `main` — no PR-only failures; the failure set matched clean `main` under the same Windows harness.
- Administrator ETW smoke as documented above.
- Environment: Windows 11 + Windows Terminal as default terminal.

Refs #634

🤖 Generated with [Claude Code](https://claude.com/claude-code)
