### PR TITLE
fix: show consistent agent icons in tutorial

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -143,6 +143,7 @@ const { focusCodexThreadTarget } = require("./session-focus-handoff");
 const { isSessionInProgress } = require("./state-session-snapshot");
 const { restoreSessionsFromRecoveryLeases } = require("./session-recovery-loader");
 const { getAllAgents, getAgent } = require("../agents/registry");
+const { getAgentIconUrl } = require("./state-agent-icons");
 // ── Autoplay policy: allow sound playback without user gesture ──
 // MUST be set before any BrowserWindow is created (before app.whenReady)
 app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
@@ -1913,6 +1914,7 @@ function buildTutorialAgentOnboardingState() {
     detectionAgents: detection.agents,
     agentsPref: _settingsController.get("agents") || {},
     installableIds: INSTALLABLE_AGENT_IDS,
+    getAgentIconUrl,
   });
 }
 

--- a/src/tutorial-agent-buckets.js
+++ b/src/tutorial-agent-buckets.js
@@ -13,7 +13,24 @@
 // Low-confidence detections are intentionally NOT offered for install — a bare
 // parent directory isn't a strong enough signal to recommend writing a hook.
 // Kept side-effect-free so it can be unit-tested without Electron or the fs.
-function bucketAgentsForTutorial({ detectionAgents, agentsPref, installableIds } = {}) {
+// The icon resolver is injected by the main process so this module does not
+// need to know how bundled assets are located.
+function resolveIconUrl(iconUrlFor, agentId) {
+  if (typeof iconUrlFor !== "function") return null;
+  try {
+    const value = iconUrlFor(agentId);
+    return typeof value === "string" && value.length ? value : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function bucketAgentsForTutorial({
+  detectionAgents,
+  agentsPref,
+  installableIds,
+  getAgentIconUrl: iconUrlFor,
+} = {}) {
   const byId = new Map();
   for (const entry of detectionAgents || []) {
     if (entry && typeof entry.agentId === "string") byId.set(entry.agentId, entry);
@@ -22,7 +39,11 @@ function bucketAgentsForTutorial({ detectionAgents, agentsPref, installableIds }
   const buckets = { install: [], cleanup: [], active: [] };
   for (const agentId of installableIds || []) {
     const entry = byId.get(agentId);
-    const item = { agentId, label: (entry && entry.agentName) || agentId };
+    const item = {
+      agentId,
+      label: (entry && entry.agentName) || agentId,
+      iconUrl: resolveIconUrl(iconUrlFor, agentId),
+    };
     const integrationInstalled = !!(prefs[agentId] && prefs[agentId].integrationInstalled);
     const detected = !!(entry && entry.detectedInstalled);
     const confidence = entry && entry.confidence;

--- a/src/tutorial-renderer.js
+++ b/src/tutorial-renderer.js
@@ -220,13 +220,6 @@
     }, label);
   }
 
-  function initials(name) {
-    const parts = String(name || "").trim().split(/\s+/).filter(Boolean);
-    if (!parts.length) return "?";
-    if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
-    return (parts[0][0] + parts[1][0]).toUpperCase();
-  }
-
   function statusBadge(kind) {
     if (kind === "active") return el("span", { class: "ag-tag ok" }, i18n("tutorialAgentsActiveTag", "On"));
     if (kind === "install") return el("span", { class: "ag-tag info" }, i18n("tutorialAgentsInstallTag", "Found"));
@@ -240,7 +233,34 @@
   }
 
   function agentAvatar(a, kind) {
-    return el("span", { class: "ag-avatar " + kind }, initials(agentLabel(a)));
+    const avatar = el("span", { class: "ag-avatar " + kind });
+    const iconUrl = a && typeof a.iconUrl === "string" ? a.iconUrl : "";
+    const fallbackUrl = typeof STATE.heroSrc === "string" ? STATE.heroSrc : "";
+    let showingFallback = !iconUrl;
+    const initialUrl = iconUrl || fallbackUrl;
+
+    if (!initialUrl) {
+      avatar.classList.add("fallback");
+      return avatar;
+    }
+
+    const image = el("img", {
+      class: "ag-avatar-icon",
+      src: initialUrl,
+      alt: "",
+      draggable: "false",
+    });
+    image.addEventListener("error", () => {
+      if (!showingFallback && fallbackUrl && fallbackUrl !== iconUrl) {
+        showingFallback = true;
+        image.setAttribute("src", fallbackUrl);
+        return;
+      }
+      image.setAttribute("hidden", "");
+      avatar.classList.add("fallback");
+    });
+    avatar.appendChild(image);
+    return avatar;
   }
 
   function selectableAgentRow(a, kind) {

--- a/src/tutorial.html
+++ b/src/tutorial.html
@@ -250,12 +250,26 @@ body { user-select: none; }
   justify-content: center;
   width: 30px;
   height: 30px;
+  overflow: hidden;
   border-radius: 8px;
   background: var(--surface-alt);
-  color: var(--muted);
-  font-size: 10px;
-  font-weight: 800;
-  letter-spacing: 0;
+}
+.ag-avatar-icon {
+  display: block;
+  flex: 0 0 24px;
+  width: 24px;
+  height: 24px;
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+.ag-avatar.fallback::after {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border: 2px solid currentColor;
+  border-radius: 4px 4px 7px 7px;
+  opacity: 0.72;
 }
 .ag-avatar.install { background: rgba(217, 119, 87, 0.13); color: var(--accent); }
 .ag-avatar.cleanup { background: var(--warn-bg); color: var(--warn); }

--- a/src/tutorial.html
+++ b/src/tutorial.html
@@ -248,19 +248,20 @@ body { user-select: none; }
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex: 0 0 30px;
   width: 30px;
   height: 30px;
+  padding: 2px;
   overflow: hidden;
   border-radius: 8px;
   background: var(--surface-alt);
 }
 .ag-avatar-icon {
   display: block;
-  flex: 0 0 24px;
-  width: 24px;
-  height: 24px;
-  max-width: 100%;
-  max-height: 100%;
+  width: 100%;
+  height: 100%;
+  border-radius: 6px;
+  background: var(--surface);
   object-fit: contain;
 }
 .ag-avatar.fallback::after {

--- a/test/state-agent-icons.test.js
+++ b/test/state-agent-icons.test.js
@@ -8,6 +8,7 @@ const path = require("path");
 const { fileURLToPath } = require("url");
 
 const { getAllAgents } = require("../agents/registry");
+const { INSTALLABLE_AGENT_IDS } = require("../src/settings-actions-agents");
 const {
   getElectronBinary,
   hashSvgSource,
@@ -98,6 +99,17 @@ describe("state agent icons", () => {
       assert.ok(
         runtimeIconFiles.has(`${agent.id}.png`),
         `Missing exact runtime PNG icon for ${agent.id}`
+      );
+    }
+  });
+
+  it("resolves an icon URL for every installable tutorial agent", () => {
+    for (const agentId of INSTALLABLE_AGENT_IDS) {
+      const iconUrl = getAgentIconUrl(agentId);
+      assert.ok(iconUrl, `Missing tutorial icon URL for ${agentId}`);
+      assert.strictEqual(
+        path.normalize(fileURLToPath(iconUrl)),
+        path.join(AGENT_ICON_DIR, `${agentId}.png`),
       );
     }
   });

--- a/test/tutorial-agent-buckets.test.js
+++ b/test/tutorial-agent-buckets.test.js
@@ -33,9 +33,9 @@ describe("bucketAgentsForTutorial", () => {
       },
     });
 
-    assert.deepStrictEqual(result.active, [{ agentId: "claude-code", label: "Claude Code" }]);
-    assert.deepStrictEqual(result.cleanup, [{ agentId: "codex", label: "Codex" }]);
-    assert.deepStrictEqual(result.install, [{ agentId: "gemini-cli", label: "Gemini CLI" }]);
+    assert.deepStrictEqual(result.active, [{ agentId: "claude-code", label: "Claude Code", iconUrl: null }]);
+    assert.deepStrictEqual(result.cleanup, [{ agentId: "codex", label: "Codex", iconUrl: null }]);
+    assert.deepStrictEqual(result.install, [{ agentId: "gemini-cli", label: "Gemini CLI", iconUrl: null }]);
   });
 
   it("offers medium-confidence detections for install but never low", () => {
@@ -58,7 +58,7 @@ describe("bucketAgentsForTutorial", () => {
       detectionAgents: [detect("pi", undefined, true, "high")],
       agentsPref: {},
     });
-    assert.deepStrictEqual(result.install, [{ agentId: "pi", label: "pi" }]);
+    assert.deepStrictEqual(result.install, [{ agentId: "pi", label: "pi", iconUrl: null }]);
   });
 
   it("treats an installable agent with no detector entry as not detected", () => {
@@ -69,7 +69,7 @@ describe("bucketAgentsForTutorial", () => {
       detectionAgents: [],
       agentsPref: { codex: { integrationInstalled: true } },
     });
-    assert.deepStrictEqual(result.cleanup, [{ agentId: "codex", label: "codex" }]);
+    assert.deepStrictEqual(result.cleanup, [{ agentId: "codex", label: "codex", iconUrl: null }]);
     assert.strictEqual(result.install.length, 0);
     assert.strictEqual(result.active.length, 0);
   });
@@ -83,5 +83,36 @@ describe("bucketAgentsForTutorial", () => {
       bucketAgentsForTutorial({ installableIds: ["codex"], detectionAgents: null, agentsPref: null }),
       { install: [], cleanup: [], active: [] },
     );
+  });
+
+  it("attaches the resolved icon URL to every bucket", () => {
+    const result = bucketAgentsForTutorial({
+      installableIds: ["codex"],
+      detectionAgents: [detect("codex", "Codex", true, "high")],
+      agentsPref: {},
+      getAgentIconUrl: (agentId) => `file:///icons/${agentId}.png`,
+    });
+
+    assert.deepStrictEqual(result.install, [{
+      agentId: "codex",
+      label: "Codex",
+      iconUrl: "file:///icons/codex.png",
+    }]);
+  });
+
+  it("fails closed when icon resolution throws or returns a non-string", () => {
+    const throwing = bucketAgentsForTutorial({
+      installableIds: ["codex"],
+      detectionAgents: [detect("codex", "Codex", true, "high")],
+      getAgentIconUrl: () => { throw new Error("icon lookup failed"); },
+    });
+    const invalid = bucketAgentsForTutorial({
+      installableIds: ["gemini-cli"],
+      detectionAgents: [detect("gemini-cli", "Gemini CLI", true, "high")],
+      getAgentIconUrl: () => 42,
+    });
+
+    assert.strictEqual(throwing.install[0].iconUrl, null);
+    assert.strictEqual(invalid.install[0].iconUrl, null);
   });
 });

--- a/test/tutorial-renderer-agent-icons.test.js
+++ b/test/tutorial-renderer-agent-icons.test.js
@@ -1,0 +1,245 @@
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const { describe, it } = require("node:test");
+
+const RENDERER_SOURCE = fs.readFileSync(
+  path.join(__dirname, "..", "src", "tutorial-renderer.js"),
+  "utf8",
+);
+
+class FakeClassList {
+  constructor(owner) {
+    this.owner = owner;
+  }
+
+  values() {
+    return new Set(String(this.owner.className || "").split(/\s+/).filter(Boolean));
+  }
+
+  write(values) {
+    this.owner.className = Array.from(values).join(" ");
+  }
+
+  add(...names) {
+    const values = this.values();
+    for (const name of names) values.add(name);
+    this.write(values);
+  }
+
+  remove(...names) {
+    const values = this.values();
+    for (const name of names) values.delete(name);
+    this.write(values);
+  }
+
+  toggle(name, force) {
+    const values = this.values();
+    const next = force == null ? !values.has(name) : !!force;
+    if (next) values.add(name);
+    else values.delete(name);
+    this.write(values);
+    return next;
+  }
+
+  contains(name) {
+    return this.values().has(name);
+  }
+}
+
+class FakeTextNode {
+  constructor(value) {
+    this.textContent = String(value == null ? "" : value);
+    this.parentNode = null;
+  }
+}
+
+class FakeElement {
+  constructor(tagName) {
+    this.tagName = String(tagName || "div").toUpperCase();
+    this.children = [];
+    this.parentNode = null;
+    this.attributes = {};
+    this.eventListeners = new Map();
+    this.style = {};
+    this._className = "";
+    this._textContent = "";
+    this._innerHTML = "";
+    this.classList = new FakeClassList(this);
+  }
+
+  get className() {
+    return this._className;
+  }
+
+  set className(value) {
+    this._className = String(value == null ? "" : value);
+  }
+
+  get textContent() {
+    return this._textContent + this.children.map((child) => child.textContent || "").join("");
+  }
+
+  set textContent(value) {
+    this._textContent = String(value == null ? "" : value);
+    this.children = [];
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = String(value == null ? "" : value);
+    this.children = [];
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    this.children.push(child);
+    return child;
+  }
+
+  setAttribute(name, value) {
+    const stringValue = String(value == null ? "" : value);
+    this.attributes[name] = stringValue;
+    if (name === "class") this.className = stringValue;
+    if (name === "src") this.src = stringValue;
+  }
+
+  getAttribute(name) {
+    return Object.prototype.hasOwnProperty.call(this.attributes, name)
+      ? this.attributes[name]
+      : null;
+  }
+
+  addEventListener(type, callback) {
+    const listeners = this.eventListeners.get(type) || [];
+    listeners.push(callback);
+    this.eventListeners.set(type, listeners);
+  }
+
+  dispatchEvent(event = {}) {
+    const payload = { ...event, target: event.target || this };
+    for (const callback of this.eventListeners.get(payload.type) || []) callback(payload);
+  }
+}
+
+function findAll(node, predicate, output = []) {
+  if (predicate(node)) output.push(node);
+  for (const child of node.children || []) findAll(child, predicate, output);
+  return output;
+}
+
+function createHarness(state) {
+  const roots = new Map([
+    ["steps", new FakeElement("div")],
+    ["body", new FakeElement("main")],
+    ["footer", new FakeElement("footer")],
+  ]);
+  const documentListeners = new Map();
+  const stateListeners = new Set();
+  const document = {
+    createElement: (tagName) => new FakeElement(tagName),
+    createTextNode: (value) => new FakeTextNode(value),
+    getElementById: (id) => roots.get(id) || null,
+    addEventListener: (type, callback) => {
+      const listeners = documentListeners.get(type) || [];
+      listeners.push(callback);
+      documentListeners.set(type, listeners);
+    },
+  };
+  const api = {
+    getState: () => Promise.resolve(state),
+    onState: (callback) => {
+      stateListeners.add(callback);
+      return () => stateListeners.delete(callback);
+    },
+  };
+  const context = {
+    console,
+    document,
+    Promise,
+    setTimeout,
+    clearTimeout,
+    tutorialAPI: api,
+    addEventListener: () => {},
+  };
+  context.window = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(RENDERER_SOURCE, context);
+
+  return {
+    body: roots.get("body"),
+    footer: roots.get("footer"),
+    renderAgents: () => {
+      const primary = findAll(roots.get("footer"), (node) =>
+        node.classList && node.classList.contains("btn-primary"))[0];
+      assert.ok(primary, "tutorial primary button should be rendered");
+      primary.dispatchEvent({ type: "click" });
+    },
+    getStateListeners: () => stateListeners,
+  };
+}
+
+async function loadAgentsState(agents) {
+  const harness = createHarness({
+    i18n: {},
+    lang: "en",
+    langs: ["en"],
+    heroSrc: "file:///clawd.png",
+    doneHeroSvg: "",
+    platform: "win32",
+    shortcuts: [],
+    agents,
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  harness.renderAgents();
+  return harness;
+}
+
+describe("tutorial agent icon renderer", () => {
+  it("renders official icons for active, install, and cleanup rows without initials", async () => {
+    const harness = await loadAgentsState({
+      active: [{ agentId: "claude-code", label: "Claude Code", iconUrl: "file:///claude.png" }],
+      install: [{ agentId: "codex", label: "Codex", iconUrl: "file:///codex.png" }],
+      cleanup: [{ agentId: "gemini-cli", label: "Gemini CLI", iconUrl: "file:///gemini.png" }],
+    });
+    const avatars = findAll(harness.body, (node) =>
+      node.classList && node.classList.contains("ag-avatar"));
+    assert.strictEqual(avatars.length, 3);
+    assert.deepStrictEqual(
+      avatars.map((avatar) => findAll(avatar, (node) => node.tagName === "IMG")[0].src),
+      ["file:///codex.png", "file:///gemini.png", "file:///claude.png"],
+    );
+    assert.deepStrictEqual(avatars.map((avatar) => avatar.textContent), ["", "", ""]);
+  });
+
+  it("uses the Clawd icon for missing assets and handles a failed fallback without letters", async () => {
+    const harness = await loadAgentsState({
+      active: [{ agentId: "missing", label: "Missing", iconUrl: null }],
+      install: [],
+      cleanup: [{ agentId: "broken", label: "Broken", iconUrl: "file:///broken.png" }],
+    });
+    const avatars = findAll(harness.body, (node) =>
+      node.classList && node.classList.contains("ag-avatar"));
+    const missingAvatar = avatars.find((avatar) =>
+      findAll(avatar, (node) => node.tagName === "IMG")[0].src === "file:///clawd.png");
+    const brokenAvatar = avatars.find((avatar) =>
+      findAll(avatar, (node) => node.tagName === "IMG")[0].src === "file:///broken.png");
+    const missingImage = findAll(missingAvatar, (node) => node.tagName === "IMG")[0];
+    const brokenImage = findAll(brokenAvatar, (node) => node.tagName === "IMG")[0];
+
+    assert.strictEqual(missingImage.src, "file:///clawd.png");
+    brokenImage.dispatchEvent({ type: "error" });
+    assert.strictEqual(brokenImage.src, "file:///clawd.png");
+    brokenImage.dispatchEvent({ type: "error" });
+    assert.strictEqual(brokenImage.getAttribute("hidden"), "");
+    assert.ok(brokenAvatar.classList.contains("fallback"));
+    assert.strictEqual(brokenAvatar.textContent, "");
+  });
+});

--- a/test/tutorial-renderer-agent-icons.test.js
+++ b/test/tutorial-renderer-agent-icons.test.js
@@ -10,6 +10,10 @@ const RENDERER_SOURCE = fs.readFileSync(
   path.join(__dirname, "..", "src", "tutorial-renderer.js"),
   "utf8",
 );
+const TUTORIAL_HTML = fs.readFileSync(
+  path.join(__dirname, "..", "src", "tutorial.html"),
+  "utf8",
+);
 
 class FakeClassList {
   constructor(owner) {
@@ -203,6 +207,17 @@ async function loadAgentsState(agents) {
 }
 
 describe("tutorial agent icon renderer", () => {
+  it("uses a stable rounded frame for every agent icon", () => {
+    assert.match(
+      TUTORIAL_HTML,
+      /\.ag-avatar\s*\{[\s\S]*?flex:\s*0 0 30px;[\s\S]*?width:\s*30px;[\s\S]*?height:\s*30px;[\s\S]*?padding:\s*2px;[\s\S]*?border-radius:\s*8px;/,
+    );
+    assert.match(
+      TUTORIAL_HTML,
+      /\.ag-avatar-icon\s*\{[\s\S]*?width:\s*100%;[\s\S]*?height:\s*100%;[\s\S]*?border-radius:\s*6px;[\s\S]*?background:\s*var\(--surface\);/,
+    );
+  });
+
   it("renders official icons for active, install, and cleanup rows without initials", async () => {
     const harness = await loadAgentsState({
       active: [{ agentId: "claude-code", label: "Claude Code", iconUrl: "file:///claude.png" }],

--- a/test/tutorial.test.js
+++ b/test/tutorial.test.js
@@ -108,7 +108,7 @@ function createHarness(ctxOverrides = {}) {
     getDoneHeroSvg: () => "<svg id=\"done-hero\"></svg>",
     setLang: (lang) => { calls.setLang.push(lang); },
     getShortcutsSummary: () => [{ id: "permissionAllow", label: "Allow", accelerator: "CommandOrControl+Shift+Y" }],
-    getAgentOnboardingState: () => ({ install: [{ agentId: "gemini-cli", label: "Gemini CLI" }], cleanup: [], active: [] }),
+    getAgentOnboardingState: () => ({ install: [{ agentId: "gemini-cli", label: "Gemini CLI", iconUrl: "file:///icons/gemini-cli.png" }], cleanup: [], active: [] }),
     installAgent: (agentId) => { calls.installAgent.push(agentId); return Promise.resolve({ status: "ok" }); },
     uninstallAgent: (agentId) => { calls.uninstallAgent.push(agentId); return Promise.resolve({ status: "ok" }); },
     registerShortcut: (payload) => { calls.registerShortcut.push(payload); return Promise.resolve({ status: "ok" }); },
@@ -178,7 +178,11 @@ describe("tutorial window shell", () => {
     assert.deepStrictEqual(stateSend.payload.langs, ["en", "zh", "ja"]);
     assert.strictEqual(stateSend.payload.heroSrc, "data:image/png;base64,hero");
     assert.strictEqual(stateSend.payload.doneHeroSvg, "<svg id=\"done-hero\"></svg>");
-    assert.deepStrictEqual(stateSend.payload.agents.install, [{ agentId: "gemini-cli", label: "Gemini CLI" }]);
+    assert.deepStrictEqual(stateSend.payload.agents.install, [{
+      agentId: "gemini-cli",
+      label: "Gemini CLI",
+      iconUrl: "file:///icons/gemini-cli.png",
+    }]);
     assert.strictEqual(stateSend.payload.shortcuts[0].accelerator, "CommandOrControl+Shift+Y");
   });
 


### PR DESCRIPTION
## Summary
- Replaces tutorial Agent initials and generic placeholders with each Agent's bundled official icon.
- Reuses the existing Agent icon resolver and carries the resolved URL through the tutorial onboarding state.
- Keeps Agent detection, bucketing, install/uninstall actions, and preference semantics unchanged.

## Problem context
The onboarding tutorial previously rendered generated initials such as `CC` and `GC` instead of the official assets already available under `assets/icons/agents`. An initial fallback-only result also showed the same Clawd icon for every row when the running Electron process had not reloaded the updated renderer.

The tutorial state only included `agentId` and `label`, so the renderer had no official icon URL to display. The existing shared Agent icon resolver was not wired into this onboarding path.

## What changed
- Resolve an icon URL for every installable tutorial Agent through the existing `state-agent-icons` helper.
- Add `iconUrl` to active, install, and cleanup tutorial entries without changing their ordering or classification.
- Render decorative Agent images instead of generated initials.
- Fall back to the Clawd product icon when an Agent asset is unavailable, then to a letter-free CSS mark if that fallback also fails.
- Standardize every row on a 30x30 frame with a 26x26 image, consistent inner rounding, neutral image background, and unchanged row height.
- Add coverage for every installable Agent asset, onboarding state propagation, renderer fallback behavior, and stable icon styling.

## Behavior after this PR
- Tutorial step 2 displays the corresponding bundled icon for each detected or configured Agent.
- Active, install, and cleanup rows use the same dimensions and rounded visual treatment.
- Missing or failed assets degrade without showing stale initials or broken-image UI.
- Agent detection confidence, integration state, selection defaults, install/uninstall commands, and persistence remain unchanged.

## Validation
- `node --test test/tutorial-agent-buckets.test.js test/tutorial-renderer-agent-icons.test.js test/tutorial.test.js test/state-agent-icons.test.js`
  - 36 passed, 0 failed.
- `git diff --check`
- Manual Electron verification on Windows:
  - all seven locally displayed Agents loaded their matching `assets/icons/agents/*.png` files;
  - each image reported a 64x64 intrinsic size;
  - rendered frames measured 30x30 with 26x26 images and 6px image rounding;
  - no row-height or text-position regression was observed.
- `npm test`
  - Current branch: 6,149 passed, 13 failed, 18 skipped.
  - Latest `origin/main` baseline: 6,143 passed, 13 failed, 18 skipped.
  - The failure set is identical on both runs and is limited to existing Windows environment assumptions in `remote-deploy.test.js`, `remote-ssh-deploy.test.js`, `remote-ssh-identity.test.js`, `remote-ssh-path-isolation.test.js`, and `server-config.test.js` (CRLF-sensitive shell assertions, POSIX remote-home fixtures, and Unix `0600` mode expectations).

## Platform note
Automated and manual verification ran on Windows with Electron 41.10.2 at 125% display scaling. Additional macOS/Linux visual QA is low risk because the change uses existing file URLs and standard CSS image rendering, but remains appropriate during normal review.

## Scope control
- This PR only changes Agent icon presentation in onboarding tutorial step 2.
- It does not modify the Agent registry, bundled icon source files, Settings Agent UI, or integration lifecycle behavior.