### PR TITLE
fix: import Codex Pet V2 spritesheets

### DIFF
--- a/src/codex-pet-adapter.js
+++ b/src/codex-pet-adapter.js
@@ -6,21 +6,38 @@ const os = require("os");
 const path = require("path");
 const zlib = require("zlib");
 
-const ADAPTER_VERSION = 3;
+const ADAPTER_VERSION = 4;
 const MARKER_FILENAME = ".clawd-codex-pet.json";
 const THEME_ID_PREFIX = "codex-pet-";
-const PNG_ALPHA_VALIDATION_SCHEMA_VERSION = 1;
+const PNG_ALPHA_VALIDATION_SCHEMA_VERSION = 2;
 const MAX_DISPLAY_NAME_LENGTH = 100;
 const MAX_DESCRIPTION_LENGTH = 500;
 
-const ATLAS = {
-  width: 1536,
-  height: 1872,
-  columns: 8,
-  rows: 9,
-  frameWidth: 192,
-  frameHeight: 208,
-};
+const DEFAULT_SPRITE_VERSION_NUMBER = 1;
+const ATLAS_BY_SPRITE_VERSION = Object.freeze({
+  1: Object.freeze({
+    spriteVersionNumber: 1,
+    width: 1536,
+    height: 1872,
+    columns: 8,
+    rows: 9,
+    frameWidth: 192,
+    frameHeight: 208,
+  }),
+  2: Object.freeze({
+    spriteVersionNumber: 2,
+    width: 1536,
+    height: 2288,
+    columns: 8,
+    rows: 11,
+    frameWidth: 192,
+    frameHeight: 208,
+  }),
+});
+
+// Keep the historical export as the V1/default atlas for callers that do not
+// need version-aware behavior.
+const ATLAS = ATLAS_BY_SPRITE_VERSION[DEFAULT_SPRITE_VERSION_NUMBER];
 
 // Mirrored from codex-pets-react/src/lib/atlas.ts at plan time on 2026-05-05.
 // Upstream timing changes require manual review before this table is bumped.
@@ -57,6 +74,23 @@ function getDefaultCodexPetsDir(homeDir = os.homedir()) {
   return path.join(homeDir, ".codex", "pets");
 }
 
+function resolveSpriteVersion(manifest) {
+  const raw = manifest && typeof manifest === "object"
+    ? manifest.spriteVersionNumber
+    : undefined;
+  const spriteVersionNumber = raw === undefined ? DEFAULT_SPRITE_VERSION_NUMBER : raw;
+  const atlas = ATLAS_BY_SPRITE_VERSION[spriteVersionNumber] || null;
+  if (!Number.isInteger(spriteVersionNumber) || !atlas) {
+    return {
+      ok: false,
+      error: "pet.json spriteVersionNumber must be 1 or 2",
+      spriteVersionNumber: null,
+      atlas: null,
+    };
+  }
+  return { ok: true, spriteVersionNumber, atlas };
+}
+
 function scanCodexPetPackages(rootDir, options = {}) {
   if (!rootDir || !fs.existsSync(rootDir)) return [];
   let entries;
@@ -89,7 +123,12 @@ function validateCodexPetPackage(packageDir, options = {}) {
     errors.push("missing pet.json");
   } else {
     try {
-      manifest = JSON.parse(fs.readFileSync(petJsonPath, "utf8"));
+      const parsed = JSON.parse(fs.readFileSync(petJsonPath, "utf8"));
+      if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+        errors.push("pet.json must be a JSON object");
+      } else {
+        manifest = parsed;
+      }
     } catch (error) {
       errors.push(`invalid pet.json: ${error.message}`);
     }
@@ -107,9 +146,11 @@ function validateCodexPetPackage(packageDir, options = {}) {
     MAX_DESCRIPTION_LENGTH
   );
   const spritesheetPath = typeof manifest?.spritesheetPath === "string" ? manifest.spritesheetPath.trim() : "";
+  const spriteVersion = resolveSpriteVersion(manifest);
 
   if (manifest && !id) errors.push("pet.json id must be a non-empty string");
   if (manifest && !spritesheetPath) errors.push("pet.json spritesheetPath must be a non-empty string");
+  if (manifest && !spriteVersion.ok) errors.push(spriteVersion.error);
 
   let normalizedSpritesheetPath = null;
   let spritesheetAbsPath = null;
@@ -132,10 +173,13 @@ function validateCodexPetPackage(packageDir, options = {}) {
         errors.push(`spritesheet not found: ${normalizedSpritesheetPath}`);
       } else if (ext === ".png" || ext === ".webp") {
         const inspected = inspectSpritesheet(spritesheetAbsPath, ext, {
+          atlas: spriteVersion.atlas,
           pngAlphaValidationCache: getPngAlphaValidationCache(options.managedMarker, {
             packageDir: resolvedPackageDir,
             spritesheetPath: normalizedSpritesheetPath,
             spritesheetStat,
+            spriteVersionNumber: spriteVersion.spriteVersionNumber,
+            atlas: spriteVersion.atlas,
           }),
         });
         imageInfo = inspected.info;
@@ -145,8 +189,15 @@ function validateCodexPetPackage(packageDir, options = {}) {
     }
   }
 
-  if (imageInfo && (imageInfo.width !== ATLAS.width || imageInfo.height !== ATLAS.height)) {
-    errors.push(`spritesheet must be ${ATLAS.width}x${ATLAS.height}, got ${imageInfo.width}x${imageInfo.height}`);
+  if (
+    imageInfo
+    && spriteVersion.atlas
+    && (imageInfo.width !== spriteVersion.atlas.width || imageInfo.height !== spriteVersion.atlas.height)
+  ) {
+    errors.push(
+      `spritesheet for spriteVersionNumber ${spriteVersion.spriteVersionNumber} must be `
+      + `${spriteVersion.atlas.width}x${spriteVersion.atlas.height}, got ${imageInfo.width}x${imageInfo.height}`
+    );
   }
   if (imageInfo && imageInfo.hasAlpha !== true) {
     errors.push("spritesheet must include an alpha channel");
@@ -167,6 +218,8 @@ function validateCodexPetPackage(packageDir, options = {}) {
     petJsonSize: petJsonStat.size,
     spritesheetMtimeMs: spritesheetStat.mtimeMs,
     spritesheetSize: spritesheetStat.size,
+    spriteVersionNumber: spriteVersion.spriteVersionNumber,
+    atlas: spriteVersion.atlas,
     image: imageInfo,
     manifest,
   } : null;
@@ -222,6 +275,7 @@ function materializeCodexPetTheme(packageInfo, userThemesDir, options = {}) {
       rowKey: spec.rowKey,
       mode: spec.mode,
       spritesheetHref: packageInfo.spritesheetAssetName,
+      atlas: packageInfo.atlas || ATLAS,
     });
     fs.writeFileSync(path.join(assetsDir, spec.filename), svg, "utf8");
   }
@@ -281,11 +335,15 @@ function syncCodexPetThemes(options = {}) {
 }
 
 function isMaterializedThemeUnchanged(marker, packageInfo, themeId, themeDir) {
+  const atlas = packageInfo.atlas || ATLAS;
   if (!marker || marker.inProgress === true) return false;
   if (marker.adapterVersion !== ADAPTER_VERSION) return false;
   if (marker.generatedThemeId !== themeId) return false;
   if (!samePath(marker.sourcePackagePath, packageInfo.packageDir)) return false;
   if (marker.sourcePetId !== packageInfo.id) return false;
+  if (marker.sourceSpriteVersionNumber !== packageInfo.spriteVersionNumber) return false;
+  if (marker.sourceAtlasColumns !== atlas.columns) return false;
+  if (marker.sourceAtlasRows !== atlas.rows) return false;
   if (marker.sourcePetJsonMtimeMs !== packageInfo.petJsonMtimeMs) return false;
   if (marker.sourcePetJsonSize !== packageInfo.petJsonSize) return false;
   if (marker.sourceSpritesheetPath !== packageInfo.spritesheetPath) return false;
@@ -319,15 +377,16 @@ function isRegularFile(filePath) {
 }
 
 function buildThemeJson(packageInfo, themeId) {
+  const atlas = packageInfo.atlas || ATLAS;
   return {
     schemaVersion: 1,
     name: packageInfo.displayName || packageInfo.id,
     version: String(packageInfo.manifest.version || "1.0.0"),
     description: packageInfo.description,
     preview: "codex-pet-idle-loop.svg",
-    viewBox: { x: 0, y: 0, width: ATLAS.frameWidth, height: ATLAS.frameHeight },
+    viewBox: { x: 0, y: 0, width: atlas.frameWidth, height: atlas.frameHeight },
     layout: {
-      contentBox: { x: 0, y: 0, width: ATLAS.frameWidth, height: ATLAS.frameHeight },
+      contentBox: { x: 0, y: 0, width: atlas.frameWidth, height: atlas.frameHeight },
     },
     source: {
       type: "codex-pet",
@@ -335,6 +394,7 @@ function buildThemeJson(packageInfo, themeId) {
       displayName: packageInfo.displayName,
       packagePath: packageInfo.packageDir,
       spritesheetPath: packageInfo.spritesheetPath,
+      spriteVersionNumber: packageInfo.spriteVersionNumber || DEFAULT_SPRITE_VERSION_NUMBER,
       adapterVersion: ADAPTER_VERSION,
     },
     eyeTracking: {
@@ -366,9 +426,9 @@ function buildThemeJson(packageInfo, themeId) {
       { minSessions: 1, file: "codex-pet-running-loop.svg" },
     ],
     hitBoxes: {
-      default: { x: 0, y: 0, w: ATLAS.frameWidth, h: ATLAS.frameHeight },
-      sleeping: { x: 0, y: 0, w: ATLAS.frameWidth, h: ATLAS.frameHeight },
-      wide: { x: 0, y: 0, w: ATLAS.frameWidth, h: ATLAS.frameHeight },
+      default: { x: 0, y: 0, w: atlas.frameWidth, h: atlas.frameHeight },
+      sleeping: { x: 0, y: 0, w: atlas.frameWidth, h: atlas.frameHeight },
+      wide: { x: 0, y: 0, w: atlas.frameWidth, h: atlas.frameHeight },
     },
     reactions: {
       drag: {
@@ -387,6 +447,7 @@ function buildThemeJson(packageInfo, themeId) {
 }
 
 function buildMarker(packageInfo, themeId, options = {}) {
+  const atlas = packageInfo.atlas || ATLAS;
   const marker = {
     managedBy: "clawd",
     kind: "codex-pet-theme",
@@ -394,6 +455,9 @@ function buildMarker(packageInfo, themeId, options = {}) {
     adapterVersion: ADAPTER_VERSION,
     generatedThemeId: themeId,
     sourcePetId: packageInfo.id,
+    sourceSpriteVersionNumber: packageInfo.spriteVersionNumber || DEFAULT_SPRITE_VERSION_NUMBER,
+    sourceAtlasColumns: atlas.columns,
+    sourceAtlasRows: atlas.rows,
     sourcePackagePath: packageInfo.packageDir,
     sourcePetJsonMtimeMs: packageInfo.petJsonMtimeMs,
     sourcePetJsonSize: packageInfo.petJsonSize,
@@ -407,7 +471,7 @@ function buildMarker(packageInfo, themeId, options = {}) {
   return marker;
 }
 
-function generateWrapperSvg({ rowKey, mode, spritesheetHref }) {
+function generateWrapperSvg({ rowKey, mode, spritesheetHref, atlas = ATLAS }) {
   const row = ROWS_BY_KEY.get(rowKey);
   if (!row) throw new Error(`unknown Codex Pet atlas row: ${rowKey}`);
   if (mode !== "loop" && mode !== "once" && mode !== "static") {
@@ -415,7 +479,7 @@ function generateWrapperSvg({ rowKey, mode, spritesheetHref }) {
   }
 
   const escapedHref = escapeXmlAttr(spritesheetHref);
-  const rowOffsetY = row.row * ATLAS.frameHeight;
+  const rowOffsetY = row.row * atlas.frameHeight;
   const animationName = `codex-pet-row-${row.key}-${mode}`;
   const initialTransform = formatTranslate(0, rowOffsetY);
   let style;
@@ -431,7 +495,7 @@ function generateWrapperSvg({ rowKey, mode, spritesheetHref }) {
     ].join("\n");
   } else {
     const totalMs = row.durations.reduce((sum, duration) => sum + duration, 0);
-    const frames = buildKeyframes(row, animationName);
+    const frames = buildKeyframes(row, animationName, atlas);
     style = [
       frames,
       ".atlas {",
@@ -449,36 +513,36 @@ function generateWrapperSvg({ rowKey, mode, spritesheetHref }) {
 
   return [
     `<!-- Generated by Clawd codex-pet-adapter v${ADAPTER_VERSION}: ${row.key} ${mode}. -->`,
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${ATLAS.frameWidth} ${ATLAS.frameHeight}" width="${ATLAS.frameWidth}" height="${ATLAS.frameHeight}">`,
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${atlas.frameWidth} ${atlas.frameHeight}" width="${atlas.frameWidth}" height="${atlas.frameHeight}">`,
     "  <defs>",
     "    <clipPath id=\"codex-pet-frame\">",
-    `      <rect x="0" y="0" width="${ATLAS.frameWidth}" height="${ATLAS.frameHeight}"/>`,
+    `      <rect x="0" y="0" width="${atlas.frameWidth}" height="${atlas.frameHeight}"/>`,
     "    </clipPath>",
     "  </defs>",
     "  <style>",
     indent(style, 4),
     "  </style>",
     "  <g clip-path=\"url(#codex-pet-frame)\">",
-    `    <image class="atlas" href="${escapedHref}" width="${ATLAS.width}" height="${ATLAS.height}" preserveAspectRatio="none"/>`,
+    `    <image class="atlas" href="${escapedHref}" width="${atlas.width}" height="${atlas.height}" preserveAspectRatio="none"/>`,
     "  </g>",
     "</svg>",
     "",
   ].join("\n");
 }
 
-function buildKeyframes(row, animationName) {
+function buildKeyframes(row, animationName, atlas = ATLAS) {
   let elapsed = 0;
   const totalMs = row.durations.reduce((sum, duration) => sum + duration, 0);
   const lines = [`@keyframes ${animationName} {`];
   row.durations.forEach((duration, column) => {
     const pct = formatPercent((elapsed / totalMs) * 100);
-    const x = column * ATLAS.frameWidth;
-    const y = row.row * ATLAS.frameHeight;
+    const x = column * atlas.frameWidth;
+    const y = row.row * atlas.frameHeight;
     lines.push(`  ${pct}% { transform: ${formatTranslate(x, y)}; }`);
     elapsed += duration;
   });
   const finalColumn = row.durations.length - 1;
-  lines.push(`  100% { transform: ${formatTranslate(finalColumn * ATLAS.frameWidth, row.row * ATLAS.frameHeight)}; }`);
+  lines.push(`  100% { transform: ${formatTranslate(finalColumn * atlas.frameWidth, row.row * atlas.frameHeight)}; }`);
   lines.push("}");
   return lines.join("\n");
 }
@@ -531,14 +595,15 @@ function inspectPngSpritesheet(filePath, options = {}) {
 
   const errors = [];
   const warnings = [];
-  if (info.width === ATLAS.width && info.height === ATLAS.height) {
+  const atlas = options.atlas || null;
+  if (atlas && info.width === atlas.width && info.height === atlas.height) {
     if (info.bitDepth !== 8 || info.colorType !== 6 || info.interlace !== 0) {
       warnings.push("PNG transparency validation only supports non-interlaced 8-bit RGBA atlases");
-    } else if (isUsablePngAlphaValidationCache(options.pngAlphaValidationCache)) {
+    } else if (isUsablePngAlphaValidationCache(options.pngAlphaValidationCache, atlas.spriteVersionNumber, atlas)) {
       info.checkedUnusedTransparency = true;
       info.checkedUnusedTransparencyCached = true;
     } else {
-      const alphaErrors = validatePngAtlasAlpha(idatChunks, info);
+      const alphaErrors = validatePngAtlasAlpha(idatChunks, info, atlas);
       errors.push(...alphaErrors);
       info.checkedUnusedTransparency = alphaErrors.length === 0;
     }
@@ -546,17 +611,23 @@ function inspectPngSpritesheet(filePath, options = {}) {
   return { info, errors, warnings };
 }
 
-function validatePngAtlasAlpha(idatChunks, info) {
-  const inflated = zlib.inflateSync(Buffer.concat(idatChunks));
+function validatePngAtlasAlpha(idatChunks, info, atlas) {
   const bytesPerPixel = 4;
   const stride = info.width * bytesPerPixel;
   const expectedLength = info.height * (1 + stride);
+  const inflated = zlib.inflateSync(Buffer.concat(idatChunks), {
+    maxOutputLength: expectedLength,
+  });
   if (inflated.length < expectedLength) return ["PNG image data is shorter than expected"];
 
   let previous = Buffer.alloc(stride);
   let current = Buffer.alloc(stride);
+  // V2 preserves the nine action rows and appends two fully populated rows
+  // containing the 16 clockwise gaze directions. Clawd does not consume those
+  // gaze frames yet, so their pixels are permitted but the rows may be empty.
   const usedColumnsByRow = ATLAS_ROWS.map((row) => row.durations.length);
-  const usedVisible = new Array(ATLAS.rows).fill(false);
+  while (usedColumnsByRow.length < atlas.rows) usedColumnsByRow.push(atlas.columns);
+  const usedVisible = new Array(atlas.rows).fill(false);
 
   for (let y = 0; y < info.height; y += 1) {
     const rowStart = y * (1 + stride);
@@ -564,10 +635,10 @@ function validatePngAtlasAlpha(idatChunks, info) {
     const scanline = inflated.subarray(rowStart + 1, rowStart + 1 + stride);
     unfilterPngScanline(filter, scanline, previous, current, bytesPerPixel);
 
-    const atlasRow = Math.floor(y / ATLAS.frameHeight);
+    const atlasRow = Math.floor(y / atlas.frameHeight);
     const usedColumns = usedColumnsByRow[atlasRow];
     for (let x = 0; x < info.width; x += 1) {
-      const column = Math.floor(x / ATLAS.frameWidth);
+      const column = Math.floor(x / atlas.frameWidth);
       const alpha = current[x * 4 + 3];
       if (column < usedColumns) {
         if (alpha !== 0) usedVisible[atlasRow] = true;
@@ -581,7 +652,7 @@ function validatePngAtlasAlpha(idatChunks, info) {
     current = temp;
   }
 
-  const emptyRow = usedVisible.findIndex((visible) => !visible);
+  const emptyRow = usedVisible.slice(0, ATLAS_ROWS.length).findIndex((visible) => !visible);
   if (emptyRow >= 0) return [`atlas row ${emptyRow} has no visible pixels in active cells`];
   return [];
 }
@@ -611,13 +682,17 @@ function findManagedMarkerForPackage(markersByPackagePath, packageDir) {
   return markersByPackagePath.get(pathKey(packageDir)) || null;
 }
 
-function getPngAlphaValidationCache(marker, { packageDir, spritesheetPath, spritesheetStat }) {
-  if (!marker || !spritesheetStat) return null;
+function getPngAlphaValidationCache(
+  marker,
+  { packageDir, spritesheetPath, spritesheetStat, spriteVersionNumber, atlas }
+) {
+  if (!marker || !spritesheetStat || !atlas) return null;
   if (!samePath(marker.sourcePackagePath, packageDir)) return null;
+  if (marker.sourceSpriteVersionNumber !== spriteVersionNumber) return null;
   if (marker.sourceSpritesheetPath !== spritesheetPath) return null;
   if (marker.sourceSpritesheetMtimeMs !== spritesheetStat.mtimeMs) return null;
   if (marker.sourceSpritesheetSize !== spritesheetStat.size) return null;
-  if (!isUsablePngAlphaValidationCache(marker.sourcePngAlphaValidation)) return null;
+  if (!isUsablePngAlphaValidationCache(marker.sourcePngAlphaValidation, spriteVersionNumber, atlas)) return null;
   if (marker.sourcePngAlphaValidation.spritesheetMtimeMs !== spritesheetStat.mtimeMs) return null;
   if (marker.sourcePngAlphaValidation.spritesheetSize !== spritesheetStat.size) return null;
   return marker.sourcePngAlphaValidation;
@@ -627,6 +702,9 @@ function buildPngAlphaValidationCache(packageInfo) {
   if (!requiresPngAlphaValidationCache(packageInfo)) return null;
   return {
     schemaVersion: PNG_ALPHA_VALIDATION_SCHEMA_VERSION,
+    spriteVersionNumber: packageInfo.spriteVersionNumber,
+    atlasWidth: packageInfo.atlas.width,
+    atlasHeight: packageInfo.atlas.height,
     spritesheetMtimeMs: packageInfo.spritesheetMtimeMs,
     spritesheetSize: packageInfo.spritesheetSize,
     checkedUnusedTransparency: true,
@@ -646,16 +724,20 @@ function isPngAlphaValidationCacheFresh(marker, packageInfo) {
   if (!marker || !packageInfo) return false;
   const cache = marker.sourcePngAlphaValidation;
   return !!(
-    isUsablePngAlphaValidationCache(cache)
+    isUsablePngAlphaValidationCache(cache, packageInfo.spriteVersionNumber, packageInfo.atlas)
     && cache.spritesheetMtimeMs === packageInfo.spritesheetMtimeMs
     && cache.spritesheetSize === packageInfo.spritesheetSize
   );
 }
 
-function isUsablePngAlphaValidationCache(cache) {
+function isUsablePngAlphaValidationCache(cache, spriteVersionNumber, atlas) {
   return !!(
     cache
     && cache.schemaVersion === PNG_ALPHA_VALIDATION_SCHEMA_VERSION
+    && cache.spriteVersionNumber === spriteVersionNumber
+    && atlas
+    && cache.atlasWidth === atlas.width
+    && cache.atlasHeight === atlas.height
     && cache.checkedUnusedTransparency === true
     && Number.isFinite(cache.spritesheetMtimeMs)
     && Number.isFinite(cache.spritesheetSize)
@@ -971,11 +1053,14 @@ module.exports = {
   ADAPTER_VERSION,
   MAX_DISPLAY_NAME_LENGTH,
   MAX_DESCRIPTION_LENGTH,
+  DEFAULT_SPRITE_VERSION_NUMBER,
   ATLAS,
+  ATLAS_BY_SPRITE_VERSION,
   ATLAS_ROWS,
   WRAPPER_SPECS,
   MARKER_FILENAME,
   getDefaultCodexPetsDir,
+  resolveSpriteVersion,
   scanCodexPetPackages,
   validateCodexPetPackage,
   materializeCodexPetTheme,

--- a/src/codex-pet-main.js
+++ b/src/codex-pet-main.js
@@ -253,6 +253,16 @@ function createCodexPetMain(options = {}) {
         sourcePackagePath: marker.sourcePackagePath || "",
         previewAtlasUrl: getPreviewAtlasUrl(theme.id, marker),
         adapterVersion: marker.adapterVersion || 0,
+        atlasColumns: Number.isInteger(marker.sourceAtlasColumns)
+          && marker.sourceAtlasColumns >= 1
+          && marker.sourceAtlasColumns <= 64
+          ? marker.sourceAtlasColumns
+          : 8,
+        atlasRows: Number.isInteger(marker.sourceAtlasRows)
+          && marker.sourceAtlasRows >= 1
+          && marker.sourceAtlasRows <= 64
+          ? marker.sourceAtlasRows
+          : 9,
       },
     };
   }

--- a/src/settings-tab-theme.js
+++ b/src/settings-tab-theme.js
@@ -146,6 +146,18 @@
     img.src = getCodexPetPreviewAtlasUrl(theme);
     img.alt = "";
     img.draggable = false;
+    const columns = Number.isInteger(theme.codexPet.atlasColumns)
+      && theme.codexPet.atlasColumns >= 1
+      && theme.codexPet.atlasColumns <= 64
+      ? theme.codexPet.atlasColumns
+      : 8;
+    const rows = Number.isInteger(theme.codexPet.atlasRows)
+      && theme.codexPet.atlasRows >= 1
+      && theme.codexPet.atlasRows <= 64
+      ? theme.codexPet.atlasRows
+      : 9;
+    img.style.width = `${columns * 100}%`;
+    img.style.height = `${rows * 100}%`;
     frame.appendChild(img);
     return frame;
   }

--- a/test/codex-pet-adapter.test.js
+++ b/test/codex-pet-adapter.test.js
@@ -13,9 +13,12 @@ const FRAME_WIDTH = 192;
 const FRAME_HEIGHT = 208;
 const COLUMNS = 8;
 const ROWS = 9;
+const V2_ROWS = 11;
 const ATLAS_WIDTH = FRAME_WIDTH * COLUMNS;
 const ATLAS_HEIGHT = FRAME_HEIGHT * ROWS;
+const V2_ATLAS_HEIGHT = FRAME_HEIGHT * V2_ROWS;
 const USED_COLUMNS_BY_ROW = [6, 8, 8, 4, 5, 8, 6, 6, 6];
+const V2_USED_COLUMNS_BY_ROW = [...USED_COLUMNS_BY_ROW, 8, 8];
 const tempDirs = [];
 
 afterEach(() => {
@@ -64,6 +67,44 @@ function readPng(filePath) {
 
   const rgba = zlib.inflateSync(Buffer.concat(idatChunks));
   return { width, height, bitDepth, colorType, rgba };
+}
+
+function pngChunk(type, data = Buffer.alloc(0)) {
+  const out = Buffer.alloc(8 + data.length + 4);
+  out.writeUInt32BE(data.length, 0);
+  out.write(type, 4, 4, "ascii");
+  data.copy(out, 8);
+  return out;
+}
+
+function makeRgbaAtlasPng({ rows, usedColumnsByRow, extraInflatedBytes = 0 }) {
+  const height = FRAME_HEIGHT * rows;
+  const stride = ATLAS_WIDTH * 4;
+  const raw = Buffer.alloc(height * (1 + stride) + extraInflatedBytes);
+
+  usedColumnsByRow.forEach((usedColumns, row) => {
+    const y = row * FRAME_HEIGHT + Math.floor(FRAME_HEIGHT / 2);
+    for (let column = 0; column < usedColumns; column += 1) {
+      const x = column * FRAME_WIDTH + Math.floor(FRAME_WIDTH / 2);
+      const pixel = y * (1 + stride) + 1 + x * 4;
+      raw[pixel] = 0x44;
+      raw[pixel + 1] = 0x88;
+      raw[pixel + 2] = 0xcc;
+      raw[pixel + 3] = 0xff;
+    }
+  });
+
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(ATLAS_WIDTH, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  return Buffer.concat([
+    Buffer.from("89504e470d0a1a0a", "hex"),
+    pngChunk("IHDR", ihdr),
+    pngChunk("IDAT", zlib.deflateSync(raw)),
+    pngChunk("IEND"),
+  ]);
 }
 
 function alphaAt(png, x, y) {
@@ -197,6 +238,8 @@ describe("codex-pet-adapter package validation", () => {
     assert.strictEqual(result.packageInfo.id, "tiny-atlas-png");
     assert.strictEqual(result.packageInfo.slug, "tiny-atlas-png");
     assert.strictEqual(result.packageInfo.spritesheetPath, "spritesheet.png");
+    assert.strictEqual(result.packageInfo.spriteVersionNumber, 1);
+    assert.strictEqual(result.packageInfo.atlas, adapter.ATLAS_BY_SPRITE_VERSION[1]);
     assert.strictEqual(result.packageInfo.image.width, adapter.ATLAS.width);
     assert.strictEqual(result.packageInfo.image.height, adapter.ATLAS.height);
     assert.strictEqual(result.packageInfo.image.checkedUnusedTransparency, true);
@@ -238,7 +281,7 @@ describe("codex-pet-adapter package validation", () => {
     assert.strictEqual(themeJson.description.length, adapter.MAX_DESCRIPTION_LENGTH);
   });
 
-  it("reports missing or malformed manifests", () => {
+  it("reports missing, malformed, and non-object manifests without aborting the full sync", () => {
     const root = makeTempDir();
     const missingDir = path.join(root, "missing");
     fs.mkdirSync(missingDir, { recursive: true });
@@ -248,6 +291,30 @@ describe("codex-pet-adapter package validation", () => {
     fs.mkdirSync(badDir, { recursive: true });
     fs.writeFileSync(path.join(badDir, "pet.json"), "{", "utf8");
     assert.match(adapter.validateCodexPetPackage(badDir).errors.join("; "), /invalid pet\.json/);
+
+    const petsDir = path.join(root, "pets");
+    copyFixturePackage(petsDir, "valid");
+    for (const [folderName, value] of [
+      ["null", null],
+      ["zero", 0],
+      ["false", false],
+      ["empty-string", ""],
+      ["array", []],
+    ]) {
+      const packageDir = path.join(petsDir, folderName);
+      fs.mkdirSync(packageDir, { recursive: true });
+      fs.writeFileSync(path.join(packageDir, "pet.json"), JSON.stringify(value), "utf8");
+      const result = adapter.validateCodexPetPackage(packageDir);
+      assert.strictEqual(result.ok, false);
+      assert.match(result.errors.join("; "), /pet\.json must be a JSON object/);
+    }
+
+    const summary = adapter.syncCodexPetThemes({
+      codexPetsDir: petsDir,
+      userDataDir: path.join(root, "userData"),
+    });
+    assert.strictEqual(summary.imported, 1);
+    assert.strictEqual(summary.invalid, 5);
   });
 
   it("rejects unsafe or unsupported spritesheet paths", () => {
@@ -288,7 +355,163 @@ describe("codex-pet-adapter package validation", () => {
 
     const result = adapter.validateCodexPetPackage(packageDir);
     assert.strictEqual(result.ok, false);
-    assert.match(result.errors.join("; "), /must be 1536x1872, got 1535x1872/);
+    assert.match(result.errors.join("; "), /spriteVersionNumber 1 must be 1536x1872, got 1535x1872/);
+  });
+
+  it("accepts V2 PNG atlases and preserves both gaze rows as active cells", () => {
+    const root = makeTempDir();
+    const packageDir = path.join(root, "v2-png");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "spritesheet.png"),
+      makeRgbaAtlasPng({ rows: V2_ROWS, usedColumnsByRow: V2_USED_COLUMNS_BY_ROW })
+    );
+    writeJson(path.join(packageDir, "pet.json"), {
+      id: "v2-png",
+      displayName: "V2 PNG",
+      spriteVersionNumber: 2,
+      spritesheetPath: "spritesheet.png",
+    });
+
+    const result = adapter.validateCodexPetPackage(packageDir);
+    assert.strictEqual(result.ok, true, result.errors.join("; "));
+    assert.strictEqual(result.packageInfo.spriteVersionNumber, 2);
+    assert.strictEqual(result.packageInfo.image.width, ATLAS_WIDTH);
+    assert.strictEqual(result.packageInfo.image.height, V2_ATLAS_HEIGHT);
+    assert.strictEqual(result.packageInfo.image.checkedUnusedTransparency, true);
+
+    const userData = path.join(root, "userData");
+    const materialized = adapter.materializeCodexPetTheme(
+      result.packageInfo,
+      path.join(userData, "themes")
+    );
+    const themeJson = readJson(path.join(materialized.themeDir, "theme.json"));
+    const idleWrapper = fs.readFileSync(
+      path.join(materialized.themeDir, "assets", "codex-pet-idle-loop.svg"),
+      "utf8"
+    );
+    const marker = readJson(path.join(materialized.themeDir, adapter.MARKER_FILENAME));
+    assert.strictEqual(themeJson.source.spriteVersionNumber, 2);
+    assert.strictEqual(themeJson.eyeTracking.enabled, false);
+    assert.match(idleWrapper, /<image class="atlas"[^>]+width="1536" height="2288"/);
+    assert.strictEqual(marker.sourceSpriteVersionNumber, 2);
+    assert.strictEqual(marker.sourceAtlasColumns, 8);
+    assert.strictEqual(marker.sourceAtlasRows, 11);
+    assert.strictEqual(marker.sourcePngAlphaValidation.spriteVersionNumber, 2);
+    assert.strictEqual(marker.sourcePngAlphaValidation.atlasHeight, 2288);
+
+    makeThemeLoaderFixture(userData);
+    const loaded = themeLoader.loadTheme(materialized.themeId, { strict: true });
+    assert.strictEqual(loaded.source.spriteVersionNumber, 2);
+    assert.strictEqual(loaded.states.idle[0], "codex-pet-idle-loop.svg");
+  });
+
+  it("allows empty V2 gaze rows while keeping action rows required", () => {
+    const root = makeTempDir();
+    const packageDir = path.join(root, "v2-empty-gaze");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "spritesheet.png"),
+      makeRgbaAtlasPng({ rows: V2_ROWS, usedColumnsByRow: USED_COLUMNS_BY_ROW })
+    );
+    writeJson(path.join(packageDir, "pet.json"), {
+      id: "v2-empty-gaze",
+      spriteVersionNumber: 2,
+      spritesheetPath: "spritesheet.png",
+    });
+
+    const accepted = adapter.validateCodexPetPackage(packageDir);
+    assert.strictEqual(accepted.ok, true, accepted.errors.join("; "));
+
+    fs.writeFileSync(
+      path.join(packageDir, "spritesheet.png"),
+      makeRgbaAtlasPng({
+        rows: V2_ROWS,
+        usedColumnsByRow: [7, ...USED_COLUMNS_BY_ROW.slice(1)],
+      })
+    );
+    const strayActionPixel = adapter.validateCodexPetPackage(packageDir);
+    assert.strictEqual(strayActionPixel.ok, false);
+    assert.match(
+      strayActionPixel.errors.join("; "),
+      /unused atlas cell row 0 column 6 must be transparent/
+    );
+
+    fs.writeFileSync(
+      path.join(packageDir, "spritesheet.png"),
+      makeRgbaAtlasPng({
+        rows: V2_ROWS,
+        usedColumnsByRow: [0, ...USED_COLUMNS_BY_ROW.slice(1)],
+      })
+    );
+    const rejected = adapter.validateCodexPetPackage(packageDir);
+    assert.strictEqual(rejected.ok, false);
+    assert.match(rejected.errors.join("; "), /atlas row 0 has no visible pixels in active cells/);
+  });
+
+  it("bounds PNG decompression to the declared atlas size", () => {
+    const root = makeTempDir();
+    const packageDir = path.join(root, "oversized-png-output");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "spritesheet.png"),
+      makeRgbaAtlasPng({
+        rows: ROWS,
+        usedColumnsByRow: USED_COLUMNS_BY_ROW,
+        extraInflatedBytes: 1,
+      })
+    );
+    writeJson(path.join(packageDir, "pet.json"), {
+      id: "oversized-png-output",
+      spritesheetPath: "spritesheet.png",
+    });
+
+    const result = adapter.validateCodexPetPackage(packageDir);
+    assert.strictEqual(result.ok, false);
+    assert.match(result.errors.join("; "), /failed to inspect spritesheet/);
+  });
+
+  it("rejects unsupported sprite versions and version-specific dimension mismatches", () => {
+    const root = makeTempDir();
+    const v2WithV1Atlas = writeWebpPackage(root, "v2-with-v1-atlas", makeVp8xWebp(), {
+      spriteVersionNumber: 2,
+    });
+    assert.match(
+      adapter.validateCodexPetPackage(v2WithV1Atlas).errors.join("; "),
+      /spriteVersionNumber 2 must be 1536x2288, got 1536x1872/
+    );
+
+    const v1WithV2Atlas = writeWebpPackage(
+      root,
+      "v1-with-v2-atlas",
+      makeVp8xWebp({ height: V2_ATLAS_HEIGHT }),
+      { spriteVersionNumber: 1 }
+    );
+    assert.match(
+      adapter.validateCodexPetPackage(v1WithV2Atlas).errors.join("; "),
+      /spriteVersionNumber 1 must be 1536x1872, got 1536x2288/
+    );
+
+    const unsupported = writeWebpPackage(
+      root,
+      "unsupported-version",
+      makeVp8xWebp({ height: V2_ATLAS_HEIGHT }),
+      { spriteVersionNumber: 3 }
+    );
+    const unsupportedResult = adapter.validateCodexPetPackage(unsupported);
+    assert.strictEqual(unsupportedResult.ok, false);
+    assert.match(unsupportedResult.errors.join("; "), /spriteVersionNumber must be 1 or 2/);
+    assert.doesNotMatch(unsupportedResult.errors.join("; "), /spritesheet for spriteVersionNumber/);
+
+    const explicitNull = writeWebpPackage(
+      root,
+      "null-version",
+      makeVp8xWebp(),
+      { spriteVersionNumber: null }
+    );
+    const explicitNullResult = adapter.validateCodexPetPackage(explicitNull);
+    assert.strictEqual(explicitNullResult.ok, false);
+    assert.match(explicitNullResult.errors.join("; "), /spriteVersionNumber must be 1 or 2/);
   });
 
   it("accepts valid VP8X and VP8L WebP atlas headers", () => {
@@ -307,6 +530,17 @@ describe("codex-pet-adapter package validation", () => {
     const vp8l = adapter.validateCodexPetPackage(vp8lDir);
     assert.strictEqual(vp8l.ok, true, vp8l.errors.join("; "));
     assert.strictEqual(vp8l.packageInfo.image.encoding, "VP8L");
+
+    const v2Vp8lDir = writeWebpPackage(
+      root,
+      "v2-vp8l",
+      makeVp8lWebp({ height: V2_ATLAS_HEIGHT }),
+      { spriteVersionNumber: 2 }
+    );
+    const v2Vp8l = adapter.validateCodexPetPackage(v2Vp8lDir);
+    assert.strictEqual(v2Vp8l.ok, true, v2Vp8l.errors.join("; "));
+    assert.strictEqual(v2Vp8l.packageInfo.image.encoding, "VP8L");
+    assert.strictEqual(v2Vp8l.packageInfo.image.height, V2_ATLAS_HEIGHT);
   });
 
   it("rejects malformed WebP headers and non-alpha WebP variants", () => {
@@ -385,6 +619,8 @@ describe("codex-pet-adapter wrapper generation and materialization", () => {
     assert.strictEqual(marker.adapterVersion, adapter.ADAPTER_VERSION);
     assert.strictEqual(marker.generatedThemeId, materialized.themeId);
     assert.strictEqual(marker.sourcePetId, "tiny-atlas-png");
+    assert.strictEqual(marker.sourceAtlasColumns, 8);
+    assert.strictEqual(marker.sourceAtlasRows, 9);
 
     makeThemeLoaderFixture(userData);
     const loaded = themeLoader.loadTheme(materialized.themeId, { strict: true });
@@ -522,7 +758,10 @@ describe("codex-pet-adapter wrapper generation and materialization", () => {
       assert.strictEqual(first.imported, 1);
       assert.ok(inflateCalls > 0);
       assert.deepStrictEqual(marker.sourcePngAlphaValidation, {
-        schemaVersion: 1,
+        schemaVersion: 2,
+        spriteVersionNumber: 1,
+        atlasWidth: 1536,
+        atlasHeight: 1872,
         spritesheetMtimeMs: fs.statSync(path.join(packageDir, "spritesheet.png")).mtimeMs,
         spritesheetSize: fs.statSync(path.join(packageDir, "spritesheet.png")).size,
         checkedUnusedTransparency: true,
@@ -539,6 +778,78 @@ describe("codex-pet-adapter wrapper generation and materialization", () => {
       const third = adapter.syncCodexPetThemes({ codexPetsDir: petsDir, userDataDir });
       assert.strictEqual(third.updated, 1);
       assert.ok(inflateCalls > 0);
+    } finally {
+      zlib.inflateSync = originalInflateSync;
+    }
+  });
+
+  it("caches V2 PNG validation and upgrades legacy markers on the next sync", () => {
+    const root = makeTempDir();
+    const petsDir = path.join(root, "pets");
+    const packageDir = path.join(petsDir, "v2-cache");
+    const userDataDir = path.join(root, "userData");
+    fs.mkdirSync(packageDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(packageDir, "spritesheet.png"),
+      makeRgbaAtlasPng({ rows: V2_ROWS, usedColumnsByRow: V2_USED_COLUMNS_BY_ROW })
+    );
+    writeJson(path.join(packageDir, "pet.json"), {
+      id: "v2-cache",
+      spriteVersionNumber: 2,
+      spritesheetPath: "spritesheet.png",
+    });
+
+    const originalInflateSync = zlib.inflateSync;
+    let inflateCalls = 0;
+    zlib.inflateSync = (...args) => {
+      inflateCalls += 1;
+      return originalInflateSync(...args);
+    };
+
+    try {
+      const first = adapter.syncCodexPetThemes({ codexPetsDir: petsDir, userDataDir });
+      assert.strictEqual(first.imported, 1);
+      assert.ok(inflateCalls > 0);
+
+      const themeDir = path.join(userDataDir, "themes", first.themes[0].themeId);
+      const markerPath = path.join(themeDir, adapter.MARKER_FILENAME);
+      const wrapperPath = path.join(themeDir, "assets", "codex-pet-idle-loop.svg");
+      let marker = readJson(markerPath);
+      assert.strictEqual(marker.sourceSpriteVersionNumber, 2);
+      assert.strictEqual(marker.sourceAtlasRows, 11);
+      assert.strictEqual(marker.sourcePngAlphaValidation.schemaVersion, 2);
+      assert.strictEqual(marker.sourcePngAlphaValidation.atlasHeight, V2_ATLAS_HEIGHT);
+
+      inflateCalls = 0;
+      const second = adapter.syncCodexPetThemes({ codexPetsDir: petsDir, userDataDir });
+      assert.strictEqual(second.unchanged, 1);
+      assert.strictEqual(inflateCalls, 0);
+
+      marker.adapterVersion = 3;
+      delete marker.sourceSpriteVersionNumber;
+      delete marker.sourceAtlasColumns;
+      delete marker.sourceAtlasRows;
+      marker.sourcePngAlphaValidation = {
+        schemaVersion: 1,
+        spritesheetMtimeMs: marker.sourceSpritesheetMtimeMs,
+        spritesheetSize: marker.sourceSpritesheetSize,
+        checkedUnusedTransparency: true,
+      };
+      writeJson(markerPath, marker);
+
+      inflateCalls = 0;
+      const upgraded = adapter.syncCodexPetThemes({ codexPetsDir: petsDir, userDataDir });
+      assert.strictEqual(upgraded.updated, 1);
+      assert.ok(inflateCalls > 0);
+      assert.match(fs.readFileSync(wrapperPath, "utf8"), /width="1536" height="2288"/);
+
+      marker = readJson(markerPath);
+      assert.strictEqual(marker.adapterVersion, adapter.ADAPTER_VERSION);
+      assert.strictEqual(marker.sourceSpriteVersionNumber, 2);
+      assert.strictEqual(marker.sourceAtlasColumns, 8);
+      assert.strictEqual(marker.sourceAtlasRows, 11);
+      assert.strictEqual(marker.sourcePngAlphaValidation.schemaVersion, 2);
+      assert.strictEqual(marker.sourcePngAlphaValidation.atlasHeight, V2_ATLAS_HEIGHT);
     } finally {
       zlib.inflateSync = originalInflateSync;
     }

--- a/test/codex-pet-importer.test.js
+++ b/test/codex-pet-importer.test.js
@@ -29,6 +29,28 @@ function fixtureSpritesheet() {
   return fs.readFileSync(path.join(FIXTURE_DIR, "spritesheet.png"));
 }
 
+function makeVp8xWebp({ width = 1536, height = 2288 } = {}) {
+  const image = Buffer.alloc(10);
+  image[0] = 0x10;
+  const widthMinusOne = width - 1;
+  const heightMinusOne = height - 1;
+  image[4] = widthMinusOne & 0xff;
+  image[5] = (widthMinusOne >> 8) & 0xff;
+  image[6] = (widthMinusOne >> 16) & 0xff;
+  image[7] = heightMinusOne & 0xff;
+  image[8] = (heightMinusOne >> 8) & 0xff;
+  image[9] = (heightMinusOne >> 16) & 0xff;
+
+  const chunkHeader = Buffer.alloc(8);
+  chunkHeader.write("VP8X", 0, 4, "ascii");
+  chunkHeader.writeUInt32LE(image.length, 4);
+  const body = Buffer.concat([Buffer.from("WEBP", "ascii"), chunkHeader, image]);
+  const riff = Buffer.alloc(8);
+  riff.write("RIFF", 0, 4, "ascii");
+  riff.writeUInt32LE(body.length, 4);
+  return Buffer.concat([riff, body]);
+}
+
 function makeZip(entries) {
   const localParts = [];
   const centralParts = [];
@@ -300,6 +322,32 @@ test("imports zip packages from root or one top-level folder", async () => {
     () => importer.importCodexPetFromZipBuffer(Buffer.alloc(importer.MAX_ZIP_BYTES + 1)),
     /zip package exceeds/
   );
+});
+
+test("imports V2 zip packages with 8x11 spritesheets", async () => {
+  const root = makeTempDir();
+  const manifest = fixtureManifest({
+    id: "v2-wild-boar-shape",
+    displayName: "V2 Wild Boar Shape",
+    spriteVersionNumber: 2,
+    spritesheetPath: "spritesheet.webp",
+  });
+  const zip = makeZip([
+    { name: "pet.json", data: JSON.stringify(manifest), method: 8 },
+    { name: "spritesheet.webp", data: makeVp8xWebp(), method: 0 },
+  ]);
+
+  const imported = await importer.importCodexPetFromZipBuffer(zip, {
+    codexPetsDir: path.join(root, "pets"),
+  });
+
+  assert.strictEqual(path.basename(imported.packageDir), "v2-wild-boar-shape");
+  assert.strictEqual(imported.packageInfo.spriteVersionNumber, 2);
+  assert.deepStrictEqual(
+    { width: imported.packageInfo.image.width, height: imported.packageInfo.image.height },
+    { width: 1536, height: 2288 }
+  );
+  assert.strictEqual(adapter.validateCodexPetPackage(imported.packageDir).ok, true);
 });
 
 test("rejects unsafe zip paths and missing package files", () => {

--- a/test/codex-pet-main.test.js
+++ b/test/codex-pet-main.test.js
@@ -156,6 +156,49 @@ test("Codex Pet main runtime records sync summaries and normalizes adapter failu
   assert.strictEqual(failingRuntime.getLastSyncSummary(), failed);
 });
 
+test("Codex Pet theme metadata carries the versioned atlas grid into Settings previews", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-codex-pet-main-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const themesRoot = path.join(root, "themes");
+  const themeId = "codex-pet-v2";
+  const assetsDir = path.join(themesRoot, themeId, "assets");
+  fs.mkdirSync(assetsDir, { recursive: true });
+  fs.writeFileSync(path.join(assetsDir, "spritesheet.webp"), "fixture");
+
+  const runtime = createCodexPetMain({
+    app: {
+      getPath: () => root,
+      isReady: () => false,
+    },
+    dialog: {},
+    shell: {},
+    settingsController: {
+      get: () => "clawd",
+    },
+    themeLoader: {
+      ensureUserThemesDir: () => themesRoot,
+    },
+    codexPetAdapter: {
+      syncCodexPetThemes: () => ({ themes: [] }),
+      readManagedMarker: () => ({
+        sourcePetId: "v2",
+        sourcePackagePath: path.join(root, "pets", "v2"),
+        sourceSpritesheetPath: "spritesheet.webp",
+        sourceAtlasColumns: 8,
+        sourceAtlasRows: 11,
+        adapterVersion: 4,
+      }),
+    },
+    codexPetImporter: {},
+  });
+
+  const decorated = runtime.decorateThemeMetadata({ id: themeId, name: "V2" });
+  assert.strictEqual(decorated.managedCodexPet, true);
+  assert.strictEqual(decorated.codexPet.atlasColumns, 8);
+  assert.strictEqual(decorated.codexPet.atlasRows, 11);
+  assert.match(decorated.codexPet.previewAtlasUrl, /spritesheet\.webp$/);
+});
+
 test("Codex Pet settings refresh hot reloads an updated active managed theme", async () => {
   let reloadCalls = 0;
   let syncCalls = 0;

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -5497,6 +5497,56 @@ describe("settings renderer browser environment", () => {
     assert.deepStrictEqual(commands, []);
   });
 
+  it("renders Codex Pet atlas previews with V1, V2, and legacy grid ratios", () => {
+    const { content } = loadThemeTabForTest({
+      themes: [
+        {
+          id: "pet-v1",
+          name: "Pet V1",
+          managedCodexPet: true,
+          active: true,
+          codexPet: {
+            previewAtlasUrl: "file:///pets/v1/spritesheet.webp",
+            atlasColumns: 8,
+            atlasRows: 9,
+          },
+        },
+        {
+          id: "pet-v2",
+          name: "Pet V2",
+          managedCodexPet: true,
+          active: false,
+          codexPet: {
+            previewAtlasUrl: "file:///pets/v2/spritesheet.webp",
+            atlasColumns: 8,
+            atlasRows: 11,
+          },
+        },
+        {
+          id: "pet-legacy",
+          name: "Pet Legacy",
+          managedCodexPet: true,
+          active: false,
+          codexPet: {
+            previewAtlasUrl: "file:///pets/legacy/spritesheet.webp",
+          },
+        },
+      ],
+    });
+
+    const previews = content.querySelectorAll(".theme-thumb-atlas-frame");
+    assert.strictEqual(previews.length, 3);
+    const images = previews.map((preview) => preview.querySelector("img"));
+    assert.deepStrictEqual(
+      images.map((img) => [img.style.width, img.style.height]),
+      [
+        ["800%", "900%"],
+        ["800%", "1100%"],
+        ["800%", "900%"],
+      ]
+    );
+  });
+
   it("keeps customization visible on every capable pet while omitting Calico", () => {
     const supported = loadThemeTabForTest({
       themes: [


### PR DESCRIPTION
## Summary

- add version-aware Codex Pet atlas support: V1 remains `8x9 / 1536x1872`, while `spriteVersionNumber: 2` uses `8x11 / 1536x2288`
- carry sprite version and atlas grid through materialization markers, PNG validation caches, generated themes, and Settings preview metadata
- render imported V2 thumbnails with the correct `800% x 1100%` crop while keeping legacy V1 fallback behavior
- harden package validation by rejecting non-object manifests and explicit null sprite versions, and cap PNG decompression at the declared atlas size
- permit empty V2 gaze rows because Clawd does not consume them yet, while preserving action-row visibility and unused-cell transparency checks

## Verification

- `node --check src/codex-pet-adapter.js`
- `node --check src/codex-pet-main.js`
- `node --check src/settings-tab-theme.js`
- `node --test test/codex-pet-adapter.test.js test/codex-pet-importer.test.js test/codex-pet-main.test.js test/settings-renderer-browser-env.test.js` — 235 passed
- real Electron smoke with a public Wild Boar V2 package using a 1536x2288 VP8L WebP: production import/materialization, Settings preview, and idle/working/error/notification/attention/thinking/sleeping rendering verified
- `npm test` — 6650 passed, 23 failed, 20 skipped; the 23 failures are existing Windows/cross-platform environment failures in macOS/AppImage, Orca, Remote SSH POSIX-home, CRLF/mode, and PID tests, with no Codex Pet failures

Fixes #772