### PR TITLE
feat(#690): Phase 1 — shared display-edge helper + signed X materialization

### DIFF
--- a/src/display-edge.js
+++ b/src/display-edge.js
@@ -1,0 +1,122 @@
+"use strict";
+
+// src/display-edge.js — shared horizontal display-edge topology resolver.
+//
+// Both src/mini.js's internal-seam clip (`seamBoundary()`) and the Linux
+// edge-virtualization materializer (`materializeVirtualBounds()` in
+// src/drag-position.js, wired up in a later phase) need the same answer to
+// "is this edge an internal seam shared with a neighbouring display, or an
+// outer workArea edge with nothing beyond it?". Keeping two independent
+// approximations of that question is how you get "mini thinks it's an
+// internal seam but the materializer thinks it's an outer edge" bugs — see
+// docs/plans/plan-issue-690-gnome-mini-edge-snap.md §4.1.
+//
+// Pure module: no `require("electron")`, no reads of global state. Every
+// input (display list, workArea, vertical band) is passed in by the caller
+// so this can run in tests without a screen.
+
+// Absorbs OS-side rounding when comparing display edges. Carried over from
+// the tolerance src/mini.js's `seamBoundary()` already used.
+const SEAM_TOLERANCE_PX = 4;
+
+function isFiniteRect(rect) {
+  return !!rect
+    && Number.isFinite(rect.x)
+    && Number.isFinite(rect.y)
+    && Number.isFinite(rect.width)
+    && Number.isFinite(rect.height);
+}
+
+function isUsableDisplay(display) {
+  return !!display
+    && isFiniteRect(display.bounds)
+    && isFiniteRect(display.workArea)
+    && display.bounds.width > 0
+    && display.bounds.height > 0
+    && display.workArea.width > 0
+    && display.workArea.height > 0;
+}
+
+function overlapsVerticalBand(bounds, yMid) {
+  if (!Number.isFinite(yMid)) return false;
+  return yMid >= bounds.y && yMid <= bounds.y + bounds.height;
+}
+
+// The "local" display is whichever one's workArea contains the centre of
+// the caller's workArea. Mirrors src/mini.js's previous inline lookup.
+function findLocalDisplay(displays, workArea) {
+  const cx = workArea.x + workArea.width / 2;
+  const cy = workArea.y + workArea.height / 2;
+  return displays.find((d) =>
+    cx >= d.workArea.x && cx <= d.workArea.x + d.workArea.width &&
+    cy >= d.workArea.y && cy <= d.workArea.y + d.workArea.height
+  ) || null;
+}
+
+function resolveSide(edge, workArea, localBounds, displays, local, yMid) {
+  const workAreaBoundary = edge === "right"
+    ? workArea.x + workArea.width
+    : workArea.x;
+  const physicalBoundary = edge === "right"
+    ? localBounds.x + localBounds.width
+    : localBounds.x;
+
+  const yMidUsable = Number.isFinite(yMid);
+  const hasAdjacentDisplay = yMidUsable && displays.some((d) => {
+    if (d === local || !overlapsVerticalBand(d.bounds, yMid)) return false;
+    const neighbourEdge = edge === "right" ? d.bounds.x : d.bounds.x + d.bounds.width;
+    return Math.abs(neighbourEdge - physicalBoundary) <= SEAM_TOLERANCE_PX;
+  });
+
+  // "Outer" is a pure topology question: is there another display to go to
+  // past this edge? A side dock does NOT change that answer — its effect
+  // shows up in `workAreaBoundary` (which is where a clamp lands), not in
+  // whether we clamp at all. Folding the dock into this flag would make a
+  // multi-display seam with a dock report `isOuterWorkAreaEdge` and
+  // `hasAdjacentDisplay` both true, turning on horizontal virtualization and
+  // mini's seam clip simultaneously — exactly the disagreement this module
+  // exists to prevent, and a violation of the plan's invariant I3.
+  //
+  // With no usable yMid we can't judge the topology, so fail conservative:
+  // no virtualization (pre-fix behavior) rather than moving a window
+  // off-screen on a guess. `hasAdjacentDisplay` stays false in that case too,
+  // which preserves seamBoundary()'s pre-existing "no clip" behavior.
+  const isOuterWorkAreaEdge = yMidUsable && !hasAdjacentDisplay;
+
+  return { workAreaBoundary, physicalBoundary, hasAdjacentDisplay, isOuterWorkAreaEdge };
+}
+
+// resolveHorizontalEdgeContext({ displays, workArea, yMid })
+//   => { left: {...}, right: {...} }
+//
+// Resolves both horizontal edges in one call — deliberately does not take
+// an `edge` argument. The two sides can have different answers (three
+// monitors side by side: the middle one is a seam on both sides; two
+// monitors side by side: the left one is outer on its left, a seam on its
+// right) and a caller writing a window doesn't necessarily know in advance
+// which side it might overflow toward.
+function resolveHorizontalEdgeContext({ displays, workArea, yMid } = {}) {
+  const wa = isFiniteRect(workArea) ? workArea : { x: 0, y: 0, width: 0, height: 0 };
+  const usableDisplays = Array.isArray(displays) ? displays.filter(isUsableDisplay) : [];
+
+  // Rule 3: empty/damaged display list — fall back to a single synthetic
+  // display built from the caller's own workArea so we never produce NaN.
+  // bounds === workArea here: with no real display metadata we can't tell
+  // physical bounds from workArea, so both edges collapse to the same
+  // boundary (no dock, no neighbour).
+  const displaysForLookup = usableDisplays.length > 0
+    ? usableDisplays
+    : [{ bounds: wa, workArea: wa }];
+
+  const local = findLocalDisplay(displaysForLookup, wa);
+  const localBounds = local ? local.bounds : wa;
+
+  return {
+    left: resolveSide("left", wa, localBounds, displaysForLookup, local, yMid),
+    right: resolveSide("right", wa, localBounds, displaysForLookup, local, yMid),
+  };
+}
+
+module.exports = {
+  resolveHorizontalEdgeContext,
+};

--- a/src/display-edge.js
+++ b/src/display-edge.js
@@ -99,7 +99,7 @@ function resolveHorizontalEdgeContext({ displays, workArea, yMid } = {}) {
   const wa = isFiniteRect(workArea) ? workArea : { x: 0, y: 0, width: 0, height: 0 };
   const usableDisplays = Array.isArray(displays) ? displays.filter(isUsableDisplay) : [];
 
-  // Rule 3: empty/damaged display list — fall back to a single synthetic
+  // Rule 4: empty/damaged display list — fall back to a single synthetic
   // display built from the caller's own workArea so we never produce NaN.
   // bounds === workArea here: with no real display metadata we can't tell
   // physical bounds from workArea, so both edges collapse to the same

--- a/src/drag-position.js
+++ b/src/drag-position.js
@@ -59,6 +59,14 @@ function needsFinalClampAdjustment(bounds, size, clampPosition) {
 // and `viewportOffsetX: 0`, i.e. zero behavior change. When given, each
 // bound is used exactly as passed (no display lookup happens in here); the
 // two sides are clamped independently of one another.
+//
+// When the two-sided constraint is unsatisfiable — crossed bounds
+// (leftBound > rightBound) or a window wider than the feasible interval
+// (rightBound - leftBound < width) — the LEFT bound wins by design:
+// rightBound is applied first, leftBound last, so physical X lands exactly
+// on leftBound and the right edge overflows past rightBound. The result
+// stays finite and deterministic; callers must not rely on the right edge
+// being contained in that case.
 function materializeVirtualBounds(virtualBounds, workArea, { leftBound = null, rightBound = null } = {}) {
   if (!virtualBounds) return null;
   const minY = workArea && Number.isFinite(workArea.y) ? workArea.y : -Infinity;

--- a/src/drag-position.js
+++ b/src/drag-position.js
@@ -42,17 +42,44 @@ function needsFinalClampAdjustment(bounds, size, clampPosition) {
   );
 }
 
-function materializeVirtualBounds(virtualBounds, workArea) {
+// materializeVirtualBounds(virtualBounds, workArea, { leftBound, rightBound })
+//   => { bounds, viewportOffsetX, viewportOffsetY }
+//
+// Turns a logical (possibly off-screen) window rect into a safe physical
+// rect plus the viewport offsets a renderer/hit-window need to keep the
+// visual position matching the logical one.
+//
+// Y semantics are unchanged from before this was extended: the physical Y
+// is clamped to the workArea top only, and `viewportOffsetY` is always a
+// non-negative "top lift" (`physicalY - logicalY`).
+//
+// X is new and signed: `viewportOffsetX = logicalX - physicalX`. `leftBound`
+// / `rightBound` are `null` by default, meaning "don't clamp that side" —
+// existing callers that don't pass the third argument get X back unchanged
+// and `viewportOffsetX: 0`, i.e. zero behavior change. When given, each
+// bound is used exactly as passed (no display lookup happens in here); the
+// two sides are clamped independently of one another.
+function materializeVirtualBounds(virtualBounds, workArea, { leftBound = null, rightBound = null } = {}) {
   if (!virtualBounds) return null;
   const minY = workArea && Number.isFinite(workArea.y) ? workArea.y : -Infinity;
   const realY = Math.max(virtualBounds.y, minY);
+
+  let realX = virtualBounds.x;
+  if (Number.isFinite(rightBound)) {
+    realX = Math.min(realX, rightBound - virtualBounds.width);
+  }
+  if (Number.isFinite(leftBound)) {
+    realX = Math.max(realX, leftBound);
+  }
+
   return {
     bounds: {
-      x: virtualBounds.x,
+      x: realX,
       y: realY,
       width: virtualBounds.width,
       height: virtualBounds.height,
     },
+    viewportOffsetX: virtualBounds.x - realX,
     viewportOffsetY: Math.max(0, realY - virtualBounds.y),
   };
 }

--- a/src/mini.js
+++ b/src/mini.js
@@ -2,6 +2,7 @@
 // Extracted from main.js L315-331, L2700-2911
 
 const { screen } = require("electron");
+const { resolveHorizontalEdgeContext } = require("./display-edge");
 
 module.exports = function initMini(ctx) {
 
@@ -163,26 +164,15 @@ function animateWindowParabola(targetX, targetY, durationMs, onDone) {
 // is the physical boundary the neighbouring monitor begins at (and the same
 // place a single-display mini gets physically cut off by the screen edge).
 // Returns null at an outer screen edge (single display, or no neighbour at
-// the pet's vertical band). The 4px tolerance absorbs OS-side rounding.
+// the pet's vertical band). Delegates the actual topology judgment to the
+// shared src/display-edge.js helper so mini's internal-seam clip and the
+// Linux edge-virtualization materializer can't disagree about which edges
+// are seams — see docs/plans/plan-issue-690-gnome-mini-edge-snap.md §4.1.
 function seamBoundary(wa, yMid, edge) {
   const displays = screen.getAllDisplays();
-  const cx = wa.x + wa.width / 2;
-  const cy = wa.y + wa.height / 2;
-  const local = displays.find((d) =>
-    cx >= d.workArea.x && cx <= d.workArea.x + d.workArea.width &&
-    cy >= d.workArea.y && cy <= d.workArea.y + d.workArea.height);
-  const lb = local ? local.bounds : wa;
-  const seam = edge === "right" ? lb.x + lb.width : lb.x;
-  const overlapsY = (d) => {
-    if (!Number.isFinite(yMid)) return false;
-    return yMid >= d.bounds.y && yMid <= d.bounds.y + d.bounds.height;
-  };
-  const hasNeighbour = displays.some((d) => {
-    if (d === local || !overlapsY(d)) return false;
-    const dEdge = edge === "right" ? d.bounds.x : d.bounds.x + d.bounds.width;
-    return Math.abs(dEdge - seam) <= 4;
-  });
-  return hasNeighbour ? seam : null;
+  const context = resolveHorizontalEdgeContext({ displays, workArea: wa, yMid });
+  const side = edge === "right" ? context.right : context.left;
+  return side.hasAdjacentDisplay ? side.physicalBoundary : null;
 }
 
 // Multi-monitor seam state: when the mini pet sits at an internal seam, the

--- a/test/display-edge.test.js
+++ b/test/display-edge.test.js
@@ -149,13 +149,93 @@ describe("resolveHorizontalEdgeContext", () => {
   });
 
   it("stays conservative when yMid is missing or not finite", () => {
-    const ctx = resolveHorizontalEdgeContext({
-      displays: SIDE_BY_SIDE, workArea: SIDE_BY_SIDE[0].workArea,
+    // Every non-finite-number shape, not just "argument omitted": explicit
+    // NaN, both infinities, and a numeric string (Number.isFinite does not
+    // coerce) must all fail conservative.
+    const unusable = [undefined, null, NaN, Infinity, -Infinity, "300"];
+    for (const yMid of unusable) {
+      const ctx = resolveHorizontalEdgeContext({
+        displays: SIDE_BY_SIDE, workArea: SIDE_BY_SIDE[0].workArea, yMid,
+      });
+
+      assert.equal(ctx.right.hasAdjacentDisplay, false,
+        `yMid=${String(yMid)} matches seamBoundary()'s existing behavior`);
+      assert.equal(ctx.right.isOuterWorkAreaEdge, false,
+        `yMid=${String(yMid)} must not enable virtualization`);
+      assert.equal(ctx.left.isOuterWorkAreaEdge, false, `yMid=${String(yMid)}`);
+    }
+  });
+
+  it("treats the yMid band as a closed interval at the neighbour's top and bottom edges", () => {
+    // overlapsVerticalBand() compares with >= / <= — a pet centre sitting
+    // exactly on the neighbour's bounds.y or bounds.y + height still counts
+    // as covered; one pixel past either edge does not.
+    const displays = [
+      { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+      { bounds: bounds(800, 150, 800, 300), workArea: bounds(800, 150, 800, 300) },
+    ];
+    const wa = displays[0].workArea;
+    const at = (yMid) => resolveHorizontalEdgeContext({ displays, workArea: wa, yMid });
+
+    assert.equal(at(150).right.hasAdjacentDisplay, true, "exactly at the neighbour's top edge");
+    assert.equal(at(450).right.hasAdjacentDisplay, true, "exactly at the neighbour's bottom edge (150+300)");
+    assert.equal(at(149).right.hasAdjacentDisplay, false, "one px above the band");
+    assert.equal(at(451).right.hasAdjacentDisplay, false, "one px below the band");
+  });
+
+  it("honours the 4px seam tolerance boundary exactly", () => {
+    const withGap = (gap) => resolveHorizontalEdgeContext({
+      displays: [
+        { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+        { bounds: bounds(800 + gap, 0, 800, 600), workArea: bounds(800 + gap, 0, 800, 600) },
+      ],
+      workArea: bounds(0, 0, 800, 600),
+      yMid: 300,
     });
 
-    assert.equal(ctx.right.hasAdjacentDisplay, false, "matches seamBoundary()'s existing behavior");
-    assert.equal(ctx.right.isOuterWorkAreaEdge, false, "unknown topology must not enable virtualization");
-    assert.equal(ctx.left.isOuterWorkAreaEdge, false);
+    assert.equal(withGap(4).right.hasAdjacentDisplay, true, "gap == tolerance is still a seam");
+    assert.equal(withGap(4).right.isOuterWorkAreaEdge, false);
+    assert.equal(withGap(5).right.hasAdjacentDisplay, false, "gap just past tolerance is not");
+    assert.equal(withGap(5).right.isOuterWorkAreaEdge, true);
+  });
+
+  it("does not depend on the order of the display list", () => {
+    const reversed = [...SIDE_BY_SIDE].reverse();
+    const ctx = resolveHorizontalEdgeContext({
+      displays: reversed, workArea: SIDE_BY_SIDE[0].workArea, yMid: 300,
+    });
+
+    assert.equal(ctx.right.hasAdjacentDisplay, true);
+    assert.equal(ctx.right.isOuterWorkAreaEdge, false);
+    assert.equal(ctx.left.hasAdjacentDisplay, false);
+    assert.equal(ctx.left.isOuterWorkAreaEdge, true);
+  });
+
+  it("falls back to the caller's workArea when no display contains its centre", () => {
+    // findLocalDisplay() misses → localBounds falls back to the workArea
+    // itself, so the two boundaries collapse on both sides…
+    const orphanWa = bounds(2000, 0, 800, 600);
+    const alone = resolveHorizontalEdgeContext({
+      displays: SINGLE, workArea: orphanWa, yMid: 300,
+    });
+
+    assert.equal(alone.left.physicalBoundary, alone.left.workAreaBoundary);
+    assert.equal(alone.right.physicalBoundary, alone.right.workAreaBoundary);
+    assert.equal(alone.right.isOuterWorkAreaEdge, true, "nothing touches the orphan workArea");
+
+    // …and with local === null every display takes part in the adjacency
+    // check, so a display that happens to touch the orphan workArea's edge
+    // still registers as a seam.
+    const touching = resolveHorizontalEdgeContext({
+      displays: [
+        { bounds: bounds(2800, 0, 800, 600), workArea: bounds(2800, 0, 800, 600) },
+      ],
+      workArea: orphanWa,
+      yMid: 300,
+    });
+
+    assert.equal(touching.right.hasAdjacentDisplay, true);
+    assert.equal(touching.right.isOuterWorkAreaEdge, false);
   });
 
   it("does not count a physical gap between displays as a seam", () => {
@@ -180,6 +260,10 @@ describe("resolveHorizontalEdgeContext", () => {
     assert.equal(empty.left.hasAdjacentDisplay, false);
     assert.equal(empty.left.isOuterWorkAreaEdge, true);
     assert.equal(empty.right.isOuterWorkAreaEdge, true);
+    // The synthetic display is built from the workArea itself, so the two
+    // boundaries must collapse — no dock, no neighbour.
+    assert.equal(empty.left.physicalBoundary, empty.left.workAreaBoundary);
+    assert.equal(empty.right.physicalBoundary, empty.right.workAreaBoundary);
 
     const damaged = resolveHorizontalEdgeContext({
       displays: [
@@ -196,6 +280,8 @@ describe("resolveHorizontalEdgeContext", () => {
     assert.equal(Number.isFinite(damaged.right.physicalBoundary), true);
     assert.equal(damaged.left.isOuterWorkAreaEdge, true);
     assert.equal(damaged.right.isOuterWorkAreaEdge, true);
+    assert.equal(damaged.left.physicalBoundary, damaged.left.workAreaBoundary);
+    assert.equal(damaged.right.physicalBoundary, damaged.right.workAreaBoundary);
   });
 
   it("returns both sides' conclusions from a single call", () => {

--- a/test/display-edge.test.js
+++ b/test/display-edge.test.js
@@ -1,0 +1,209 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+
+const { resolveHorizontalEdgeContext } = require("../src/display-edge");
+
+const bounds = (x, y, w, h) => ({ x, y, width: w, height: h });
+
+// Single display: D1 [0,800) x [0,600).
+const SINGLE = [
+  { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+];
+
+// Two displays tiled side by side: D1 [0,800) and D2 [800,1600), same height.
+const SIDE_BY_SIDE = [
+  { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+  { bounds: bounds(800, 0, 800, 600), workArea: bounds(800, 0, 800, 600) },
+];
+
+const THREE_SIDE_BY_SIDE = [
+  { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+  { bounds: bounds(800, 0, 800, 600), workArea: bounds(800, 0, 800, 600) },
+  { bounds: bounds(1600, 0, 800, 600), workArea: bounds(1600, 0, 800, 600) },
+];
+
+describe("resolveHorizontalEdgeContext", () => {
+  it("treats both edges of a single display as outer", () => {
+    const wa = SINGLE[0].workArea;
+    const ctx = resolveHorizontalEdgeContext({ displays: SINGLE, workArea: wa, yMid: 300 });
+
+    assert.equal(ctx.left.isOuterWorkAreaEdge, true);
+    assert.equal(ctx.left.hasAdjacentDisplay, false);
+    assert.equal(ctx.left.workAreaBoundary, 0);
+    assert.equal(ctx.left.physicalBoundary, 0);
+
+    assert.equal(ctx.right.isOuterWorkAreaEdge, true);
+    assert.equal(ctx.right.hasAdjacentDisplay, false);
+    assert.equal(ctx.right.workAreaBoundary, 800);
+    assert.equal(ctx.right.physicalBoundary, 800);
+  });
+
+  it("treats the shared edge between two horizontally adjacent, y-overlapping displays as an internal seam", () => {
+    const wa = SIDE_BY_SIDE[0].workArea; // pet lives on D1
+    const ctx = resolveHorizontalEdgeContext({ displays: SIDE_BY_SIDE, workArea: wa, yMid: 300 });
+
+    assert.equal(ctx.right.hasAdjacentDisplay, true, "D1's right edge touches D2");
+    assert.equal(ctx.right.isOuterWorkAreaEdge, false);
+    assert.equal(ctx.right.physicalBoundary, 800);
+
+    assert.equal(ctx.left.hasAdjacentDisplay, false, "nothing to D1's left");
+    assert.equal(ctx.left.isOuterWorkAreaEdge, true);
+  });
+
+  it("still counts as an internal seam when the neighbour is vertically offset but still covers the pet's yMid", () => {
+    const displays = [
+      { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+      // D2 shifted down 150px — still overlaps D1's vertical band at yMid≈240.
+      { bounds: bounds(800, 150, 800, 600), workArea: bounds(800, 150, 800, 600) },
+    ];
+    const wa = displays[0].workArea;
+    const ctx = resolveHorizontalEdgeContext({ displays, workArea: wa, yMid: 240 });
+
+    assert.equal(ctx.right.hasAdjacentDisplay, true);
+    assert.equal(ctx.right.isOuterWorkAreaEdge, false);
+  });
+
+  it("treats the edge as outer when the neighbour does not cover the pet's yMid", () => {
+    const displays = [
+      { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+      // Neighbour starts below the pet's vertical band entirely.
+      { bounds: bounds(800, 700, 800, 600), workArea: bounds(800, 700, 800, 600) },
+    ];
+    const wa = displays[0].workArea;
+    const ctx = resolveHorizontalEdgeContext({ displays, workArea: wa, yMid: 300 });
+
+    assert.equal(ctx.right.hasAdjacentDisplay, false);
+    assert.equal(ctx.right.isOuterWorkAreaEdge, true);
+  });
+
+  it("supports a display with negative coordinates to the left of the origin", () => {
+    // D1 sits to the left of the origin: [-800,0). D2 is the primary [0,800).
+    const displays = [
+      { bounds: bounds(-800, 0, 800, 600), workArea: bounds(-800, 0, 800, 600) },
+      { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+    ];
+    const wa = displays[1].workArea; // pet lives on D2
+    const ctx = resolveHorizontalEdgeContext({ displays, workArea: wa, yMid: 300 });
+
+    assert.equal(ctx.left.hasAdjacentDisplay, true, "D2's left edge touches D1 at x=0");
+    assert.equal(ctx.left.isOuterWorkAreaEdge, false);
+    assert.equal(ctx.left.physicalBoundary, 0);
+
+    assert.equal(ctx.right.hasAdjacentDisplay, false);
+    assert.equal(ctx.right.isOuterWorkAreaEdge, true);
+    assert.equal(ctx.right.physicalBoundary, 800);
+  });
+
+  it("treats both edges of the middle display in a three-monitor row as seams", () => {
+    const wa = THREE_SIDE_BY_SIDE[1].workArea; // pet on the middle display
+    const ctx = resolveHorizontalEdgeContext({ displays: THREE_SIDE_BY_SIDE, workArea: wa, yMid: 300 });
+
+    assert.equal(ctx.left.hasAdjacentDisplay, true);
+    assert.equal(ctx.left.isOuterWorkAreaEdge, false);
+    assert.equal(ctx.left.physicalBoundary, 800);
+
+    assert.equal(ctx.right.hasAdjacentDisplay, true);
+    assert.equal(ctx.right.isOuterWorkAreaEdge, false);
+    assert.equal(ctx.right.physicalBoundary, 1600);
+  });
+
+  it("keeps a dock-inset edge a seam when a display still touches beyond it", () => {
+    // D1's workArea is narrower than its bounds (a right-side dock/panel).
+    // D2's workArea is also inset on its left. The two displays' physical
+    // bounds still touch at x=800, so this stays an internal seam: the pet
+    // can still cross to D2 and mini's seam clip still applies. The dock only
+    // changes *where* a clamp would land (workAreaBoundary=770), never
+    // whether the edge is outer — reporting both flags true would enable
+    // horizontal virtualization and the seam clip at the same time.
+    const displays = [
+      { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 770, 560) },
+      { bounds: bounds(800, 0, 800, 600), workArea: bounds(830, 0, 770, 560) },
+    ];
+    const wa = displays[0].workArea;
+    const ctx = resolveHorizontalEdgeContext({ displays, workArea: wa, yMid: 280 });
+
+    assert.equal(ctx.right.workAreaBoundary, 770);
+    assert.equal(ctx.right.physicalBoundary, 800);
+    assert.equal(ctx.right.hasAdjacentDisplay, true, "physical bounds still touch");
+    assert.equal(ctx.right.isOuterWorkAreaEdge, false, "a dock does not change the topology");
+  });
+
+  it("reports a dock-inset outer edge with the workArea boundary, not the display bounds edge", () => {
+    // Single display with a right-side dock: nothing beyond it, so this edge
+    // IS outer — and a clamp must land at the dock edge (770), not at the
+    // physical display edge (800). This is how plan rule 1 actually takes
+    // effect: through workAreaBoundary's value, not through the outer flag.
+    const displays = [
+      { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 770, 560) },
+    ];
+    const ctx = resolveHorizontalEdgeContext({
+      displays, workArea: displays[0].workArea, yMid: 280,
+    });
+
+    assert.equal(ctx.right.isOuterWorkAreaEdge, true);
+    assert.equal(ctx.right.hasAdjacentDisplay, false);
+    assert.equal(ctx.right.workAreaBoundary, 770);
+    assert.equal(ctx.right.physicalBoundary, 800);
+  });
+
+  it("stays conservative when yMid is missing or not finite", () => {
+    const ctx = resolveHorizontalEdgeContext({
+      displays: SIDE_BY_SIDE, workArea: SIDE_BY_SIDE[0].workArea,
+    });
+
+    assert.equal(ctx.right.hasAdjacentDisplay, false, "matches seamBoundary()'s existing behavior");
+    assert.equal(ctx.right.isOuterWorkAreaEdge, false, "unknown topology must not enable virtualization");
+    assert.equal(ctx.left.isOuterWorkAreaEdge, false);
+  });
+
+  it("does not count a physical gap between displays as a seam", () => {
+    const displays = [
+      { bounds: bounds(0, 0, 800, 600), workArea: bounds(0, 0, 800, 600) },
+      // 50px gap between D1's right edge (800) and D2's left edge (850).
+      { bounds: bounds(850, 0, 800, 600), workArea: bounds(850, 0, 800, 600) },
+    ];
+    const wa = displays[0].workArea;
+    const ctx = resolveHorizontalEdgeContext({ displays, workArea: wa, yMid: 300 });
+
+    assert.equal(ctx.right.hasAdjacentDisplay, false);
+    assert.equal(ctx.right.isOuterWorkAreaEdge, true);
+  });
+
+  it("falls back to a single-display topology without NaN when the display list is empty or damaged", () => {
+    const wa = bounds(0, 0, 800, 600);
+
+    const empty = resolveHorizontalEdgeContext({ displays: [], workArea: wa, yMid: 300 });
+    assert.equal(Number.isFinite(empty.left.workAreaBoundary), true);
+    assert.equal(Number.isFinite(empty.left.physicalBoundary), true);
+    assert.equal(empty.left.hasAdjacentDisplay, false);
+    assert.equal(empty.left.isOuterWorkAreaEdge, true);
+    assert.equal(empty.right.isOuterWorkAreaEdge, true);
+
+    const damaged = resolveHorizontalEdgeContext({
+      displays: [
+        { bounds: bounds(0, 0, NaN, 600), workArea: bounds(0, 0, 800, 600) },
+        { bounds: null, workArea: bounds(800, 0, 800, 600) },
+        undefined,
+      ],
+      workArea: wa,
+      yMid: 300,
+    });
+    assert.equal(Number.isFinite(damaged.left.workAreaBoundary), true);
+    assert.equal(Number.isFinite(damaged.left.physicalBoundary), true);
+    assert.equal(Number.isFinite(damaged.right.workAreaBoundary), true);
+    assert.equal(Number.isFinite(damaged.right.physicalBoundary), true);
+    assert.equal(damaged.left.isOuterWorkAreaEdge, true);
+    assert.equal(damaged.right.isOuterWorkAreaEdge, true);
+  });
+
+  it("returns both sides' conclusions from a single call", () => {
+    const wa = SIDE_BY_SIDE[0].workArea; // left display of a two-display row
+    const ctx = resolveHorizontalEdgeContext({ displays: SIDE_BY_SIDE, workArea: wa, yMid: 300 });
+
+    assert.ok(ctx.left && ctx.right, "both sides present in one result");
+    assert.equal(ctx.left.isOuterWorkAreaEdge, true, "nothing to the left of the left display");
+    assert.equal(ctx.right.hasAdjacentDisplay, true, "D2 sits right next to it");
+  });
+});

--- a/test/drag-position.test.js
+++ b/test/drag-position.test.js
@@ -205,4 +205,50 @@ describe("materializeVirtualBounds", () => {
     // to sit past the workArea — nothing in this function pulls it back.
     assert.equal(result.bounds.x + result.bounds.width, 2000);
   });
+
+  // --- Unsatisfiable two-sided constraints. The documented contract when
+  // leftBound > rightBound - width (crossed bounds, or a window wider than
+  // the feasible interval) is: the left bound wins. rightBound is applied
+  // first and leftBound last, so physical X lands exactly on leftBound and
+  // the right edge overflows. Deterministic and finite — never NaN, never
+  // a left/right flip.
+
+  it("lets the left bound win when the two bounds cross", () => {
+    const result = materializeVirtualBounds(
+      { x: 60, y: 100, width: 20, height: 20 },
+      wa(0, 0, 1920, 1080),
+      { leftBound: 100, rightBound: 50 }
+    );
+
+    assert.equal(result.bounds.x, 100);
+    assert.equal(result.viewportOffsetX, -40);
+  });
+
+  it("lands on the left bound when the window is wider than the bounded interval", () => {
+    const result = materializeVirtualBounds(
+      { x: 100, y: 100, width: 2000, height: 209 },
+      wa(0, 0, 1920, 1080),
+      { leftBound: 0, rightBound: 1920 }
+    );
+
+    assert.equal(result.bounds.x, 0);
+    assert.equal(result.viewportOffsetX, 100);
+    assert.equal(
+      result.bounds.x + result.bounds.width, 2000,
+      "right edge is allowed to overflow past rightBound in the unsatisfiable case"
+    );
+  });
+
+  it("stays finite when both sides overflow at once", () => {
+    const result = materializeVirtualBounds(
+      { x: -50, y: 100, width: 2000, height: 209 },
+      wa(0, 0, 1920, 1080),
+      { leftBound: 0, rightBound: 1920 }
+    );
+
+    assert.equal(result.bounds.x, 0, "left bound wins");
+    assert.equal(result.viewportOffsetX, -50);
+    assert.equal(Number.isFinite(result.bounds.x), true);
+    assert.equal(Number.isFinite(result.viewportOffsetX), true);
+  });
 });

--- a/test/drag-position.test.js
+++ b/test/drag-position.test.js
@@ -83,6 +83,10 @@ describe("anchored drag positioning", () => {
 });
 
 describe("materializeVirtualBounds", () => {
+  // --- Existing Y-axis behavior. Untouched by the leftBound/rightBound
+  // extension: the third argument is optional and defaults to both bounds
+  // null, so these keep exercising exactly the pre-existing code path
+  // (the expected objects just also carry the new viewportOffsetX: 0 key).
   it("keeps in-bounds virtual coordinates unchanged", () => {
     const result = materializeVirtualBounds(
       { x: 100, y: 120, width: 200, height: 200 },
@@ -91,6 +95,7 @@ describe("materializeVirtualBounds", () => {
 
     assert.deepStrictEqual(result, {
       bounds: { x: 100, y: 120, width: 200, height: 200 },
+      viewportOffsetX: 0,
       viewportOffsetY: 0,
     });
   });
@@ -103,6 +108,7 @@ describe("materializeVirtualBounds", () => {
 
     assert.deepStrictEqual(result, {
       bounds: { x: 100, y: 0, width: 200, height: 200 },
+      viewportOffsetX: 0,
       viewportOffsetY: 74,
     });
   });
@@ -115,7 +121,88 @@ describe("materializeVirtualBounds", () => {
 
     assert.deepStrictEqual(result, {
       bounds: { x: 50, y: -20, width: 100, height: 100 },
+      viewportOffsetX: 0,
       viewportOffsetY: 0,
     });
+  });
+
+  // --- §6.1 new X-axis edge-clamp test matrix (plan-issue-690 Phase 1).
+
+  it("keeps the original X when both leftBound and rightBound are null", () => {
+    const result = materializeVirtualBounds(
+      { x: 1768, y: 100, width: 203, height: 209 },
+      wa(0, 0, 1920, 1080),
+      { leftBound: null, rightBound: null }
+    );
+
+    assert.equal(result.bounds.x, 1768);
+    assert.equal(result.viewportOffsetX, 0);
+  });
+
+  it("clamps a right-side logical overflow to a safe physical X with a positive offset", () => {
+    // #690 fixture: logical mini X=1816 wants to sit 99px past the safe
+    // physical edge (rightBound=1920, width=203 → safe X=1717).
+    const result = materializeVirtualBounds(
+      { x: 1816, y: 100, width: 203, height: 209 },
+      wa(0, 0, 1920, 1080),
+      { rightBound: 1920 }
+    );
+
+    assert.equal(result.bounds.x, 1717);
+    assert.equal(result.viewportOffsetX, 99);
+  });
+
+  it("clamps a left-side logical overflow to a safe physical X with a negative offset", () => {
+    const result = materializeVirtualBounds(
+      { x: -99, y: 100, width: 203, height: 209 },
+      wa(0, 0, 1920, 1080),
+      { leftBound: 0 }
+    );
+
+    assert.equal(result.bounds.x, 0);
+    assert.equal(result.viewportOffsetX, -99);
+  });
+
+  it("returns a zero offset once the logical position is back on-screen", () => {
+    const result = materializeVirtualBounds(
+      { x: 800, y: 100, width: 203, height: 209 },
+      wa(0, 0, 1920, 1080),
+      { leftBound: 0, rightBound: 1920 }
+    );
+
+    assert.equal(result.bounds.x, 800);
+    assert.equal(result.viewportOffsetX, 0);
+  });
+
+  it("uses the caller-supplied bound exactly, without guessing display bounds (side dock)", () => {
+    // A side dock means the workArea boundary the caller passes in differs
+    // from the display's raw physical bounds edge (which this function
+    // never sees). The clamp must land exactly on the supplied bound.
+    const dockRightBound = 1890; // e.g. a 30px dock trims the workArea edge
+    const result = materializeVirtualBounds(
+      { x: 1850, y: 100, width: 203, height: 209 },
+      wa(0, 0, 1920, 1080),
+      { rightBound: dockRightBound }
+    );
+
+    assert.equal(result.bounds.x, dockRightBound - 203);
+    assert.equal(result.viewportOffsetX, 1850 - (dockRightBound - 203));
+  });
+
+  it("clamps each side independently — only the bound that is a number applies", () => {
+    // leftBound set, rightBound null: left overflow gets clamped, but a
+    // simultaneous "right overflow" (window wider than the workArea) is
+    // left completely alone because rightBound opted out.
+    const result = materializeVirtualBounds(
+      { x: -50, y: 100, width: 2000, height: 209 },
+      wa(0, 0, 1920, 1080),
+      { leftBound: 0, rightBound: null }
+    );
+
+    assert.equal(result.bounds.x, 0, "left side is clamped");
+    assert.equal(result.viewportOffsetX, -50, "left clamp produces the offset");
+    // Sanity: with rightBound null, the right edge (x + width) is allowed
+    // to sit past the workArea — nothing in this function pulls it back.
+    assert.equal(result.bounds.x + result.bounds.width, 2000);
   });
 });


### PR DESCRIPTION
#690 修复的 **Phase 1**：只做纯函数与拓扑层，**运行时零行为变化**。renderer、runtime 和任何窗口写入路径都还没接。

方案见 `docs/plans/plan-issue-690-gnome-mini-edge-snap.md` 的 §4.1 / §4.2 / Phase 1（本地文档，未入库）。

## 改了什么

**新增 `src/display-edge.js`** —— `resolveHorizontalEdgeContext({ displays, workArea, yMid })`，一次返回左右两侧结论。

刻意**不吃 `edge` 入参**：两侧答案经常不同（三屏中间那台左右都是接缝；两屏的左屏是"左外缘 + 右接缝"），而写窗时未必知道会往哪一侧溢出。

`isOuterWorkAreaEdge` 是**纯拓扑判断**（`!hasAdjacentDisplay`）。侧边 dock 不参与它——dock 的作用是让 `workAreaBoundary` 与 `physicalBoundary` 分离，钳制时用前者、mini 的 seam clip 用后者。把 dock 折进这个标志会让"多屏 + 接缝侧 dock"同时报两个标志为真，于是水平虚拟化和 seam clip 一起生效，正是这个 helper 要消除的分歧。

`yMid` 无效时两个标志都保守为 `false`：拓扑未知就不启用虚拟化，也维持 `seamBoundary()` 原有的"不裁剪"行为。

**扩展 `src/drag-position.js` 的 `materializeVirtualBounds()`** —— 新增可选第三参数 `{ leftBound, rightBound }`，两侧可为 `null` 且**独立**钳制。默认值让 X 和 `viewportOffsetX` 保持不变，因此现有调用点行为完全不变。Y 语义（只做顶部抬升、`viewportOffsetY` 非负）一个字节没动。

**`src/mini.js` 的 `seamBoundary()`** 改为委托给共享 helper，不再保留第二套近似逻辑。旧的 `hasNeighbour ? seam : null` 逐项映射为 `hasAdjacentDisplay ? physicalBoundary : null`。

## 测试

新增 `test/display-edge.test.js`（12 条）+ 扩展 `test/drag-position.test.js`（6 条新增）。

`node --test test/mini.test.js test/drag-position.test.js test/display-edge.test.js` → **42 pass / 0 fail**。

mini 的 11 条既有 seam clip 用例原样未改、原样通过，这是 `seamBoundary()` 改接等价性的主要依据。`drag-position.test.js` 的既有 negative-Y 用例只补了 `viewportOffsetX: 0` 键（返回值多了字段），值和语义未动；实际调用方只解构 `.bounds` / `.viewportOffsetY`，运行时无影响。

`npm test` 全量另有 13 个失败，全部落在 `remote-deploy` / `remote-ssh-*` / `server-config` 里，是 POSIX 权限位（0600 在 Windows 上读成 0666）、POSIX home 路径、CRLF 这类既有平台性失败，与本 PR 无关且这些文件未被修改。

## 影响面

- Windows / macOS：无变化（新参数默认不启用）
- Linux：无变化（本阶段没有调用方传入 bound）
- 多显示器接缝：无变化（`seamBoundary()` 等价替换）

## 后续

Phase 2（runtime 逻辑/物理映射 + renderer translate + hit clip + reconcile 状态机）与 Phase 3（mini 全路径）会合成一个 PR——中间态会在 Linux 外缘留下不一致，不适合单独合。

Phase 3 之后打包请报告人验证，同时采集 P1-4 所需的真机数据（`Super`+拖动抓到哪一层窗口），采样请求已发在 #690。
