### PR TITLE
fix: prevent settings language menu clipping

### DIFF
--- a/src/settings.css
+++ b/src/settings.css
@@ -219,6 +219,10 @@ html, body {
 .section {
   margin-bottom: 28px;
 }
+.section:has(.language-picker.open) {
+  position: relative;
+  z-index: 1;
+}
 .section-title {
   font-size: 11px;
   font-weight: 700;
@@ -253,6 +257,9 @@ html, body {
   border-radius: 10px;
   border: 1px solid var(--border);
   overflow: hidden;
+}
+.section-rows:has(.language-picker.open) {
+  overflow: visible;
 }
 @media (prefers-color-scheme: dark) {
   .section-rows { background: #1a1a1d; }

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -3600,6 +3600,21 @@ describe("settings renderer browser environment", () => {
     assert.ok(!css.includes(".language-segmented"));
   });
 
+  it("lets the open language picker escape its section without changing closed-card clipping", () => {
+    const css = fs.readFileSync(SETTINGS_CSS, "utf8");
+    const sectionRowsRule = css.match(/\.section-rows\s*\{([^}]*)\}/);
+    const openSectionRule = css.match(/\.section:has\(\.language-picker\.open\)\s*\{([^}]*)\}/);
+    const openRowsRule = css.match(/\.section-rows:has\(\.language-picker\.open\)\s*\{([^}]*)\}/);
+
+    assert.ok(sectionRowsRule, "settings cards should retain their base clipping rule");
+    assert.match(sectionRowsRule[1], /overflow:\s*hidden;/);
+    assert.ok(openSectionRule, "the section containing an open language picker should be raised");
+    assert.match(openSectionRule[1], /position:\s*relative;/);
+    assert.match(openSectionRule[1], /z-index:\s*1;/);
+    assert.ok(openRowsRule, "the open language picker should escape the settings card");
+    assert.match(openRowsRule[1], /overflow:\s*visible;/);
+  });
+
   it("populates the language picker with current selection and propagates click changes", () => {
     const harness = loadGeneralLanguageRowForTest({
       snapshot: { lang: "en" },


### PR DESCRIPTION
## Summary

- Prevent the Settings language dropdown from being clipped by the Appearance card.
- Temporarily expose overflow and raise the containing section only while the language picker is open.
- Preserve the existing card layout, closed-state clipping, language persistence, and picker interactions.

## Problem context

The language menu is absolutely positioned below its trigger, but the shared `.section-rows` container uses `overflow: hidden` to preserve rounded Settings cards. Because Language is the first row in Appearance, the five-option menu extended across the Size and Text Size rows and was clipped at the card boundary.

## What changed

- Add an open-state rule that gives the section containing `.language-picker.open` a positioned stacking context.
- Change the containing `.section-rows` overflow to `visible` only while that picker is open.
- Add a regression test that verifies closed cards retain `overflow: hidden`, while an open picker receives visible overflow and the expected section stacking level.

## Behavior after this PR

- Opening the Settings language picker renders all five language options above the following Appearance rows.
- The menu remains a floating overlay and does not increase the card height or move the Size and Text Size controls.
- Closing the picker restores the existing clipping, border, and rounded-corner behavior automatically.
- Mouse, keyboard, Escape, outside-click, language update, and persistence behavior remain unchanged.

## Validation

- `node --test test/settings-renderer-browser-env.test.js` (174 passed)
- `git diff --check`
- Manual Windows verification confirmed that all five options render without clipping and the menu overlays the following rows without shifting layout.
- `npm test` was also run: 6,071 passed and 13 failed. Running the same command on the latest `origin/main` produced the same 13 failures, with 6,070 passed; the additional regression test in this branch passes.
- The baseline failures are confined to `test/remote-deploy.test.js`, `test/remote-ssh-deploy.test.js`, `test/remote-ssh-identity.test.js`, `test/remote-ssh-path-isolation.test.js`, and `test/server-config.test.js`. They involve Windows CRLF-sensitive shell assertions, POSIX remote-home validation, and existing secure-diagnostic size expectations, outside the CSS and Settings renderer files changed here.

## Platform note

- Automated verification ran on Windows in PowerShell.
- Manual Windows QA covered the reported Appearance-card clipping behavior.

## Scope control

- This PR only addresses clipping of the Settings language picker.
- Tutorial picker reuse, tutorial agent icons, and confirmation-window changes remain isolated for separate branches and PRs.
