### PR TITLE
chore: add repository asset audit and hook test isolation

### DIFF
--- a/.github/workflows/repository-asset-audit.yml
+++ b/.github/workflows/repository-asset-audit.yml
@@ -7,6 +7,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/repository-asset-audit.yml
+++ b/.github/workflows/repository-asset-audit.yml
@@ -1,0 +1,32 @@
+name: Repository Asset Audit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Test audit and spawned-hook isolation
+        run: >-
+          node --test
+          test/repository-asset-audit.test.js
+          test/spawned-hook-helper.test.js
+          test/claude-recovery-lease-hook.test.js
+          test/codex-hook.test.js
+          test/qwen-code-hook.test.js
+          test/workbuddy-hook.test.js
+      - run: npm run audit:assets
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: repository-asset-audit
+          path: dist/repository-asset-audit/*.json

--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ scripts/*
 !scripts/verify-sidecar-binaries.js
 !scripts/verify-electron-install.js
 !scripts/fetch-sidecar-binaries.js
+!scripts/audit-repository-assets.js
 
 # oh-my-cursor state
 .omc/

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "prebuild:linux": "node scripts/verify-sidecar-binaries.js",
     "prebuild:all": "node scripts/verify-sidecar-binaries.js",
     "test": "node test/run-tests.js",
+    "audit:assets": "node scripts/audit-repository-assets.js",
     "create-theme": "node scripts/create-theme.js",
     "export-agent-icons": "node scripts/export-agent-icons.js",
     "install:claude-hooks": "node hooks/install.js",

--- a/scripts/audit-repository-assets.js
+++ b/scripts/audit-repository-assets.js
@@ -20,13 +20,31 @@ const BINARY_MEDIA_EXTENSIONS = new Set([
   ".jpg", ".m4v", ".mkv", ".mov", ".mp3", ".mp4", ".node", ".png",
   ".so", ".svg", ".webm", ".webp",
 ]);
+const FAT_MACHO_MAGICS = new Map([
+  [0xcafebabe, { endian: "be", recordBytes: 20 }],
+  [0xbebafeca, { endian: "le", recordBytes: 20 }],
+  [0xcafebabf, { endian: "be", recordBytes: 32 }],
+  [0xbfbafeca, { endian: "le", recordBytes: 32 }],
+]);
 
 function normalizePath(value) {
   return String(value || "").replace(/\\/g, "/").replace(/^\.\/+/, "");
 }
 
 function globToRegExp(glob) {
+  if (typeof glob !== "string" || !glob.trim()) {
+    throw new TypeError("glob must be a non-empty string");
+  }
   const input = normalizePath(glob);
+  if (input.startsWith("!")) {
+    throw new Error(`unsupported glob negation: ${glob}`);
+  }
+  if (/[{}[\]]/.test(input)) {
+    throw new Error(`unsupported glob brace or character-class syntax: ${glob}`);
+  }
+  if (/[?*+@!]\(/.test(input)) {
+    throw new Error(`unsupported glob extglob syntax: ${glob}`);
+  }
   let source = "^";
   for (let i = 0; i < input.length; i += 1) {
     const char = input[i];
@@ -163,6 +181,7 @@ function packageEntry(fullPath, sourcePath, packagePath, origin, asarUnpack) {
 function buildSourcePackageManifest(repoRoot, build, revision) {
   const buildFiles = stableSort(build.files || []);
   const unpackGlobs = stableSort(build.asarUnpack || []);
+  for (const glob of [...buildFiles, ...unpackGlobs]) globToRegExp(glob);
   const allFiles = walkFiles(repoRoot);
   const appSources = new Map();
 
@@ -247,7 +266,30 @@ function resolvePolicy(policy, filePath) {
   const normalized = normalizePath(filePath);
   const exact = (policy.entries || []).find((entry) => normalizePath(entry.path) === normalized);
   if (exact) return exact;
-  return (policy.pathRules || []).find((rule) => matchesGlob(normalized, rule.pattern)) || null;
+  // Prefer the narrowest matching rule so a broad rule cannot shadow a later
+  // retention or ownership exception merely because the JSON was reordered.
+  const matchingRules = (policy.pathRules || [])
+    .filter((rule) => matchesGlob(normalized, rule.pattern))
+    .map((rule) => {
+      const pattern = normalizePath(rule.pattern);
+      const wildcards = (pattern.match(/[*?]/g) || []).length;
+      const firstWildcard = pattern.search(/[*?]/);
+      return {
+        rule,
+        literalPrefixCharacters: firstWildcard === -1 ? pattern.length : firstWildcard,
+        literalCharacters: pattern.replace(/[*?]/g, "").length,
+        wildcards,
+        pattern,
+      };
+    })
+    .sort((a, b) => (
+      b.literalPrefixCharacters - a.literalPrefixCharacters
+      || b.literalCharacters - a.literalCharacters
+      || a.wildcards - b.wildcards
+      || b.pattern.length - a.pattern.length
+      || compareText(a.pattern, b.pattern)
+    ));
+  return matchingRules.length ? matchingRules[0].rule : null;
 }
 
 function validatePolicy(policy) {
@@ -275,6 +317,13 @@ function validatePolicy(policy) {
   const owners = policy.owners || {};
   const classes = policy.classes || {};
   for (const item of [...(policy.pathRules || []), ...(policy.entries || [])]) {
+    if (item.pattern) {
+      try {
+        globToRegExp(item.pattern);
+      } catch (error) {
+        errors.push(`${item.pattern} is invalid: ${error.message}`);
+      }
+    }
     if (!item.owner || item.owner === "unknown" || !owners[item.owner]) {
       errors.push(`${item.path || item.pattern || "(policy item)"} has an unknown owner`);
     }
@@ -321,6 +370,12 @@ function readUInt32(buffer, offset, endian) {
   return endian === "be" ? buffer.readUInt32BE(offset) : buffer.readUInt32LE(offset);
 }
 
+function darwinArchForCpuType(cpuType) {
+  if (cpuType === 0x01000007) return "x64";
+  if (cpuType === 0x0100000c) return "arm64";
+  return `cpu-0x${cpuType.toString(16)}`;
+}
+
 function inspectNativeBuffer(buffer) {
   if (!Buffer.isBuffer(buffer) || buffer.length < 20) return null;
 
@@ -343,14 +398,31 @@ function inspectNativeBuffer(buffer) {
   }
 
   const magicBe = buffer.readUInt32BE(0);
+  const fatMagic = FAT_MACHO_MAGICS.get(magicBe);
+  if (fatMagic) {
+    const count = readUInt32(buffer, 4, fatMagic.endian);
+    const headerBytes = 8 + count * fatMagic.recordBytes;
+    if (count === 0 || count > 128 || headerBytes > buffer.length) return null;
+    const architectures = stableSort(Array.from(new Set(
+      Array.from({ length: count }, (_, index) => {
+        const offset = 8 + index * fatMagic.recordBytes;
+        return darwinArchForCpuType(readUInt32(buffer, offset, fatMagic.endian));
+      }),
+    )));
+    return {
+      os: "darwin",
+      arch: architectures.length === 1 ? architectures[0] : "universal",
+      architectures,
+      format: "mach-o-fat",
+    };
+  }
+
   let endian = null;
   if (magicBe === 0xfeedfacf || magicBe === 0xfeedface) endian = "be";
   if (magicBe === 0xcffaedfe || magicBe === 0xcefaedfe) endian = "le";
   if (endian) {
     const cpuType = readUInt32(buffer, 4, endian);
-    if (cpuType === 0x01000007) return { os: "darwin", arch: "x64", format: "mach-o" };
-    if (cpuType === 0x0100000c) return { os: "darwin", arch: "arm64", format: "mach-o" };
-    return { os: "darwin", arch: `cpu-0x${cpuType.toString(16)}`, format: "mach-o" };
+    return { os: "darwin", arch: darwinArchForCpuType(cpuType), format: "mach-o" };
   }
   return null;
 }
@@ -382,15 +454,20 @@ function findForeignNativeFiles(manifest, repoRoot, packageRoot) {
   if (!manifest.target) return [];
   const foreign = [];
   for (const file of manifest.files) {
-    if (!isNativeCandidate(file)) continue;
-    const tagged = targetTaggedInPath(file.packagePath) || targetTaggedInPath(file.sourcePath);
+    const namedCandidate = isNativeCandidate(file);
+    if (manifest.scope !== "extracted-package" && !namedCandidate) continue;
     let inspected = null;
     const relative = manifest.scope === "extracted-package" ? file.packagePath : file.sourcePath;
     const base = manifest.scope === "extracted-package" ? packageRoot : repoRoot;
     const fullPath = base && path.join(base, ...normalizePath(relative).split("/"));
     if (fullPath && fs.existsSync(fullPath)) inspected = inspectNativeFile(fullPath);
-    const inspectedTarget = inspected && `${inspected.os}-${inspected.arch}`;
-    const detectedTargets = stableSort(Array.from(new Set([tagged, inspectedTarget].filter(Boolean))));
+    if (!namedCandidate && !inspected) continue;
+    const tagged = targetTaggedInPath(file.packagePath) || targetTaggedInPath(file.sourcePath);
+    const inspectedArchitectures = inspected
+      ? (inspected.architectures || [inspected.arch])
+      : [];
+    const inspectedTargets = inspectedArchitectures.map((arch) => `${inspected.os}-${arch}`);
+    const detectedTargets = stableSort(Array.from(new Set([tagged, ...inspectedTargets].filter(Boolean))));
     if (detectedTargets.some((detected) => detected !== manifest.target)) {
       foreign.push({
         packagePath: file.packagePath,

--- a/scripts/audit-repository-assets.js
+++ b/scripts/audit-repository-assets.js
@@ -1,0 +1,730 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const MIB = 1024 * 1024;
+const KNOWN_TARGETS = new Set([
+  "windows-x64",
+  "windows-arm64",
+  "darwin-x64",
+  "darwin-arm64",
+  "linux-x64",
+  "linux-arm64",
+]);
+const BINARY_MEDIA_EXTENSIONS = new Set([
+  ".apng", ".avi", ".dll", ".dylib", ".exe", ".gif", ".ico", ".jpeg",
+  ".jpg", ".m4v", ".mkv", ".mov", ".mp3", ".mp4", ".node", ".png",
+  ".so", ".svg", ".webm", ".webp",
+]);
+
+function normalizePath(value) {
+  return String(value || "").replace(/\\/g, "/").replace(/^\.\/+/, "");
+}
+
+function globToRegExp(glob) {
+  const input = normalizePath(glob);
+  let source = "^";
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+    if (char === "*") {
+      if (input[i + 1] === "*") {
+        i += 1;
+        if (input[i + 1] === "/") {
+          i += 1;
+          source += "(?:.*/)?";
+        } else {
+          source += ".*";
+        }
+      } else {
+        source += "[^/]*";
+      }
+    } else if (char === "?") {
+      source += "[^/]";
+    } else {
+      source += char.replace(/[|\\{}()[\]^$+?.]/g, "\\$&");
+    }
+  }
+  return new RegExp(`${source}$`);
+}
+
+function matchesGlob(filePath, glob) {
+  return globToRegExp(glob).test(normalizePath(filePath));
+}
+
+function matchesAnyGlob(filePath, globs) {
+  return (globs || []).some((glob) => matchesGlob(filePath, glob));
+}
+
+function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function compareText(left, right) {
+  const a = String(left);
+  const b = String(right);
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function stableSort(items, key = (value) => value) {
+  return items.slice().sort((a, b) => compareText(key(a), key(b)));
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function formatMiB(bytes) {
+  return (Number(bytes || 0) / MIB).toFixed(2);
+}
+
+function parseTrackedTree(raw) {
+  return String(raw || "")
+    .split("\0")
+    .filter(Boolean)
+    .map((entry) => {
+      const match = entry.match(/^(\d+)\s+blob\s+([0-9a-f]+)\s+(\d+)\t([\s\S]+)$/);
+      if (!match) return null;
+      const filePath = normalizePath(match[4]);
+      return {
+        path: filePath,
+        mode: match[1],
+        gitBlob: match[2],
+        bytes: Number(match[3]),
+        extension: path.posix.extname(filePath).toLowerCase() || "(none)",
+        topLevel: filePath.includes("/") ? filePath.split("/")[0] : filePath,
+      };
+    })
+    .filter(Boolean);
+}
+
+function readTrackedTree(repoRoot) {
+  const raw = execFileSync("git", ["ls-tree", "-r", "-l", "-z", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 32 * MIB,
+  });
+  return parseTrackedTree(raw);
+}
+
+function readRevision(repoRoot) {
+  return execFileSync("git", ["rev-parse", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).trim();
+}
+
+function walkFiles(root, options = {}) {
+  const excluded = new Set(options.excludedDirectories || [
+    ".git", ".worktrees", "dist", "node_modules",
+  ]);
+  const files = [];
+  if (!fs.existsSync(root)) return files;
+
+  function visit(current, relative) {
+    const entries = fs.readdirSync(current, { withFileTypes: true })
+      .sort((a, b) => compareText(a.name, b.name));
+    for (const entry of entries) {
+      const rel = normalizePath(relative ? `${relative}/${entry.name}` : entry.name);
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (!excluded.has(entry.name)) visit(full, rel);
+      } else if (entry.isFile()) {
+        files.push({ path: rel, fullPath: full });
+      }
+    }
+  }
+
+  visit(root, "");
+  return files;
+}
+
+function readPackageConfig(repoRoot) {
+  return JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")).build || {};
+}
+
+function packageEntry(fullPath, sourcePath, packagePath, origin, asarUnpack) {
+  const stat = fs.statSync(fullPath);
+  return {
+    sourcePath: normalizePath(sourcePath),
+    packagePath: normalizePath(packagePath),
+    origin,
+    asarUnpack: !!asarUnpack,
+    bytes: stat.size,
+    sha256: sha256File(fullPath),
+  };
+}
+
+function buildSourcePackageManifest(repoRoot, build, revision) {
+  const buildFiles = stableSort(build.files || []);
+  const unpackGlobs = stableSort(build.asarUnpack || []);
+  const allFiles = walkFiles(repoRoot);
+  const appSources = new Map();
+
+  for (const file of allFiles) {
+    if (matchesAnyGlob(file.path, buildFiles)) appSources.set(file.path, file);
+  }
+
+  const implicitPackageJson = path.join(repoRoot, "package.json");
+  if (fs.existsSync(implicitPackageJson) && !appSources.has("package.json")) {
+    appSources.set("package.json", { path: "package.json", fullPath: implicitPackageJson });
+  }
+
+  const files = stableSort(Array.from(appSources.values()), (file) => file.path)
+    .map((file) => packageEntry(
+      file.fullPath,
+      file.path,
+      `app/${file.path}`,
+      "build.files",
+      matchesAnyGlob(file.path, unpackGlobs),
+    ));
+
+  const extraResources = (build.extraResources || []).map((entry) => ({
+    from: normalizePath(entry && entry.from),
+    to: normalizePath(entry && entry.to),
+  }));
+
+  for (const entry of extraResources) {
+    if (!entry.from) continue;
+    const from = path.join(repoRoot, ...entry.from.split("/"));
+    if (!fs.existsSync(from)) continue;
+    const stat = fs.statSync(from);
+    if (stat.isFile()) {
+      files.push(packageEntry(
+        from,
+        entry.from,
+        `resources/${entry.to || path.posix.basename(entry.from)}`,
+        "extraResources",
+        false,
+      ));
+      continue;
+    }
+    for (const child of walkFiles(from, { excludedDirectories: [] })) {
+      files.push(packageEntry(
+        child.fullPath,
+        `${entry.from}/${child.path}`,
+        `resources/${entry.to}/${child.path}`,
+        "extraResources",
+        false,
+      ));
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    revision,
+    scope: "repository-owned-package-inputs",
+    target: null,
+    buildFiles,
+    asarUnpack: unpackGlobs,
+    extraResources: stableSort(extraResources, (entry) => `${entry.from}\0${entry.to}`),
+    files: stableSort(files, (file) => `${file.packagePath}\0${file.sourcePath}`),
+  };
+}
+
+function buildExtractedPackageManifest(packageRoot, target, revision) {
+  const files = walkFiles(packageRoot, { excludedDirectories: [] }).map((file) => (
+    packageEntry(file.fullPath, file.path, file.path, "extracted-package", false)
+  ));
+  return {
+    schemaVersion: 1,
+    revision,
+    scope: "extracted-package",
+    target,
+    buildFiles: [],
+    asarUnpack: [],
+    extraResources: [],
+    files: stableSort(files, (file) => file.packagePath),
+  };
+}
+
+function resolvePolicy(policy, filePath) {
+  const normalized = normalizePath(filePath);
+  const exact = (policy.entries || []).find((entry) => normalizePath(entry.path) === normalized);
+  if (exact) return exact;
+  return (policy.pathRules || []).find((rule) => matchesGlob(normalized, rule.pattern)) || null;
+}
+
+function validatePolicy(policy) {
+  const errors = [];
+  if (!policy || policy.schemaVersion !== 1) {
+    errors.push("policy schemaVersion must be 1");
+    return errors;
+  }
+  const requiredPatterns = [
+    "themes/**",
+    "assets/gif/**",
+    "assets/videos/**",
+    "assets/source/**",
+    "test/fixtures/**",
+  ];
+  for (const pattern of requiredPatterns) {
+    if (!(policy.pathRules || []).some((rule) => rule.pattern === pattern)) {
+      errors.push(`policy is missing required path rule ${pattern}`);
+    }
+  }
+  const license = (policy.entries || []).find((entry) => entry.path === "assets/LICENSE");
+  if (!license || license.owner !== "legal" || license.retention !== "permanent") {
+    errors.push("assets/LICENSE must be owned by legal and retained permanently");
+  }
+  const owners = policy.owners || {};
+  const classes = policy.classes || {};
+  for (const item of [...(policy.pathRules || []), ...(policy.entries || [])]) {
+    if (!item.owner || item.owner === "unknown" || !owners[item.owner]) {
+      errors.push(`${item.path || item.pattern || "(policy item)"} has an unknown owner`);
+    }
+    if (!item.class || !classes[item.class]) {
+      errors.push(`${item.path || item.pattern || "(policy item)"} has an unknown class`);
+    }
+  }
+  return errors;
+}
+
+function aggregateBy(items, key) {
+  const groups = new Map();
+  for (const item of items) {
+    const name = key(item);
+    const current = groups.get(name) || { name, files: 0, bytes: 0 };
+    current.files += 1;
+    current.bytes += item.bytes;
+    groups.set(name, current);
+  }
+  return Array.from(groups.values())
+    .sort((a, b) => b.bytes - a.bytes || compareText(a.name, b.name));
+}
+
+function groupDuplicates(items, hashKey, pathKey) {
+  const groups = new Map();
+  for (const item of items) {
+    const hash = hashKey(item);
+    const group = groups.get(hash) || [];
+    group.push(item);
+    groups.set(hash, group);
+  }
+  return Array.from(groups.entries())
+    .filter(([, group]) => group.length > 1)
+    .map(([hash, group]) => ({
+      hash,
+      bytes: group[0].bytes,
+      copies: group.length,
+      paths: stableSort(group.map(pathKey)),
+    }))
+    .sort((a, b) => b.bytes - a.bytes || compareText(a.paths[0], b.paths[0]));
+}
+
+function readUInt32(buffer, offset, endian) {
+  return endian === "be" ? buffer.readUInt32BE(offset) : buffer.readUInt32LE(offset);
+}
+
+function inspectNativeBuffer(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 20) return null;
+
+  if (buffer[0] === 0x4d && buffer[1] === 0x5a && buffer.length >= 0x40) {
+    const peOffset = buffer.readUInt32LE(0x3c);
+    if (peOffset + 6 <= buffer.length && buffer.toString("ascii", peOffset, peOffset + 4) === "PE\0\0") {
+      const machine = buffer.readUInt16LE(peOffset + 4);
+      if (machine === 0x8664) return { os: "windows", arch: "x64", format: "pe" };
+      if (machine === 0xaa64) return { os: "windows", arch: "arm64", format: "pe" };
+      return { os: "windows", arch: `machine-0x${machine.toString(16)}`, format: "pe" };
+    }
+  }
+
+  if (buffer[0] === 0x7f && buffer.toString("ascii", 1, 4) === "ELF") {
+    const endian = buffer[5] === 2 ? "be" : "le";
+    const machine = endian === "be" ? buffer.readUInt16BE(18) : buffer.readUInt16LE(18);
+    if (machine === 62) return { os: "linux", arch: "x64", format: "elf" };
+    if (machine === 183) return { os: "linux", arch: "arm64", format: "elf" };
+    return { os: "linux", arch: `machine-${machine}`, format: "elf" };
+  }
+
+  const magicBe = buffer.readUInt32BE(0);
+  let endian = null;
+  if (magicBe === 0xfeedfacf || magicBe === 0xfeedface) endian = "be";
+  if (magicBe === 0xcffaedfe || magicBe === 0xcefaedfe) endian = "le";
+  if (endian) {
+    const cpuType = readUInt32(buffer, 4, endian);
+    if (cpuType === 0x01000007) return { os: "darwin", arch: "x64", format: "mach-o" };
+    if (cpuType === 0x0100000c) return { os: "darwin", arch: "arm64", format: "mach-o" };
+    return { os: "darwin", arch: `cpu-0x${cpuType.toString(16)}`, format: "mach-o" };
+  }
+  return null;
+}
+
+function inspectNativeFile(filePath) {
+  const fd = fs.openSync(filePath, "r");
+  try {
+    const buffer = Buffer.alloc(4096);
+    const bytes = fs.readSync(fd, buffer, 0, buffer.length, 0);
+    return inspectNativeBuffer(buffer.subarray(0, bytes));
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function targetTaggedInPath(filePath) {
+  const match = normalizePath(filePath).match(/(?:^|\/)(windows|darwin|linux)-(x64|arm64)(?:\/|$)/);
+  return match ? `${match[1]}-${match[2]}` : null;
+}
+
+function isNativeCandidate(file) {
+  const basename = path.posix.basename(normalizePath(file.packagePath || file.sourcePath)).toLowerCase();
+  return basename === "cc-connect-clawd"
+    || basename === "cc-connect-clawd.exe"
+    || [".dll", ".dylib", ".exe", ".node", ".so"].includes(path.posix.extname(basename));
+}
+
+function findForeignNativeFiles(manifest, repoRoot, packageRoot) {
+  if (!manifest.target) return [];
+  const foreign = [];
+  for (const file of manifest.files) {
+    if (!isNativeCandidate(file)) continue;
+    const tagged = targetTaggedInPath(file.packagePath) || targetTaggedInPath(file.sourcePath);
+    let inspected = null;
+    const relative = manifest.scope === "extracted-package" ? file.packagePath : file.sourcePath;
+    const base = manifest.scope === "extracted-package" ? packageRoot : repoRoot;
+    const fullPath = base && path.join(base, ...normalizePath(relative).split("/"));
+    if (fullPath && fs.existsSync(fullPath)) inspected = inspectNativeFile(fullPath);
+    const inspectedTarget = inspected && `${inspected.os}-${inspected.arch}`;
+    const detectedTargets = stableSort(Array.from(new Set([tagged, inspectedTarget].filter(Boolean))));
+    if (detectedTargets.some((detected) => detected !== manifest.target)) {
+      foreign.push({
+        packagePath: file.packagePath,
+        detectedTargets,
+        expectedTarget: manifest.target,
+      });
+    }
+  }
+  return stableSort(foreign, (item) => item.packagePath);
+}
+
+function duplicateIsExempt(duplicate, manifest, policy) {
+  const sourceByPackagePath = new Map(manifest.files.map((file) => [file.packagePath, file.sourcePath]));
+  const sources = duplicate.paths.map((packagePath) => sourceByPackagePath.get(packagePath) || packagePath);
+  return (policy.duplicatePayloadExemptions || []).some((entry) => {
+    const expected = stableSort((entry.paths || []).map(normalizePath));
+    return JSON.stringify(expected) === JSON.stringify(stableSort(sources));
+  });
+}
+
+function analyzeAudit({
+  trackedFiles,
+  manifest,
+  policy,
+  repoRoot,
+  packageRoot,
+  baselinePackageBytes = null,
+}) {
+  const findings = [];
+  const thresholds = policy.thresholds || {};
+  const trackedBytes = trackedFiles.reduce((sum, file) => sum + file.bytes, 0);
+  const packageBytes = manifest.files.reduce((sum, file) => sum + file.bytes, 0);
+
+  for (const message of validatePolicy(policy)) {
+    findings.push({ level: "error", rule: "asset-policy-valid", message });
+  }
+
+  if (!trackedFiles.some((file) => file.path === "assets/LICENSE")) {
+    findings.push({
+      level: "error",
+      rule: "assets-license-retained",
+      path: "assets/LICENSE",
+      message: "assets/LICENSE must remain tracked permanently.",
+    });
+  }
+
+  if (trackedBytes > Number(thresholds.trackedTreeHardBytes || Infinity)) {
+    findings.push({
+      level: "error",
+      rule: "tracked-tree-hard-budget",
+      message: `Tracked tree ${trackedBytes} bytes exceeds hard budget ${thresholds.trackedTreeHardBytes} bytes.`,
+    });
+  } else if (trackedBytes > Number(thresholds.trackedTreeWarningBytes || Infinity)) {
+    findings.push({
+      level: "warning",
+      rule: "tracked-tree-warning-budget",
+      message: `Tracked tree ${trackedBytes} bytes exceeds warning budget ${thresholds.trackedTreeWarningBytes} bytes.`,
+    });
+  }
+
+  for (const file of trackedFiles) {
+    const largeMedia = file.bytes > Number(thresholds.largeTrackedBinaryMediaBytes || Infinity)
+      && BINARY_MEDIA_EXTENSIONS.has(file.extension);
+    if (largeMedia) {
+      const resolved = resolvePolicy(policy, file.path);
+      if (!resolved || !resolved.owner || resolved.owner === "unknown" || !policy.owners[resolved.owner]) {
+        findings.push({
+          level: "error",
+          rule: "large-tracked-file-owned",
+          path: file.path,
+          message: `Large tracked binary/media file (${file.bytes} bytes) has no known policy owner.`,
+        });
+      }
+    }
+    if (file.path.startsWith("bin/cc-connect-clawd/")
+      && /(?:^|\/)cc-connect-clawd(?:\.exe)?$/i.test(file.path)) {
+      findings.push({
+        level: "error",
+        rule: "sidecar-executable-untracked",
+        path: file.path,
+        message: "cc-connect-clawd executables must remain generated/ignored, never tracked.",
+      });
+    }
+  }
+
+  const packagedSources = new Set(manifest.files.map((file) => normalizePath(file.sourcePath)));
+  for (const file of manifest.files) {
+    const source = normalizePath(file.sourcePath);
+    const packaged = normalizePath(file.packagePath);
+    if (source.startsWith("assets/source/") || packaged.includes("/assets/source/") || packaged.startsWith("assets/source/")) {
+      findings.push({
+        level: "error",
+        rule: "source-assets-not-packaged",
+        path: file.packagePath,
+        message: "assets/source/** must never be matched by package inputs.",
+      });
+    }
+    const resolved = resolvePolicy(policy, source);
+    if (resolved && resolved.packaged === false) {
+      findings.push({
+        level: "error",
+        rule: "policy-excluded-file-not-packaged",
+        path: file.packagePath,
+        message: `${source} is marked packaged=false by asset policy.`,
+      });
+    }
+  }
+
+  if (manifest.scope === "repository-owned-package-inputs") {
+    for (const file of trackedFiles) {
+      const resolved = resolvePolicy(policy, file.path);
+      if (resolved && resolved.packaged === true && !packagedSources.has(file.path)) {
+        findings.push({
+          level: "error",
+          rule: "policy-required-file-packaged",
+          path: file.path,
+          message: `${file.path} is marked packaged=true but is absent from the package manifest.`,
+        });
+      }
+    }
+  }
+
+  const foreignNative = findForeignNativeFiles(manifest, repoRoot, packageRoot);
+  for (const foreign of foreignNative) {
+    findings.push({
+      level: "error",
+      rule: "foreign-target-native",
+      path: foreign.packagePath,
+      message: `Expected ${foreign.expectedTarget}; detected ${foreign.detectedTargets.join(", ")}.`,
+    });
+  }
+
+  const packagedDuplicates = groupDuplicates(
+    manifest.files,
+    (file) => file.sha256,
+    (file) => file.packagePath,
+  ).map((duplicate) => ({
+    ...duplicate,
+    exempt: duplicateIsExempt(duplicate, manifest, policy),
+  }));
+  for (const duplicate of packagedDuplicates) {
+    if (duplicate.bytes > Number(thresholds.duplicatePackagedPayloadWarningBytes || Infinity)
+      && !duplicate.exempt) {
+      findings.push({
+        level: "warning",
+        rule: "duplicate-packaged-payload",
+        paths: duplicate.paths,
+        message: `${duplicate.copies} packaged copies share ${duplicate.bytes} identical bytes.`,
+      });
+    }
+  }
+
+  let growth = null;
+  if (Number.isFinite(baselinePackageBytes) && baselinePackageBytes >= 0) {
+    const addedBytes = packageBytes - baselinePackageBytes;
+    const addedRatio = baselinePackageBytes > 0 ? addedBytes / baselinePackageBytes : null;
+    growth = {
+      baselineBytes: baselinePackageBytes,
+      currentBytes: packageBytes,
+      addedBytes,
+      addedRatio,
+    };
+    if (addedBytes > Number(thresholds.artifactGrowthWarningBytes || Infinity)
+      || (addedRatio !== null && addedRatio > Number(thresholds.artifactGrowthWarningRatio || Infinity))) {
+      findings.push({
+        level: "warning",
+        rule: "package-growth-budget",
+        message: `Package manifest grew by ${addedBytes} bytes`
+          + `${addedRatio === null ? "" : ` (${(addedRatio * 100).toFixed(2)}%)`}.`,
+      });
+    }
+  }
+
+  const sortedFindings = findings.sort((a, b) => (
+    compareText(a.level, b.level)
+    || compareText(a.rule, b.rule)
+    || compareText(
+      a.path || (a.paths || []).join("\0"),
+      b.path || (b.paths || []).join("\0"),
+    )
+  ));
+
+  return {
+    schemaVersion: 1,
+    revision: manifest.revision,
+    tracked: {
+      files: trackedFiles.length,
+      bytes: trackedBytes,
+      byTopLevel: aggregateBy(trackedFiles, (file) => file.topLevel),
+      byExtension: aggregateBy(trackedFiles, (file) => file.extension),
+      largestFiles: trackedFiles.slice()
+        .sort((a, b) => b.bytes - a.bytes || compareText(a.path, b.path))
+        .slice(0, 50)
+        .map(({ path: filePath, bytes, gitBlob }) => ({ path: filePath, bytes, gitBlob })),
+      duplicateBlobs: groupDuplicates(
+        trackedFiles,
+        (file) => file.gitBlob,
+        (file) => file.path,
+      ),
+    },
+    package: {
+      scope: manifest.scope,
+      target: manifest.target,
+      files: manifest.files.length,
+      bytes: packageBytes,
+      duplicatePayloads: packagedDuplicates,
+      foreignNativeFiles: foreignNative,
+      growth,
+    },
+    findings: sortedFindings,
+  };
+}
+
+function parseArgs(argv) {
+  const args = {
+    output: "dist/repository-asset-audit",
+    packageRoot: null,
+    target: null,
+    baselineManifest: null,
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (value === "--output") args.output = argv[++i];
+    else if (value === "--package-root") args.packageRoot = argv[++i];
+    else if (value === "--target") args.target = argv[++i];
+    else if (value === "--baseline-manifest") args.baselineManifest = argv[++i];
+    else if (value === "--help") args.help = true;
+    else throw new Error(`Unknown argument: ${value}`);
+  }
+  if (args.packageRoot && !args.target) {
+    throw new Error("--package-root requires --target");
+  }
+  if (args.target && !KNOWN_TARGETS.has(args.target)) {
+    throw new Error(`Unsupported target ${args.target}; expected one of ${Array.from(KNOWN_TARGETS).join(", ")}`);
+  }
+  return args;
+}
+
+function runAudit(options = {}) {
+  const repoRoot = path.resolve(options.repoRoot || path.join(__dirname, ".."));
+  const policyPath = path.resolve(options.policyPath || path.join(repoRoot, "tools", "repository-asset-policy.json"));
+  const outputDir = path.resolve(repoRoot, options.output || "dist/repository-asset-audit");
+  const packageRoot = options.packageRoot ? path.resolve(repoRoot, options.packageRoot) : null;
+  const revision = options.revision || readRevision(repoRoot);
+  const trackedFiles = options.trackedFiles || readTrackedTree(repoRoot);
+  const policy = options.policy || JSON.parse(fs.readFileSync(policyPath, "utf8"));
+  const build = options.build || readPackageConfig(repoRoot);
+  const manifest = options.manifest || (packageRoot
+    ? buildExtractedPackageManifest(packageRoot, options.target, revision)
+    : buildSourcePackageManifest(repoRoot, build, revision));
+  if (options.target && !manifest.target) manifest.target = options.target;
+  let baselinePackageBytes = options.baselinePackageBytes;
+  if (baselinePackageBytes === undefined && options.baselineManifest) {
+    const baselinePath = path.resolve(repoRoot, options.baselineManifest);
+    const baseline = JSON.parse(fs.readFileSync(baselinePath, "utf8"));
+    baselinePackageBytes = baseline.package && Number.isFinite(baseline.package.bytes)
+      ? baseline.package.bytes
+      : (baseline.files || []).reduce((sum, file) => sum + Number(file.bytes || 0), 0);
+  }
+  const report = analyzeAudit({
+    trackedFiles,
+    manifest,
+    policy,
+    repoRoot,
+    packageRoot,
+    baselinePackageBytes,
+  });
+
+  fs.mkdirSync(outputDir, { recursive: true });
+  fs.writeFileSync(path.join(outputDir, "package-manifest.json"), stableJson(manifest), "utf8");
+  fs.writeFileSync(path.join(outputDir, "tracked-large-files.json"), stableJson({
+    schemaVersion: 1,
+    revision,
+    files: report.tracked.largestFiles,
+  }), "utf8");
+  fs.writeFileSync(path.join(outputDir, "audit-report.json"), stableJson(report), "utf8");
+
+  return { report, manifest, outputDir };
+}
+
+function printSummary(report) {
+  const warnings = report.findings.filter((finding) => finding.level === "warning");
+  const errors = report.findings.filter((finding) => finding.level === "error");
+  process.stdout.write([
+    `Repository asset audit @ ${report.revision}`,
+    `Tracked: ${report.tracked.files} files, ${report.tracked.bytes} bytes (${formatMiB(report.tracked.bytes)} MiB)`,
+    `Package manifest (${report.package.scope}): ${report.package.files} files, ${report.package.bytes} bytes (${formatMiB(report.package.bytes)} MiB)`,
+    `Findings: ${errors.length} error(s), ${warnings.length} warning(s)`,
+    ...report.findings.map((finding) => {
+      const location = finding.path || (finding.paths || []).join(", ");
+      return `${finding.level.toUpperCase()} ${finding.rule}`
+        + `${location ? ` ${location}` : ""}: ${finding.message}`;
+    }),
+    "",
+  ].join("\n"));
+}
+
+function printHelp() {
+  process.stdout.write(
+    "Usage: node scripts/audit-repository-assets.js [--output DIR] "
+    + "[--baseline-manifest PREVIOUS_JSON] "
+    + "[--package-root EXTRACTED_DIR --target windows-x64|windows-arm64|darwin-x64|darwin-arm64|linux-x64]\n",
+  );
+}
+
+if (require.main === module) {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+      printHelp();
+      process.exit(0);
+    }
+    const { report, outputDir } = runAudit(args);
+    printSummary(report);
+    process.stdout.write(`Reports: ${normalizePath(path.relative(path.join(__dirname, ".."), outputDir))}\n`);
+    process.exit(report.findings.some((finding) => finding.level === "error") ? 1 : 0);
+  } catch (error) {
+    process.stderr.write(`Repository asset audit failed: ${error.message}\n`);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  analyzeAudit,
+  buildExtractedPackageManifest,
+  buildSourcePackageManifest,
+  findForeignNativeFiles,
+  globToRegExp,
+  inspectNativeBuffer,
+  matchesGlob,
+  parseArgs,
+  parseTrackedTree,
+  resolvePolicy,
+  runAudit,
+  stableJson,
+  validatePolicy,
+};

--- a/test/antigravity-hook.test.js
+++ b/test/antigravity-hook.test.js
@@ -3,17 +3,20 @@ const assert = require("node:assert");
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
-const { spawnSync } = require("child_process");
+const {
+  createSpawnedHookHarness,
+  runSpawnedHook,
+} = require("./helpers/spawned-hook");
 const { __test } = require("../hooks/antigravity-hook");
 
 function runAntigravityHook(argvEvent, payload = {}) {
   const scriptPath = path.resolve(__dirname, "..", "hooks", "antigravity-hook.js");
-  const httpBlockerPath = path.resolve(__dirname, "hook-http-blocker.js");
-  return spawnSync(process.execPath, ["--require", httpBlockerPath, scriptPath, argvEvent], {
-    env: { ...process.env, CLAWD_REMOTE: "1" },
-    input: JSON.stringify(payload),
-    encoding: "utf8",
-    windowsHide: true,
+  return runSpawnedHook({
+    script: scriptPath,
+    args: [argvEvent],
+    payload,
+    httpContract: "block",
+    env: { CLAWD_REMOTE: "1" },
   });
 }
 
@@ -292,31 +295,37 @@ describe("Antigravity hook script", () => {
 
   it("fails open when local hook setup throws", () => {
     const scriptPath = path.resolve(__dirname, "..", "hooks", "antigravity-hook.js");
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-antigravity-hook-"));
-    const preloadPath = path.join(tmpDir, "preload.js");
-    const preload = `
-      const Module = require("module");
-      const original = Module._load;
-      Module._load = function(request, parent, isMain) {
-        if (request.endsWith("./shared-process") || request.endsWith("/shared-process")) {
-          return {
-            getPlatformConfig: () => ({}),
-            readStdinJson: () => Promise.reject(new Error("stdin failed")),
-            createPidResolver: () => () => { throw new Error("pid failed"); },
-          };
-        }
-        return original.apply(this, arguments);
-      };
-    `;
-    fs.writeFileSync(preloadPath, preload);
-    const result = spawnSync(process.execPath, ["--require", preloadPath, scriptPath, "PreToolUse"], {
-      input: JSON.stringify({ conversationId: "c1" }),
-      encoding: "utf8",
-      windowsHide: true,
-    });
+    const harness = createSpawnedHookHarness({ prefix: "clawd-antigravity-hook-" });
+    try {
+      const preloadPath = path.join(harness.home, "preload.js");
+      const preload = `
+        const Module = require("module");
+        const original = Module._load;
+        Module._load = function(request, parent, isMain) {
+          if (request.endsWith("./shared-process") || request.endsWith("/shared-process")) {
+            return {
+              getPlatformConfig: () => ({}),
+              readStdinJson: () => Promise.reject(new Error("stdin failed")),
+              createPidResolver: () => () => { throw new Error("pid failed"); },
+            };
+          }
+          return original.apply(this, arguments);
+        };
+      `;
+      fs.writeFileSync(preloadPath, preload);
+      const result = harness.run({
+        script: scriptPath,
+        args: ["PreToolUse"],
+        payload: { conversationId: "c1" },
+        preloads: [preloadPath],
+        httpContract: "expect-none",
+      });
 
-    assert.strictEqual(result.status, 0);
-    assert.strictEqual(result.stderr, "");
-    assert.deepStrictEqual(JSON.parse(result.stdout), { decision: "ask" });
+      assert.strictEqual(result.status, 0);
+      assert.strictEqual(result.stderr, "");
+      assert.deepStrictEqual(JSON.parse(result.stdout), { decision: "ask" });
+    } finally {
+      harness.cleanup();
+    }
   });
 });

--- a/test/claude-recovery-lease-hook.test.js
+++ b/test/claude-recovery-lease-hook.test.js
@@ -2,10 +2,10 @@
 
 const { describe, it, beforeEach, afterEach } = require("node:test");
 const assert = require("node:assert");
-const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { createSpawnedHookHarness } = require("./helpers/spawned-hook");
 const {
   getLeaseFilePath,
   readLeaseFile,
@@ -13,14 +13,15 @@ const {
 } = require("../hooks/session-recovery-lease");
 
 const HOOK = path.join(__dirname, "..", "hooks", "clawd-hook.js");
-const HTTP_BLOCKER = path.join(__dirname, "hook-http-blocker.js");
 
 describe("Claude hook recovery lease ordering", () => {
   let home;
   let recoveryDir;
+  let hookHarness;
 
   beforeEach(() => {
     home = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-hook-recovery-"));
+    hookHarness = createSpawnedHookHarness({ home });
     recoveryDir = path.join(home, ".clawd", "session-recovery-v1");
     updateRecoveryLeaseFromStateBody({
       agent_id: "claude-code",
@@ -43,14 +44,11 @@ describe("Claude hook recovery lease ordering", () => {
   afterEach(() => fs.rmSync(home, { recursive: true, force: true }));
 
   function run(event, payload = {}) {
-    const env = { ...process.env, HOME: home, USERPROFILE: home };
-    delete env.CLAWD_REMOTE;
-    return spawnSync(process.execPath, ["--require", HTTP_BLOCKER, HOOK, event], {
-      input: `${JSON.stringify({ session_id: "offline-session", cwd: "C:/work/project", ...payload })}\n`,
-      encoding: "utf8",
-      windowsHide: true,
-      timeout: 20000,
-      env,
+    return hookHarness.run({
+      script: HOOK,
+      args: [event],
+      payload: { session_id: "offline-session", cwd: "C:/work/project", ...payload },
+      httpContract: "expect-attempt",
     });
   }
 

--- a/test/codewhale-hook.test.js
+++ b/test/codewhale-hook.test.js
@@ -1,7 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
-const { spawnSync } = require("node:child_process");
 const path = require("node:path");
+const { runSpawnedHook } = require("./helpers/spawned-hook");
 const { __test } = require("../hooks/codewhale-hook");
 
 function cacheDeps(initial = null) {
@@ -105,10 +105,10 @@ describe("CodeWhale hook script", () => {
 
   it("exits cleanly without stdout or stderr for unknown CLI events", () => {
     const scriptPath = path.resolve(__dirname, "..", "hooks", "codewhale-hook.js");
-    const blockerPath = path.resolve(__dirname, "hook-http-blocker.js");
-    const result = spawnSync(process.execPath, ["--require", blockerPath, scriptPath, "shell_env"], {
-      encoding: "utf8",
-      windowsHide: true,
+    const result = runSpawnedHook({
+      script: scriptPath,
+      args: ["shell_env"],
+      httpContract: "expect-none",
     });
 
     assert.strictEqual(result.status, 0);

--- a/test/codex-debug-hook.test.js
+++ b/test/codex-debug-hook.test.js
@@ -3,7 +3,7 @@ const assert = require("node:assert");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
-const { spawnSync } = require("child_process");
+const { runSpawnedHook } = require("./helpers/spawned-hook");
 const {
   appendDebugEntry,
   buildDebugEntry,
@@ -83,11 +83,11 @@ describe("Codex debug hook", () => {
     const tmpDir = makeTempDir();
     const logPath = path.join(tmpDir, "debug.jsonl");
     const scriptPath = path.resolve(__dirname, "..", "hooks", "codex-debug-hook.js");
-    const result = spawnSync(process.execPath, [scriptPath], {
-      input: JSON.stringify({ hook_event_name: "Stop", session_id: "session-1" }),
-      encoding: "utf8",
-      env: { ...process.env, CLAWD_CODEX_DEBUG_LOG: logPath },
-      windowsHide: true,
+    const result = runSpawnedHook({
+      script: scriptPath,
+      payload: { hook_event_name: "Stop", session_id: "session-1" },
+      httpContract: "expect-none",
+      env: { CLAWD_CODEX_DEBUG_LOG: logPath },
     });
 
     assert.strictEqual(result.status, 0);

--- a/test/codex-hook.test.js
+++ b/test/codex-hook.test.js
@@ -2,8 +2,8 @@ const { describe, it, before, after } = require("node:test");
 const assert = require("node:assert");
 const fs = require("fs");
 const os = require("os");
-const { spawnSync } = require("child_process");
 const path = require("path");
+const { runSpawnedHook } = require("./helpers/spawned-hook");
 const {
   buildCodexNoDecisionOutput,
   buildCodexPermissionOutput,
@@ -506,19 +506,20 @@ describe("Codex official hook", () => {
 
   it("writes no stdout and exits 0 when stop_hook_active=true", () => {
     const scriptPath = path.resolve(__dirname, "..", "hooks", "codex-hook.js");
-    const result = spawnSync(process.execPath, [scriptPath], {
-      input: JSON.stringify({
+    const result = runSpawnedHook({
+      script: scriptPath,
+      payload: {
         hook_event_name: "Stop",
         session_id: "s1",
         turn_id: "turn-1",
         stop_hook_active: true,
-      }),
-      encoding: "utf8",
-      windowsHide: true,
+      },
+      httpContract: "expect-none",
     });
 
     assert.strictEqual(result.status, 0);
     assert.strictEqual(result.stdout, "");
+    assert.strictEqual(result.stderr, "");
   });
 
   it("reuses the runtime port for state and permission hooks", async () => {

--- a/test/fixtures/spawned-hook/http-contract.js
+++ b/test/fixtures/spawned-hook/http-contract.js
@@ -1,0 +1,23 @@
+"use strict";
+
+const http = require("node:http");
+
+if (process.argv[2] === "attempt") {
+  const request = http.request({
+    host: "127.0.0.1",
+    port: 23333,
+    path: "/state",
+    method: "POST",
+  });
+  request.on("error", () => process.exit(0));
+  request.end("{}");
+} else {
+  process.stdout.write(JSON.stringify({
+    home: process.env.HOME,
+    userProfile: process.env.USERPROFILE,
+    userData: process.env.CLAWD_TEST_USER_DATA,
+    appData: process.env.APPDATA,
+    codexHome: process.env.CODEX_HOME || null,
+    nodeOptions: process.env.NODE_OPTIONS || null,
+  }));
+}

--- a/test/gemini-hook.test.js
+++ b/test/gemini-hook.test.js
@@ -1,17 +1,17 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const path = require("path");
-const { spawnSync } = require("child_process");
+const { runSpawnedHook } = require("./helpers/spawned-hook");
 const { __test } = require("../hooks/gemini-hook");
 
 function runGeminiHook(argvEvent, payload = {}) {
   const scriptPath = path.resolve(__dirname, "..", "hooks", "gemini-hook.js");
-  const httpBlockerPath = path.resolve(__dirname, "hook-http-blocker.js");
-  return spawnSync(process.execPath, ["--require", httpBlockerPath, scriptPath, argvEvent], {
-    env: { ...process.env, CLAWD_REMOTE: "1" },
-    input: JSON.stringify(payload),
-    encoding: "utf8",
-    windowsHide: true,
+  return runSpawnedHook({
+    script: scriptPath,
+    args: [argvEvent],
+    payload,
+    httpContract: "block",
+    env: { CLAWD_REMOTE: "1" },
   });
 }
 

--- a/test/helpers/spawned-hook.js
+++ b/test/helpers/spawned-hook.js
@@ -1,0 +1,178 @@
+"use strict";
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const HTTP_BLOCKER = path.resolve(__dirname, "..", "hook-http-blocker.js");
+const HTTP_RECORDER = path.resolve(__dirname, "hook-post-recorder.js");
+const OFFLINE_PROBE = path.resolve(__dirname, "hook-offline-probe.js");
+const HTTP_CONTRACTS = new Set(["block", "expect-attempt", "expect-none"]);
+
+function readJsonIfPresent(filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function createSpawnedHookHarness(options = {}) {
+  const ownsHome = !options.home;
+  const home = options.home || fs.mkdtempSync(path.join(os.tmpdir(), options.prefix || "clawd-hook-test-"));
+  const userData = path.join(home, "user-data");
+  const appData = path.join(home, "app-data");
+  const localAppData = path.join(home, "local-app-data");
+  const xdgConfigHome = path.join(home, "xdg-config");
+  const clawdDir = path.join(home, ".clawd");
+  let sequence = 0;
+
+  for (const directory of [home, userData, appData, localAppData, xdgConfigHome, clawdDir]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+
+  function run(runOptions = {}) {
+    const script = path.resolve(runOptions.script || "");
+    if (!runOptions.script || !fs.existsSync(script)) {
+      throw new Error(`spawned hook script does not exist: ${runOptions.script || "(missing)"}`);
+    }
+
+    const httpContract = runOptions.httpContract || "block";
+    if (!HTTP_CONTRACTS.has(httpContract)) {
+      throw new Error(`unknown spawned-hook HTTP contract: ${httpContract}`);
+    }
+
+    sequence += 1;
+    const attemptsPath = path.join(home, `http-attempts-${sequence}.json`);
+    const spawnsPath = path.join(home, `process-spawns-${sequence}.json`);
+    const runtimePath = path.join(clawdDir, "runtime.json");
+    for (const outputPath of [attemptsPath, spawnsPath]) {
+      try { fs.unlinkSync(outputPath); } catch { /* first run */ }
+    }
+
+    if (runOptions.runtimeJson === undefined) {
+      try { fs.unlinkSync(runtimePath); } catch { /* already absent */ }
+    } else {
+      fs.writeFileSync(runtimePath, JSON.stringify(runOptions.runtimeJson), "utf8");
+    }
+
+    const env = { ...process.env };
+    for (const key of Object.keys(env)) {
+      if (key.startsWith("CLAWD_")) delete env[key];
+    }
+    for (const key of [
+      "CODEX_HOME",
+      "COPILOT_HOME",
+      "HERMES_HOME",
+      "KIMI_CODE_HOME",
+      "NODE_OPTIONS",
+      "REASONIX_HOME",
+      "TMUX",
+      "TMUX_PANE",
+    ]) {
+      delete env[key];
+    }
+    Object.assign(env, runOptions.env || {});
+    Object.assign(env, {
+      HOME: home,
+      USERPROFILE: home,
+      APPDATA: appData,
+      LOCALAPPDATA: localAppData,
+      XDG_CONFIG_HOME: xdgConfigHome,
+      CLAWD_TEST_USER_DATA: userData,
+    });
+
+    const preloads = [];
+    if (runOptions.probeProcessSpawns) {
+      preloads.push(OFFLINE_PROBE);
+      env.CLAWD_PROBE_OUT = spawnsPath;
+    } else if (httpContract === "block") {
+      preloads.push(HTTP_BLOCKER);
+    } else {
+      preloads.push(HTTP_RECORDER);
+      env.CLAWD_POST_OUT = attemptsPath;
+    }
+    preloads.push(...(runOptions.preloads || []).map((preload) => path.resolve(preload)));
+
+    const argv = [];
+    for (const preload of preloads) argv.push("--require", preload);
+    argv.push(script, ...(runOptions.args || []).map(String));
+
+    const input = runOptions.input !== undefined
+      ? String(runOptions.input)
+      : `${JSON.stringify(runOptions.payload === undefined ? {} : runOptions.payload)}\n`;
+    const result = spawnSync(process.execPath, argv, {
+      input,
+      encoding: "utf8",
+      windowsHide: true,
+      timeout: runOptions.timeout || 20000,
+      env,
+      cwd: runOptions.cwd,
+    });
+
+    const attempts = httpContract === "block" || runOptions.probeProcessSpawns
+      ? null
+      : readJsonIfPresent(attemptsPath);
+    const spawns = runOptions.probeProcessSpawns ? readJsonIfPresent(spawnsPath) : null;
+
+    if (httpContract === "expect-none") {
+      assert.ok(
+        Array.isArray(attempts),
+        `spawned hook did not report HTTP attempts; status=${result.status}, stderr=${result.stderr}`,
+      );
+      assert.deepStrictEqual(
+        attempts,
+        [],
+        `business logic must not attempt HTTP; got ${JSON.stringify(attempts)}`,
+      );
+    } else if (httpContract === "expect-attempt") {
+      assert.ok(
+        Array.isArray(attempts),
+        `spawned hook did not report blocked HTTP attempts; status=${result.status}, stderr=${result.stderr}`,
+      );
+      assert.ok(
+        attempts.length > 0,
+        "business logic should attempt HTTP, but the preload recorder observed none",
+      );
+    }
+
+    return Object.assign(result, {
+      attempts,
+      spawns,
+      testHome: home,
+      testUserData: userData,
+      preloads,
+    });
+  }
+
+  function cleanup() {
+    if (!ownsHome) return;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+
+  return {
+    home,
+    userData,
+    run,
+    cleanup,
+  };
+}
+
+function runSpawnedHook(options) {
+  const harness = createSpawnedHookHarness(options && options.harness);
+  try {
+    return harness.run(options);
+  } finally {
+    harness.cleanup();
+  }
+}
+
+module.exports = {
+  HTTP_BLOCKER,
+  HTTP_RECORDER,
+  OFFLINE_PROBE,
+  createSpawnedHookHarness,
+  runSpawnedHook,
+};

--- a/test/helpers/spawned-hook.js
+++ b/test/helpers/spawned-hook.js
@@ -43,6 +43,11 @@ function createSpawnedHookHarness(options = {}) {
     if (!HTTP_CONTRACTS.has(httpContract)) {
       throw new Error(`unknown spawned-hook HTTP contract: ${httpContract}`);
     }
+    if (runOptions.probeProcessSpawns && httpContract !== "block") {
+      throw new Error(
+        `probeProcessSpawns cannot be combined with spawned-hook HTTP contract ${httpContract}`,
+      );
+    }
 
     sequence += 1;
     const attemptsPath = path.join(home, `http-attempts-${sequence}.json`);

--- a/test/hook-adapter-offline-contract.test.js
+++ b/test/hook-adapter-offline-contract.test.js
@@ -26,13 +26,11 @@
 
 const { describe, it, before, after } = require("node:test");
 const assert = require("node:assert");
-const { spawnSync } = require("node:child_process");
 const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
+const { createSpawnedHookHarness } = require("./helpers/spawned-hook");
 
 const HOOKS_DIR = path.resolve(__dirname, "..", "hooks");
-const PROBE = path.resolve(__dirname, "helpers", "hook-offline-probe.js");
 
 // Every createPidResolver consumer. Cross-checked against
 // `grep -l createPidResolver hooks/*.js` — if a 15th adapter appears without a
@@ -72,49 +70,31 @@ const ADAPTERS = [
   { name: "workbuddy-hook.js", payload: { hook_event_name: "PreToolUse", session_id: "s-681", cwd: "D:/repo" }, stdout: "{}\n" },
 ];
 
-let fakeHome;
-let probeOut;
+let hookHarness;
 
 before(() => {
   // An empty home: server-config's RUNTIME_CONFIG_PATH resolves under it, finds
   // nothing, and the resolver gate reads "Clawd is offline". Verified upfront
   // that Node's os.homedir() honors USERPROFILE on Windows.
-  fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-681-offline-home-"));
-  probeOut = path.join(fakeHome, "spawns.json");
+  hookHarness = createSpawnedHookHarness({ prefix: "clawd-681-offline-home-" });
 });
 
-after(() => {
-  try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* best effort */ }
-});
+after(() => hookHarness.cleanup());
 
 // A live runtime naming THIS process, which is trivially alive. Used only by the
 // vacuity guard below — every other case here wants Clawd to look gone.
 const LIVE_RUNTIME = () => ({ app: "clawd-on-desk", port: 23333, ownerPid: process.pid });
 
-function runHookOffline(adapter, { runtimeJson } = {}) {
-  const clawdDir = path.join(fakeHome, ".clawd");
-  fs.rmSync(clawdDir, { recursive: true, force: true });
-  if (runtimeJson !== undefined) {
-    fs.mkdirSync(clawdDir, { recursive: true });
-    fs.writeFileSync(path.join(clawdDir, "runtime.json"), JSON.stringify(runtimeJson), "utf8");
-  }
-  try { fs.unlinkSync(probeOut); } catch { /* first run */ }
-
-  const env = { ...process.env, USERPROFILE: fakeHome, HOME: fakeHome, CLAWD_PROBE_OUT: probeOut };
-  delete env.CLAWD_REMOTE;
-
-  const argv = ["--require", PROBE, path.join(HOOKS_DIR, adapter.name), ...(adapter.argv || [])];
-  const result = spawnSync(process.execPath, argv, {
-    input: `${JSON.stringify(adapter.payload)}\n`,
-    encoding: "utf8",
-    windowsHide: true,
-    timeout: 20000,
+function runHookOffline(adapter, { runtimeJson, env } = {}) {
+  return hookHarness.run({
+    script: path.join(HOOKS_DIR, adapter.name),
+    args: adapter.argv || [],
+    payload: adapter.payload,
+    runtimeJson,
     env,
+    httpContract: "block",
+    probeProcessSpawns: true,
   });
-
-  let spawns = null;
-  try { spawns = JSON.parse(fs.readFileSync(probeOut, "utf8")); } catch { /* hook never exited cleanly */ }
-  return { ...result, spawns };
 }
 
 describe("#681 — every adapter survives a clean offline with zero spawn", { skip: process.platform !== "win32" }, () => {
@@ -198,27 +178,13 @@ describe("#681 — a stale runtime.json is not a live Clawd", { skip: process.pl
   }
 
   it("CLAWD_REMOTE suppresses the local walk even with a perfectly live runtime.json", () => {
-    const clawdDir = path.join(fakeHome, ".clawd");
-    fs.mkdirSync(clawdDir, { recursive: true });
-    fs.writeFileSync(
-      path.join(clawdDir, "runtime.json"),
-      JSON.stringify({ app: "clawd-on-desk", port: 23333, ownerPid: process.pid }),
-      "utf8"
-    );
-    try { fs.unlinkSync(probeOut); } catch { /* first run */ }
-
     const adapter = ADAPTERS.find((a) => a.name === "kiro-hook.js");
-    const r = spawnSync(process.execPath, ["--require", PROBE, path.join(HOOKS_DIR, adapter.name)], {
-      input: `${JSON.stringify(adapter.payload)}\n`,
-      encoding: "utf8",
-      windowsHide: true,
-      timeout: 20000,
-      env: { ...process.env, USERPROFILE: fakeHome, HOME: fakeHome, CLAWD_PROBE_OUT: probeOut, CLAWD_REMOTE: "1" },
+    const r = runHookOffline(adapter, {
+      runtimeJson: { app: "clawd-on-desk", port: 23333, ownerPid: process.pid },
+      env: { CLAWD_REMOTE: "1" },
     });
 
-    let spawns = null;
-    try { spawns = JSON.parse(fs.readFileSync(probeOut, "utf8")); } catch { /* ignore */ }
-    assert.deepStrictEqual(spawns, [], "a remote hook must never walk THIS machine's process tree");
+    assert.deepStrictEqual(r.spawns, [], "a remote hook must never walk THIS machine's process tree");
     assert.strictEqual(r.status, 0);
   });
 });

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -35,6 +35,11 @@ describe("package build config", () => {
       assert.match(workflow, /pull_request:/);
       assert.match(workflow, /npm run audit:assets/);
       assert.match(workflow, /dist\/repository-asset-audit\/\*\.json/);
+      assert.match(
+        workflow,
+        /^permissions:\r?\n\s+contents: read$/m,
+        "repository asset audit should use a read-only GitHub token",
+      );
     });
   });
 

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -12,6 +12,32 @@ function matchedByAnyGlob(globs, target) {
 }
 
 describe("package build config", () => {
+  describe("repository asset audit", () => {
+    it("exposes a Windows-compatible npm audit command", () => {
+      assert.strictEqual(
+        pkg.scripts["audit:assets"],
+        "node scripts/audit-repository-assets.js"
+      );
+    });
+
+    it("does not match retained source artwork with package globs", () => {
+      assert.strictEqual(
+        matchedByAnyGlob(pkg.build.files, "assets/source/dock-icon-fullbleed.png"),
+        false,
+        "assets/source/** must stay outside build.files"
+      );
+    });
+
+    it("runs in pull-request CI and uploads stable JSON manifests", () => {
+      const workflowPath = path.join(ROOT, ".github", "workflows", "repository-asset-audit.yml");
+      assert.ok(fs.existsSync(workflowPath), "repository asset audit workflow should exist");
+      const workflow = fs.readFileSync(workflowPath, "utf8");
+      assert.match(workflow, /pull_request:/);
+      assert.match(workflow, /npm run audit:assets/);
+      assert.match(workflow, /dist\/repository-asset-audit\/\*\.json/);
+    });
+  });
+
   it("ships project window icons in packaged builds", () => {
     assert.ok(
       pkg.build.files.includes("assets/icons/**/*"),

--- a/test/qwen-code-hook.test.js
+++ b/test/qwen-code-hook.test.js
@@ -1,7 +1,7 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
-const { spawnSync } = require("node:child_process");
 const path = require("path");
+const { runSpawnedHook } = require("./helpers/spawned-hook");
 const {
   buildPermissionBody,
   buildQwenNoDecisionOutput,
@@ -183,13 +183,13 @@ describe("Qwen Code hook", () => {
 
   it("prints exact no-decision stdout and empty stderr for unknown events", () => {
     const scriptPath = path.resolve(__dirname, "..", "hooks", "qwen-code-hook.js");
-    const result = spawnSync(process.execPath, [scriptPath], {
-      input: JSON.stringify({
+    const result = runSpawnedHook({
+      script: scriptPath,
+      payload: {
         hook_event_name: "UnknownEvent",
         session_id: "s1",
-      }),
-      encoding: "utf8",
-      windowsHide: true,
+      },
+      httpContract: "expect-none",
     });
 
     assert.strictEqual(result.status, 0);

--- a/test/reasonix-hook.test.js
+++ b/test/reasonix-hook.test.js
@@ -1,15 +1,14 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
-const { spawnSync } = require("node:child_process");
 const path = require("node:path");
+const { runSpawnedHook } = require("./helpers/spawned-hook");
 
 function runReasonixHook(payload) {
   const scriptPath = path.resolve(__dirname, "..", "hooks", "reasonix-hook.js");
-  const blockerPath = path.resolve(__dirname, "hook-http-blocker.js");
-  return spawnSync(process.execPath, ["--require", blockerPath, scriptPath], {
-    input: `${JSON.stringify(payload)}\n`,
-    encoding: "utf8",
-    windowsHide: true,
+  return runSpawnedHook({
+    script: scriptPath,
+    payload,
+    httpContract: "block",
   });
 }
 

--- a/test/repository-asset-audit.test.js
+++ b/test/repository-asset-audit.test.js
@@ -1,0 +1,301 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const {
+  analyzeAudit,
+  buildExtractedPackageManifest,
+  buildSourcePackageManifest,
+  inspectNativeBuffer,
+  matchesGlob,
+  runAudit,
+  stableJson,
+  validatePolicy,
+} = require("../scripts/audit-repository-assets");
+
+function basePolicy() {
+  return {
+    schemaVersion: 1,
+    owners: {
+      build: "build",
+      design: "design",
+      docs: "docs",
+      legal: "legal",
+      tests: "tests",
+      themes: "themes",
+    },
+    classes: {
+      "runtime-required": "runtime",
+      "source-of-truth": "source",
+      "docs-marketing": "docs",
+      "tests-fixtures": "tests",
+      "legal": "legal",
+    },
+    thresholds: {
+      trackedTreeWarningBytes: 100,
+      trackedTreeHardBytes: 200,
+      largeTrackedBinaryMediaBytes: 10,
+      duplicatePackagedPayloadWarningBytes: 4,
+    },
+    pathRules: [
+      { pattern: "themes/**", class: "runtime-required", owner: "themes", packaged: true },
+      { pattern: "assets/gif/**", class: "docs-marketing", owner: "docs", packaged: false },
+      { pattern: "assets/videos/**", class: "docs-marketing", owner: "docs", packaged: false },
+      { pattern: "assets/source/**", class: "source-of-truth", owner: "design", packaged: false },
+      { pattern: "test/fixtures/**", class: "tests-fixtures", owner: "tests", packaged: false },
+    ],
+    entries: [
+      {
+        path: "assets/LICENSE",
+        class: "legal",
+        owner: "legal",
+        packaged: false,
+        retention: "permanent",
+      },
+    ],
+    duplicatePayloadExemptions: [],
+  };
+}
+
+function tracked(filePath, bytes, gitBlob = filePath) {
+  return {
+    path: filePath,
+    bytes,
+    gitBlob,
+    extension: path.posix.extname(filePath) || "(none)",
+    topLevel: filePath.split("/")[0],
+  };
+}
+
+function manifest(files, target = null) {
+  return {
+    schemaVersion: 1,
+    revision: "deadbeef",
+    scope: "repository-owned-package-inputs",
+    target,
+    buildFiles: [],
+    asarUnpack: [],
+    extraResources: [],
+    files,
+  };
+}
+
+describe("repository asset audit", () => {
+  it("matches recursive package and policy globs consistently", () => {
+    assert.strictEqual(matchesGlob("themes/calico/theme.json", "themes/**"), true);
+    assert.strictEqual(matchesGlob("assets/icons/a.png", "assets/icons/**/*"), true);
+    assert.strictEqual(matchesGlob("assets/source/a.png", "assets/icons/**/*"), false);
+  });
+
+  it("requires all policy categories and permanent assets/LICENSE retention", () => {
+    assert.deepStrictEqual(validatePolicy(basePolicy()), []);
+    const broken = basePolicy();
+    broken.entries = [];
+    assert.ok(validatePolicy(broken).some((message) => message.includes("assets/LICENSE")));
+  });
+
+  it("hard-fails assets/source package matches and ownerless large media", () => {
+    const policy = basePolicy();
+    const trackedFiles = [
+      tracked("assets/LICENSE", 5),
+      tracked("assets/unowned.mp4", 20),
+      tracked("assets/source/raw.png", 20),
+    ];
+    const report = analyzeAudit({
+      trackedFiles,
+      manifest: manifest([{
+        sourcePath: "assets/source/raw.png",
+        packagePath: "app/assets/source/raw.png",
+        origin: "build.files",
+        asarUnpack: false,
+        bytes: 20,
+        sha256: "one",
+      }]),
+      policy,
+    });
+    const rules = report.findings.filter((finding) => finding.level === "error").map((finding) => finding.rule);
+    assert.ok(rules.includes("source-assets-not-packaged"));
+    assert.ok(rules.includes("policy-excluded-file-not-packaged"));
+    assert.ok(rules.includes("large-tracked-file-owned"));
+  });
+
+  it("hard-fails when a packaged=true policy category is missing from source inputs", () => {
+    const report = analyzeAudit({
+      trackedFiles: [
+        tracked("assets/LICENSE", 5),
+        tracked("themes/clawd/theme.json", 5),
+      ],
+      manifest: manifest([]),
+      policy: basePolicy(),
+    });
+    const missing = report.findings.find((finding) => finding.rule === "policy-required-file-packaged");
+    assert.strictEqual(missing.level, "error");
+    assert.strictEqual(missing.path, "themes/clawd/theme.json");
+  });
+
+  it("hard-fails a tracked cc-connect-clawd executable", () => {
+    const report = analyzeAudit({
+      trackedFiles: [
+        tracked("assets/LICENSE", 5),
+        tracked("bin/cc-connect-clawd/windows-x64/cc-connect-clawd.exe", 5),
+      ],
+      manifest: manifest([]),
+      policy: basePolicy(),
+    });
+    const executable = report.findings.find((finding) => finding.rule === "sidecar-executable-untracked");
+    assert.strictEqual(executable.level, "error");
+  });
+
+  it("reports duplicate packaged payloads as warnings and budgets independently", () => {
+    const policy = basePolicy();
+    const report = analyzeAudit({
+      trackedFiles: [tracked("assets/LICENSE", 5)],
+      manifest: manifest([
+        { sourcePath: "a.bin", packagePath: "app/a.bin", bytes: 8, sha256: "same" },
+        { sourcePath: "b.bin", packagePath: "resources/b.bin", bytes: 8, sha256: "same" },
+      ]),
+      policy,
+    });
+    assert.ok(report.findings.some((finding) => (
+      finding.level === "warning" && finding.rule === "duplicate-packaged-payload"
+    )));
+  });
+
+  it("warns on package growth without turning the initial budget into a hard failure", () => {
+    const policy = basePolicy();
+    policy.thresholds.artifactGrowthWarningBytes = 5;
+    policy.thresholds.artifactGrowthWarningRatio = 0.05;
+    const report = analyzeAudit({
+      trackedFiles: [tracked("assets/LICENSE", 5)],
+      manifest: manifest([
+        { sourcePath: "a.bin", packagePath: "app/a.bin", bytes: 20, sha256: "one" },
+      ]),
+      policy,
+      baselinePackageBytes: 10,
+    });
+    const growth = report.findings.find((finding) => finding.rule === "package-growth-budget");
+    assert.strictEqual(growth.level, "warning");
+    assert.deepStrictEqual(report.package.growth, {
+      baselineBytes: 10,
+      currentBytes: 20,
+      addedBytes: 10,
+      addedRatio: 1,
+    });
+  });
+
+  it("parses PE, ELF, and Mach-O architecture headers", () => {
+    const pe = Buffer.alloc(128);
+    pe.write("MZ", 0, "ascii");
+    pe.writeUInt32LE(64, 0x3c);
+    pe.write("PE\0\0", 64, "ascii");
+    pe.writeUInt16LE(0xaa64, 68);
+    assert.deepStrictEqual(inspectNativeBuffer(pe), { os: "windows", arch: "arm64", format: "pe" });
+
+    const elf = Buffer.alloc(64);
+    elf.set([0x7f, 0x45, 0x4c, 0x46, 2, 1], 0);
+    elf.writeUInt16LE(62, 18);
+    assert.deepStrictEqual(inspectNativeBuffer(elf), { os: "linux", arch: "x64", format: "elf" });
+
+    const macho = Buffer.alloc(32);
+    macho.writeUInt32BE(0xfeedfacf, 0);
+    macho.writeUInt32BE(0x0100000c, 4);
+    assert.deepStrictEqual(inspectNativeBuffer(macho), { os: "darwin", arch: "arm64", format: "mach-o" });
+  });
+
+  it("hard-fails a foreign-target native binary in an extracted package", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-foreign-"));
+    try {
+      const relative = path.join(
+        "resources",
+        "sidecars",
+        "cc-connect-clawd",
+        "windows-arm64",
+        "cc-connect-clawd.exe",
+      );
+      const executable = path.join(root, relative);
+      fs.mkdirSync(path.dirname(executable), { recursive: true });
+      const pe = Buffer.alloc(128);
+      pe.write("MZ", 0, "ascii");
+      pe.writeUInt32LE(64, 0x3c);
+      pe.write("PE\0\0", 64, "ascii");
+      pe.writeUInt16LE(0xaa64, 68);
+      fs.writeFileSync(executable, pe);
+
+      const extracted = buildExtractedPackageManifest(root, "windows-x64", "abc");
+      const report = analyzeAudit({
+        trackedFiles: [tracked("assets/LICENSE", 5)],
+        manifest: extracted,
+        policy: basePolicy(),
+        packageRoot: root,
+      });
+      const foreign = report.findings.find((finding) => finding.rule === "foreign-target-native");
+      assert.strictEqual(foreign.level, "error");
+      assert.match(foreign.path, /windows-arm64/);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("builds a deterministic source package manifest including extraResources", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-manifest-"));
+    try {
+      fs.mkdirSync(path.join(root, "assets", "source"), { recursive: true });
+      fs.mkdirSync(path.join(root, "runtime"), { recursive: true });
+      fs.writeFileSync(path.join(root, "package.json"), "{}");
+      fs.writeFileSync(path.join(root, "runtime", "a.txt"), "same");
+      fs.writeFileSync(path.join(root, "assets", "source", "raw.txt"), "raw");
+      const build = {
+        files: ["runtime/**/*"],
+        asarUnpack: ["runtime/**/*"],
+        extraResources: [{ from: "runtime", to: "runtime-copy" }],
+      };
+      const first = buildSourcePackageManifest(root, build, "abc");
+      const second = buildSourcePackageManifest(root, build, "abc");
+      assert.strictEqual(stableJson(first), stableJson(second));
+      assert.deepStrictEqual(
+        first.files.map((file) => file.packagePath),
+        ["app/package.json", "app/runtime/a.txt", "resources/runtime-copy/a.txt"],
+      );
+      assert.strictEqual(first.files[1].asarUnpack, true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps serialized audit output byte-for-byte stable", () => {
+    const value = { revision: "abc", files: [{ path: "a", bytes: 1 }] };
+    assert.strictEqual(stableJson(value), stableJson(value));
+    assert.ok(stableJson(value).endsWith("\n"));
+  });
+
+  it("audits the repository twice with byte-identical manifests and reports", () => {
+    const root = path.resolve(__dirname, "..");
+    const firstOutput = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-first-"));
+    const secondOutput = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-second-"));
+    try {
+      const first = runAudit({ repoRoot: root, output: firstOutput });
+      const second = runAudit({ repoRoot: root, output: secondOutput });
+      assert.deepStrictEqual(
+        first.report.findings.filter((finding) => finding.level === "error"),
+        [],
+      );
+      for (const fileName of [
+        "audit-report.json",
+        "package-manifest.json",
+        "tracked-large-files.json",
+      ]) {
+        assert.strictEqual(
+          fs.readFileSync(path.join(firstOutput, fileName), "utf8"),
+          fs.readFileSync(path.join(secondOutput, fileName), "utf8"),
+          `${fileName} changed between identical audit runs`,
+        );
+      }
+    } finally {
+      fs.rmSync(firstOutput, { recursive: true, force: true });
+      fs.rmSync(secondOutput, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/repository-asset-audit.test.js
+++ b/test/repository-asset-audit.test.js
@@ -11,6 +11,8 @@ const {
   buildSourcePackageManifest,
   inspectNativeBuffer,
   matchesGlob,
+  parseArgs,
+  resolvePolicy,
   runAudit,
   stableJson,
   validatePolicy,
@@ -90,11 +92,70 @@ describe("repository asset audit", () => {
     assert.strictEqual(matchesGlob("assets/source/a.png", "assets/icons/**/*"), false);
   });
 
+  it("fails closed on glob syntax the audit engine does not implement", () => {
+    assert.throws(
+      () => matchesGlob("src/x.map", "!**/*.map"),
+      /unsupported glob negation/,
+    );
+    assert.throws(
+      () => matchesGlob("a.png", "*.{png,gif}"),
+      /unsupported glob brace/,
+    );
+    assert.throws(
+      () => matchesGlob("a.png", "*.[pj]ng"),
+      /unsupported glob brace or character-class/,
+    );
+  });
+
   it("requires all policy categories and permanent assets/LICENSE retention", () => {
     assert.deepStrictEqual(validatePolicy(basePolicy()), []);
     const broken = basePolicy();
     broken.entries = [];
     assert.ok(validatePolicy(broken).some((message) => message.includes("assets/LICENSE")));
+
+    const unsupportedGlob = basePolicy();
+    unsupportedGlob.pathRules.push({
+      pattern: "assets/{raw,source}/**",
+      class: "source-of-truth",
+      owner: "design",
+      packaged: false,
+    });
+    assert.ok(validatePolicy(unsupportedGlob).some((message) => (
+      message.includes("unsupported glob brace")
+    )));
+  });
+
+  it("resolves the most specific policy rule regardless of declaration order", () => {
+    const policy = basePolicy();
+    policy.pathRules.unshift({
+      pattern: "assets/**",
+      class: "docs-marketing",
+      owner: "docs",
+      packaged: false,
+    });
+    assert.strictEqual(resolvePolicy(policy, "assets/source/raw.png").owner, "design");
+  });
+
+  it("hard-fails when assets/LICENSE is absent from the tracked tree", () => {
+    const report = analyzeAudit({
+      trackedFiles: [],
+      manifest: manifest([]),
+      policy: basePolicy(),
+    });
+    const finding = report.findings.find((item) => item.rule === "assets-license-retained");
+    assert.strictEqual(finding.level, "error");
+  });
+
+  it("hard-fails the tracked-tree hard budget instead of emitting only a warning", () => {
+    const report = analyzeAudit({
+      trackedFiles: [tracked("assets/LICENSE", 201)],
+      manifest: manifest([]),
+      policy: basePolicy(),
+    });
+    assert.ok(report.findings.some((finding) => (
+      finding.level === "error" && finding.rule === "tracked-tree-hard-budget"
+    )));
+    assert.ok(!report.findings.some((finding) => finding.rule === "tracked-tree-warning-budget"));
   });
 
   it("hard-fails assets/source package matches and ownerless large media", () => {
@@ -186,7 +247,7 @@ describe("repository asset audit", () => {
     });
   });
 
-  it("parses PE, ELF, and Mach-O architecture headers", () => {
+  it("parses PE, ELF, thin Mach-O, and fat Mach-O architecture headers", () => {
     const pe = Buffer.alloc(128);
     pe.write("MZ", 0, "ascii");
     pe.writeUInt32LE(64, 0x3c);
@@ -203,6 +264,18 @@ describe("repository asset audit", () => {
     macho.writeUInt32BE(0xfeedfacf, 0);
     macho.writeUInt32BE(0x0100000c, 4);
     assert.deepStrictEqual(inspectNativeBuffer(macho), { os: "darwin", arch: "arm64", format: "mach-o" });
+
+    const fatMacho = Buffer.alloc(48);
+    fatMacho.writeUInt32BE(0xcafebabe, 0);
+    fatMacho.writeUInt32BE(2, 4);
+    fatMacho.writeUInt32BE(0x01000007, 8);
+    fatMacho.writeUInt32BE(0x0100000c, 28);
+    assert.deepStrictEqual(inspectNativeBuffer(fatMacho), {
+      os: "darwin",
+      arch: "universal",
+      architectures: ["arm64", "x64"],
+      format: "mach-o-fat",
+    });
   });
 
   it("hard-fails a foreign-target native binary in an extracted package", () => {
@@ -239,6 +312,65 @@ describe("repository asset audit", () => {
     }
   });
 
+  it("sniffs extensionless native binaries in extracted packages", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-extensionless-"));
+    try {
+      const executable = path.join(root, "Electron Framework");
+      const macho = Buffer.alloc(32);
+      macho.writeUInt32BE(0xfeedfacf, 0);
+      macho.writeUInt32BE(0x0100000c, 4);
+      fs.writeFileSync(executable, macho);
+
+      const extracted = buildExtractedPackageManifest(root, "windows-x64", "abc");
+      const report = analyzeAudit({
+        trackedFiles: [tracked("assets/LICENSE", 5)],
+        manifest: extracted,
+        policy: basePolicy(),
+        packageRoot: root,
+      });
+      const foreign = report.findings.find((finding) => finding.rule === "foreign-target-native");
+      assert.strictEqual(foreign.level, "error");
+      assert.deepStrictEqual(report.package.foreignNativeFiles, [{
+        packagePath: "Electron Framework",
+        detectedTargets: ["darwin-arm64"],
+        expectedTarget: "windows-x64",
+      }]);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("hard-fails a foreign architecture inside an extensionless fat Mach-O", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-fat-macho-"));
+    try {
+      const executable = path.join(root, "Clawd");
+      const fatMacho = Buffer.alloc(48);
+      fatMacho.writeUInt32BE(0xcafebabe, 0);
+      fatMacho.writeUInt32BE(2, 4);
+      fatMacho.writeUInt32BE(0x01000007, 8);
+      fatMacho.writeUInt32BE(0x0100000c, 28);
+      fs.writeFileSync(executable, fatMacho);
+
+      const extracted = buildExtractedPackageManifest(root, "darwin-x64", "abc");
+      const report = analyzeAudit({
+        trackedFiles: [tracked("assets/LICENSE", 5)],
+        manifest: extracted,
+        policy: basePolicy(),
+        packageRoot: root,
+      });
+      assert.deepStrictEqual(report.package.foreignNativeFiles, [{
+        packagePath: "Clawd",
+        detectedTargets: ["darwin-arm64", "darwin-x64"],
+        expectedTarget: "darwin-x64",
+      }]);
+      assert.ok(report.findings.some((finding) => (
+        finding.level === "error" && finding.rule === "foreign-target-native"
+      )));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("builds a deterministic source package manifest including extraResources", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-manifest-"));
     try {
@@ -260,6 +392,47 @@ describe("repository asset audit", () => {
         ["app/package.json", "app/runtime/a.txt", "resources/runtime-copy/a.txt"],
       );
       assert.strictEqual(first.files[1].asarUnpack, true);
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("validates build globs eagerly even when the repository has no files", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-glob-"));
+    try {
+      assert.throws(
+        () => buildSourcePackageManifest(root, { files: ["!**/*.map"] }, "abc"),
+        /unsupported glob negation/,
+      );
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("requires an explicit target when auditing an extracted package", () => {
+    assert.throws(
+      () => parseArgs(["--package-root", "dist/unpacked"]),
+      /--package-root requires --target/,
+    );
+  });
+
+  it("fails closed when the policy file is malformed JSON", () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-policy-"));
+    try {
+      const policyPath = path.join(root, "policy.json");
+      fs.writeFileSync(policyPath, "{ invalid", "utf8");
+      assert.throws(
+        () => runAudit({
+          repoRoot: root,
+          output: path.join(root, "output"),
+          policyPath,
+          revision: "abc",
+          trackedFiles: [],
+          build: {},
+          manifest: manifest([]),
+        }),
+        /JSON/,
+      );
     } finally {
       fs.rmSync(root, { recursive: true, force: true });
     }

--- a/test/spawned-hook-helper.test.js
+++ b/test/spawned-hook-helper.test.js
@@ -54,4 +54,16 @@ describe("spawned-hook test harness", () => {
       harness.cleanup();
     }
   });
+
+  it("rejects process-spawn probing combined with an HTTP assertion contract", () => {
+    assert.throws(
+      () => runSpawnedHook({
+        script: FIXTURE,
+        args: ["none"],
+        httpContract: "expect-none",
+        probeProcessSpawns: true,
+      }),
+      /probeProcessSpawns cannot be combined/,
+    );
+  });
 });

--- a/test/spawned-hook-helper.test.js
+++ b/test/spawned-hook-helper.test.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert");
+const path = require("node:path");
+const {
+  createSpawnedHookHarness,
+  runSpawnedHook,
+} = require("./helpers/spawned-hook");
+
+const FIXTURE = path.join(__dirname, "fixtures", "spawned-hook", "http-contract.js");
+
+describe("spawned-hook test harness", () => {
+  it("preloads the recorder and permits an expected blocked HTTP attempt", () => {
+    const result = runSpawnedHook({
+      script: FIXTURE,
+      args: ["attempt"],
+      httpContract: "expect-attempt",
+    });
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.ok(result.preloads.some((preload) => preload.endsWith("hook-post-recorder.js")));
+    assert.strictEqual(result.attempts[0].port, 23333);
+    assert.strictEqual(result.attempts[0].path, "/state");
+  });
+
+  it("distinguishes business logic that must make no HTTP attempt", () => {
+    const result = runSpawnedHook({
+      script: FIXTURE,
+      args: ["none"],
+      httpContract: "expect-none",
+    });
+
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.deepStrictEqual(result.attempts, []);
+  });
+
+  it("isolates HOME, USERPROFILE, and userData for every child", () => {
+    const harness = createSpawnedHookHarness({ prefix: "spawned-hook-env-" });
+    try {
+      const result = harness.run({
+        script: FIXTURE,
+        args: ["none"],
+        httpContract: "expect-none",
+      });
+      const env = JSON.parse(result.stdout);
+      assert.strictEqual(env.home, harness.home);
+      assert.strictEqual(env.userProfile, harness.home);
+      assert.strictEqual(env.userData, harness.userData);
+      assert.ok(env.appData.startsWith(harness.home));
+      assert.strictEqual(env.codexHome, null);
+      assert.strictEqual(env.nodeOptions, null);
+    } finally {
+      harness.cleanup();
+    }
+  });
+});

--- a/test/workbuddy-hook.test.js
+++ b/test/workbuddy-hook.test.js
@@ -1,9 +1,7 @@
 const { describe, it, before, after } = require("node:test");
 const assert = require("node:assert");
-const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
-const { spawnSync } = require("node:child_process");
+const { createSpawnedHookHarness } = require("./helpers/spawned-hook");
 const {
   HOOK_MAP,
   stdoutForEvent,
@@ -151,40 +149,27 @@ describe("WorkBuddy hook session title (#648)", () => {
 // stdout bytes, and the number of outbound HTTP attempts.
 describe("WorkBuddy hook session_id filter (#618 / #648) — real subprocess", () => {
   const HOOK = path.resolve(__dirname, "..", "hooks", "workbuddy-hook.js");
-  const RECORDER = path.resolve(__dirname, "helpers", "hook-post-recorder.js");
-  let fakeHome;
-  let postOut;
+  let hookHarness;
 
   before(() => {
-    // Empty home ⇒ no ~/.clawd/runtime.json ⇒ every port looks offline. This is
-    // what makes "zero HTTP attempts" mean "the hook chose not to forward",
-    // not "the hook tried but the socket was refused".
-    fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), "wb-sessfilter-"));
-    postOut = path.join(fakeHome, "attempts.json");
+    hookHarness = createSpawnedHookHarness({ prefix: "wb-sessfilter-" });
   });
 
-  after(() => {
-    try { fs.rmSync(fakeHome, { recursive: true, force: true }); } catch { /* best effort */ }
-  });
+  after(() => hookHarness.cleanup());
 
-  function runHook(payload) {
-    try { fs.unlinkSync(postOut); } catch { /* first run */ }
-    const env = { ...process.env, USERPROFILE: fakeHome, HOME: fakeHome, CLAWD_POST_OUT: postOut };
-    delete env.CLAWD_REMOTE;
-    const result = spawnSync(process.execPath, ["--require", RECORDER, HOOK], {
-      input: `${JSON.stringify(payload)}\n`,
-      encoding: "utf8",
-      windowsHide: true,
-      timeout: 20000,
-      env,
+  function runHook(payload, httpContract) {
+    return hookHarness.run({
+      script: HOOK,
+      payload,
+      httpContract,
     });
-    let attempts = null;
-    try { attempts = JSON.parse(fs.readFileSync(postOut, "utf8")); } catch { /* hook never exited cleanly */ }
-    return { ...result, attempts };
   }
 
   it("forwards nothing and produces no placeholder session when session_id is absent", () => {
-    const r = runHook({ hook_event_name: "UserPromptSubmit", prompt: "do a thing", cwd: "/tmp/repo" });
+    const r = runHook(
+      { hook_event_name: "UserPromptSubmit", prompt: "do a thing", cwd: "/tmp/repo" },
+      "expect-none",
+    );
 
     assert.strictEqual(r.status, 0, `must exit 0; stderr=${r.stderr}`);
     assert.strictEqual(r.stderr, "", "must not surface an error to WorkBuddy");
@@ -195,7 +180,10 @@ describe("WorkBuddy hook session_id filter (#618 / #648) — real subprocess", (
   });
 
   it("also short-circuits when session_id is blank / whitespace", () => {
-    const r = runHook({ hook_event_name: "PreToolUse", session_id: "   ", cwd: "/tmp/repo" });
+    const r = runHook(
+      { hook_event_name: "PreToolUse", session_id: "   ", cwd: "/tmp/repo" },
+      "expect-none",
+    );
 
     assert.strictEqual(r.status, 0, `must exit 0; stderr=${r.stderr}`);
     assert.strictEqual(r.stdout, "{}\n",
@@ -208,7 +196,10 @@ describe("WorkBuddy hook session_id filter (#618 / #648) — real subprocess", (
   // this a hook that never posts at all would pass the case above for the wrong
   // reason (the exact class of bug #681's guard was written to catch).
   it("attempts to reach Clawd when session_id IS present (so the case above is not vacuous)", () => {
-    const r = runHook({ hook_event_name: "PreToolUse", session_id: "s-618", cwd: "/tmp/repo" });
+    const r = runHook(
+      { hook_event_name: "PreToolUse", session_id: "s-618", cwd: "/tmp/repo" },
+      "expect-attempt",
+    );
 
     assert.strictEqual(r.status, 0, `must exit 0; stderr=${r.stderr}`);
     assert.strictEqual(r.stdout, "{}\n");

--- a/tools/repository-asset-policy.json
+++ b/tools/repository-asset-policy.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": 1,
+  "owners": {
+    "build-release": "Electron packaging and release engineering",
+    "design-assets": "Editable source artwork and retained design inputs",
+    "docs-readme": "Localized README and product documentation media",
+    "legal": "Licensing and distribution notices",
+    "test-suite": "Automated test fixtures and regression coverage",
+    "theme-runtime": "Built-in theme runtime assets"
+  },
+  "classes": {
+    "runtime-required": "Runtime files directly or dynamically consumed by the product",
+    "target-specific-runtime": "Runtime payload that belongs to exactly one OS/architecture target",
+    "source-of-truth": "Editable or retained source used to produce runtime assets",
+    "docs-marketing": "Documentation, README, screenshot, or demonstration media",
+    "compatibility-bridge": "Versioned migration, rollback, or legacy-format support",
+    "tests-fixtures": "Regression tests and deterministic fixtures",
+    "generated-cache": "Deterministically generated or cached content that must remain ignored",
+    "safety-tombstone": "Minimal fail-fast replacement for a retired unsafe entry point",
+    "legal": "License or distribution notice with permanent retention requirements"
+  },
+  "thresholds": {
+    "trackedTreeWarningBytes": 52428800,
+    "trackedTreeHardBytes": 57671680,
+    "largeTrackedBinaryMediaBytes": 1048576,
+    "duplicatePackagedPayloadWarningBytes": 262144,
+    "artifactGrowthWarningBytes": 5242880,
+    "artifactGrowthWarningRatio": 0.05
+  },
+  "pathRules": [
+    {
+      "pattern": "themes/**",
+      "class": "runtime-required",
+      "owner": "theme-runtime",
+      "packaged": true,
+      "retentionReason": "Built-in themes are runtime product capabilities."
+    },
+    {
+      "pattern": "assets/gif/**",
+      "class": "docs-marketing",
+      "owner": "docs-readme",
+      "packaged": false,
+      "retentionReason": "README and state-guide previews; repository references and external raw links must be audited before retirement."
+    },
+    {
+      "pattern": "assets/videos/**",
+      "class": "docs-marketing",
+      "owner": "docs-readme",
+      "packaged": false,
+      "retentionReason": "Localized README demonstration media."
+    },
+    {
+      "pattern": "assets/source/cloudling-pointer-bridge/**",
+      "class": "source-of-truth",
+      "owner": "design-assets",
+      "packaged": false,
+      "retention": "permanent",
+      "retentionReason": "Retained Cloudling pointer-bridge source files; runtime logic is inlined into theme SVGs."
+    },
+    {
+      "pattern": "assets/source/**",
+      "class": "source-of-truth",
+      "owner": "design-assets",
+      "packaged": false,
+      "retentionReason": "Editable or retained source artwork; never a packaging input."
+    },
+    {
+      "pattern": "test/fixtures/**",
+      "class": "tests-fixtures",
+      "owner": "test-suite",
+      "packaged": false,
+      "retentionReason": "Deterministic regression fixtures; test count or age is not retirement evidence."
+    }
+  ],
+  "entries": [
+    {
+      "path": "assets/LICENSE",
+      "class": "legal",
+      "owner": "legal",
+      "packaged": false,
+      "retention": "permanent",
+      "retentionReason": "Asset license must be retained regardless of code references."
+    },
+    {
+      "path": "assets/hero.gif",
+      "class": "docs-marketing",
+      "owner": "docs-readme",
+      "packaged": false,
+      "retentionReason": "Hero animation linked by localized READMEs.",
+      "reviewAfter": "2026-10-01"
+    },
+    {
+      "path": "assets/icon.png",
+      "class": "runtime-required",
+      "owner": "build-release",
+      "packaged": true,
+      "retentionReason": "Canonical application icon used by packaging and runtime integrations."
+    },
+    {
+      "path": "assets/tray-icon.png",
+      "class": "runtime-required",
+      "owner": "build-release",
+      "packaged": true,
+      "retentionReason": "Current Windows/Linux tray and README path; canonicalization belongs to PR C1.",
+      "reviewAfter": "2026-10-01"
+    }
+  ],
+  "duplicatePayloadExemptions": [
+    {
+      "paths": [
+        "themes/calico/assets/calico-mini-crabwalk.apng",
+        "themes/calico/assets/calico-roam-crabwalk.apng"
+      ],
+      "owner": "theme-runtime",
+      "reason": "The states currently require different file-keyed offsets; consolidation is blocked pending a renderer and hit-geometry design."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add a deterministic repository/package asset audit with stable JSON manifests
- add a machine-readable asset ownership/retention policy for themes, docs media, source artwork, fixtures, and permanent legal assets
- hard-fail dangerous invariants such as packaged `assets/source/**`, unknown owners for large media, tracked sidecar executables, missing required package inputs, and foreign-target native binaries
- keep initial size/growth and duplicate-payload budgets as warnings
- introduce one spawned-hook harness that isolates HOME/user data and preloads the existing HTTP blocker/recorder/offline probe
- distinguish tests that may attempt blocked HTTP from business logic that must make no HTTP attempt
- run the audit in pull-request CI and upload stable manifests

## Safety boundaries

- no assets or tests are deleted
- `assets/LICENSE` is permanently retained
- no sidecar packaging changes (those remain separate)
- no platform binaries, icons, Telegram/Calico/source media, Git history, or #690 runtime/window code changes
- existing Windows Remote SSH CRLF/POSIX-path/chmod baselines are not modified

## Audit baseline

- tracked tree: 1,053 files / 48,030,468 bytes (45.81 MiB)
- repository-owned package inputs: 486 files / 22,786,939 bytes (21.73 MiB)
- errors: 0
- warnings: 2 known duplicate payloads
  - packaged `assets/icon.ico`: 270,622 duplicate bytes
  - packaged `assets/icon.png` / `assets/tray-icon.png`: 1,460,311 duplicate bytes

## Validation

- targeted audit and migrated spawned-hook tests: 175/175 pass
- two consecutive audits at `a1a8dc5` produced byte-identical `audit-report.json`, `package-manifest.json`, and `tracked-large-files.json`
- spawned-hook tests were run while Clawd/Electron was live; real HTTP is blocked by `--require` preload and no fake HUD/happy state was observed
- local Windows `npm test`: 6,284 tests / 6,250 pass / 14 known platform-baseline failures / 20 skip
  - 13 existing Remote SSH CRLF/POSIX-path/chmod failures
  - one unchanged live process-chain probe failure in `test/shared-process.test.js`
- `git diff --check` passes

## Follow-up boundary

Target-specific sidecar packaging and five-target artifact validation are intentionally separate from this PR.
