### PR TITLE
test(audit): harden FAT Mach-O detection

### DIFF
--- a/scripts/audit-repository-assets.js
+++ b/scripts/audit-repository-assets.js
@@ -26,6 +26,9 @@ const FAT_MACHO_MAGICS = new Map([
   [0xcafebabf, { endian: "be", recordBytes: 32 }],
   [0xbfbafeca, { endian: "le", recordBytes: 32 }],
 ]);
+// CAFEBABE is also the Java class magic; its following version bytes decode as
+// an implausibly large Mach-O slice count (Java class versions start at 45).
+const MAX_FAT_MACHO_ARCHITECTURES = 8;
 
 function normalizePath(value) {
   return String(value || "").replace(/\\/g, "/").replace(/^\.\/+/, "");
@@ -402,7 +405,9 @@ function inspectNativeBuffer(buffer) {
   if (fatMagic) {
     const count = readUInt32(buffer, 4, fatMagic.endian);
     const headerBytes = 8 + count * fatMagic.recordBytes;
-    if (count === 0 || count > 128 || headerBytes > buffer.length) return null;
+    if (count === 0 || count > MAX_FAT_MACHO_ARCHITECTURES || headerBytes > buffer.length) {
+      return null;
+    }
     const architectures = stableSort(Array.from(new Set(
       Array.from({ length: count }, (_, index) => {
         const offset = 8 + index * fatMagic.recordBytes;

--- a/test/repository-asset-audit.test.js
+++ b/test/repository-asset-audit.test.js
@@ -85,6 +85,20 @@ function manifest(files, target = null) {
   };
 }
 
+function fatMachoBuffer({ magic, endian, recordBytes }) {
+  const architectures = [0x01000007, 0x0100000c];
+  const buffer = Buffer.alloc(8 + architectures.length * recordBytes);
+  buffer.writeUInt32BE(magic, 0);
+  const writeUInt32 = endian === "be"
+    ? buffer.writeUInt32BE.bind(buffer)
+    : buffer.writeUInt32LE.bind(buffer);
+  writeUInt32(architectures.length, 4);
+  architectures.forEach((cpuType, index) => {
+    writeUInt32(cpuType, 8 + index * recordBytes);
+  });
+  return buffer;
+}
+
 describe("repository asset audit", () => {
   it("matches recursive package and policy globs consistently", () => {
     assert.strictEqual(matchesGlob("themes/calico/theme.json", "themes/**"), true);
@@ -104,6 +118,14 @@ describe("repository asset audit", () => {
     assert.throws(
       () => matchesGlob("a.png", "*.[pj]ng"),
       /unsupported glob brace or character-class/,
+    );
+    assert.throws(
+      () => matchesGlob("a.png", "+(a|b).png"),
+      /unsupported glob extglob/,
+    );
+    assert.throws(
+      () => matchesGlob("foo.png", "foo?(x).png"),
+      /unsupported glob extglob/,
     );
   });
 
@@ -265,17 +287,43 @@ describe("repository asset audit", () => {
     macho.writeUInt32BE(0x0100000c, 4);
     assert.deepStrictEqual(inspectNativeBuffer(macho), { os: "darwin", arch: "arm64", format: "mach-o" });
 
-    const fatMacho = Buffer.alloc(48);
-    fatMacho.writeUInt32BE(0xcafebabe, 0);
-    fatMacho.writeUInt32BE(2, 4);
-    fatMacho.writeUInt32BE(0x01000007, 8);
-    fatMacho.writeUInt32BE(0x0100000c, 28);
-    assert.deepStrictEqual(inspectNativeBuffer(fatMacho), {
-      os: "darwin",
-      arch: "universal",
-      architectures: ["arm64", "x64"],
-      format: "mach-o-fat",
-    });
+    for (const fat of [
+      { magic: 0xcafebabe, endian: "be", recordBytes: 20 },
+      { magic: 0xbebafeca, endian: "le", recordBytes: 20 },
+      { magic: 0xcafebabf, endian: "be", recordBytes: 32 },
+      { magic: 0xbfbafeca, endian: "le", recordBytes: 32 },
+    ]) {
+      assert.deepStrictEqual(inspectNativeBuffer(fatMachoBuffer(fat)), {
+        os: "darwin",
+        arch: "universal",
+        architectures: ["arm64", "x64"],
+        format: "mach-o-fat",
+      });
+    }
+  });
+
+  it("does not mistake a Java class header for a fat Mach-O", () => {
+    const javaClass = Buffer.alloc(8 + 61 * 20);
+    javaClass.writeUInt32BE(0xcafebabe, 0);
+    javaClass.writeUInt16BE(0, 4);
+    javaClass.writeUInt16BE(61, 6);
+    assert.strictEqual(inspectNativeBuffer(javaClass), null);
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-java-class-"));
+    try {
+      fs.writeFileSync(path.join(root, "Example.class"), javaClass);
+      const extracted = buildExtractedPackageManifest(root, "windows-x64", "abc");
+      const report = analyzeAudit({
+        trackedFiles: [tracked("assets/LICENSE", 5)],
+        manifest: extracted,
+        policy: basePolicy(),
+        packageRoot: root,
+      });
+      assert.deepStrictEqual(report.package.foreignNativeFiles, []);
+      assert.ok(!report.findings.some((finding) => finding.rule === "foreign-target-native"));
+    } finally {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it("hard-fails a foreign-target native binary in an extracted package", () => {
@@ -344,11 +392,11 @@ describe("repository asset audit", () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "asset-audit-fat-macho-"));
     try {
       const executable = path.join(root, "Clawd");
-      const fatMacho = Buffer.alloc(48);
-      fatMacho.writeUInt32BE(0xcafebabe, 0);
-      fatMacho.writeUInt32BE(2, 4);
-      fatMacho.writeUInt32BE(0x01000007, 8);
-      fatMacho.writeUInt32BE(0x0100000c, 28);
+      const fatMacho = fatMachoBuffer({
+        magic: 0xcafebabe,
+        endian: "be",
+        recordBytes: 20,
+      });
       fs.writeFileSync(executable, fatMacho);
 
       const extracted = buildExtractedPackageManifest(root, "darwin-x64", "abc");


### PR DESCRIPTION
## Summary

- reject implausible FAT Mach-O slice counts so Java class files do not collide with CAFEBABE detection
- cover all four FAT Mach-O magic/endianness variants
- cover fail-closed extglob rejection and extracted-package Java class behavior

## Validation

- targeted audit tests: 48/48 pass
- npm test: 6295 total, 6262 pass, 13 known Windows Remote SSH baseline failures, 20 skip
- asset audit double-run: byte-identical outputs, 0 errors / 2 existing duplicate-icon warnings
- git diff --check

This is a detector-only follow-up to #760. It does not change packaging or remove assets.