### PR TITLE
fix: 修正 Cursor 兼容 hook 的会话归属

### DIFF
--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -44,6 +44,18 @@ const TOOL_MATCH_ARRAY_MAX = 16;
 const TOOL_MATCH_OBJECT_KEYS_MAX = 32;
 const TOOL_MATCH_DEPTH_MAX = 6;
 const ASSISTANT_OUTPUT_CONTROL_RE = /[\u0000-\u0008\u000b\u000c\u000e-\u001F\u007F-\u009F]+/g;
+const CURSOR_VERSION_MAX = 128;
+
+function resolveReportingAgentId(payload) {
+  const cursorVersion = payload && typeof payload.cursor_version === "string"
+    ? payload.cursor_version.trim()
+    : "";
+  const isCursorCompatibilityHook =
+    cursorVersion.length > 0
+    && cursorVersion.length <= CURSOR_VERSION_MAX
+    && !/[\0\r\n]/.test(cursorVersion);
+  return isCursorCompatibilityHook ? "cursor-agent" : "claude-code";
+}
 
 function normalizeTitle(value) {
   if (typeof value !== "string") return null;
@@ -437,11 +449,14 @@ function buildStateBody(event, payload, resolve) {
   const resolvedEvent = syntheticSubagentStart ? "SubagentStart" : event;
 
   const body = { state: resolvedState, session_id: sessionId, event: resolvedEvent };
-  body.agent_id = "claude-code";
-  // Claude's command-hook payload uses agent_id/agent_type for subagent
-  // provenance. Keep the public Clawd agent_id canonical, but preserve that
-  // identity separately so a SubagentStop/PostToolUse event can settle only
-  // the matching subagent's pending permission.
+  // Cursor imports Claude user hooks and adds cursor_version to the hook input.
+  // Use that explicit caller provenance instead of the process tree: a genuine
+  // Claude CLI launched inside Cursor's terminal must remain Claude Code.
+  body.agent_id = resolveReportingAgentId(payload);
+  // Claude-compatible command-hook payloads use agent_id/agent_type for
+  // subagent provenance. Keep the public Clawd agent_id canonical, but preserve
+  // that identity separately so a SubagentStop/PostToolUse event can settle
+  // only the matching subagent's pending permission.
   const reportedSubagentId = typeof payload.agent_id === "string"
     ? payload.agent_id.trim()
     : "";

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -59,6 +59,38 @@ describe("buildStateBody", () => {
     assert.strictEqual(body.cwd, "/tmp/p");
   });
 
+  it("attributes Cursor-imported Claude hooks to Cursor Agent (#773)", () => {
+    const body = buildStateBody(
+      "SessionStart",
+      {
+        conversation_id: "cursor-conversation-1",
+        session_id: "cursor-conversation-1",
+        hook_event_name: "SessionStart",
+        cursor_version: "3.13.25",
+        workspace_roots: ["/tmp/p"],
+        cwd: "/tmp/p",
+      },
+      mockResolve
+    );
+    assert.strictEqual(body.agent_id, "cursor-agent");
+  });
+
+  it("keeps Claude Code launched from Cursor's terminal attributed to Claude Code (#773)", () => {
+    const resolveFromCursorTerminal = () => ({
+      stablePid: 12345,
+      agentPid: 67890,
+      detectedEditor: "cursor",
+      pidChain: [67890, 12345],
+    });
+    const body = buildStateBody(
+      "SessionStart",
+      { session_id: "claude-in-cursor-terminal", cwd: "/tmp/p" },
+      resolveFromCursorTerminal
+    );
+    assert.strictEqual(body.agent_id, "claude-code");
+    assert.strictEqual(body.editor, "cursor");
+  });
+
   it("preserves Claude subagent provenance without replacing the canonical agent id", () => {
     const body = buildStateBody(
       "SessionEnd",

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -75,6 +75,26 @@ describe("buildStateBody", () => {
     assert.strictEqual(body.agent_id, "cursor-agent");
   });
 
+  for (const [label, cursorVersion] of [
+    ["blank", " \t "],
+    ["overlong", "v".repeat(129)],
+    ["line break", "3.13.25\nspoofed"],
+    ["non-string", 31325],
+  ]) {
+    it(`rejects ${label} Cursor provenance and keeps Claude Code attribution (#773)`, () => {
+      const body = buildStateBody(
+        "SessionStart",
+        {
+          session_id: `malformed-cursor-version-${label.replace(/\s+/g, "-")}`,
+          cursor_version: cursorVersion,
+          cwd: "/tmp/p",
+        },
+        mockResolve
+      );
+      assert.strictEqual(body.agent_id, "claude-code");
+    });
+  }
+
   it("keeps Claude Code launched from Cursor's terminal attributed to Claude Code (#773)", () => {
     const resolveFromCursorTerminal = () => ({
       stablePid: 12345,


### PR DESCRIPTION
## 问题

Cursor 会自动加载 Claude user hooks。Cursor Agent 对话执行 `clawd-hook.js` 时，现有实现固定上报 `agent_id: claude-code`，导致同一条 Cursor 会话在 Dashboard / Session HUD 中被标成 Claude Code。

## 修复

- 当 Claude 兼容 hook payload 携带有效的 `cursor_version` 时，上报为 `cursor-agent`
- 只使用 hook payload 的显式来源信息，不按进程树或编辑器环境猜测；因此从 Cursor 终端启动的真实 Claude CLI 仍保持 `claude-code`
- 增加 Cursor 兼容路径、Claude-in-Cursor-terminal 边界，以及 malformed `cursor_version` 安全降级的回归测试

## 行为说明

Cursor Agent 未启用时，识别后的事件会遵循现有 agent gate 被忽略。要显示 Cursor 会话，Cursor Agent 必须在 Settings → Agent 管理中处于启用状态；推荐使用 Install 完成安装并启用。

## 验证

- `node --test test/clawd-hook.test.js`：113 passed
- `npm test`：6157 passed，0 failed，18 skipped
- macOS 真机，Cursor 3.13.25：Cursor 专用 hook 与 Claude user 兼容 hook 同时执行，所有事件均归属 `cursor-agent`；Dashboard 显示 Cursor Agent

Closes #773