### PR TITLE
build: package sidecars per target architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,26 @@ jobs:
       - run: npm run fetch:sidecars -- --target windows-x64,windows-arm64
       - run: node scripts/verify-sidecar-binaries.js prebuild:win:all
       - run: npx electron-builder --win --publish never
+      - name: Assert packaged Windows sidecars
+        run: |
+          npm run assert:packaged-sidecar -- --target windows-x64
+          npm run assert:packaged-sidecar -- --target windows-arm64
+          npm run audit:assets -- --package-root dist/win-unpacked/resources/sidecars/cc-connect-clawd --target windows-x64 --output dist/repository-asset-audit/windows-x64
+          npm run audit:assets -- --package-root dist/win-arm64-unpacked/resources/sidecars/cc-connect-clawd --target windows-arm64 --output dist/repository-asset-audit/windows-arm64
       - uses: actions/upload-artifact@v4
         with:
           name: windows-installer
           path: |
             dist/*.exe
             dist/latest.yml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-package-manifests
+          path: |
+            dist/sidecar-package-manifests/*.json
+            dist/repository-asset-audit/*/*.json
+          if-no-files-found: warn
 
   build-mac:
     runs-on: macos-latest
@@ -38,12 +52,26 @@ jobs:
       - run: npm run fetch:sidecars -- --target darwin-x64,darwin-arm64
       - run: node scripts/verify-sidecar-binaries.js prebuild:mac
       - run: npx electron-builder --mac --publish never
+      - name: Assert packaged macOS sidecars
+        run: |
+          npm run assert:packaged-sidecar -- --target darwin-x64
+          npm run assert:packaged-sidecar -- --target darwin-arm64
+          npm run audit:assets -- --package-root "dist/mac/Clawd on Desk.app/Contents/Resources/sidecars/cc-connect-clawd" --target darwin-x64 --output dist/repository-asset-audit/darwin-x64
+          npm run audit:assets -- --package-root "dist/mac-arm64/Clawd on Desk.app/Contents/Resources/sidecars/cc-connect-clawd" --target darwin-arm64 --output dist/repository-asset-audit/darwin-arm64
       - uses: actions/upload-artifact@v4
         with:
           name: mac-installer
           path: |
             dist/*.dmg
             dist/latest-mac.yml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mac-package-manifests
+          path: |
+            dist/sidecar-package-manifests/*.json
+            dist/repository-asset-audit/*/*.json
+          if-no-files-found: warn
 
   build-linux:
     runs-on: ubuntu-latest
@@ -57,6 +85,10 @@ jobs:
       - run: npm run fetch:sidecars -- --target linux-x64
       - run: node scripts/verify-sidecar-binaries.js prebuild:linux
       - run: npx electron-builder --linux --publish never
+      - name: Assert packaged Linux sidecar
+        run: |
+          npm run assert:packaged-sidecar -- --target linux-x64
+          npm run audit:assets -- --package-root dist/linux-unpacked/resources/sidecars/cc-connect-clawd --target linux-x64 --output dist/repository-asset-audit/linux-x64
       - uses: actions/upload-artifact@v4
         with:
           name: linux-installer
@@ -64,6 +96,14 @@ jobs:
             dist/*.AppImage
             dist/*.deb
             dist/latest-linux.yml
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: linux-package-manifests
+          path: |
+            dist/sidecar-package-manifests/*.json
+            dist/repository-asset-audit/*/*.json
+          if-no-files-found: warn
 
   release:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -76,6 +116,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: "*-installer"
           merge-multiple: true
       - uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,12 @@ on:
     tags:
       - "v*"
   workflow_dispatch:
+    inputs:
+      artifact_validation_only:
+        description: "Use focused package tests for Windows while retaining full macOS/Linux tests"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-windows:
@@ -16,6 +22,10 @@ jobs:
           node-version-file: .nvmrc
       - run: npm install
       - run: npm test
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.artifact_validation_only }}
+      - name: Run package validation tests
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact_validation_only }}
+        run: node --test test/assert-packaged-sidecar.test.js test/package-build-config.test.js test/telegram-approval-sidecar.test.js test/verify-sidecar-binaries.test.js
       - run: npm run fetch:sidecars -- --target windows-x64,windows-arm64
       - run: node scripts/verify-sidecar-binaries.js prebuild:win:all
       - run: npx electron-builder --win --publish never
@@ -26,6 +36,7 @@ jobs:
           npm run audit:assets -- --package-root dist/win-unpacked/resources/sidecars/cc-connect-clawd --target windows-x64 --output dist/repository-asset-audit/windows-x64
           npm run audit:assets -- --package-root dist/win-arm64-unpacked/resources/sidecars/cc-connect-clawd --target windows-arm64 --output dist/repository-asset-audit/windows-arm64
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: windows-installer
           path: |
@@ -59,6 +70,7 @@ jobs:
           npm run audit:assets -- --package-root "dist/mac/Clawd on Desk.app/Contents/Resources/sidecars/cc-connect-clawd" --target darwin-x64 --output dist/repository-asset-audit/darwin-x64
           npm run audit:assets -- --package-root "dist/mac-arm64/Clawd on Desk.app/Contents/Resources/sidecars/cc-connect-clawd" --target darwin-arm64 --output dist/repository-asset-audit/darwin-arm64
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: mac-installer
           path: |
@@ -90,6 +102,7 @@ jobs:
           npm run assert:packaged-sidecar -- --target linux-x64
           npm run audit:assets -- --package-root dist/linux-unpacked/resources/sidecars/cc-connect-clawd --target linux-x64 --output dist/repository-asset-audit/linux-x64
       - uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: linux-installer
           path: |

--- a/.github/workflows/sidecar-package-audit.yml
+++ b/.github/workflows/sidecar-package-audit.yml
@@ -1,0 +1,97 @@
+name: Sidecar Package Audit
+
+on:
+  pull_request:
+    paths:
+      - "package.json"
+      - "package-lock.json"
+      - "bin/cc-connect-clawd/README.md"
+      - "scripts/assert-packaged-sidecar.js"
+      - "scripts/audit-repository-assets.js"
+      - "scripts/fetch-sidecar-binaries.js"
+      - "scripts/verify-sidecar-binaries.js"
+      - "test/assert-packaged-sidecar.test.js"
+      - "test/package-build-config.test.js"
+      - "test/verify-sidecar-binaries.test.js"
+      - ".github/workflows/build.yml"
+      - ".github/workflows/sidecar-package-audit.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - run: npm install
+      - run: |
+          node --test \
+            test/assert-packaged-sidecar.test.js \
+            test/package-build-config.test.js \
+            test/telegram-approval-sidecar.test.js \
+            test/verify-sidecar-binaries.test.js
+
+  package:
+    needs: unit
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: windows-x64
+            runner: windows-latest
+            build_script: build:win:x64
+            package_root: dist/win-unpacked/resources/sidecars/cc-connect-clawd
+            artifact_glob: dist/Clawd-on-Desk-Setup-*-x64.exe
+          - target: windows-arm64
+            runner: windows-latest
+            build_script: build:win:arm64
+            package_root: dist/win-arm64-unpacked/resources/sidecars/cc-connect-clawd
+            artifact_glob: dist/Clawd-on-Desk-Setup-*-arm64.exe
+          - target: darwin-x64
+            runner: macos-latest
+            build_script: build:mac:x64
+            package_root: dist/mac/Clawd on Desk.app/Contents/Resources/sidecars/cc-connect-clawd
+            artifact_glob: dist/Clawd-on-Desk-*-x64.dmg
+          - target: darwin-arm64
+            runner: macos-latest
+            build_script: build:mac:arm64
+            package_root: dist/mac-arm64/Clawd on Desk.app/Contents/Resources/sidecars/cc-connect-clawd
+            artifact_glob: dist/Clawd-on-Desk-*-arm64.dmg
+          - target: linux-x64
+            runner: ubuntu-latest
+            build_script: build:linux:x64
+            package_root: dist/linux-unpacked/resources/sidecars/cc-connect-clawd
+            artifact_glob: |
+              dist/Clawd-on-Desk-*-x64.AppImage
+              dist/Clawd-on-Desk-*-x64.deb
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - run: npm install
+      - run: npm run fetch:sidecars -- --target ${{ matrix.target }}
+      - run: npm run ${{ matrix.build_script }} -- --publish never
+      - run: npm run assert:packaged-sidecar -- --target ${{ matrix.target }}
+      - run: >-
+          npm run audit:assets --
+          --package-root "${{ matrix.package_root }}"
+          --target ${{ matrix.target }}
+          --output dist/repository-asset-audit/${{ matrix.target }}
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sidecar-package-${{ matrix.target }}
+          path: |
+            ${{ matrix.artifact_glob }}
+            dist/sidecar-package-manifests/*.json
+            dist/repository-asset-audit/*/*.json
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/sidecar-package-audit.yml
+++ b/.github/workflows/sidecar-package-audit.yml
@@ -68,8 +68,8 @@ jobs:
             build_script: build:linux:x64
             package_root: dist/linux-unpacked/resources/sidecars/cc-connect-clawd
             artifact_glob: |
-              dist/Clawd-on-Desk-*-x64.AppImage
-              dist/Clawd-on-Desk-*-x64.deb
+              dist/Clawd-on-Desk-*-x86_64.AppImage
+              dist/Clawd-on-Desk-*-amd64.deb
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ scripts/*
 !scripts/verify-electron-install.js
 !scripts/fetch-sidecar-binaries.js
 !scripts/audit-repository-assets.js
+!scripts/assert-packaged-sidecar.js
 
 # oh-my-cursor state
 .omc/

--- a/bin/cc-connect-clawd/README.md
+++ b/bin/cc-connect-clawd/README.md
@@ -1,9 +1,9 @@
 cc-connect-clawd sidecar binaries
 =================================
 
-Electron packaged builds copy this directory to:
+Electron packaged builds copy only the current target directory to:
 
-  resources/sidecars/cc-connect-clawd/
+  resources/sidecars/cc-connect-clawd/<platform>-<arch>/
 
 Place built sidecar binaries in platform/architecture directories:
 

--- a/package.json
+++ b/package.json
@@ -10,18 +10,25 @@
     "build:win:arm64": "electron-builder --win nsis:arm64",
     "build:win:all": "electron-builder --win nsis:x64 nsis:arm64",
     "build:mac": "electron-builder --mac",
+    "build:mac:x64": "electron-builder --mac dmg:x64",
+    "build:mac:arm64": "electron-builder --mac dmg:arm64",
     "build:linux": "electron-builder --linux",
+    "build:linux:x64": "electron-builder --linux AppImage:x64 deb:x64",
     "build:all": "electron-builder --win --mac --linux",
     "fetch:sidecars": "node scripts/fetch-sidecar-binaries.js",
     "verify:electron": "node scripts/verify-electron-install.js",
     "verify:sidecars": "node scripts/verify-sidecar-binaries.js",
+    "assert:packaged-sidecar": "node scripts/assert-packaged-sidecar.js",
     "postinstall": "node scripts/verify-electron-install.js --context postinstall",
     "prebuild": "node scripts/verify-sidecar-binaries.js",
     "prebuild:win:x64": "node scripts/verify-sidecar-binaries.js",
     "prebuild:win:arm64": "node scripts/verify-sidecar-binaries.js",
     "prebuild:win:all": "node scripts/verify-sidecar-binaries.js",
     "prebuild:mac": "node scripts/verify-sidecar-binaries.js",
+    "prebuild:mac:x64": "node scripts/verify-sidecar-binaries.js",
+    "prebuild:mac:arm64": "node scripts/verify-sidecar-binaries.js",
     "prebuild:linux": "node scripts/verify-sidecar-binaries.js",
+    "prebuild:linux:x64": "node scripts/verify-sidecar-binaries.js",
     "prebuild:all": "node scripts/verify-sidecar-binaries.js",
     "test": "node test/run-tests.js",
     "audit:assets": "node scripts/audit-repository-assets.js",
@@ -95,7 +102,13 @@
       "category": "public.app-category.entertainment",
       "extendInfo": {
         "LSUIElement": true
-      }
+      },
+      "extraResources": [
+        {
+          "from": "bin/cc-connect-clawd/darwin-${arch}",
+          "to": "sidecars/cc-connect-clawd/darwin-${arch}"
+        }
+      ]
     },
     "win": {
       "icon": "assets/icon.ico",
@@ -107,6 +120,12 @@
             "x64",
             "arm64"
           ]
+        }
+      ],
+      "extraResources": [
+        {
+          "from": "bin/cc-connect-clawd/windows-${arch}",
+          "to": "sidecars/cc-connect-clawd/windows-${arch}"
         }
       ]
     },
@@ -127,6 +146,12 @@
           "arch": [
             "x64"
           ]
+        }
+      ],
+      "extraResources": [
+        {
+          "from": "bin/cc-connect-clawd/linux-${arch}",
+          "to": "sidecars/cc-connect-clawd/linux-${arch}"
         }
       ]
     },
@@ -170,10 +195,6 @@
       {
         "from": "assets/icon.ico",
         "to": "icon.ico"
-      },
-      {
-        "from": "bin/cc-connect-clawd",
-        "to": "sidecars/cc-connect-clawd"
       }
     ],
     "publish": [

--- a/scripts/assert-packaged-sidecar.js
+++ b/scripts/assert-packaged-sidecar.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const fs = require("node:fs");
-const os = require("node:os");
 const path = require("node:path");
 const { spawnSync } = require("node:child_process");
 
@@ -148,6 +147,92 @@ function relativeOrBasename(repoRoot, filePath) {
     : relative;
 }
 
+function normalizeMachOSignaturePayload(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < 32) {
+    return { ok: false, error: "Mach-O file is too small" };
+  }
+  const magic = buffer.readUInt32BE(0);
+  let endian = null;
+  let headerBytes = null;
+  if (magic === 0xfeedfacf) {
+    endian = "be";
+    headerBytes = 32;
+  } else if (magic === 0xcffaedfe) {
+    endian = "le";
+    headerBytes = 32;
+  } else if (magic === 0xfeedface) {
+    endian = "be";
+    headerBytes = 28;
+  } else if (magic === 0xcefaedfe) {
+    endian = "le";
+    headerBytes = 28;
+  } else {
+    return { ok: false, error: "Expected a thin Mach-O binary" };
+  }
+  const readUInt32 = (offset) => (
+    endian === "be" ? buffer.readUInt32BE(offset) : buffer.readUInt32LE(offset)
+  );
+  const ncmds = readUInt32(16);
+  const sizeofcmds = readUInt32(20);
+  const loadCommandsEnd = headerBytes + sizeofcmds;
+  if (loadCommandsEnd > buffer.length) {
+    return { ok: false, error: "Mach-O load commands exceed the file size" };
+  }
+
+  let cursor = headerBytes;
+  let signature = null;
+  for (let index = 0; index < ncmds; index += 1) {
+    if (cursor + 8 > loadCommandsEnd) {
+      return { ok: false, error: "Mach-O load command header exceeds sizeofcmds" };
+    }
+    const command = readUInt32(cursor);
+    const commandBytes = readUInt32(cursor + 4);
+    if (commandBytes < 8 || cursor + commandBytes > loadCommandsEnd) {
+      return { ok: false, error: "Mach-O load command has an invalid size" };
+    }
+    if (command === 0x1d) {
+      if (signature) return { ok: false, error: "Mach-O contains multiple LC_CODE_SIGNATURE commands" };
+      if (commandBytes < 16) {
+        return { ok: false, error: "Mach-O LC_CODE_SIGNATURE command is truncated" };
+      }
+      signature = {
+        commandOffset: cursor,
+        commandBytes,
+        dataOffset: readUInt32(cursor + 8),
+        dataBytes: readUInt32(cursor + 12),
+      };
+    }
+    cursor += commandBytes;
+  }
+  if (cursor !== loadCommandsEnd) {
+    return { ok: false, error: "Mach-O load command sizes do not equal sizeofcmds" };
+  }
+  if (!signature) {
+    return {
+      ok: true,
+      buffer: Buffer.from(buffer),
+      signaturePresent: false,
+      signatureOffset: null,
+      signatureBytes: 0,
+    };
+  }
+  if (signature.dataBytes === 0
+    || signature.dataOffset < loadCommandsEnd
+    || signature.dataOffset + signature.dataBytes !== buffer.length) {
+    return { ok: false, error: "Mach-O code signature is not the final bounded payload" };
+  }
+
+  const normalized = Buffer.from(buffer.subarray(0, signature.dataOffset));
+  normalized.fill(0, signature.commandOffset, signature.commandOffset + signature.commandBytes);
+  return {
+    ok: true,
+    buffer: normalized,
+    signaturePresent: true,
+    signatureOffset: signature.dataOffset,
+    signatureBytes: signature.dataBytes,
+  };
+}
+
 function normalizeDarwinCodeSignature(filePath, options = {}) {
   const fsModule = options.fs || fs;
   const spawn = options.spawnSync || spawnSync;
@@ -158,42 +243,24 @@ function normalizeDarwinCodeSignature(filePath, options = {}) {
   if (verification.error) {
     return { ok: false, error: `codesign verification could not start: ${verification.error.message}` };
   }
-  if (verification.status !== 0) {
-    if (!requireSignature) {
-      return {
-        ok: true,
-        buffer: fsModule.readFileSync(filePath),
-        signed: false,
-        method: "unsigned-source",
-      };
-    }
+  if (verification.status !== 0 && requireSignature) {
     const detail = String(verification.stderr || verification.stdout || "").trim();
     return { ok: false, error: `codesign verification failed${detail ? `: ${detail}` : ""}` };
   }
 
-  const tempDir = fsModule.mkdtempSync(path.join(os.tmpdir(), "clawd-sidecar-codesign-"));
-  const tempPath = path.join(tempDir, path.basename(filePath));
-  try {
-    fsModule.copyFileSync(filePath, tempPath);
-    const removal = spawn("codesign", ["--remove-signature", tempPath], {
-      encoding: "utf8",
-    });
-    if (removal.error) {
-      return { ok: false, error: `codesign signature removal could not start: ${removal.error.message}` };
-    }
-    if (removal.status !== 0) {
-      const detail = String(removal.stderr || removal.stdout || "").trim();
-      return { ok: false, error: `codesign signature removal failed${detail ? `: ${detail}` : ""}` };
-    }
-    return {
-      ok: true,
-      buffer: fsModule.readFileSync(tempPath),
-      signed: true,
-      method: "codesign-stripped",
-    };
-  } finally {
-    fsModule.rmSync(tempDir, { recursive: true, force: true });
+  const normalized = normalizeMachOSignaturePayload(fsModule.readFileSync(filePath));
+  if (!normalized.ok) return normalized;
+  if (verification.status === 0 && !normalized.signaturePresent) {
+    return { ok: false, error: "codesign verified a Mach-O without LC_CODE_SIGNATURE" };
   }
+  if (requireSignature && !normalized.signaturePresent) {
+    return { ok: false, error: "Packaged Mach-O has no LC_CODE_SIGNATURE" };
+  }
+  return {
+    ...normalized,
+    signed: verification.status === 0,
+    method: normalized.signaturePresent ? "macho-signature-excluded" : "unsigned-source",
+  };
 }
 
 function inspectPackagedSidecar(options = {}) {
@@ -237,6 +304,8 @@ function inspectPackagedSidecar(options = {}) {
   let normalizedSha256 = null;
   let sourceSigned = null;
   let packagedSigned = null;
+  let sourceSignatureBytes = null;
+  let packagedSignatureBytes = null;
   const executableRequired = target.platform !== "windows";
   const executableChecked = executableRequired && hostPlatform !== "win32";
 
@@ -274,6 +343,8 @@ function inspectPackagedSidecar(options = {}) {
           });
           sourceSigned = sourceNormalized.ok ? sourceNormalized.signed : null;
           packagedSigned = packagedNormalized.ok ? packagedNormalized.signed : null;
+          sourceSignatureBytes = sourceNormalized.ok ? sourceNormalized.signatureBytes : null;
+          packagedSignatureBytes = packagedNormalized.ok ? packagedNormalized.signatureBytes : null;
           if (!sourceNormalized.ok) {
             errors.push(`Could not normalize source ${target.dir} signature: ${sourceNormalized.error}`);
           }
@@ -352,6 +423,8 @@ function inspectPackagedSidecar(options = {}) {
         normalizedSha256,
         sourceSigned,
         packagedSigned,
+        sourceSignatureBytes,
+        packagedSignatureBytes,
         executableRequired,
         executableChecked,
         executable,
@@ -445,6 +518,7 @@ module.exports = {
   defaultLayout,
   inspectPackagedSidecar,
   normalizeDarwinCodeSignature,
+  normalizeMachOSignaturePayload,
   parseArgs,
   runAssertion,
   summarizeTree,

--- a/scripts/assert-packaged-sidecar.js
+++ b/scripts/assert-packaged-sidecar.js
@@ -1,13 +1,16 @@
 "use strict";
 
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
+const { spawnSync } = require("node:child_process");
 
 const {
   TARGETS,
   PINNED_CHECKSUMS,
   binaryChecksumName,
   sha256,
+  targetBinaryPath,
 } = require("./fetch-sidecar-binaries");
 const {
   inspectNativeBuffer,
@@ -63,8 +66,8 @@ function defaultLayout(targetName, pkg) {
       packageRoot: path.join("dist", "linux-unpacked"),
       resourcesRoot: path.join("dist", "linux-unpacked", "resources"),
       artifacts: [
-        path.join("dist", `Clawd-on-Desk-${version}-x64.AppImage`),
-        path.join("dist", `Clawd-on-Desk-${version}-x64.deb`),
+        path.join("dist", `Clawd-on-Desk-${version}-x86_64.AppImage`),
+        path.join("dist", `Clawd-on-Desk-${version}-amd64.deb`),
       ],
     },
   };
@@ -145,6 +148,54 @@ function relativeOrBasename(repoRoot, filePath) {
     : relative;
 }
 
+function normalizeDarwinCodeSignature(filePath, options = {}) {
+  const fsModule = options.fs || fs;
+  const spawn = options.spawnSync || spawnSync;
+  const requireSignature = options.requireSignature === true;
+  const verification = spawn("codesign", ["--verify", "--strict", filePath], {
+    encoding: "utf8",
+  });
+  if (verification.error) {
+    return { ok: false, error: `codesign verification could not start: ${verification.error.message}` };
+  }
+  if (verification.status !== 0) {
+    if (!requireSignature) {
+      return {
+        ok: true,
+        buffer: fsModule.readFileSync(filePath),
+        signed: false,
+        method: "unsigned-source",
+      };
+    }
+    const detail = String(verification.stderr || verification.stdout || "").trim();
+    return { ok: false, error: `codesign verification failed${detail ? `: ${detail}` : ""}` };
+  }
+
+  const tempDir = fsModule.mkdtempSync(path.join(os.tmpdir(), "clawd-sidecar-codesign-"));
+  const tempPath = path.join(tempDir, path.basename(filePath));
+  try {
+    fsModule.copyFileSync(filePath, tempPath);
+    const removal = spawn("codesign", ["--remove-signature", tempPath], {
+      encoding: "utf8",
+    });
+    if (removal.error) {
+      return { ok: false, error: `codesign signature removal could not start: ${removal.error.message}` };
+    }
+    if (removal.status !== 0) {
+      const detail = String(removal.stderr || removal.stdout || "").trim();
+      return { ok: false, error: `codesign signature removal failed${detail ? `: ${detail}` : ""}` };
+    }
+    return {
+      ok: true,
+      buffer: fsModule.readFileSync(tempPath),
+      signed: true,
+      method: "codesign-stripped",
+    };
+  } finally {
+    fsModule.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
 function inspectPackagedSidecar(options = {}) {
   const fsModule = options.fs || fs;
   const repoRoot = options.repoRoot || path.join(__dirname, "..");
@@ -181,14 +232,70 @@ function inspectPackagedSidecar(options = {}) {
   const expectedRecord = fileRecords.find((item) => item.path === expectedRelativePath) || null;
   let native = null;
   let executable = null;
+  let expectedSha256 = null;
+  let checksumMode = null;
+  let normalizedSha256 = null;
+  let sourceSigned = null;
+  let packagedSigned = null;
   const executableRequired = target.platform !== "windows";
   const executableChecked = executableRequired && hostPlatform !== "win32";
 
   if (expectedRecord && isFile(fsModule, expectedPath)) {
-    const expectedSha256 = String(checksums[binaryChecksumName(target)] || "").toLowerCase();
+    expectedSha256 = String(checksums[binaryChecksumName(target)] || "").toLowerCase() || null;
     if (!expectedSha256) {
       errors.push(`Missing pinned checksum for ${binaryChecksumName(target)}`);
-    } else if (expectedRecord.sha256 !== expectedSha256) {
+    } else if (expectedRecord.sha256 === expectedSha256) {
+      checksumMode = "exact";
+    } else if (target.platform === "darwin"
+      && (hostPlatform === "darwin" || typeof options.normalizeDarwinBinary === "function")) {
+      const sourcePath = targetBinaryPath(repoRoot, target);
+      if (!isFile(fsModule, sourcePath)) {
+        errors.push(`Missing pinned source sidecar for signature comparison: ${target.dir}/${target.exe}`);
+      } else {
+        const sourceBuffer = fsModule.readFileSync(sourcePath);
+        const sourceSha256 = sha256(sourceBuffer);
+        if (sourceSha256 !== expectedSha256) {
+          errors.push(
+            `Source sidecar checksum mismatch for ${target.dir}: got ${sourceSha256}, expected ${expectedSha256}`,
+          );
+        } else {
+          const normalize = options.normalizeDarwinBinary || normalizeDarwinCodeSignature;
+          const sourceNormalized = normalize(sourcePath, {
+            fs: fsModule,
+            role: "source",
+            requireSignature: false,
+            spawnSync: options.spawnSync,
+          });
+          const packagedNormalized = normalize(expectedPath, {
+            fs: fsModule,
+            role: "packaged",
+            requireSignature: true,
+            spawnSync: options.spawnSync,
+          });
+          sourceSigned = sourceNormalized.ok ? sourceNormalized.signed : null;
+          packagedSigned = packagedNormalized.ok ? packagedNormalized.signed : null;
+          if (!sourceNormalized.ok) {
+            errors.push(`Could not normalize source ${target.dir} signature: ${sourceNormalized.error}`);
+          }
+          if (!packagedNormalized.ok) {
+            errors.push(`Could not normalize packaged ${target.dir} signature: ${packagedNormalized.error}`);
+          }
+          if (sourceNormalized.ok && packagedNormalized.ok) {
+            const sourceNormalizedSha256 = sha256(sourceNormalized.buffer);
+            const packagedNormalizedSha256 = sha256(packagedNormalized.buffer);
+            normalizedSha256 = packagedNormalizedSha256;
+            if (sourceNormalizedSha256 === packagedNormalizedSha256) {
+              checksumMode = "codesign-normalized";
+            } else {
+              errors.push(
+                `Packaged sidecar normalized checksum mismatch for ${target.dir}: `
+                + `got ${packagedNormalizedSha256}, expected ${sourceNormalizedSha256}`,
+              );
+            }
+          }
+        }
+      }
+    } else {
       errors.push(
         `Packaged sidecar checksum mismatch for ${target.dir}: got ${expectedRecord.sha256}, expected ${expectedSha256}`,
       );
@@ -240,6 +347,11 @@ function inspectPackagedSidecar(options = {}) {
         files: fileRecords,
         bytes: fileRecords.reduce((total, item) => total + item.bytes, 0),
         native,
+        expectedSha256,
+        checksumMode,
+        normalizedSha256,
+        sourceSigned,
+        packagedSigned,
         executableRequired,
         executableChecked,
         executable,
@@ -332,6 +444,7 @@ module.exports = {
   SIDECAR_RESOURCE_ROOT,
   defaultLayout,
   inspectPackagedSidecar,
+  normalizeDarwinCodeSignature,
   parseArgs,
   runAssertion,
   summarizeTree,

--- a/scripts/assert-packaged-sidecar.js
+++ b/scripts/assert-packaged-sidecar.js
@@ -1,0 +1,340 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  TARGETS,
+  PINNED_CHECKSUMS,
+  binaryChecksumName,
+  sha256,
+} = require("./fetch-sidecar-binaries");
+const {
+  inspectNativeBuffer,
+  stableJson,
+} = require("./audit-repository-assets");
+
+const ASSERT_COMMAND = "node scripts/assert-packaged-sidecar.js";
+const SIDECAR_RESOURCE_ROOT = path.join("sidecars", "cc-connect-clawd");
+
+function normalizePath(value) {
+  return String(value || "").replace(/\\/g, "/");
+}
+
+function compareText(a, b) {
+  return String(a).localeCompare(String(b), "en");
+}
+
+function targetByName(name) {
+  const target = TARGETS.find((item) => item.dir === name);
+  if (!target) {
+    throw new Error(
+      `Unsupported sidecar target "${name}". Expected one of: ${TARGETS.map((item) => item.dir).join(", ")}`,
+    );
+  }
+  return target;
+}
+
+function defaultLayout(targetName, pkg) {
+  const version = pkg.version;
+  const productName = pkg.build && pkg.build.productName;
+  const layouts = {
+    "windows-x64": {
+      packageRoot: path.join("dist", "win-unpacked"),
+      resourcesRoot: path.join("dist", "win-unpacked", "resources"),
+      artifacts: [path.join("dist", `Clawd-on-Desk-Setup-${version}-x64.exe`)],
+    },
+    "windows-arm64": {
+      packageRoot: path.join("dist", "win-arm64-unpacked"),
+      resourcesRoot: path.join("dist", "win-arm64-unpacked", "resources"),
+      artifacts: [path.join("dist", `Clawd-on-Desk-Setup-${version}-arm64.exe`)],
+    },
+    "darwin-x64": {
+      packageRoot: path.join("dist", "mac", `${productName}.app`),
+      resourcesRoot: path.join("dist", "mac", `${productName}.app`, "Contents", "Resources"),
+      artifacts: [path.join("dist", `Clawd-on-Desk-${version}-x64.dmg`)],
+    },
+    "darwin-arm64": {
+      packageRoot: path.join("dist", "mac-arm64", `${productName}.app`),
+      resourcesRoot: path.join("dist", "mac-arm64", `${productName}.app`, "Contents", "Resources"),
+      artifacts: [path.join("dist", `Clawd-on-Desk-${version}-arm64.dmg`)],
+    },
+    "linux-x64": {
+      packageRoot: path.join("dist", "linux-unpacked"),
+      resourcesRoot: path.join("dist", "linux-unpacked", "resources"),
+      artifacts: [
+        path.join("dist", `Clawd-on-Desk-${version}-x64.AppImage`),
+        path.join("dist", `Clawd-on-Desk-${version}-x64.deb`),
+      ],
+    },
+  };
+  const layout = layouts[targetName];
+  if (!layout) targetByName(targetName);
+  return layout;
+}
+
+function resolveFrom(root, value) {
+  return path.isAbsolute(value) ? value : path.join(root, value);
+}
+
+function isDirectory(fsModule, filePath) {
+  try {
+    return fsModule.statSync(filePath).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function isFile(fsModule, filePath) {
+  try {
+    return fsModule.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function walkRelativeFiles(root, fsModule = fs) {
+  if (!isDirectory(fsModule, root)) return [];
+  const files = [];
+  function visit(current, relative) {
+    const entries = fsModule.readdirSync(current, { withFileTypes: true })
+      .slice()
+      .sort((a, b) => compareText(a.name, b.name));
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      const relativePath = relative ? path.join(relative, entry.name) : entry.name;
+      if (entry.isDirectory()) {
+        visit(fullPath, relativePath);
+      } else if (entry.isFile()) {
+        files.push(normalizePath(relativePath));
+      } else {
+        throw new Error(`Unsupported non-file package entry: ${fullPath}`);
+      }
+    }
+  }
+  visit(root, "");
+  return files;
+}
+
+function summarizeTree(root, label, fsModule = fs) {
+  const files = walkRelativeFiles(root, fsModule);
+  return {
+    path: normalizePath(label),
+    files: files.length,
+    bytes: files.reduce(
+      (total, relativePath) => total + fsModule.statSync(resolveFrom(root, relativePath)).size,
+      0,
+    ),
+  };
+}
+
+function packagedFileRecord(root, relativePath, fsModule = fs) {
+  const fullPath = resolveFrom(root, relativePath);
+  const contents = fsModule.readFileSync(fullPath);
+  return {
+    path: normalizePath(relativePath),
+    bytes: contents.length,
+    sha256: sha256(contents),
+  };
+}
+
+function relativeOrBasename(repoRoot, filePath) {
+  const relative = normalizePath(path.relative(repoRoot, filePath));
+  return relative.startsWith("../") || relative === ".."
+    ? normalizePath(path.basename(filePath))
+    : relative;
+}
+
+function inspectPackagedSidecar(options = {}) {
+  const fsModule = options.fs || fs;
+  const repoRoot = options.repoRoot || path.join(__dirname, "..");
+  const pkg = options.packageJson || require(path.join(repoRoot, "package.json"));
+  const target = targetByName(options.target);
+  const resourcesRoot = resolveFrom(repoRoot, options.resourcesRoot);
+  const resourcesLabel = options.resourcesLabel || relativeOrBasename(repoRoot, resourcesRoot);
+  const artifactPaths = (options.artifacts || []).map((item) => resolveFrom(repoRoot, item));
+  const checksums = options.checksums || PINNED_CHECKSUMS;
+  const hostPlatform = options.hostPlatform || process.platform;
+  const errors = [];
+
+  if (!isDirectory(fsModule, resourcesRoot)) {
+    errors.push(`Missing packaged resources directory: ${normalizePath(resourcesLabel)}`);
+  }
+
+  const resources = summarizeTree(resourcesRoot, resourcesLabel, fsModule);
+  const sidecarRoot = path.join(resourcesRoot, SIDECAR_RESOURCE_ROOT);
+  const sidecarFiles = walkRelativeFiles(sidecarRoot, fsModule);
+  const expectedRelativePath = normalizePath(path.join(target.dir, target.exe));
+  const expectedPath = path.join(sidecarRoot, ...expectedRelativePath.split("/"));
+  const expectedFiles = [expectedRelativePath];
+
+  if (!isDirectory(fsModule, sidecarRoot)) {
+    errors.push(`Missing packaged sidecar directory: ${normalizePath(path.join(resourcesLabel, SIDECAR_RESOURCE_ROOT))}`);
+  }
+  if (JSON.stringify(sidecarFiles) !== JSON.stringify(expectedFiles)) {
+    errors.push(
+      `Packaged sidecar files for ${target.dir} must equal ${expectedFiles.join(", ")}; found ${sidecarFiles.join(", ") || "(none)"}`,
+    );
+  }
+
+  const fileRecords = sidecarFiles.map((relativePath) => packagedFileRecord(sidecarRoot, relativePath, fsModule));
+  const expectedRecord = fileRecords.find((item) => item.path === expectedRelativePath) || null;
+  let native = null;
+  let executable = null;
+  const executableRequired = target.platform !== "windows";
+  const executableChecked = executableRequired && hostPlatform !== "win32";
+
+  if (expectedRecord && isFile(fsModule, expectedPath)) {
+    const expectedSha256 = String(checksums[binaryChecksumName(target)] || "").toLowerCase();
+    if (!expectedSha256) {
+      errors.push(`Missing pinned checksum for ${binaryChecksumName(target)}`);
+    } else if (expectedRecord.sha256 !== expectedSha256) {
+      errors.push(
+        `Packaged sidecar checksum mismatch for ${target.dir}: got ${expectedRecord.sha256}, expected ${expectedSha256}`,
+      );
+    }
+
+    native = inspectNativeBuffer(fsModule.readFileSync(expectedPath));
+    if (!native) {
+      errors.push(`Packaged sidecar for ${target.dir} is not a recognized native executable`);
+    } else if (`${native.os}-${native.arch}` !== target.dir) {
+      errors.push(
+        `Packaged sidecar native target mismatch: expected ${target.dir}, detected ${native.os}-${native.arch}`,
+      );
+    }
+
+    if (executableChecked) {
+      executable = (fsModule.statSync(expectedPath).mode & 0o111) !== 0;
+      if (!executable) {
+        errors.push(`Packaged sidecar for ${target.dir} is missing an executable mode bit`);
+      }
+    }
+  }
+
+  const artifacts = [];
+  for (const artifactPath of artifactPaths) {
+    const label = relativeOrBasename(repoRoot, artifactPath);
+    if (!isFile(fsModule, artifactPath)) {
+      errors.push(`Missing built artifact: ${label}`);
+      continue;
+    }
+    artifacts.push({
+      path: label,
+      bytes: fsModule.statSync(artifactPath).size,
+    });
+  }
+
+  errors.sort(compareText);
+  return {
+    ok: errors.length === 0,
+    errors,
+    manifest: {
+      schemaVersion: 1,
+      target: target.dir,
+      packageVersion: String(pkg.version),
+      resources,
+      artifacts: artifacts.sort((a, b) => compareText(a.path, b.path)),
+      sidecar: {
+        root: normalizePath(SIDECAR_RESOURCE_ROOT),
+        expectedPath: expectedRelativePath,
+        files: fileRecords,
+        bytes: fileRecords.reduce((total, item) => total + item.bytes, 0),
+        native,
+        executableRequired,
+        executableChecked,
+        executable,
+      },
+      errors,
+    },
+  };
+}
+
+function parseArgs(argv) {
+  const out = {
+    target: "",
+    resourcesRoot: "",
+    artifacts: [],
+    output: "",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--target") out.target = argv[++index];
+    else if (arg === "--resources-root") out.resourcesRoot = argv[++index];
+    else if (arg === "--artifact") out.artifacts.push(argv[++index]);
+    else if (arg === "--output") out.output = argv[++index];
+    else if (arg === "--help" || arg === "-h") out.help = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!out.help && !out.target) throw new Error("--target is required");
+  return out;
+}
+
+function printHelp(stdout = process.stdout) {
+  stdout.write(
+    `Usage: ${ASSERT_COMMAND} --target <platform-arch> `
+    + "[--resources-root DIR] [--artifact FILE ...] [--output FILE]\n",
+  );
+}
+
+function runAssertion(options = {}) {
+  const repoRoot = options.repoRoot || path.join(__dirname, "..");
+  const pkg = options.packageJson || require(path.join(repoRoot, "package.json"));
+  const layout = defaultLayout(options.target, pkg);
+  const resourcesRoot = options.resourcesRoot || layout.resourcesRoot;
+  const artifacts = options.artifacts && options.artifacts.length
+    ? options.artifacts
+    : layout.artifacts;
+  const output = options.output
+    || path.join("dist", "sidecar-package-manifests", `${options.target}.json`);
+  const result = inspectPackagedSidecar({
+    ...options,
+    repoRoot,
+    packageJson: pkg,
+    resourcesRoot,
+    artifacts,
+  });
+  const outputPath = resolveFrom(repoRoot, output);
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, stableJson(result.manifest), "utf8");
+  return { ...result, outputPath };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return;
+  }
+  const result = runAssertion(args);
+  process.stdout.write([
+    `Packaged sidecar ${result.manifest.target}: ${result.ok ? "PASS" : "FAIL"}`,
+    `Resources: ${result.manifest.resources.files} files, ${result.manifest.resources.bytes} bytes`,
+    `Sidecar: ${result.manifest.sidecar.files.length} file(s), ${result.manifest.sidecar.bytes} bytes`,
+    `Artifacts: ${result.manifest.artifacts.map((item) => `${item.path} (${item.bytes} bytes)`).join(", ")}`,
+    ...result.errors.map((message) => `ERROR ${message}`),
+    `Manifest: ${normalizePath(path.relative(path.join(__dirname, ".."), result.outputPath))}`,
+    "",
+  ].join("\n"));
+  if (!result.ok) process.exitCode = 1;
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`Packaged sidecar assertion failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  ASSERT_COMMAND,
+  SIDECAR_RESOURCE_ROOT,
+  defaultLayout,
+  inspectPackagedSidecar,
+  parseArgs,
+  runAssertion,
+  summarizeTree,
+  targetByName,
+  walkRelativeFiles,
+};

--- a/scripts/assert-packaged-sidecar.js
+++ b/scripts/assert-packaged-sidecar.js
@@ -172,6 +172,10 @@ function normalizeMachOSignaturePayload(buffer) {
   const readUInt32 = (offset) => (
     endian === "be" ? buffer.readUInt32BE(offset) : buffer.readUInt32LE(offset)
   );
+  const readUInt64 = (offset) => {
+    const value = endian === "be" ? buffer.readBigUInt64BE(offset) : buffer.readBigUInt64LE(offset);
+    return value <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(value) : null;
+  };
   const ncmds = readUInt32(16);
   const sizeofcmds = readUInt32(20);
   const loadCommandsEnd = headerBytes + sizeofcmds;
@@ -181,6 +185,7 @@ function normalizeMachOSignaturePayload(buffer) {
 
   let cursor = headerBytes;
   let signature = null;
+  let linkedit = null;
   for (let index = 0; index < ncmds; index += 1) {
     if (cursor + 8 > loadCommandsEnd) {
       return { ok: false, error: "Mach-O load command header exceeds sizeofcmds" };
@@ -202,6 +207,34 @@ function normalizeMachOSignaturePayload(buffer) {
         dataBytes: readUInt32(cursor + 12),
       };
     }
+    if (command === 0x19 || command === 0x1) {
+      const segment64 = command === 0x19;
+      const minimumBytes = segment64 ? 72 : 56;
+      if (commandBytes < minimumBytes) {
+        return { ok: false, error: "Mach-O segment command is truncated" };
+      }
+      const segmentName = buffer.toString("ascii", cursor + 8, cursor + 24).replace(/\0.*$/, "");
+      if (segmentName === "__LINKEDIT") {
+        if (linkedit) return { ok: false, error: "Mach-O contains multiple __LINKEDIT segments" };
+        const virtualSizeOffset = cursor + (segment64 ? 32 : 28);
+        const fileOffsetOffset = cursor + (segment64 ? 40 : 32);
+        const fileSizeOffset = cursor + (segment64 ? 48 : 36);
+        const virtualBytes = segment64 ? readUInt64(virtualSizeOffset) : readUInt32(virtualSizeOffset);
+        const fileOffset = segment64 ? readUInt64(fileOffsetOffset) : readUInt32(fileOffsetOffset);
+        const fileBytes = segment64 ? readUInt64(fileSizeOffset) : readUInt32(fileSizeOffset);
+        if (virtualBytes === null || fileOffset === null || fileBytes === null) {
+          return { ok: false, error: "Mach-O __LINKEDIT fields exceed safe integer bounds" };
+        }
+        linkedit = {
+          virtualSizeOffset,
+          fileSizeOffset,
+          fieldBytes: segment64 ? 8 : 4,
+          virtualBytes,
+          fileOffset,
+          fileBytes,
+        };
+      }
+    }
     cursor += commandBytes;
   }
   if (cursor !== loadCommandsEnd) {
@@ -221,15 +254,26 @@ function normalizeMachOSignaturePayload(buffer) {
     || signature.dataOffset + signature.dataBytes !== buffer.length) {
     return { ok: false, error: "Mach-O code signature is not the final bounded payload" };
   }
+  if (!linkedit) {
+    return { ok: false, error: "Signed Mach-O has no __LINKEDIT segment" };
+  }
+  if (linkedit.fileOffset > signature.dataOffset
+    || linkedit.fileOffset + linkedit.fileBytes !== buffer.length
+    || linkedit.virtualBytes < linkedit.fileBytes) {
+    return { ok: false, error: "Mach-O __LINKEDIT does not bound the signed tail" };
+  }
 
   const normalized = Buffer.from(buffer.subarray(0, signature.dataOffset));
   normalized.fill(0, signature.commandOffset, signature.commandOffset + signature.commandBytes);
+  normalized.fill(0, linkedit.virtualSizeOffset, linkedit.virtualSizeOffset + linkedit.fieldBytes);
+  normalized.fill(0, linkedit.fileSizeOffset, linkedit.fileSizeOffset + linkedit.fieldBytes);
   return {
     ok: true,
     buffer: normalized,
     signaturePresent: true,
     signatureOffset: signature.dataOffset,
     signatureBytes: signature.dataBytes,
+    linkeditFileBytes: linkedit.fileBytes,
   };
 }
 
@@ -306,6 +350,10 @@ function inspectPackagedSidecar(options = {}) {
   let packagedSigned = null;
   let sourceSignatureBytes = null;
   let packagedSignatureBytes = null;
+  let sourceSignatureOffset = null;
+  let packagedSignatureOffset = null;
+  let sourceLinkeditBytes = null;
+  let packagedLinkeditBytes = null;
   const executableRequired = target.platform !== "windows";
   const executableChecked = executableRequired && hostPlatform !== "win32";
 
@@ -345,6 +393,10 @@ function inspectPackagedSidecar(options = {}) {
           packagedSigned = packagedNormalized.ok ? packagedNormalized.signed : null;
           sourceSignatureBytes = sourceNormalized.ok ? sourceNormalized.signatureBytes : null;
           packagedSignatureBytes = packagedNormalized.ok ? packagedNormalized.signatureBytes : null;
+          sourceSignatureOffset = sourceNormalized.ok ? sourceNormalized.signatureOffset : null;
+          packagedSignatureOffset = packagedNormalized.ok ? packagedNormalized.signatureOffset : null;
+          sourceLinkeditBytes = sourceNormalized.ok ? sourceNormalized.linkeditFileBytes : null;
+          packagedLinkeditBytes = packagedNormalized.ok ? packagedNormalized.linkeditFileBytes : null;
           if (!sourceNormalized.ok) {
             errors.push(`Could not normalize source ${target.dir} signature: ${sourceNormalized.error}`);
           }
@@ -425,6 +477,10 @@ function inspectPackagedSidecar(options = {}) {
         packagedSigned,
         sourceSignatureBytes,
         packagedSignatureBytes,
+        sourceSignatureOffset,
+        packagedSignatureOffset,
+        sourceLinkeditBytes,
+        packagedLinkeditBytes,
         executableRequired,
         executableChecked,
         executable,

--- a/scripts/verify-sidecar-binaries.js
+++ b/scripts/verify-sidecar-binaries.js
@@ -25,7 +25,16 @@ const BUILD_REQUIREMENTS = Object.freeze({
     ["darwin", "x64"],
     ["darwin", "arm64"],
   ],
+  "build:mac:x64": [
+    ["darwin", "x64"],
+  ],
+  "build:mac:arm64": [
+    ["darwin", "arm64"],
+  ],
   "build:linux": [
+    ["linux", "x64"],
+  ],
+  "build:linux:x64": [
     ["linux", "x64"],
   ],
   "build:all": [

--- a/test/assert-packaged-sidecar.test.js
+++ b/test/assert-packaged-sidecar.test.js
@@ -11,6 +11,7 @@ const {
   defaultLayout,
   inspectPackagedSidecar,
   normalizeDarwinCodeSignature,
+  normalizeMachOSignaturePayload,
   parseArgs,
 } = require("../scripts/assert-packaged-sidecar");
 const {
@@ -45,6 +46,21 @@ function machoBuffer(cpuType, marker = 0) {
   buffer.writeUInt32BE(0xfeedfacf, 0);
   buffer.writeUInt32BE(cpuType, 4);
   buffer.writeUInt8(marker, 127);
+  return buffer;
+}
+
+function signedMachoBuffer(cpuType, signatureBytes, signatureMarker) {
+  const buffer = Buffer.alloc(128 + signatureBytes, signatureMarker);
+  buffer.fill(0, 0, 128);
+  buffer.writeUInt32BE(0xfeedfacf, 0);
+  buffer.writeUInt32BE(cpuType, 4);
+  buffer.writeUInt32BE(1, 16);
+  buffer.writeUInt32BE(16, 20);
+  buffer.writeUInt32BE(0x1d, 32);
+  buffer.writeUInt32BE(16, 36);
+  buffer.writeUInt32BE(128, 40);
+  buffer.writeUInt32BE(signatureBytes, 44);
+  buffer.writeUInt8(7, 100);
   return buffer;
 }
 
@@ -189,9 +205,9 @@ test("packaged sidecar assertion rejects checksum and native architecture mismat
   }
 });
 
-test("Darwin packages accept only a signed copy matching the pinned source after signature removal", () => {
-  const packagedContents = machoBuffer(0x0100000c, 2);
-  const sourceContents = machoBuffer(0x0100000c, 1);
+test("Darwin packages accept only a signed copy matching the pinned source outside the bounded signature payload", () => {
+  const packagedContents = signedMachoBuffer(0x0100000c, 33, 2);
+  const sourceContents = signedMachoBuffer(0x0100000c, 56, 1);
   const item = fixture("darwin-arm64", packagedContents);
   const sourcePath = path.join(
     item.root,
@@ -202,8 +218,6 @@ test("Darwin packages accept only a signed copy matching the pinned source after
   );
   fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
   fs.writeFileSync(sourcePath, sourceContents);
-  const normalizedContents = machoBuffer(0x0100000c);
-  const normalizedCalls = [];
   try {
     const result = inspectPackagedSidecar({
       target: item.target.dir,
@@ -216,54 +230,46 @@ test("Darwin packages accept only a signed copy matching the pinned source after
         [binaryChecksumName(item.target)]: sha256(sourceContents),
       },
       hostPlatform: "win32",
-      normalizeDarwinBinary(filePath, options) {
-        normalizedCalls.push([filePath, options.role, options.requireSignature]);
-        return {
-          ok: true,
-          buffer: normalizedContents,
-          signed: options.role === "packaged",
-        };
+      normalizeDarwinBinary: normalizeDarwinCodeSignature,
+      spawnSync() {
+        return { status: 0, stdout: "", stderr: "" };
       },
     });
     assert.strictEqual(result.ok, true);
     assert.strictEqual(result.manifest.sidecar.expectedSha256, sha256(sourceContents));
     assert.strictEqual(result.manifest.sidecar.checksumMode, "codesign-normalized");
-    assert.strictEqual(result.manifest.sidecar.normalizedSha256, sha256(normalizedContents));
-    assert.strictEqual(result.manifest.sidecar.sourceSigned, false);
+    assert.strictEqual(
+      result.manifest.sidecar.normalizedSha256,
+      sha256(normalizeMachOSignaturePayload(sourceContents).buffer),
+    );
+    assert.strictEqual(result.manifest.sidecar.sourceSigned, true);
     assert.strictEqual(result.manifest.sidecar.packagedSigned, true);
-    assert.deepStrictEqual(normalizedCalls, [
-      [sourcePath, "source", false],
-      [item.binaryPath, "packaged", true],
-    ]);
+    assert.strictEqual(result.manifest.sidecar.sourceSignatureBytes, 56);
+    assert.strictEqual(result.manifest.sidecar.packagedSignatureBytes, 33);
   } finally {
     removeFixture(item);
   }
 });
 
-test("Darwin signature normalization verifies before stripping and rejects an unsigned package", () => {
+test("Darwin signature normalization verifies before excluding signature bytes and rejects an unsigned package", () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-codesign-normalize-"));
   const signedPath = path.join(root, "cc-connect-clawd");
-  const signedContents = machoBuffer(0x0100000c, 2);
-  const normalizedContents = machoBuffer(0x0100000c);
+  const signedContents = signedMachoBuffer(0x0100000c, 33, 2);
   fs.writeFileSync(signedPath, signedContents);
   const calls = [];
   try {
     const normalized = normalizeDarwinCodeSignature(signedPath, {
       spawnSync(command, args) {
         calls.push([command, ...args]);
-        if (args[0] === "--verify") return { status: 0, stdout: "", stderr: "" };
-        fs.writeFileSync(args[1], normalizedContents);
         return { status: 0, stdout: "", stderr: "" };
       },
       requireSignature: true,
     });
     assert.strictEqual(normalized.ok, true);
     assert.strictEqual(normalized.signed, true);
-    assert.deepStrictEqual(normalized.buffer, normalizedContents);
-    assert.deepStrictEqual(calls.map((call) => call.slice(0, 3)), [
-      ["codesign", "--verify", "--strict"],
-      ["codesign", "--remove-signature", calls[1][2]],
-    ]);
+    assert.strictEqual(normalized.signatureBytes, 33);
+    assert.strictEqual(normalized.buffer.length, 128);
+    assert.deepStrictEqual(calls, [["codesign", "--verify", "--strict", signedPath]]);
 
     const rejected = normalizeDarwinCodeSignature(signedPath, {
       spawnSync() {
@@ -276,6 +282,29 @@ test("Darwin signature normalization verifies before stripping and rejects an un
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }
+});
+
+test("Mach-O normalization excludes only the declared final signature payload", () => {
+  const first = signedMachoBuffer(0x0100000c, 56, 1);
+  const resigned = signedMachoBuffer(0x0100000c, 33, 2);
+  const firstNormalized = normalizeMachOSignaturePayload(first);
+  const resignedNormalized = normalizeMachOSignaturePayload(resigned);
+  assert.strictEqual(firstNormalized.ok, true);
+  assert.strictEqual(resignedNormalized.ok, true);
+  assert.deepStrictEqual(firstNormalized.buffer, resignedNormalized.buffer);
+
+  const changedPayload = Buffer.from(resigned);
+  changedPayload.writeUInt8(8, 100);
+  assert.notDeepStrictEqual(
+    firstNormalized.buffer,
+    normalizeMachOSignaturePayload(changedPayload).buffer,
+    "non-signature payload changes must remain visible",
+  );
+  const trailingBytes = Buffer.concat([resigned, Buffer.from([0])]);
+  assert.deepStrictEqual(normalizeMachOSignaturePayload(trailingBytes), {
+    ok: false,
+    error: "Mach-O code signature is not the final bounded payload",
+  });
 });
 
 test("packaged sidecar assertion checks executable mode on POSIX package runners", () => {

--- a/test/assert-packaged-sidecar.test.js
+++ b/test/assert-packaged-sidecar.test.js
@@ -1,0 +1,231 @@
+"use strict";
+
+const assert = require("node:assert");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  defaultLayout,
+  inspectPackagedSidecar,
+  parseArgs,
+} = require("../scripts/assert-packaged-sidecar");
+const {
+  binaryChecksumName,
+  TARGETS,
+} = require("../scripts/fetch-sidecar-binaries");
+
+function sha256(buffer) {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+function peBuffer(machine) {
+  const buffer = Buffer.alloc(128);
+  buffer.write("MZ", 0, "ascii");
+  buffer.writeUInt32LE(64, 0x3c);
+  buffer.write("PE\0\0", 64, "ascii");
+  buffer.writeUInt16LE(machine, 68);
+  return buffer;
+}
+
+function elfBuffer(machine) {
+  const buffer = Buffer.alloc(128);
+  buffer[0] = 0x7f;
+  buffer.write("ELF", 1, "ascii");
+  buffer[5] = 1;
+  buffer.writeUInt16LE(machine, 18);
+  return buffer;
+}
+
+function fixture(targetName, contents) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-packaged-sidecar-"));
+  const resourcesRoot = path.join(root, "resources");
+  const target = TARGETS.find((item) => item.dir === targetName);
+  const binaryPath = path.join(
+    resourcesRoot,
+    "sidecars",
+    "cc-connect-clawd",
+    target.dir,
+    target.exe,
+  );
+  fs.mkdirSync(path.dirname(binaryPath), { recursive: true });
+  fs.writeFileSync(binaryPath, contents);
+  return {
+    root,
+    resourcesRoot,
+    target,
+    binaryPath,
+    checksums: {
+      [binaryChecksumName(target)]: sha256(contents),
+    },
+  };
+}
+
+function removeFixture(item) {
+  fs.rmSync(item.root, { recursive: true, force: true });
+}
+
+test("default layouts cover all five release targets with target-specific unpacked roots", () => {
+  const pkg = require("../package.json");
+  const targets = [
+    "windows-x64",
+    "windows-arm64",
+    "darwin-x64",
+    "darwin-arm64",
+    "linux-x64",
+  ];
+  assert.deepStrictEqual(
+    targets.map((target) => [target, defaultLayout(target, pkg).resourcesRoot]),
+    [
+      ["windows-x64", path.join("dist", "win-unpacked", "resources")],
+      ["windows-arm64", path.join("dist", "win-arm64-unpacked", "resources")],
+      ["darwin-x64", path.join("dist", "mac", "Clawd on Desk.app", "Contents", "Resources")],
+      ["darwin-arm64", path.join("dist", "mac-arm64", "Clawd on Desk.app", "Contents", "Resources")],
+      ["linux-x64", path.join("dist", "linux-unpacked", "resources")],
+    ],
+  );
+});
+
+test("packaged sidecar assertion emits a deterministic manifest for the one expected target", () => {
+  const item = fixture("windows-x64", peBuffer(0x8664));
+  try {
+    const options = {
+      target: item.target.dir,
+      repoRoot: item.root,
+      packageJson: { version: "test" },
+      resourcesRoot: item.resourcesRoot,
+      resourcesLabel: "package/resources",
+      artifacts: [],
+      checksums: item.checksums,
+      hostPlatform: "win32",
+    };
+    const first = inspectPackagedSidecar(options);
+    const second = inspectPackagedSidecar(options);
+    assert.strictEqual(first.ok, true);
+    assert.deepStrictEqual(first, second);
+    assert.deepStrictEqual(first.manifest.sidecar.files.map((file) => file.path), [
+      "windows-x64/cc-connect-clawd.exe",
+    ]);
+    assert.deepStrictEqual(first.manifest.sidecar.native, {
+      os: "windows",
+      arch: "x64",
+      format: "pe",
+    });
+  } finally {
+    removeFixture(item);
+  }
+});
+
+test("packaged sidecar assertion rejects additional target payloads", () => {
+  const item = fixture("windows-x64", peBuffer(0x8664));
+  try {
+    const foreignPath = path.join(
+      item.resourcesRoot,
+      "sidecars",
+      "cc-connect-clawd",
+      "windows-arm64",
+      "cc-connect-clawd.exe",
+    );
+    fs.mkdirSync(path.dirname(foreignPath), { recursive: true });
+    fs.writeFileSync(foreignPath, peBuffer(0xaa64));
+    const result = inspectPackagedSidecar({
+      target: item.target.dir,
+      repoRoot: item.root,
+      packageJson: { version: "test" },
+      resourcesRoot: item.resourcesRoot,
+      resourcesLabel: "package/resources",
+      artifacts: [],
+      checksums: item.checksums,
+      hostPlatform: "win32",
+    });
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some((message) => message.includes("must equal")));
+    assert.deepStrictEqual(result.manifest.sidecar.files.map((file) => file.path), [
+      "windows-arm64/cc-connect-clawd.exe",
+      "windows-x64/cc-connect-clawd.exe",
+    ]);
+  } finally {
+    removeFixture(item);
+  }
+});
+
+test("packaged sidecar assertion rejects checksum and native architecture mismatches", () => {
+  const item = fixture("windows-x64", peBuffer(0xaa64));
+  try {
+    const result = inspectPackagedSidecar({
+      target: item.target.dir,
+      repoRoot: item.root,
+      packageJson: { version: "test" },
+      resourcesRoot: item.resourcesRoot,
+      resourcesLabel: "package/resources",
+      artifacts: [],
+      checksums: {
+        [binaryChecksumName(item.target)]: "0".repeat(64),
+      },
+      hostPlatform: "win32",
+    });
+    assert.strictEqual(result.ok, false);
+    assert.ok(result.errors.some((message) => message.includes("checksum mismatch")));
+    assert.ok(result.errors.some((message) => message.includes("native target mismatch")));
+  } finally {
+    removeFixture(item);
+  }
+});
+
+test("packaged sidecar assertion checks executable mode on POSIX package runners", () => {
+  const item = fixture("linux-x64", elfBuffer(62));
+  try {
+    const fsWithoutExecutableBit = {
+      existsSync: fs.existsSync.bind(fs),
+      readFileSync: fs.readFileSync.bind(fs),
+      readdirSync: fs.readdirSync.bind(fs),
+      statSync(filePath) {
+        const stat = fs.statSync(filePath);
+        if (path.resolve(filePath) !== path.resolve(item.binaryPath)) return stat;
+        return {
+          ...stat,
+          mode: stat.mode & ~0o111,
+          isDirectory: () => stat.isDirectory(),
+          isFile: () => stat.isFile(),
+        };
+      },
+    };
+    const result = inspectPackagedSidecar({
+      target: item.target.dir,
+      repoRoot: item.root,
+      packageJson: { version: "test" },
+      resourcesRoot: item.resourcesRoot,
+      resourcesLabel: "package/resources",
+      artifacts: [],
+      checksums: item.checksums,
+      hostPlatform: "linux",
+      fs: fsWithoutExecutableBit,
+    });
+    assert.strictEqual(result.ok, false);
+    assert.strictEqual(result.manifest.sidecar.executableChecked, true);
+    assert.strictEqual(result.manifest.sidecar.executable, false);
+    assert.ok(result.errors.some((message) => message.includes("executable mode bit")));
+  } finally {
+    removeFixture(item);
+  }
+});
+
+test("CLI parser supports explicit package paths and rejects a missing target", () => {
+  assert.deepStrictEqual(
+    parseArgs([
+      "--target", "windows-x64",
+      "--resources-root", "dist/custom/resources",
+      "--artifact", "dist/custom.exe",
+      "--output", "dist/custom.json",
+    ]),
+    {
+      target: "windows-x64",
+      resourcesRoot: "dist/custom/resources",
+      artifacts: ["dist/custom.exe"],
+      output: "dist/custom.json",
+    },
+  );
+  assert.throws(() => parseArgs([]), /--target is required/);
+});

--- a/test/assert-packaged-sidecar.test.js
+++ b/test/assert-packaged-sidecar.test.js
@@ -10,6 +10,7 @@ const test = require("node:test");
 const {
   defaultLayout,
   inspectPackagedSidecar,
+  normalizeDarwinCodeSignature,
   parseArgs,
 } = require("../scripts/assert-packaged-sidecar");
 const {
@@ -36,6 +37,14 @@ function elfBuffer(machine) {
   buffer.write("ELF", 1, "ascii");
   buffer[5] = 1;
   buffer.writeUInt16LE(machine, 18);
+  return buffer;
+}
+
+function machoBuffer(cpuType, marker = 0) {
+  const buffer = Buffer.alloc(128);
+  buffer.writeUInt32BE(0xfeedfacf, 0);
+  buffer.writeUInt32BE(cpuType, 4);
+  buffer.writeUInt8(marker, 127);
   return buffer;
 }
 
@@ -86,6 +95,10 @@ test("default layouts cover all five release targets with target-specific unpack
       ["linux-x64", path.join("dist", "linux-unpacked", "resources")],
     ],
   );
+  assert.deepStrictEqual(defaultLayout("linux-x64", pkg).artifacts, [
+    path.join("dist", `Clawd-on-Desk-${pkg.version}-x86_64.AppImage`),
+    path.join("dist", `Clawd-on-Desk-${pkg.version}-amd64.deb`),
+  ]);
 });
 
 test("packaged sidecar assertion emits a deterministic manifest for the one expected target", () => {
@@ -113,6 +126,8 @@ test("packaged sidecar assertion emits a deterministic manifest for the one expe
       arch: "x64",
       format: "pe",
     });
+    assert.strictEqual(first.manifest.sidecar.expectedSha256, item.checksums[binaryChecksumName(item.target)]);
+    assert.strictEqual(first.manifest.sidecar.checksumMode, "exact");
   } finally {
     removeFixture(item);
   }
@@ -171,6 +186,95 @@ test("packaged sidecar assertion rejects checksum and native architecture mismat
     assert.ok(result.errors.some((message) => message.includes("native target mismatch")));
   } finally {
     removeFixture(item);
+  }
+});
+
+test("Darwin packages accept only a signed copy matching the pinned source after signature removal", () => {
+  const packagedContents = machoBuffer(0x0100000c, 2);
+  const sourceContents = machoBuffer(0x0100000c, 1);
+  const item = fixture("darwin-arm64", packagedContents);
+  const sourcePath = path.join(
+    item.root,
+    "bin",
+    "cc-connect-clawd",
+    item.target.dir,
+    item.target.exe,
+  );
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+  fs.writeFileSync(sourcePath, sourceContents);
+  const normalizedContents = machoBuffer(0x0100000c);
+  const normalizedCalls = [];
+  try {
+    const result = inspectPackagedSidecar({
+      target: item.target.dir,
+      repoRoot: item.root,
+      packageJson: { version: "test" },
+      resourcesRoot: item.resourcesRoot,
+      resourcesLabel: "package/resources",
+      artifacts: [],
+      checksums: {
+        [binaryChecksumName(item.target)]: sha256(sourceContents),
+      },
+      hostPlatform: "win32",
+      normalizeDarwinBinary(filePath, options) {
+        normalizedCalls.push([filePath, options.role, options.requireSignature]);
+        return {
+          ok: true,
+          buffer: normalizedContents,
+          signed: options.role === "packaged",
+        };
+      },
+    });
+    assert.strictEqual(result.ok, true);
+    assert.strictEqual(result.manifest.sidecar.expectedSha256, sha256(sourceContents));
+    assert.strictEqual(result.manifest.sidecar.checksumMode, "codesign-normalized");
+    assert.strictEqual(result.manifest.sidecar.normalizedSha256, sha256(normalizedContents));
+    assert.strictEqual(result.manifest.sidecar.sourceSigned, false);
+    assert.strictEqual(result.manifest.sidecar.packagedSigned, true);
+    assert.deepStrictEqual(normalizedCalls, [
+      [sourcePath, "source", false],
+      [item.binaryPath, "packaged", true],
+    ]);
+  } finally {
+    removeFixture(item);
+  }
+});
+
+test("Darwin signature normalization verifies before stripping and rejects an unsigned package", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-codesign-normalize-"));
+  const signedPath = path.join(root, "cc-connect-clawd");
+  const signedContents = machoBuffer(0x0100000c, 2);
+  const normalizedContents = machoBuffer(0x0100000c);
+  fs.writeFileSync(signedPath, signedContents);
+  const calls = [];
+  try {
+    const normalized = normalizeDarwinCodeSignature(signedPath, {
+      spawnSync(command, args) {
+        calls.push([command, ...args]);
+        if (args[0] === "--verify") return { status: 0, stdout: "", stderr: "" };
+        fs.writeFileSync(args[1], normalizedContents);
+        return { status: 0, stdout: "", stderr: "" };
+      },
+      requireSignature: true,
+    });
+    assert.strictEqual(normalized.ok, true);
+    assert.strictEqual(normalized.signed, true);
+    assert.deepStrictEqual(normalized.buffer, normalizedContents);
+    assert.deepStrictEqual(calls.map((call) => call.slice(0, 3)), [
+      ["codesign", "--verify", "--strict"],
+      ["codesign", "--remove-signature", calls[1][2]],
+    ]);
+
+    const rejected = normalizeDarwinCodeSignature(signedPath, {
+      spawnSync() {
+        return { status: 1, stdout: "", stderr: "code object is not signed at all" };
+      },
+      requireSignature: true,
+    });
+    assert.strictEqual(rejected.ok, false);
+    assert.match(rejected.error, /codesign verification failed/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/test/assert-packaged-sidecar.test.js
+++ b/test/assert-packaged-sidecar.test.js
@@ -54,13 +54,19 @@ function signedMachoBuffer(cpuType, signatureBytes, signatureMarker) {
   buffer.fill(0, 0, 128);
   buffer.writeUInt32BE(0xfeedfacf, 0);
   buffer.writeUInt32BE(cpuType, 4);
-  buffer.writeUInt32BE(1, 16);
-  buffer.writeUInt32BE(16, 20);
-  buffer.writeUInt32BE(0x1d, 32);
-  buffer.writeUInt32BE(16, 36);
-  buffer.writeUInt32BE(128, 40);
-  buffer.writeUInt32BE(signatureBytes, 44);
-  buffer.writeUInt8(7, 100);
+  buffer.writeUInt32BE(2, 16);
+  buffer.writeUInt32BE(88, 20);
+  buffer.writeUInt32BE(0x19, 32);
+  buffer.writeUInt32BE(72, 36);
+  buffer.write("__LINKEDIT", 40, "ascii");
+  buffer.writeBigUInt64BE(BigInt(8 + signatureBytes), 64);
+  buffer.writeBigUInt64BE(120n, 72);
+  buffer.writeBigUInt64BE(BigInt(8 + signatureBytes), 80);
+  buffer.writeUInt32BE(0x1d, 104);
+  buffer.writeUInt32BE(16, 108);
+  buffer.writeUInt32BE(128, 112);
+  buffer.writeUInt32BE(signatureBytes, 116);
+  buffer.writeUInt8(7, 124);
   return buffer;
 }
 
@@ -246,6 +252,10 @@ test("Darwin packages accept only a signed copy matching the pinned source outsi
     assert.strictEqual(result.manifest.sidecar.packagedSigned, true);
     assert.strictEqual(result.manifest.sidecar.sourceSignatureBytes, 56);
     assert.strictEqual(result.manifest.sidecar.packagedSignatureBytes, 33);
+    assert.strictEqual(result.manifest.sidecar.sourceSignatureOffset, 128);
+    assert.strictEqual(result.manifest.sidecar.packagedSignatureOffset, 128);
+    assert.strictEqual(result.manifest.sidecar.sourceLinkeditBytes, 64);
+    assert.strictEqual(result.manifest.sidecar.packagedLinkeditBytes, 41);
   } finally {
     removeFixture(item);
   }
@@ -268,6 +278,7 @@ test("Darwin signature normalization verifies before excluding signature bytes a
     assert.strictEqual(normalized.ok, true);
     assert.strictEqual(normalized.signed, true);
     assert.strictEqual(normalized.signatureBytes, 33);
+    assert.strictEqual(normalized.linkeditFileBytes, 41);
     assert.strictEqual(normalized.buffer.length, 128);
     assert.deepStrictEqual(calls, [["codesign", "--verify", "--strict", signedPath]]);
 

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -266,15 +266,47 @@ describe("package build config", () => {
       assert.match(pkg.scripts.start, /node scripts\/ensure-sidecar-binaries\.js && node launch\.js/);
     });
 
-    it("copies cc-connect-clawd sidecars into packaged resources", () => {
-      const extra = pkg.build.extraResources || [];
-      const copied = extra.some(
-        (e) => e && e.from === "bin/cc-connect-clawd" && e.to === "sidecars/cc-connect-clawd"
+    it("does not copy the whole cc-connect-clawd workspace into every artifact", () => {
+      const commonExtra = pkg.build.extraResources || [];
+      assert.strictEqual(
+        commonExtra.some((entry) => entry && entry.from === "bin/cc-connect-clawd"),
+        false,
+        "common build.extraResources must not copy the whole sidecar workspace"
       );
-      assert.ok(
-        copied,
-        "build.extraResources must copy bin/cc-connect-clawd -> sidecars/cc-connect-clawd"
+    });
+
+    it("copies exactly the current platform and architecture sidecar via ${arch}", () => {
+      const expected = {
+        win: {
+          from: "bin/cc-connect-clawd/windows-${arch}",
+          to: "sidecars/cc-connect-clawd/windows-${arch}",
+        },
+        mac: {
+          from: "bin/cc-connect-clawd/darwin-${arch}",
+          to: "sidecars/cc-connect-clawd/darwin-${arch}",
+        },
+        linux: {
+          from: "bin/cc-connect-clawd/linux-${arch}",
+          to: "sidecars/cc-connect-clawd/linux-${arch}",
+        },
+      };
+      for (const [platform, entry] of Object.entries(expected)) {
+        assert.deepStrictEqual(
+          pkg.build[platform] && pkg.build[platform].extraResources,
+          [entry],
+          `${platform}.extraResources must copy only its current \${arch} sidecar`
+        );
+      }
+    });
+
+    it("exposes build and package assertion commands for all five targets", () => {
+      assert.strictEqual(
+        pkg.scripts["assert:packaged-sidecar"],
+        "node scripts/assert-packaged-sidecar.js"
       );
+      assert.strictEqual(pkg.scripts["build:mac:x64"], "electron-builder --mac dmg:x64");
+      assert.strictEqual(pkg.scripts["build:mac:arm64"], "electron-builder --mac dmg:arm64");
+      assert.strictEqual(pkg.scripts["build:linux:x64"], "electron-builder --linux AppImage:x64 deb:x64");
     });
 
     it("documents the expected sidecar binary names in the README", () => {
@@ -306,6 +338,44 @@ describe("package build config", () => {
         "node scripts/verify-sidecar-binaries.js prebuild:linux",
         "npx electron-builder --linux --publish never"
       );
+    });
+
+    it("asserts all five unpacked package targets after release builds", () => {
+      const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
+      for (const target of [
+        "windows-x64",
+        "windows-arm64",
+        "darwin-x64",
+        "darwin-arm64",
+        "linux-x64",
+      ]) {
+        assert.match(
+          workflow,
+          new RegExp(`npm run assert:packaged-sidecar -- --target ${target}`),
+          `release workflow should assert ${target}`
+        );
+      }
+    });
+
+    it("builds and uploads all five target artifacts in pull-request CI", () => {
+      const workflowPath = path.join(ROOT, ".github", "workflows", "sidecar-package-audit.yml");
+      assert.ok(fs.existsSync(workflowPath), "sidecar package audit workflow should exist");
+      const workflow = fs.readFileSync(workflowPath, "utf8");
+      assert.match(workflow, /pull_request:/);
+      for (const target of [
+        "windows-x64",
+        "windows-arm64",
+        "darwin-x64",
+        "darwin-arm64",
+        "linux-x64",
+      ]) {
+        assert.match(workflow, new RegExp(`target: ${target}`));
+        assert.match(
+          workflow,
+          new RegExp(`sidecar-package-\\$\\{\\{ matrix\\.target \\}\\}`),
+          "five-target CI should upload target-specific artifacts and manifests"
+        );
+      }
     });
 
     it("publishes GitHub releases only for version tags", () => {

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -357,6 +357,30 @@ describe("package build config", () => {
       }
     });
 
+    it("keeps full tag tests while allowing a manual packaging-only evidence run", () => {
+      const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
+      assert.match(workflow, /artifact_validation_only:/);
+      assert.strictEqual(
+        (workflow.match(/github\.event_name != 'workflow_dispatch' \|\| !inputs\.artifact_validation_only/g) || []).length,
+        1,
+        "the Windows release job must keep npm test for tag pushes and normal manual runs"
+      );
+      assert.strictEqual(
+        (workflow.match(/github\.event_name == 'workflow_dispatch' && inputs\.artifact_validation_only/g) || []).length,
+        1,
+        "only the Windows job should substitute the package-validation tests in evidence mode"
+      );
+      assert.strictEqual(
+        (workflow.match(/node --test test\/assert-packaged-sidecar\.test\.js test\/package-build-config\.test\.js test\/telegram-approval-sidecar\.test\.js test\/verify-sidecar-binaries\.test\.js/g) || []).length,
+        1
+      );
+      assert.strictEqual(
+        (workflow.match(/      - run: npm test/g) || []).length,
+        3,
+        "Windows, macOS, and Linux release jobs must all retain their npm test step"
+      );
+    });
+
     it("builds and uploads all five target artifacts in pull-request CI", () => {
       const workflowPath = path.join(ROOT, ".github", "workflows", "sidecar-package-audit.yml");
       assert.ok(fs.existsSync(workflowPath), "sidecar package audit workflow should exist");
@@ -376,6 +400,8 @@ describe("package build config", () => {
           "five-target CI should upload target-specific artifacts and manifests"
         );
       }
+      assert.match(workflow, /Clawd-on-Desk-\*-x86_64\.AppImage/);
+      assert.match(workflow, /Clawd-on-Desk-\*-amd64\.deb/);
     });
 
     it("publishes GitHub releases only for version tags", () => {

--- a/test/verify-sidecar-binaries.test.js
+++ b/test/verify-sidecar-binaries.test.js
@@ -38,6 +38,15 @@ test("getRequiredSidecarsForLifecycle maps configured build targets", () => {
     { platform: "darwin", arch: "x64" },
     { platform: "darwin", arch: "arm64" },
   ]);
+  assert.deepEqual(getRequiredSidecarsForLifecycle("prebuild:mac:x64"), [
+    { platform: "darwin", arch: "x64" },
+  ]);
+  assert.deepEqual(getRequiredSidecarsForLifecycle("prebuild:mac:arm64"), [
+    { platform: "darwin", arch: "arm64" },
+  ]);
+  assert.deepEqual(getRequiredSidecarsForLifecycle("prebuild:linux:x64"), [
+    { platform: "linux", arch: "x64" },
+  ]);
 });
 
 test("sidecarBinaryPath uses resolver-compatible binary names", () => {
@@ -89,7 +98,10 @@ test("package build scripts use the sidecar verification command", () => {
     "prebuild:win:arm64",
     "prebuild:win:all",
     "prebuild:mac",
+    "prebuild:mac:x64",
+    "prebuild:mac:arm64",
     "prebuild:linux",
+    "prebuild:linux:x64",
     "prebuild:all",
   ]) {
     assert.equal(pkg.scripts[name], VERIFY_COMMAND, `${name} should verify bundled sidecars before packaging`);


### PR DESCRIPTION
## Summary

- move cc-connect-clawd from common whole-directory extraResources to platform-specific ${arch} entries
- hard-fail after packaging unless the sidecar subtree contains exactly the current target binary with the pinned checksum and native architecture
- verify POSIX executable mode and signed macOS payloads
- build and retain temporary CI evidence for Windows x64/ARM64, macOS x64/ARM64, and Linux x64
- keep the legacy Telegram runtime and source/download layout unchanged

## Windows before/after evidence

| Target | Installer before | Installer after | Delta | Unpacked before | Unpacked after | Sidecar files |
|---|---:|---:|---:|---:|---:|---|
| windows-x64 | 141,663,929 | 132,232,642 | -9,431,287 | 529,608,458 | 499,717,900 | 6 -> 1 |
| windows-arm64 | 143,123,497 | 133,437,353 | -9,686,144 | 529,064,762 | 498,476,348 | 6 -> 1 |

The full package path-set comparison removed only README.md plus the four non-target sidecars from each Windows artifact; it added no paths.

## Audit scope

The PR B hard assertion intentionally audits
esources/sidecars/cc-connect-clawd/**. A separate full-tree audit also found Koffi's bundled multi-platform native payloads and electron-builder's intentional ia32
esources/elevate.exe; those are not silently exempted or removed here and will be tracked separately.

## Validation

- focused package/config/runtime/checksum tests: 68/68 pass
- real Windows x64 and ARM64 NSIS builds: pass
- packaged sidecar assertions: both pass, 1 file each, pinned SHA256 and target PE arch
- sidecar-scoped repository audits: 0 errors / 0 warnings for both Windows targets
- npm test: 6,309 total / 6,276 pass / 13 known Windows Remote SSH baseline failures / 20 skip; no new failures
- git diff --check

No tag is created and this PR does not publish a release or delete legacy assets/runtime.


## Five-target PR CI evidence

Run 30326248145 built all five targets without a tag or release:

| Target | Artifact bytes | Resources bytes | Sidecar bytes | Result |
|---|---:|---:|---:|---|
| windows-x64 | 132,232,643 | 138,506,830 | 7,824,896 | PASS |
| windows-arm64 | 133,437,353 | 137,808,974 | 7,127,040 | PASS |
| darwin-x64 | 163,222,920 | 139,878,256 | 7,817,744 | PASS |
| darwin-arm64 | 157,474,529 | 139,348,674 | 7,288,162 | PASS |
| linux-x64 | AppImage 159,779,467; deb 123,686,164 | 137,803,803 | 7,655,586 | PASS |

Every sidecar manifest contains exactly one target binary. Every sidecar-scoped extracted audit reports 0 errors / 0 warnings. The POSIX jobs also enforce executable mode. Historical v0.13.0 release asset sizes are only a cross-reference, not a same-commit baseline; exact same-commit before/after data above is limited to the two locally reproducible Windows targets.

The Koffi/elevate full-package follow-up is tracked in #763.
