### PR TITLE
fix(reasonix): desktop rename and cold start

### DIFF
--- a/agents/reasonix.js
+++ b/agents/reasonix.js
@@ -6,8 +6,8 @@
 module.exports = {
   id: "reasonix",
   name: "Reasonix",
-  processNames: { win: ["reasonix.exe"], mac: ["reasonix"], linux: ["reasonix"] },
-  startupRecoveryProcessNames: { win: ["reasonix.exe"], mac: ["reasonix"], linux: ["reasonix"] },
+  processNames: { win: ["reasonix.exe", "reasonix-desktop.exe", "reasonix-cli.exe"], mac: ["reasonix", "reasonix-desktop"], linux: ["reasonix", "reasonix-desktop"] },
+  startupRecoveryProcessNames: { win: ["reasonix.exe", "reasonix-desktop.exe", "reasonix-cli.exe"], mac: ["reasonix", "reasonix-desktop"], linux: ["reasonix", "reasonix-desktop"] },
   eventSource: "hook",
   eventMap: {
     SessionStart: "idle",

--- a/agents/reasonix.js
+++ b/agents/reasonix.js
@@ -7,7 +7,10 @@ module.exports = {
   id: "reasonix",
   name: "Reasonix",
   processNames: { win: ["reasonix.exe", "reasonix-desktop.exe", "reasonix-cli.exe"], mac: ["reasonix", "reasonix-desktop"], linux: ["reasonix", "reasonix-desktop"] },
-  startupRecoveryProcessNames: { win: ["reasonix.exe", "reasonix-desktop.exe", "reasonix-cli.exe"], mac: ["reasonix", "reasonix-desktop"], linux: ["reasonix", "reasonix-desktop"] },
+  // reasonix-desktop(.exe) is a resident GUI: valid for process detection and
+  // hook PID attribution, but its mere presence is not turn activity. Keep it
+  // out of startup recovery, matching the Qoder/QoderWork/WorkBuddy boundary.
+  startupRecoveryProcessNames: { win: ["reasonix.exe", "reasonix-cli.exe"], mac: ["reasonix"], linux: ["reasonix"] },
   eventSource: "hook",
   eventMap: {
     SessionStart: "idle",

--- a/hooks/reasonix-hook.js
+++ b/hooks/reasonix-hook.js
@@ -32,9 +32,9 @@ const EVENT_TO_LIFECYCLE = {
 const config = getPlatformConfig();
 const resolve = createPidResolver({
   agentNames: {
-    win: new Set(["reasonix.exe"]),
-    mac: new Set(["reasonix"]),
-    linux: new Set(["reasonix"]),
+    win: new Set(["reasonix.exe", "reasonix-desktop.exe", "reasonix-cli.exe"]),
+    mac: new Set(["reasonix", "reasonix-desktop"]),
+    linux: new Set(["reasonix", "reasonix-desktop"]),
   },
   platformConfig: config,
 });

--- a/hooks/reasonix-hook.js
+++ b/hooks/reasonix-hook.js
@@ -6,6 +6,12 @@
 // Reasonix owns its own permission flow natively (Gate + terminal prompt);
 // Clawd only observes state for the desktop pet animation.
 
+// Start the in-process budget before loading helper modules. Reasonix measures
+// its outer timeout from the PowerShell/cmd wrapper, which starts even earlier;
+// the blocking deadline below deliberately leaves another second for that
+// unobservable launch overhead.
+const HOOK_STARTED_AT = Date.now();
+
 const { postStateToRunningServer, readHostPrefix, applyWslSourceFields } = require("./server-config");
 const { createPidResolver, readStdinJsonDetailed, getPlatformConfig, applyOrcaPaneKey } = require("./shared-process");
 
@@ -46,6 +52,16 @@ function normalizeReasonixSessionId(value) {
   return raw.startsWith("reasonix:") ? raw : `reasonix:${raw}`;
 }
 
+function readRawReasonixSessionId(payload) {
+  if (!payload || typeof payload !== "object") return "";
+  // Keep the legacy snake_case input working, but prefer Reasonix's official
+  // native `sessionId` contract whenever the legacy field is absent/empty.
+  for (const value of [payload.session_id, payload.sessionId]) {
+    if (value != null && value !== "") return String(value);
+  }
+  return "";
+}
+
 // Reasonix fires PostToolUse and Stop in quick succession when a turn ends.
 // Both spawn separate hook processes — if Stop's POST arrives at the server
 // before PostToolUse's, the state ends up as "working" instead of "attention".
@@ -66,11 +82,12 @@ const STDIN_READ_TIMEOUT_MS = 2000;
 // the pet just looked "disconnected" after every long idle.
 // Blocking hooks (UserPromptSubmit/PreToolUse) get a 5s budget from Reasonix
 // and a timeout becomes a DecisionBlock that ABORTS the user's turn, so the
-// absolute deadline stays below it — including the cmd/PowerShell startup
-// before node that we cannot observe from here. Non-blocking events (upstream
-// budget 30s) use a relaxed deadline instead.
-const startedAt = Date.now();
-const HARD_DEADLINE_MS = 4500;
+// internal deadline leaves a full second for the cmd/PowerShell + Node startup
+// that happens before this script can observe time. Blocking events also never
+// perform a fresh synchronous process walk (see the local PID branch below),
+// so a cold WMI/ps call cannot pin the event loop past this guard. Non-blocking
+// events (upstream budget 30s) use a relaxed deadline instead.
+const HARD_DEADLINE_MS = 4000;
 const RELAXED_DEADLINE_MS = 15000;
 const STDIN_PHASE_BUDGET_MS = STDIN_READ_TIMEOUT_MS + 500;
 const POST_STDIN_BUDGET_MS = 3500;
@@ -81,7 +98,7 @@ let safetyTimer = null;
 
 function armSafety(ms, deadlineMs = HARD_DEADLINE_MS) {
   if (safetyTimer) clearTimeout(safetyTimer);
-  const remaining = deadlineMs - (Date.now() - startedAt);
+  const remaining = deadlineMs - (Date.now() - HOOK_STARTED_AT);
   safetyTimer = setTimeout(() => safeExit(0), Math.max(1, Math.min(ms, remaining)));
 }
 
@@ -100,6 +117,7 @@ readStdinJsonDetailed({ timeoutMs: STDIN_READ_TIMEOUT_MS })
   .then((result) => {
     const payload = result.payload;
     const hookName = (payload && typeof payload.event === "string" && payload.event) || "";
+    const isBlockingHook = BLOCKING_HOOKS.has(hookName);
 
     // stdin settled (payload or read timeout) — re-arm for resolve() + POST.
     // Stop is non-blocking (30s upstream) and gets the relaxed deadline plus
@@ -107,7 +125,7 @@ readStdinJsonDetailed({ timeoutMs: STDIN_READ_TIMEOUT_MS })
     const isStop = hookName === "Stop";
     armSafety(
       isStop ? POST_STDIN_BUDGET_MS + STOP_EXTRA_MS : POST_STDIN_BUDGET_MS,
-      BLOCKING_HOOKS.has(hookName) ? HARD_DEADLINE_MS : RELAXED_DEADLINE_MS
+      isBlockingHook ? HARD_DEADLINE_MS : RELAXED_DEADLINE_MS
     );
 
     const mapped = EVENT_TO_STATE[hookName];
@@ -121,9 +139,10 @@ readStdinJsonDetailed({ timeoutMs: STDIN_READ_TIMEOUT_MS })
 
     if (hookName === "SessionStart" && !remote) resolve();
 
+    const rawSessionId = readRawReasonixSessionId(payload);
     const body = {
       state: mapped,
-      session_id: normalizeReasonixSessionId(payload && payload.session_id),
+      session_id: normalizeReasonixSessionId(rawSessionId),
       event: hookName,
       agent_id: "reasonix",
     };
@@ -141,17 +160,29 @@ readStdinJsonDetailed({ timeoutMs: STDIN_READ_TIMEOUT_MS })
       applyOrcaPaneKey(body);
     } else {
       applyWslSourceFields(body);
-      // #634: cacheable keys off the RAW session id — the normalized value is
-      // prefixed, so its "reasonix:default" fallback would defeat the #583
-      // guard; a literal raw "default" is rejected for the same reason.
-      const rawSessionId = (payload && payload.session_id) || "";
-      const { stablePid, agentPid, detectedEditor, pidChain } = resolve({
-        namespace: "reasonix",
-        sessionId: body.session_id,
-        cacheCwd: body.cwd || "",
-        lifecycle: EVENT_TO_LIFECYCLE[hookName] || "event",
-        cacheable: !!rawSessionId && rawSessionId !== "default" && !!body.cwd,
-      });
+      // Reasonix aborts UserPromptSubmit/PreToolUse when a hook exceeds its 5s
+      // outer budget. A JS timer cannot interrupt createPidResolver's sync WMI
+      // or ps walk, so blocking events must never take a fresh snapshot:
+      //   - Windows uses the resolver's cache-only `prompt` lifecycle. A live
+      //     v2 entry still restores PID/editor metadata without spawning.
+      //   - macOS/Linux have no cross-process PID cache; even `prompt` resolves
+      //     fresh there, so skip the resolver entirely.
+      // SessionStart, PostToolUse and Stop are non-blocking and still populate
+      // or repair metadata. src/state.js keeps existing PID fields when a
+      // blocking body omits them, so this safety rule never erases a good PID.
+      let pidMetadata = {};
+      if (!isBlockingHook || process.platform === "win32") {
+        pidMetadata = resolve({
+          namespace: "reasonix",
+          sessionId: body.session_id,
+          cacheCwd: body.cwd || "",
+          lifecycle: isBlockingHook ? "prompt" : (EVENT_TO_LIFECYCLE[hookName] || "event"),
+          // Cacheability keys off the raw ID. The normalized fallback would
+          // otherwise make unrelated missing/default sessions share one file.
+          cacheable: !!rawSessionId && rawSessionId !== "default" && !!body.cwd,
+        });
+      }
+      const { stablePid, agentPid, detectedEditor, pidChain } = pidMetadata;
       if (Number.isFinite(stablePid) && stablePid > 0) body.source_pid = Math.floor(stablePid);
       if (detectedEditor) body.editor = detectedEditor;
       if (Number.isFinite(agentPid) && agentPid > 0) body.agent_pid = Math.floor(agentPid);

--- a/hooks/reasonix-hook.js
+++ b/hooks/reasonix-hook.js
@@ -7,7 +7,7 @@
 // Clawd only observes state for the desktop pet animation.
 
 const { postStateToRunningServer, readHostPrefix, applyWslSourceFields } = require("./server-config");
-const { createPidResolver, readStdinJson, getPlatformConfig, applyOrcaPaneKey } = require("./shared-process");
+const { createPidResolver, readStdinJsonDetailed, getPlatformConfig, applyOrcaPaneKey } = require("./shared-process");
 
 const EVENT_TO_STATE = {
   SessionStart: "idle",
@@ -34,7 +34,9 @@ const resolve = createPidResolver({
   agentNames: {
     win: new Set(["reasonix.exe", "reasonix-desktop.exe", "reasonix-cli.exe"]),
     mac: new Set(["reasonix", "reasonix-desktop"]),
-    linux: new Set(["reasonix", "reasonix-desktop"]),
+    // reasonix-deskto: Linux comm is truncated to TASK_COMM_LEN(16)-1 = 15
+    // chars, so ps/pgrep never see the full "reasonix-desktop".
+    linux: new Set(["reasonix", "reasonix-desktop", "reasonix-deskto"]),
   },
   platformConfig: config,
 });
@@ -50,12 +52,38 @@ function normalizeReasonixSessionId(value) {
 // A short delay on Stop lets PostToolUse's POST land first.
 const STOP_DELAY_MS = 200;
 
+// Reasonix (Go CLI / Wails desktop) can take longer than the shared 400ms
+// default to flush the hook payload to stdin after a long idle period (Go
+// scheduler warm-up + child-process pipe setup on first event). Use a wider
+// 2000ms read window so the first post-idle event actually arrives.
+const STDIN_READ_TIMEOUT_MS = 2000;
+
 // Safety timeout: guarantee the hook exits even if stdin never arrives.
-// Stop gets extra time to accommodate the delay above.
-const SAFETY_TIMEOUT_MS = 800;
-const SAFETY_TIMEOUT_STOP_MS = SAFETY_TIMEOUT_MS + STOP_DELAY_MS + 200;
+// Phased, deadline-based budgets instead of one blanket 800ms — the single
+// budget fired while a cold machine was still legitimately working (post-idle
+// stdin flush + cold WMI snapshot inside resolve()), and safeExit(0)
+// swallowed the event BEFORE the POST with a clean exit 0: no error anywhere,
+// the pet just looked "disconnected" after every long idle.
+// Blocking hooks (UserPromptSubmit/PreToolUse) get a 5s budget from Reasonix
+// and a timeout becomes a DecisionBlock that ABORTS the user's turn, so the
+// absolute deadline stays below it — including the cmd/PowerShell startup
+// before node that we cannot observe from here. Non-blocking events (upstream
+// budget 30s) use a relaxed deadline instead.
+const startedAt = Date.now();
+const HARD_DEADLINE_MS = 4500;
+const RELAXED_DEADLINE_MS = 15000;
+const STDIN_PHASE_BUDGET_MS = STDIN_READ_TIMEOUT_MS + 500;
+const POST_STDIN_BUDGET_MS = 3500;
+const STOP_EXTRA_MS = STOP_DELAY_MS + 200;
+const BLOCKING_HOOKS = new Set(["UserPromptSubmit", "PreToolUse"]);
 let _exited = false;
 let safetyTimer = null;
+
+function armSafety(ms, deadlineMs = HARD_DEADLINE_MS) {
+  if (safetyTimer) clearTimeout(safetyTimer);
+  const remaining = deadlineMs - (Date.now() - startedAt);
+  safetyTimer = setTimeout(() => safeExit(0), Math.max(1, Math.min(ms, remaining)));
+}
 
 function safeExit(code) {
   if (_exited) return;
@@ -66,11 +94,22 @@ function safeExit(code) {
   process.exit(code);
 }
 
-safetyTimer = setTimeout(() => safeExit(0), SAFETY_TIMEOUT_MS);
+armSafety(STDIN_PHASE_BUDGET_MS);
 
-readStdinJson()
-  .then((payload) => {
+readStdinJsonDetailed({ timeoutMs: STDIN_READ_TIMEOUT_MS })
+  .then((result) => {
+    const payload = result.payload;
     const hookName = (payload && typeof payload.event === "string" && payload.event) || "";
+
+    // stdin settled (payload or read timeout) — re-arm for resolve() + POST.
+    // Stop is non-blocking (30s upstream) and gets the relaxed deadline plus
+    // its ordering-delay allowance.
+    const isStop = hookName === "Stop";
+    armSafety(
+      isStop ? POST_STDIN_BUDGET_MS + STOP_EXTRA_MS : POST_STDIN_BUDGET_MS,
+      BLOCKING_HOOKS.has(hookName) ? HARD_DEADLINE_MS : RELAXED_DEADLINE_MS
+    );
+
     const mapped = EVENT_TO_STATE[hookName];
     if (!mapped) {
       safeExit(0);
@@ -81,12 +120,6 @@ readStdinJson()
     const host = remote ? readHostPrefix() : undefined;
 
     if (hookName === "SessionStart" && !remote) resolve();
-
-    // Use longer safety timeout for Stop to accommodate the delay
-    if (hookName === "Stop") {
-      if (safetyTimer) clearTimeout(safetyTimer);
-      safetyTimer = setTimeout(() => safeExit(0), SAFETY_TIMEOUT_STOP_MS);
-    }
 
     const body = {
       state: mapped,

--- a/test/hook-adapter-offline-contract.test.js
+++ b/test/hook-adapter-offline-contract.test.js
@@ -69,7 +69,9 @@ const ADAPTERS = [
   // (offline, online, error). session_id is required for state POSTing and
   // avoids the early-drop seen on other adapters.
   { name: "zcode-hook.js", payload: { hook_event_name: "PreToolUse", session_id: "s-681", cwd: "D:/repo" }, stdout: "{}\n" },
-  { name: "reasonix-hook.js", payload: { event: "PreToolUse", cwd: "D:/repo", toolName: "bash" }, stdout: "" },
+  // Reasonix blocking hooks are intentionally cache-only/zero-spawn even when
+  // Clawd is live. PostToolUse keeps this offline gate assertion non-vacuous.
+  { name: "reasonix-hook.js", payload: { event: "PostToolUse", sessionId: "s-681", cwd: "D:/repo", toolName: "bash" }, stdout: "" },
   // WorkBuddy reads pidChain.length bare too, so the tightened resolver's
   // []-not-null offline shape is still load-bearing here. session_id is
   // REQUIRED: workbuddy-hook.js

--- a/test/hook-http-hanger.js
+++ b/test/hook-http-hanger.js
@@ -1,0 +1,17 @@
+// Test preloader: leaves every outbound HTTP request permanently unsettled.
+// The hook's own safety deadline must be what exits the process; unlike
+// hook-http-blocker.js, this emits no error and invokes no timeout callback.
+const http = require("http");
+const { EventEmitter } = require("events");
+
+function hangingRequest() {
+  const req = new EventEmitter();
+  req.setTimeout = () => req;
+  req.destroy = () => req;
+  req.write = () => true;
+  req.end = () => req;
+  return req;
+}
+
+http.get = () => hangingRequest();
+http.request = () => hangingRequest();

--- a/test/hook-http-recorder.js
+++ b/test/hook-http-recorder.js
@@ -1,0 +1,67 @@
+// Test preloader: records every outbound http GET/POST the hook attempts as
+// JSON lines in CLAWD_HOOK_HTTP_RECORD, and answers every request as a
+// healthy Clawd server (x-clawd-server header), so the probe+post pipeline in
+// postStateToRunningServer completes with no real server and no open ports.
+// Sibling of hook-http-blocker.js — that one fails everything, this one
+// succeeds and keeps the receipts for body assertions.
+const http = require("http");
+const { EventEmitter } = require("events");
+const fs = require("fs");
+
+const recordPath = process.env.CLAWD_HOOK_HTTP_RECORD;
+
+function record(entry) {
+  if (!recordPath) return;
+  try {
+    fs.appendFileSync(recordPath, JSON.stringify(entry) + "\n");
+  } catch {}
+}
+
+function fakeResponse(callback) {
+  const res = new EventEmitter();
+  res.statusCode = 200;
+  res.headers = { "x-clawd-server": "clawd-on-desk" };
+  res.setEncoding = () => res;
+  res.resume = () => res;
+  if (callback) {
+    process.nextTick(() => {
+      callback(res);
+      process.nextTick(() => res.emit("end"));
+    });
+  }
+  return res;
+}
+
+function fakeRequest(method, options, callback) {
+  const req = new EventEmitter();
+  const chunks = [];
+  let ended = false;
+  req.setTimeout = () => req;
+  req.destroy = () => req;
+  req.write = (chunk) => {
+    chunks.push(Buffer.from(chunk));
+    return true;
+  };
+  req.end = (chunk) => {
+    if (ended) return req;
+    ended = true;
+    if (chunk) chunks.push(Buffer.from(chunk));
+    record({
+      method,
+      port: options && options.port,
+      path: options && options.path,
+      body: Buffer.concat(chunks).toString("utf8"),
+    });
+    fakeResponse(callback);
+    return req;
+  };
+  return req;
+}
+
+http.get = (options, callback) => {
+  const req = fakeRequest("GET", options, callback);
+  // Real http.get calls req.end() implicitly; callers never do.
+  process.nextTick(() => req.end());
+  return req;
+};
+http.request = (options, callback) => fakeRequest("POST", options, callback);

--- a/test/hook-orca-spy.js
+++ b/test/hook-orca-spy.js
@@ -1,0 +1,28 @@
+// Test preloader: spies on applyOrcaPaneKey calls from the hook under test,
+// recording each call's event name as JSON lines in CLAWD_TEST_ORCA_RECORD.
+// Also stubs createPidResolver with a no-metadata resolver so Orca coverage
+// needs no PowerShell snapshot and no runtime identity. Everything else in
+// shared-process passes through untouched via prototype delegation.
+const Module = require("module");
+const fs = require("fs");
+
+const recordPath = process.env.CLAWD_TEST_ORCA_RECORD;
+const originalLoad = Module._load;
+
+Module._load = function (request, parent, isMain) {
+  const loaded = originalLoad.apply(this, arguments);
+  if (request === "./shared-process" || request.endsWith("shared-process")) {
+    const wrapped = Object.create(loaded);
+    wrapped.applyOrcaPaneKey = (body) => {
+      if (recordPath) {
+        try {
+          fs.appendFileSync(recordPath, JSON.stringify({ event: body && body.event }) + "\n");
+        } catch {}
+      }
+      return loaded.applyOrcaPaneKey(body);
+    };
+    wrapped.createPidResolver = () => () => ({});
+    return wrapped;
+  }
+  return loaded;
+};

--- a/test/hook-pid-cache-contexts.test.js
+++ b/test/hook-pid-cache-contexts.test.js
@@ -326,7 +326,7 @@ describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully
     { name: "codebuddy-hook.js", ns: "codebuddy", raw: sid("cb"), cacheSid: sid("cb"),
       payload: { hook_event_name: "PreToolUse", session_id: sid("cb"), cwd: "D:/repo" } },
     { name: "reasonix-hook.js", ns: "reasonix", raw: sid("rx"), cacheSid: `reasonix:${sid("rx")}`,
-      payload: { event: "PreToolUse", session_id: sid("rx"), cwd: "D:/repo", toolName: "bash" } },
+      payload: { event: "PostToolUse", sessionId: sid("rx"), cwd: "D:/repo", toolName: "bash" } },
   ];
 
   for (const row of HIT_ROWS) {
@@ -423,11 +423,18 @@ describe("#634 subprocess — cache hits spawn nothing; kiro degrades gracefully
     assert.deepStrictEqual(r.spawns, [], "the end contract never takes a fresh snapshot, hit or miss");
   });
 
-  it("reasonix-hook.js: a literal \"default\" session id ignores a seeded entry and stays fresh", () => {
+  it("reasonix-hook.js: a blocking cache miss never spawns, including literal default", () => {
     seedLiveCache("reasonix", "reasonix:default", "D:/repo");
     const r = runHook("reasonix-hook.js", { event: "PreToolUse", session_id: "default", cwd: "D:/repo", toolName: "bash" });
     assert.ok(Array.isArray(r.spawns), `reasonix did not report — stderr=${r.stderr}`);
-    assert.strictEqual(r.spawns.length, 1, "literal default must not be cacheable: per-event fresh snapshot, like kiro");
+    assert.deepStrictEqual(r.spawns, [], "blocking hooks must stay spawn-free even when cacheability is rejected");
+  });
+
+  it("reasonix-hook.js: a non-blocking event repairs a literal-default cache miss fresh", () => {
+    seedLiveCache("reasonix", "reasonix:default", "D:/repo");
+    const r = runHook("reasonix-hook.js", { event: "PostToolUse", session_id: "default", cwd: "D:/repo", toolName: "bash" });
+    assert.ok(Array.isArray(r.spawns), `reasonix did not report — stderr=${r.stderr}`);
+    assert.strictEqual(r.spawns.length, 1, "non-blocking events retain the fresh PID recovery path");
   });
 });
 

--- a/test/reasonix-hook-delivery.test.js
+++ b/test/reasonix-hook-delivery.test.js
@@ -5,6 +5,7 @@
 // conditions that used to silently drop events. Helpers:
 //   hook-http-recorder.js  — answers http as a healthy Clawd server, records bodies
 //   reasonix-hook-snapshot-fake.js — plants a reasonix.exe ancestor in the WMI snapshot
+//   reasonix-hook-platform-probe.js — fakes POSIX and records forbidden sync spawns
 //   hook-orca-spy.js       — spies on applyOrcaPaneKey, stubs the resolver
 //   hook-http-blocker.js   — fails all http (existing)
 
@@ -14,12 +15,17 @@ const { spawn, spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const pidCache = require("../hooks/pid-cache");
+const { __test: reasonixInstallTest } = require("../hooks/reasonix-install");
 
 const HOOK_PATH = path.resolve(__dirname, "..", "hooks", "reasonix-hook.js");
 const RECORDER_PATH = path.resolve(__dirname, "hook-http-recorder.js");
 const SNAPSHOT_FAKE_PATH = path.resolve(__dirname, "reasonix-hook-snapshot-fake.js");
+const PLATFORM_PROBE_PATH = path.resolve(__dirname, "reasonix-hook-platform-probe.js");
 const ORCA_SPY_PATH = path.resolve(__dirname, "hook-orca-spy.js");
 const BLOCKER_PATH = path.resolve(__dirname, "hook-http-blocker.js");
+const HANGER_PATH = path.resolve(__dirname, "hook-http-hanger.js");
+const HANGER_NODE_OPTIONS_PATH = HANGER_PATH.replace(/\\/g, "/");
 
 const tempDirs = [];
 
@@ -36,7 +42,16 @@ afterEach(() => {
 });
 
 function hookEnv(homeDir, extra = {}) {
-  return { ...process.env, HOME: homeDir, USERPROFILE: homeDir, ...extra };
+  const tempDir = path.join(homeDir, "tmp");
+  fs.mkdirSync(tempDir, { recursive: true });
+  return {
+    ...process.env,
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+    TEMP: tempDir,
+    TMP: tempDir,
+    ...extra,
+  };
 }
 
 // A well-formed Clawd runtime identity owned by this (living) test runner, so
@@ -104,6 +119,7 @@ describe("reasonix hook delivery", () => {
     const body = JSON.parse(posts[0].body);
     assert.strictEqual(body.event, "UserPromptSubmit");
     assert.strictEqual(body.state, "thinking");
+    assert.strictEqual(body.session_id, "reasonix:s-1");
   });
 
   it("attaches PID metadata on non-SessionStart events too", () => {
@@ -112,7 +128,9 @@ describe("reasonix hook delivery", () => {
     const record = path.join(home, "http.jsonl");
     const result = spawnHook({
       preload: [RECORDER_PATH, SNAPSHOT_FAKE_PATH],
-      payload: { event: "PreToolUse", toolName: "bash", cwd: "D:/proj" },
+      // PostToolUse is non-blocking, so a cache miss may safely take the fresh
+      // snapshot that repairs a missed SessionStart / mid-session Clawd launch.
+      payload: { event: "PostToolUse", sessionId: "native-pid", toolName: "bash", cwd: "D:/proj" },
       env: { CLAWD_HOOK_HTTP_RECORD: record },
       home,
     });
@@ -121,12 +139,132 @@ describe("reasonix hook delivery", () => {
     const posts = readRecords(record).filter((entry) => entry.method === "POST");
     assert.strictEqual(posts.length, 1);
     const body = JSON.parse(posts[0].body);
-    assert.strictEqual(body.event, "PreToolUse");
+    assert.strictEqual(body.event, "PostToolUse");
     // Planted by reasonix-hook-snapshot-fake.js: reasonix.exe at pid 4000,
     // the direct parent of the hook's own parent.
     assert.strictEqual(body.agent_pid, 4000);
     assert.ok(Number.isInteger(body.source_pid) && body.source_pid > 0);
     assert.ok(Array.isArray(body.pid_chain) && body.pid_chain.includes(4000));
+  });
+
+  it("keeps legacy snake_case session ids ahead of the native camelCase field", () => {
+    const home = makeTempDir();
+    const record = path.join(home, "http.jsonl");
+    const result = spawnHook({
+      preload: [RECORDER_PATH],
+      payload: {
+        event: "Stop",
+        session_id: "legacy-session",
+        sessionId: "native-session",
+        cwd: "D:/proj",
+      },
+      env: { CLAWD_HOOK_HTTP_RECORD: record },
+      home,
+    });
+
+    assert.strictEqual(result.status, 0);
+    const posts = readRecords(record).filter((entry) => entry.method === "POST");
+    assert.strictEqual(posts.length, 1);
+    const body = JSON.parse(posts[0].body);
+    assert.strictEqual(body.session_id, "reasonix:legacy-session");
+  });
+
+  it("posts a delayed blocking event without entering a cold synchronous WMI walk", { skip: process.platform !== "win32" }, async () => {
+    const home = makeTempDir();
+    writeRuntimeIdentity(home);
+    const httpRecord = path.join(home, "http.jsonl");
+    const snapshotRecord = path.join(home, "snapshot.jsonl");
+    const startedAt = Date.now();
+    const child = spawn(
+      process.execPath,
+      ["--require", RECORDER_PATH, "--require", SNAPSHOT_FAKE_PATH, HOOK_PATH],
+      {
+        env: hookEnv(home, {
+          CLAWD_HOOK_HTTP_RECORD: httpRecord,
+          CLAWD_TEST_REASONIX_SNAPSHOT_RECORD: snapshotRecord,
+          // A regression into resolve(event) blocks the JS timer for 3s and
+          // pushes this 1800ms-late event beyond Reasonix's 5s outer budget.
+          CLAWD_TEST_REASONIX_SNAPSHOT_DELAY_MS: "3000",
+        }),
+      }
+    );
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+
+    const code = await new Promise((resolve) => {
+      setTimeout(() => {
+        child.stdin.end(JSON.stringify({
+          event: "PreToolUse",
+          sessionId: "native-blocking",
+          cwd: "D:/proj",
+          toolName: "bash",
+        }) + "\n");
+      }, 1800);
+      child.on("exit", resolve);
+    });
+    const elapsed = Date.now() - startedAt;
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(stdout, "");
+    assert.strictEqual(stderr, "");
+    assert.ok(elapsed >= 1800, `test must exercise delayed stdin (${elapsed}ms)`);
+    assert.ok(elapsed < 4000, `blocking hook must leave wrapper headroom (${elapsed}ms)`);
+    assert.deepStrictEqual(readRecords(snapshotRecord), [], "blocking cache miss must not start WMI");
+    const posts = readRecords(httpRecord).filter((entry) => entry.method === "POST");
+    assert.strictEqual(posts.length, 1);
+    const body = JSON.parse(posts[0].body);
+    assert.strictEqual(body.event, "PreToolUse");
+    assert.strictEqual(body.session_id, "reasonix:native-blocking");
+  });
+
+  it("restores cached PID metadata for native camelCase blocking events without WMI", { skip: process.platform !== "win32" }, () => {
+    const home = makeTempDir();
+    const cacheDir = path.join(home, "tmp");
+    fs.mkdirSync(cacheDir, { recursive: true });
+    const rawSessionId = "native-cache-hit";
+    const sessionId = `reasonix:${rawSessionId}`;
+    const cwd = "D:/proj";
+    const httpRecord = path.join(home, "http.jsonl");
+    const snapshotRecord = path.join(home, "snapshot.jsonl");
+
+    pidCache.__setCacheDirForTests(cacheDir);
+    try {
+      assert.strictEqual(pidCache.writePidCacheV2("reasonix", sessionId, cwd, {
+        stablePid: process.pid,
+        agentPid: process.pid,
+        headless: false,
+        detectedEditor: "vscode",
+      }), true);
+
+      const result = spawnHook({
+        preload: [RECORDER_PATH, SNAPSHOT_FAKE_PATH],
+        payload: { event: "PreToolUse", sessionId: rawSessionId, cwd, toolName: "bash" },
+        env: {
+          TEMP: cacheDir,
+          TMP: cacheDir,
+          CLAWD_HOOK_HTTP_RECORD: httpRecord,
+          CLAWD_TEST_REASONIX_SNAPSHOT_RECORD: snapshotRecord,
+        },
+        home,
+      });
+
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stdout, "");
+      assert.strictEqual(result.stderr, "");
+      assert.deepStrictEqual(readRecords(snapshotRecord), [], "cache hit must not start WMI");
+      const posts = readRecords(httpRecord).filter((entry) => entry.method === "POST");
+      assert.strictEqual(posts.length, 1);
+      const body = JSON.parse(posts[0].body);
+      assert.strictEqual(body.session_id, sessionId);
+      assert.strictEqual(body.source_pid, process.pid);
+      assert.strictEqual(body.agent_pid, process.pid);
+      assert.strictEqual(body.editor, "vscode");
+    } finally {
+      pidCache.dropPidCacheV2("reasonix", sessionId, cwd);
+      pidCache.__setCacheDirForTests(null);
+    }
   });
 
   it("exits inside the blocking budget when stdin never arrives", async () => {
@@ -135,15 +273,102 @@ describe("reasonix hook delivery", () => {
     const child = spawn(process.execPath, ["--require", BLOCKER_PATH, HOOK_PATH], {
       env: hookEnv(home),
     });
-    // Never write and never close stdin: the phase-1 budget (2500ms) must fire
-    // well below the 4500ms absolute deadline — and below Reasonix's outer 5s
-    // blocking-hook budget, whose timeout would abort the user's turn.
+    // Never write and never close stdin: readStdinJsonDetailed's 2s window must
+    // settle and fail open inside the 4s in-process deadline, leaving another
+    // second for Reasonix's outer PowerShell/cmd wrapper.
     const code = await new Promise((resolve) => child.on("exit", resolve));
     const elapsed = Date.now() - startedAt;
 
     assert.strictEqual(code, 0);
     assert.ok(elapsed >= 1800, `hook should wait out most of the stdin window (${elapsed}ms)`);
-    assert.ok(elapsed < 5500, `hook must not outlive the blocking budget (${elapsed}ms)`);
+    assert.ok(elapsed < 4000, `hook must leave outer-wrapper headroom (${elapsed}ms)`);
+  });
+
+  it("keeps the real Windows EncodedCommand wrapper below Reasonix's 5s timeout", { skip: process.platform !== "win32" }, () => {
+    const home = makeTempDir();
+    const command = reasonixInstallTest.buildReasonixHookCommand(process.execPath, HOOK_PATH, {
+      platform: "win32",
+    });
+    const startedAt = Date.now();
+    const result = spawnSync("cmd.exe", ["/d", "/c", command], {
+      input: JSON.stringify({
+        event: "PreToolUse",
+        sessionId: "native-wrapper",
+        cwd: "D:/proj",
+        toolName: "bash",
+      }) + "\n",
+      encoding: "utf8",
+      env: hookEnv(home, { NODE_OPTIONS: `--require="${HANGER_NODE_OPTIONS_PATH}"` }),
+      windowsHide: true,
+      timeout: 6500,
+    });
+    const elapsed = Date.now() - startedAt;
+
+    assert.strictEqual(result.error, undefined, `wrapper timeout/error: ${result.error && result.error.message}`);
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout, "");
+    assert.strictEqual(result.stderr, "");
+    assert.ok(elapsed >= 3000, `HTTP hanger must reach the hook safety timer (${elapsed}ms)`);
+    assert.ok(elapsed < 5000, `wrapper must finish before Reasonix blocks the turn (${elapsed}ms)`);
+  });
+
+  it("never starts a POSIX process walk from blocking events", () => {
+    for (const platform of ["darwin", "linux"]) {
+      const home = makeTempDir();
+      const httpRecord = path.join(home, `${platform}-http.jsonl`);
+      const spawnRecord = path.join(home, `${platform}-spawns.json`);
+      const result = spawnHook({
+        preload: [PLATFORM_PROBE_PATH, RECORDER_PATH],
+        payload: {
+          event: "PreToolUse",
+          sessionId: `native-${platform}`,
+          cwd: "/tmp/proj",
+          toolName: "bash",
+        },
+        env: {
+          CLAWD_TEST_PLATFORM: platform,
+          CLAWD_TEST_SYNC_SPAWN_RECORD: spawnRecord,
+          CLAWD_HOOK_HTTP_RECORD: httpRecord,
+        },
+        home,
+      });
+
+      assert.strictEqual(result.status, 0, `${platform} exit`);
+      assert.strictEqual(result.stdout, "", `${platform} stdout`);
+      assert.strictEqual(result.stderr, "", `${platform} stderr`);
+      assert.deepStrictEqual(JSON.parse(fs.readFileSync(spawnRecord, "utf8")), [], `${platform} sync spawns`);
+      const posts = readRecords(httpRecord).filter((entry) => entry.method === "POST");
+      assert.strictEqual(posts.length, 1, `${platform} POST`);
+
+      // Vacuity guard: prove that the synthetic platform took effect and that
+      // the probe would catch the POSIX walk if this event were non-blocking.
+      const nonBlockingHttpRecord = path.join(home, `${platform}-nonblocking-http.jsonl`);
+      const nonBlockingSpawnRecord = path.join(home, `${platform}-nonblocking-spawns.json`);
+      const nonBlockingResult = spawnHook({
+        preload: [PLATFORM_PROBE_PATH, RECORDER_PATH],
+        payload: {
+          event: "PostToolUse",
+          sessionId: `native-${platform}-nonblocking`,
+          cwd: "/tmp/proj",
+          toolName: "bash",
+        },
+        env: {
+          CLAWD_TEST_PLATFORM: platform,
+          CLAWD_TEST_SYNC_SPAWN_RECORD: nonBlockingSpawnRecord,
+          CLAWD_HOOK_HTTP_RECORD: nonBlockingHttpRecord,
+        },
+        home,
+      });
+
+      assert.strictEqual(nonBlockingResult.status, 0, `${platform} non-blocking exit`);
+      assert.strictEqual(nonBlockingResult.stdout, "", `${platform} non-blocking stdout`);
+      assert.strictEqual(nonBlockingResult.stderr, "", `${platform} non-blocking stderr`);
+      const nonBlockingSpawns = JSON.parse(fs.readFileSync(nonBlockingSpawnRecord, "utf8"));
+      assert.strictEqual(nonBlockingSpawns.length, 1, `${platform} vacuity-guard spawn count`);
+      assert.strictEqual(nonBlockingSpawns[0].file, "ps", `${platform} vacuity-guard executable`);
+      const nonBlockingPosts = readRecords(nonBlockingHttpRecord).filter((entry) => entry.method === "POST");
+      assert.strictEqual(nonBlockingPosts.length, 1, `${platform} non-blocking POST`);
+    }
   });
 
   it("resolver name set covers the Linux comm-truncated reasonix-deskto", () => {
@@ -212,11 +437,7 @@ describe("reasonix hook delivery", () => {
         state: "thinking",
         event: "UserPromptSubmit",
         agent_id: "reasonix",
-        // TODO(sessionId contract): native Reasonix payloads carry camelCase
-        // `sessionId`, which the hook does not map yet, so sessions fall back
-        // to reasonix:default. Update this expectation when the contract fix
-        // lands (tracked as a follow-up, intentionally out of this PR).
-        session_id: "reasonix:default",
+        session_id: "reasonix:9f1c2a",
         cwd: "D:/proj",
       }
     );

--- a/test/reasonix-hook-delivery.test.js
+++ b/test/reasonix-hook-delivery.test.js
@@ -1,0 +1,224 @@
+"use strict";
+
+// Delivery-level tests for hooks/reasonix-hook.js: not just "silent exit 0",
+// but what actually reaches the Clawd server, under the timing and platform
+// conditions that used to silently drop events. Helpers:
+//   hook-http-recorder.js  — answers http as a healthy Clawd server, records bodies
+//   reasonix-hook-snapshot-fake.js — plants a reasonix.exe ancestor in the WMI snapshot
+//   hook-orca-spy.js       — spies on applyOrcaPaneKey, stubs the resolver
+//   hook-http-blocker.js   — fails all http (existing)
+
+const { describe, it, afterEach } = require("node:test");
+const assert = require("node:assert");
+const { spawn, spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const HOOK_PATH = path.resolve(__dirname, "..", "hooks", "reasonix-hook.js");
+const RECORDER_PATH = path.resolve(__dirname, "hook-http-recorder.js");
+const SNAPSHOT_FAKE_PATH = path.resolve(__dirname, "reasonix-hook-snapshot-fake.js");
+const ORCA_SPY_PATH = path.resolve(__dirname, "hook-orca-spy.js");
+const BLOCKER_PATH = path.resolve(__dirname, "hook-http-blocker.js");
+
+const tempDirs = [];
+
+function makeTempDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-reasonix-delivery-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function hookEnv(homeDir, extra = {}) {
+  return { ...process.env, HOME: homeDir, USERPROFILE: homeDir, ...extra };
+}
+
+// A well-formed Clawd runtime identity owned by this (living) test runner, so
+// the resolver's #681 zero-spawn gate opens inside spawned hooks.
+function writeRuntimeIdentity(homeDir) {
+  const clawdDir = path.join(homeDir, ".clawd");
+  fs.mkdirSync(clawdDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(clawdDir, "runtime.json"),
+    JSON.stringify({ app: "clawd-on-desk", port: 23333, ownerPid: process.pid })
+  );
+}
+
+function readRecords(file) {
+  try {
+    return fs
+      .readFileSync(file, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch {
+    return [];
+  }
+}
+
+function spawnHook({ preload = [], payload, env = {}, home, timeout = 30000 }) {
+  const homeDir = home || makeTempDir();
+  return spawnSync(process.execPath, [...preload.flatMap((p) => ["--require", p]), HOOK_PATH], {
+    input: JSON.stringify(payload) + "\n",
+    encoding: "utf8",
+    env: hookEnv(homeDir, env),
+    windowsHide: true,
+    timeout,
+  });
+}
+
+describe("reasonix hook delivery", () => {
+  it("still posts after a delayed (1800ms) stdin flush", async () => {
+    const home = makeTempDir();
+    const record = path.join(home, "http.jsonl");
+    const startedAt = Date.now();
+    const child = spawn(process.execPath, ["--require", RECORDER_PATH, HOOK_PATH], {
+      env: hookEnv(home, { CLAWD_HOOK_HTTP_RECORD: record }),
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => (stdout += chunk));
+    child.stderr.on("data", (chunk) => (stderr += chunk));
+
+    const code = await new Promise((resolve) => {
+      setTimeout(() => {
+        child.stdin.end(
+          JSON.stringify({ event: "UserPromptSubmit", sessionId: "s-1", cwd: "D:/proj", turn: 1 }) + "\n"
+        );
+      }, 1800);
+      child.on("exit", resolve);
+    });
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(stdout, "");
+    assert.strictEqual(stderr, "");
+    assert.ok(Date.now() - startedAt >= 1800, "hook must actually wait for the late payload");
+    const posts = readRecords(record).filter((entry) => entry.method === "POST");
+    assert.strictEqual(posts.length, 1);
+    const body = JSON.parse(posts[0].body);
+    assert.strictEqual(body.event, "UserPromptSubmit");
+    assert.strictEqual(body.state, "thinking");
+  });
+
+  it("attaches PID metadata on non-SessionStart events too", () => {
+    const home = makeTempDir();
+    writeRuntimeIdentity(home);
+    const record = path.join(home, "http.jsonl");
+    const result = spawnHook({
+      preload: [RECORDER_PATH, SNAPSHOT_FAKE_PATH],
+      payload: { event: "PreToolUse", toolName: "bash", cwd: "D:/proj" },
+      env: { CLAWD_HOOK_HTTP_RECORD: record },
+      home,
+    });
+
+    assert.strictEqual(result.status, 0);
+    const posts = readRecords(record).filter((entry) => entry.method === "POST");
+    assert.strictEqual(posts.length, 1);
+    const body = JSON.parse(posts[0].body);
+    assert.strictEqual(body.event, "PreToolUse");
+    // Planted by reasonix-hook-snapshot-fake.js: reasonix.exe at pid 4000,
+    // the direct parent of the hook's own parent.
+    assert.strictEqual(body.agent_pid, 4000);
+    assert.ok(Number.isInteger(body.source_pid) && body.source_pid > 0);
+    assert.ok(Array.isArray(body.pid_chain) && body.pid_chain.includes(4000));
+  });
+
+  it("exits inside the blocking budget when stdin never arrives", async () => {
+    const home = makeTempDir();
+    const startedAt = Date.now();
+    const child = spawn(process.execPath, ["--require", BLOCKER_PATH, HOOK_PATH], {
+      env: hookEnv(home),
+    });
+    // Never write and never close stdin: the phase-1 budget (2500ms) must fire
+    // well below the 4500ms absolute deadline — and below Reasonix's outer 5s
+    // blocking-hook budget, whose timeout would abort the user's turn.
+    const code = await new Promise((resolve) => child.on("exit", resolve));
+    const elapsed = Date.now() - startedAt;
+
+    assert.strictEqual(code, 0);
+    assert.ok(elapsed >= 1800, `hook should wait out most of the stdin window (${elapsed}ms)`);
+    assert.ok(elapsed < 5500, `hook must not outlive the blocking budget (${elapsed}ms)`);
+  });
+
+  it("resolver name set covers the Linux comm-truncated reasonix-deskto", () => {
+    // Linux /proc comm is capped at TASK_COMM_LEN(16)-1 = 15 chars, so
+    // "reasonix-desktop" shows up as "reasonix-deskto" in ps/pgrep output.
+    // Resolver matching is plain Set membership, so the truncated form must
+    // be in the set. This runner is Windows (no linux ps walk available), so
+    // pin the set at the source.
+    const source = fs.readFileSync(HOOK_PATH, "utf8");
+    assert.match(source, /linux:\s*new Set\(\[[^\]]*"reasonix-deskto"/);
+  });
+
+  it("keeps applyOrcaPaneKey on both local and remote paths", () => {
+    for (const remote of [false, true]) {
+      const home = makeTempDir();
+      const record = path.join(home, "orca.jsonl");
+      const result = spawnHook({
+        preload: [ORCA_SPY_PATH, RECORDER_PATH],
+        payload: { event: "PreToolUse", toolName: "bash", cwd: "D:/proj" },
+        env: {
+          CLAWD_TEST_ORCA_RECORD: record,
+          CLAWD_HOOK_HTTP_RECORD: path.join(home, "http.jsonl"),
+          ...(remote ? { CLAWD_REMOTE: "1" } : {}),
+        },
+        home,
+      });
+
+      const label = remote ? "remote" : "local";
+      assert.strictEqual(result.status, 0, `${label} exit`);
+      const calls = readRecords(record);
+      assert.strictEqual(calls.length, 1, `${label} must call applyOrcaPaneKey exactly once`);
+      assert.strictEqual(calls[0].event, "PreToolUse");
+    }
+  });
+
+  it("posts the expected body for a real Reasonix native payload", () => {
+    const home = makeTempDir();
+    const record = path.join(home, "http.jsonl");
+    const result = spawnHook({
+      preload: [RECORDER_PATH],
+      payload: {
+        event: "UserPromptSubmit",
+        sessionId: "9f1c2a",
+        cwd: "D:/proj",
+        prompt: "你好",
+        turn: 3,
+      },
+      env: { CLAWD_HOOK_HTTP_RECORD: record },
+      home,
+    });
+
+    assert.strictEqual(result.status, 0);
+    assert.strictEqual(result.stdout, "");
+    const posts = readRecords(record).filter((entry) => entry.method === "POST");
+    assert.strictEqual(posts.length, 1);
+    const body = JSON.parse(posts[0].body);
+    assert.deepStrictEqual(
+      {
+        state: body.state,
+        event: body.event,
+        agent_id: body.agent_id,
+        session_id: body.session_id,
+        cwd: body.cwd,
+      },
+      {
+        state: "thinking",
+        event: "UserPromptSubmit",
+        agent_id: "reasonix",
+        // TODO(sessionId contract): native Reasonix payloads carry camelCase
+        // `sessionId`, which the hook does not map yet, so sessions fall back
+        // to reasonix:default. Update this expectation when the contract fix
+        // lands (tracked as a follow-up, intentionally out of this PR).
+        session_id: "reasonix:default",
+        cwd: "D:/proj",
+      }
+    );
+  });
+});

--- a/test/reasonix-hook-platform-probe.js
+++ b/test/reasonix-hook-platform-probe.js
@@ -1,0 +1,23 @@
+// Test preloader: runs reasonix-hook.js under a synthetic platform and records
+// every synchronous child-process attempt. Blocking Reasonix events must not
+// reach the POSIX ps/tmux resolver path at all.
+const childProcess = require("child_process");
+const fs = require("fs");
+
+const platform = String(process.env.CLAWD_TEST_PLATFORM || "").trim();
+if (platform) {
+  const descriptor = Object.getOwnPropertyDescriptor(process, "platform");
+  Object.defineProperty(process, "platform", { ...descriptor, value: platform });
+}
+
+const spawns = [];
+childProcess.execFileSync = function (file, args) {
+  spawns.push({ file: String(file), args: Array.isArray(args) ? args.map(String) : [] });
+  throw Object.assign(new Error("unexpected synchronous resolver spawn"), { code: "ETESTSPAWN" });
+};
+
+process.on("exit", () => {
+  const out = process.env.CLAWD_TEST_SYNC_SPAWN_RECORD;
+  if (!out) return;
+  try { fs.writeFileSync(out, JSON.stringify(spawns), "utf8"); } catch {}
+});

--- a/test/reasonix-hook-snapshot-fake.js
+++ b/test/reasonix-hook-snapshot-fake.js
@@ -1,0 +1,45 @@
+// Test preloader: replaces the resolver's full-machine WMI process snapshot
+// with a three-process tree — this hook's real parent pid, parented under
+// reasonix.exe (pid 4000), parented under explorer.exe (pid 5000, a system
+// boundary). Lets PID-attribution tests assert stablePid/agentPid without
+// spawning PowerShell or depending on the host's real process list. Any
+// execFileSync call that is NOT the snapshot passes through to the real one.
+const childProcess = require("child_process");
+
+const realExecFileSync = childProcess.execFileSync;
+const hookParentPid = process.ppid;
+
+const SNAPSHOT = {
+  processes: [
+    {
+      ProcessId: hookParentPid,
+      ParentProcessId: 4000,
+      Name: "node.exe",
+      CommandLine: "node hooks/reasonix-hook.js",
+      StartIdentity: "100",
+    },
+    {
+      ProcessId: 4000,
+      ParentProcessId: 5000,
+      Name: "reasonix.exe",
+      CommandLine: "reasonix.exe",
+      StartIdentity: "90",
+    },
+    {
+      ProcessId: 5000,
+      ParentProcessId: 0,
+      Name: "explorer.exe",
+      CommandLine: "explorer.exe",
+      StartIdentity: "1",
+    },
+  ],
+  foreground: { hwnd: null, pid: 0, className: "" },
+};
+
+childProcess.execFileSync = function (file, args) {
+  const text = [file, ...(Array.isArray(args) ? args : [])].join(" ");
+  if (/powershell(\.exe)?/i.test(String(file)) && text.includes("Win32_Process")) {
+    return JSON.stringify(SNAPSHOT);
+  }
+  return realExecFileSync.apply(this, arguments);
+};

--- a/test/reasonix-hook-snapshot-fake.js
+++ b/test/reasonix-hook-snapshot-fake.js
@@ -5,6 +5,7 @@
 // spawning PowerShell or depending on the host's real process list. Any
 // execFileSync call that is NOT the snapshot passes through to the real one.
 const childProcess = require("child_process");
+const fs = require("fs");
 
 const realExecFileSync = childProcess.execFileSync;
 const hookParentPid = process.ppid;
@@ -36,9 +37,24 @@ const SNAPSHOT = {
   foreground: { hwnd: null, pid: 0, className: "" },
 };
 
-childProcess.execFileSync = function (file, args) {
+childProcess.execFileSync = function (file, args, options) {
   const text = [file, ...(Array.isArray(args) ? args : [])].join(" ");
   if (/powershell(\.exe)?/i.test(String(file)) && text.includes("Win32_Process")) {
+    const recordPath = process.env.CLAWD_TEST_REASONIX_SNAPSHOT_RECORD;
+    if (recordPath) {
+      try {
+        fs.appendFileSync(recordPath, JSON.stringify({
+          timeout: options && options.timeout,
+          at: Date.now(),
+        }) + "\n");
+      } catch {}
+    }
+    const delayMs = Number(process.env.CLAWD_TEST_REASONIX_SNAPSHOT_DELAY_MS) || 0;
+    if (delayMs > 0) {
+      // Deliberately synchronous: this reproduces the exact property under
+      // review — JS safety timers cannot run while execFileSync/WMI is blocked.
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delayMs);
+    }
     return JSON.stringify(SNAPSHOT);
   }
   return realExecFileSync.apply(this, arguments);

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -239,6 +239,10 @@ describe("Agent Registry", () => {
       registry.getAgent("qoder").startupRecoveryProcessNames.win,
       ["qodercli.exe", "qoder-cli.exe"]
     );
+    assert.deepStrictEqual(
+      registry.getAgent("reasonix").startupRecoveryProcessNames,
+      { win: ["reasonix.exe", "reasonix-cli.exe"], mac: ["reasonix"], linux: ["reasonix"] }
+    );
   });
 
   it("should have correct capabilities", () => {

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -92,7 +92,7 @@ describe("Agent Registry", () => {
     assert.deepStrictEqual(qoder.processNames.win, ["qoder.exe", "qodercli.exe", "qoder-cli.exe"]);
 
     const reasonix = registry.getAgent("reasonix");
-    assert.deepStrictEqual(reasonix.processNames.win, ["reasonix.exe"]);
+    assert.deepStrictEqual(reasonix.processNames.win, ["reasonix.exe", "reasonix-desktop.exe", "reasonix-cli.exe"]);
 
     const qoderwork = registry.getAgent("qoderwork");
     assert.deepStrictEqual(qoderwork.processNames.win, ["QoderWork.exe"]);
@@ -146,7 +146,7 @@ describe("Agent Registry", () => {
     assert.deepStrictEqual(qoder.processNames.linux, ["qoder", "qodercli", "qoder-cli"]);
 
     const reasonix = registry.getAgent("reasonix");
-    assert.deepStrictEqual(reasonix.processNames.linux, ["reasonix"]);
+    assert.deepStrictEqual(reasonix.processNames.linux, ["reasonix", "reasonix-desktop"]);
 
     const qoderwork = registry.getAgent("qoderwork");
     assert.deepStrictEqual(qoderwork.processNames.linux, ["QoderWork"]);


### PR DESCRIPTION
## Overview


1. **Process name tracking**: Reasonix official split the Windows distribution package into a multi-EXE layout in v1.17.x. The desktop main process changed from `reasonix.exe` to `reasonix-desktop.exe`, but Clawd's process list was not updated, causing desktop session detection to fail.
2. **Cold start event dropping**: The hook's 800ms safety timer conflicts with cold start costs (slow stdin flush + full-machine WMI snapshot per event). The first event after boot or prolonged idle is silently swallowed by `safeExit(0)` before POST is sent (exit 0, no error output), manifesting as a "disconnection."

## Commit 1 — fix(reasonix): track renamed desktop and bundled CLI processes

**Upstream timeline**:

- 2026-07-14: Guard multi-EXE "release unit" layout introduced (esengine/DeepSeek-Reasonix@3baf0b3)
- 2026-07-22: v1.17.19 **renamed the bundled CLI** in the desktop package to `reasonix-cli.exe` to avoid name collision with the `Reasonix.exe` graphical launcher in the same directory (esengine/DeepSeek-Reasonix#6806, release note)
- 2026-07-24: v1.17.20 released; local portable package's six EXEs have timestamps = 7/24 12:20, `reasonix.exe` is now a 9.8MB launcher stub (built alongside guard/launcher)

**Changes**:

- `agents/reasonix.js`: Added `reasonix-desktop.exe` (three platforms) and `reasonix-cli.exe` (Windows only) to `processNames` / `startupRecoveryProcessNames`
- `hooks/reasonix-hook.js`: Synced PID parser `agentNames`
- `test/registry.test.js`: Synced assertions

**Verification**: npm standalone CLI v1.17.21 (latest) process is still `reasonix.exe`; desktop v1.17.20 process is `reasonix-desktop.exe`; both are now detected correctly. `reasonix.exe` is retained to cover npm standalone CLI and pre-rename legacy versions.

## Commit 2 — fix(reasonix): stop dropping first events on cold start

**Question** — both completely silent (exit code 0, no error anywhere):

- After a long idle period (tens of minutes away from Reasonix), the next conversation gets no reaction from the desktop pet at all, as if it were disconnected. Continuous conversation works fine; only the events right after a gap go missing.
- The same thing happens on the very first message right after opening Clawd or booting the machine.

**Root cause** — entirely inside hooks/reasonix-hook.js:

- A single 800ms safety timer armed at process start covered the whole run: stdin read (400ms default window; up to ~2s after idle due to Reasonix's post-idle Go flush) + PID resolution (one extra PowerShell + a full-machine WMI snapshot per event, ~300ms warm / 1-3s cold) + POST. On a cold machine the total is 3-7s, so the timer fired before the POST and safeExit(0) swallowed the event. Even warm runs measured ~1.1s — already past the budget, surviving only because localhost POSTs complete in milliseconds.
- Clawd's stale-session cleanup makes it look worse: sessions whose agent process is undetectable (see previous commit) are deleted after 10 minutes, so the pet has no session card left when the dropped event would have rebuilt one — hence "disconnected".

**Fix**:

- Phased safety budget: 2500ms for the stdin wait (covering the 2000ms post-idle flush window), re-armed to 3500ms once stdin settles (covering resolve + POST). Stop keeps its extra allowance. The timer now only fires on a real hang.
- PID metadata only on SessionStart: the WMI snapshot no longer runs on every event. The server merges the session's known PID (src/state.js: sourcePid || existing.sourcePid) and reuses it, including for the UserPromptSubmit wt_hwnd sampling gate. UserPromptSubmit must stay fast anyway — Reasonix gives it a 5s budget and turns a timeout into a DecisionBlock that aborts the user's turn.
- Widen the stdin read window from the 400ms shared default to 2000ms (readStdinJsonDetailed), matching Reasonix's post-idle flush latency.

SessionStart unchanged by design; node --test reasonix suites 32/32