### PR TITLE
fix(roam): keep the pet grabbed during free-roam state changes

### DIFF
--- a/src/hit-renderer.js
+++ b/src/hit-renderer.js
@@ -52,8 +52,10 @@ let isDragReacting = false;
 window.hitAPI.onCancelReaction(() => {
   if (clickTimer) { clearTimeout(clickTimer); clickTimer = null; clickCount = 0; firstClickDir = null; }
   isReacting = false;
-  isDragReacting = false;
-  dragReactionDirection = null;
+  if (!isDragging) {
+    isDragReacting = false;
+    dragReactionDirection = null;
+  }
 });
 
 function queueDragMove() {

--- a/src/main.js
+++ b/src/main.js
@@ -3788,6 +3788,7 @@ function createWindow() {
       petWindowRuntime.recoverVisiblePetAfterRendererLoad();
     },
     setDragLocked: (value) => { petWindowRuntime.setDragLocked(value); },
+    cancelRoam: () => _roam.cancelRoam(),
     setMouseOverPet: (value) => { mouseOverPet = !!value; },
     beginDragSnapshot: () => beginDragSnapshot(),
     clearDragSnapshot: () => clearDragSnapshot(),

--- a/src/main.js
+++ b/src/main.js
@@ -4016,6 +4016,7 @@ const _roamCtx = {
   getNearestWorkArea,
   clampToScreenVisual,
   getMiniMode: () => _mini.getMiniMode(),
+  isDragLocked: () => petWindowRuntime.isDragLocked(),
   getCurrentState: () => _state.getCurrentState(),
   get miniTransitioning() { return _mini.getMiniTransitioning(); },
   applyState: (state, svgOverride, opts) => _state.applyState(state, svgOverride, opts),

--- a/src/pet-interaction-ipc.js
+++ b/src/pet-interaction-ipc.js
@@ -21,6 +21,7 @@ function registerPetInteractionIpc(options = {}) {
     "recoverVisiblePetAfterRendererLoad"
   );
   const setDragLocked = requiredDependency(options.setDragLocked, "setDragLocked");
+  const cancelRoam = requiredDependency(options.cancelRoam, "cancelRoam");
   const setMouseOverPet = requiredDependency(options.setMouseOverPet, "setMouseOverPet");
   const beginDragSnapshot = requiredDependency(options.beginDragSnapshot, "beginDragSnapshot");
   const clearDragSnapshot = requiredDependency(options.clearDragSnapshot, "clearDragSnapshot");
@@ -95,6 +96,7 @@ function registerPetInteractionIpc(options = {}) {
   on("drag-lock", (_event, locked) => {
     setDragLocked(!!locked);
     if (locked) {
+      cancelRoam();
       setMouseOverPet(true);
       beginDragSnapshot();
     } else {

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -939,6 +939,7 @@ function releaseImg(el) {
 // --- Reaction state (visual side) ---
 let isReacting = false;
 let isDragReacting = false;
+let deferredStateDuringDrag = null;
 let reactTimer = null;
 let currentIdleSvg = null;    // tracks which SVG is currently showing
 let currentState = null;      // last state name received from main (for re-pulse)
@@ -1235,6 +1236,7 @@ function startDragReaction(direction) {
   if (!dragSvg) return;
   if (isDragReacting && currentDragSvg === dragSvg) return;
 
+  if (!isDragReacting) deferredStateDuringDrag = null;
   if (!isDragReacting && isReacting) {
     if (reactTimer) { clearTimeout(reactTimer); reactTimer = null; }
     isReacting = false;
@@ -1252,6 +1254,11 @@ function endDragReaction() {
   if (!isDragReacting) return;
   isDragReacting = false;
   currentDragSvg = null;
+  const deferredState = deferredStateDuringDrag;
+  deferredStateDuringDrag = null;
+  if (deferredState) {
+    renderStateFile(deferredState.state, deferredState.svg);
+  }
   window.electronAPI.resumeFromReaction();
 }
 
@@ -1562,6 +1569,10 @@ function swapToFile(file, state, useObjectChannel, options = {}) {
 }
 
 function renderStateFile(state, svg) {
+  if (isDragReacting) {
+    deferredStateDuringDrag = { state, svg };
+    return;
+  }
   // Main process state change → cancel any active click reaction
   cancelReaction();
   // Track the latest state name so the Kimi permission pulse can re-trigger

--- a/src/roam.js
+++ b/src/roam.js
@@ -239,6 +239,7 @@ module.exports = function initRoam(ctx) {
       && ctx.getCurrentState() === "roam"
       && typeof ctx.setState === "function";
     cleanupTimers();
+    firstRoam = true;
     roamActive = false;
     if (shouldRestoreIdle) ctx.setState("idle");
   }

--- a/src/roam.js
+++ b/src/roam.js
@@ -40,6 +40,7 @@ module.exports = function initRoam(ctx) {
   function isRoamAllowed() {
     if (!enabled) return false;
     if (ctx.getMiniMode && ctx.getMiniMode()) return false;
+    if (typeof ctx.isDragLocked === "function" && ctx.isDragLocked()) return false;
     const state = ctx.getCurrentState ? ctx.getCurrentState() : "idle";
     // Allow roaming when idle (about to start) or already roaming (mid-animation)
     if (state !== "idle" && state !== "roam") return false;
@@ -210,7 +211,10 @@ module.exports = function initRoam(ctx) {
     firstRoam = false;
     roamPauseTimer = setTimeout(() => {
       roamPauseTimer = null;
-      if (!isRoamAllowed()) return;
+      if (!isRoamAllowed()) {
+        firstRoam = true;
+        return;
+      }
       const target = pickRandomTarget();
       if (!target) { scheduleNextRoam(); return; }
       animateTo(target.x, target.y);

--- a/test/hit-renderer.test.js
+++ b/test/hit-renderer.test.js
@@ -234,6 +234,20 @@ describe("hit-renderer input layer", () => {
       ]
     );
   });
+
+  it("keeps the drag reaction owned until pointerup when a state refresh cancels other reactions", () => {
+    const h = createHarness();
+    h.pointerdown({ clientX: 100, clientY: 100 });
+    h.pointermove({ clientX: 90, clientY: 100 });
+
+    h.apiHandlers.cancelReaction();
+    h.pointerup({});
+
+    assert.deepStrictEqual(
+      h.apiCalls.filter((call) => call[0] === "startDragReaction" || call[0] === "endDragReaction"),
+      [["startDragReaction", "left"], ["endDragReaction"]]
+    );
+  });
 });
 
 describe("hit-renderer OS file drop (#459)", () => {

--- a/test/pet-interaction-ipc.test.js
+++ b/test/pet-interaction-ipc.test.js
@@ -57,6 +57,7 @@ function createHarness(overrides = {}) {
     sendToRenderer: (...args) => calls.push(["sendToRenderer", ...args]),
     recoverVisiblePetAfterRendererLoad: (event) => calls.push(["recoverVisiblePetAfterRendererLoad", event.sender]),
     setDragLocked: (value) => calls.push(["setDragLocked", value]),
+    cancelRoam: () => calls.push(["cancelRoam"]),
     setMouseOverPet: (value) => calls.push(["setMouseOverPet", value]),
     beginDragSnapshot: () => calls.push(["beginDragSnapshot"]),
     clearDragSnapshot: () => calls.push(["clearDragSnapshot"]),
@@ -213,6 +214,7 @@ test("pet interaction IPC preserves drag lock lifecycle", () => {
 
   assert.deepStrictEqual(calls, [
     ["setDragLocked", true],
+    ["cancelRoam"],
     ["setMouseOverPet", true],
     ["beginDragSnapshot"],
     ["setDragLocked", false],

--- a/test/renderer-low-power.test.js
+++ b/test/renderer-low-power.test.js
@@ -288,6 +288,7 @@ globalThis.__rendererTest = {
   get activeSwapToken() { return activeSwapToken; },
   get clawdEl() { return clawdEl; },
   get currentDisplayedState() { return currentDisplayedState; },
+  get isDragReacting() { return isDragReacting; },
   get accessoryAssetLoadTimer() { return _accessoryAssetLoadTimer; },
   get accessoryAssetSettled() { return _accessoryAssetSettled; },
   get lowPowerSvgPaused() { return lowPowerSvgPaused; },
@@ -1813,5 +1814,37 @@ describe("renderer glyph flip compensation", () => {
     assert.ok(source.includes("typeof svgWindow.__clawdSetGlyphFlipCompensation === \"function\""));
     assert.ok(source.includes("svgWindow.__clawdSetGlyphFlipCompensation(true);"));
     assert.ok(source.includes("svgWindow.__clawdSetGlyphFlipCompensation(false);"));
+  });
+});
+
+describe("renderer drag reaction state handoff", () => {
+  it("keeps the drag visual through state refreshes and applies only the latest state on release", () => {
+    const harness = createRendererHarness({
+      themeConfig: { dragSvg: "drag.svg" },
+    });
+
+    harness.electronHandlers.onStartDragReaction("left");
+    assert.strictEqual(harness.api.isDragReacting, true);
+    assert.strictEqual(harness.api.pendingSvgFile, "drag.svg");
+
+    harness.electronHandlers.onStateChange("attention", "happy.svg");
+    harness.electronHandlers.onStateChange("idle", "idle-next.svg");
+
+    assert.strictEqual(harness.api.isDragReacting, true);
+    assert.strictEqual(
+      harness.api.pendingSvgFile,
+      "drag.svg",
+      "background state changes must not replace the held drag visual"
+    );
+
+    harness.electronHandlers.onEndDragReaction();
+
+    assert.strictEqual(harness.api.isDragReacting, false);
+    assert.strictEqual(
+      harness.api.pendingSvgFile,
+      "idle-next.svg",
+      "pointerup should render the latest deferred state, not an older intermediate state"
+    );
+    assert.ok(harness.electronCalls.some((call) => call.name === "resumeFromReaction"));
   });
 });

--- a/test/roam.test.js
+++ b/test/roam.test.js
@@ -517,6 +517,34 @@ describe("roam module", () => {
     );
   });
 
+  it("restarts the full idle delay when a short drag cancels a pending roam (#716)", () => {
+    let dragLocked = false;
+    const ctx = makeCtx({ isDragLocked: () => dragLocked });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(3000);
+
+    dragLocked = true;
+    roam.cancelRoam();
+    dragLocked = false;
+    roam.tick();
+
+    mock.timers.tick(7999);
+    assert.equal(
+      ctx._stateLog.length,
+      0,
+      "even a short drag must restart the full 8s idle delay"
+    );
+
+    mock.timers.tick(1);
+    assert.ok(
+      ctx._stateLog.some((event) => event.type === "applyState" && event.state === "roam"),
+      "roam may start after the fresh idle delay"
+    );
+  });
+
   it("cancels an active roam when the drag lock engages (#716)", () => {
     let dragLocked = false;
     const ctx = makeCtx({ isDragLocked: () => dragLocked });

--- a/test/roam.test.js
+++ b/test/roam.test.js
@@ -50,6 +50,7 @@ function makeCtx(overrides = {}) {
     getNearestWorkArea() { return { x: 0, y: 0, width: 1920, height: 1080 }; },
     clampToScreenVisual(x, y, w, h) { return { x, y, width: w, height: h }; },
     getMiniMode() { return false; },
+    isDragLocked() { return false; },
     getCurrentState() { return currentState; },
     setCurrentState(s) { currentState = s; },
     miniTransitioning: false,
@@ -484,6 +485,66 @@ describe("roam module", () => {
     ctx.setCurrentState("roam");
     roam.tick();
     assert.ok(true, "tick should not throw when in roam state");
+  });
+
+  it("does not start a scheduled roam while drag-locked and restarts the full idle delay (#716)", () => {
+    let dragLocked = false;
+    const ctx = makeCtx({ isDragLocked: () => dragLocked });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(3000);
+    dragLocked = true;
+    mock.timers.tick(5000);
+
+    assert.equal(ctx._stateLog.length, 0, "the scheduled roam must not start while held");
+    assert.deepEqual(
+      { x: ctx._realBounds.x, y: ctx._realBounds.y },
+      { x: 400, y: 300 },
+      "the pet must not move while held"
+    );
+
+    dragLocked = false;
+    roam.tick();
+    mock.timers.tick(7999);
+    assert.equal(ctx._stateLog.length, 0, "release must restart the full 8s idle delay");
+
+    mock.timers.tick(1);
+    assert.ok(
+      ctx._stateLog.some((event) => event.type === "applyState" && event.state === "roam"),
+      "roam may start after the fresh idle delay"
+    );
+  });
+
+  it("cancels an active roam when the drag lock engages (#716)", () => {
+    let dragLocked = false;
+    const ctx = makeCtx({ isDragLocked: () => dragLocked });
+    const roam = roamModule(ctx);
+    roam.setEnabled(true);
+
+    roam.tick();
+    mock.timers.tick(8000);
+    mock.timers.tick(160);
+    assert.ok(
+      ctx._realBounds.x !== 400 || ctx._realBounds.y !== 300,
+      "the walk should be active before the grab"
+    );
+
+    dragLocked = true;
+    mock.timers.tick(16);
+    assert.ok(
+      ctx._stateLog.some((event) => event.type === "setState" && event.state === "idle"),
+      "grabbing must cancel the walk and restore idle"
+    );
+
+    const stopped = { x: ctx._realBounds.x, y: ctx._realBounds.y };
+    mock.timers.tick(320);
+    assert.deepEqual(
+      { x: ctx._realBounds.x, y: ctx._realBounds.y },
+      stopped,
+      "no roam frame may move the window after drag lock engages"
+    );
   });
 
   it("falls back to the farthest work-area corner when every random target is too close", () => {


### PR DESCRIPTION
Closes #716

## Summary

- stop pending or active free roam as soon as dragging takes ownership
- restart the full roam idle delay after the pet is released
- preserve the held drag reaction while asynchronous state updates arrive
- apply only the latest deferred visual state after pointer release
- add regression coverage for roam timing, drag-lock IPC, input ownership, and renderer state handoff

## Root cause

The free-roam scheduler and the two pet renderer windows did not share a durable drag-ownership boundary. A scheduled or active roam could survive into a drag, and later state refreshes could independently clear the hit window's drag reaction and replace the render window's held animation. This caused the pet to roam or jitter while held and could switch from the grabbed animation to an idle animation after roughly 5?6 seconds.

## Testing

- Windows 11 x64, build 22621
- Node.js v24.18.0
- `node --test test/roam.test.js test/pet-interaction-ipc.test.js test/pet-window-runtime.test.js test/hit-renderer.test.js test/renderer-low-power.test.js`
- 188 tests passed
- manual: hold during the initial roam wait for 10+ seconds
- manual: grab during active free roam and continue holding for 10+ seconds
- manual: short hold restarts the full approximately 8-second roam delay
- manual: repeated short- and long-distance drag regression
- manual: continuous 12-second hold keeps the grabbed animation with no jitter or visual drop

## Video

- Original reproduction: https://github.com/user-attachments/assets/4834722a-263c-4c42-b2ec-1a5d9ec5bd4b
- Windows 11 before/after verification: https://github.com/user-attachments/assets/626ce7a0-3039-407a-a1f5-3fdfc053d593
