### PR TITLE
test: isolate recovery lease hook HTTP

### DIFF
--- a/test/claude-recovery-lease-hook.test.js
+++ b/test/claude-recovery-lease-hook.test.js
@@ -13,6 +13,7 @@ const {
 } = require("../hooks/session-recovery-lease");
 
 const HOOK = path.join(__dirname, "..", "hooks", "clawd-hook.js");
+const HTTP_BLOCKER = path.join(__dirname, "hook-http-blocker.js");
 
 describe("Claude hook recovery lease ordering", () => {
   let home;
@@ -44,7 +45,7 @@ describe("Claude hook recovery lease ordering", () => {
   function run(event, payload = {}) {
     const env = { ...process.env, HOME: home, USERPROFILE: home };
     delete env.CLAWD_REMOTE;
-    return spawnSync(process.execPath, [HOOK, event], {
+    return spawnSync(process.execPath, ["--require", HTTP_BLOCKER, HOOK, event], {
       input: `${JSON.stringify({ session_id: "offline-session", cwd: "C:/work/project", ...payload })}\n`,
       encoding: "utf8",
       windowsHide: true,


### PR DESCRIPTION
## Summary

- preload the existing `test/hook-http-blocker.js` before the real Claude hook subprocess
- keep the temporary `HOME` / `USERPROFILE` recovery-lease fixture unchanged
- prevent spawned-hook tests from reaching a live Clawd on `127.0.0.1:23333-23337`

## Why

Without the preload, a missing temporary `runtime.json` lets the hook scan the real local port range. If Clawd is running during `npm test`, the test can create a fake Claude session in the HUD and trigger happy animations.

This PR is test-only; production hook discovery and networking behavior are unchanged.

## Test

- `node --test test/claude-recovery-lease-hook.test.js` — 2/2 pass
- verified with a real Clawd process occupying the local state-server port: no fake HUD session or test-triggered happy animation