### PR TITLE
ci: isolate Wayland smoke scenarios

### DIFF
--- a/.github/workflows/wayland-smoke.yml
+++ b/.github/workflows/wayland-smoke.yml
@@ -1,23 +1,15 @@
-# Headless-Wayland smoke test for the XWayland auto-relaunch (issue #441, PR #443).
+# Packaged Linux smoke tests for the XWayland auto-relaunch (issue #441).
 #
-# We have no Linux/Wayland hardware to verify on — this job stands in: it
-# builds the AppImage from source, boots a REAL Wayland compositor (weston
-# headless) + Xwayland on the runner, and asserts the app relaunches itself
-# onto XWayland and comes up healthy. See ci/wayland-smoke.sh for the exact
-# assertions.
+# Build once, then download the exact same AppImage into fresh runner jobs.
+# Each scenario owns its HOME, Electron userData, D-Bus session, Weston/Xwayland
+# compositor and process namespace. This prevents a failed teardown or stale
+# singleton/runtime file in one scenario from contaminating another.
 #
-# History: the first revision of this job ran the v3 (app.relaunch) build that
-# had been posted to the #441 reporter — run 27110582080 — and caught it red:
-# Electron's relauncher helper runs from the AppImage FUSE mount, which dies
-# with the first process, so the helper never launches the replacement (run
-# 27248005113). The spawn()-based fix this job verifies went green in run
-# 27248372732.
-#
-# Triggers: Electron upgrades are the main regression vector (the Ozone
-# default flipped in Electron 38, which caused #441), hence the
-# package.json/package-lock.json paths. src/main.js hosts the relaunch block
-# but changes in nearly every PR, so it is deliberately NOT a path trigger —
-# use workflow_dispatch after touching that block.
+# Native Wayland remains a packaged contract check, not a full GUI-health
+# assertion: weston --backend=headless has no real input seat or DRM render
+# node, so requiring the complete Electron app and /state server there is
+# host-dependent. Real native-Wayland rendering still needs a VM/hardware field
+# test. The two XWayland scenarios remain full end-to-end health checks.
 name: Wayland smoke (issue 441)
 
 on:
@@ -40,46 +32,119 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  xwayland-relaunch:
+  build-appimage:
+    name: Build AppImage
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 
+      - name: Install dependencies and verify the Ozone resolver
+        run: |
+          npm ci
+          node --test test/linux-ozone.test.js
+
       - name: Build the AppImage from this ref
         run: |
-          npm install
-          node --test test/linux-ozone.test.js
           npm run fetch:sidecars -- --target linux-x64
           node scripts/verify-sidecar-binaries.js prebuild:linux
           npx electron-builder --linux AppImage --publish never
           ls -l dist/*.AppImage
 
-      - name: Install headless Wayland stack
+      - name: Upload AppImage for isolated smoke jobs
+        uses: actions/upload-artifact@v4
+        with:
+          # Preserve the established download name used by issue #441 field
+          # testers and the regular Linux build workflow.
+          name: linux-installer
+          path: dist/*.AppImage
+          if-no-files-found: error
+          retention-days: 3
+
+  xwayland-smoke:
+    name: XWayland / ${{ matrix.scenario }}
+    needs: build-appimage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - manual-x11
+          - auto-xwayland
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - uses: actions/download-artifact@v4
+        with:
+          name: linux-installer
+          path: dist
+
+      - name: Install isolated headless Wayland stack
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            weston xwayland libfuse2t64 x11-utils xdotool
+            dbus-x11 weston xwayland libfuse2t64 x11-utils xdotool
 
       # Ubuntu 24.04 restricts unprivileged user namespaces (AppArmor), which
-      # breaks Chromium's sandbox. Relax the restriction instead of passing
-      # --no-sandbox: the test must run the AppImage exactly as a user does —
-      # no extra argv.
+      # breaks Chromium's sandbox. Keep the real sandboxed AppImage invocation
+      # instead of weakening it with --no-sandbox.
       - name: Allow Chromium userns sandbox
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-      - name: Smoke test
-        run: bash ci/wayland-smoke.sh dist/*.AppImage
+      - name: Run isolated ${{ matrix.scenario }} smoke
+        run: |
+          dbus-run-session -- \
+            bash ci/wayland-smoke.sh "${{ matrix.scenario }}" dist/*.AppImage
 
-      # The smoke-tested binary, ready to hand to Wayland users on #441.
-      # Same artifact name as build.yml so download instructions stay familiar.
-      - name: Upload tested AppImage
+      - name: Upload ${{ matrix.scenario }} diagnostics
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          name: wayland-smoke-${{ matrix.scenario }}-diagnostics
+          path: wayland-smoke-artifacts/${{ matrix.scenario }}/
+          if-no-files-found: warn
+          retention-days: 7
+
+  native-wayland-contract:
+    name: Native Wayland / packaged contract
+    needs: build-appimage
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - uses: actions/download-artifact@v4
+        with:
           name: linux-installer
-          path: dist/*.AppImage
-          if-no-files-found: ignore
+          path: dist
+
+      - name: Install isolated headless Wayland stack
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            dbus-x11 weston xwayland libfuse2t64 x11-utils
+
+      - name: Allow Chromium userns sandbox
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
+
+      - name: Verify the packaged native-Wayland escape hatch
+        run: |
+          dbus-run-session -- \
+            bash ci/wayland-smoke.sh native-wayland-contract dist/*.AppImage
+
+      - name: Upload native-Wayland diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wayland-smoke-native-wayland-diagnostics
+          path: wayland-smoke-artifacts/native-wayland-contract/
+          if-no-files-found: warn
+          retention-days: 7

--- a/ci/wayland-smoke.sh
+++ b/ci/wayland-smoke.sh
@@ -1,83 +1,57 @@
 #!/usr/bin/env bash
-# ci/wayland-smoke.sh — headless-Wayland smoke test for the XWayland
-# auto-relaunch (issue #441 / PR #443).
+# ci/wayland-smoke.sh — one isolated packaged-AppImage scenario per invocation.
 #
-# Proves, on a real Wayland compositor with the shipped AppImage:
-#   A. Manual `--ozone-platform=x11` (the reporter's known-good workaround)
-#      boots, serves /state, puts a window on the X server, and does NOT
-#      trigger the auto-relaunch (argv guard).
-#   B. A plain, no-argument launch on a Wayland session relaunches itself
-#      onto XWayland: relaunch logged exactly once, throwaway first process
-#      exits 0, the relaunched browser process carries --ozone-platform=x11
-#      on its REAL cmdline, /state answers, the window exists on the X
-#      server, and the process set is stable (no relaunch loop).
-#   C. Negative control: CLAWD_OZONE_PLATFORM=wayland boots natively with NO
-#      relaunch and stays alive (the escape hatch works).
+# Usage:
+#   wayland-smoke.sh manual-x11 <AppImage>
+#   wayland-smoke.sh auto-xwayland <AppImage>
+#   wayland-smoke.sh native-wayland-contract <AppImage>
 #
-# What it can NOT prove: behavior on the reporter's exact Fedora/KDE box
-# (KWin vs weston, their session env). That residual still needs a field test.
-#
-# Child-side assertions go through /proc, X, and HTTP rather than logs, so
-# they hold for any relaunch mechanism (v3's app.relaunch silenced the child
-# entirely; v4's spawn inherits stdio — asserted separately). Two extra eyes
-# for debugging: ELECTRON_ENABLE_LOGGING=file (env is inherited, so even a
-# silenced child writes Chromium logs to ELECTRON_LOG_FILE) and a /proc
-# sampler that records every Clawd/relauncher process's appearance and
-# disappearance.
+# manual-x11 and auto-xwayland are full health checks: /state answers and an X
+# client window exists. native-wayland-contract deliberately checks only the
+# escape-hatch contract (no relaunch, no X11 browser, process remains alive).
+# weston --backend=headless has no real input seat or DRM render node, so it is
+# not a deterministic environment for full native-Wayland Electron health.
 
-set -u
+set -euo pipefail
 
-APPIMAGE_ARG="${1:?usage: wayland-smoke.sh <path-to-AppImage>}"
+SCENARIO="${1:?usage: wayland-smoke.sh <manual-x11|auto-xwayland|native-wayland-contract> <AppImage>}"
+APPIMAGE_ARG="${2:?usage: wayland-smoke.sh <manual-x11|auto-xwayland|native-wayland-contract> <AppImage>}"
+case "$SCENARIO" in
+  manual-x11 | auto-xwayland | native-wayland-contract) ;;
+  *) printf 'Unknown scenario: %s\n' "$SCENARIO" >&2; exit 2 ;;
+esac
+
 APPIMAGE="$(readlink -f "$APPIMAGE_ARG")"
-STATE_URL="http://127.0.0.1:23333/state"
 RELAUNCH_MARK="relaunching under XWayland"
 PASS=0
+ORIGINAL_PWD="$PWD"
+ARTIFACT_DIR="$ORIGINAL_PWD/wayland-smoke-artifacts/$SCENARIO"
+mkdir -p "$ARTIFACT_DIR"
+
+ISOLATION_ROOT="$(mktemp -d "/tmp/clawd-wayland-${SCENARIO}.XXXXXX")"
+export HOME="$ISOLATION_ROOT/home"
+export XDG_CONFIG_HOME="$ISOLATION_ROOT/config"
+export XDG_CACHE_HOME="$ISOLATION_ROOT/cache"
+export XDG_DATA_HOME="$ISOLATION_ROOT/data"
+export XDG_RUNTIME_DIR="$ISOLATION_ROOT/runtime"
+USER_DATA_DIR="$ISOLATION_ROOT/user-data"
+RUNTIME_CONFIG="$HOME/.clawd/runtime.json"
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_CACHE_HOME" "$XDG_DATA_HOME" \
+  "$XDG_RUNTIME_DIR" "$USER_DATA_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+WAYLAND_SOCKET="wayland-smoke-${SCENARIO}-$$"
+WESTON_PID=""
+APP_LAUNCH_PID=""
+XDISPLAY=""
 
 note() { printf '\n== %s ==\n' "$*"; }
 ok() { PASS=$((PASS + 1)); printf 'PASS %s: %s\n' "$PASS" "$*"; }
 
-proc_timeline() {
-  # procwatch.raw: "<time> <pid> <cmd...>" — collapse to one line per pid with
-  # first/last sighting so short-lived processes and their lifespan are visible.
-  awk '{
-    key = $2
-    if (!(key in first)) { first[key] = $1; cmd[key] = substr($0, index($0, $3)) }
-    last[key] = $1
-  } END {
-    for (k in first) printf "pid %-7s %s -> %s  %.160s\n", k, first[k], last[k], cmd[k]
-  }' procwatch.raw 2>/dev/null | sort -k3
-}
-
-dump_diagnostics() {
-  note "diagnostics: process timeline (first seen -> last seen)"
-  proc_timeline || true
-  note "diagnostics: manual-x11 log (manual.log)"
-  cat manual.log 2>/dev/null || true
-  note "diagnostics: first-process log (first.log)"
-  cat first.log 2>/dev/null || true
-  note "diagnostics: negative-control log (negative.log)"
-  cat negative.log 2>/dev/null || true
-  note "diagnostics: chromium log of the most recent process (electron-child.log)"
-  tail -n 80 electron-child.log 2>/dev/null || true
-  note "diagnostics: weston log (tail)"
-  tail -n 30 weston.log 2>/dev/null || true
-  note "diagnostics: live processes"
-  ps ax -o pid,ppid,stat,etime,args | grep -iE 'clawd|\.mount_|relauncher' | grep -v grep || true
-  note "diagnostics: port 23333"
-  ss -tlnp 2>/dev/null | grep 23333 || echo "(nothing listening)"
-  note "diagnostics: X clients on ${XDISPLAY:-unset}"
-  [ -n "${XDISPLAY:-}" ] && xlsclients -display "$XDISPLAY" -l 2>/dev/null | head -30 || true
-}
-
-fail() {
-  printf '\nFAIL: %s\n' "$*"
-  dump_diagnostics
-  exit 1
-}
-
-# poll <seconds> <cmd...> — retry cmd (silenced) every 0.5s until the deadline
+# poll <seconds> <cmd...> — retry cmd every 0.5s until the deadline.
 poll() {
-  local deadline=$(($(date +%s) + $1))
+  local deadline
+  deadline=$(($(date +%s) + $1))
   shift
   while true; do
     "$@" >/dev/null 2>&1 && return 0
@@ -86,173 +60,265 @@ poll() {
   done
 }
 
-# Electron BROWSER processes of our AppImage: cmdline runs through the squashfs
-# mountpoint (/tmp/.mount_Clawd*) and has no Chromium --type= child marker.
-# Pass "x11" to keep only those carrying --ozone-platform=x11.
-browser_pids() {
-  local want_flag="${1:-}" d pid cmd
+runtime_port() {
+  node -e '
+    const fs = require("fs");
+    try {
+      const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+      const port = Number(value && value.port);
+      if (value.app !== "clawd-on-desk" || !Number.isInteger(port) || port < 23333 || port > 23337) {
+        process.exit(1);
+      }
+      process.stdout.write(String(port));
+    } catch {
+      process.exit(1);
+    }
+  ' "$RUNTIME_CONFIG"
+}
+
+state_ok() {
+  local port
+  port="$(runtime_port)" || return 1
+  curl -fsS --max-time 2 "http://127.0.0.1:${port}/state" >/dev/null
+}
+
+server_ports_clear() {
+  ! ss -H -ltn 2>/dev/null | grep -Eq ':(23333|23334|23335|23336|23337)[[:space:]]'
+}
+
+# Every AppImage launch carries this unique marker. It survives the automatic
+# XWayland relaunch and appears on browser/renderer command lines, giving this
+# invocation an exact ownership boundary without broad pkill patterns.
+owned_pids() {
+  local d pid cmd
   for d in /proc/[0-9]*; do
+    [ -r "$d/cmdline" ] || continue
     pid="${d#/proc/}"
-    cmd="$(tr '\0' ' ' <"$d/cmdline" 2>/dev/null)" || continue
-    case "$cmd" in *".mount_Clawd"*) ;; *) continue ;; esac
-    case "$cmd" in *"--type="*) continue ;; esac
-    if [ "$want_flag" = "x11" ]; then
-      case "$cmd" in *"--ozone-platform=x11"*) echo "$pid" ;; esac
-    else
-      echo "$pid"
-    fi
+    cmd="$(tr '\0' ' ' 2>/dev/null <"$d/cmdline")" || continue
+    case "$cmd" in
+      *"--user-data-dir=$USER_DATA_DIR"*) printf '%s\n' "$pid" ;;
+    esac
   done
 }
 
+browser_pids() {
+  local want_flag="${1:-}" pid cmd
+  while read -r pid; do
+    [ -n "$pid" ] || continue
+    cmd="$(tr '\0' ' ' 2>/dev/null <"/proc/$pid/cmdline")" || continue
+    case "$cmd" in *"--type="*) continue ;; esac
+    if [ "$want_flag" = "x11" ]; then
+      case "$cmd" in *"--ozone-platform=x11"*) printf '%s\n' "$pid" ;; esac
+    else
+      printf '%s\n' "$pid"
+    fi
+  done < <(owned_pids)
+}
+
+has_browser() { [ -n "$(browser_pids)" ]; }
 has_x11_browser() { [ -n "$(browser_pids x11)" ]; }
 no_x11_browser() { [ -z "$(browser_pids x11)" ]; }
-state_ok() { curl -fsS --max-time 2 "$STATE_URL" >/dev/null; }
-state_gone() { ! curl -fsS --max-time 1 "$STATE_URL" >/dev/null 2>&1; }
+no_owned_processes() { [ -z "$(owned_pids)" ]; }
+
 x_has_clawd() {
   xlsclients -display "$XDISPLAY" -l 2>/dev/null | grep -qi clawd ||
     xwininfo -root -tree -display "$XDISPLAY" 2>/dev/null | grep -qi clawd
 }
 
-kill_app() {
-  local p
-  for p in $(browser_pids); do kill "$p" 2>/dev/null || true; done
-  sleep 1
-  for p in $(browser_pids); do kill -9 "$p" 2>/dev/null || true; done
-  pkill -9 -f '\.mount_Clawd' 2>/dev/null || true
-  poll 15 state_gone || fail "port 23333 still occupied after teardown"
+dump_diagnostics() {
+  note "diagnostics: scenario"
+  printf 'scenario=%s\nisolation_root=%s\nuser_data=%s\nruntime_config=%s\n' \
+    "$SCENARIO" "$ISOLATION_ROOT" "$USER_DATA_DIR" "$RUNTIME_CONFIG"
+  note "diagnostics: app log"
+  cat "$ARTIFACT_DIR/app.log" 2>/dev/null || true
+  note "diagnostics: Chromium log"
+  tail -n 120 "$ARTIFACT_DIR/electron-child.log" 2>/dev/null || true
+  note "diagnostics: Weston log"
+  tail -n 80 "$ARTIFACT_DIR/weston.log" 2>/dev/null || true
+  note "diagnostics: runtime.json"
+  cat "$RUNTIME_CONFIG" 2>/dev/null || true
+  note "diagnostics: owned processes"
+  for pid in $(owned_pids); do
+    ps -o pid,ppid,pgid,sid,stat,etime,args -p "$pid" 2>/dev/null || true
+  done
+  note "diagnostics: Clawd/AppImage processes"
+  ps ax -o pid,ppid,pgid,sid,stat,etime,args |
+    grep -iE 'clawd|\.mount_|AppImage|relauncher' |
+    grep -v grep || true
+  note "diagnostics: server ports"
+  ss -tlnp 2>/dev/null | grep -E ':(23333|23334|23335|23336|23337)[[:space:]]' ||
+    echo "(nothing listening)"
+  note "diagnostics: X clients on ${XDISPLAY:-unset}"
+  [ -n "${XDISPLAY:-}" ] &&
+    xlsclients -display "$XDISPLAY" -l 2>/dev/null | head -30 || true
+}
+
+fail() {
+  printf '\nFAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+kill_owned_processes() {
+  local pid pgid own_pgid
+  local -a pgids=()
+  own_pgid="$(ps -o pgid= -p $$ | tr -d ' ')"
+
+  while read -r pid; do
+    [ -n "$pid" ] || continue
+    pgid="$(ps -o pgid= -p "$pid" 2>/dev/null | tr -d ' ')"
+    [ -n "$pgid" ] || continue
+    [ "$pgid" = "$own_pgid" ] && continue
+    case " ${pgids[*]:-} " in
+      *" $pgid "*) ;;
+      *) pgids+=("$pgid") ;;
+    esac
+  done < <(owned_pids)
+
+  for pgid in "${pgids[@]:-}"; do
+    [ -n "$pgid" ] && kill -TERM -- "-$pgid" 2>/dev/null || true
+  done
+  poll 8 no_owned_processes && return 0
+
+  for pid in $(owned_pids); do
+    kill -KILL "$pid" 2>/dev/null || true
+  done
+  poll 5 no_owned_processes || true
+}
+
+cleanup() {
+  local rc=$?
+  trap - EXIT INT TERM
+  set +e
+  [ "$rc" -eq 0 ] || dump_diagnostics
+  kill_owned_processes
+  if [ -n "$APP_LAUNCH_PID" ]; then
+    wait "$APP_LAUNCH_PID" 2>/dev/null || true
+  fi
+  if [ -n "$WESTON_PID" ]; then
+    kill "$WESTON_PID" 2>/dev/null || true
+    wait "$WESTON_PID" 2>/dev/null || true
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+launch_app() {
+  local log_file="$ARTIFACT_DIR/app.log"
+  : >"$log_file"
+  setsid "$@" "--user-data-dir=$USER_DATA_DIR" >"$log_file" 2>&1 &
+  APP_LAUNCH_PID=$!
 }
 
 chmod +x "$APPIMAGE"
+server_ports_clear || fail "a Clawd state port was occupied before launch"
 
-# ── headless Wayland compositor + Xwayland ──────────────────────────────────
-note "starting weston (headless) + Xwayland"
-XDG_RUNTIME_DIR="$(mktemp -d /tmp/xdg-runtime.XXXXXX)"
-export XDG_RUNTIME_DIR
-chmod 700 "$XDG_RUNTIME_DIR"
-weston --backend=headless --xwayland --socket=wayland-smoke \
-  --width=1280 --height=800 --idle-time=0 >weston.log 2>&1 &
+note "starting isolated weston (headless) + Xwayland"
+weston --backend=headless --xwayland --socket="$WAYLAND_SOCKET" \
+  --width=1280 --height=800 --idle-time=0 >"$ARTIFACT_DIR/weston.log" 2>&1 &
 WESTON_PID=$!
-poll 15 test -e "$XDG_RUNTIME_DIR/wayland-smoke" ||
-  fail "weston wayland socket never appeared"
+poll 15 test -S "$XDG_RUNTIME_DIR/$WAYLAND_SOCKET" ||
+  fail "Weston Wayland socket never appeared"
 
-# weston spawns Xwayland lazily but logs which display it listens on; fall back
-# to probing :0..:5 (a probe connection also forces the lazy spawn).
-XDISPLAY="$(grep -oE 'display :[0-9]+' weston.log | head -1 | grep -oE ':[0-9]+' || true)"
-if [ -z "${XDISPLAY:-}" ]; then
-  for n in 0 1 2 3 4 5 0 1 2 3 4 5; do
-    if env DISPLAY=":$n" timeout 5 xdpyinfo >/dev/null 2>&1; then
+# Weston starts Xwayland lazily. Probe a small display range to trigger it, then
+# read the assigned display from the compositor log.
+for _ in 1 2 3; do
+  XDISPLAY="$(grep -oE 'display :[0-9]+' "$ARTIFACT_DIR/weston.log" |
+    tail -1 | grep -oE ':[0-9]+' || true)"
+  [ -n "$XDISPLAY" ] && break
+  for n in 0 1 2 3 4 5; do
+    if env DISPLAY=":$n" timeout 2 xdpyinfo >/dev/null 2>&1; then
       XDISPLAY=":$n"
-      break
+      break 2
     fi
   done
-fi
-[ -n "${XDISPLAY:-}" ] || fail "could not find the Xwayland display"
-poll 15 env DISPLAY="$XDISPLAY" xdpyinfo || fail "Xwayland on $XDISPLAY not answering"
-echo "weston up (pid $WESTON_PID), Xwayland on $XDISPLAY"
+  sleep 1
+done
+[ -n "$XDISPLAY" ] || fail "could not find the Xwayland display"
+poll 15 env DISPLAY="$XDISPLAY" xdpyinfo ||
+  fail "Xwayland on $XDISPLAY did not answer"
 
-# The reporter's broken scenario: a Wayland session with XWayland available.
-export WAYLAND_DISPLAY=wayland-smoke
+export WAYLAND_DISPLAY="$WAYLAND_SOCKET"
 export XDG_SESSION_TYPE=wayland
 export DISPLAY="$XDISPLAY"
-export LIBGL_ALWAYS_SOFTWARE=1 # headless runner: keep GL in software
-
-# Inherited by every process, including the relauncher's silenced child —
-# Chromium-level errors land in this file even when stdio is /dev/null.
+export LIBGL_ALWAYS_SOFTWARE=1
 export ELECTRON_ENABLE_LOGGING=file
-export ELECTRON_LOG_FILE="$PWD/electron-child.log"
+export ELECTRON_LOG_FILE="$ARTIFACT_DIR/electron-child.log"
+printf 'weston pid=%s, Xwayland display=%s\n' "$WESTON_PID" "$XDISPLAY"
 
-# 10 Hz process sampler: catches even short-lived Clawd/relauncher processes.
-(
-  while :; do
-    t="$(date +%H:%M:%S.%2N)"
-    for d in /proc/[0-9]*; do
-      cmd="$(tr '\0' ' ' <"$d/cmdline" 2>/dev/null)" || continue
-      case "$cmd" in
-      *[Cc]lawd* | *relauncher*) printf '%s %s %s\n' "$t" "${d#/proc/}" "$cmd" ;;
-      esac
-    done
-    sleep 0.1
-  done
-) >procwatch.raw 2>/dev/null &
-PROCWATCH_PID=$!
+case "$SCENARIO" in
+  manual-x11)
+    note "manual --ozone-platform=x11"
+    launch_app "$APPIMAGE" --ozone-platform=x11
+    poll 90 state_ok || fail "manual X11: state server from runtime.json never answered"
+    kill -0 "$APP_LAUNCH_PID" 2>/dev/null || fail "manual X11: launch process died"
+    poll 60 has_x11_browser || fail "manual X11: no browser with --ozone-platform=x11"
+    poll 60 x_has_clawd || fail "manual X11: no Clawd client/window on the X server"
+    grep -q "$RELAUNCH_MARK" "$ARTIFACT_DIR/app.log" &&
+      fail "manual X11 triggered the automatic relaunch"
+    ok "manual X11 boots healthy with an X client window and no relaunch"
+    ;;
 
-# ── phase A: manual --ozone-platform=x11 (reporter's known-good workaround) ──
-note "phase A: manual --ozone-platform=x11"
-"$APPIMAGE" --ozone-platform=x11 >manual.log 2>&1 &
-MANUAL_PID=$!
+  auto-xwayland)
+    note "plain launch must relaunch onto XWayland"
+    launch_app "$APPIMAGE"
+    poll 30 grep -q "$RELAUNCH_MARK" "$ARTIFACT_DIR/app.log" ||
+      fail "initial process never logged the XWayland relaunch"
+    ok "initial process planned and logged the XWayland relaunch"
 
-poll 90 state_ok || fail "manual x11: state server $STATE_URL never answered"
-kill -0 "$MANUAL_PID" 2>/dev/null || fail "manual x11: process died"
-poll 60 x_has_clawd || fail "manual x11: no Clawd client/window on the X server"
-if grep -q "$RELAUNCH_MARK" manual.log; then
-  fail "manual x11 triggered the auto-relaunch (argv guard broken)"
-fi
-ok "manual --ozone-platform=x11 boots, healthy, window on X, no relaunch"
+    poll 30 sh -c "! kill -0 $APP_LAUNCH_PID 2>/dev/null" ||
+      fail "throwaway process was still alive after 30 seconds"
+    if wait "$APP_LAUNCH_PID"; then
+      first_rc=0
+    else
+      first_rc=$?
+    fi
+    APP_LAUNCH_PID=""
+    [ "$first_rc" -eq 0 ] || fail "throwaway process exited rc=$first_rc instead of 0"
+    ok "throwaway process exited 0"
 
-note "phase A done — tearing down"
-kill_app
+    poll 45 has_x11_browser ||
+      fail "no replacement browser carried --ozone-platform=x11"
+    first_x11_pids="$(browser_pids x11 | sort | tr '\n' ' ')"
+    ok "replacement browser runs with --ozone-platform=x11 (pid(s): $first_x11_pids)"
 
-# ── phase B: plain launch must relaunch onto XWayland ───────────────────────
-note "phase B: launching AppImage with NO arguments (reporter's scenario)"
-"$APPIMAGE" >first.log 2>&1 &
-LAUNCH_PID=$!
+    poll 90 state_ok || fail "replacement state server from runtime.json never answered"
+    ok "replacement GET /state answers"
+    poll 30 grep -q "state server listening" "$ARTIFACT_DIR/app.log" ||
+      fail "replacement logs did not flow back to the launching terminal"
+    ok "replacement logs are inherited"
+    poll 60 x_has_clawd ||
+      fail "replacement has no Clawd client/window on the X server"
+    ok "replacement window is an XWayland client"
 
-poll 30 grep -q "$RELAUNCH_MARK" first.log ||
-  fail "first process never logged the XWayland relaunch line"
-ok "first process planned + logged the relaunch"
+    sleep 5
+    later_x11_pids="$(browser_pids x11 | sort | tr '\n' ' ')"
+    [ "$first_x11_pids" = "$later_x11_pids" ] ||
+      fail "browser pid set changed ('$first_x11_pids' -> '$later_x11_pids')"
+    relaunch_lines="$(grep -c "$RELAUNCH_MARK" "$ARTIFACT_DIR/app.log")"
+    [ "$relaunch_lines" -eq 1 ] ||
+      fail "expected exactly one relaunch log line, got $relaunch_lines"
+    ok "exactly one relaunch and a stable browser pid set"
+    ;;
 
-poll 30 sh -c "! kill -0 $LAUNCH_PID 2>/dev/null" ||
-  fail "throwaway first process still alive after 30s"
-wait "$LAUNCH_PID"
-FIRST_RC=$?
-[ "$FIRST_RC" -eq 0 ] || fail "first process exited rc=$FIRST_RC (expected 0)"
-ok "throwaway first process exited 0"
+  native-wayland-contract)
+    note "CLAWD_OZONE_PLATFORM=wayland packaged escape-hatch contract"
+    export CLAWD_OZONE_PLATFORM=wayland
+    launch_app "$APPIMAGE"
+    poll 15 has_browser || fail "native Wayland browser process never appeared"
+    sleep 15
+    kill -0 "$APP_LAUNCH_PID" 2>/dev/null ||
+      fail "native Wayland launch process did not remain alive for the contract window"
+    has_browser ||
+      fail "native Wayland browser did not remain alive for the contract window"
+    grep -q "$RELAUNCH_MARK" "$ARTIFACT_DIR/app.log" &&
+      fail "native Wayland override triggered the XWayland relaunch"
+    no_x11_browser ||
+      fail "native Wayland override produced a browser with --ozone-platform=x11"
+    ok "packaged native-Wayland override stays alive without relaunching to X11"
+    ;;
+esac
 
-poll 45 has_x11_browser ||
-  fail "no relaunched browser process with --ozone-platform=x11 on its cmdline"
-X11_PIDS="$(browser_pids x11 | sort | tr '\n' ' ')"
-ok "relaunched browser process up with --ozone-platform=x11 (pid(s): $X11_PIDS)"
-
-poll 90 state_ok || fail "state server $STATE_URL never answered after relaunch"
-ok "GET /state answers — relaunched app is healthy"
-
-# v4 spawns with stdio "inherit", so unlike app.relaunch (which piped the
-# child to /dev/null) the replacement's logs must reach the original terminal.
-poll 30 grep -q "state server listening" first.log ||
-  fail "child logs missing from the launching terminal (stdio inherit broken?)"
-ok "child logs flow back to the launching terminal (stdio inherit)"
-
-poll 60 x_has_clawd ||
-  fail "no Clawd client/window on the X server — not running as an XWayland client?"
-ok "app window present on the X server => really an XWayland client"
-
-sleep 5
-X11_PIDS_LATER="$(browser_pids x11 | sort | tr '\n' ' ')"
-[ "$X11_PIDS" = "$X11_PIDS_LATER" ] ||
-  fail "browser pid set changed ('$X11_PIDS' -> '$X11_PIDS_LATER') — relaunch loop?"
-RELAUNCH_LINES="$(grep -c "$RELAUNCH_MARK" first.log)"
-[ "$RELAUNCH_LINES" -eq 1 ] ||
-  fail "expected exactly 1 relaunch log line, got $RELAUNCH_LINES"
-ok "stable: exactly one relaunch, pid set unchanged after 5s"
-
-note "phase B done — tearing down"
-kill_app
-
-# ── phase C: explicit native Wayland must NOT relaunch ──────────────────────
-note "phase C: launching with CLAWD_OZONE_PLATFORM=wayland (escape hatch)"
-CLAWD_OZONE_PLATFORM=wayland "$APPIMAGE" >negative.log 2>&1 &
-NEG_PID=$!
-
-poll 90 state_ok || fail "negative control: state server never answered under native Wayland"
-kill -0 "$NEG_PID" 2>/dev/null || fail "negative control: process died"
-if grep -q "$RELAUNCH_MARK" negative.log; then
-  fail "negative control relaunched despite CLAWD_OZONE_PLATFORM=wayland"
-fi
-no_x11_browser || fail "negative control: found a browser process with --ozone-platform=x11"
-ok "escape hatch works: native Wayland boot, no relaunch, app healthy"
-
-kill_app
-kill "$PROCWATCH_PID" 2>/dev/null || true
-kill "$WESTON_PID" 2>/dev/null || true
-
+kill_owned_processes
+poll 15 server_ports_clear || fail "Clawd state port remained occupied after teardown"
 note "ALL $PASS CHECKS PASSED"


### PR DESCRIPTION
## Summary

- build the AppImage once, then run `manual-x11`, `auto-xwayland`, and `native-wayland-contract` in separate fresh GitHub-hosted runners
- isolate HOME, XDG directories, Electron userData, D-Bus, Weston/Xwayland, runtime.json, ports, and process ownership per scenario
- discover the state server from the isolated runtime.json instead of assuming port 23333
- replace broad process scanning/`pkill` teardown with a unique userData marker and process-group cleanup
- keep full `/state` + X client health checks for X11/XWayland; scope headless native Wayland to the packaged escape-hatch contract because Weston headless has no real seat/DRM node
- upload scenario-specific diagnostics while preserving the established `linux-installer` artifact name

## Why

The previous job ran all three phases in one compositor/process environment and required full native-Wayland health from a headless Weston backend. Recent reruns failed at different phases despite identical app/server code. This separates scenario state and makes each assertion match what the runner can deterministically prove.

## Validation

- `bash -n ci/wayland-smoke.sh`
- workflow YAML parsed and matrix structure checked
- `node --test test/linux-ozone.test.js` — 35 pass, 0 fail
- `npm test` — 5985 tests, 5965 pass, 0 fail, 20 skipped
- `git diff --check`

## Residual

A full native-Wayland GUI health test still requires a VM or hardware runner with a real/virtual input seat and DRM render node. This PR deliberately does not pretend Weston headless can provide that evidence.

Closes no issue; hardens the CI coverage for #441.
## Hosted-runner proof

Workflow run [30016305789](https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/30016305789) completed successfully twice (initial run + full rerun). Both attempts passed all four jobs: AppImage build, manual X11 health, automatic XWayland relaunch health, and the packaged native-Wayland contract.