### PR TITLE
fix: recognize Claude Opus 5 1M context window

### DIFF
--- a/hooks/context-usage.js
+++ b/hooks/context-usage.js
@@ -9,7 +9,7 @@ const CLAUDE_1M_CONTEXT_LIMIT = 1000000;
 // Source: https://platform.claude.com/docs/en/build-with-claude/context-windows
 // ("Context window sizes by model") — update this list as new models ship.
 const CLAUDE_1M_CONTEXT_MODEL_TOKENS = [
-  "opus-4-6", "opus-4-7", "opus-4-8",
+  "opus-4-6", "opus-4-7", "opus-4-8", "opus-5",
   "sonnet-4-6", "sonnet-5",
   "fable-5", "mythos-5", "mythos-preview",
 ];

--- a/test/context-usage.test.js
+++ b/test/context-usage.test.js
@@ -64,6 +64,7 @@ describe("Claude context usage parser", () => {
       "claude-opus-4-6",
       "claude-opus-4-7",
       "claude-opus-4-8-20250929",
+      "claude-opus-5",
       "claude-sonnet-4-6",
       "claude-sonnet-5",
       "claude-fable-5",
@@ -95,8 +96,37 @@ describe("Claude context usage parser", () => {
     });
   });
 
+  it("uses the 1M Opus 5 limit for a real issue #631 usage shape", () => {
+    const usage = extractClaudeContextUsageFromEntries([
+      {
+        type: "assistant",
+        message: {
+          model: "claude-opus-5",
+          usage: {
+            input_tokens: 406987,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        },
+      },
+    ]);
+
+    assert.deepStrictEqual(usage, {
+      used: 406987,
+      limit: 1000000,
+      percent: 41,
+      source: "claude",
+    });
+  });
+
   it("keeps the 200k limit for models without a 1M context window", () => {
     for (const model of ["claude-sonnet-4-5", "claude-haiku-4-5", "claude-opus-4-5"]) {
+      assert.strictEqual(resolveClaudeContextLimit(model), 200000, model);
+    }
+  });
+
+  it("requires token boundaries when matching 1M model ids", () => {
+    for (const model of ["claude-opus-50", "claude-xopus-5"]) {
       assert.strictEqual(resolveClaudeContextLimit(model), 200000, model);
     }
   });


### PR DESCRIPTION
## Summary

- recognize claude-opus-5 as a model with a 1M context window
- add an end-to-end regression for the real Issue #631 usage shape
- cover model-token boundaries so names such as claude-opus-50 do not match accidentally
- preserve the existing 200k fallback for models outside the 1M allowlist

## Validation

- node --test test/context-usage.test.js test/clawd-hook.test.js: 129 passed, 0 failed
- npm test: 6,539 passed, 2 failed, 18 skipped; the two existing failures are unrelated focus-orca assertions for untouched hooks/zcode-hook.js
- launched the branch on macOS and confirmed a real Opus 5 session displays 117,854 / 1,000,000 (12%) in the Dashboard instead of a 200k cap

Closes #631