### PR TITLE
fix: persist Settings window bounds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -719,7 +719,11 @@ const settingsWindowRuntime = createSettingsWindowRuntime({
   discordDefaultAppIdPresent: !!discordPresenceSettings.DEFAULT_CLAWD_DISCORD_APP_ID,
   getPetWindowBounds: () => getPetWindowBounds(),
   getNearestWorkArea: (cx, cy) => getNearestWorkArea(cx, cy),
-  getTextScale: () => effectiveTextScaleForKey(getSettingsDisplayKey()),
+  getTextScale: (bounds) => effectiveTextScaleForKey(
+    getDisplayKeyForBounds(bounds) || getSettingsDisplayKey()
+  ),
+  getSavedBounds: () => _settingsController.get("settingsWindowBounds"),
+  onSaveBounds: (bounds) => _settingsController.applyUpdate("settingsWindowBounds", bounds),
   getTitle: () => translate("settingsWindowTitle"),
   onBeforeCreate: () => bumpAnimationOverridePreviewPosterGeneration(),
   onBeforeClosed: () => {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -56,7 +56,7 @@ const {
   PET_ACCESSORY_IDS,
 } = require("./pet-customization-catalog");
 
-const CURRENT_VERSION = 13;
+const CURRENT_VERSION = 12;
 const DEFAULT_INTEGRATION_INSTALLED_IDS = Object.freeze(["claude-code", "codex"]);
 const DEFAULT_INTEGRATION_INSTALLED_SET = new Set(DEFAULT_INTEGRATION_INSTALLED_IDS);
 
@@ -104,7 +104,8 @@ const SCHEMA = {
   },
   // Normal-state geometry for the resizable Settings window. `null` means the
   // user has not placed it yet, so the runtime centers it on the pet display.
-  // Maximized/minimized/fullscreen bounds are never stored here.
+  // The Settings runtime prefers Electron's normal bounds so maximized,
+  // minimized, and fullscreen rectangles are not stored here.
   settingsWindowBounds: {
     type: "object",
     defaultFactory: () => null,
@@ -740,11 +741,6 @@ function migrate(raw) {
   if (out.version < 12) {
     if (!("showDock" in out)) out.showDock = true;
     out.version = 12;
-  }
-  // v12 -> v13: Settings-window geometry persistence. No backfill is needed:
-  // an absent/null value intentionally keeps the existing centered placement.
-  if (out.version < 13) {
-    out.version = 13;
   }
   if ((typeof out.version === "number" ? out.version : 0) < CURRENT_VERSION) {
     out.version = CURRENT_VERSION;

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -56,7 +56,7 @@ const {
   PET_ACCESSORY_IDS,
 } = require("./pet-customization-catalog");
 
-const CURRENT_VERSION = 12;
+const CURRENT_VERSION = 13;
 const DEFAULT_INTEGRATION_INSTALLED_IDS = Object.freeze(["claude-code", "codex"]);
 const DEFAULT_INTEGRATION_INSTALLED_SET = new Set(DEFAULT_INTEGRATION_INSTALLED_IDS);
 
@@ -72,7 +72,7 @@ const SCHEMA = {
     type: "number",
     default: CURRENT_VERSION,
   },
-  // Window state
+  // Pet window state
   x: { type: "number", default: 0, validate: (v) => Number.isFinite(v) },
   y: { type: "number", default: 0, validate: (v) => Number.isFinite(v) },
   positionSaved: { type: "boolean", default: false },
@@ -101,6 +101,14 @@ const SCHEMA = {
     type: "object",
     defaultFactory: () => null,
     normalize: normalizeSavedPixelWorkArea,
+  },
+  // Normal-state geometry for the resizable Settings window. `null` means the
+  // user has not placed it yet, so the runtime centers it on the pet display.
+  // Maximized/minimized/fullscreen bounds are never stored here.
+  settingsWindowBounds: {
+    type: "object",
+    defaultFactory: () => null,
+    normalize: normalizeSettingsWindowBounds,
   },
   size: {
     type: "string",
@@ -733,6 +741,11 @@ function migrate(raw) {
     if (!("showDock" in out)) out.showDock = true;
     out.version = 12;
   }
+  // v12 -> v13: Settings-window geometry persistence. No backfill is needed:
+  // an absent/null value intentionally keeps the existing centered placement.
+  if (out.version < 13) {
+    out.version = 13;
+  }
   if ((typeof out.version === "number" ? out.version : 0) < CURRENT_VERSION) {
     out.version = CURRENT_VERSION;
   }
@@ -811,6 +824,37 @@ function normalizeSavedPixelWorkArea(value) {
   if (!Number.isFinite(w) || w <= 0) return null;
   if (!Number.isFinite(h) || h <= 0) return null;
   return { width: w, height: h };
+}
+
+function isValidSettingsWindowBounds(value) {
+  return !!value
+    && typeof value === "object"
+    && !Array.isArray(value)
+    && Number.isSafeInteger(value.x)
+    && Number.isSafeInteger(value.y)
+    && Number.isSafeInteger(value.width)
+    && Number.isSafeInteger(value.height)
+    && value.width > 0
+    && value.height > 0;
+}
+
+function normalizeSettingsWindowBounds(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  if (
+    !Number.isFinite(value.x)
+    || !Number.isFinite(value.y)
+    || !Number.isFinite(value.width)
+    || !Number.isFinite(value.height)
+  ) {
+    return null;
+  }
+  const normalized = {
+    x: Math.round(value.x),
+    y: Math.round(value.y),
+    width: Math.round(value.width),
+    height: Math.round(value.height),
+  };
+  return isValidSettingsWindowBounds(normalized) ? normalized : null;
 }
 
 function normalizePositionDisplay(value) {
@@ -1284,6 +1328,7 @@ module.exports = {
   normalizeShortcuts,
   normalizeOptionalHttpUrl,
   normalizePathList,
+  isValidSettingsWindowBounds,
   MAX_CUSTOM_DISCOVERY_PATHS,
   MAX_CUSTOM_DISCOVERY_PATH_LENGTH,
 };

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -51,6 +51,7 @@
 const {
   CURRENT_VERSION,
   MAX_CUSTOM_DISCOVERY_PATHS,
+  isValidSettingsWindowBounds,
   normalizePathList,
 } = require("./prefs");
 const {
@@ -239,6 +240,13 @@ const updateRegistry = {
   },
   savedPixelWidth: requireNonNegativeFiniteNumber("savedPixelWidth"),
   savedPixelHeight: requireNonNegativeFiniteNumber("savedPixelHeight"),
+  settingsWindowBounds: (value) => {
+    if (value === null || isValidSettingsWindowBounds(value)) return { status: "ok" };
+    return {
+      status: "error",
+      message: "settingsWindowBounds must be null or integer { x, y, width, height } with positive dimensions",
+    };
+  },
   // #408: frozen-origin work area for keepSizeAcrossDisplays. null = unknown
   // (legacy prefs / never seeded); otherwise positive width+height.
   savedPixelWorkArea: (value) => {

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -45,6 +45,10 @@
   // startsWith("Mac") not /\bMac\b/ — "MacIntel" has \w after "c", fails \b (regression #135).
   const IS_MAC = (navigator.platform || "").startsWith("Mac");
   const COLLAPSED_GROUPS_STORAGE_KEY = "clawd.settings.collapsedGroups.v1";
+  // Runtime-only geometry belongs in the snapshot for consistency, but has no
+  // mounted Settings control. Re-rendering for it would destroy focused inputs
+  // and reset the active tab's scroll position after every window move/resize.
+  const RENDERER_INERT_SETTINGS_KEYS = new Set(["settingsWindowBounds"]);
 
   const state = {
     snapshot: null,
@@ -1476,6 +1480,13 @@
     if (!state.snapshot) return;
 
     const changes = payload && payload.changes;
+    const changeKeys = changes && typeof changes === "object" ? Object.keys(changes) : [];
+    if (
+      changeKeys.length > 0
+      && changeKeys.every((key) => RENDERER_INERT_SETTINGS_KEYS.has(key))
+    ) {
+      return;
+    }
     clearTransientStateForChanges(changes);
     const needsAnimOverridesRefresh = !!(changes && (
       "theme" in changes || "themeVariant" in changes || "themeOverrides" in changes

--- a/src/settings-window.js
+++ b/src/settings-window.js
@@ -395,6 +395,23 @@ function createSettingsWindowRuntime(options = {}) {
     if (typeof options.onBeforeCreate === "function") options.onBeforeCreate();
     settingsWindow = new BrowserWindow(opts);
     const createdWindow = settingsWindow;
+    // BrowserWindow's constructor can quantize framed window geometry at
+    // fractional Windows DPI (for example, a persisted outer width of 960
+    // may initially report as 962). Re-apply the requested outer bounds via
+    // setBounds before listeners are attached so repeated reopen cycles do
+    // not persist and accumulate that native-frame drift.
+    try {
+      const createdBounds = typeof createdWindow.getBounds === "function"
+        ? roundedBounds(createdWindow.getBounds())
+        : null;
+      if (
+        createdBounds
+        && !sameBounds(createdBounds, bounds)
+        && typeof createdWindow.setBounds === "function"
+      ) {
+        createdWindow.setBounds(bounds);
+      }
+    } catch {}
     if (isWin && typeof createdWindow.setAppDetails === "function") {
       const taskbarDetails = getTaskbarDetails();
       if (taskbarDetails && taskbarDetails.appIconPath) {

--- a/src/settings-window.js
+++ b/src/settings-window.js
@@ -412,6 +412,11 @@ function createSettingsWindowRuntime(options = {}) {
         createdWindow.setBounds(bounds);
       }
     } catch {}
+    // Treat the post-correction native rectangle as the initial baseline.
+    // Closing an untouched window must not rewrite prefs, and any platform
+    // that cannot adopt the requested rectangle exactly must not feed its
+    // constructor/frame quantization back into the next launch.
+    lastSavedBounds = getNormalWindowBounds(createdWindow) || bounds;
     if (isWin && typeof createdWindow.setAppDetails === "function") {
       const taskbarDetails = getTaskbarDetails();
       if (taskbarDetails && taskbarDetails.appIconPath) {

--- a/src/settings-window.js
+++ b/src/settings-window.js
@@ -16,6 +16,7 @@ const MIN_WIDTH = 640;
 const MIN_HEIGHT = 480;
 const READY_TO_SHOW_FALLBACK_MS = 2000;
 const SETTINGS_FRONT_LIFT_MS = 200;
+const BOUNDS_SAVE_DEBOUNCE_MS = 500;
 const FALLBACK_WORK_AREA = { x: 0, y: 0, width: 1280, height: 800 };
 
 function requiredDependency(value, name) {
@@ -52,6 +53,26 @@ function clampBoundsToWorkArea(bounds, workArea) {
   };
 }
 
+function roundedBounds(bounds) {
+  if (!isUsableBounds(bounds)) return null;
+  const normalized = {
+    x: Math.round(bounds.x),
+    y: Math.round(bounds.y),
+    width: Math.round(bounds.width),
+    height: Math.round(bounds.height),
+  };
+  return isUsableBounds(normalized) ? normalized : null;
+}
+
+function sameBounds(a, b) {
+  return !!a
+    && !!b
+    && a.x === b.x
+    && a.y === b.y
+    && a.width === b.width
+    && a.height === b.height;
+}
+
 function createSettingsWindowRuntime(options = {}) {
   const app = requiredDependency(options.app, "app");
   const BrowserWindow = requiredDependency(options.BrowserWindow, "BrowserWindow");
@@ -72,6 +93,8 @@ function createSettingsWindowRuntime(options = {}) {
   let settingsWindow = null;
   let readyToShowFallbackTimer = null;
   let liftTimer = null;
+  let saveBoundsTimer = null;
+  let lastSavedBounds = null;
   let showPendingSettingsWindow = null;
 
   function getWindow() {
@@ -100,6 +123,12 @@ function createSettingsWindowRuntime(options = {}) {
     liftTimer = null;
   }
 
+  function clearSaveBoundsTimer() {
+    if (!saveBoundsTimer) return;
+    clearScheduled(saveBoundsTimer);
+    saveBoundsTimer = null;
+  }
+
   function getIconPath() {
     return getSettingsWindowIconPath({
       platform,
@@ -123,9 +152,17 @@ function createSettingsWindowRuntime(options = {}) {
   }
 
   function computeInitialBounds() {
+    let savedBounds = null;
+    if (typeof options.getSavedBounds === "function") {
+      try { savedBounds = roundedBounds(options.getSavedBounds()); } catch {}
+    }
+
     let cx = 0;
     let cy = 0;
-    if (typeof options.getPetWindowBounds === "function") {
+    if (savedBounds) {
+      cx = savedBounds.x + savedBounds.width / 2;
+      cy = savedBounds.y + savedBounds.height / 2;
+    } else if (typeof options.getPetWindowBounds === "function") {
       try {
         const petBounds = options.getPetWindowBounds();
         if (isUsableBounds(petBounds)) {
@@ -144,7 +181,16 @@ function createSettingsWindowRuntime(options = {}) {
       }
     }
 
-    const scale = getTextScale();
+    const scale = getTextScale(savedBounds || workArea);
+    const minWidth = scaleWidth(MIN_WIDTH, scale);
+    const minHeight = scaleHeight(MIN_HEIGHT, scale);
+    if (savedBounds) {
+      return clampBoundsToWorkArea({
+        ...savedBounds,
+        width: Math.max(savedBounds.width, minWidth),
+        height: Math.max(savedBounds.height, minHeight),
+      }, workArea);
+    }
     const width = Math.min(scaleWidth(DEFAULT_WIDTH, scale), Math.max(1, workArea.width));
     const height = Math.min(scaleHeight(DEFAULT_HEIGHT, scale), Math.max(1, workArea.height));
     return clampBoundsToWorkArea({
@@ -155,8 +201,64 @@ function createSettingsWindowRuntime(options = {}) {
     }, workArea);
   }
 
-  function getTextScale() {
-    return clampTextScale(typeof options.getTextScale === "function" ? options.getTextScale() : 1);
+  function getTextScale(bounds = null) {
+    return clampTextScale(typeof options.getTextScale === "function" ? options.getTextScale(bounds) : 1);
+  }
+
+  function getNormalWindowBounds(win) {
+    if (!isLiveWindow(win)) return null;
+    try {
+      if (typeof win.getNormalBounds === "function") {
+        const bounds = roundedBounds(win.getNormalBounds());
+        if (bounds) return bounds;
+      }
+    } catch {}
+    try {
+      return typeof win.getBounds === "function" ? roundedBounds(win.getBounds()) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function persistWindowBoundsNow(win) {
+    clearSaveBoundsTimer();
+    if (typeof options.onSaveBounds !== "function") return false;
+    const bounds = getNormalWindowBounds(win);
+    if (!bounds || sameBounds(bounds, lastSavedBounds)) return false;
+    try {
+      const result = options.onSaveBounds(bounds);
+      if (result && typeof result.then === "function") {
+        const attemptedBounds = bounds;
+        Promise.resolve(result).then(
+          (response) => {
+            if (!response || response.status !== "error") return;
+            if (sameBounds(lastSavedBounds, attemptedBounds)) lastSavedBounds = null;
+            console.warn("Clawd: failed to persist Settings window bounds:", response.message);
+          },
+          (err) => {
+            if (sameBounds(lastSavedBounds, attemptedBounds)) lastSavedBounds = null;
+            console.warn("Clawd: failed to persist Settings window bounds:", err && err.message);
+          },
+        );
+      } else if (result && result.status === "error") {
+        console.warn("Clawd: failed to persist Settings window bounds:", result.message);
+        return false;
+      }
+      lastSavedBounds = bounds;
+      return true;
+    } catch (err) {
+      console.warn("Clawd: failed to persist Settings window bounds:", err && err.message);
+      return false;
+    }
+  }
+
+  function scheduleWindowBoundsSave(win) {
+    if (typeof options.onSaveBounds !== "function") return;
+    clearSaveBoundsTimer();
+    saveBoundsTimer = scheduleTimer(() => {
+      saveBoundsTimer = null;
+      persistWindowBoundsNow(win);
+    }, BOUNDS_SAVE_DEBOUNCE_MS);
   }
 
   function getTitle() {
@@ -193,13 +295,13 @@ function createSettingsWindowRuntime(options = {}) {
   function applyTextScaleToWindow() {
     const win = getWindow();
     if (!isLiveWindow(win)) return;
-    const scale = getTextScale();
+    const bounds = typeof win.getBounds === "function" ? win.getBounds() : null;
+    const scale = getTextScale(bounds);
     applyZoomToWindow(win, scale);
     notifyTextScaleContextChanged(win);
     const minW = scaleWidth(MIN_WIDTH, scale);
     const minH = scaleHeight(MIN_HEIGHT, scale);
     if (typeof win.setMinimumSize === "function") win.setMinimumSize(minW, minH);
-    const bounds = typeof win.getBounds === "function" ? win.getBounds() : null;
     if (bounds && (bounds.width < minW || bounds.height < minH)) {
       win.setBounds({
         ...bounds,
@@ -260,11 +362,11 @@ function createSettingsWindowRuntime(options = {}) {
 
     const iconPath = getIconPath();
     const bounds = computeInitialBounds();
-    const createScale = getTextScale();
+    const createScale = getTextScale(bounds);
     const opts = {
       ...bounds,
-      minWidth: scaleWidth(MIN_WIDTH, createScale),
-      minHeight: scaleHeight(MIN_HEIGHT, createScale),
+      minWidth: Math.min(scaleWidth(MIN_WIDTH, createScale), bounds.width),
+      minHeight: Math.min(scaleHeight(MIN_HEIGHT, createScale), bounds.height),
       show: false,
       frame: true,
       transparent: false,
@@ -309,15 +411,20 @@ function createSettingsWindowRuntime(options = {}) {
     }
     // textScale is per-display: re-resolve after the user drags the window
     // somewhere else (debounced — "move" fires continuously during drags).
+    let moveTextScaleTimer = null;
     if (typeof createdWindow.on === "function") {
-      let moveTextScaleTimer = null;
       createdWindow.on("move", () => {
         if (moveTextScaleTimer) clearScheduled(moveTextScaleTimer);
         moveTextScaleTimer = scheduleTimer(() => {
           moveTextScaleTimer = null;
           applyTextScaleToWindow();
         }, 350);
+        scheduleWindowBoundsSave(createdWindow);
       });
+      createdWindow.on("resize", () => scheduleWindowBoundsSave(createdWindow));
+      // `closed` is too late to query native geometry. Flush while the window
+      // is still live so a pending debounce cannot lose the user's last move.
+      createdWindow.on("close", () => persistWindowBoundsNow(createdWindow));
     }
     let didShowCreatedWindow = false;
     function showCreatedWindow(showOptions = {}) {
@@ -338,6 +445,11 @@ function createSettingsWindowRuntime(options = {}) {
         showPendingSettingsWindow = null;
         clearReadyToShowFallbackTimer();
         clearLiftTimer();
+        clearSaveBoundsTimer();
+        if (moveTextScaleTimer) {
+          clearScheduled(moveTextScaleTimer);
+          moveTextScaleTimer = null;
+        }
       }
       if (typeof options.onBeforeClosed === "function") options.onBeforeClosed();
       if (isCurrentWindow) settingsWindow = null;

--- a/test/prefs.test.js
+++ b/test/prefs.test.js
@@ -68,6 +68,7 @@ describe("prefs.getDefaults", () => {
     assert.strictEqual(d.savedPixelWidth, 0);
     assert.strictEqual(d.savedPixelHeight, 0);
     assert.strictEqual(d.savedPixelWorkArea, null);
+    assert.strictEqual(d.settingsWindowBounds, null);
     assert.strictEqual(d.permissionBubblesEnabled, true);
     assert.strictEqual(d.notificationBubbleAutoCloseSeconds, 6);
     assert.strictEqual(d.updateBubbleAutoCloseSeconds, 9);
@@ -1239,6 +1240,23 @@ describe("prefs.migrate v11 → v12 (showDock default off for fresh installs)", 
   });
 });
 
+describe("prefs.migrate v12 → v13 (Settings window bounds)", () => {
+  it("advances the schema without inventing geometry for existing users", () => {
+    const upgraded = prefs.validate(prefs.migrate({ version: 12, lang: "zh" }));
+    assert.strictEqual(upgraded.version, prefs.CURRENT_VERSION);
+    assert.strictEqual(upgraded.settingsWindowBounds, null);
+  });
+
+  it("preserves valid geometry from an early v12 build or hand-edited file", () => {
+    const bounds = { x: -1180, y: 90, width: 920, height: 680 };
+    const upgraded = prefs.validate(prefs.migrate({
+      version: 12,
+      settingsWindowBounds: bounds,
+    }));
+    assert.deepStrictEqual(upgraded.settingsWindowBounds, bounds);
+  });
+});
+
 describe("prefs permission automation safe startup persistence", () => {
   it("defaults to off, preserves auto-tools, and downgrades unattended", () => {
     assert.strictEqual(prefs.getDefaults().permissionAutomationMode, "off");
@@ -1472,12 +1490,45 @@ describe("prefs.save", () => {
     snap.lang = "zh";
     snap.bubbleFollowPet = true;
     snap.x = 42;
+    snap.settingsWindowBounds = { x: -1200, y: 80, width: 900, height: 640 };
     prefs.save(p, snap);
     const { snapshot } = prefs.load(p);
     assert.strictEqual(snapshot.lang, "zh");
     assert.strictEqual(snapshot.bubbleFollowPet, true);
     assert.strictEqual(snapshot.x, 42);
+    assert.deepStrictEqual(snapshot.settingsWindowBounds, {
+      x: -1200,
+      y: 80,
+      width: 900,
+      height: 640,
+    });
     assert.strictEqual(snapshot.version, prefs.CURRENT_VERSION);
+  });
+
+  it("normalizes Settings window bounds and drops invalid geometry", () => {
+    assert.deepStrictEqual(
+      prefs.validate({
+        settingsWindowBounds: {
+          x: 10.4,
+          y: -20.6,
+          width: 801.7,
+          height: 559.8,
+          ignored: true,
+        },
+      }).settingsWindowBounds,
+      { x: 10, y: -21, width: 802, height: 560 },
+    );
+
+    for (const value of [
+      { x: 0, y: 0, width: 0, height: 560 },
+      { x: Infinity, y: 0, width: 800, height: 560 },
+      { x: "0", y: 0, width: 800, height: 560 },
+      { x: 0, y: 0, width: 800 },
+      [],
+      "800x560",
+    ]) {
+      assert.strictEqual(prefs.validate({ settingsWindowBounds: value }).settingsWindowBounds, null);
+    }
   });
 
   it("round-trips per-theme pet tints and drops invalid entries before writing", () => {

--- a/test/prefs.test.js
+++ b/test/prefs.test.js
@@ -1240,14 +1240,14 @@ describe("prefs.migrate v11 → v12 (showDock default off for fresh installs)", 
   });
 });
 
-describe("prefs.migrate v12 → v13 (Settings window bounds)", () => {
-  it("advances the schema without inventing geometry for existing users", () => {
+describe("prefs Settings window bounds schema addition", () => {
+  it("uses the current schema default without a version bump", () => {
     const upgraded = prefs.validate(prefs.migrate({ version: 12, lang: "zh" }));
     assert.strictEqual(upgraded.version, prefs.CURRENT_VERSION);
     assert.strictEqual(upgraded.settingsWindowBounds, null);
   });
 
-  it("preserves valid geometry from an early v12 build or hand-edited file", () => {
+  it("preserves valid geometry in a current-version or hand-edited file", () => {
     const bounds = { x: -1180, y: 90, width: 920, height: 680 };
     const upgraded = prefs.validate(prefs.migrate({
       version: 12,

--- a/test/settings-actions.test.js
+++ b/test/settings-actions.test.js
@@ -207,6 +207,24 @@ describe("updateRegistry pure-data validators", () => {
     }
   });
 
+  it("Settings window bounds accept normal integer geometry or null", () => {
+    const validate = updateRegistry.settingsWindowBounds;
+    assert.strictEqual(validate(null).status, "ok");
+    assert.strictEqual(
+      validate({ x: -1200, y: 80, width: 900, height: 640 }).status,
+      "ok",
+    );
+    for (const value of [
+      { x: 0.5, y: 0, width: 800, height: 560 },
+      { x: 0, y: 0, width: 0, height: 560 },
+      { x: 0, y: 0, width: 800 },
+      [],
+      "800x560",
+    ]) {
+      assert.strictEqual(validate(value).status, "error");
+    }
+  });
+
   it("object-form boolean fields validate via entry.validate", () => {
     const deps = { snapshot: baseSnapshot };
     for (const key of ["autoStartWithClaude", "manageClaudeHooksAutomatically", "openAtLogin"]) {

--- a/test/settings-controller.test.js
+++ b/test/settings-controller.test.js
@@ -565,6 +565,16 @@ describe("applyUpdate", () => {
     assert.strictEqual(prefs.load(p).snapshot.tutorialSeen, true);
   });
 
+  it("persists Settings window bounds through the controller-only write path", async () => {
+    const p = makeTempPath();
+    const ctrl = createSettingsController({ prefsPath: p });
+    const bounds = { x: -1180, y: 90, width: 920, height: 680 };
+    const r = await ctrl.applyUpdate("settingsWindowBounds", bounds);
+    assert.strictEqual(r.status, "ok");
+    assert.deepStrictEqual(ctrl.get("settingsWindowBounds"), bounds);
+    assert.deepStrictEqual(prefs.load(p).snapshot.settingsWindowBounds, bounds);
+  });
+
 
   it("persists Codex hook health notification prefs through applyUpdate", async () => {
     const p = makeTempPath();

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -5309,6 +5309,25 @@ describe("settings renderer browser environment", () => {
     assert.ok(clearIndex < renderIndex, "broadcast cleanup must happen before full rerender");
   });
 
+  it("updates runtime-only Settings bounds without rebuilding the active tab", () => {
+    const initialSnapshot = makeGeneralSnapshot({ settingsWindowBounds: null });
+    const harness = loadGeneralTabForTest({ snapshot: initialSnapshot });
+    harness.renderContent();
+    const mountedControl = harness.getSwitch("sessionHudEnabled");
+    harness.content.scrollTop = 317;
+    const bounds = { x: -1200, y: 80, width: 900, height: 640 };
+
+    harness.core.ops.applyChanges({
+      changes: { settingsWindowBounds: bounds },
+      snapshot: { ...initialSnapshot, settingsWindowBounds: bounds },
+    });
+
+    assert.deepStrictEqual(harness.core.state.snapshot.settingsWindowBounds, bounds);
+    assert.strictEqual(harness.getContentRenderCount(), 1);
+    assert.strictEqual(harness.getSwitch("sessionHudEnabled"), mountedControl);
+    assert.strictEqual(harness.content.scrollTop, 317);
+  });
+
   it("patches the Session HUD master switch without rebuilding General content", async () => {
     const updateCalls = [];
     const initialSnapshot = {

--- a/test/settings-window.test.js
+++ b/test/settings-window.test.js
@@ -6,14 +6,16 @@ const createSettingsWindowRuntime = require("../src/settings-window");
 
 class FakeBrowserWindow {
   static instances = [];
+  static constructorBoundsOffset = null;
 
   constructor(options) {
+    const offset = FakeBrowserWindow.constructorBoundsOffset || {};
     this.options = options;
     this.bounds = {
-      x: options.x,
-      y: options.y,
-      width: options.width,
-      height: options.height,
+      x: options.x + (offset.x || 0),
+      y: options.y + (offset.y || 0),
+      width: options.width + (offset.width || 0),
+      height: options.height + (offset.height || 0),
     };
     this.normalBounds = { ...this.bounds };
     this.destroyed = false;
@@ -166,6 +168,7 @@ function findPendingTimer(timers, delay) {
 
 function createRuntime(options = {}) {
   FakeBrowserWindow.instances = [];
+  FakeBrowserWindow.constructorBoundsOffset = options.constructorBoundsOffset || null;
   const { app, listeners } = createFakeApp(options.app);
   const fakeTimers = createFakeTimers();
   const fs = {
@@ -393,6 +396,26 @@ test("settings window runtime restores saved bounds on the saved display", () =>
     saved,
   );
   assert.deepStrictEqual(scaleBounds, [saved, saved]);
+});
+
+test("saved outer bounds override native constructor frame drift", () => {
+  const saved = { x: 120, y: 90, width: 960, height: 720 };
+  const { runtime } = createRuntime({
+    constructorBoundsOffset: { width: 2 },
+    runtime: {
+      getSavedBounds: () => saved,
+      getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1040 }),
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+
+  assert.deepStrictEqual(win.getBounds(), saved);
+  assert.deepStrictEqual(
+    win.calls.find((call) => Array.isArray(call) && call[0] === "setBounds"),
+    ["setBounds", saved],
+  );
 });
 
 test("saved Settings bounds are clamped to a live work area and current scaled minimum", () => {

--- a/test/settings-window.test.js
+++ b/test/settings-window.test.js
@@ -9,6 +9,13 @@ class FakeBrowserWindow {
 
   constructor(options) {
     this.options = options;
+    this.bounds = {
+      x: options.x,
+      y: options.y,
+      width: options.width,
+      height: options.height,
+    };
+    this.normalBounds = { ...this.bounds };
     this.destroyed = false;
     this.minimized = false;
     this.calls = [];
@@ -70,6 +77,25 @@ class FakeBrowserWindow {
   setTitle(value) {
     this.calls.push(["setTitle", value]);
     this.title = value;
+  }
+
+  getBounds() {
+    return { ...this.bounds };
+  }
+
+  getNormalBounds() {
+    return { ...this.normalBounds };
+  }
+
+  setBounds(bounds) {
+    this.calls.push(["setBounds", bounds]);
+    this.bounds = { ...bounds };
+    this.normalBounds = { ...bounds };
+  }
+
+  setMinimumSize(width, height) {
+    this.calls.push(["setMinimumSize", width, height]);
+    this.minimumSize = { width, height };
   }
 
   loadFile(filePath) {
@@ -334,6 +360,97 @@ test("settings window runtime places the first Settings window on the pet displa
   assert.strictEqual(win.options.height, 560);
 });
 
+test("settings window runtime restores saved bounds on the saved display", () => {
+  let nearestArgs = null;
+  let petBoundsReads = 0;
+  const scaleBounds = [];
+  const saved = { x: 1480, y: 90, width: 900, height: 650 };
+  const { runtime } = createRuntime({
+    runtime: {
+      getSavedBounds: () => saved,
+      getPetWindowBounds: () => {
+        petBoundsReads += 1;
+        return { x: 10, y: 10, width: 100, height: 100 };
+      },
+      getNearestWorkArea: (cx, cy) => {
+        nearestArgs = { cx, cy };
+        return { x: 1280, y: 40, width: 1600, height: 900 };
+      },
+      getTextScale: (bounds) => {
+        scaleBounds.push(bounds);
+        return 1;
+      },
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+
+  assert.deepStrictEqual(nearestArgs, { cx: 1930, cy: 415 });
+  assert.strictEqual(petBoundsReads, 0);
+  assert.deepStrictEqual(
+    { x: win.options.x, y: win.options.y, width: win.options.width, height: win.options.height },
+    saved,
+  );
+  assert.deepStrictEqual(scaleBounds, [saved, saved]);
+});
+
+test("saved Settings bounds are clamped to a live work area and current scaled minimum", () => {
+  const { runtime } = createRuntime({
+    runtime: {
+      getSavedBounds: () => ({ x: 2800, y: 900, width: 600, height: 400 }),
+      getNearestWorkArea: () => ({ x: 0, y: 0, width: 1200, height: 700 }),
+      getTextScale: () => 1.25,
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+
+  assert.deepStrictEqual(
+    { x: win.options.x, y: win.options.y, width: win.options.width, height: win.options.height },
+    { x: 400, y: 100, width: 800, height: 600 },
+  );
+  assert.strictEqual(win.options.minWidth, 800);
+  assert.strictEqual(win.options.minHeight, 600);
+});
+
+test("a tiny work area caps both restored bounds and BrowserWindow minimums", () => {
+  const { runtime } = createRuntime({
+    runtime: {
+      getSavedBounds: () => ({ x: 1000, y: 800, width: 900, height: 700 }),
+      getNearestWorkArea: () => ({ x: 50, y: 60, width: 500, height: 400 }),
+      getTextScale: () => 1.6,
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  assert.deepStrictEqual(
+    { x: win.options.x, y: win.options.y, width: win.options.width, height: win.options.height },
+    { x: 50, y: 60, width: 500, height: 400 },
+  );
+  assert.strictEqual(win.options.minWidth, 500);
+  assert.strictEqual(win.options.minHeight, 400);
+});
+
+test("invalid saved Settings bounds fall back to pet-display centering", () => {
+  const { runtime } = createRuntime({
+    runtime: {
+      getSavedBounds: () => ({ x: "bad", y: 0, width: 900, height: 650 }),
+      getPetWindowBounds: () => ({ x: 1700, y: 100, width: 280, height: 280 }),
+      getNearestWorkArea: () => ({ x: 1280, y: 40, width: 1600, height: 900 }),
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  assert.deepStrictEqual(
+    { x: win.options.x, y: win.options.y, width: win.options.width, height: win.options.height },
+    { x: 1680, y: 210, width: 800, height: 560 },
+  );
+});
+
 test("settings window runtime shows from timeout if ready-to-show never fires", () => {
   const { runtime, timers } = createRuntime();
 
@@ -414,6 +531,96 @@ test("settings window move re-applies text scale and pokes the slider context (d
 
   moveTimers[1].callback();
   assert.deepStrictEqual(sends, ["settings:text-scale-context-changed"]);
+});
+
+test("settings window move and resize persist normal bounds with a shared debounce", () => {
+  const saved = [];
+  const { runtime, timers } = createRuntime({
+    runtime: {
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  win.normalBounds = { x: 310, y: 220, width: 880, height: 620 };
+  win.emit("move");
+  win.emit("resize");
+
+  const saveTimers = timers.filter((timer) => timer.delay === 500);
+  assert.strictEqual(saveTimers.length, 2);
+  assert.strictEqual(saveTimers[0].cleared, true);
+  assert.strictEqual(saveTimers[1].cleared, false);
+  assert.deepStrictEqual(saved, []);
+
+  saveTimers[1].callback();
+  assert.deepStrictEqual(saved, [
+    { x: 310, y: 220, width: 880, height: 620 },
+  ]);
+
+  // A duplicate native event after the same geometry must not rewrite prefs.
+  win.emit("resize");
+  timers.filter((timer) => timer.delay === 500).at(-1).callback();
+  assert.strictEqual(saved.length, 1);
+});
+
+test("persisted Settings bounds are used when the window is recreated", () => {
+  let persisted = null;
+  const { runtime } = createRuntime({
+    runtime: {
+      getSavedBounds: () => persisted,
+      onSaveBounds: (bounds) => {
+        persisted = bounds;
+        return { status: "ok" };
+      },
+      getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1040 }),
+    },
+  });
+
+  runtime.open();
+  const first = FakeBrowserWindow.instances[0];
+  first.normalBounds = { x: 420, y: 230, width: 940, height: 700 };
+  first.emit("close");
+  first.emit("closed");
+
+  runtime.open();
+  const reopened = FakeBrowserWindow.instances[1];
+  assert.deepStrictEqual(
+    { x: reopened.options.x, y: reopened.options.y, width: reopened.options.width, height: reopened.options.height },
+    persisted,
+  );
+});
+
+test("settings window close flushes pending geometry and saves normal, not maximized, bounds", () => {
+  const saved = [];
+  const { runtime, timers } = createRuntime({
+    runtime: {
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  win.bounds = { x: 0, y: 0, width: 1920, height: 1040 };
+  win.normalBounds = { x: 260, y: 180, width: 920, height: 680 };
+  win.emit("resize");
+  const pendingSave = findPendingTimer(timers, 500);
+  assert.ok(pendingSave);
+
+  win.emit("close");
+  assert.strictEqual(pendingSave.cleared, true);
+  assert.deepStrictEqual(saved, [
+    { x: 260, y: 180, width: 920, height: 680 },
+  ]);
+
+  win.emit("closed");
+  assert.strictEqual(runtime.getWindow(), null);
 });
 
 test("applyTextScaleToWindow pokes the slider context even when zoom injection is unavailable", () => {

--- a/test/settings-window.test.js
+++ b/test/settings-window.test.js
@@ -7,6 +7,7 @@ const createSettingsWindowRuntime = require("../src/settings-window");
 class FakeBrowserWindow {
   static instances = [];
   static constructorBoundsOffset = null;
+  static setBoundsOffset = null;
 
   constructor(options) {
     const offset = FakeBrowserWindow.constructorBoundsOffset || {};
@@ -91,8 +92,14 @@ class FakeBrowserWindow {
 
   setBounds(bounds) {
     this.calls.push(["setBounds", bounds]);
-    this.bounds = { ...bounds };
-    this.normalBounds = { ...bounds };
+    const offset = FakeBrowserWindow.setBoundsOffset || {};
+    this.bounds = {
+      x: bounds.x + (offset.x || 0),
+      y: bounds.y + (offset.y || 0),
+      width: bounds.width + (offset.width || 0),
+      height: bounds.height + (offset.height || 0),
+    };
+    this.normalBounds = { ...this.bounds };
   }
 
   setMinimumSize(width, height) {
@@ -169,6 +176,7 @@ function findPendingTimer(timers, delay) {
 function createRuntime(options = {}) {
   FakeBrowserWindow.instances = [];
   FakeBrowserWindow.constructorBoundsOffset = options.constructorBoundsOffset || null;
+  FakeBrowserWindow.setBoundsOffset = options.setBoundsOffset || null;
   const { app, listeners } = createFakeApp(options.app);
   const fakeTimers = createFakeTimers();
   const fs = {
@@ -418,6 +426,32 @@ test("saved outer bounds override native constructor frame drift", () => {
   );
 });
 
+test("an untouched window does not persist native frame quantization on close", () => {
+  const saved = { x: 120, y: 90, width: 960, height: 720 };
+  const writes = [];
+  const { runtime } = createRuntime({
+    constructorBoundsOffset: { width: 2 },
+    // Simulate a WM that cannot adopt the requested outer width exactly even
+    // when the runtime follows up with setBounds().
+    setBoundsOffset: { width: 1 },
+    runtime: {
+      getSavedBounds: () => saved,
+      getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1040 }),
+      onSaveBounds: (bounds) => {
+        writes.push(bounds);
+        return { status: "ok" };
+      },
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  assert.deepStrictEqual(win.getNormalBounds(), { ...saved, width: 961 });
+
+  win.emit("close");
+  assert.deepStrictEqual(writes, []);
+});
+
 test("saved Settings bounds are clamped to a live work area and current scaled minimum", () => {
   const { runtime } = createRuntime({
     runtime: {
@@ -436,6 +470,23 @@ test("saved Settings bounds are clamped to a live work area and current scaled m
   );
   assert.strictEqual(win.options.minWidth, 800);
   assert.strictEqual(win.options.minHeight, 600);
+});
+
+test("saved Settings bounds clamp correctly on a negative-origin display", () => {
+  const { runtime } = createRuntime({
+    runtime: {
+      getSavedBounds: () => ({ x: -2600, y: -180, width: 900, height: 650 }),
+      getNearestWorkArea: () => ({ x: -1920, y: 0, width: 1920, height: 1040 }),
+      getTextScale: () => 1,
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  assert.deepStrictEqual(
+    { x: win.options.x, y: win.options.y, width: win.options.width, height: win.options.height },
+    { x: -1920, y: 0, width: 900, height: 650 },
+  );
 });
 
 test("a tiny work area caps both restored bounds and BrowserWindow minimums", () => {
@@ -644,6 +695,100 @@ test("settings window close flushes pending geometry and saves normal, not maxim
 
   win.emit("closed");
   assert.strictEqual(runtime.getWindow(), null);
+});
+
+test("a synchronous persistence error remains retryable", () => {
+  const attempts = [];
+  const { runtime, timers } = createRuntime({
+    runtime: {
+      onSaveBounds: (bounds) => {
+        attempts.push(bounds);
+        return attempts.length === 1
+          ? { status: "error", message: "read only" }
+          : { status: "ok" };
+      },
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  win.normalBounds = { x: 310, y: 220, width: 880, height: 620 };
+  win.emit("resize");
+  timers.filter((timer) => timer.delay === 500).at(-1).callback();
+  win.emit("resize");
+  timers.filter((timer) => timer.delay === 500).at(-1).callback();
+
+  assert.strictEqual(attempts.length, 2);
+});
+
+test("an asynchronous persistence error remains retryable", async () => {
+  const attempts = [];
+  const { runtime, timers } = createRuntime({
+    runtime: {
+      onSaveBounds: (bounds) => {
+        attempts.push(bounds);
+        return Promise.resolve(attempts.length === 1
+          ? { status: "error", message: "disk full" }
+          : { status: "ok" });
+      },
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  win.normalBounds = { x: 310, y: 220, width: 880, height: 620 };
+  win.emit("resize");
+  timers.filter((timer) => timer.delay === 500).at(-1).callback();
+  await Promise.resolve();
+  await Promise.resolve();
+  win.emit("resize");
+  timers.filter((timer) => timer.delay === 500).at(-1).callback();
+
+  assert.strictEqual(attempts.length, 2);
+});
+
+test("destroyed windows and closed cleanup cannot fire a pending bounds save", () => {
+  const writes = [];
+  const { runtime, timers } = createRuntime({
+    runtime: {
+      onSaveBounds: (bounds) => {
+        writes.push(bounds);
+        return { status: "ok" };
+      },
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  win.normalBounds = { x: 310, y: 220, width: 880, height: 620 };
+  win.emit("resize");
+  const pendingSave = timers.filter((timer) => timer.delay === 500).at(-1);
+  win.destroyed = true;
+  win.emit("closed");
+
+  assert.strictEqual(pendingSave.cleared, true);
+  pendingSave.callback();
+  assert.deepStrictEqual(writes, []);
+});
+
+test("normal-bounds lookup falls back to current bounds when unavailable", () => {
+  const writes = [];
+  const { runtime } = createRuntime({
+    runtime: {
+      onSaveBounds: (bounds) => {
+        writes.push(bounds);
+        return { status: "ok" };
+      },
+    },
+  });
+
+  runtime.open();
+  const win = FakeBrowserWindow.instances[0];
+  win.bounds = { x: 330, y: 240, width: 860, height: 610 };
+  win.getNormalBounds = () => { throw new Error("unsupported"); };
+  win.emit("close");
+
+  assert.deepStrictEqual(writes, [{ x: 330, y: 240, width: 860, height: 610 }]);
 });
 
 test("applyTextScaleToWindow pokes the slider context even when zoom injection is unavailable", () => {


### PR DESCRIPTION
## Summary
- persist the Settings window's normal position and size through the existing settings controller
- restore saved geometry on reopen and app restart, clamped to the nearest live work area
- preserve normal bounds across maximized/minimized/fullscreen states and respect per-display text-scale minimums
- keep restored outer bounds stable when Windows fractional-DPI frame quantization changes the constructor's initial geometry
- update renderer snapshots for saved window geometry without rebuilding the active Settings tab or losing scroll/focus/drafts
- add prefs normalization/validation, controller coverage, Settings lifecycle tests, and renderer regression coverage without an unnecessary prefs version bump

## Behavior
- move and resize events share a 500 ms debounce to avoid repeated disk writes
- the `close` event flushes pending geometry before the native window is destroyed
- invalid saved geometry falls back to the existing pet-display centered placement
- removed or rearranged displays clamp the saved rectangle into the nearest current work area
- tiny work areas cap both the initial bounds and BrowserWindow minimum size
- constructor-time native frame drift is corrected while the window is hidden and before move/resize listeners are registered
- the post-correction native normal rectangle becomes the initial save baseline, so closing an untouched window does not rewrite prefs or feed residual WM quantization into the next launch
- pure `settingsWindowBounds` broadcasts update the renderer snapshot but skip Settings DOM reconstruction; mixed changes still follow the existing patch/render path

## Validation
- `node --test test/settings-window.test.js test/settings-renderer-browser-env.test.js test/prefs.test.js test/settings-actions.test.js test/settings-controller.test.js` — 645 passed, 0 failed
- `node --check src/main.js src/prefs.js src/settings-actions.js src/settings-window.js src/settings-ui-core.js`
- `git diff --check`
- external Claude review's H1/M2 findings are addressed in `182cb257`; the post-fix independent sub-agent review found no blocker/high/medium issues
- `npm test` — 6761 passed, 23 failed, 20 skipped; all failures remain in unchanged Windows-host cross-platform/environment cases (macOS/AppImage path assertions, Orca discovery/process behavior, Remote SSH POSIX path/file-mode expectations, and shared-process PID-chain discovery). No failure points to the modified Settings/prefs/renderer suites.

Additional regression coverage now includes pure-geometry snapshot updates without DOM rebuild or scroll reset, native frame quantization that remains inexact after `setBounds`, untouched-close write suppression, negative-origin displays, synchronous/asynchronous save retry, destroyed-window timer cleanup, and normal-bounds fallback.

## Windows native smoke
Verified on Windows 11 at 150% display scale using an isolated `userData`/home and a separate single-instance lock:

- close/reopen restored `x=120, y=90, 960x720`
- a full app quit/relaunch restored persisted bounds
- maximizing from normal bounds `x=260, y=140, 920x680`, then closing, persisted and reopened the normal bounds rather than the maximized rectangle
- the smoke exposed a native constructor frame drift from width `960` to `962`; commit `7a0ab3ac` corrects it before listeners attach, and the repeated reopen stayed exactly `960x720`

Automated coverage handles invalid/off-screen saved geometry and current-work-area clamping. Existing live-window behavior when moving a high-text-scale Settings window onto a work area shorter than its scaled minimum is unchanged and outside this issue; reopening safely clamps restored geometry.

Closes #765
