### PR TITLE
fix(focus): match cmux workspaces by workspaceId so session focus reaches the right workspace

### DIFF
--- a/src/focus.js
+++ b/src/focus.js
@@ -1243,10 +1243,7 @@ function findCmuxPanelMatch(sessionData, ttyName) {
     const tm = win?.tabManager;
     if (!tm) continue;
     for (const ws of tm.workspaces ?? []) {
-      // cmux persists the workspace UUID as `workspaceId`; older payloads used `id`.
-      const workspaceId = typeof ws?.workspaceId === "string" ? ws.workspaceId
-        : typeof ws?.id === "string" ? ws.id
-        : null;
+      const workspaceId = typeof ws?.workspaceId === "string" ? ws.workspaceId : null;
       if (!workspaceId) continue;
       for (const p of ws.panels ?? []) {
         if (p?.ttyName === ttyName && typeof p.id === "string" && p.id) {

--- a/src/focus.js
+++ b/src/focus.js
@@ -1243,7 +1243,10 @@ function findCmuxPanelMatch(sessionData, ttyName) {
     const tm = win?.tabManager;
     if (!tm) continue;
     for (const ws of tm.workspaces ?? []) {
-      const workspaceId = typeof ws?.id === "string" ? ws.id : null;
+      // cmux persists the workspace UUID as `workspaceId`; older payloads used `id`.
+      const workspaceId = typeof ws?.workspaceId === "string" ? ws.workspaceId
+        : typeof ws?.id === "string" ? ws.id
+        : null;
       if (!workspaceId) continue;
       for (const p of ws.panels ?? []) {
         if (p?.ttyName === ttyName && typeof p.id === "string" && p.id) {

--- a/test/focus-cmux.test.js
+++ b/test/focus-cmux.test.js
@@ -55,7 +55,7 @@ describe("cmux panel focus (macOS)", () => {
   it("should call cmux focus-panel with matched panel UUID", (t, done) => {
     const panelId = "18AA1EB5-3055-445C-B780-60C88B21341B";
     const { tmpDir, cleanup: cleanupFile } = writeMockSessionFile([{
-      id: "ws-uuid-1",
+      workspaceId: "ws-uuid-1",
       panels: [{ id: panelId, ttyName: "ttys007", type: "terminal" }]
     }]);
     const origHome = process.env.HOME;
@@ -106,12 +106,59 @@ describe("cmux panel focus (macOS)", () => {
     }, 2500);
   });
 
+  // Legacy session payloads keyed the workspace UUID as `id` instead of `workspaceId`.
+  it("should still match workspaces from legacy `id` session payloads", (t, done) => {
+    const panelId = "9C1D2E3F-4A5B-6C7D-8E9F-0A1B2C3D4E5F";
+    const { tmpDir, cleanup: cleanupFile } = writeMockSessionFile([{
+      id: "legacy-ws-uuid",
+      panels: [{ id: panelId, ttyName: "ttys007", type: "terminal" }]
+    }]);
+    const origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+
+    const calls = [];
+    const mock = function (cmd, args, opts, cb) {
+      if (typeof opts === "function") { cb = opts; opts = {}; }
+      calls.push({ cmd, args: [...args] });
+      if (cmd === "osascript") { if (cb) cb(null, "", ""); return; }
+      if (cmd === "ps") {
+        const a = args.join(" ");
+        if (a.includes("comm=")) {
+          if (cb) cb(null, "501 /bin/zsh\n502 /Applications/cmux.app/Contents/MacOS/cmux\n", "");
+          return;
+        }
+        if (a.includes("tty=")) {
+          if (cb) cb(null, "501 ttys007\n", "");
+          return;
+        }
+      }
+      if (cb) cb(null, "", "");
+    };
+
+    const { initFocus, cleanup } = loadFocusWithMock(mock);
+    const { focusTerminalWindow } = initFocus({});
+    focusTerminalWindow(501, "/test/cwd", null, [501, 502]);
+
+    setTimeout(() => {
+      cleanup();
+      cleanupFile();
+      process.env.HOME = origHome;
+
+      const panelCall = calls.find(c => c.cmd === CMUX_BIN && c.args.includes("focus-panel"));
+      assert.ok(panelCall, "Should still focus a panel for legacy `id` payloads");
+      const workspaceArgIdx = panelCall.args.indexOf("--workspace");
+      assert.strictEqual(panelCall.args[workspaceArgIdx + 1], "legacy-ws-uuid", "Should fall back to the legacy `id` key");
+
+      done();
+    }, 2500);
+  });
+
   // TDD Red 2: fallback to select-workspace when focus-panel fails
   it("should call cmux select-workspace when focus-panel fails", (t, done) => {
     const panelId = "18AA1EB5-3055-445C-B780-60C88B21341B";
     const workspaceId = "ws-uuid-1";
     const { tmpDir, cleanup: cleanupFile } = writeMockSessionFile([{
-      id: workspaceId,
+      workspaceId,
       panels: [{ id: panelId, ttyName: "ttys007", type: "terminal" }]
     }]);
     const origHome = process.env.HOME;
@@ -164,7 +211,7 @@ describe("cmux panel focus (macOS)", () => {
     const panel2Id = "panel-id-2";
     const matchedTty = "ttys003";
     const { tmpDir, cleanup: cleanupFile } = writeMockSessionFile([{
-      id: "ws-split",
+      workspaceId: "ws-split",
       panels: [
         { id: panel1Id, ttyName: "ttys001", type: "terminal" },
         { id: panel2Id, ttyName: matchedTty, type: "terminal" }

--- a/test/focus-cmux.test.js
+++ b/test/focus-cmux.test.js
@@ -106,53 +106,6 @@ describe("cmux panel focus (macOS)", () => {
     }, 2500);
   });
 
-  // Legacy session payloads keyed the workspace UUID as `id` instead of `workspaceId`.
-  it("should still match workspaces from legacy `id` session payloads", (t, done) => {
-    const panelId = "9C1D2E3F-4A5B-6C7D-8E9F-0A1B2C3D4E5F";
-    const { tmpDir, cleanup: cleanupFile } = writeMockSessionFile([{
-      id: "legacy-ws-uuid",
-      panels: [{ id: panelId, ttyName: "ttys007", type: "terminal" }]
-    }]);
-    const origHome = process.env.HOME;
-    process.env.HOME = tmpDir;
-
-    const calls = [];
-    const mock = function (cmd, args, opts, cb) {
-      if (typeof opts === "function") { cb = opts; opts = {}; }
-      calls.push({ cmd, args: [...args] });
-      if (cmd === "osascript") { if (cb) cb(null, "", ""); return; }
-      if (cmd === "ps") {
-        const a = args.join(" ");
-        if (a.includes("comm=")) {
-          if (cb) cb(null, "501 /bin/zsh\n502 /Applications/cmux.app/Contents/MacOS/cmux\n", "");
-          return;
-        }
-        if (a.includes("tty=")) {
-          if (cb) cb(null, "501 ttys007\n", "");
-          return;
-        }
-      }
-      if (cb) cb(null, "", "");
-    };
-
-    const { initFocus, cleanup } = loadFocusWithMock(mock);
-    const { focusTerminalWindow } = initFocus({});
-    focusTerminalWindow(501, "/test/cwd", null, [501, 502]);
-
-    setTimeout(() => {
-      cleanup();
-      cleanupFile();
-      process.env.HOME = origHome;
-
-      const panelCall = calls.find(c => c.cmd === CMUX_BIN && c.args.includes("focus-panel"));
-      assert.ok(panelCall, "Should still focus a panel for legacy `id` payloads");
-      const workspaceArgIdx = panelCall.args.indexOf("--workspace");
-      assert.strictEqual(panelCall.args[workspaceArgIdx + 1], "legacy-ws-uuid", "Should fall back to the legacy `id` key");
-
-      done();
-    }, 2500);
-  });
-
   // TDD Red 2: fallback to select-workspace when focus-panel fails
   it("should call cmux select-workspace when focus-panel fails", (t, done) => {
     const panelId = "18AA1EB5-3055-445C-B780-60C88B21341B";
@@ -263,7 +216,7 @@ describe("cmux panel focus (macOS)", () => {
   it("should search later cmux session files when the newest file has no matching TTY", (t, done) => {
     const panelId = "panel-in-older-session";
     const { tmpDir, cmuxDir, cleanup: cleanupFile } = writeMockSessionFile([{
-      id: "newer-wrong-workspace",
+      workspaceId: "newer-wrong-workspace",
       panels: [{ id: "wrong-panel", ttyName: "ttys001", type: "terminal" }]
     }], "newer");
     const olderSessionPath = path.join(cmuxDir, "session-older.json");
@@ -272,7 +225,7 @@ describe("cmux panel focus (macOS)", () => {
         tabManager: {
           selectedWorkspaceIndex: 0,
           workspaces: [{
-            id: "older-matched-workspace",
+            workspaceId: "older-matched-workspace",
             panels: [{ id: panelId, ttyName: "ttys007", type: "terminal" }]
           }]
         }


### PR DESCRIPTION
## Summary
- Session focus into cmux never selects the workspace: cmux is brought to the front, but the previously selected workspace stays active.
- `findCmuxPanelMatch` reads the workspace UUID from `ws.id`, while cmux writes it as `ws.workspaceId`, so every lookup returns `cmux-workspace-not-found`.
- Reads `workspaceId`, and corrects the cmux test fixtures to the schema cmux actually writes.

## Problem context
I hit this by clicking a session in the HUD: cmux came to the front, but I landed on the workspace I had left, not the one running that session.

That click runs `scheduleCmuxWorkspaceSwitch`, which resolves the terminal TTY and matches it against `~/Library/Application Support/cmux/session-*.json` to find the owning workspace and panel. On cmux 0.64.17 the match never succeeds, 20 out of 20 times in my `focus-debug.log`:

```
focus result branch=mac-open reason=ok bundle=cmux.app
focus result branch=cmux reason=cmux-workspace-not-found
```

A workspace entry in the session file carries `workspaceId`, not `id`:

```json
{
  "workspaceId": "A7804655-ABD6-409C-B59B-EE270C6E0DCA",
  "focusedPanelId": "DD445FB9-...",
  "panels": [ { "id": "DD445FB9-...", "ttyName": "ttys000", "type": "terminal" } ]
}
```

`typeof ws?.id === "string" ? ws.id : null` is therefore always `null`, and the loop `continue`s past every workspace. As a result, neither `focus-panel` nor the `select-workspace` fallback is ever reached. Panels are unaffected. cmux does key those by `id`, which is likely where the assumption came from.

This has been present since cmux support was added in #259 (issue #248) and was never caught, because `test/focus-cmux.test.js` builds its fixtures with `id` as well. The tests describe a payload shape cmux does not produce, so they stayed green while the runtime path was broken.

## What changed
- `src/focus.js`: read the workspace UUID from `ws.workspaceId`.
- `test/focus-cmux.test.js`: correct the five workspace fixtures to `workspaceId`, matching real session files.

## Validation
- Clicking in the HUD: I loaded this patch into the installed 0.13.0 app and clicked sessions in the session HUD. `focus-debug.log` recorded 9 `cmux-workspace-selected` results. That string appears nowhere in the log before the patch, where 20 of 20 cmux evaluations ended in `cmux-workspace-not-found`. Five failures remained, all for one pane that cmux itself no longer reports, which is #767 rather than this key mismatch.
- Live session file: the patched matcher resolves `ttys000` to workspace `A7804655-ABD6-409C-B59B-EE270C6E0DCA` and panel `DD445FB9-94E6-4590-B1A6-CFCA3D89BA06`, the workspace that hosts that terminal.
- `node --test test/focus-cmux.test.js`: fixtures corrected but code unchanged gives 4 failed, 4 passed, so the bug reproduces. After the code change, 8 passed, 0 failed. The unmodified `main` suite reports 8 passed because its fixtures use `id`, the key this bug never reaches.
- `npm test`: 5,957 passed, 13 failed, 18 skipped, identical to the `origin/main` baseline. Those 13 come from this environment and are unrelated to focus.
- `git diff --check`

## Platform note
Verified on macOS 26.5.2 with cmux 0.64.17 and Clawd 0.13.0. The click test ran against the installed release with this patch swapped in, not a fresh `electron-builder` package, and the app was restored afterwards.

## Scope control
After this fix, clicking a cmux-hosted session selects the owning workspace and focuses the exact panel instead of only raising the app.

This PR changes only the workspace UUID read and the matching fixtures. Untouched:

- TTY resolution and session-file discovery order
- the `focus-panel` to `select-workspace` to AppleScript fallback chain
- other terminal hosts, and the Windows and Linux paths

`scheduleCmuxWorkspaceSwitch` still returns early unless a process in `pidChain` has a `cmux` command name, the same host check used by the iTerm2, Ghostty, tmux, and Superset branches.

## Deliberate trade-offs (open to changing)
- No `id` fallback: every workspace entry I inspected carries `workspaceId`, and I found no evidence of a build that wrote `id`. Say the word if you know of one and I will add it.
- A workspace miss also loses the panel id, so the AppleScript `focus terminal id` fallback never runs even though it needs no workspace. Focus dies entirely instead of degrading, which is worth fixing separately.
- Reading the mapping from cmux instead of its session file would drop the private-schema dependency: `cmux debug-terminals` already reports `tty=ttys003 ... workspace=workspace:8 pane=pane:14`, and #248 proposed `CMUX_WORKSPACE_ID` via `ps eww`. Happy to open a follow-up if you want either.

Refs #259, #248
