### PR TITLE
fix: replace native permission automation confirmation

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -77,6 +77,7 @@ const {
   shouldOpenSettingsWindowFromArgv,
 } = require("./settings-window-icon");
 const createSettingsWindowRuntime = require("./settings-window");
+const createPermissionAutomationConfirmationRuntime = require("./permission-automation-confirmation");
 const {
   createSettingsSizePreviewSession,
 } = require("./settings-size-preview-session");
@@ -703,6 +704,15 @@ const settingsWindowRuntime = createSettingsWindowRuntime({
     endTextScalePreview();
   },
   onAfterClosed: () => maybeDestroyIdleAnimationPreviewPosterWindow(),
+});
+
+const permissionAutomationConfirmationRuntime = createPermissionAutomationConfirmationRuntime({
+  BrowserWindow,
+  ipcMain,
+  nativeTheme,
+  screen,
+  path,
+  iconPath: settingsWindowRuntime.getIconPath(),
 });
 
 function getSettingsWindow() {
@@ -1780,24 +1790,16 @@ async function showSessionAutomationWarning(entry) {
     entry,
     petWindow: win,
   });
-  const result = await electronDialog.showMessageBox(parent, {
-    type: "warning",
-    buttons: [
-      translate("sessionAutomationConfirmEnable"),
-      translate("permissionAutomationCancel"),
-    ],
-    defaultId: 1,
-    cancelId: 1,
+  return permissionAutomationConfirmationRuntime.confirmPermissionAutomation({
+    parent,
+    lang: _settingsController.get("lang") || lang || "en",
     title: translate("sessionAutomationConfirmTitle"),
     message: translate("sessionAutomationConfirmMessage"),
     detail: translate("sessionAutomationConfirmDetail"),
     checkboxLabel: translate("permissionAutomationAutoToolsDontShowAgain"),
-    checkboxChecked: false,
+    confirmLabel: translate("sessionAutomationConfirmEnable"),
+    cancelLabel: translate("permissionAutomationCancel"),
   });
-  return {
-    confirmed: result.response === 0,
-    suppressFutureConfirmation: result.response === 0 && result.checkboxChecked === true,
-  };
 }
 
 sessionAutomationStore = createSessionAutomationStore({
@@ -3260,6 +3262,12 @@ const _menuCtx = {
       return { status: "error", message: err && err.message };
     });
   },
+  confirmPermissionAutomation: (payload) => (
+    permissionAutomationConfirmationRuntime.confirmPermissionAutomation(payload)
+  ),
+  showPermissionAutomationError: (payload) => (
+    permissionAutomationConfirmationRuntime.showPermissionAutomationError(payload)
+  ),
   get soundMuted() { return soundMuted; },
   set soundMuted(v) { _settingsController.applyUpdate("soundMuted", v); },
   get soundVolume() { return soundVolume; },
@@ -4411,6 +4419,7 @@ if (!gotTheLock) {
     flushRuntimeStateToPrefs();
     globalShortcut.unregisterAll();
     void settingsSizePreviewSession.cleanup();
+    permissionAutomationConfirmationRuntime.dispose();
     if (_telegramMigrationController
       && typeof _telegramMigrationController.dispose === "function") {
       void _telegramMigrationController.dispose();

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { app, BrowserWindow, screen, Menu, Tray, nativeImage, dialog } = require("electron");
+const { app, BrowserWindow, screen, Menu, Tray, nativeImage } = require("electron");
 const path = require("path");
 const { keepOutOfTaskbar } = require("./taskbar");
 const { loadTrayNormalIcon } = require("./tray-flash-icon");
@@ -93,19 +93,16 @@ module.exports = function initMenu(ctx) {
       : (typeof reason === "string" ? reason : "Unknown error");
     console.warn("Clawd: permission automation mode change failed:", message);
     try {
-      return Promise.resolve(dialog.showMessageBox({
-        type: "error",
-        buttons: ["OK"],
-        defaultId: 0,
-        cancelId: 0,
+      return Promise.resolve(ctx.showPermissionAutomationError({
+        lang: ctx.lang,
         title: t("menuPermissionAutomation"),
-        message: t("menuPermissionAutomation"),
         detail: message,
+        dismissLabel: t("dismiss"),
       })).catch((err) => {
-        console.warn("Clawd: permission automation error dialog failed:", err && err.message);
+        console.warn("Clawd: permission automation error window failed:", err && err.message);
       });
     } catch (err) {
-      console.warn("Clawd: permission automation error dialog failed:", err && err.message);
+      console.warn("Clawd: permission automation error window failed:", err && err.message);
       return Promise.resolve();
     }
   }
@@ -142,20 +139,10 @@ module.exports = function initMenu(ctx) {
         return;
       }
       Promise.resolve(
-        dialog.showMessageBox({
-          type: "warning",
-          buttons: [
-            t(unattended
-              ? "permissionAutomationEnableUnattended"
-              : "permissionAutomationEnableAutoTools"),
-            t("permissionAutomationCancel"),
-          ],
-          defaultId: 1,
-          cancelId: 1,
+        ctx.confirmPermissionAutomation({
+          mode,
+          lang: ctx.lang,
           title: t(unattended
-            ? "permissionAutomationUnattendedConfirmTitle"
-            : "permissionAutomationAutoToolsConfirmTitle"),
-          message: t(unattended
             ? "permissionAutomationUnattendedConfirmTitle"
             : "permissionAutomationAutoToolsConfirmTitle"),
           detail: t(unattended
@@ -164,13 +151,16 @@ module.exports = function initMenu(ctx) {
           checkboxLabel: t(unattended
             ? "permissionAutomationUnattendedDontShowAgain"
             : "permissionAutomationAutoToolsDontShowAgain"),
-          checkboxChecked: false,
+          confirmLabel: t(unattended
+            ? "permissionAutomationEnableUnattended"
+            : "permissionAutomationEnableAutoTools"),
+          cancelLabel: t("permissionAutomationCancel"),
         })
       ).then((res) => {
-        if (res && res.response === 0) {
+        if (res && res.confirmed === true) {
           return applyPermissionAutomationMode(mode, {
             confirmed: true,
-            suppressFutureConfirmation: res.checkboxChecked === true,
+            suppressFutureConfirmation: res.suppressFutureConfirmation === true,
           });
         }
         return undefined;

--- a/src/permission-automation-confirmation-renderer.js
+++ b/src/permission-automation-confirmation-renderer.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const bridge = window.permissionAutomationConfirmation;
+const root = document.getElementById("dialog");
+const title = document.getElementById("title");
+const message = document.getElementById("message");
+const detail = document.getElementById("detail");
+const checkboxRow = document.getElementById("checkbox-row");
+const checkbox = document.getElementById("suppress");
+const checkboxLabel = document.getElementById("checkbox-label");
+const confirmButton = document.getElementById("confirm");
+const cancelButton = document.getElementById("cancel");
+const closeButton = document.getElementById("close");
+
+function submit(action) {
+  bridge.submit({
+    action,
+    suppressFutureConfirmation: checkbox.checked,
+  });
+}
+
+bridge.onState((state = {}) => {
+  const isError = state.kind === "error";
+  document.documentElement.lang = state.lang || "en";
+  document.title = state.title || "Clawd";
+  root.dataset.kind = isError ? "error" : "confirm";
+  title.textContent = state.title || "";
+  message.textContent = state.message || "";
+  message.hidden = !state.message;
+  detail.textContent = state.detail || "";
+  checkboxLabel.textContent = state.checkboxLabel || "";
+  confirmButton.textContent = isError ? (state.dismissLabel || "OK") : (state.confirmLabel || "OK");
+  cancelButton.textContent = state.cancelLabel || "Cancel";
+  closeButton.title = isError ? (state.dismissLabel || "Close") : (state.cancelLabel || "Cancel");
+  closeButton.setAttribute("aria-label", closeButton.title);
+  checkboxRow.hidden = isError || !state.checkboxLabel;
+  cancelButton.hidden = isError;
+  confirmButton.classList.toggle("danger", !isError);
+  if (isError) confirmButton.focus();
+  else cancelButton.focus();
+  bridge.stateApplied();
+});
+bridge.ready();
+
+confirmButton.addEventListener("click", () => {
+  submit(root.dataset.kind === "error" ? "dismiss" : "confirm");
+});
+cancelButton.addEventListener("click", () => submit("cancel"));
+closeButton.addEventListener("click", () => submit("cancel"));
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape") {
+    event.preventDefault();
+    submit("cancel");
+  }
+});

--- a/src/permission-automation-confirmation.css
+++ b/src/permission-automation-confirmation.css
@@ -1,0 +1,181 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", system-ui, sans-serif;
+  font-size: 14px;
+  color: #24262b;
+  background: #f7f7f8;
+}
+
+* { box-sizing: border-box; }
+
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
+body {
+  border: 1px solid #c9cbd1;
+  background: #f7f7f8;
+}
+
+.dialog {
+  display: grid;
+  grid-template-rows: 44px 1fr auto;
+  min-width: 0;
+  height: 100%;
+}
+
+.titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-left: 18px;
+  border-bottom: 1px solid #dedfe3;
+  background: #ffffff;
+  -webkit-app-region: drag;
+}
+
+.brand {
+  font-size: 12px;
+  font-weight: 600;
+  color: #646872;
+}
+
+.icon-button {
+  width: 44px;
+  height: 43px;
+  border: 0;
+  border-left: 1px solid transparent;
+  border-radius: 0;
+  color: #5b5f68;
+  background: transparent;
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  -webkit-app-region: no-drag;
+}
+
+.icon-button:hover {
+  color: #ffffff;
+  background: #c42b1c;
+}
+
+.content {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  gap: 14px;
+  padding: 28px 28px 18px;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+
+.warning-icon {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  color: #ffffff;
+  background: #d05d14;
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.copy { min-width: 0; }
+
+h1 {
+  margin: 0 0 10px;
+  font-size: 19px;
+  line-height: 1.3;
+  letter-spacing: 0;
+  overflow-wrap: anywhere;
+}
+
+p {
+  margin: 0;
+  color: #565a63;
+  font-size: 13px;
+  line-height: 1.55;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.message {
+  margin-bottom: 10px;
+  color: #3d4149;
+  font-weight: 600;
+}
+
+.message[hidden] { display: none; }
+
+.checkbox-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  margin-top: 18px;
+  color: #3d4149;
+  font-size: 12px;
+  line-height: 1.4;
+  cursor: pointer;
+}
+
+.checkbox-row[hidden] { display: none; }
+
+input[type="checkbox"] {
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  margin: 1px 0 0;
+  accent-color: #d05d14;
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 14px 24px 18px;
+  border-top: 1px solid #dedfe3;
+  background: #ffffff;
+}
+
+.actions button {
+  min-width: 94px;
+  min-height: 34px;
+  padding: 7px 14px;
+  border: 1px solid #b8bbc2;
+  border-radius: 6px;
+  color: #25272c;
+  background: #ffffff;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.actions button:hover { background: #f0f1f3; }
+
+.actions .danger {
+  border-color: #b74336;
+  color: #ffffff;
+  background: #b74336;
+}
+
+.actions .danger:hover { background: #9f352b; }
+
+.dialog[data-kind="error"] .warning-icon { background: #b74336; }
+
+@media (prefers-color-scheme: dark) {
+  :root { color: #f1f2f4; background: #202124; }
+  body { border-color: #50535a; background: #202124; }
+  .titlebar, .actions { border-color: #404249; background: #282a2f; }
+  .brand { color: #b4b7bf; }
+  .icon-button { color: #c5c7cd; }
+  p { color: #c1c4ca; }
+  .message { color: #e0e2e6; }
+  .checkbox-row { color: #e0e2e6; }
+  .actions button { border-color: #60636b; color: #f1f2f4; background: #35373d; }
+  .actions button:hover { background: #42454c; }
+  .actions .danger { border-color: #d05d4f; background: #b74336; }
+  .actions .danger:hover { background: #c44b3e; }
+}

--- a/src/permission-automation-confirmation.html
+++ b/src/permission-automation-confirmation.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self'; script-src 'self'">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Clawd</title>
+  <link rel="stylesheet" href="permission-automation-confirmation.css">
+</head>
+<body>
+  <main id="dialog" class="dialog" data-kind="confirm" role="dialog" aria-modal="true" aria-labelledby="title" aria-describedby="detail">
+    <header class="titlebar">
+      <span class="brand">Clawd on Desk</span>
+      <button id="close" class="icon-button" type="button" aria-label="Close" title="Close">&times;</button>
+    </header>
+    <section class="content">
+      <div class="warning-icon" aria-hidden="true">!</div>
+      <div class="copy">
+        <h1 id="title"></h1>
+        <p id="message" class="message" hidden></p>
+        <p id="detail"></p>
+        <label id="checkbox-row" class="checkbox-row">
+          <input id="suppress" type="checkbox">
+          <span id="checkbox-label"></span>
+        </label>
+      </div>
+    </section>
+    <footer class="actions">
+      <button id="cancel" type="button"></button>
+      <button id="confirm" type="button"></button>
+    </footer>
+  </main>
+  <script src="permission-automation-confirmation-renderer.js"></script>
+</body>
+</html>

--- a/src/permission-automation-confirmation.js
+++ b/src/permission-automation-confirmation.js
@@ -1,0 +1,340 @@
+"use strict";
+
+const defaultPath = require("path");
+
+const RESULT_CHANNEL = "permission-automation-confirmation:result";
+const STATE_CHANNEL = "permission-automation-confirmation:state";
+const READY_CHANNEL = "permission-automation-confirmation:ready";
+const STATE_APPLIED_CHANNEL = "permission-automation-confirmation:state-applied";
+const STARTUP_TIMEOUT_MS = 5000;
+const DEFAULT_WORK_AREA = { x: 0, y: 0, width: 1280, height: 800 };
+const DEFAULT_WIDTH = 520;
+const CONFIRM_HEIGHT = 430;
+const ERROR_HEIGHT = 280;
+const SUPPORTED_LANGS = new Set(["en", "zh", "zh-TW", "ko", "ja"]);
+
+function isUsableWorkArea(value) {
+  return !!value
+    && Number.isFinite(value.x)
+    && Number.isFinite(value.y)
+    && Number.isFinite(value.width)
+    && Number.isFinite(value.height)
+    && value.width > 0
+    && value.height > 0;
+}
+
+function computeCenteredBounds(screen, height) {
+  let workArea = DEFAULT_WORK_AREA;
+  try {
+    const point = screen.getCursorScreenPoint();
+    const display = screen.getDisplayNearestPoint(point) || screen.getPrimaryDisplay();
+    if (display && isUsableWorkArea(display.workArea)) workArea = display.workArea;
+  } catch {
+    try {
+      const primary = screen.getPrimaryDisplay();
+      if (primary && isUsableWorkArea(primary.workArea)) workArea = primary.workArea;
+    } catch {}
+  }
+  const width = Math.min(DEFAULT_WIDTH, workArea.width);
+  const boundedHeight = Math.min(height, workArea.height);
+  return {
+    width,
+    height: boundedHeight,
+    x: Math.round(workArea.x + (workArea.width - width) / 2),
+    y: Math.round(workArea.y + (workArea.height - boundedHeight) / 2),
+  };
+}
+
+function normalizeText(value) {
+  return typeof value === "string" ? value : "";
+}
+
+function normalizeLang(value) {
+  return SUPPORTED_LANGS.has(value) ? value : "en";
+}
+
+function createPermissionAutomationConfirmationRuntime(options = {}) {
+  const BrowserWindow = options.BrowserWindow;
+  const ipcMain = options.ipcMain;
+  const nativeTheme = options.nativeTheme;
+  const screen = options.screen;
+  const path = options.path || defaultPath;
+  const scheduleLater = typeof options.setTimeout === "function" ? options.setTimeout : setTimeout;
+  const clearScheduled = typeof options.clearTimeout === "function" ? options.clearTimeout : clearTimeout;
+  if (!BrowserWindow || !ipcMain || !screen) {
+    throw new Error("permission automation confirmation requires BrowserWindow, ipcMain, and screen");
+  }
+
+  const htmlPath = options.htmlPath || path.join(__dirname, "permission-automation-confirmation.html");
+  const preloadPath = options.preloadPath || path.join(__dirname, "preload-permission-automation-confirmation.js");
+  let activeWindow = null;
+  let activeResolve = null;
+  let activeKind = null;
+  let activeState = null;
+  let pageLoaded = false;
+  let rendererReady = false;
+  let stateSent = false;
+  let stateApplied = false;
+  let windowReadyToShow = false;
+  let windowShown = false;
+  let startupTimer = null;
+
+  function isLiveWindow(win) {
+    return !!win && (typeof win.isDestroyed !== "function" || !win.isDestroyed());
+  }
+
+  function focusActiveWindow() {
+    if (!isLiveWindow(activeWindow)) return false;
+    // A duplicate request must not bypass the startup gate and expose a blank
+    // or partially initialized renderer.
+    if (!windowShown) return true;
+    try {
+      if (typeof activeWindow.isMinimized === "function" && activeWindow.isMinimized()) {
+        activeWindow.restore();
+      }
+      activeWindow.show();
+      activeWindow.focus();
+    } catch {
+      settle(defaultResult(activeKind));
+    }
+    return true;
+  }
+
+  function defaultResult(kind) {
+    return kind === "confirm"
+      ? { confirmed: false, suppressFutureConfirmation: false }
+      : undefined;
+  }
+
+  function clearStartupTimer() {
+    if (!startupTimer) return;
+    clearScheduled(startupTimer);
+    startupTimer = null;
+  }
+
+  function settle(result, closeWindow = true) {
+    const win = activeWindow;
+    const resolve = activeResolve;
+    const kind = activeKind;
+    activeWindow = null;
+    activeResolve = null;
+    activeKind = null;
+    activeState = null;
+    pageLoaded = false;
+    rendererReady = false;
+    stateSent = false;
+    stateApplied = false;
+    windowReadyToShow = false;
+    windowShown = false;
+    clearStartupTimer();
+    if (typeof resolve === "function") resolve(result === undefined ? defaultResult(kind) : result);
+    if (closeWindow && isLiveWindow(win)) {
+      try { win.close(); } catch {
+        try { win.destroy(); } catch {}
+      }
+    }
+  }
+
+  function handleResult(event, payload) {
+    if (!isLiveWindow(activeWindow) || event.sender !== activeWindow.webContents) return;
+    const action = payload && payload.action;
+    if (activeKind === "confirm" && action === "confirm") {
+      settle({
+        confirmed: true,
+        suppressFutureConfirmation: payload.suppressFutureConfirmation === true,
+      });
+      return;
+    }
+    settle(defaultResult(activeKind));
+  }
+
+  function finishStartupWhenReady() {
+    if (!isLiveWindow(activeWindow)) return;
+    if (pageLoaded && rendererReady && !stateSent) {
+      try {
+        activeWindow.webContents.send(STATE_CHANNEL, activeState);
+      } catch {
+        settle(defaultResult(activeKind));
+        return;
+      }
+      activeState = null;
+      stateSent = true;
+    }
+    if (
+      !stateSent
+      || !stateApplied
+      || !windowReadyToShow
+      || windowShown
+      || !isLiveWindow(activeWindow)
+    ) return;
+    try {
+      activeWindow.show();
+      activeWindow.focus();
+      windowShown = true;
+      clearStartupTimer();
+    } catch {
+      settle(defaultResult(activeKind));
+    }
+  }
+
+  function handleReady(event) {
+    if (!isLiveWindow(activeWindow) || event.sender !== activeWindow.webContents) return;
+    rendererReady = true;
+    finishStartupWhenReady();
+  }
+
+  function handleStateApplied(event) {
+    if (
+      !isLiveWindow(activeWindow)
+      || event.sender !== activeWindow.webContents
+      || !stateSent
+    ) return;
+    stateApplied = true;
+    finishStartupWhenReady();
+  }
+
+  ipcMain.on(RESULT_CHANNEL, handleResult);
+  ipcMain.on(READY_CHANNEL, handleReady);
+  ipcMain.on(STATE_APPLIED_CHANNEL, handleStateApplied);
+
+  function openWindow(kind, payload) {
+    if (focusActiveWindow()) return Promise.resolve(defaultResult(kind));
+
+    const parent = isLiveWindow(payload.parent) ? payload.parent : null;
+    const height = kind === "confirm" ? CONFIRM_HEIGHT : ERROR_HEIGHT;
+    const bounds = computeCenteredBounds(screen, height);
+    const backgroundColor = nativeTheme && nativeTheme.shouldUseDarkColors ? "#202124" : "#f7f7f8";
+    const windowOptions = {
+      ...bounds,
+      minWidth: Math.min(460, bounds.width),
+      minHeight: Math.min(kind === "confirm" ? 320 : 250, bounds.height),
+      show: false,
+      frame: false,
+      transparent: false,
+      resizable: false,
+      minimizable: false,
+      maximizable: false,
+      fullscreenable: false,
+      skipTaskbar: !!parent,
+      alwaysOnTop: !parent,
+      title: normalizeText(payload.title),
+      backgroundColor,
+      webPreferences: {
+        preload: preloadPath,
+        nodeIntegration: false,
+        contextIsolation: true,
+        sandbox: true,
+      },
+    };
+    if (parent) {
+      windowOptions.parent = parent;
+      windowOptions.modal = true;
+    }
+    if (options.iconPath) windowOptions.icon = options.iconPath;
+
+    let win;
+    try {
+      win = new BrowserWindow(windowOptions);
+    } catch {
+      return Promise.resolve(defaultResult(kind));
+    }
+    activeWindow = win;
+    activeKind = kind;
+    activeState = {
+      kind,
+      lang: normalizeLang(payload.lang),
+      title: normalizeText(payload.title),
+      message: normalizeText(payload.message),
+      detail: normalizeText(payload.detail),
+      checkboxLabel: normalizeText(payload.checkboxLabel),
+      confirmLabel: normalizeText(payload.confirmLabel),
+      cancelLabel: normalizeText(payload.cancelLabel),
+      dismissLabel: normalizeText(payload.dismissLabel),
+    };
+    pageLoaded = false;
+    rendererReady = false;
+    stateSent = false;
+    stateApplied = false;
+    windowReadyToShow = false;
+    windowShown = false;
+
+    const resultPromise = new Promise((resolve) => {
+      activeResolve = resolve;
+    });
+
+    try {
+      if (typeof win.setMenuBarVisibility === "function") win.setMenuBarVisibility(false);
+      win.webContents.once("did-finish-load", () => {
+        if (activeWindow !== win || !isLiveWindow(win)) return;
+        pageLoaded = true;
+        finishStartupWhenReady();
+      });
+      win.webContents.once("did-fail-load", (_event, _code, _description, _url, isMainFrame) => {
+        if (isMainFrame === false) return;
+        if (activeWindow === win) settle(defaultResult(kind));
+      });
+      win.webContents.once("render-process-gone", () => {
+        if (activeWindow === win) settle(defaultResult(kind));
+      });
+      win.once("ready-to-show", () => {
+        if (activeWindow !== win || !isLiveWindow(win)) return;
+        windowReadyToShow = true;
+        finishStartupWhenReady();
+      });
+      win.on("closed", () => {
+        if (activeWindow === win) settle(defaultResult(kind), false);
+      });
+
+      startupTimer = scheduleLater(() => {
+        if (activeWindow === win && !windowShown) {
+          settle(defaultResult(kind));
+        }
+      }, STARTUP_TIMEOUT_MS);
+      if (startupTimer && typeof startupTimer.unref === "function") startupTimer.unref();
+
+      const loadResult = win.loadFile(htmlPath);
+      if (loadResult && typeof loadResult.catch === "function") {
+        loadResult.catch(() => {
+          if (activeWindow === win) settle(defaultResult(kind));
+        });
+      }
+    } catch {
+      settle(defaultResult(kind));
+    }
+    return resultPromise;
+  }
+
+  function confirmPermissionAutomation(payload = {}) {
+    return openWindow("confirm", payload);
+  }
+
+  function showPermissionAutomationError(payload = {}) {
+    // Persistence failures must not disappear behind an unrelated confirmation.
+    // Cancel the pending trust change before replacing it with the error.
+    if (isLiveWindow(activeWindow)) settle(defaultResult(activeKind));
+    return openWindow("error", payload).then(() => undefined);
+  }
+
+  function dispose() {
+    if (typeof ipcMain.removeListener === "function") ipcMain.removeListener(RESULT_CHANNEL, handleResult);
+    if (typeof ipcMain.removeListener === "function") ipcMain.removeListener(READY_CHANNEL, handleReady);
+    if (typeof ipcMain.removeListener === "function") {
+      ipcMain.removeListener(STATE_APPLIED_CHANNEL, handleStateApplied);
+    }
+    settle(defaultResult(activeKind));
+  }
+
+  return {
+    confirmPermissionAutomation,
+    showPermissionAutomationError,
+    dispose,
+    getWindow: () => activeWindow,
+  };
+}
+
+module.exports = createPermissionAutomationConfirmationRuntime;
+module.exports.computeCenteredBounds = computeCenteredBounds;
+module.exports.RESULT_CHANNEL = RESULT_CHANNEL;
+module.exports.STATE_CHANNEL = STATE_CHANNEL;
+module.exports.READY_CHANNEL = READY_CHANNEL;
+module.exports.STATE_APPLIED_CHANNEL = STATE_APPLIED_CHANNEL;

--- a/src/preload-permission-automation-confirmation.js
+++ b/src/preload-permission-automation-confirmation.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("permissionAutomationConfirmation", {
+  ready() {
+    ipcRenderer.send("permission-automation-confirmation:ready");
+  },
+  stateApplied() {
+    ipcRenderer.send("permission-automation-confirmation:state-applied");
+  },
+  onState(callback) {
+    if (typeof callback !== "function") return () => {};
+    const listener = (_event, state) => callback(state);
+    ipcRenderer.on("permission-automation-confirmation:state", listener);
+    return () => ipcRenderer.removeListener("permission-automation-confirmation:state", listener);
+  },
+  submit(payload) {
+    const action = payload && typeof payload.action === "string" ? payload.action : "cancel";
+    ipcRenderer.send("permission-automation-confirmation:result", {
+      action,
+      suppressFutureConfirmation: payload && payload.suppressFutureConfirmation === true,
+    });
+  },
+});

--- a/test/menu-auto-approve.test.js
+++ b/test/menu-auto-approve.test.js
@@ -1,8 +1,5 @@
 "use strict";
 
-// Three-state permission automation control in the pet context and tray menus.
-// Both automatic modes require a native confirmation; Ask every time is immediate.
-
 const assert = require("node:assert");
 const Module = require("node:module");
 const { describe, it } = require("node:test");
@@ -23,10 +20,8 @@ function loadMenuWithElectron(fakeElectron) {
   }
 }
 
-function makeFakeElectron(messageBoxResponse, checkboxChecked = false) {
-  const dialogCalls = [];
+function makeFakeElectron() {
   return {
-    _dialogCalls: dialogCalls,
     app: { quit() {}, setActivationPolicy() {}, dock: { show() {}, hide() {} } },
     BrowserWindow: function BrowserWindow() {},
     Menu: { buildFromTemplate(template) { return { template }; } },
@@ -37,23 +32,12 @@ function makeFakeElectron(messageBoxResponse, checkboxChecked = false) {
       getCursorScreenPoint: () => ({ x: 0, y: 0 }),
       getDisplayNearestPoint: () => ({ id: 1 }),
     },
-    dialog: {
-      // Electron's showMessageBox is overloaded: (options) or (parent, options).
-      // The auto-pilot confirm must be parentless (standalone, screen-centered)
-      // so it doesn't render as a sheet on the tiny pet window — so normalize
-      // both shapes and record whether a parent window was passed.
-      showMessageBox(arg1, arg2) {
-        const hasParent = arg2 !== undefined;
-        const parent = hasParent ? arg1 : undefined;
-        const opts = hasParent ? arg2 : arg1;
-        dialogCalls.push({ parent, opts });
-        return Promise.resolve({ response: messageBoxResponse, checkboxChecked });
-      },
-    },
   };
 }
 
 function makeCtx(overrides = {}) {
+  const confirmationCalls = [];
+  const errorCalls = [];
   return {
     win: { isDestroyed: () => false },
     sessions: new Map(),
@@ -74,6 +58,8 @@ function makeCtx(overrides = {}) {
     contextMenuOwner: null,
     contextMenu: null,
     isQuitting: false,
+    confirmationCalls,
+    errorCalls,
     getMiniMode: () => false,
     getMiniTransitioning: () => false,
     getDisableMiniMode: () => false,
@@ -102,6 +88,13 @@ function makeCtx(overrides = {}) {
       if (mode === "unattended") return this.permissionAutomationUnattendedWarningDismissed;
       return false;
     },
+    async confirmPermissionAutomation(payload) {
+      confirmationCalls.push(payload);
+      return { confirmed: true, suppressFutureConfirmation: false };
+    },
+    async showPermissionAutomationError(payload) {
+      errorCalls.push(payload);
+    },
     async setPermissionAutomationMode(mode, options = {}) {
       this.permissionAutomationMode = mode;
       if (options.suppressFutureConfirmation === true && mode === "auto-tools") {
@@ -127,108 +120,46 @@ function findModeItem(item, label) {
   return item.submenu.find((entry) => entry.label === label);
 }
 
-describe("permission automation menu", () => {
-  it("shows three explicit radio choices with Ask every time selected by default", () => {
-    const menu = loadMenuWithElectron(makeFakeElectron(0));
-    const ctx = makeCtx({ permissionAutomationMode: "off" });
-    const m = menu(ctx);
-    m.buildContextMenu();
-    const item = findPermissionAutomationItem(ctx.contextMenu.template);
-    assert.ok(item, "permission automation item present in context menu");
-    assert.strictEqual(item.submenu.length, 3);
-    assert.ok(item.submenu.every((entry) => entry.type === "radio"));
-    assert.strictEqual(findModeItem(item, "Ask every time").checked, true);
-  });
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
 
-  it("reflects Auto-approve as the committed state", () => {
-    const menu = loadMenuWithElectron(makeFakeElectron(0));
+describe("permission automation menu", () => {
+  it("shows three radio choices and reflects the committed mode", () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
     const ctx = makeCtx({ permissionAutomationMode: "unattended" });
     const m = menu(ctx);
     m.buildContextMenu();
     const item = findPermissionAutomationItem(ctx.contextMenu.template);
+    assert.ok(item);
+    assert.strictEqual(item.submenu.length, 3);
+    assert.ok(item.submenu.every((entry) => entry.type === "radio"));
     assert.strictEqual(findModeItem(item, "Auto-approve").checked, true);
   });
 
-  it("switches to Ask every time immediately without a confirm dialog", async () => {
-    const fake = makeFakeElectron(0);
-    const menu = loadMenuWithElectron(fake);
+  it("turns automation off immediately without confirmation", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
     const calls = [];
     const ctx = makeCtx({
       permissionAutomationMode: "unattended",
-      async setPermissionAutomationMode(mode) {
-        calls.push(mode);
-        this.permissionAutomationMode = mode;
+      async setPermissionAutomationMode(mode, options) {
+        calls.push({ mode, options });
         return { status: "ok" };
       },
     });
     const m = menu(ctx);
     m.buildContextMenu();
     findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Ask every time").click();
-    await new Promise((r) => setTimeout(r, 0));
-    assert.deepStrictEqual(calls, ["off"]);
-    assert.strictEqual(fake._dialogCalls.length, 0, "no confirm dialog on disable");
+    await flushPromises();
+    assert.deepStrictEqual(ctx.confirmationCalls, []);
+    assert.deepStrictEqual(calls, [{ mode: "off", options: { confirmed: false } }]);
   });
 
-  it("Question prompts only shows a confirm dialog and commits only when confirmed", async () => {
-    const fake = makeFakeElectron(0); // 0 = Enable button
-    const menu = loadMenuWithElectron(fake);
+  it("passes localized auto-tools copy to the shared confirmation window", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
     const calls = [];
     const ctx = makeCtx({
-      async setPermissionAutomationMode(mode) {
-        calls.push(mode);
-        this.permissionAutomationMode = mode;
-        return { status: "ok" };
-      },
-    });
-    const m = menu(ctx);
-    m.buildContextMenu();
-    findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Question prompts only").click();
-    await new Promise((r) => setTimeout(r, 0));
-    assert.strictEqual(fake._dialogCalls.length, 1, "confirm dialog shown");
-    assert.strictEqual(fake._dialogCalls[0].opts.type, "warning");
-    assert.strictEqual(fake._dialogCalls[0].parent, undefined, "dialog is parentless (screen-centered, not a sheet on the pet)");
-    assert.match(fake._dialogCalls[0].opts.checkboxLabel, /understand the risks/i);
-    assert.strictEqual(fake._dialogCalls[0].opts.checkboxChecked, false);
-    assert.deepStrictEqual(calls, ["auto-tools"]);
-    const rebuiltItem = findPermissionAutomationItem(ctx.contextMenu.template);
-    assert.strictEqual(findModeItem(rebuiltItem, "Question prompts only").checked, true);
-  });
-
-  it("automatic mode does NOT commit when the user cancels", async () => {
-    const fake = makeFakeElectron(1); // 1 = Cancel button
-    const menu = loadMenuWithElectron(fake);
-    const calls = [];
-    const ctx = makeCtx({
-      async setPermissionAutomationMode(mode) {
-        calls.push(mode);
-        return { status: "ok" };
-      },
-    });
-    const m = menu(ctx);
-    m.buildContextMenu();
-    findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Auto-approve").click();
-    await new Promise((r) => setTimeout(r, 0));
-    assert.strictEqual(fake._dialogCalls.length, 1, "confirm dialog shown");
-    assert.deepStrictEqual(calls, [], "nothing committed on cancel");
-  });
-
-  it("uses the stronger warning when escalating to Auto-approve", async () => {
-    const fake = makeFakeElectron(0);
-    const menu = loadMenuWithElectron(fake);
-    const ctx = makeCtx({ permissionAutomationMode: "auto-tools" });
-    const m = menu(ctx);
-    m.buildContextMenu();
-    findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Auto-approve").click();
-    await new Promise((r) => setTimeout(r, 0));
-    assert.match(fake._dialogCalls[0].opts.title, /tools and decisions/i);
-  });
-
-  it("persists don't-show-again only after a confirmed automatic choice", async () => {
-    const fake = makeFakeElectron(0, true);
-    const menu = loadMenuWithElectron(fake);
-    const calls = [];
-    const ctx = makeCtx({
-      async setPermissionAutomationMode(mode, options = {}) {
+      async setPermissionAutomationMode(mode, options) {
         calls.push({ mode, options });
         return { status: "ok" };
       },
@@ -236,20 +167,77 @@ describe("permission automation menu", () => {
     const m = menu(ctx);
     m.buildContextMenu();
     findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Question prompts only").click();
-    await new Promise((r) => setTimeout(r, 0));
+    await flushPromises();
+    assert.strictEqual(ctx.confirmationCalls.length, 1);
+    assert.strictEqual(ctx.confirmationCalls[0].mode, "auto-tools");
+    assert.match(ctx.confirmationCalls[0].title, /tool requests/i);
+    assert.match(ctx.confirmationCalls[0].checkboxLabel, /understand the risks/i);
+    assert.deepStrictEqual(calls, [{
+      mode: "auto-tools",
+      options: { confirmed: true, suppressFutureConfirmation: false },
+    }]);
+  });
+
+  it("uses the stronger unattended warning", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
+    const ctx = makeCtx({ permissionAutomationMode: "auto-tools" });
+    const m = menu(ctx);
+    m.buildContextMenu();
+    findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Auto-approve").click();
+    await flushPromises();
+    assert.strictEqual(ctx.confirmationCalls[0].mode, "unattended");
+    assert.match(ctx.confirmationCalls[0].title, /tools and decisions/i);
+  });
+
+  it("fails closed when confirmation is cancelled", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
+    const calls = [];
+    const ctx = makeCtx({
+      async confirmPermissionAutomation(payload) {
+        this.confirmationCalls.push(payload);
+        return { confirmed: false, suppressFutureConfirmation: true };
+      },
+      async setPermissionAutomationMode(mode) {
+        calls.push(mode);
+        return { status: "ok" };
+      },
+    });
+    const m = menu(ctx);
+    m.buildContextMenu();
+    findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Auto-approve").click();
+    await flushPromises();
+    assert.deepStrictEqual(calls, []);
+  });
+
+  it("persists do-not-show-again only after explicit confirmation", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
+    const calls = [];
+    const ctx = makeCtx({
+      async confirmPermissionAutomation(payload) {
+        this.confirmationCalls.push(payload);
+        return { confirmed: true, suppressFutureConfirmation: true };
+      },
+      async setPermissionAutomationMode(mode, options) {
+        calls.push({ mode, options });
+        return { status: "ok" };
+      },
+    });
+    const m = menu(ctx);
+    m.buildContextMenu();
+    findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Question prompts only").click();
+    await flushPromises();
     assert.deepStrictEqual(calls, [{
       mode: "auto-tools",
       options: { confirmed: true, suppressFutureConfirmation: true },
     }]);
   });
 
-  it("skips only the warning previously dismissed for that exact mode", async () => {
-    const fake = makeFakeElectron(0);
-    const menu = loadMenuWithElectron(fake);
+  it("skips only the warning dismissed for the matching mode", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
     const calls = [];
     const ctx = makeCtx({
       permissionAutomationAutoToolsWarningDismissed: true,
-      async setPermissionAutomationMode(mode, options = {}) {
+      async setPermissionAutomationMode(mode, options) {
         calls.push({ mode, options });
         this.permissionAutomationMode = mode;
         return { status: "ok" };
@@ -258,22 +246,19 @@ describe("permission automation menu", () => {
     const m = menu(ctx);
     m.buildContextMenu();
     findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Question prompts only").click();
-    await new Promise((r) => setTimeout(r, 0));
-    assert.strictEqual(fake._dialogCalls.length, 0);
-    assert.deepStrictEqual(calls, [{
-      mode: "auto-tools",
-      options: { confirmed: false },
-    }]);
+    await flushPromises();
+    assert.deepStrictEqual(ctx.confirmationCalls, []);
+    assert.deepStrictEqual(calls, [{ mode: "auto-tools", options: { confirmed: false } }]);
 
     m.buildContextMenu();
     findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Auto-approve").click();
-    await new Promise((r) => setTimeout(r, 0));
-    assert.strictEqual(fake._dialogCalls.length, 1, "auto-tools acknowledgement must not suppress unattended");
+    await flushPromises();
+    assert.strictEqual(ctx.confirmationCalls.length, 1);
+    assert.strictEqual(ctx.confirmationCalls[0].mode, "unattended");
   });
 
-  it("shows a native error when a confirmed mode change is not persisted", async () => {
-    const fake = makeFakeElectron(0);
-    const menu = loadMenuWithElectron(fake);
+  it("uses the styled error window when persistence fails", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
     const ctx = makeCtx({
       async setPermissionAutomationMode() {
         return { status: "error", message: "disk full" };
@@ -281,24 +266,15 @@ describe("permission automation menu", () => {
     });
     const m = menu(ctx);
     m.buildContextMenu();
-
-    findModeItem(
-      findPermissionAutomationItem(ctx.contextMenu.template),
-      "Question prompts only"
-    ).click();
-    await new Promise((r) => setTimeout(r, 0));
-    await new Promise((r) => setTimeout(r, 0));
-
-    assert.strictEqual(fake._dialogCalls.length, 2);
-    assert.strictEqual(fake._dialogCalls[0].opts.type, "warning");
-    assert.strictEqual(fake._dialogCalls[1].opts.type, "error");
-    assert.strictEqual(fake._dialogCalls[1].opts.detail, "disk full");
-    assert.strictEqual(ctx.permissionAutomationMode, "off");
+    findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Question prompts only").click();
+    await flushPromises();
+    await flushPromises();
+    assert.strictEqual(ctx.errorCalls.length, 1);
+    assert.strictEqual(ctx.errorCalls[0].detail, "disk full");
   });
 
-  it("shows a native error when turning automation off rejects", async () => {
-    const fake = makeFakeElectron(0);
-    const menu = loadMenuWithElectron(fake);
+  it("uses the styled error window when turning automation off rejects", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
     const ctx = makeCtx({
       permissionAutomationMode: "auto-tools",
       async setPermissionAutomationMode() {
@@ -307,27 +283,23 @@ describe("permission automation menu", () => {
     });
     const m = menu(ctx);
     m.buildContextMenu();
-
-    findModeItem(
-      findPermissionAutomationItem(ctx.contextMenu.template),
-      "Ask every time"
-    ).click();
-    await new Promise((r) => setTimeout(r, 0));
-    await new Promise((r) => setTimeout(r, 0));
-
-    assert.strictEqual(fake._dialogCalls.length, 1);
-    assert.strictEqual(fake._dialogCalls[0].opts.type, "error");
-    assert.strictEqual(fake._dialogCalls[0].opts.detail, "read only");
+    findModeItem(findPermissionAutomationItem(ctx.contextMenu.template), "Ask every time").click();
+    await flushPromises();
+    await flushPromises();
+    assert.strictEqual(ctx.errorCalls.length, 1);
+    assert.strictEqual(ctx.errorCalls[0].detail, "read only");
   });
 
-  it("is present in the tray menu too", () => {
-    const menu = loadMenuWithElectron(makeFakeElectron(0));
+  it("uses the same confirmation flow in the tray menu", async () => {
+    const menu = loadMenuWithElectron(makeFakeElectron());
     let trayTemplate = null;
     const ctx = makeCtx({
-      tray: { setContextMenu(menuObj) { trayTemplate = menuObj.template; } },
+      tray: { setContextMenu(menuObject) { trayTemplate = menuObject.template; } },
     });
     const m = menu(ctx);
     m.buildTrayMenu();
-    assert.ok(findPermissionAutomationItem(trayTemplate), "permission automation item present in tray menu");
+    findModeItem(findPermissionAutomationItem(trayTemplate), "Question prompts only").click();
+    await flushPromises();
+    assert.strictEqual(ctx.confirmationCalls.length, 1);
   });
 });

--- a/test/permission-automation-confirmation.test.js
+++ b/test/permission-automation-confirmation.test.js
@@ -1,0 +1,481 @@
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+const { describe, it } = require("node:test");
+const createRuntime = require("../src/permission-automation-confirmation");
+const {
+  computeCenteredBounds,
+  RESULT_CHANNEL,
+  STATE_CHANNEL,
+  READY_CHANNEL,
+  STATE_APPLIED_CHANNEL,
+} = require("../src/permission-automation-confirmation");
+
+function createHarness(overrides = {}) {
+  const listeners = new Map();
+  const windows = [];
+  const timers = [];
+  const ipcMain = {
+    on(channel, listener) { listeners.set(channel, listener); },
+    removeListener(channel, listener) {
+      if (listeners.get(channel) === listener) listeners.delete(channel);
+    },
+  };
+
+  class FakeBrowserWindow {
+    constructor(options) {
+      if (overrides.constructorThrows) throw new Error("window unavailable");
+      this.options = options;
+      this.destroyed = false;
+      this.shown = false;
+      this.focusCount = 0;
+      this.events = new Map();
+      this.webEvents = new Map();
+      this.sent = [];
+      this.webContents = {
+        once: (name, listener) => this.webEvents.set(name, listener),
+        send: (channel, payload) => this.sent.push({ channel, payload }),
+        isDestroyed: () => this.destroyed,
+      };
+      windows.push(this);
+    }
+    isDestroyed() { return this.destroyed; }
+    isMinimized() { return false; }
+    setMenuBarVisibility() {}
+    loadFile(file) {
+      this.loadedFile = file;
+      return overrides.loadReject ? Promise.reject(new Error("load failed")) : Promise.resolve();
+    }
+    once(name, listener) { this.events.set(name, listener); }
+    on(name, listener) { this.events.set(name, listener); }
+    show() {
+      if (overrides.showThrows) throw new Error("show unavailable");
+      this.shown = true;
+    }
+    focus() { this.focusCount += 1; }
+    close() {
+      this.destroyed = true;
+      const listener = this.events.get("closed");
+      if (listener) listener();
+    }
+    emit(name, ...args) {
+      const listener = this.events.get(name) || this.webEvents.get(name);
+      if (listener) listener(...args);
+    }
+  }
+
+  const nearestDisplay = overrides.nearestDisplay || {
+    workArea: { x: 1920, y: 20, width: 1600, height: 900 },
+  };
+  const primaryDisplay = overrides.primaryDisplay || {
+    workArea: { x: 0, y: 0, width: 1280, height: 760 },
+  };
+  const screen = {
+    getCursorScreenPoint: () => ({ x: 2300, y: 300 }),
+    getDisplayNearestPoint: () => nearestDisplay,
+    getPrimaryDisplay: () => primaryDisplay,
+  };
+  if (overrides.screenThrows) screen.getCursorScreenPoint = () => { throw new Error("unavailable"); };
+
+  const runtime = createRuntime({
+    BrowserWindow: FakeBrowserWindow,
+    ipcMain,
+    nativeTheme: { shouldUseDarkColors: overrides.dark === true },
+    screen,
+    iconPath: "D:\\app\\icon.ico",
+    htmlPath: "D:\\app\\confirmation.html",
+    preloadPath: "D:\\app\\preload.js",
+    setTimeout(callback) {
+      const timer = { callback, cleared: false, unref() {} };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimeout(timer) { timer.cleared = true; },
+  });
+
+  return { runtime, listeners, windows, timers };
+}
+
+function readyRenderer(harness, win) {
+  harness.listeners.get(READY_CHANNEL)({ sender: win.webContents });
+  win.emit("did-finish-load");
+}
+
+function showReadyWindow(harness, win) {
+  readyRenderer(harness, win);
+  harness.listeners.get(STATE_APPLIED_CHANNEL)({ sender: win.webContents });
+  win.emit("ready-to-show");
+}
+
+function confirmPayload() {
+  return {
+    mode: "auto-tools",
+    title: "Approve tool requests?",
+    detail: "Supported tool requests will be approved.",
+    checkboxLabel: "Do not show this again",
+    confirmLabel: "Approve tools",
+    cancelLabel: "Cancel",
+  };
+}
+
+describe("permission automation confirmation runtime", () => {
+  it("centers on the cursor display and falls back to primary display", () => {
+    const nearest = computeCenteredBounds({
+      getCursorScreenPoint: () => ({ x: 2000, y: 10 }),
+      getDisplayNearestPoint: () => ({ workArea: { x: 1920, y: 40, width: 1600, height: 900 } }),
+      getPrimaryDisplay: () => null,
+    }, 350);
+    assert.deepStrictEqual(nearest, { x: 2460, y: 315, width: 520, height: 350 });
+
+    const primary = computeCenteredBounds({
+      getCursorScreenPoint: () => { throw new Error("no cursor"); },
+      getPrimaryDisplay: () => ({ workArea: { x: -1280, y: 0, width: 1280, height: 720 } }),
+    }, 350);
+    assert.deepStrictEqual(primary, { x: -900, y: 185, width: 520, height: 350 });
+  });
+
+  it("creates a secure fixed window and sends only normalized state", async () => {
+    const harness = createHarness({ dark: true });
+    const promise = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    const win = harness.windows[0];
+    assert.strictEqual(win.options.x, 2460);
+    assert.strictEqual(win.options.y, 255);
+    assert.strictEqual(win.options.resizable, false);
+    assert.strictEqual(win.options.webPreferences.nodeIntegration, false);
+    assert.strictEqual(win.options.webPreferences.contextIsolation, true);
+    assert.strictEqual(win.options.webPreferences.sandbox, true);
+    assert.strictEqual(win.options.backgroundColor, "#202124");
+    showReadyWindow(harness, win);
+    assert.strictEqual(win.shown, true);
+    assert.strictEqual(harness.timers[0].cleared, true);
+    assert.strictEqual(win.sent.length, 1);
+    assert.strictEqual(win.sent[0].channel, STATE_CHANNEL);
+    assert.deepStrictEqual(win.sent[0].payload, {
+      kind: "confirm",
+      lang: "en",
+      title: "Approve tool requests?",
+      message: "",
+      detail: "Supported tool requests will be approved.",
+      checkboxLabel: "Do not show this again",
+      confirmLabel: "Approve tools",
+      cancelLabel: "Cancel",
+      dismissLabel: "",
+    });
+    harness.listeners.get(RESULT_CHANNEL)({ sender: win.webContents }, {
+      action: "confirm",
+      suppressFutureConfirmation: true,
+    });
+    assert.deepStrictEqual(await promise, { confirmed: true, suppressFutureConfirmation: true });
+  });
+
+  it("creates a modal child for session automation without exposing its parent to the renderer", async () => {
+    const harness = createHarness();
+    const parent = { isDestroyed: () => false };
+    const promise = harness.runtime.confirmPermissionAutomation({
+      ...confirmPayload(),
+      parent,
+      message: "Stop asking for this session?",
+    });
+    const win = harness.windows[0];
+    assert.strictEqual(win.options.parent, parent);
+    assert.strictEqual(win.options.modal, true);
+    assert.strictEqual(win.options.skipTaskbar, true);
+    assert.strictEqual(win.options.alwaysOnTop, false);
+    showReadyWindow(harness, win);
+    assert.strictEqual(win.sent[0].payload.message, "Stop asking for this session?");
+    assert.strictEqual(Object.hasOwn(win.sent[0].payload, "parent"), false);
+    harness.listeners.get(RESULT_CHANNEL)({ sender: win.webContents }, { action: "cancel" });
+    assert.strictEqual((await promise).confirmed, false);
+  });
+
+  it("ignores results from any sender except the active window", async () => {
+    const harness = createHarness();
+    const promise = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    const win = harness.windows[0];
+    let settled = false;
+    promise.then(() => { settled = true; });
+    harness.listeners.get(RESULT_CHANNEL)({ sender: {} }, { action: "confirm" });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    assert.strictEqual(settled, false);
+    harness.listeners.get(RESULT_CHANNEL)({ sender: win.webContents }, { action: "cancel" });
+    assert.deepStrictEqual(await promise, { confirmed: false, suppressFutureConfirmation: false });
+  });
+
+  it("treats the OS close action as cancellation", async () => {
+    const harness = createHarness();
+    const promise = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    harness.windows[0].close();
+    assert.deepStrictEqual(await promise, { confirmed: false, suppressFutureConfirmation: false });
+  });
+
+  it("fails closed for duplicates without exposing an unfinished window, then focuses it once shown", async () => {
+    const harness = createHarness();
+    const first = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    const duplicateDuringStartup = harness.runtime.confirmPermissionAutomation({
+      ...confirmPayload(),
+      mode: "unattended",
+    });
+    assert.strictEqual(harness.windows.length, 1);
+    assert.strictEqual(harness.windows[0].shown, false);
+    assert.strictEqual(harness.windows[0].focusCount, 0);
+    assert.deepStrictEqual(
+      await duplicateDuringStartup,
+      { confirmed: false, suppressFutureConfirmation: false }
+    );
+    showReadyWindow(harness, harness.windows[0]);
+    assert.strictEqual(harness.windows[0].shown, true);
+    assert.strictEqual(harness.windows[0].focusCount, 1);
+    const duplicateAfterShow = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    assert.strictEqual(harness.windows[0].focusCount, 2);
+    assert.deepStrictEqual(
+      await duplicateAfterShow,
+      { confirmed: false, suppressFutureConfirmation: false }
+    );
+    harness.listeners.get(RESULT_CHANNEL)({ sender: harness.windows[0].webContents }, { action: "cancel" });
+    await first;
+  });
+
+  it("fails closed when the renderer cannot load", async () => {
+    const harness = createHarness({ loadReject: true });
+    const result = await harness.runtime.confirmPermissionAutomation(confirmPayload());
+    assert.deepStrictEqual(result, { confirmed: false, suppressFutureConfirmation: false });
+    assert.strictEqual(harness.runtime.getWindow(), null);
+  });
+
+  it("fails closed when the renderer bridge never becomes ready", async () => {
+    const harness = createHarness();
+    const promise = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    harness.windows[0].emit("did-finish-load");
+    harness.timers[0].callback();
+    assert.deepStrictEqual(await promise, { confirmed: false, suppressFutureConfirmation: false });
+  });
+
+  it("keeps the startup timeout armed until the initialized window is actually shown", async () => {
+    const harness = createHarness();
+    const promise = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    readyRenderer(harness, harness.windows[0]);
+    harness.listeners.get(STATE_APPLIED_CHANNEL)({ sender: harness.windows[0].webContents });
+    assert.strictEqual(harness.windows[0].sent.length, 1);
+    assert.strictEqual(harness.windows[0].shown, false);
+    assert.strictEqual(harness.timers[0].cleared, false);
+    harness.timers[0].callback();
+    assert.deepStrictEqual(await promise, { confirmed: false, suppressFutureConfirmation: false });
+    assert.strictEqual(harness.runtime.getWindow(), null);
+  });
+
+  it("fails closed when the renderer never acknowledges that it applied the state", async () => {
+    const harness = createHarness();
+    const promise = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    readyRenderer(harness, harness.windows[0]);
+    harness.windows[0].emit("ready-to-show");
+    assert.strictEqual(harness.windows[0].shown, false);
+    harness.timers[0].callback();
+    assert.deepStrictEqual(await promise, { confirmed: false, suppressFutureConfirmation: false });
+  });
+
+  it("fails closed when the window cannot be created", async () => {
+    const harness = createHarness({ constructorThrows: true });
+    const result = await harness.runtime.confirmPermissionAutomation(confirmPayload());
+    assert.deepStrictEqual(result, { confirmed: false, suppressFutureConfirmation: false });
+    assert.strictEqual(harness.windows.length, 0);
+  });
+
+  it("fails closed when the initialized window cannot be shown", async () => {
+    const harness = createHarness({ showThrows: true });
+    const promise = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    showReadyWindow(harness, harness.windows[0]);
+    assert.deepStrictEqual(await promise, { confirmed: false, suppressFutureConfirmation: false });
+    assert.strictEqual(harness.runtime.getWindow(), null);
+  });
+
+  it("uses the same window for styled persistence errors", async () => {
+    const harness = createHarness();
+    const promise = harness.runtime.showPermissionAutomationError({
+      title: "Permission handling",
+      detail: "disk full",
+      dismissLabel: "Dismiss",
+    });
+    const win = harness.windows[0];
+    readyRenderer(harness, win);
+    assert.strictEqual(win.sent[0].payload.kind, "error");
+    assert.strictEqual(win.sent[0].payload.detail, "disk full");
+    harness.listeners.get(RESULT_CHANNEL)({ sender: win.webContents }, { action: "dismiss" });
+    assert.strictEqual(await promise, undefined);
+  });
+
+  it("cancels an active confirmation before showing a persistence error", async () => {
+    const harness = createHarness();
+    const confirmation = harness.runtime.confirmPermissionAutomation(confirmPayload());
+    const error = harness.runtime.showPermissionAutomationError({
+      title: "Permission handling",
+      detail: "read only",
+      dismissLabel: "Dismiss",
+    });
+    assert.deepStrictEqual(
+      await confirmation,
+      { confirmed: false, suppressFutureConfirmation: false }
+    );
+    assert.strictEqual(harness.windows.length, 2);
+    const errorWindow = harness.windows[1];
+    showReadyWindow(harness, errorWindow);
+    harness.listeners.get(RESULT_CHANNEL)({ sender: errorWindow.webContents }, { action: "dismiss" });
+    assert.strictEqual(await error, undefined);
+  });
+
+  it("removes its IPC listener when disposed", () => {
+    const harness = createHarness();
+    assert.ok(harness.listeners.has(RESULT_CHANNEL));
+    harness.runtime.dispose();
+    assert.strictEqual(harness.listeners.has(RESULT_CHANNEL), false);
+    assert.strictEqual(harness.listeners.has(STATE_APPLIED_CHANNEL), false);
+  });
+});
+
+describe("permission automation confirmation document", () => {
+  it("declares accessible dialog semantics", () => {
+    const html = fs.readFileSync(
+      path.join(__dirname, "../src/permission-automation-confirmation.html"),
+      "utf8"
+    );
+    assert.match(
+      html,
+      /<main id="dialog" class="dialog" data-kind="confirm" role="dialog" aria-modal="true" aria-labelledby="title" aria-describedby="detail">/
+    );
+  });
+});
+
+describe("permission automation confirmation renderer", () => {
+  function createRendererHarness() {
+    const elements = new Map();
+    const makeElement = () => ({
+      textContent: "",
+      title: "",
+      hidden: false,
+      checked: false,
+      dataset: {},
+      listeners: new Map(),
+      classList: { toggle() {} },
+      addEventListener(name, listener) { this.listeners.set(name, listener); },
+      setAttribute(name, value) { this[name] = value; },
+      focus() { this.focused = true; },
+    });
+    for (const id of ["dialog", "title", "message", "detail", "checkbox-row", "suppress", "checkbox-label", "confirm", "cancel", "close"]) {
+      elements.set(id, makeElement());
+    }
+    const documentListeners = new Map();
+    const submissions = [];
+    let readyCount = 0;
+    let stateAppliedCount = 0;
+    let stateListener = null;
+    const documentElement = { lang: "en" };
+    const sandbox = {
+      window: {
+        permissionAutomationConfirmation: {
+          onState(listener) { stateListener = listener; },
+          ready() { readyCount += 1; },
+          stateApplied() { stateAppliedCount += 1; },
+          submit(payload) { submissions.push(payload); },
+        },
+      },
+      document: {
+        documentElement,
+        title: "",
+        getElementById: (id) => elements.get(id),
+        addEventListener: (name, listener) => documentListeners.set(name, listener),
+      },
+    };
+    const source = fs.readFileSync(
+      path.join(__dirname, "../src/permission-automation-confirmation-renderer.js"),
+      "utf8"
+    );
+    vm.runInNewContext(source, sandbox);
+    return {
+      elements,
+      documentListeners,
+      submissions,
+      stateListener,
+      readyCount,
+      documentElement,
+      get documentTitle() { return sandbox.document.title; },
+      get stateAppliedCount() { return stateAppliedCount; },
+    };
+  }
+
+  it("submits explicit confirmation with the checkbox state", () => {
+    const harness = createRendererHarness();
+    assert.strictEqual(harness.readyCount, 1);
+    harness.stateListener({
+      kind: "confirm",
+      title: "Approve tools?",
+      detail: "Details",
+      checkboxLabel: "Do not show again",
+      confirmLabel: "Approve",
+      cancelLabel: "Cancel",
+    });
+    harness.elements.get("suppress").checked = true;
+    harness.elements.get("confirm").listeners.get("click")();
+    assert.strictEqual(harness.submissions.length, 1);
+    assert.strictEqual(harness.submissions[0].action, "confirm");
+    assert.strictEqual(harness.submissions[0].suppressFutureConfirmation, true);
+    assert.strictEqual(harness.elements.get("close").title, "Cancel");
+    assert.strictEqual(harness.elements.get("cancel").focused, true);
+    assert.strictEqual(harness.elements.get("confirm").focused, undefined);
+    assert.strictEqual(harness.stateAppliedCount, 1);
+    assert.strictEqual(harness.elements.get("dialog").dataset.kind, "confirm");
+  });
+
+  it("shows the optional message and focuses only the safe default action", () => {
+    const harness = createRendererHarness();
+    harness.stateListener({
+      kind: "confirm",
+      lang: "ko",
+      title: "Trust this session?",
+      message: "Stop asking for tool permissions in this session?",
+      detail: "This ends with the session.",
+      confirmLabel: "Trust this session",
+      cancelLabel: "Cancel",
+    });
+    assert.strictEqual(
+      harness.elements.get("message").textContent,
+      "Stop asking for tool permissions in this session?"
+    );
+    assert.strictEqual(harness.elements.get("message").hidden, false);
+    assert.strictEqual(harness.elements.get("cancel").focused, true);
+    assert.strictEqual(harness.elements.get("confirm").focused, undefined);
+    assert.strictEqual(harness.documentElement.lang, "ko");
+    assert.strictEqual(harness.documentTitle, "Trust this session?");
+  });
+
+  it("focuses Dismiss for an error because it is the only action", () => {
+    const harness = createRendererHarness();
+    harness.stateListener({
+      kind: "error",
+      title: "Permission handling",
+      detail: "disk full",
+      dismissLabel: "Dismiss",
+    });
+    assert.strictEqual(harness.elements.get("message").hidden, true);
+    assert.strictEqual(harness.elements.get("confirm").focused, true);
+    assert.strictEqual(harness.elements.get("cancel").hidden, true);
+  });
+
+  it("maps Cancel, close, and Escape to fail-closed cancellation", () => {
+    const harness = createRendererHarness();
+    harness.elements.get("cancel").listeners.get("click")();
+    harness.elements.get("close").listeners.get("click")();
+    let prevented = false;
+    harness.documentListeners.get("keydown")({
+      key: "Escape",
+      preventDefault() { prevented = true; },
+    });
+    assert.strictEqual(prevented, true);
+    assert.deepStrictEqual(harness.submissions.map((entry) => entry.action), [
+      "cancel",
+      "cancel",
+      "cancel",
+    ]);
+  });
+});

--- a/test/session-automation-dialog-parent.test.js
+++ b/test/session-automation-dialog-parent.test.js
@@ -2,6 +2,8 @@
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
 const {
   selectSessionAutomationDialogParent,
 } = require("../src/session-automation-dialog-parent");
@@ -38,4 +40,20 @@ test("session automation warning falls back safely when candidate windows are go
     entry: { warningParent: windowStub(true) },
     petWindow: windowStub(true),
   }), null);
+});
+
+test("main routes the session automation warning through the shared styled runtime", () => {
+  const mainSource = fs.readFileSync(path.join(__dirname, "../src/main.js"), "utf8");
+  const start = mainSource.indexOf("async function showSessionAutomationWarning(entry)");
+  const end = mainSource.indexOf("sessionAutomationStore = createSessionAutomationStore", start);
+  assert.notEqual(start, -1);
+  assert.notEqual(end, -1);
+  const functionSource = mainSource.slice(start, end);
+  assert.match(
+    functionSource,
+    /permissionAutomationConfirmationRuntime\.confirmPermissionAutomation\(\{/
+  );
+  assert.match(functionSource, /\bparent,/);
+  assert.match(functionSource, /message:\s*translate\("sessionAutomationConfirmMessage"\)/);
+  assert.doesNotMatch(functionSource, /showMessageBox/);
 });


### PR DESCRIPTION
## Summary
- Replaces the native Windows permission automation prompts with a Clawd-styled confirmation window.
- Uses the same secured runtime for pet/tray global automation and the session-scoped trust flow added by #749.
- Preserves the existing `off`, `auto-tools`, and `unattended` modes, per-mode warning suppression, and the settings-controller confirmation gate.

## Problem context
The pet and tray permission automation menus used `dialog.showMessageBox()`. On Windows this displayed a native system dialog that did not match the rest of Clawd and could appear disconnected from the menu action.

Permission automation crosses a meaningful trust boundary. The replacement therefore defaults focus to Cancel and fails closed unless the active renderer loads, applies the supplied state, becomes display-ready, and returns an explicit validated confirmation.

## What changed
- Added a standalone Clawd confirmation window with localized title, optional message, detail, actions, and per-mode "do not show again" copy.
- Reuses the styled window for global permission automation, session-scoped trust, and persistence errors.
- Parents session-trust confirmations to the live permission bubble or invoking Dashboard window; standalone menu confirmations remain centered on the cursor display.
- Supports light/dark themes, wrapped and scrollable content, a custom close button, Cancel, Escape, OS close behavior, and localized document metadata.
- Uses `nodeIntegration: false`, `contextIsolation: true`, `sandbox: true`, a narrow preload API, and strict active-`webContents` sender validation.
- Uses a bounded load → renderer-ready → state-applied → display-ready handshake. The startup timeout remains armed until the initialized window is actually shown.
- Enforces one active confirmation window. Duplicate requests fail closed without exposing an unfinished renderer; persistence errors cancel a pending confirmation before replacing it.
- Disposes the runtime and IPC listeners during app shutdown.
- Adds focused menu, runtime, positioning, parent/modal, IPC, lifecycle, concurrency, renderer interaction, and #749 wiring tests.

## Behavior after this PR
- Selecting `Ask every time` still applies immediately without confirmation.
- Selecting `Question prompts only` or `Auto-approve` opens the styled confirmation window unless that exact mode's warning was previously dismissed.
- Session-scoped trust uses the same styled window and remains attached to its permission bubble or Dashboard.
- Cancel owns the initial keyboard focus. Only an explicit Confirm result from the active window enables automation.
- Cancel, Escape, close, duplicate requests, load/render/display failures, timeout, invalid IPC senders, and app shutdown never enable automation.
- The settings controller remains the only persistent writer and retains the final confirmation gate.

## Validation
- Related permission automation, session automation, Settings, IPC, and i18n suite: 342 passed.
- Final post-rebase suite including #776 Cursor hook coverage: 178 passed.
- `npm test`: 6,307 passed; 13 existing Windows Remote SSH/environment failures remain (CRLF shell assertions, POSIX remote-home fixtures, and Unix `0600` mode expectations).
- One unrelated Windows process-tree test flaked during a repeated full-suite run and passed immediately in isolation (53/53).
- `npm run verify:electron` verified Electron 41.10.2.
- `git diff --check`.
- Real Electron render QA completed for long English/light and Korean/dark confirmation content; both reached visible state without clipping and showed Cancel as the focused action.

## Remaining manual QA
End-to-end Windows QA is still recommended for pet, tray, permission-bubble, and Dashboard entry points, plus 125%/150% display scaling.
