### PR TITLE
fix: improve Settings interaction stability

### DIFF
--- a/src/language-picker.css
+++ b/src/language-picker.css
@@ -21,7 +21,7 @@
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
   transition: border-color 0.14s ease, box-shadow 0.14s ease, background 0.14s ease;
 }
-.language-picker-trigger:hover,
+.language-picker-trigger:hover:not(:disabled),
 .language-picker.open .language-picker-trigger {
   border-color: color-mix(in srgb, var(--accent) 58%, var(--border));
   background: var(--panel-bg, var(--surface));
@@ -30,6 +30,9 @@
 .language-picker-trigger:focus-visible {
   outline: 2px solid color-mix(in srgb, var(--accent) 78%, transparent);
   outline-offset: 2px;
+}
+.language-picker-trigger:disabled {
+  box-shadow: none;
 }
 .language-picker-value {
   min-width: 0;

--- a/src/language-picker.js
+++ b/src/language-picker.js
@@ -1,6 +1,8 @@
 "use strict";
 
 (function initLanguagePicker(root) {
+  let nextPickerId = 1;
+
   function normalizeOptions(options) {
     if (!Array.isArray(options)) return [];
     return options.map((option) => {
@@ -17,11 +19,13 @@
     const options = normalizeOptions(config.options);
     const ariaLabel = config.ariaLabel == null ? "" : String(config.ariaLabel);
     const picker = document.createElement("div");
-    picker.className = "language-picker";
+    const extraClassName = config.className == null ? "" : String(config.className).trim();
+    picker.className = `language-picker${extraClassName ? ` ${extraClassName}` : ""}`;
 
     const trigger = document.createElement("button");
     trigger.type = "button";
     trigger.className = "language-picker-trigger";
+    trigger.setAttribute("role", "combobox");
     trigger.setAttribute("aria-haspopup", "listbox");
     trigger.setAttribute("aria-expanded", "false");
 
@@ -35,8 +39,10 @@
 
     const menu = document.createElement("div");
     menu.className = "language-picker-menu";
+    menu.id = `settings-picker-menu-${nextPickerId++}`;
     menu.setAttribute("role", "listbox");
     menu.setAttribute("aria-hidden", "true");
+    trigger.setAttribute("aria-controls", menu.id);
     if (ariaLabel) menu.setAttribute("aria-label", ariaLabel);
 
     const optionElements = [];
@@ -58,6 +64,8 @@
     let committedValue = "";
     let isOpen = false;
     let disposed = false;
+    let disabled = config.disabled === true || optionElements.length === 0;
+    let pending = config.pending === true;
     let changeSeq = 0;
     let latestRequestSeq = 0;
     const pendingChanges = new Map();
@@ -88,6 +96,13 @@
         item.element.setAttribute("aria-selected", selected ? "true" : "false");
         item.element.tabIndex = isOpen && selected ? 0 : -1;
       }
+    }
+
+    function paintInteractivity() {
+      picker.classList.toggle("disabled", disabled);
+      picker.classList.toggle("pending", pending);
+      trigger.disabled = disabled || (config.lockWhilePending === true && pending);
+      trigger.setAttribute("aria-disabled", trigger.disabled ? "true" : "false");
     }
 
     function focusElement(element) {
@@ -208,7 +223,7 @@
 
     function setOpen(next, { focusTrigger = false } = {}) {
       if (disposed) return;
-      isOpen = !!next && optionElements.length > 0;
+      isOpen = !!next && optionElements.length > 0 && !trigger.disabled;
       picker.classList.toggle("open", isOpen);
       trigger.setAttribute("aria-expanded", isOpen ? "true" : "false");
       menu.setAttribute("aria-hidden", isOpen ? "false" : "true");
@@ -229,10 +244,12 @@
 
       const latestPending = pendingChanges.get(latestRequestSeq);
       paintValue(latestPending || committedValue);
+      pending = pendingChanges.size > 0;
+      paintInteractivity();
     }
 
     function choose(value) {
-      if (disposed) return;
+      if (disposed || trigger.disabled) return;
       const entry = findOption(value);
       if (!entry) return;
       if (entry.data.value === activeValue) {
@@ -246,6 +263,8 @@
       const seq = ++changeSeq;
       latestRequestSeq = seq;
       pendingChanges.set(seq, entry.data.value);
+      pending = true;
+      paintInteractivity();
       let result;
       try {
         result = typeof config.onChange === "function"
@@ -284,6 +303,13 @@
       if (event.key === "Escape" && isOpen) {
         event.preventDefault();
         setOpen(false, { focusTrigger: true });
+        return;
+      }
+      if (event.key === "Home" || event.key === "End") {
+        event.preventDefault();
+        setOpen(true);
+        const target = event.key === "Home" ? optionElements[0] : optionElements[optionElements.length - 1];
+        focusElement(target && target.element);
       }
     });
 
@@ -304,6 +330,12 @@
         if (event.key === "ArrowDown" || event.key === "ArrowUp") {
           event.preventDefault();
           moveFocus(index, event.key === "ArrowDown" ? 1 : -1);
+          return;
+        }
+        if (event.key === "Home" || event.key === "End") {
+          event.preventDefault();
+          const target = event.key === "Home" ? optionElements[0] : optionElements[optionElements.length - 1];
+          focusElement(target && target.element);
         }
       });
     }
@@ -327,7 +359,7 @@
 
     paintValue(config.value);
     committedValue = activeValue;
-    trigger.disabled = optionElements.length === 0;
+    paintInteractivity();
 
     return {
       element: picker,
@@ -340,6 +372,21 @@
         pendingChanges.clear();
         paintValue(value);
         committedValue = activeValue;
+      },
+      setDisabled(value) {
+        if (disposed) return;
+        disabled = value === true || optionElements.length === 0;
+        if (disabled) setOpen(false);
+        paintInteractivity();
+      },
+      setPending(value) {
+        if (disposed) return;
+        pending = value === true;
+        if (pending && config.lockWhilePending === true) setOpen(false);
+        paintInteractivity();
+      },
+      getValue() {
+        return activeValue;
       },
       dispose() {
         if (disposed) return;
@@ -363,5 +410,8 @@
     };
   }
 
-  root.ClawdLanguagePicker = { createLanguagePicker };
+  root.ClawdLanguagePicker = {
+    createLanguagePicker,
+    createSettingsSelect: createLanguagePicker,
+  };
 })(globalThis);

--- a/src/settings-tab-about.js
+++ b/src/settings-tab-about.js
@@ -1,6 +1,7 @@
 "use strict";
 
 (function initSettingsTabAbout(root) {
+  let state = null;
   let runtime = null;
   let helpers = null;
   let ops = null;
@@ -319,14 +320,71 @@
       autoUpdateLabelWrap.appendChild(autoUpdateDesc);
       const autoUpdateValue = document.createElement("div");
       autoUpdateValue.className = "about-info-value";
-      const autoUpdateBox = document.createElement("input");
-      autoUpdateBox.type = "checkbox";
-      autoUpdateBox.checked = safe.autoUpdateCheck !== false;
-      autoUpdateBox.addEventListener("change", () => {
-        if (!window.settingsAPI || typeof window.settingsAPI.update !== "function") return;
-        window.settingsAPI.update("autoUpdateCheck", autoUpdateBox.checked).catch(() => {});
+      const autoUpdateSwitch = document.createElement("div");
+      autoUpdateSwitch.className = "switch about-auto-update-switch";
+      autoUpdateSwitch.setAttribute("role", "switch");
+      autoUpdateSwitch.setAttribute("tabindex", "0");
+      autoUpdateSwitch.setAttribute("aria-label", t("autoUpdateCheck"));
+      let committedAutoUpdate = safe.autoUpdateCheck !== false;
+      let autoUpdatePending = false;
+
+      function paintAutoUpdate(value, pending = autoUpdatePending) {
+        helpers.setSwitchVisual(autoUpdateSwitch, value, { pending });
+        autoUpdateSwitch.classList.toggle("disabled", pending);
+        autoUpdateSwitch.setAttribute("aria-disabled", pending ? "true" : "false");
+      }
+
+      function syncAutoUpdateFromSnapshot() {
+        const snapshotHasValue = state.snapshot
+          && Object.prototype.hasOwnProperty.call(state.snapshot, "autoUpdateCheck");
+        committedAutoUpdate = snapshotHasValue
+          ? state.snapshot.autoUpdateCheck !== false
+          : runtime.about.infoCache.autoUpdateCheck !== false;
+        runtime.about.infoCache.autoUpdateCheck = committedAutoUpdate;
+        autoUpdatePending = false;
+        paintAutoUpdate(committedAutoUpdate, false);
+      }
+
+      function toggleAutoUpdate() {
+        if (autoUpdatePending || !window.settingsAPI || typeof window.settingsAPI.update !== "function") return;
+        const previous = committedAutoUpdate;
+        const next = !committedAutoUpdate;
+        committedAutoUpdate = next;
+        autoUpdatePending = true;
+        runtime.about.infoCache.autoUpdateCheck = next;
+        paintAutoUpdate(next, true);
+        Promise.resolve(window.settingsAPI.update("autoUpdateCheck", next))
+          .then((result) => {
+            if (!result || result.status !== "ok") {
+              committedAutoUpdate = previous;
+              runtime.about.infoCache.autoUpdateCheck = previous;
+              ops.showToast((result && result.message) || t("toastSaveFailed"), { error: true });
+            }
+          })
+          .catch((err) => {
+            committedAutoUpdate = previous;
+            runtime.about.infoCache.autoUpdateCheck = previous;
+            const message = err && err.message ? err.message : "unknown error";
+            ops.showToast(t("toastSaveFailed") + message, { error: true });
+          })
+          .finally(() => {
+            autoUpdatePending = false;
+            if (document.body.contains(autoUpdateSwitch)) paintAutoUpdate(committedAutoUpdate, false);
+          });
+      }
+
+      autoUpdateSwitch.addEventListener("click", toggleAutoUpdate);
+      autoUpdateSwitch.addEventListener("keydown", (event) => {
+        if (event.key !== " " && event.key !== "Enter") return;
+        event.preventDefault();
+        toggleAutoUpdate();
       });
-      autoUpdateValue.appendChild(autoUpdateBox);
+      state.mountedControls.aboutAutoUpdate = {
+        element: autoUpdateSwitch,
+        syncFromSnapshot: syncAutoUpdateFromSnapshot,
+      };
+      paintAutoUpdate(committedAutoUpdate, false);
+      autoUpdateValue.appendChild(autoUpdateSwitch);
       autoUpdateRow.appendChild(autoUpdateLabelWrap);
       autoUpdateRow.appendChild(autoUpdateValue);
       infoSection.appendChild(autoUpdateRow);
@@ -368,12 +426,22 @@
   }
 
   function init(core) {
+    state = core.state;
     runtime = core.runtime;
     helpers = core.helpers;
     ops = core.ops;
     i18n = core.i18n;
     core.tabs.about = {
       render,
+      patchInPlace(changes) {
+        if (!changes || Object.keys(changes).some((key) => key !== "autoUpdateCheck")) return false;
+        if (!Object.prototype.hasOwnProperty.call(changes, "autoUpdateCheck")) return false;
+        const control = state.mountedControls.aboutAutoUpdate;
+        if (!control || !document.body.contains(control.element)) return false;
+        runtime.about.infoCache.autoUpdateCheck = changes.autoUpdateCheck !== false;
+        control.syncFromSnapshot();
+        return true;
+      },
     };
   }
 

--- a/src/settings-tab-anim-map.js
+++ b/src/settings-tab-anim-map.js
@@ -74,8 +74,8 @@
     return row;
   }
 
-  // Rendered as the "on / off" subtab of the Animation & Sound Overrides tab,
-  // so the parent tab already supplies the <h1> — we start at the subtitle.
+  // The parent tab supplies the stable title, subtitle, and subtab switcher.
+  // This module only renders the map-specific explanation and controls.
   function renderMapSubtab(parent) {
     const subtitle = document.createElement("p");
     subtitle.className = "subtitle";

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -19,6 +19,7 @@
   let ops = null;
   let i18n = null;
   let readers = null;
+  let mountedSubtabBody = null;
 
   function t(key) {
     return helpers.t(key);
@@ -723,7 +724,7 @@
           syncMountedWideHitboxToggles();
           syncMountedOverrideStatusControls();
         } else if (state.activeTab === "animOverrides") {
-          ops.requestRender({ content: true });
+          refreshMountedSubtabBody();
         }
         ops.requestRender({ modal: true });
         return result;
@@ -1106,6 +1107,103 @@
     return frame;
   }
 
+  function getSubtabScrollPositions() {
+    if (!runtime.animOverridesScrollTop || typeof runtime.animOverridesScrollTop !== "object") {
+      runtime.animOverridesScrollTop = { map: 0, animations: 0, sounds: 0 };
+    }
+    return runtime.animOverridesScrollTop;
+  }
+
+  function normalizeSubtab(value = runtime.animOverridesSubtab) {
+    return value === "sounds" ? "sounds" : value === "map" ? "map" : "animations";
+  }
+
+  function restoreSubtabScroll(scroller, subtab) {
+    if (!scroller) return;
+    const saved = Number(getSubtabScrollPositions()[subtab]);
+    requestAnimationFrame(() => {
+      if (state.activeTab !== "animOverrides" || normalizeSubtab() !== subtab) return;
+      scroller.scrollTop = Number.isFinite(saved) && saved > 0 ? saved : 0;
+    });
+  }
+
+  function clearSubtabControls() {
+    if (typeof ops.clearMountedControls === "function") {
+      ops.clearMountedControls();
+      return;
+    }
+    if (state.mountedControls.idleVisualPicker
+      && typeof state.mountedControls.idleVisualPicker.dispose === "function") {
+      state.mountedControls.idleVisualPicker.dispose();
+      state.mountedControls.idleVisualPicker = null;
+    }
+    if (state.mountedControls.animMapSwitches && typeof state.mountedControls.animMapSwitches.clear === "function") {
+      state.mountedControls.animMapSwitches.clear();
+    }
+    state.mountedControls.animMapReset = null;
+    if (state.mountedControls.animOverrideTimingSliders
+      && typeof state.mountedControls.animOverrideTimingSliders.clear === "function") {
+      state.mountedControls.animOverrideTimingSliders.clear();
+    }
+  }
+
+  function renderSubtabBody(body) {
+    if (!body) return;
+    mountedSubtabBody = body;
+    body.innerHTML = "";
+    const subtab = normalizeSubtab();
+
+    // "On / off" reads themeOverrides directly, so it does not wait for the
+    // animation asset payload used by the other two subtabs.
+    if (subtab === "map") {
+      root.ClawdSettingsTabAnimMap.renderMapSubtab(body);
+      return;
+    }
+
+    if (runtime.animationOverridesData === null) {
+      const loading = document.createElement("div");
+      loading.className = "placeholder-desc";
+      loading.textContent = t("animOverridesLoading");
+      body.appendChild(loading);
+      ops.fetchAnimationOverridesData().then(() => {
+        if (state.activeTab !== "animOverrides" || mountedSubtabBody !== body) return;
+        if (normalizeSubtab() !== subtab) return;
+        if (runtime.animationOverridesData === null) return;
+        clearSubtabControls();
+        renderSubtabBody(body);
+        restoreSubtabScroll(document.getElementById("content"), subtab);
+      });
+      return;
+    }
+
+    reconcilePendingAnimationOverrideEdits();
+    reconcilePendingWideHitboxOverrideEdits();
+    const data = runtime.animationOverridesData;
+
+    if (subtab === "sounds") {
+      body.appendChild(buildSoundOverridesSection(data));
+    } else {
+      body.appendChild(buildAnimOverrideThemeMeta(data));
+      const sections = Array.isArray(data.sections) ? data.sections : [];
+      for (const section of sections) {
+        if (!section || !Array.isArray(section.cards) || !section.cards.length) continue;
+        body.appendChild(buildAnimOverrideSection(section));
+      }
+    }
+    if (runtime.assetPicker.state) ops.requestRender({ modal: true });
+  }
+
+  function refreshMountedSubtabBody() {
+    if (state.activeTab !== "animOverrides" || !mountedSubtabBody) return false;
+    const scroller = document.getElementById("content");
+    const subtab = normalizeSubtab();
+    if (scroller) getSubtabScrollPositions()[subtab] = scroller.scrollTop;
+    clearSubtabControls();
+    renderSubtabBody(mountedSubtabBody);
+    restoreSubtabScroll(scroller, subtab);
+    return true;
+  }
+
   function render(parent) {
     const h1 = document.createElement("h1");
     h1.textContent = t("animOverridesTitle");
@@ -1115,41 +1213,13 @@
     subtitle.className = "subtitle";
     subtitle.textContent = t("animOverridesSubtitle");
     parent.appendChild(subtitle);
-    parent.appendChild(buildSubtabSwitcher());
-
-    // "On / off" reads themeOverrides directly, so it does not wait for the
-    // animation asset payload used by the other two subtabs.
-    if (runtime.animOverridesSubtab === "map") {
-      root.ClawdSettingsTabAnimMap.renderMapSubtab(parent);
-      return;
-    }
-
-    if (runtime.animationOverridesData === null) {
-      const loading = document.createElement("div");
-      loading.className = "placeholder-desc";
-      loading.textContent = t("animOverridesLoading");
-      parent.appendChild(loading);
-      ops.fetchAnimationOverridesData().then(() => {
-        if (state.activeTab === "animOverrides") ops.requestRender({ content: true });
-      });
-      return;
-    }
-
-    reconcilePendingAnimationOverrideEdits();
-    reconcilePendingWideHitboxOverrideEdits();
-    const data = runtime.animationOverridesData;
-
-    if (runtime.animOverridesSubtab === "sounds") {
-      parent.appendChild(buildSoundOverridesSection(data));
-    } else {
-      parent.appendChild(buildAnimOverrideThemeMeta(data));
-      const sections = Array.isArray(data.sections) ? data.sections : [];
-      for (const section of sections) {
-        if (!section || !Array.isArray(section.cards) || !section.cards.length) continue;
-        parent.appendChild(buildAnimOverrideSection(section));
-      }
-    }
-    if (runtime.assetPicker.state) ops.requestRender({ modal: true });
+    const switcher = buildSubtabSwitcher();
+    parent.appendChild(switcher);
+    const body = document.createElement("div");
+    body.className = "anim-override-subtab-body";
+    parent.appendChild(body);
+    renderSubtabBody(body);
+    restoreSubtabScroll(document.getElementById("content"), normalizeSubtab());
   }
 
   function buildSubtabSwitcher() {
@@ -1175,18 +1245,20 @@
       btn.addEventListener("click", () => {
         if (runtime.animOverridesSubtab === entry.key) return;
         const scroller = document.getElementById("content");
-        const previousScrollTop = scroller ? scroller.scrollTop : 0;
+        const previousSubtab = normalizeSubtab();
+        if (scroller) getSubtabScrollPositions()[previousSubtab] = scroller.scrollTop;
         runtime.animOverridesSubtab = entry.key;
-        ops.requestRender({ content: true });
-        if (scroller) {
-          scroller.scrollTop = previousScrollTop;
-          requestAnimationFrame(() => {
-            const activeButton = scroller.querySelector(".anim-override-subtabs .active");
-            if (activeButton && typeof activeButton.focus === "function") {
-              try { activeButton.focus({ preventScroll: true }); } catch (_) { activeButton.focus(); }
-            }
-          });
+        for (const candidate of group.querySelectorAll("button")) {
+          candidate.classList.toggle("active", candidate.dataset.animOverridesSubtab === entry.key);
         }
+        clearSubtabControls();
+        renderSubtabBody(mountedSubtabBody);
+        restoreSubtabScroll(scroller, entry.key);
+        requestAnimationFrame(() => {
+          if (typeof btn.focus === "function") {
+            try { btn.focus({ preventScroll: true }); } catch (_) { btn.focus(); }
+          }
+        });
       });
       group.appendChild(btn);
     }
@@ -1203,7 +1275,7 @@
 
   function refreshSoundOverridesUi() {
     return ops.fetchAnimationOverridesData().then(() => {
-      if (state.activeTab === "animOverrides") ops.requestRender({ content: true });
+      refreshMountedSubtabBody();
     });
   }
 
@@ -2265,6 +2337,9 @@
   }
 
   function onExit() {
+    const scroller = document.getElementById("content");
+    if (scroller) getSubtabScrollPositions()[normalizeSubtab()] = scroller.scrollTop;
+    mountedSubtabBody = null;
     ops.closeAssetPicker();
   }
 

--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -1111,20 +1111,18 @@
     h1.textContent = t("animOverridesTitle");
     parent.appendChild(h1);
 
-    // "On / off" subtab: which interrupt reactions play at all. It reads
-    // themeOverrides straight from the snapshot (no asset data needed), so it
-    // renders before the animationOverridesData loading gate and hands off to
-    // the anim-map module. Its own subtitle carries the explanatory copy.
-    if (runtime.animOverridesSubtab === "map") {
-      parent.appendChild(buildSubtabSwitcher());
-      root.ClawdSettingsTabAnimMap.renderMapSubtab(parent);
-      return;
-    }
-
     const subtitle = document.createElement("p");
     subtitle.className = "subtitle";
     subtitle.textContent = t("animOverridesSubtitle");
     parent.appendChild(subtitle);
+    parent.appendChild(buildSubtabSwitcher());
+
+    // "On / off" reads themeOverrides directly, so it does not wait for the
+    // animation asset payload used by the other two subtabs.
+    if (runtime.animOverridesSubtab === "map") {
+      root.ClawdSettingsTabAnimMap.renderMapSubtab(parent);
+      return;
+    }
 
     if (runtime.animationOverridesData === null) {
       const loading = document.createElement("div");
@@ -1140,8 +1138,6 @@
     reconcilePendingAnimationOverrideEdits();
     reconcilePendingWideHitboxOverrideEdits();
     const data = runtime.animationOverridesData;
-
-    parent.appendChild(buildSubtabSwitcher());
 
     if (runtime.animOverridesSubtab === "sounds") {
       parent.appendChild(buildSoundOverridesSection(data));
@@ -1174,11 +1170,23 @@
       const btn = document.createElement("button");
       btn.type = "button";
       btn.textContent = entry.label;
+      btn.dataset.animOverridesSubtab = entry.key;
       if (entry.key === current) btn.classList.add("active");
       btn.addEventListener("click", () => {
         if (runtime.animOverridesSubtab === entry.key) return;
+        const scroller = document.getElementById("content");
+        const previousScrollTop = scroller ? scroller.scrollTop : 0;
         runtime.animOverridesSubtab = entry.key;
         ops.requestRender({ content: true });
+        if (scroller) {
+          scroller.scrollTop = previousScrollTop;
+          requestAnimationFrame(() => {
+            const activeButton = scroller.querySelector(".anim-override-subtabs .active");
+            if (activeButton && typeof activeButton.focus === "function") {
+              try { activeButton.focus({ preventScroll: true }); } catch (_) { activeButton.focus(); }
+            }
+          });
+        }
       });
       group.appendChild(btn);
     }

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -470,17 +470,12 @@
     // (WSL / SSH remotes). Hidden by default so single-machine users never see
     // a confusing no-op switch; revealed once multiple sources are confirmed.
     mergeRow.style.display = "none";
-    if (window.settingsAPI && typeof window.settingsAPI.getQuotaSourceCount === "function") {
-      Promise.resolve(window.settingsAPI.getQuotaSourceCount())
-        .then((count) => { if (Number(count) > 1) mergeRow.style.display = ""; })
-        .catch(() => {});
-    }
     const optionList = buildOptionList("quota-ring-option-list", [
       enabledRow,
       claudeCollectionRow,
       mergeRow,
     ]);
-    return helpers.buildCollapsibleGroup({
+    const group = helpers.buildCollapsibleGroup({
       id: "general:quota-ring",
       title: t("rowQuotaRingGroup"),
       desc: t("rowQuotaRingGroupDesc"),
@@ -488,6 +483,18 @@
       className: "quota-ring-collapsible",
       children: [optionList],
     });
+    if (window.settingsAPI && typeof window.settingsAPI.getQuotaSourceCount === "function") {
+      Promise.resolve(window.settingsAPI.getQuotaSourceCount())
+        .then((count) => {
+          if (Number(count) <= 1) return;
+          mergeRow.style.display = "";
+          if (typeof group.refreshCollapsibleHeight === "function") {
+            group.refreshCollapsibleHeight();
+          }
+        })
+        .catch(() => {});
+    }
+    return group;
   }
 
   function buildOptionList(className, rows) {

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -488,9 +488,13 @@
       Promise.resolve(window.settingsAPI.getQuotaSourceCount())
         .then((count) => {
           if (Number(count) <= 1) return;
-          mergeRow.style.display = "";
-          if (typeof group.refreshCollapsibleHeight === "function") {
-            group.refreshCollapsibleHeight();
+          const revealMergeRow = () => {
+            mergeRow.style.display = "";
+          };
+          if (typeof group.mutateCollapsibleBody === "function") {
+            group.mutateCollapsibleBody(revealMergeRow);
+          } else {
+            revealMergeRow();
           }
         })
         .catch(() => {});

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -481,6 +481,7 @@
       desc: t("rowQuotaRingGroupDesc"),
       defaultCollapsed: true,
       className: "quota-ring-collapsible",
+      animateExpansion: false,
       children: [optionList],
     });
     if (window.settingsAPI && typeof window.settingsAPI.getQuotaSourceCount === "function") {

--- a/src/settings-tab-telegram-approval.js
+++ b/src/settings-tab-telegram-approval.js
@@ -1196,29 +1196,26 @@
 
     const ctrl = document.createElement("div");
     ctrl.className = "row-control";
-    const select = document.createElement("select");
-    select.className = "tg-approval-input tg-approval-output-select";
-    select.disabled = view.configPending;
-    for (const value of ["off", "full"]) {
-      const option = document.createElement("option");
-      option.value = value;
-      option.textContent = t("telegramApprovalCompletionOutput_" + value);
-      select.appendChild(option);
-    }
-    select.value = mode;
-    select.addEventListener("change", () => {
-      const nextMode = ["off", "full"].includes(select.value) ? select.value : "off";
-      if (nextMode === mode) return;
-      if (nextMode === "full") {
-        const ok = window.confirm(t("telegramApprovalCompletionOutputFullConfirm"));
-        if (!ok) {
-          select.value = mode;
-          return;
+    const picker = helpers.buildSettingsSelect({
+      value: mode,
+      options: ["off", "full"].map((value) => ({
+        value,
+        label: t("telegramApprovalCompletionOutput_" + value),
+      })),
+      ariaLabel: t("telegramApprovalCompletionOutput"),
+      className: "tg-approval-output-select",
+      disabled: view.configPending,
+      onChange(value) {
+        const nextMode = ["off", "full"].includes(value) ? value : "off";
+        if (nextMode === mode) return true;
+        if (nextMode === "full") {
+          const ok = window.confirm(t("telegramApprovalCompletionOutputFullConfirm"));
+          if (!ok) return false;
         }
-      }
-      saveConfig({ ...cfg, completionOutputMode: nextMode }, { resetDraft: false });
+        return saveConfig({ ...cfg, completionOutputMode: nextMode }, { resetDraft: false });
+      },
     });
-    ctrl.appendChild(select);
+    ctrl.appendChild(picker.element);
     row.appendChild(ctrl);
     return row;
   }
@@ -1719,22 +1716,23 @@
 
     const ctrl = document.createElement("div");
     ctrl.className = "row-control";
-    const select = document.createElement("select");
-    select.className = "tg-approval-input tg-approval-output-select feishu-approval-timeout-select";
-    select.disabled = feishuView.configPending;
-    for (const value of [5, 10, 15, 30, 60]) {
-      const option = document.createElement("option");
-      option.value = String(value);
-      option.textContent = t("feishuApprovalConnectionTimeoutOption").replace("{seconds}", String(value));
-      select.appendChild(option);
-    }
-    select.value = String(cfg.connectionTimeoutSeconds);
-    select.addEventListener("change", () => {
-      const nextTimeout = Number(select.value);
-      if (![5, 10, 15, 30, 60].includes(nextTimeout) || nextTimeout === cfg.connectionTimeoutSeconds) return;
-      saveFeishuConfig({ ...cfg, connectionTimeoutSeconds: nextTimeout }, { resetDraft: false });
+    const picker = helpers.buildSettingsSelect({
+      value: String(cfg.connectionTimeoutSeconds),
+      options: [5, 10, 15, 30, 60].map((value) => ({
+        value: String(value),
+        label: t("feishuApprovalConnectionTimeoutOption").replace("{seconds}", String(value)),
+      })),
+      ariaLabel: t("feishuApprovalConnectionTimeout"),
+      className: "tg-approval-output-select feishu-approval-timeout-select",
+      disabled: feishuView.configPending,
+      onChange(value) {
+        const nextTimeout = Number(value);
+        if (![5, 10, 15, 30, 60].includes(nextTimeout)) return false;
+        if (nextTimeout === cfg.connectionTimeoutSeconds) return true;
+        return saveFeishuConfig({ ...cfg, connectionTimeoutSeconds: nextTimeout }, { resetDraft: false });
+      },
     });
-    ctrl.appendChild(select);
+    ctrl.appendChild(picker.element);
     row.appendChild(ctrl);
     return row;
   }
@@ -1805,50 +1803,54 @@
   function saveConfig(next, options = {}) {
     if (!window.settingsAPI || typeof window.settingsAPI.update !== "function") {
       ops.showToast(t("toastSaveFailed") + "settings API unavailable", { error: true });
-      return;
+      return Promise.resolve(false);
     }
     view.configPending = true;
     ops.requestRender({ content: true });
-    window.settingsAPI.update("tgApproval", next).then((result) => {
+    return window.settingsAPI.update("tgApproval", next).then((result) => {
       view.configPending = false;
       if (!result || result.status !== "ok") {
         ops.showToast((result && result.message) || t("toastSaveFailed"), { error: true });
         ops.requestRender({ content: true });
-        return;
+        return false;
       }
       ops.showToast(t("telegramApprovalConfigSaved"));
       if (options.resetDraft !== false) resetFormDraft();
       view.status = null;
       refreshStatus({ forceRender: true });
+      return true;
     }).catch((err) => {
       view.configPending = false;
       ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
       ops.requestRender({ content: true });
+      return false;
     });
   }
 
   function saveFeishuConfig(next, options = {}) {
     if (!window.settingsAPI || typeof window.settingsAPI.update !== "function") {
       ops.showToast(t("toastSaveFailed") + "settings API unavailable", { error: true });
-      return;
+      return Promise.resolve(false);
     }
     feishuView.configPending = true;
     ops.requestRender({ content: true });
-    window.settingsAPI.update("feishuApproval", next).then((result) => {
+    return window.settingsAPI.update("feishuApproval", next).then((result) => {
       feishuView.configPending = false;
       if (!result || result.status !== "ok") {
         ops.showToast((result && result.message) || t("toastSaveFailed"), { error: true });
         ops.requestRender({ content: true });
-        return;
+        return false;
       }
       ops.showToast(tBrand("feishuApprovalConfigSaved"));
       if (options.resetDraft !== false) resetFeishuFormDraft();
       feishuView.status = null;
       refreshFeishuStatus({ forceRender: true });
+      return true;
     }).catch((err) => {
       feishuView.configPending = false;
       ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
       ops.requestRender({ content: true });
+      return false;
     });
   }
 

--- a/src/settings-tab-theme.js
+++ b/src/settings-tab-theme.js
@@ -352,64 +352,47 @@
 
     const control = document.createElement("div");
     control.className = "row-control";
-    const select = document.createElement("select");
-    select.className = "pet-tint-select";
-    select.setAttribute("aria-label", t("rowPetColor"));
     const options = getTintOptions();
-    for (const entry of options) {
-      const option = document.createElement("option");
-      option.value = entry.id;
-      option.textContent = t(entry.labelKey);
-      select.appendChild(option);
-    }
-    if (options.length === 0) {
-      const option = document.createElement("option");
-      option.value = "none";
-      option.textContent = t("tintNone");
-      select.appendChild(option);
-      select.disabled = true;
-    }
-
-    function syncFromSnapshot() {
-      select.value = getThemeTintId(theme.id, options);
-      select.classList.remove("pending");
-      select.disabled = options.length === 0;
-    }
-
-    select.addEventListener("change", () => {
-      if (select.disabled || select.classList.contains("pending")) return;
-      const next = select.value;
-      const committed = getThemeTintId(theme.id, options);
-      if (next === committed) return;
-      const current = state.snapshot && state.snapshot.petTint;
-      const nextMap = current && typeof current === "object" && !Array.isArray(current)
-        ? { ...current }
-        : {};
-      if (next === "none") delete nextMap[theme.id];
-      else nextMap[theme.id] = next;
-      select.classList.add("pending");
-      select.disabled = true;
-      Promise.resolve(window.settingsAPI.update("petTint", nextMap))
-        .then((result) => {
-          if (result && result.status === "ok") return;
-          const message = (result && result.message) || "unknown error";
-          ops.showToast(t("toastSaveFailed") + message, { error: true });
-          syncFromSnapshot();
-        })
-        .catch((err) => {
-          const message = (err && err.message) || "unknown error";
-          ops.showToast(t("toastSaveFailed") + message, { error: true });
-          syncFromSnapshot();
-        })
-        .finally(() => {
-          if (document.body.contains(select)) {
-            select.classList.remove("pending");
-            select.disabled = options.length === 0;
-          }
-        });
+    const pickerOptions = options.length > 0
+      ? options.map((entry) => ({ value: entry.id, label: t(entry.labelKey) }))
+      : [{ value: "none", label: t("tintNone") }];
+    const picker = helpers.buildSettingsSelect({
+      value: getThemeTintId(theme.id, options),
+      options: pickerOptions,
+      ariaLabel: t("rowPetColor"),
+      className: "pet-tint-select",
+      disabled: options.length === 0,
+      onChange(next) {
+        const committed = getThemeTintId(theme.id, options);
+        if (next === committed) return true;
+        const current = state.snapshot && state.snapshot.petTint;
+        const nextMap = current && typeof current === "object" && !Array.isArray(current)
+          ? { ...current }
+          : {};
+        if (next === "none") delete nextMap[theme.id];
+        else nextMap[theme.id] = next;
+        return Promise.resolve(window.settingsAPI.update("petTint", nextMap))
+          .then((result) => {
+            if (result && result.status === "ok") return true;
+            const message = (result && result.message) || "unknown error";
+            ops.showToast(t("toastSaveFailed") + message, { error: true });
+            return false;
+          })
+          .catch((err) => {
+            const message = (err && err.message) || "unknown error";
+            ops.showToast(t("toastSaveFailed") + message, { error: true });
+            return false;
+          });
+      },
     });
 
-    control.appendChild(select);
+    function syncFromSnapshot() {
+      picker.setValue(getThemeTintId(theme.id, options));
+      picker.setPending(false);
+      picker.setDisabled(options.length === 0);
+    }
+
+    control.appendChild(picker.element);
     row.appendChild(text);
     row.appendChild(control);
     syncFromSnapshot();
@@ -433,64 +416,47 @@
 
     const control = document.createElement("div");
     control.className = "row-control";
-    const select = document.createElement("select");
-    select.className = "pet-accessory-select";
-    select.setAttribute("aria-label", t("rowPetAccessory"));
     const options = getAccessoryOptions();
-    for (const entry of options) {
-      const option = document.createElement("option");
-      option.value = entry.id;
-      option.textContent = t(entry.labelKey);
-      select.appendChild(option);
-    }
-    if (options.length === 0) {
-      const option = document.createElement("option");
-      option.value = "none";
-      option.textContent = t("accessoryNone");
-      select.appendChild(option);
-      select.disabled = true;
-    }
-
-    function syncFromSnapshot() {
-      select.value = getThemeAccessoryId(theme.id, options);
-      select.classList.remove("pending");
-      select.disabled = options.length === 0;
-    }
-
-    select.addEventListener("change", () => {
-      if (select.disabled || select.classList.contains("pending")) return;
-      const next = select.value;
-      const committed = getThemeAccessoryId(theme.id, options);
-      if (next === committed) return;
-      const current = state.snapshot && state.snapshot.petAccessory;
-      const nextMap = current && typeof current === "object" && !Array.isArray(current)
-        ? { ...current }
-        : {};
-      if (next === "none") delete nextMap[theme.id];
-      else nextMap[theme.id] = next;
-      select.classList.add("pending");
-      select.disabled = true;
-      Promise.resolve(window.settingsAPI.update("petAccessory", nextMap))
-        .then((result) => {
-          if (result && result.status === "ok") return;
-          const message = (result && result.message) || "unknown error";
-          ops.showToast(t("toastSaveFailed") + message, { error: true });
-          syncFromSnapshot();
-        })
-        .catch((err) => {
-          const message = (err && err.message) || "unknown error";
-          ops.showToast(t("toastSaveFailed") + message, { error: true });
-          syncFromSnapshot();
-        })
-        .finally(() => {
-          if (document.body.contains(select)) {
-            select.classList.remove("pending");
-            select.disabled = options.length === 0;
-          }
-        });
+    const pickerOptions = options.length > 0
+      ? options.map((entry) => ({ value: entry.id, label: t(entry.labelKey) }))
+      : [{ value: "none", label: t("accessoryNone") }];
+    const picker = helpers.buildSettingsSelect({
+      value: getThemeAccessoryId(theme.id, options),
+      options: pickerOptions,
+      ariaLabel: t("rowPetAccessory"),
+      className: "pet-accessory-select",
+      disabled: options.length === 0,
+      onChange(next) {
+        const committed = getThemeAccessoryId(theme.id, options);
+        if (next === committed) return true;
+        const current = state.snapshot && state.snapshot.petAccessory;
+        const nextMap = current && typeof current === "object" && !Array.isArray(current)
+          ? { ...current }
+          : {};
+        if (next === "none") delete nextMap[theme.id];
+        else nextMap[theme.id] = next;
+        return Promise.resolve(window.settingsAPI.update("petAccessory", nextMap))
+          .then((result) => {
+            if (result && result.status === "ok") return true;
+            const message = (result && result.message) || "unknown error";
+            ops.showToast(t("toastSaveFailed") + message, { error: true });
+            return false;
+          })
+          .catch((err) => {
+            const message = (err && err.message) || "unknown error";
+            ops.showToast(t("toastSaveFailed") + message, { error: true });
+            return false;
+          });
+      },
     });
 
-    control.appendChild(select);
+    function syncFromSnapshot() {
+      picker.setValue(getThemeAccessoryId(theme.id, options));
+      picker.setPending(false);
+      picker.setDisabled(options.length === 0);
+    }
+
+    control.appendChild(picker.element);
     row.appendChild(text);
     row.appendChild(control);
     syncFromSnapshot();

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -411,6 +411,7 @@
     children = [],
     defaultCollapsed = false,
     className = "",
+    animateExpansion = true,
   }) {
     const storedState = readCollapsedGroupState();
     let collapsed = Object.prototype.hasOwnProperty.call(storedState, id)
@@ -549,7 +550,7 @@
       const nextState = readCollapsedGroupState();
       nextState[id] = collapsed;
       writeCollapsedGroupState(nextState);
-      preserveScrollAnchor(() => applyCollapsedState({ animate: true }));
+      preserveScrollAnchor(() => applyCollapsedState({ animate: animateExpansion }));
     }
 
     header.addEventListener("click", toggleCollapsed);

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -30,6 +30,7 @@
     || ((data) => data);
   const applyAnimationPosterPayloadToRuntime = animMergeApi.applyAnimationPosterPayload
     || (() => ({ valid: false, stored: false, applied: false }));
+  const selectPickerApi = root.ClawdLanguagePicker || {};
 
   const shortcutApi = root.ClawdShortcutActions || {};
   const SHORTCUT_ACTIONS = shortcutApi.SHORTCUT_ACTIONS || {};
@@ -77,6 +78,8 @@
       soundSummary: null,
       soundVolume: null,
       textScale: null,
+      settingsSelects: new Set(),
+      aboutAutoUpdate: null,
     },
     shortcutRecordingActionId: null,
     shortcutRecordingError: "",
@@ -350,6 +353,21 @@
     return section;
   }
 
+  function buildSettingsSelect(config = {}) {
+    const factory = selectPickerApi.createSettingsSelect || selectPickerApi.createLanguagePicker;
+    if (typeof factory !== "function") {
+      throw new Error("language-picker.js failed to load before settings-ui-core.js");
+    }
+    const className = ["settings-select", config.className || ""].filter(Boolean).join(" ");
+    const control = factory({
+      ...config,
+      className,
+      lockWhilePending: config.lockWhilePending !== false,
+    });
+    state.mountedControls.settingsSelects.add(control);
+    return control;
+  }
+
   function readCollapsedGroupState() {
     try {
       const raw = localStorage.getItem(COLLAPSED_GROUPS_STORAGE_KEY);
@@ -452,6 +470,13 @@
       body.style.setProperty("--collapsible-body-height", measureCollapsibleBodyHeight());
     }
 
+    function refreshCollapsibleHeight() {
+      if (collapsed || !group.classList.contains("expanding")) return;
+      requestAnimationFrame(() => {
+        if (!collapsed && group.classList.contains("expanding")) setExpandedBodyHeight();
+      });
+    }
+
     function setBodyInteractivity(isCollapsed) {
       body.setAttribute("aria-hidden", isCollapsed ? "true" : "false");
       if ("inert" in body) {
@@ -548,6 +573,7 @@
     requestAnimationFrame(() => {
       if (!collapsed) body.style.setProperty("--collapsible-body-height", "none");
     });
+    group.refreshCollapsibleHeight = refreshCollapsibleHeight;
     return group;
   }
 
@@ -858,6 +884,10 @@
     if (state.mountedControls.textScale && typeof state.mountedControls.textScale.dispose === "function") {
       state.mountedControls.textScale.dispose();
     }
+    for (const control of state.mountedControls.settingsSelects) {
+      if (control && typeof control.dispose === "function") control.dispose();
+    }
+    state.mountedControls.settingsSelects.clear();
     state.mountedControls.generalSwitches.clear();
     state.mountedControls.bubblePolicyControls.clear();
     state.mountedControls.sessionCleanupControls.clear();
@@ -875,6 +905,7 @@
     state.mountedControls.soundSummary = null;
     state.mountedControls.soundVolume = null;
     state.mountedControls.textScale = null;
+    state.mountedControls.aboutAutoUpdate = null;
   }
 
   function syncMountedSizeControl({ fromBroadcast = false } = {}) {
@@ -1461,6 +1492,7 @@
     attachAnimatedSwitch,
     buildSwitchRow,
     buildSection,
+    buildSettingsSelect,
     buildCollapsibleGroup,
     createDisclosureChevron,
     attachActivation,

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -108,6 +108,7 @@
     pendingAnimationOverrideEdits: new Map(),
     nextAnimationOverrideEditSeq: 1,
     animOverridesSubtab: "map",
+    settingsTabScrollPositions: new Map(),
     // null = not chosen yet; the Agents tab resolves it from what is connected.
     agentsSubtab: null,
     agentsUnavailableQuery: "",
@@ -478,6 +479,37 @@
       });
     }
 
+    function mutateCollapsibleBody(mutate) {
+      if (typeof mutate !== "function") return;
+      if (collapsed || group.classList.contains("collapsing")) {
+        mutate();
+        return;
+      }
+      if (group.classList.contains("expanding")) {
+        mutate();
+        refreshCollapsibleHeight();
+        return;
+      }
+
+      const beforeHeight = body.scrollHeight;
+      mutate();
+      const afterHeight = body.scrollHeight;
+      const prefersReducedMotion = typeof window.matchMedia === "function"
+        && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+      if (beforeHeight === afterHeight || prefersReducedMotion) return;
+
+      // The settled-open body normally uses max-height:none so reflow can grow
+      // freely. Pin its pre-mutation height for one frame, then animate to the
+      // new measured height instead of letting async rows cause a layout jump.
+      body.style.setProperty("--collapsible-body-height", `${beforeHeight}px`);
+      group.classList.add("resizing");
+      void body.offsetHeight;
+      requestAnimationFrame(() => {
+        if (collapsed || !group.classList.contains("resizing")) return;
+        body.style.setProperty("--collapsible-body-height", `${afterHeight}px`);
+      });
+    }
+
     function setBodyInteractivity(isCollapsed) {
       body.setAttribute("aria-hidden", isCollapsed ? "true" : "false");
       if ("inert" in body) {
@@ -509,7 +541,7 @@
     function applyCollapsedState({ animate = false } = {}) {
       header.setAttribute("aria-expanded", collapsed ? "false" : "true");
       header.setAttribute("aria-label", collapsed ? t("collapsibleExpand") : t("collapsibleCollapse"));
-      group.classList.remove("expanding", "collapsing");
+      group.classList.remove("expanding", "collapsing", "resizing");
       if (!animate) {
         group.classList.toggle("collapsed", collapsed);
         setBodyInteractivity(collapsed);
@@ -565,7 +597,7 @@
     group.appendChild(body);
     body.addEventListener("transitionend", (ev) => {
       if (ev.target !== body || ev.propertyName !== "max-height") return;
-      group.classList.remove("expanding", "collapsing");
+      group.classList.remove("expanding", "collapsing", "resizing");
       // Release the pinned height once settled so later reflows (text zoom,
       // window resize) can grow the body instead of clipping at the bottom.
       if (!collapsed) body.style.setProperty("--collapsible-body-height", "none");
@@ -575,6 +607,7 @@
       if (!collapsed) body.style.setProperty("--collapsible-body-height", "none");
     });
     group.refreshCollapsibleHeight = refreshCollapsibleHeight;
+    group.mutateCollapsibleBody = mutateCollapsibleBody;
     return group;
   }
 
@@ -938,12 +971,25 @@
   function selectTab(nextTab) {
     const prevTabId = state.activeTab;
     if (prevTabId === nextTab) return;
+    const content = document.getElementById("content");
+    if (content) {
+      runtime.settingsTabScrollPositions.set(prevTabId, content.scrollTop);
+    }
     const prevTab = tabs[prevTabId];
     if (prevTab && typeof prevTab.onExit === "function") {
       prevTab.onExit(core);
     }
     state.activeTab = nextTab;
     requestRender({ sidebar: true, content: true, modal: true });
+    if (!content) return;
+
+    const targetScrollTop = runtime.settingsTabScrollPositions.get(nextTab) || 0;
+    content.scrollTop = targetScrollTop;
+    requestAnimationFrame(() => {
+      if (state.activeTab !== nextTab) return;
+      if (document.getElementById("content") !== content) return;
+      content.scrollTop = targetScrollTop;
+    });
   }
 
   function applyBootstrap(snapshotValue) {

--- a/src/settings.css
+++ b/src/settings.css
@@ -535,6 +535,9 @@ html, body {
 .collapsible-group.collapsing .collapsible-group-body {
   pointer-events: none;
 }
+.collapsible-group:not(.collapsed):has(.language-picker.open) > .collapsible-group-body {
+  overflow: visible;
+}
 .agent-subgroup .collapsible-group-body {
   padding: 0;
 }
@@ -944,16 +947,17 @@ html, body {
   min-width: min(100%, 260px);
 }
 .agent-custom-tools-section .custom-tool-discovery-row {
-  align-items: stretch;
-  flex-direction: column;
-  gap: 14px;
-  padding: 18px;
+  align-items: center;
+  flex-direction: row;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 16px 18px;
   border: 1px solid color-mix(in srgb, var(--accent) 28%, var(--border));
   background: color-mix(in srgb, var(--panel-bg) 94%, var(--accent) 6%);
 }
 .agent-custom-tools-section .row-text {
-  flex: 0 0 auto;
-  width: 100%;
+  flex: 1 1 360px;
+  min-width: 0;
 }
 .agent-custom-tools-section .row-label {
   color: var(--text-primary);
@@ -974,6 +978,16 @@ html, body {
   flex-wrap: wrap;
   gap: 10px;
   min-width: 0;
+}
+@media (max-width: 760px) {
+  .agent-custom-tools-section .custom-tool-discovery-row {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .agent-custom-tools-section .row-text {
+    flex-basis: auto;
+  }
 }
 /* Needs the extra .soft-btn to outrank the later `.soft-btn.accent` tinted
    rule — at equal specificity source order wins and the primary action
@@ -1311,32 +1325,20 @@ html, body {
   opacity: 0.48;
   cursor: not-allowed;
 }
-.pet-tint-select,
-.pet-accessory-select {
+.settings-select {
   min-width: 176px;
   max-width: 240px;
-  padding: 7px 30px 7px 10px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--panel-bg);
-  color: var(--text-primary);
-  font: inherit;
-  cursor: pointer;
+  width: 220px;
 }
-.pet-tint-select:hover:not(:disabled),
-.pet-tint-select:focus-visible,
-.pet-accessory-select:hover:not(:disabled),
-.pet-accessory-select:focus-visible {
-  border-color: var(--accent);
-  outline: none;
+.settings-select .language-picker-trigger {
+  height: 38px;
 }
-.pet-tint-select.pending,
-.pet-tint-select:disabled,
-.pet-accessory-select.pending,
-.pet-accessory-select:disabled {
-  cursor: wait;
+.settings-select.pending .language-picker-trigger,
+.settings-select.disabled .language-picker-trigger {
   opacity: 0.62;
 }
+.settings-select.pending .language-picker-trigger { cursor: progress; }
+.settings-select.disabled .language-picker-trigger { cursor: not-allowed; }
 .codex-permission-mode-segmented {
   --codex-permission-mode-active-index: 0;
   position: relative;
@@ -3724,7 +3726,7 @@ html, body {
   border-color: var(--accent);
 }
 .tg-approval-output-select {
-  min-width: 180px;
+  min-width: 220px;
 }
 
 .feishu-approval-secrets-grid {

--- a/src/settings.css
+++ b/src/settings.css
@@ -532,7 +532,8 @@ html, body {
   transform: translateY(-4px);
 }
 .collapsible-group.expanding .collapsible-group-body,
-.collapsible-group.collapsing .collapsible-group-body {
+.collapsible-group.collapsing .collapsible-group-body,
+.collapsible-group.resizing .collapsible-group-body {
   pointer-events: none;
 }
 .collapsible-group:not(.collapsed):has(.language-picker.open) > .collapsible-group-body {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -888,6 +888,20 @@ function findAncestorByClass(el, className) {
   return null;
 }
 
+function choosePickerOption(picker, value) {
+  picker.querySelector(".language-picker-trigger").dispatchEvent({ type: "click" });
+  const option = picker.querySelectorAll(".language-picker-option")
+    .find((candidate) => candidate.dataset.lang === String(value));
+  assert.ok(option, `picker option ${value} should exist`);
+  option.dispatchEvent({ type: "click" });
+}
+
+function getSelectedPickerValue(picker) {
+  const selected = picker.querySelectorAll(".language-picker-option")
+    .find((option) => option.classList.contains("selected"));
+  return selected ? selected.dataset.lang : null;
+}
+
 function loadThemeTabForTest({
   themes,
   snapshot,
@@ -895,6 +909,7 @@ function loadThemeTabForTest({
   petAccessoryOptions,
   settingsAPI = {},
 } = {}) {
+  const documentListeners = new Map();
   const body = new FakeElement("body");
   const content = new FakeElement("main");
   content.id = "content";
@@ -909,6 +924,14 @@ function loadThemeTabForTest({
     getElementById(id) {
       if (id === "content") return content;
       return null;
+    },
+    addEventListener(type, handler) {
+      if (!documentListeners.has(type)) documentListeners.set(type, new Set());
+      documentListeners.get(type).add(handler);
+    },
+    removeEventListener(type, handler) {
+      const listeners = documentListeners.get(type);
+      if (listeners) listeners.delete(handler);
     },
   };
 
@@ -977,6 +1000,7 @@ function loadThemeTabForTest({
   context.window = context;
   context.globalThis = context;
   vm.createContext(context);
+  vm.runInContext(fs.readFileSync(LANGUAGE_PICKER_JS, "utf8"), context);
   vm.runInContext(fs.readFileSync(SETTINGS_ANIM_OVERRIDES_MERGE, "utf8"), context);
   vm.runInContext(fs.readFileSync(SETTINGS_UI_CORE, "utf8"), context);
   vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-theme.js"), "utf8"), context);
@@ -1256,6 +1280,7 @@ function loadTelegramApprovalTabForTest({
   settingsAPI = {},
   confirm = () => true,
 } = {}) {
+  const documentListeners = new Map();
   const body = new FakeElement("body");
   const content = new FakeElement("main");
   content.id = "content";
@@ -1271,6 +1296,14 @@ function loadTelegramApprovalTabForTest({
     getElementById(id) {
       if (id === "content") return content;
       return null;
+    },
+    addEventListener(type, handler) {
+      if (!documentListeners.has(type)) documentListeners.set(type, new Set());
+      documentListeners.get(type).add(handler);
+    },
+    removeEventListener(type, handler) {
+      const listeners = documentListeners.get(type);
+      if (listeners) listeners.delete(handler);
     },
   };
   const api = {
@@ -1318,6 +1351,7 @@ function loadTelegramApprovalTabForTest({
   context.window = context;
   context.globalThis = context;
   vm.createContext(context);
+  vm.runInContext(fs.readFileSync(LANGUAGE_PICKER_JS, "utf8"), context);
   vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-telegram-approval.js"), "utf8"), context);
 
   const core = {
@@ -1336,6 +1370,9 @@ function loadTelegramApprovalTabForTest({
         },
       },
       activeTab: "telegram-approval",
+      mountedControls: {
+        settingsSelects: new Set(),
+      },
     },
     runtime: {},
     helpers: {
@@ -1349,6 +1386,11 @@ function loadTelegramApprovalTabForTest({
         el.classList.toggle("on", !!checked);
         el.classList.toggle("pending", !!options.pending);
         el.setAttribute("aria-checked", checked ? "true" : "false");
+      },
+      buildSettingsSelect: (config) => {
+        const control = context.ClawdLanguagePicker.createSettingsSelect(config);
+        core.state.mountedControls.settingsSelects.add(control);
+        return control;
       },
       // Mirror the real buildCollapsibleGroup just enough that header content,
       // title/summary, and children all end up in the DOM tree; collapsed
@@ -1409,6 +1451,69 @@ function loadTelegramApprovalTabForTest({
   return { core, content, updates, commands, render, renderRequests, timers };
 }
 
+function loadAboutTabForTest({ snapshot = {}, update } = {}) {
+  const body = new FakeElement("body");
+  const content = new FakeElement("main");
+  content.id = "content";
+  body.appendChild(content);
+  const updateCalls = [];
+  const toasts = [];
+  const document = {
+    body,
+    createElement: (tagName) => new FakeElement(tagName),
+    getElementById: (id) => (id === "content" ? content : null),
+  };
+  const context = {
+    console,
+    document,
+    window: null,
+    globalThis: null,
+    settingsAPI: {
+      getAboutInfo: () => Promise.resolve({
+        version: "1.0.0",
+        autoUpdateCheck: snapshot.autoUpdateCheck !== false,
+      }),
+      update: (key, value) => {
+        updateCalls.push({ key, value });
+        return update ? update(key, value) : Promise.resolve({ status: "ok" });
+      },
+      command: () => Promise.resolve({ status: "ok" }),
+      checkForUpdates: () => Promise.resolve({ status: "ok" }),
+    },
+  };
+  context.window = context;
+  context.globalThis = context;
+  vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-about.js"), "utf8"), context);
+
+  const core = {
+    state: {
+      snapshot: { autoUpdateCheck: true, ...snapshot },
+      activeTab: "about",
+      mountedControls: { aboutAutoUpdate: null },
+    },
+    runtime: { about: { infoCache: null, clickCount: 0 } },
+    helpers: {
+      t: (key) => key,
+      setSwitchVisual: (element, checked, options = {}) => {
+        element.classList.toggle("on", !!checked);
+        element.classList.toggle("pending", !!options.pending);
+        element.setAttribute("aria-checked", checked ? "true" : "false");
+      },
+      openExternalSafe: () => {},
+      showSettingsConfirmModal: () => Promise.resolve("cancel"),
+    },
+    ops: {
+      showToast: (message, options) => toasts.push({ message, options }),
+    },
+    i18n: { CONTRIBUTORS: [], MAINTAINERS: [] },
+    tabs: {},
+  };
+  context.ClawdSettingsTabAbout.init(core);
+  core.tabs.about.render(content, core);
+  return { core, content, updateCalls, toasts };
+}
+
 function loadAnimOverridesTabForTest({
   runtime,
   modalRoot,
@@ -1418,10 +1523,12 @@ function loadAnimOverridesTabForTest({
   helpersOverrides = {},
 }) {
   const documentListeners = new Map();
+  const content = new FakeElement("main");
+  content.id = "content";
   const document = {
     body: new FakeElement("body"),
     createElement: (tagName) => new FakeElement(tagName),
-    getElementById: (id) => (id === "modalRoot" ? modalRoot : null),
+    getElementById: (id) => (id === "modalRoot" ? modalRoot : id === "content" ? content : null),
     querySelector: () => null,
     addEventListener(type, handler) {
       if (!documentListeners.has(type)) documentListeners.set(type, new Set());
@@ -1432,6 +1539,7 @@ function loadAnimOverridesTabForTest({
       if (listeners) listeners.delete(handler);
     },
   };
+  document.body.appendChild(content);
   const context = {
     console,
     document,
@@ -1503,6 +1611,7 @@ function loadAnimOverridesTabForTest({
   context.ClawdSettingsTabAnimOverrides.init(core);
   return {
     core,
+    content,
     document,
     documentListenerCount: (type) => (documentListeners.get(type) || new Set()).size,
   };
@@ -1762,6 +1871,49 @@ describe("settings renderer browser environment", () => {
     for (const login of VERIFIED_GITHUB_CONTRIBUTORS) {
       assert.ok(i18nBundle.CONTRIBUTORS.includes(login), `About contributors should include ${login}`);
     }
+  });
+
+  it("updates the About auto-update switch in place and blocks rapid duplicate saves", async () => {
+    const save = createDeferred();
+    const harness = loadAboutTabForTest({
+      snapshot: { autoUpdateCheck: true },
+      update: () => save.promise,
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const autoUpdateSwitch = harness.content.querySelector(".about-auto-update-switch");
+    assert.ok(autoUpdateSwitch);
+    autoUpdateSwitch.dispatchEvent({ type: "click" });
+    autoUpdateSwitch.dispatchEvent({ type: "click" });
+    assert.deepStrictEqual(harness.updateCalls, [{ key: "autoUpdateCheck", value: false }]);
+    assert.equal(autoUpdateSwitch.classList.contains("pending"), true);
+    assert.equal(autoUpdateSwitch.getAttribute("aria-disabled"), "true");
+
+    save.resolve({ status: "ok" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(autoUpdateSwitch.classList.contains("pending"), false);
+    assert.equal(autoUpdateSwitch.getAttribute("aria-checked"), "false");
+
+    harness.core.state.snapshot.autoUpdateCheck = true;
+    assert.equal(harness.core.tabs.about.patchInPlace({ autoUpdateCheck: true }), true);
+    assert.strictEqual(harness.content.querySelector(".about-auto-update-switch"), autoUpdateSwitch);
+    assert.equal(autoUpdateSwitch.getAttribute("aria-checked"), "true");
+  });
+
+  it("rolls the About auto-update switch back when persistence fails", async () => {
+    const harness = loadAboutTabForTest({
+      snapshot: { autoUpdateCheck: true },
+      update: () => Promise.resolve({ status: "error", message: "disk full" }),
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    const autoUpdateSwitch = harness.content.querySelector(".about-auto-update-switch");
+    autoUpdateSwitch.dispatchEvent({ type: "click" });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(autoUpdateSwitch.getAttribute("aria-checked"), "true");
+    assert.equal(autoUpdateSwitch.classList.contains("pending"), false);
+    assert.equal(harness.toasts.length, 1);
+    assert.equal(harness.toasts[0].options.error, true);
   });
 
   it("keeps every Telegram retirement gate string in all supported languages", () => {
@@ -2340,13 +2492,16 @@ describe("settings renderer browser environment", () => {
     harness.render();
 
     const select = harness.content.querySelector(".tg-approval-output-select");
-    assert.deepStrictEqual(select.children.map((option) => option.value), ["off", "full"]);
-    select.value = "full";
-    select.dispatchEvent({ type: "change" });
+    assert.deepStrictEqual(
+      select.querySelectorAll(".language-picker-option").map((option) => option.dataset.lang),
+      ["off", "full"]
+    );
+    choosePickerOption(select, "full");
+    await Promise.resolve();
 
     assert.deepStrictEqual(confirmCalls, ["telegramApprovalCompletionOutputFullConfirm"]);
     assert.deepStrictEqual(JSON.parse(JSON.stringify(harness.updates)), []);
-    assert.equal(select.value, "off");
+    assert.equal(select.querySelector(".language-picker-value").textContent, "telegramApprovalCompletionOutput_off");
 
     const confirmed = loadTelegramApprovalTabForTest({
       snapshot: {
@@ -2365,8 +2520,7 @@ describe("settings renderer browser environment", () => {
     confirmed.render();
 
     const confirmedSelect = confirmed.content.querySelector(".tg-approval-output-select");
-    confirmedSelect.value = "full";
-    confirmedSelect.dispatchEvent({ type: "change" });
+    choosePickerOption(confirmedSelect, "full");
 
     assert.deepStrictEqual(JSON.parse(JSON.stringify(confirmed.updates)), [{
       key: "tgApproval",
@@ -2953,9 +3107,8 @@ describe("settings renderer browser environment", () => {
 
     const select = harness.content.querySelector(".feishu-approval-timeout-select");
     assert.ok(select, "Feishu timeout select should render");
-    assert.equal(select.value, "15");
-    select.value = "30";
-    select.dispatchEvent({ type: "change" });
+    assert.equal(getSelectedPickerValue(select), "15");
+    choosePickerOption(select, "30");
 
     await Promise.resolve();
     assert.deepStrictEqual(JSON.parse(JSON.stringify(harness.updates.find((call) => call.key === "feishuApproval"))), {
@@ -4029,8 +4182,10 @@ describe("settings renderer browser environment", () => {
       String.raw`\];`
     ).test(generalSource));
     assert.ok(generalSource.includes("createLanguagePicker"));
-    assert.ok(pickerSource.includes(`className = "language-picker"`));
+    assert.ok(pickerSource.includes("picker.className = `language-picker"));
+    assert.ok(pickerSource.includes(`role", "combobox"`));
     assert.ok(pickerSource.includes(`aria-haspopup", "listbox"`));
+    assert.ok(pickerSource.includes(`aria-controls", menu.id`));
     assert.ok(pickerSource.includes(`role", "listbox"`));
     assert.ok(pickerSource.includes(`aria-hidden", "true"`));
     assert.ok(pickerSource.includes(`role", "option"`));
@@ -4152,6 +4307,39 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(harness.getLangValue().textContent, "English");
     assert.strictEqual(trigger.focused, true);
     assert.strictEqual(harness.getToastText(), "Failed: synthetic failure");
+  });
+
+  it("supports Home/End navigation and locks disabled or pending Settings pickers", () => {
+    const harness = loadGeneralLanguageRowForTest({ snapshot: { lang: "en" } });
+    harness.core.ops.requestRender({ content: true });
+    const trigger = harness.getLangTrigger();
+    const options = harness.getLangOptions();
+    trigger.dispatchEvent(createKeyboardEventForTest("ArrowDown"));
+    for (const option of options) option.focused = false;
+    trigger.dispatchEvent(createKeyboardEventForTest("End"));
+    assert.equal(options[options.length - 1].focused, true);
+    for (const option of options) option.focused = false;
+    trigger.dispatchEvent(createKeyboardEventForTest("Home"));
+    assert.equal(options[0].focused, true);
+    assert.equal(trigger.getAttribute("role"), "combobox");
+    assert.equal(trigger.getAttribute("aria-controls"), harness.getLangMenu().id);
+
+    const locked = harness.core.helpers.buildSettingsSelect({
+      value: "a",
+      options: [{ value: "a", label: "A" }, { value: "b", label: "B" }],
+      lockWhilePending: true,
+    });
+    harness.content.appendChild(locked.element);
+    const lockedTrigger = locked.element.querySelector(".language-picker-trigger");
+    locked.setDisabled(true);
+    lockedTrigger.dispatchEvent({ type: "click" });
+    assert.equal(locked.element.classList.contains("open"), false);
+    assert.equal(lockedTrigger.disabled, true);
+    locked.setDisabled(false);
+    locked.setPending(true);
+    lockedTrigger.dispatchEvent({ type: "click" });
+    assert.equal(locked.element.classList.contains("open"), false);
+    assert.equal(lockedTrigger.disabled, true);
   });
 
   it("rolls concurrent failed language saves back to the last committed value", async () => {
@@ -4813,6 +5001,26 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(harness.getSwitchMeta("quotaMergeSources").row.style.display, "");
     assert.strictEqual(summary.children.length, 1);
     assert.strictEqual(summary.children[0].textContent, "HUD: off");
+  });
+
+  it("remeasures an expanding quota group when async source options appear", async () => {
+    const sourceCount = createDeferred();
+    const harness = loadGeneralTabForTest({
+      snapshot: makeGeneralSnapshot({ quotaMergeSources: false }),
+      settingsAPI: { getQuotaSourceCount: () => sourceCount.promise },
+    });
+    harness.renderContent();
+    const group = harness.content.querySelector(".quota-ring-collapsible");
+    const header = group.querySelector(".collapsible-group-header");
+    const body = group.querySelector(".collapsible-group-body");
+    header.dispatchEvent({ type: "click" });
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "40px");
+
+    body.appendChild(new FakeElement("div"));
+    sourceCount.resolve(2);
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "80px");
+    assert.equal(harness.getSwitchMeta("quotaMergeSources").row.style.display, "");
   });
 
   it("groups sound and volume into one collapsible control with in-place summary updates", () => {
@@ -5766,14 +5974,13 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(harness.content.querySelector(".theme-grid"), null);
 
     const select = harness.content.querySelector(".pet-tint-select");
-    assert.strictEqual(select.value, "matcha");
+    assert.strictEqual(getSelectedPickerValue(select), "matcha");
     assert.deepStrictEqual(
-      select.children.map((option) => option.textContent),
+      select.querySelectorAll(".language-picker-option").map((option) => option.textContent),
       ["Default", "🌙 Midnight", "🥇 Gold", "🌸 Vaporwave", "🍵 Matcha", "⬜ Monochrome"]
     );
 
-    select.value = "gold";
-    select.dispatchEvent({ type: "change" });
+    choosePickerOption(select, "gold");
     assert.deepStrictEqual(
       JSON.parse(JSON.stringify(harness.updates)),
       [{
@@ -5781,22 +5988,21 @@ describe("settings renderer browser environment", () => {
         value: { clawd: "gold", cloudling: "vaporwave" },
       }]
     );
-    assert.strictEqual(select.disabled, true);
+    assert.strictEqual(select.querySelector(".language-picker-trigger").disabled, true);
     assert.strictEqual(select.classList.contains("pending"), true);
     await Promise.resolve();
     await Promise.resolve();
     await new Promise((resolve) => setImmediate(resolve));
-    assert.strictEqual(select.disabled, false);
+    assert.strictEqual(select.querySelector(".language-picker-trigger").disabled, false);
     assert.strictEqual(select.classList.contains("pending"), false);
 
     const accessorySelect = harness.content.querySelector(".pet-accessory-select");
-    assert.strictEqual(accessorySelect.value, "wizard-hat");
+    assert.strictEqual(getSelectedPickerValue(accessorySelect), "wizard-hat");
     assert.deepStrictEqual(
-      accessorySelect.children.map((option) => option.textContent),
+      accessorySelect.querySelectorAll(".language-picker-option").map((option) => option.textContent),
       ["None", "Cowboy hat", "Wizard hat", "Halo"]
     );
-    accessorySelect.value = "halo";
-    accessorySelect.dispatchEvent({ type: "change" });
+    choosePickerOption(accessorySelect, "halo");
     assert.deepStrictEqual(
       JSON.parse(JSON.stringify(harness.updates[1])),
       {
@@ -5804,11 +6010,11 @@ describe("settings renderer browser environment", () => {
         value: { clawd: "halo", cloudling: "halo" },
       }
     );
-    assert.strictEqual(accessorySelect.disabled, true);
+    assert.strictEqual(accessorySelect.querySelector(".language-picker-trigger").disabled, true);
     await Promise.resolve();
     await Promise.resolve();
     await new Promise((resolve) => setImmediate(resolve));
-    assert.strictEqual(accessorySelect.disabled, false);
+    assert.strictEqual(accessorySelect.querySelector(".language-picker-trigger").disabled, false);
 
     harness.content.querySelector(".theme-detail-back").dispatchEvent({ type: "click" });
     assert.ok(harness.content.querySelector(".theme-grid"));
@@ -5995,7 +6201,8 @@ describe("settings renderer browser environment", () => {
     assert.ok(agentsSource.includes('control.className = "custom-tool-wsl-scan"'));
     assert.ok(!agentsSource.includes('toolbar.className = "agent-scan-toolbar"'));
     assert.ok(css.includes(".custom-tool-result-status"));
-    assert.match(css, /\.agent-custom-tools-section \.custom-tool-discovery-row\s*\{[^}]*flex-direction:\s*column;/s);
+    assert.match(css, /\.agent-custom-tools-section \.custom-tool-discovery-row\s*\{[^}]*flex-direction:\s*row;/s);
+    assert.match(css, /@media \(max-width:\s*760px\)\s*\{[\s\S]*?\.agent-custom-tools-section \.custom-tool-discovery-row\s*\{[^}]*flex-direction:\s*column;/);
     // The primary picker must keep a higher-specificity selector than the
     // generic `.soft-btn.accent` tinted rule that follows it, or the cascade
     // falls back to source order and drops the solid accent fill.
@@ -7410,6 +7617,53 @@ describe("settings renderer browser environment", () => {
       harness.core.state.mountedControls.animMapReset,
       "the reset-all control should mount under the subtab"
     );
+  });
+
+  it("keeps Animation subtab headers and scroll position stable across consecutive switches", () => {
+    const harness = loadAnimMapTabForTest({
+      snapshot: { theme: "clawd", themeOverrides: {} },
+    });
+    harness.core.runtime.animationOverridesData = {
+      theme: { id: "clawd", name: "Clawd" },
+      assets: [],
+      sections: [],
+      cards: [],
+      sounds: [],
+    };
+    harness.core.runtime.animOverridesSubtab = "map";
+    const render = () => {
+      harness.content.innerHTML = "";
+      harness.core.tabs.animOverrides.render(harness.content, harness.core);
+    };
+    harness.core.ops.installRenderHooks({ content: render, modal: () => {} });
+    render();
+
+    function headerShape() {
+      return harness.content.children.slice(0, 3).map((child) => ({
+        tag: child.tagName,
+        className: child.className,
+      }));
+    }
+    const expectedHeader = headerShape();
+    assert.deepStrictEqual(expectedHeader, [
+      { tag: "H1", className: "" },
+      { tag: "P", className: "subtitle" },
+      { tag: "DIV", className: "anim-override-subtabs" },
+    ]);
+
+    for (const subtab of ["animations", "sounds", "map"]) {
+      harness.content.scrollTop = 240;
+      const button = harness.content.querySelectorAll("button")
+        .find((candidate) => candidate.dataset.animOverridesSubtab === subtab);
+      assert.ok(button, `${subtab} tab should render`);
+      button.dispatchEvent({ type: "click" });
+      assert.deepStrictEqual(headerShape(), expectedHeader);
+      assert.equal(harness.content.scrollTop, 240);
+      const active = harness.content.querySelectorAll("button")
+        .find((candidate) => candidate.classList.contains("active"));
+      assert.equal(active.dataset.animOverridesSubtab, subtab);
+      assert.equal(active.focused, true);
+    }
   });
 
   it("keeps Animation Map theme override broadcasts in place and syncs the mounted switch", () => {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -7619,7 +7619,7 @@ describe("settings renderer browser environment", () => {
     );
   });
 
-  it("keeps Animation subtab headers and scroll position stable across consecutive switches", () => {
+  it("keeps the Animation shell mounted and restores scroll per subtab", () => {
     const harness = loadAnimMapTabForTest({
       snapshot: { theme: "clawd", themeOverrides: {} },
     });
@@ -7638,32 +7638,37 @@ describe("settings renderer browser environment", () => {
     harness.core.ops.installRenderHooks({ content: render, modal: () => {} });
     render();
 
-    function headerShape() {
-      return harness.content.children.slice(0, 3).map((child) => ({
-        tag: child.tagName,
-        className: child.className,
-      }));
-    }
-    const expectedHeader = headerShape();
-    assert.deepStrictEqual(expectedHeader, [
-      { tag: "H1", className: "" },
-      { tag: "P", className: "subtitle" },
-      { tag: "DIV", className: "anim-override-subtabs" },
-    ]);
+    const [heading, subtitle, tablist, body] = harness.content.children;
+    assert.equal(heading.tagName, "H1");
+    assert.equal(subtitle.className, "subtitle");
+    assert.equal(tablist.className, "anim-override-subtabs");
+    assert.equal(body.className, "anim-override-subtab-body");
 
-    for (const subtab of ["animations", "sounds", "map"]) {
-      harness.content.scrollTop = 240;
+    function switchTo(subtab) {
       const button = harness.content.querySelectorAll("button")
         .find((candidate) => candidate.dataset.animOverridesSubtab === subtab);
       assert.ok(button, `${subtab} tab should render`);
       button.dispatchEvent({ type: "click" });
-      assert.deepStrictEqual(headerShape(), expectedHeader);
-      assert.equal(harness.content.scrollTop, 240);
+      assert.strictEqual(harness.content.children[0], heading);
+      assert.strictEqual(harness.content.children[1], subtitle);
+      assert.strictEqual(harness.content.children[2], tablist);
+      assert.strictEqual(harness.content.children[3], body);
       const active = harness.content.querySelectorAll("button")
         .find((candidate) => candidate.classList.contains("active"));
       assert.equal(active.dataset.animOverridesSubtab, subtab);
       assert.equal(active.focused, true);
     }
+
+    switchTo("animations");
+    harness.content.scrollTop = 240;
+    switchTo("sounds");
+    assert.equal(harness.content.scrollTop, 0, "the short target subtab starts at its own scroll position");
+
+    // Chromium clamps a short page to zero. Returning to Animations must use
+    // its saved position rather than this clamped value from Sounds.
+    harness.content.scrollTop = 0;
+    switchTo("animations");
+    assert.equal(harness.content.scrollTop, 240);
   });
 
   it("keeps Animation Map theme override broadcasts in place and syncs the mounted switch", () => {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -5003,7 +5003,7 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(summary.children[0].textContent, "HUD: off");
   });
 
-  it("remeasures an expanding quota group when async source options appear", async () => {
+  it("reveals existing quota options immediately and absorbs async sources without a second expansion", async () => {
     const sourceCount = createDeferred();
     const harness = loadGeneralTabForTest({
       snapshot: makeGeneralSnapshot({ quotaMergeSources: false }),
@@ -5014,12 +5014,16 @@ describe("settings renderer browser environment", () => {
     const header = group.querySelector(".collapsible-group-header");
     const body = group.querySelector(".collapsible-group-body");
     header.dispatchEvent({ type: "click" });
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "40px");
+    assert.equal(group.classList.contains("expanding"), false);
+    assert.equal(group.classList.contains("collapsed"), false);
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
+    assert.equal(body.attributes["aria-hidden"], "false");
 
     body.appendChild(new FakeElement("div"));
     sourceCount.resolve(2);
     await new Promise((resolve) => setImmediate(resolve));
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "80px");
+    assert.equal(group.classList.contains("expanding"), false);
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
     assert.equal(harness.getSwitchMeta("quotaMergeSources").row.style.display, "");
   });
 

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -69,7 +69,17 @@ function loadSettingsI18nForTest() {
   return loadSettingsI18nBundleForTest().STRINGS;
 }
 
-function loadSettingsCoreForTest(settingsAPI) {
+function loadSettingsCoreForTest(settingsAPI, {
+  document: documentOverride = null,
+  requestAnimationFrame = (cb) => {
+    cb();
+    return 1;
+  },
+} = {}) {
+  const document = documentOverride || {
+    body: { contains: () => false },
+    getElementById: () => null,
+  };
   const context = {
     console,
     navigator: { platform: "Win32" },
@@ -77,14 +87,8 @@ function loadSettingsCoreForTest(settingsAPI) {
       getItem: () => null,
       setItem: () => {},
     },
-    document: {
-      body: { contains: () => false },
-      getElementById: () => null,
-    },
-    requestAnimationFrame: (cb) => {
-      cb();
-      return 1;
-    },
+    document,
+    requestAnimationFrame,
     window: null,
     globalThis: null,
     settingsAPI,
@@ -616,6 +620,10 @@ function loadGeneralLanguageRowForTest({
 function loadGeneralTabForTest({
   snapshot,
   settingsAPI = {},
+  requestAnimationFrame = (cb) => {
+    cb();
+    return 1;
+  },
 } = {}) {
   const body = new FakeElement("body");
   const content = new FakeElement("main");
@@ -639,10 +647,7 @@ function loadGeneralTabForTest({
       setItem: () => {},
     },
     document,
-    requestAnimationFrame: (cb) => {
-      cb();
-      return 1;
-    },
+    requestAnimationFrame,
     getComputedStyle: () => ({
       getPropertyValue: () => "",
     }),
@@ -1771,6 +1776,53 @@ describe("settings renderer browser environment", () => {
       assert.ok(!source.includes("settingsAPI.onShortcutFailuresChanged"), `${path.basename(file)} must not subscribe to settingsAPI.onShortcutFailuresChanged`);
       assert.ok(!source.includes("settingsAPI.onRemoteApprovalStatusChanged"), `${path.basename(file)} must not subscribe to remote approval status directly`);
     }
+  });
+
+  it("keeps sidebar page scroll positions isolated when a shorter page clamps scrollTop", () => {
+    let rawScrollTop = 1480;
+    let maxScrollTop = 2000;
+    const raf = createQueuedRaf();
+    const content = {
+      get scrollTop() {
+        return Math.min(rawScrollTop, maxScrollTop);
+      },
+      set scrollTop(value) {
+        rawScrollTop = Math.max(0, Math.min(Number(value) || 0, maxScrollTop));
+      },
+    };
+    const document = {
+      body: { contains: () => false },
+      getElementById: (id) => (id === "content" ? content : null),
+    };
+    const core = loadSettingsCoreForTest({}, {
+      document,
+      requestAnimationFrame: raf.requestAnimationFrame,
+    });
+    core.state.activeTab = "remote-ssh";
+    core.tabs["remote-ssh"] = {};
+    core.tabs.theme = {};
+    core.ops.installRenderHooks({
+      sidebar: () => {},
+      modal: () => {},
+      content: () => {
+        maxScrollTop = core.state.activeTab === "theme" ? 398 : 2000;
+        content.scrollTop = content.scrollTop;
+      },
+    });
+
+    core.ops.selectTab("theme");
+    assert.equal(content.scrollTop, 0, "a sidebar page starts at the top on first entry");
+    raf.flush();
+
+    content.scrollTop = 240;
+    core.ops.selectTab("remote-ssh");
+    assert.equal(content.scrollTop, 1480, "the long source page restores its saved position");
+
+    // Switch again before the remote page's deferred restore runs. Its stale
+    // callback must not overwrite the newly active Theme page.
+    core.ops.selectTab("theme");
+    raf.flush();
+    assert.equal(content.scrollTop, 240, "the short target page keeps its own position");
   });
 
   it("waits for remote cleanup before deleting a profile and warns on incomplete uninstall", () => {
@@ -5005,26 +5057,53 @@ describe("settings renderer browser environment", () => {
 
   it("reveals existing quota options immediately and absorbs async sources without a second expansion", async () => {
     const sourceCount = createDeferred();
+    const animationFrames = [];
+    const flushAnimationFrame = () => {
+      const callbacks = animationFrames.splice(0);
+      for (const callback of callbacks) callback();
+    };
     const harness = loadGeneralTabForTest({
       snapshot: makeGeneralSnapshot({ quotaMergeSources: false }),
       settingsAPI: { getQuotaSourceCount: () => sourceCount.promise },
+      requestAnimationFrame: (callback) => {
+        animationFrames.push(callback);
+        return animationFrames.length;
+      },
     });
     harness.renderContent();
+    flushAnimationFrame();
     const group = harness.content.querySelector(".quota-ring-collapsible");
     const header = group.querySelector(".collapsible-group-header");
     const body = group.querySelector(".collapsible-group-body");
+    const mergeRow = harness.getSwitchMeta("quotaMergeSources").row;
+    Object.defineProperty(body, "scrollHeight", {
+      configurable: true,
+      get: () => (mergeRow.style.display === "none" ? 80 : 120),
+    });
     header.dispatchEvent({ type: "click" });
     assert.equal(group.classList.contains("expanding"), false);
     assert.equal(group.classList.contains("collapsed"), false);
     assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
     assert.equal(body.attributes["aria-hidden"], "false");
+    flushAnimationFrame();
 
-    body.appendChild(new FakeElement("div"));
     sourceCount.resolve(2);
     await new Promise((resolve) => setImmediate(resolve));
     assert.equal(group.classList.contains("expanding"), false);
+    assert.equal(group.classList.contains("resizing"), true);
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "80px");
+    assert.equal(mergeRow.style.display, "");
+
+    flushAnimationFrame();
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "120px");
+
+    body.dispatchEvent({
+      type: "transitionend",
+      propertyName: "max-height",
+      bubbles: false,
+    });
+    assert.equal(group.classList.contains("resizing"), false);
     assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
-    assert.equal(harness.getSwitchMeta("quotaMergeSources").row.style.display, "");
   });
 
   it("groups sound and volume into one collapsible control with in-place summary updates", () => {


### PR DESCRIPTION
## Summary
- Stabilize Settings interactions across General, Agents, Theme, Animation / Sound, Remote Approval, and About.
- Reuse a keyboard-accessible Settings dropdown for the scoped Theme and Remote Approval controls.
- Preserve existing preference fields, persistence behavior, confirmation gates, and IPC contracts.

## Problem context
Several Settings views showed delayed expansion, layout movement, native-control visual mismatches, or full-page flicker during rapid interaction. The affected controls also lacked one consistent keyboard and pending-state model.

## What changed
- Remeasure the quota-ring collapsible group after asynchronous source options become visible.
- Use a compact responsive layout for the Agent discovery controls.
- Migrate pet color, accessory, Telegram completion output, and Feishu/Lark timeout selectors to the shared Settings dropdown.
- Keep Animation / Sound title, subtitle, subtab order, focus, and scroll position stable across subtab changes.
- Patch the About automatic-update switch in place, serialize rapid saves, and roll back failed persistence.
- Add browser-environment coverage for rendering, keyboard operation, confirmation cancellation, pending state, failed-save rollback, and rapid switching.

## Behavior after this PR
Settings content no longer clips when asynchronous options increase an expanded group. The affected selectors support mouse, Arrow keys, Home/End, Enter/Space, Escape, outside-click close, focus restoration, and ARIA combobox/listbox semantics. Existing values and confirmation behavior remain unchanged.

## Validation
- `node --test test/settings-renderer-browser-env.test.js` (194 passed, 0 failed)
- `node --check` for all modified JavaScript files
- `git diff --check`
- Windows Chinese Settings smoke: Settings opened and Agent page navigation rendered correctly.
- Full `npm test` was run but is not green in this Windows checkout because of pre-existing/environment-specific Orca metadata, Remote SSH CRLF/POSIX validation, and Windows file-mode expectation failures outside the modified Settings files.

## Platform note
Automated validation and the basic manual smoke ran on Windows. The update bubble overlapped the Settings window during desktop automation, so narrow-window, light/dark, and every control-level interaction still need reviewer manual QA.

## Scope control
This PR only changes Settings presentation and local rendering behavior. It does not change preference schemas, configuration formats, IPC contracts, or remote approval semantics.

Related to #784