### PR TITLE
fix: intercept interactive Codex subagent approvals

### DIFF
--- a/docs/investigations/codex-subagent-session-meta.md
+++ b/docs/investigations/codex-subagent-session-meta.md
@@ -57,10 +57,14 @@ The subagent sample was `rollout-2026-05-01T12-16-50-019de1c0-ed8e-73b0-992d-109
 
 - Treat unknown fields as `unknown` and fail open as root/interactive behavior.
 - Do not infer subagents from cwd or timing.
-- ~~Do not classify `/permission` requests; subagent PermissionRequest still needs a user decision.~~
-  **Superseded by PR #448 (2026-06-10).** The auto-pilot work made the `/permission` route gate
-  headless requests before the bubble/auto-approve chokepoint, and codex subagent requests are
-  deliberately treated as headless (no-decision → native fallback) rather than shown as bubbles
-  (`isHeadlessPermissionRequest`, `src/server-route-permission.js`). To make that gate
-  deterministic, `buildPermissionBody` now carries `codex_session_role` on PermissionRequest
-  payloads too (`hooks/codex-hook.js`, #448 follow-up). The state-path guidance above is unchanged.
+- `/permission` must classify subagents, but role and interactivity are separate concerns.
+  **PR #448's permission behavior was superseded on 2026-07-31.** Codex uses `headless:true`
+  on subagent state sessions to keep background child activity out of HUD/focus/completion
+  priority; that presentation marker must not suppress an official `PermissionRequest` from a
+  visible Agent thread. `buildPermissionBody` therefore still carries `codex_session_role` (plus
+  the child nickname/parent provenance). The interactive exception is limited to the resolved
+  Codex adapter plus audited CLI/Desktop originators; `codex_exec`, unknown originators, and an
+  explicit or derived `headless:true` stay on no-decision → native fallback, including when the
+  permission is the first event and no in-memory session exists yet. Ordinary headless
+  sessions still use the existing session gate. Interactive child requests enter the same
+  bubble/automation chokepoint as their parent. The state-path guidance above is unchanged.

--- a/hooks/codex-hook.js
+++ b/hooks/codex-hook.js
@@ -27,7 +27,10 @@ const {
   extractLastAssistantTextFromTranscript,
 } = require("./codex-assistant-output");
 const { readCodexThreadName } = require("./codex-session-index");
-const { isCodexDesktopOriginator } = require("./codex-originator");
+const {
+  isCodexCliOriginator,
+  isCodexDesktopOriginator,
+} = require("./codex-originator");
 const { fitStateBodyToByteBudget } = require("./state-payload-size");
 
 const TOOL_MATCH_STRING_MAX = 240;
@@ -189,9 +192,46 @@ function applyCodexSessionMetaFields(body, payload, sessionMeta) {
   const source = payload && typeof payload === "object" ? payload : {};
   const meta = sessionMeta && typeof sessionMeta === "object" ? sessionMeta : {};
   const originator = firstString(meta.originator, source.originator);
-  const codexSource = firstString(meta.source, source.source);
+  let codexSource = firstString(meta.source, source.source);
+  const metaSubagent = meta.source && typeof meta.source === "object"
+    ? meta.source.subagent
+    : null;
+  const hookSubagent = source.source && typeof source.source === "object"
+    ? source.source.subagent
+    : null;
+  const subagent = metaSubagent && typeof metaSubagent === "object"
+    ? metaSubagent
+    : (hookSubagent && typeof hookSubagent === "object" ? hookSubagent : null);
+  const spawn = subagent && subagent.thread_spawn && typeof subagent.thread_spawn === "object"
+    ? subagent.thread_spawn
+    : {};
+
+  // A subagent session_meta replaces the root's string source ("cli") with
+  // a structured `source.subagent` object. `originator:"codex-tui"` is the
+  // audited local-CLI provenance for that shape, so preserve the inherited
+  // source instead of making every interactive child fail automation identity.
+  if (!codexSource && subagent && isCodexCliOriginator(originator)) codexSource = "cli";
   if (originator) body.codex_originator = originator;
   if (codexSource) body.codex_source = codexSource;
+
+  const agentNickname = firstString(
+    meta.agent_nickname,
+    source.agent_nickname,
+    spawn.agent_nickname,
+  );
+  const agentRole = firstString(
+    meta.agent_role,
+    source.agent_role,
+    spawn.agent_role,
+  );
+  const parentThreadId = firstString(
+    meta.parent_thread_id,
+    source.parent_thread_id,
+    spawn.parent_thread_id,
+  );
+  if (agentNickname) body.codex_agent_nickname = agentNickname.slice(0, 100);
+  if (agentRole) body.codex_agent_role = agentRole.slice(0, 100);
+  if (parentThreadId) body.codex_parent_thread_id = parentThreadId.slice(0, 200);
 }
 
 function isCodexDesktopSession(payload, sessionMeta) {
@@ -214,7 +254,7 @@ function applyLocalProcessFields(body, resolve, options = {}) {
   const lifecycle = options.event === "SessionStart" ? "start"
     : options.event === "UserPromptSubmit" ? "prompt"
     : "event";
-  const { stablePid, agentPid, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient } = resolve({
+  const { stablePid, agentPid, detectedEditor, pidChain, foregroundWtHwnd, tmuxSocket, tmuxClient, headless } = resolve({
     namespace: "codex",
     sessionId: body.session_id,
     cacheCwd: body.cwd || "",
@@ -225,6 +265,7 @@ function applyLocalProcessFields(body, resolve, options = {}) {
   body.source_pid = sourcePid;
   if (detectedEditor) body.editor = detectedEditor;
   if (agentPid) body.agent_pid = agentPid;
+  if (agentPid && headless === true) body.headless = true;
   if (pidChain.length) body.pid_chain = pidChain;
   if (tmuxSocket) body.tmux_socket = tmuxSocket;
   if (tmuxClient) body.tmux_client = tmuxClient;
@@ -318,10 +359,11 @@ function buildPermissionBody(payload, resolve) {
     body.transcript_path = payload.transcript_path;
   }
   if (typeof payload.model === "string" && payload.model) body.model = payload.model;
-  // Carry the session role so the /permission route's headless gate
-  // (isHeadlessPermissionRequest) can identify subagent requests even when
-  // no state event has populated the sessions map yet. Before PR #448
-  // subagent permissions deliberately bubbled, so the role was state-only.
+  if (payload.headless === true) body.headless = true;
+  // Permission routing must distinguish a visible Agent thread from a truly
+  // non-interactive process. Carry the role for provenance/UI. An explicit or
+  // resolver-derived `headless` bit remains a hard bypass; the server also
+  // fail-closes subagents whose originator is not an audited interactive client.
   const codexRole = resolveCodexSessionRole(payload, sessionMeta);
   if (codexRole !== ROLE_UNKNOWN) body.codex_session_role = codexRole;
   applyCodexSessionMetaFields(body, payload, sessionMeta);

--- a/hooks/codex-originator.js
+++ b/hooks/codex-originator.js
@@ -9,6 +9,10 @@ const CODEX_DESKTOP_ORIGINATORS = new Set([
   "codex desktop",
   "codex_work_desktop",
 ]);
+const CODEX_CLI_ORIGINATORS = new Set([
+  "codex-tui",
+  "codex_cli_rs",
+]);
 
 function normalizeCodexOriginator(value) {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
@@ -18,6 +22,11 @@ function isCodexDesktopOriginator(value) {
   return CODEX_DESKTOP_ORIGINATORS.has(normalizeCodexOriginator(value));
 }
 
+function isCodexCliOriginator(value) {
+  return CODEX_CLI_ORIGINATORS.has(normalizeCodexOriginator(value));
+}
+
 module.exports = {
+  isCodexCliOriginator,
   isCodexDesktopOriginator,
 };

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -42,6 +42,7 @@ const ELICITATION_OTHER_KEY = "__other__";
 
 function setSessionTag(data) {
   const parts = [];
+  if (data.isCodexSubagent) parts.push(data.codexAgentNickname || bubbleText(data.lang, "agent"));
   if (data.sessionFolder) parts.push(data.sessionFolder);
   if (data.sessionShortId) parts.push("#" + data.sessionShortId);
   if (parts.length) {
@@ -64,6 +65,7 @@ const BUBBLE_STRINGS = {
     alwaysAllow: "Always allow",
     sessionTrust: "Don’t ask again in this session",
     permissionRequest: "Permission Request",
+    agent: "Agent",
     allow: "Allow",
     deny: "Deny",
     alwaysAllowBlanket: "Always Allow (blanket)",
@@ -106,6 +108,7 @@ const BUBBLE_STRINGS = {
     alwaysAllow: "\u59CB\u7EC8\u5141\u8BB8",
     sessionTrust: "\u672C\u4F1A\u8BDD\u4E0D\u518D\u8BE2\u95EE",
     permissionRequest: "\u6743\u9650\u8BF7\u6C42",
+    agent: "\u52A9\u624B",
     allow: "\u6279\u51C6",
     deny: "\u62D2\u7EDD",
     alwaysAllowBlanket: "\u59CB\u7EC8\u5141\u8BB8\uFF08\u901A\u914D\uFF09",
@@ -148,6 +151,7 @@ const BUBBLE_STRINGS = {
     alwaysAllow: "一律允許",
     sessionTrust: "本工作階段不再詢問",
     permissionRequest: "權限請求",
+    agent: "助手",
     allow: "允許",
     deny: "拒絕",
     alwaysAllowBlanket: "一律允許（全部）",
@@ -190,6 +194,7 @@ const BUBBLE_STRINGS = {
     alwaysAllow: "\uD56D\uC0C1 \uD5C8\uC6A9",
     sessionTrust: "\uC774 \uC138\uC158\uC5D0\uC11C\uB294 \uB2E4\uC2DC \uBB3B\uC9C0 \uC54A\uAE30",
     permissionRequest: "\uAD8C\uD55C \uC694\uCCAD",
+    agent: "\uC5D0\uC774\uC804\uD2B8",
     allow: "\uD5C8\uC6A9",
     deny: "\uAC70\uBD80",
     alwaysAllowBlanket: "\uD56D\uC0C1 \uD5C8\uC6A9 (\uC804\uCCB4)",
@@ -232,6 +237,7 @@ const BUBBLE_STRINGS = {
     alwaysAllow: "常に許可",
     sessionTrust: "このセッションでは今後確認しない",
     permissionRequest: "権限リクエスト",
+    agent: "エージェント",
     allow: "許可",
     deny: "拒否",
     alwaysAllowBlanket: "常に許可（包括）",

--- a/src/permission.js
+++ b/src/permission.js
@@ -790,6 +790,24 @@ function isPermissionEntryLive(permEntry) {
   return true;
 }
 
+function isInteractiveCodexSubagentEntry(permEntry) {
+  return !!(permEntry
+    && permEntry.isCodex === true
+    && permEntry.codexInteractiveSubagent === true
+    && permEntry.headless !== true);
+}
+
+function isPermissionEntryHeadless(permEntry) {
+  if (!permEntry || typeof permEntry !== "object") return false;
+  if (permEntry.headless === true) return true;
+  const session = ctx.sessions && typeof ctx.sessions.get === "function"
+    ? ctx.sessions.get(permEntry.sessionId)
+    : null;
+  return !!(session
+    && session.headless === true
+    && !isInteractiveCodexSubagentEntry(permEntry));
+}
+
 function canAutoResolvePendingPermission(permEntry, options = {}) {
   if (!isPermissionEntryLive(permEntry)) return false;
   if (ctx.doNotDisturb) return false;
@@ -817,12 +835,7 @@ function canAutoResolvePendingPermission(permEntry, options = {}) {
     return false;
   }
 
-  const session = ctx.sessions && typeof ctx.sessions.get === "function"
-    ? ctx.sessions.get(permEntry.sessionId)
-    : null;
-  if (permEntry.headless === true || (session && session.headless === true)) {
-    return false;
-  }
+  if (isPermissionEntryHeadless(permEntry)) return false;
 
   if (
     permEntry.isCodex
@@ -906,13 +919,15 @@ function maybeAutoApprovePermission(permEntry) {
   // override, however, may be consumed after the route has created the entry,
   // so it must pass the same current liveness/gate/identity chokepoint used by
   // warning returns, remote commit, and sweep.
-  if (
-    action === AUTOMATION_ACTION.AUTO_ALLOW
-    && typeof ctx.hasSessionAutomationOverride === "function"
-    && ctx.hasSessionAutomationOverride(permEntry)
-    && !canAutoResolvePendingPermission(permEntry, { mode })
-  ) {
-    return false;
+  if (action === AUTOMATION_ACTION.AUTO_ALLOW) {
+    const hasSessionOverride = typeof ctx.hasSessionAutomationOverride === "function"
+      && ctx.hasSessionAutomationOverride(permEntry);
+    // Interactive Codex children may inherit global automation only when the
+    // same route-owned identity and live gates used by session automation are
+    // valid. This prevents a Desktop/unknown process identity from turning an
+    // otherwise manual Agent-thread bubble into an automatic allow.
+    const needsLiveGate = hasSessionOverride || isInteractiveCodexSubagentEntry(permEntry);
+    if (needsLiveGate && !canAutoResolvePendingPermission(permEntry, { mode })) return false;
   }
 
   if (action === AUTOMATION_ACTION.AUTO_ANSWER) {
@@ -1222,6 +1237,8 @@ function buildPermissionBubblePayload(permEntry) {
     // Provenance for the renderer: lets the bubble relabel Codex MCP tool calls
     // (issue #445) without touching approval semantics. Mirrors the flags above.
     isCodex: permEntry.isCodex || false,
+    isCodexSubagent: permEntry.isCodex === true && permEntry.codexSessionRole === "subagent",
+    codexAgentNickname: permEntry.codexAgentNickname || null,
     isCodexUserInputNotify: permEntry.isCodexUserInputNotify || false,
     codexUserInputCallId: permEntry.codexUserInputCallId || null,
     isRemote: !!permEntry.host,
@@ -1316,12 +1333,10 @@ function isRemoteApprovalActionable(permEntry) {
   if (isPassiveNotifyEntry(permEntry) || isOpencodeFamilyEntry(permEntry) || permEntry.isAntigravity || permEntry.isCopilotCli) return false;
   if (isDecisionInteraction(interaction)) return false;
   if (PASSTHROUGH_TOOLS.has(permEntry.toolName)) return false;
-  // Headless sessions auto-deny locally; mirror that on the Telegram side so a
-  // non-interactive Codex/CC run never sends an actionable approval card.
-  const session = ctx.sessions && typeof ctx.sessions.get === "function"
-    ? ctx.sessions.get(permEntry.sessionId)
-    : null;
-  if (session && session.headless) return false;
+  // Mirror the local headless gate on remote channels. An audited interactive
+  // Codex Agent thread is the one exception: its state session is headless for
+  // HUD/focus policy, but the approval itself remains human-actionable.
+  if (isPermissionEntryHeadless(permEntry)) return false;
   return true;
 }
 

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -9,6 +9,10 @@ const {
   CODEX_SESSION_ROLE_SUBAGENT,
 } = require("./server-codex-official-turns");
 const {
+  isCodexCliOriginator,
+  isCodexDesktopOriginator,
+} = require("../hooks/codex-originator");
+const {
   truncateDeep,
   normalizePermissionSuggestions,
   prepareElicitationToolInput,
@@ -103,15 +107,42 @@ function shouldMuteCodexNativeNotificationSound(ctx) {
   return ctx.isCodexNativeNotificationSoundEnabled() === false;
 }
 
-function isHeadlessPermissionRequest(ctx, sessionId, data) {
+function isOfficialCodexSubagentPermission(agentId, data) {
+  return !!(data
+    && agentId === "codex"
+    && data.hook_source === CODEX_OFFICIAL_HOOK_SOURCE
+    && data.codex_session_role === CODEX_SESSION_ROLE_SUBAGENT);
+}
+
+function isInteractiveCodexSubagentPermission(agentId, data) {
+  return !!(isOfficialCodexSubagentPermission(agentId, data)
+    && (
+      isCodexCliOriginator(data.codex_originator)
+      || isCodexDesktopOriginator(data.codex_originator)
+    )
+    && data.headless !== true);
+}
+
+function isHeadlessPermissionRequest(ctx, sessionId, data, agentId) {
+  // An explicit process-level signal always wins. In contrast, Codex state
+  // sessions use headless=true for subagents as a presentation/focus policy
+  // (keep them out of HUD priority and completion noise). A PermissionRequest
+  // from a visible official Agent thread is still interactive, so that state
+  // marker must not suppress the approval bubble.
+  if (data && data.headless === true) return true;
+  if (isOfficialCodexSubagentPermission(agentId, data)) {
+    // PermissionRequest may be the first event for a child, before a session
+    // exists in memory. Only audited interactive clients may cross the
+    // chokepoint; exec/unknown children must fail safe to the native prompt.
+    return !isInteractiveCodexSubagentPermission(agentId, data);
+  }
   if (ctx && ctx.sessions && typeof ctx.sessions.get === "function") {
     const session = ctx.sessions.get(sessionId);
-    if (session && session.headless) return true;
+    if (session && session.headless) {
+      return !isInteractiveCodexSubagentPermission(agentId, data);
+    }
   }
-  if (data && data.headless === true) return true;
-  return !!(data
-    && (data.agent_id === "codex" || data.hook_source === CODEX_OFFICIAL_HOOK_SOURCE)
-    && data.codex_session_role === CODEX_SESSION_ROLE_SUBAGENT);
+  return false;
 }
 
 function arePermissionBubblesEnabled(ctx) {
@@ -185,12 +216,20 @@ function buildCodexPermissionSessionOptions(data) {
   const model = normalizeString(data.model);
   const codexOriginator = normalizeString(data.codex_originator);
   const codexSource = normalizeString(data.codex_source);
+  const codexSessionRole = normalizeString(data.codex_session_role);
+  const codexAgentNickname = normalizeString(data.codex_agent_nickname);
+  const codexAgentRole = normalizeString(data.codex_agent_role);
+  const codexParentThreadId = normalizeString(data.codex_parent_thread_id);
   if (cwd) options.cwd = cwd;
   if (host) options.host = host;
   if (platform) options.platform = platform;
   if (model) options.model = model;
   if (codexOriginator) options.codexOriginator = codexOriginator;
   if (codexSource) options.codexSource = codexSource;
+  if (codexSessionRole) options.codexSessionRole = codexSessionRole;
+  if (codexAgentNickname) options.codexAgentNickname = codexAgentNickname;
+  if (codexAgentRole) options.codexAgentRole = codexAgentRole;
+  if (codexParentThreadId) options.codexParentThreadId = codexParentThreadId;
   return options;
 }
 
@@ -548,7 +587,7 @@ function handlePermissionPost(req, res, options) {
           return;
         }
 
-        if (isHeadlessPermissionRequest(ctx, sessionId, data)) {
+        if (isHeadlessPermissionRequest(ctx, sessionId, data, agentId)) {
           recordRequestHookEvent.accepted();
           ctx.permLog(`${agentId} headless session=${sessionId} → silent drop, TUI fallback — request=${requestId}`);
           return;
@@ -669,6 +708,7 @@ function handlePermissionPost(req, res, options) {
           sessionAutomationIdentity,
           ...remoteSessionFields(sessionIdentity),
         };
+        const isCodexSubagent = isInteractiveCodexSubagentPermission(agentId, data);
 
         if (ctx.doNotDisturb) {
           recordRequestHookEvent.droppedByDnd();
@@ -677,7 +717,7 @@ function handlePermissionPost(req, res, options) {
           return;
         }
 
-        if (isHeadlessPermissionRequest(ctx, sessionId, data)) {
+        if (isHeadlessPermissionRequest(ctx, sessionId, data, agentId)) {
           recordRequestHookEvent.accepted();
           ctx.permLog(`codex headless session=${sessionId} -> no decision, native prompt fallback (tool=${toolName})`);
           sendCodexPermissionNoDecision(res);
@@ -732,6 +772,16 @@ function handlePermissionPost(req, res, options) {
           sessionAutomationIdentity,
           agentId: "codex",
           isCodex: true,
+          codexInteractiveSubagent: isCodexSubagent,
+          headless: data.headless === true,
+          codexSessionRole: codexSessionOptions.codexSessionRole || null,
+          codexAgentNickname: codexSessionOptions.codexAgentNickname || null,
+          codexAgentRole: codexSessionOptions.codexAgentRole || null,
+          codexParentThreadId: codexSessionOptions.codexParentThreadId || null,
+          subagentId: isCodexSubagent ? sessionId : null,
+          subagentType: isCodexSubagent
+            ? (codexSessionOptions.codexAgentNickname || codexSessionOptions.codexAgentRole || "Agent")
+            : null,
           sourcePid: codexSessionOptions.sourcePid || null,
           cwd: codexSessionOptions.cwd || "",
           agentPid: codexSessionOptions.agentPid || null,
@@ -805,7 +855,7 @@ function handlePermissionPost(req, res, options) {
           return;
         }
 
-        if (isHeadlessPermissionRequest(ctx, sessionId, data)) {
+        if (isHeadlessPermissionRequest(ctx, sessionId, data, agentId)) {
           recordRequestHookEvent.accepted();
           ctx.permLog(`qwen headless session=${sessionId} -> no decision, native prompt fallback (tool=${toolName})`);
           sendQwenCodePermissionNoDecision(res);
@@ -927,7 +977,7 @@ function handlePermissionPost(req, res, options) {
           return;
         }
 
-        if (isHeadlessPermissionRequest(ctx, sessionId, data)) {
+        if (isHeadlessPermissionRequest(ctx, sessionId, data, agentId)) {
           recordRequestHookEvent.accepted();
           ctx.permLog(`copilot headless session=${sessionId} -> no decision, native prompt fallback (tool=${toolName})`);
           sendCopilotPermissionNoDecision(res);
@@ -1054,7 +1104,7 @@ function handlePermissionPost(req, res, options) {
           return;
         }
 
-        if (isHeadlessPermissionRequest(ctx, sessionId, data)) {
+        if (isHeadlessPermissionRequest(ctx, sessionId, data, agentId)) {
           recordRequestHookEvent.accepted();
           ctx.permLog(`hermes headless session=${sessionId} -> no decision, native fallback (tool=${toolName})`);
           sendHermesPermissionNoDecision(res);

--- a/src/session-automation-identity.js
+++ b/src/session-automation-identity.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { isCodexCliOriginator } = require("../hooks/codex-originator");
+
 // Session automation is a security-sensitive opt-in. This table is deliberately
 // small and static: it records only adapter identity facts that have been
 // audited for this feature. It is not a runtime capability registry.
@@ -55,7 +57,6 @@ const ADAPTER_POLICY = Object.freeze({
 });
 
 const VALID_CHANNELS = new Set(["state", "permission"]);
-const CODEX_LOCAL_CLI_ORIGINATORS = new Set(["codex_cli_rs", "codex-tui"]);
 const CODEX_SESSION_ID_PATTERN =
   /^codex:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -91,7 +92,7 @@ function assessCodexIdentity({
     return result(false, "unsupported-codex-session-source");
   }
   const originator = normalizeString(codexOriginator).toLowerCase();
-  if (!CODEX_LOCAL_CLI_ORIGINATORS.has(originator)) {
+  if (!isCodexCliOriginator(originator)) {
     return result(false, "unsupported-codex-originator");
   }
   if (!Number.isFinite(agentPid) || agentPid <= 0) {

--- a/test/codex-hook.test.js
+++ b/test/codex-hook.test.js
@@ -442,12 +442,21 @@ describe("Codex official hook", () => {
     });
   });
 
-  it("classifies subagent PermissionRequest payloads so the headless gate fires without a state event", () => {
+  it("carries interactive subagent provenance without classifying the permission as headless", () => {
     withTempTranscript([
       JSON.stringify({
         type: "session_meta",
         payload: {
-          source: { subagent: { thread_spawn: { agent_role: "worker" } } },
+          source: {
+            subagent: {
+              thread_spawn: {
+                parent_thread_id: "parent-1",
+                agent_role: "worker",
+                agent_nickname: "Halley",
+              },
+            },
+          },
+          originator: "codex-tui",
           agent_role: "worker",
         },
       }),
@@ -462,7 +471,66 @@ describe("Codex official hook", () => {
 
       assert.strictEqual(body.agent_id, "codex");
       assert.strictEqual(body.codex_session_role, "subagent");
+      assert.strictEqual(body.codex_originator, "codex-tui");
+      assert.strictEqual(body.codex_source, "cli");
+      assert.strictEqual(body.codex_agent_nickname, "Halley");
+      assert.strictEqual(body.codex_agent_role, "worker");
+      assert.strictEqual(body.codex_parent_thread_id, "parent-1");
+      assert.strictEqual(Object.prototype.hasOwnProperty.call(body, "headless"), false);
     });
+  });
+
+  it("preserves an explicit process-level headless signal on PermissionRequest", () => {
+    const body = buildPermissionBody({
+      hook_event_name: "PermissionRequest",
+      session_id: "s1",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+      headless: true,
+    }, mockResolve);
+
+    assert.strictEqual(body.headless, true);
+  });
+
+  it("forwards a resolver-derived headless signal on PermissionRequest", () => {
+    const body = buildPermissionBody({
+      hook_event_name: "PermissionRequest",
+      session_id: "s1",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+    }, () => ({
+      stablePid: 123,
+      agentPid: 456,
+      pidChain: [456, 123],
+      headless: true,
+    }));
+
+    assert.strictEqual(body.headless, true);
+  });
+
+  it("does not synthesize CLI provenance for exec, Desktop, or unknown subagents", () => {
+    for (const originator of ["codex_exec", "codex_work_desktop", "unknown-client"]) {
+      withTempTranscript([
+        JSON.stringify({
+          type: "session_meta",
+          payload: {
+            source: { subagent: { thread_spawn: { agent_role: "worker" } } },
+            originator,
+          },
+        }),
+      ], (transcriptPath) => {
+        const body = buildPermissionBody({
+          hook_event_name: "PermissionRequest",
+          session_id: "s1",
+          transcript_path: transcriptPath,
+          tool_name: "Bash",
+          tool_input: { command: "npm test" },
+        }, mockResolve);
+
+        assert.strictEqual(body.codex_originator, originator);
+        assert.strictEqual(Object.prototype.hasOwnProperty.call(body, "codex_source"), false);
+      });
+    }
   });
 
   it("does not build a state payload for PermissionRequest", () => {

--- a/test/codex-originator.test.js
+++ b/test/codex-originator.test.js
@@ -3,7 +3,10 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 
-const { isCodexDesktopOriginator } = require("../hooks/codex-originator");
+const {
+  isCodexCliOriginator,
+  isCodexDesktopOriginator,
+} = require("../hooks/codex-originator");
 
 describe("Codex originator classification", () => {
   it("recognizes current and legacy Codex Desktop values", () => {
@@ -31,6 +34,15 @@ describe("Codex originator classification", () => {
       {},
     ]) {
       assert.strictEqual(isCodexDesktopOriginator(value), false, String(value));
+    }
+  });
+
+  it("recognizes only audited interactive CLI originators", () => {
+    for (const value of ["codex-tui", " CODEX-TUI ", "codex_cli_rs"]) {
+      assert.strictEqual(isCodexCliOriginator(value), true, value);
+    }
+    for (const value of ["codex_exec", "codex_work_desktop", "cli", "", null, {}]) {
+      assert.strictEqual(isCodexCliOriginator(value), false, String(value));
     }
   });
 });

--- a/test/permission-auto-approve.test.js
+++ b/test/permission-auto-approve.test.js
@@ -262,6 +262,64 @@ describe("permission automation: showPermissionBubble chokepoint", () => {
     assert.equal(res.captured.statusCode, 200);
   });
 
+  it("requires an eligible route identity before global automation can allow a Codex Agent thread", () => {
+    const ctx = makeCtx({
+      getPermissionAutomationMode: () => "auto-tools",
+      isAgentEnabled: () => true,
+      isAgentPermissionsEnabled: () => true,
+      isAgentSubagentPermissionsEnabled: () => true,
+      isCodexPermissionInterceptEnabled: () => true,
+    });
+    const perm = initPermission(ctx);
+    const res = makeCapturingRes();
+    const entry = makePermEntry({
+      res,
+      agentId: "codex",
+      isCodex: true,
+      codexSessionRole: "subagent",
+      codexInteractiveSubagent: true,
+      subagentId: "session-test",
+      sessionAutomationIdentity: { eligible: false, reason: "unsupported-codex-originator" },
+    });
+    perm.pendingPermissions.push(entry);
+
+    assert.throws(() => perm.showPermissionBubble(entry));
+    assert.equal(perm.pendingPermissions.includes(entry), true);
+    assert.equal(res.captured.statusCode, null);
+  });
+
+  it("lets an eligible TUI Agent thread inherit global auto-tools", () => {
+    const ctx = makeCtx({
+      getPermissionAutomationMode: () => "auto-tools",
+      isAgentEnabled: () => true,
+      isAgentPermissionsEnabled: () => true,
+      isAgentSubagentPermissionsEnabled: () => true,
+      isCodexPermissionInterceptEnabled: () => true,
+      sessions: new Map([["session-test", { agentId: "codex", headless: true }]]),
+    });
+    const perm = initPermission(ctx);
+    const res = makeCapturingRes();
+    const entry = makePermEntry({
+      res,
+      agentId: "codex",
+      isCodex: true,
+      codexSessionRole: "subagent",
+      codexInteractiveSubagent: true,
+      subagentId: "session-test",
+      headless: false,
+      sessionAutomationIdentity: { eligible: true, reason: "eligible" },
+    });
+    perm.pendingPermissions.push(entry);
+
+    perm.showPermissionBubble(entry);
+    assert.equal(perm.pendingPermissions.includes(entry), false);
+    assert.equal(res.captured.statusCode, 200);
+    assert.equal(
+      JSON.parse(res.captured.body).hookSpecificOutput.decision.behavior,
+      "allow"
+    );
+  });
+
   it("fails safe when an entry reaches the chokepoint without a valid interaction", () => {
     const ctx = makeCtx({ getPermissionAutomationMode: () => "unattended" });
     const perm = initPermission(ctx);

--- a/test/permission-session-automation-live-gate.test.js
+++ b/test/permission-session-automation-live-gate.test.js
@@ -132,6 +132,42 @@ describe("permission session automation live gate", () => {
     }
   });
 
+  it("allows an interactive Codex subagent to inherit automation despite its state-only headless marker", () => {
+    const { permission, entry } = makeRuntime({
+      sessions: new Map([["session-live", { agentId: "codex", headless: true }]]),
+    }, {
+      agentId: "codex",
+      isCodex: true,
+      codexInteractiveSubagent: true,
+      codexSessionRole: "subagent",
+      codexAgentNickname: "Halley",
+      subagentId: "session-live",
+      headless: false,
+      interaction: classifyPermissionInteraction({ agentId: "codex", toolName: "Bash" }),
+    });
+
+    assert.strictEqual(
+      permission.canAutoResolvePendingPermission(entry, {
+        sessionOnly: true,
+        mode: "auto-tools",
+      }),
+      true
+    );
+
+    const payload = permission.buildPermissionBubblePayload(entry);
+    assert.strictEqual(payload.isCodexSubagent, true);
+    assert.strictEqual(payload.codexAgentNickname, "Halley");
+
+    entry.headless = true;
+    assert.strictEqual(
+      permission.canAutoResolvePendingPermission(entry, {
+        sessionOnly: true,
+        mode: "auto-tools",
+      }),
+      false
+    );
+  });
+
   it("uses an explicit session mode and never reads the global mode for session-only checks", () => {
     const { permission, entry } = makeRuntime({
       getPermissionAutomationMode: () => "auto-tools",
@@ -198,6 +234,8 @@ describe("permission session automation live gate", () => {
     );
     assert.match(source, /data\.canOfferSessionTrust === true/);
     assert.match(source, /decide\("session-trust"\)/);
+    assert.match(source, /data\.isCodexSubagent/);
+    assert.match(source, /data\.codexAgentNickname \|\| bubbleText\(data\.lang, "agent"\)/);
     assert.doesNotMatch(source, /sessionAutomationIdentity/);
   });
 });

--- a/test/permission-telegram-approval.test.js
+++ b/test/permission-telegram-approval.test.js
@@ -693,6 +693,40 @@ describe("permission telegram remote approval", () => {
     assert.deepEqual(requests, []);
   });
 
+  it("keeps remote approval actionable for audited interactive Codex Agent threads", () => {
+    const requests = [];
+    const client = {
+      isEnabled: () => true,
+      requestApproval: (payload) => {
+        requests.push(payload);
+        return new Promise(() => {});
+      },
+    };
+    const ctx = makeCtx({
+      getTelegramApprovalClient: () => client,
+      sessions: new Map([["sid", { cwd: "D:\\work\\project-alpha", headless: true }]]),
+    });
+    const perm = initPermission(ctx);
+    const entry = makePermEntry({
+      agentId: "codex",
+      isCodex: true,
+      codexSessionRole: "subagent",
+      codexInteractiveSubagent: true,
+      subagentId: "sid",
+      headless: false,
+    });
+    perm.pendingPermissions.push(entry);
+
+    assert.equal(perm.maybeStartRemoteApproval(entry), true);
+    assert.equal(requests.length, 1);
+
+    entry.headless = true;
+    const explicitHeadless = makePermEntry({ ...entry, _remoteApprovalStarted: false });
+    perm.pendingPermissions.push(explicitHeadless);
+    assert.equal(perm.maybeStartRemoteApproval(explicitHeadless), false);
+    assert.equal(requests.length, 1);
+  });
+
   it("aborts the remote request when the user picks deny-and-focus (go to terminal)", () => {
     let signal;
     const client = {

--- a/test/server-codex-permission.test.js
+++ b/test/server-codex-permission.test.js
@@ -326,22 +326,103 @@ describe("Codex official /permission path", () => {
     res.destroy();
   });
 
-  it("returns no-decision for subagent PermissionRequest before auto-pilot can allow", async () => {
+  it("routes an interactive subagent PermissionRequest through the approval bubble", async () => {
+    const { handler, pendingPermissions, updates, shown } = startServer({
+      isCodexPermissionInterceptEnabled: () => true,
+    });
+    const req = makeReq({
+      hook_source: "codex-official",
+      codex_session_role: "subagent",
+      codex_originator: "codex-tui",
+      codex_agent_nickname: "Halley",
+      codex_parent_thread_id: "parent-1",
+      session_id: "codex:sub",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+    });
+    const res = makeRes();
+
+    handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(res.writableEnded, false);
+    assert.strictEqual(pendingPermissions.length, 1);
+    assert.strictEqual(shown.length, 1);
+    assert.strictEqual(pendingPermissions[0].codexSessionRole, "subagent");
+    assert.strictEqual(pendingPermissions[0].codexAgentNickname, "Halley");
+    assert.strictEqual(pendingPermissions[0].codexParentThreadId, "parent-1");
+    assert.strictEqual(pendingPermissions[0].subagentId, localSessionKey("codex:sub"));
+    assert.strictEqual(updates.length, 1);
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(updates[0][3], "headless"), false);
+
+    res.destroy();
+  });
+
+  it("does not let the state-only subagent headless marker suppress an interactive approval", async () => {
+    const sessionId = localSessionKey("codex:sub-state");
+    const { handler, pendingPermissions, shown } = startServer({
+      sessions: new Map([[sessionId, { agentId: "codex", headless: true }]]),
+      isCodexPermissionInterceptEnabled: () => true,
+    });
+    const req = makeReq({
+      hook_source: "codex-official",
+      codex_session_role: "subagent",
+      codex_originator: "codex_work_desktop",
+      session_id: "codex:sub-state",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+    });
+    const res = makeRes();
+
+    handler(req, res);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(res.writableEnded, false);
+    assert.strictEqual(pendingPermissions.length, 1);
+    assert.strictEqual(shown.length, 1);
+    res.destroy();
+  });
+
+  it("keeps an explicitly headless subagent on the native no-decision fallback", async () => {
     const { handler, pendingPermissions, updates, shown } = startServer({
       isCodexPermissionInterceptEnabled: () => true,
     });
     const res = await callPermission(handler, {
       hook_source: "codex-official",
       codex_session_role: "subagent",
-      session_id: "codex:sub",
+      codex_originator: "codex-tui",
+      headless: true,
+      session_id: "codex:sub-headless",
       tool_name: "Bash",
       tool_input: { command: "npm test" },
     });
 
     assert.strictEqual(res.statusCode, 204);
-    assert.strictEqual(res.body, "");
     assert.strictEqual(pendingPermissions.length, 0);
     assert.strictEqual(shown.length, 0);
     assert.deepStrictEqual(updates, []);
+  });
+
+  it("keeps codex_exec and unknown subagent originators on native fallback", async () => {
+    for (const originator of ["codex_exec", "unknown-client", null]) {
+      const rawSessionId = `codex:sub-${originator || "missing"}`;
+      const { handler, pendingPermissions, updates, shown } = startServer({
+        isCodexPermissionInterceptEnabled: () => true,
+      });
+      const body = {
+        hook_source: "codex-official",
+        codex_session_role: "subagent",
+        session_id: rawSessionId,
+        tool_name: "Bash",
+        tool_input: { command: "npm test" },
+      };
+      if (originator) body.codex_originator = originator;
+      const res = await callPermission(handler, body);
+
+      assert.strictEqual(res.statusCode, 204, String(originator));
+      assert.strictEqual(pendingPermissions.length, 0, String(originator));
+      assert.strictEqual(shown.length, 0, String(originator));
+      assert.deepStrictEqual(updates, [], String(originator));
+    }
   });
 });

--- a/test/server-qwen-permission.test.js
+++ b/test/server-qwen-permission.test.js
@@ -168,6 +168,9 @@ describe("Qwen Code /permission path", () => {
 
     const res = await callPermission(handler, {
       agent_id: "qwen-code",
+      hook_source: "codex-official",
+      codex_session_role: "subagent",
+      codex_originator: "codex-tui",
       session_id: sessionId,
       tool_name: "Bash",
       tool_input: { command: "npm test" },

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -726,6 +726,9 @@ describe("server-route-permission POST", () => {
     const sessionId = "opencode:headless";
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "opencode",
+      hook_source: "codex-official",
+      codex_session_role: "subagent",
+      codex_originator: "codex-tui",
       session_id: sessionId,
       tool_name: "Bash",
       tool_input: { command: "npm test" },
@@ -1419,6 +1422,9 @@ describe("server-route-permission POST", () => {
     const sessionId = "copilot:headless";
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "copilot-cli",
+      hook_source: "codex-official",
+      codex_session_role: "subagent",
+      codex_originator: "codex-tui",
       session_id: sessionId,
       tool_name: "edit",
       tool_input: { filePath: "a.txt" },
@@ -1634,6 +1640,9 @@ describe("server-route-permission POST", () => {
     const sessionId = "hermes:headless";
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "hermes",
+      hook_source: "codex-official",
+      codex_session_role: "subagent",
+      codex_originator: "codex-tui",
       session_id: sessionId,
       tool_name: "execute_bash",
       tool_input: { command: "rm -rf /tmp/test" },


### PR DESCRIPTION
## Summary

- distinguish visible Codex Agent threads from truly non-interactive subagents at the official PermissionRequest boundary
- route audited TUI/Desktop child requests through the existing Clawd bubble and remote-approval paths while keeping explicit headless, codex_exec, and unknown clients on native fallback
- require the route-owned stable identity gate before an interactive child can inherit global or session automation
- carry child nickname, role, and parent provenance into the permission bubble
- preserve the headless gate for Qwen, opencode, Copilot, and Hermes even when requests contain spoofed Codex fields

## Testing

- focused hook, route, automation, renderer-contract, and remote-approval suite: 203/203 passed
- real post-restart subagent smoke: Sagan ran an escalated gh auth status; Clawd logged PermissionRequest -> showing bubble -> auto-tools -> allow with no native fallback
- full npm test: 6,661 passed, 23 failed, 20 skipped; the 23 failures are the existing Windows/cross-platform environment assertions (POSIX paths/modes, macOS/AppImage resolution, CRLF tombstone, and process-walk fixtures)
- remote hook manifest/dependency closure: 2/2 passed; the same test file still has its unrelated Windows CRLF tombstone failure
- git diff --check passed

## Review

- independently cross-reviewed for security boundaries, hook/test coverage, and product behavior; all blocking findings were resolved before opening this PR