### PR TITLE
fix(telegram): render messages with safe HTML

### DIFF
--- a/docs/guides/telegram-approval.md
+++ b/docs/guides/telegram-approval.md
@@ -7,8 +7,9 @@ permission bubbles. When a supported agent asks for tool permission, Clawd keeps
 the local desktop bubble and also sends an approval card to your Telegram bot.
 The first explicit Allow or Deny decision resolves the same pending permission.
 
-This is approval-only. It does not create a Telegram chat bridge, remote shell,
-or prompt-submission path.
+The approval path does not create a remote shell or silently submit prompts.
+Completion notifications and Direct Send are separate opt-in Telegram features;
+their formatting does not change the approval decision policy described here.
 
 ## Supported Paths
 
@@ -70,6 +71,26 @@ button stay disabled until token and recipient are in place.
 - Repeated Telegram taps after a request is already handled do not resolve the
   permission twice.
 - Clawd logs redact Telegram tokens, chat ids, and token-like values.
+
+## Message Formatting
+
+- Completion notifications render Assistant output through a conservative
+  Markdown subset using Telegram-safe HTML. Clawd metadata such as the session
+  title, agent, folder, and host is escaped as plain dynamic text rather than
+  interpreted as Markdown.
+- Approval, session-trust, and AskUserQuestion cards use Clawd-owned structure.
+  Agent/tool/question values are redacted and escaped; they cannot add Telegram
+  tags, links, mentions, or status lines.
+- Secret redaction runs before Markdown parsing. Unsupported HTML, unsafe link
+  schemes, credentialed links, and image syntax degrade to visible text; Clawd
+  does not fetch or embed the referenced media.
+- Username-like agent prose outside code uses a full-width `＠` to avoid an
+  unintended Telegram mention. Code keeps ASCII `@` for copy fidelity.
+- If Telegram rejects the generated HTML as an entity-parse error, Clawd retries
+  the already-rendered plain version once without a parse mode. Other Telegram
+  errors keep their existing retry/fallback behavior.
+- Formatting is the default transport correction and has no Settings toggle.
+  It does not split long messages, upload documents, or use Rich Messages.
 
 ## Legacy Upgrade (v0.14.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "htmlparser2": "^12.0.0",
         "jsonc-parser": "^3.3.1",
         "koffi": "^2.15.2",
+        "markdown-it": "15.0.0",
         "ws": "^8.21.0"
       },
       "devDependencies": {
@@ -3478,6 +3479,25 @@
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-6.1.0.tgz",
+      "integrity": "sha512-wJ/TwpSDTLepCrQoYWYIExIKg5Zchex2Nn5yk2mFnB+6PtdkHtyLx742md9csRjjOnGkKIS/RrbY7l8D6gT9Vw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^3.0.0"
+      }
+    },
     "node_modules/lodash": {
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -3585,6 +3605,49 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-15.0.0.tgz",
+      "integrity": "sha512-Lf8ajvVNdRpzSNB4VegxNy7gjs8gU35l4b4+ET49LrQC5PKYwLZ72u60LeJ9gv3qiaesuYjJWCyVeQmv/QWKQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^3.0.0",
+        "entities": "^8.0.0",
+        "linkify-it": "^6.0.0",
+        "mdurl": "^2.1.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^3.0.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-3.0.0.tgz",
+      "integrity": "sha512-BOp5NMrHqKxmq/OLr+clzzrRxgOKSLkcjmkWuChp7Irqwn4s74WjOBPIgWfA/HMcBnVkZ5XEuf9uUqzlpfCQ6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "Python-2.0"
+    },
     "node_modules/matcher": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/matcher/-/matcher-3.0.0.tgz",
@@ -3607,6 +3670,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
     },
     "node_modules/mime": {
       "version": "2.6.0",
@@ -4270,6 +4339,15 @@
       "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5015,6 +5093,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-3.0.0.tgz",
+      "integrity": "sha512-U3PppEkleoTnIfi8BozMx3yju3qc/L6SwqWo2Sw+54PX+PX0q9I+r1Um5HCmqD7n9VDX5/v3vQH/AjA6deDdtw==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "7.28.0",

--- a/package.json
+++ b/package.json
@@ -190,6 +190,7 @@
     "htmlparser2": "^12.0.0",
     "jsonc-parser": "^3.3.1",
     "koffi": "^2.15.2",
+    "markdown-it": "15.0.0",
     "ws": "^8.21.0"
   }
 }

--- a/src/permission.js
+++ b/src/permission.js
@@ -1505,10 +1505,17 @@ function buildRemoteApprovalPayload(permEntry) {
     sessionFolder ? `${t("approvalDetailFolder")}: ${sessionFolder}` : null,
     `${t("approvalDetailSummary")}: ${summary}`,
   ].filter(Boolean).join("\n");
+  const fields = [
+    { label: t("approvalDetailAgent"), value: agentId },
+    { label: t("approvalDetailTool"), value: toolName },
+    sessionFolder ? { label: t("approvalDetailFolder"), value: sessionFolder } : null,
+    { label: t("approvalDetailSummary"), value: summary },
+  ].filter(Boolean);
   const suggestionButtons = buildRemoteSuggestionButtons(permEntry);
   const payload = {
     title: interpolate(interpolate(t("approvalRequestsTitle"), "{agent}", agentId), "{tool}", toolName),
     detail,
+    fields,
   };
   if (suggestionButtons.length > 0) payload.suggestions = suggestionButtons;
   return payload;

--- a/src/telegram-companion.js
+++ b/src/telegram-companion.js
@@ -1,5 +1,11 @@
 "use strict";
 
+const {
+  clipUtf16Safe,
+  concatTelegramParts,
+  renderTelegramMarkdown,
+} = require("./telegram-message-format");
+
 // R1a: Telegram "session finished" notifications.
 //
 // Driven off the session-snapshot fanout (main.js broadcastSessionSnapshot).
@@ -129,30 +135,46 @@ function truncateWithMiddle(text, maxLen) {
   if (text.length <= maxLen) return { text, truncated: false };
   const marker = "\n...[truncated]...\n";
   if (maxLen <= marker.length + 20) {
-    return { text: text.slice(0, maxLen), truncated: true };
+    return { text: clipUtf16Safe(text, maxLen), truncated: true };
   }
   const keep = maxLen - marker.length;
   const head = Math.ceil(keep / 2);
   const tail = Math.floor(keep / 2);
+  const safeHead = clipUtf16Safe(text, head);
+  let safeTail = "";
+  let safeTailLength = 0;
+  for (const character of Array.from(text).reverse()) {
+    if (safeTailLength + character.length > tail) break;
+    safeTail = `${character}${safeTail}`;
+    safeTailLength += character.length;
+  }
   return {
-    text: `${text.slice(0, head)}${marker}${text.slice(text.length - tail)}`,
+    text: `${safeHead}${marker}${safeTail}`,
     truncated: true,
   };
 }
 
-function formatAssistantOutputSection(entry, mode, locale) {
+function prepareAssistantOutput(entry, mode) {
   const outputMode = normalizeCompletionOutputMode(mode);
-  if (outputMode === "off") return "";
+  if (outputMode === "off") return null;
   const raw = entry && typeof entry.assistantLastOutput === "string" ? entry.assistantLastOutput : "";
   const redacted = redactAssistantOutputText(raw);
-  if (!redacted) return "";
+  if (!redacted) return null;
   const limited = truncateWithMiddle(redacted, OUTPUT_FULL_MAX);
-  const truncated = limited.truncated || !!(entry && entry.assistantLastOutputTruncated === true);
+  return {
+    text: limited.text,
+    truncated: limited.truncated || !!(entry && entry.assistantLastOutputTruncated === true),
+  };
+}
+
+function formatAssistantOutputSection(entry, mode, locale) {
+  const prepared = prepareAssistantOutput(entry, mode);
+  if (!prepared) return "";
   const label = locale.assistantOutput || NOTIFICATION_LOCALES.en.assistantOutput;
-  const suffix = truncated
+  const suffix = prepared.truncated
     ? ` (${locale.truncated || NOTIFICATION_LOCALES.en.truncated})`
     : "";
-  return `\n\n${label}${suffix}:\n${limited.text}`;
+  return `\n\n${label}${suffix}:\n${prepared.text}`;
 }
 
 function hasAssistantOutputSection(entry, mode) {
@@ -165,7 +187,7 @@ function hasAssistantOutputSection(entry, mode) {
 function truncateNotificationText(text, locale) {
   if (text.length <= NOTIFICATION_TEXT_MAX) return text;
   const marker = `\n... ${locale.truncated || NOTIFICATION_LOCALES.en.truncated}`;
-  return `${text.slice(0, Math.max(0, NOTIFICATION_TEXT_MAX - marker.length))}${marker}`;
+  return `${clipUtf16Safe(text, Math.max(0, NOTIFICATION_TEXT_MAX - marker.length))}${marker}`;
 }
 
 // Privacy note: displayTitle is the same session title shown on the desktop
@@ -197,6 +219,83 @@ function formatNotification(entry, options = {}) {
   const base = meta.length ? `${head}\n${meta.join(" · ")}` : head; // " · "
   const withOutput = `${base}${outputSection}`;
   return truncateNotificationText(withOutput, locale);
+}
+
+function formatTelegramNotificationMessage(entry, options = {}) {
+  if (!entry) return null;
+  const locale = getNotificationLocale(options.lang);
+  const completionOutputMode = normalizeCompletionOutputMode(options.completionOutputMode);
+  const prepared = prepareAssistantOutput(entry, completionOutputMode);
+  if (!prepared && options.includeBare === false) return null;
+
+  const interrupted = entry.badge === "interrupted";
+  const icon = interrupted ? "⚠️" : "✅";
+  const status = interrupted ? locale.interrupted : locale.done;
+  const title = entry.displayTitle || (entry.id ? `${shortId(entry.id)}..` : locale.session);
+  const meta = [];
+  if (entry.agentId) meta.push(entry.agentId);
+  const folder = folderName(entry.cwd);
+  if (folder) meta.push(folder);
+  if (entry.host) meta.push(entry.host);
+  if (entry.id) meta.push(`#${shortId(entry.id)}`);
+  const wrapStatus = typeof locale.wrapStatus === "function"
+    ? locale.wrapStatus(status)
+    : `(${status})`;
+  const baseParts = [
+    `${icon} `,
+    { text: title, bold: true, neutralizeMentions: true },
+    ` ${wrapStatus}`,
+  ];
+  if (meta.length) {
+    baseParts.push("\n", { text: meta.join(" · "), neutralizeMentions: true });
+  }
+  const truncationText = locale.truncated || NOTIFICATION_LOCALES.en.truncated;
+  const truncationMarker = `\n... ${truncationText}`;
+  if (!prepared) {
+    return concatTelegramParts(baseParts, {
+      maxLength: NOTIFICATION_TEXT_MAX,
+      truncationMarker,
+    });
+  }
+
+  const label = locale.assistantOutput || NOTIFICATION_LOCALES.en.assistantOutput;
+  function composeOutput(showTruncated) {
+    const suffix = showTruncated ? ` (${truncationText})` : "";
+    const headParts = [
+      ...baseParts,
+      "\n\n",
+      { text: `${label}${suffix}:`, bold: true },
+      "\n",
+    ];
+    const head = concatTelegramParts(headParts, {
+      maxLength: NOTIFICATION_TEXT_MAX,
+      truncationMarker,
+    });
+    const outputBudget = Math.max(0, Math.min(
+      OUTPUT_FULL_MAX,
+      NOTIFICATION_TEXT_MAX - head.budgetLength,
+    ));
+    const output = renderTelegramMarkdown(prepared.text, {
+      maxLength: outputBudget,
+      truncationMarker,
+    });
+    return { head, headParts, output };
+  }
+
+  let showTruncated = prepared.truncated === true;
+  let composed = composeOutput(showTruncated);
+  if (!showTruncated && (composed.head.truncated || composed.output.truncated)) {
+    showTruncated = true;
+    composed = composeOutput(true);
+  }
+  const truncated = prepared.truncated === true
+    || composed.head.truncated
+    || composed.output.truncated;
+  return concatTelegramParts([...composed.headParts, composed.output], {
+    maxLength: NOTIFICATION_TEXT_MAX,
+    truncationMarker,
+    reportedTruncated: truncated,
+  });
 }
 
 function createTelegramCompanion({
@@ -270,14 +369,14 @@ function createTelegramCompanion({
         includeBare = typeof getNotifyOnComplete === "function" ? getNotifyOnComplete() === true : true;
       } catch {}
       if (!includeBare && !hasAssistantOutputSection(entry, completionOutputMode)) continue;
-      const text = typeof formatText === "function"
+      const message = typeof formatText === "function"
         ? formatText(entry, { lang, completionOutputMode, includeBare })
-        : formatNotification(entry, { lang, completionOutputMode, includeBare });
-      if (!text) continue;
+        : formatTelegramNotificationMessage(entry, { lang, completionOutputMode, includeBare });
+      if (!message) continue;
       // Fire-and-forget: do NOT await — we are on the synchronous broadcast
       // path. sendNotification never throws, but guard anyway.
       Promise.resolve()
-        .then(() => client.sendNotification(text))
+        .then(() => client.sendNotification(message))
         .then((res) => {
           if (res && res.ok === false) {
             safeLog("warn", "completion notification not delivered", {
@@ -311,6 +410,7 @@ function createTelegramCompanion({
 module.exports = {
   createTelegramCompanion,
   formatNotification,
+  formatTelegramNotificationMessage,
   formatAssistantOutputSection,
   redactAssistantOutputText,
   isCompletion,

--- a/src/telegram-message-format.js
+++ b/src/telegram-message-format.js
@@ -1,0 +1,697 @@
+"use strict";
+
+const MarkdownIt = require("markdown-it");
+
+const DEFAULT_MAX_LENGTH = 3800;
+const DEFAULT_TRUNCATION_MARKER = "\n...[truncated]...";
+const MESSAGE_SEGMENTS = Symbol("telegram-message-segments");
+const ALLOWED_TAGS = new Set(["a", "b", "blockquote", "code", "i", "pre", "s"]);
+
+const markdown = new MarkdownIt({
+  html: false,
+  linkify: false,
+  typographer: false,
+  breaks: false,
+});
+// `linkify` controls bare-URL recognition. CommonMark `<scheme:value>`
+// autolinks are a separate rule, and redaction placeholders such as
+// `<redacted:token>` satisfy that grammar unless this rule is disabled.
+markdown.disable(["autolink"]);
+// Let the token layer expose every explicit Markdown destination. The custom
+// renderer below applies the real allowlist and degrades rejected schemes to
+// visible, non-clickable text; no markdown-it-generated href is ever emitted.
+markdown.validateLink = () => true;
+
+function safeText(value) {
+  return (typeof value === "string" ? value : String(value == null ? "" : value))
+    .replace(/\r\n?/g, "\n")
+    .replace(/[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]+/g, " ");
+}
+
+function escapeTelegramHtml(value) {
+  return safeText(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+function escapeTelegramAttribute(value) {
+  return escapeTelegramHtml(value).replace(/"/g, "&quot;");
+}
+
+function neutralizeTelegramMentions(value) {
+  return safeText(value).replace(
+    /(^|[^\p{L}\p{N}_])@([A-Za-z0-9_]{5,32})\b/gu,
+    (_match, prefix, username) => `${prefix}＠${username}`,
+  );
+}
+
+function sanitizeTelegramUrl(value) {
+  const raw = safeText(value).trim();
+  if (!raw) return null;
+  let parsed;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") return null;
+  if (parsed.username || parsed.password) return null;
+  return parsed.toString();
+}
+
+function displayRejectedDestination(value) {
+  const raw = safeText(value).trim();
+  if (!raw) return "";
+  try {
+    const parsed = new URL(raw);
+    if (parsed.username || parsed.password) {
+      parsed.username = "";
+      parsed.password = "";
+      return parsed.toString().slice(0, 500);
+    }
+  } catch {}
+  return raw.slice(0, 500);
+}
+
+function clipUtf16Safe(value, maxLength) {
+  if (maxLength <= 0) return "";
+  const text = safeText(value);
+  if (text.length <= maxLength) return text;
+  let result = "";
+  let length = 0;
+  for (const character of text) {
+    if (length + character.length > maxLength) break;
+    result += character;
+    length += character.length;
+  }
+  return result;
+}
+
+function tagOpen(name, attributes = "") {
+  if (!ALLOWED_TAGS.has(name)) throw new Error("Telegram formatter tag is not allowed");
+  return { kind: "open", html: `<${name}${attributes}>`, closeHtml: `</${name}>` };
+}
+
+function tagClose(name) {
+  if (!ALLOWED_TAGS.has(name)) throw new Error("Telegram formatter tag is not allowed");
+  return { kind: "close", html: `</${name}>` };
+}
+
+function textSegment(htmlText, plainText = htmlText, options = {}) {
+  return {
+    kind: "text",
+    htmlText: safeText(htmlText),
+    plainText: safeText(plainText),
+    atomic: options.atomic === true,
+  };
+}
+
+function rawMessageSegment(message) {
+  if (!isFormattedTelegramMessage(message)) {
+    throw new Error("Telegram formatted message contract is required");
+  }
+  return {
+    kind: "raw-message",
+    html: message.html,
+    plainText: message.plainText,
+    htmlVisibleLength: message.htmlVisibleLength,
+    plainVisibleLength: message.plainVisibleLength,
+    truncated: message.truncated === true,
+  };
+}
+
+function measureSegments(segments) {
+  let htmlVisibleLength = 0;
+  let plainVisibleLength = 0;
+  for (const segment of segments) {
+    if (segment.kind === "text") {
+      htmlVisibleLength += segment.htmlText.length;
+      plainVisibleLength += segment.plainText.length;
+    } else if (segment.kind === "raw-message") {
+      htmlVisibleLength += segment.htmlVisibleLength;
+      plainVisibleLength += segment.plainVisibleLength;
+    }
+  }
+  return { htmlVisibleLength, plainVisibleLength };
+}
+
+function assertTelegramHtmlAllowlist(html) {
+  const source = String(html || "");
+  const tagRe = /<\/?([a-z][a-z0-9-]*)([^>]*)>/gi;
+  let match;
+  while ((match = tagRe.exec(source))) {
+    const name = match[1].toLowerCase();
+    if (!ALLOWED_TAGS.has(name)) throw new Error("Telegram formatter emitted a disallowed tag");
+    const closing = source[match.index + 1] === "/";
+    const attributes = match[2] || "";
+    if (closing && attributes.trim()) throw new Error("Telegram formatter emitted invalid closing-tag attributes");
+    if (name === "a" && !closing) {
+      if (!/^ href="(?:[^"<>&]|&amp;|&quot;|&lt;|&gt;)*"$/.test(attributes)) {
+        throw new Error("Telegram formatter emitted a disallowed link attribute");
+      }
+    } else if (attributes.trim()) {
+      throw new Error("Telegram formatter emitted disallowed tag attributes");
+    }
+  }
+  return true;
+}
+
+function materializeSegments(rawSegments, options = {}) {
+  const segments = Array.isArray(rawSegments) ? rawSegments.slice() : [];
+  const maxLength = Number.isFinite(options.maxLength) && options.maxLength >= 0
+    ? Math.floor(options.maxLength)
+    : DEFAULT_MAX_LENGTH;
+  const marker = safeText(options.truncationMarker == null
+    ? DEFAULT_TRUNCATION_MARKER
+    : options.truncationMarker);
+  const measured = measureSegments(segments);
+  const needsTruncation = measured.htmlVisibleLength > maxLength
+    || measured.plainVisibleLength > maxLength;
+  const contentLimit = needsTruncation ? Math.max(0, maxLength - marker.length) : maxLength;
+  let html = "";
+  let plainText = "";
+  let htmlVisibleLength = 0;
+  let plainVisibleLength = 0;
+  const openTags = [];
+  let truncated = false;
+
+  for (const segment of segments) {
+    if (segment.kind === "open") {
+      html += segment.html;
+      openTags.push(segment.closeHtml);
+      continue;
+    }
+    if (segment.kind === "close") {
+      html += segment.html;
+      if (openTags.length) openTags.pop();
+      continue;
+    }
+    if (segment.kind === "raw-message") {
+      const htmlRemaining = contentLimit - htmlVisibleLength;
+      const plainRemaining = contentLimit - plainVisibleLength;
+      if (
+        segment.htmlVisibleLength <= htmlRemaining
+        && segment.plainVisibleLength <= plainRemaining
+      ) {
+        html += segment.html;
+        plainText += segment.plainText;
+        htmlVisibleLength += segment.htmlVisibleLength;
+        plainVisibleLength += segment.plainVisibleLength;
+        continue;
+      }
+      truncated = true;
+      break;
+    }
+    if (segment.kind !== "text") continue;
+
+    const htmlRemaining = contentLimit - htmlVisibleLength;
+    const plainRemaining = contentLimit - plainVisibleLength;
+    const fits = segment.htmlText.length <= htmlRemaining
+      && segment.plainText.length <= plainRemaining;
+    if (fits) {
+      html += escapeTelegramHtml(segment.htmlText);
+      plainText += segment.plainText;
+      htmlVisibleLength += segment.htmlText.length;
+      plainVisibleLength += segment.plainText.length;
+      continue;
+    }
+
+    if (!segment.atomic && segment.htmlText === segment.plainText) {
+      const clipped = clipUtf16Safe(segment.htmlText, Math.max(0, Math.min(htmlRemaining, plainRemaining)));
+      if (clipped) {
+        html += escapeTelegramHtml(clipped);
+        plainText += clipped;
+        htmlVisibleLength += clipped.length;
+        plainVisibleLength += clipped.length;
+      }
+    }
+    truncated = true;
+    break;
+  }
+
+  if (needsTruncation || truncated) {
+    while (openTags.length) html += openTags.pop();
+    const htmlMarker = clipUtf16Safe(marker, Math.max(0, maxLength - htmlVisibleLength));
+    const plainMarker = clipUtf16Safe(marker, Math.max(0, maxLength - plainVisibleLength));
+    html += escapeTelegramHtml(htmlMarker);
+    plainText += plainMarker;
+    htmlVisibleLength += htmlMarker.length;
+    plainVisibleLength += plainMarker.length;
+    truncated = true;
+  }
+
+  assertTelegramHtmlAllowlist(html);
+  const frozenSegments = Object.freeze(segments.map((segment) => Object.freeze({ ...segment })));
+  const message = {
+    html,
+    plainText,
+    htmlVisibleLength,
+    plainVisibleLength,
+    budgetLength: Math.max(htmlVisibleLength, plainVisibleLength),
+    truncated: truncated
+      || options.reportedTruncated === true
+      || segments.some((segment) => segment.kind === "raw-message" && segment.truncated === true),
+  };
+  Object.defineProperty(message, MESSAGE_SEGMENTS, { value: frozenSegments });
+  return Object.freeze(message);
+}
+
+function isFormattedTelegramMessage(value) {
+  return !!(
+    value
+    && typeof value === "object"
+    && typeof value.html === "string"
+    && typeof value.plainText === "string"
+    && Array.isArray(value[MESSAGE_SEGMENTS])
+  );
+}
+
+class SegmentWriter {
+  constructor() {
+    this.segments = [];
+    this.quoteDepth = 0;
+    this.plainLineStart = true;
+    this.plainTail = "";
+  }
+
+  _pushText(htmlText, plainText, options = {}) {
+    const segment = textSegment(htmlText, plainText, options);
+    this.segments.push(segment);
+    this.plainLineStart = segment.plainText.endsWith("\n");
+    this.plainTail = `${this.plainTail}${segment.plainText}`.slice(-4);
+  }
+
+  write(value, options = {}) {
+    const raw = safeText(value);
+    const neutralize = options.neutralizeMentions !== false;
+    const prepared = neutralize ? neutralizeTelegramMentions(raw) : raw;
+    const chunks = prepared.split(/(\n)/);
+    for (const chunk of chunks) {
+      if (!chunk) continue;
+      if (chunk === "\n") {
+        this._pushText("\n", "\n");
+        continue;
+      }
+      if (this.plainLineStart && this.quoteDepth > 0) {
+        this._pushText("", "> ", { atomic: true });
+      }
+      this._pushText(chunk, chunk, options);
+    }
+  }
+
+  writePair(htmlText, plainText, options = {}) {
+    let htmlValue = safeText(htmlText);
+    let plainValue = safeText(plainText);
+    if (options.neutralizeMentions !== false) {
+      htmlValue = neutralizeTelegramMentions(htmlValue);
+      plainValue = neutralizeTelegramMentions(plainValue);
+    }
+    if (this.plainLineStart && this.quoteDepth > 0 && plainValue && plainValue !== "\n") {
+      this._pushText("", "> ", { atomic: true });
+    }
+    this._pushText(htmlValue, plainValue, { atomic: options.atomic !== false });
+  }
+
+  open(name, attributes = "") {
+    this.segments.push(tagOpen(name, attributes));
+  }
+
+  close(name) {
+    this.segments.push(tagClose(name));
+  }
+
+  trailingNewlines() {
+    const match = this.plainTail.match(/\n+$/);
+    return match ? match[0].length : 0;
+  }
+
+  ensureNewlines(count) {
+    const missing = Math.max(0, count - this.trailingNewlines());
+    if (missing) this.write("\n".repeat(missing), { neutralizeMentions: false });
+  }
+}
+
+function tokensToTree(tokens) {
+  const root = { type: "root", children: [] };
+  const stack = [root];
+  for (const token of Array.isArray(tokens) ? tokens : []) {
+    if (token.nesting === -1) {
+      if (stack.length > 1) stack.pop();
+      continue;
+    }
+    const node = { type: token.type, token, children: [] };
+    stack[stack.length - 1].children.push(node);
+    if (Array.isArray(token.children) && token.children.length) {
+      node.children = tokensToTree(token.children).children;
+    }
+    if (token.nesting === 1) stack.push(node);
+  }
+  return root;
+}
+
+function collectNodeText(node) {
+  if (!node) return "";
+  if (node.type === "text" || node.type === "code_inline" || node.type === "code_block" || node.type === "fence") {
+    return safeText(node.token && node.token.content);
+  }
+  if (node.type === "softbreak" || node.type === "hardbreak") return "\n";
+  if (node.type === "image") return safeText((node.token && node.token.content) || "");
+  if (node.type === "html_inline" || node.type === "html_block") return safeText(node.token && node.token.content);
+  return (node.children || []).map(collectNodeText).join("");
+}
+
+function tableRows(node) {
+  const rows = [];
+  function visit(current) {
+    if (!current) return;
+    if (current.type === "tr_open") {
+      const cells = (current.children || [])
+        .filter((child) => child.type === "th_open" || child.type === "td_open")
+        .map((cell) => collectNodeText(cell).replace(/\s+/g, " ").trim());
+      rows.push(cells);
+      return;
+    }
+    for (const child of current.children || []) visit(child);
+  }
+  visit(node);
+  return rows;
+}
+
+function renderNodes(nodes, writer, context = {}) {
+  for (const node of nodes || []) renderNode(node, writer, context);
+}
+
+function renderLink(node, writer, context) {
+  const href = node.token && typeof node.token.attrGet === "function" ? node.token.attrGet("href") : "";
+  const normalized = sanitizeTelegramUrl(href);
+  const label = collectNodeText(node).trim();
+  if (!normalized) {
+    renderNodes(node.children, writer, context);
+    const destination = displayRejectedDestination(href);
+    if (destination && destination !== label) {
+      writer.write(` (${destination})`);
+    }
+    return;
+  }
+
+  writer.open("a", ` href="${escapeTelegramAttribute(normalized)}"`);
+  renderNodes(node.children, writer, context);
+  writer.close("a");
+  let hostname = "";
+  try { hostname = new URL(normalized).hostname; } catch {}
+  const labelLower = label.toLowerCase();
+  if (hostname && !labelLower.includes(hostname.toLowerCase()) && label !== normalized) {
+    writer.writePair(` (${hostname})`, ` (${normalized})`, {
+      atomic: true,
+    });
+  }
+}
+
+function renderImage(node, writer) {
+  const source = node.token && typeof node.token.attrGet === "function" ? node.token.attrGet("src") : "";
+  const alt = safeText((node.token && node.token.content) || "").trim();
+  const destination = sanitizeTelegramUrl(source) || displayRejectedDestination(source);
+  writer.write("🖼", { neutralizeMentions: false });
+  if (alt || destination) writer.write(` ${alt || destination}`);
+  if (alt && destination) writer.write(` (${destination})`);
+}
+
+function renderTable(node, writer, context = {}) {
+  const rows = tableRows(node);
+  if (!rows.length) return;
+  const text = rows.map((cells) => cells.join(" | ")).join("\n");
+  if (!context.inBlockquote) writer.open("pre");
+  writer.write(text);
+  if (!context.inBlockquote) writer.close("pre");
+  writer.ensureNewlines(2);
+}
+
+function renderList(node, writer, context, ordered) {
+  const items = (node.children || []).filter((child) => child.type === "list_item_open");
+  let start = 1;
+  if (ordered && node.token && typeof node.token.attrGet === "function") {
+    const rawStart = node.token.attrGet("start");
+    const parsed = Number(rawStart);
+    if (rawStart != null && Number.isInteger(parsed)) start = parsed;
+  }
+  items.forEach((item, index) => {
+    writer.write(ordered ? `${start + index}. ` : "• ", { neutralizeMentions: false });
+    renderNodes(item.children, writer, { ...context, inListItem: true });
+    writer.ensureNewlines(1);
+  });
+  writer.ensureNewlines(2);
+}
+
+function renderNode(node, writer, context = {}) {
+  switch (node.type) {
+    case "root":
+      renderNodes(node.children, writer, context);
+      break;
+    case "inline":
+      renderNodes(node.children, writer, context);
+      break;
+    case "paragraph_open":
+      renderNodes(node.children, writer, context);
+      writer.ensureNewlines(context.inListItem ? 1 : 2);
+      break;
+    case "heading_open":
+      writer.open("b");
+      renderNodes(node.children, writer, context);
+      writer.close("b");
+      writer.ensureNewlines(2);
+      break;
+    case "strong_open":
+      writer.open("b");
+      renderNodes(node.children, writer, context);
+      writer.close("b");
+      break;
+    case "em_open":
+      writer.open("i");
+      renderNodes(node.children, writer, context);
+      writer.close("i");
+      break;
+    case "s_open":
+      writer.open("s");
+      renderNodes(node.children, writer, context);
+      writer.close("s");
+      break;
+    case "link_open":
+      renderLink(node, writer, context);
+      break;
+    case "image":
+      renderImage(node, writer);
+      break;
+    case "text":
+      writer.write(node.token && node.token.content, { neutralizeMentions: !context.code });
+      break;
+    case "softbreak":
+    case "hardbreak":
+      writer.write("\n", { neutralizeMentions: false });
+      break;
+    case "code_inline":
+      writer.open("code");
+      writer.write(node.token && node.token.content, { neutralizeMentions: false });
+      writer.close("code");
+      break;
+    case "fence":
+    case "code_block":
+      if (!context.inBlockquote) {
+        writer.open("pre");
+        writer.open("code");
+      }
+      writer.write(node.token && node.token.content, { neutralizeMentions: false });
+      if (!context.inBlockquote) {
+        writer.close("code");
+        writer.close("pre");
+      }
+      writer.ensureNewlines(2);
+      break;
+    case "blockquote_open": {
+      const outermost = writer.quoteDepth === 0;
+      if (outermost) writer.open("blockquote");
+      writer.quoteDepth += 1;
+      renderNodes(node.children, writer, { ...context, inBlockquote: true });
+      writer.quoteDepth -= 1;
+      if (outermost) writer.close("blockquote");
+      writer.ensureNewlines(2);
+      break;
+    }
+    case "bullet_list_open":
+      renderList(node, writer, context, false);
+      break;
+    case "ordered_list_open":
+      renderList(node, writer, context, true);
+      break;
+    case "list_item_open":
+      renderNodes(node.children, writer, { ...context, inListItem: true });
+      break;
+    case "table_open":
+      renderTable(node, writer, context);
+      break;
+    case "hr":
+      writer.write("────────", { neutralizeMentions: false });
+      writer.ensureNewlines(2);
+      break;
+    case "html_inline":
+    case "html_block":
+      writer.write(node.token && node.token.content);
+      break;
+    default:
+      if (node.children && node.children.length) renderNodes(node.children, writer, context);
+      else if (node.token && node.token.content) writer.write(node.token.content, context);
+  }
+}
+
+function trimTrailingNewlines(segments) {
+  const result = segments.slice();
+  for (let index = result.length - 1; index >= 0; index -= 1) {
+    const segment = result[index];
+    if (segment.kind !== "text") continue;
+    const htmlText = segment.htmlText.replace(/\n+$/g, "");
+    const plainText = segment.plainText.replace(/\n+$/g, "");
+    if (!htmlText && !plainText) {
+      result.splice(index, 1);
+      continue;
+    }
+    result[index] = { ...segment, htmlText, plainText };
+    break;
+  }
+  return result;
+}
+
+function renderTelegramMarkdown(value, options = {}) {
+  const source = safeText(value);
+  const writer = new SegmentWriter();
+  try {
+    const tree = tokensToTree(markdown.parse(source, {}));
+    renderNode(tree, writer);
+  } catch {
+    // The fallback deliberately reports no parser/input detail.
+    return plainTelegramText(source, options);
+  }
+  return materializeSegments(trimTrailingNewlines(writer.segments), options);
+}
+
+function plainTelegramText(value, options = {}) {
+  const writer = new SegmentWriter();
+  writer.write(value, { neutralizeMentions: options.neutralizeMentions === true });
+  return materializeSegments(writer.segments, options);
+}
+
+function appendPartSegments(target, part) {
+  if (isFormattedTelegramMessage(part)) {
+    // A formatted message has already enforced its own token-aware budget and
+    // balanced its tags. Keep that result atomic when composing a larger card;
+    // reopening its source segments would discard its truncation marker and
+    // let the outer budget silently re-emit content the inner budget rejected.
+    target.push(rawMessageSegment(part));
+    return;
+  }
+  if (part && typeof part === "object" && Object.prototype.hasOwnProperty.call(part, "text")) {
+    if (part.bold === true) target.push(tagOpen("b"));
+    if (part.code === true) target.push(tagOpen("code"));
+    const value = part.neutralizeMentions === true
+      ? neutralizeTelegramMentions(part.text)
+      : safeText(part.text);
+    target.push(textSegment(value));
+    if (part.code === true) target.push(tagClose("code"));
+    if (part.bold === true) target.push(tagClose("b"));
+    return;
+  }
+  target.push(textSegment(safeText(part)));
+}
+
+function concatTelegramParts(parts, options = {}) {
+  const segments = [];
+  for (const part of Array.isArray(parts) ? parts : []) appendPartSegments(segments, part);
+  return materializeSegments(segments, options);
+}
+
+function appendTelegramStatus(message, status, options = {}) {
+  if (!isFormattedTelegramMessage(message)) {
+    throw new Error("Telegram formatted message contract is required");
+  }
+  const maxLength = Number.isFinite(options.maxLength) && options.maxLength >= 0
+    ? Math.floor(options.maxLength)
+    : DEFAULT_MAX_LENGTH;
+  const separator = "\n\n";
+  const statusMessage = concatTelegramParts([
+    { text: status, bold: options.bold !== false },
+  ], {
+    maxLength: Math.max(0, maxLength - separator.length),
+    truncationMarker: options.truncationMarker,
+  });
+  const baseBudget = Math.max(0, maxLength - separator.length - statusMessage.budgetLength);
+  const boundedBase = materializeSegments(message[MESSAGE_SEGMENTS], {
+    maxLength: baseBudget,
+    truncationMarker: options.truncationMarker,
+  });
+  return materializeSegments([
+    rawMessageSegment(boundedBase),
+    textSegment(separator),
+    rawMessageSegment(statusMessage),
+  ], {
+    maxLength,
+    truncationMarker: options.truncationMarker,
+    reportedTruncated: message.truncated || boundedBase.truncated || statusMessage.truncated,
+  });
+}
+
+function buildTelegramApprovalMessage(payload, options = {}) {
+  const title = safeText(payload && payload.title).trim();
+  if (!title) return null;
+  const parts = [{ text: title, bold: true, neutralizeMentions: true }];
+  const fields = Array.isArray(payload && payload.fields) ? payload.fields : [];
+  if (fields.length) {
+    for (const field of fields) {
+      const label = safeText(field && field.label).trim();
+      const value = safeText(field && field.value).trim();
+      if (!label || !value) continue;
+      parts.push("\n\n", { text: `${label}:`, bold: true }, " ", {
+        text: value,
+        neutralizeMentions: true,
+      });
+    }
+  } else {
+    const detail = safeText(payload && payload.detail).trim();
+    if (detail) parts.push("\n\n", { text: detail, neutralizeMentions: true });
+  }
+  return concatTelegramParts(parts, {
+    maxLength: options.maxLength || DEFAULT_MAX_LENGTH,
+    truncationMarker: options.truncationMarker,
+  });
+}
+
+function isTelegramHtmlParseError(error) {
+  const candidates = [
+    error && error.status,
+    error && error.statusCode,
+    error && error.error_code,
+    error && error.code,
+    error && error.response && error.response.error_code,
+  ];
+  const is400 = candidates.some((value) => Number(value) === 400);
+  if (!is400) return false;
+  const description = [
+    error && error.description,
+    error && error.message,
+    error && error.response && error.response.description,
+  ].find((value) => typeof value === "string") || "";
+  return /can't parse entities/i.test(description);
+}
+
+module.exports = {
+  appendTelegramStatus,
+  assertTelegramHtmlAllowlist,
+  buildTelegramApprovalMessage,
+  clipUtf16Safe,
+  concatTelegramParts,
+  escapeTelegramHtml,
+  isFormattedTelegramMessage,
+  isTelegramHtmlParseError,
+  neutralizeTelegramMentions,
+  plainTelegramText,
+  renderTelegramMarkdown,
+  sanitizeTelegramUrl,
+};

--- a/src/telegram-native-runner.js
+++ b/src/telegram-native-runner.js
@@ -32,6 +32,13 @@ const {
   parseSessionGrantRevokeAction,
   createRemoteCardWorkRegistry,
 } = require("./session-automation-remote");
+const {
+  appendTelegramStatus,
+  buildTelegramApprovalMessage,
+  isFormattedTelegramMessage,
+  isTelegramHtmlParseError,
+  plainTelegramText,
+} = require("./telegram-message-format");
 
 const APPROVAL_CALLBACK_RE = /^cp:([a-z0-9]+):(a|d|s(\d+))$/;
 const LEGACY_APPROVAL_CALLBACK_RE = /^clawdperm:([a-z0-9]+):(allow|deny)$/;
@@ -226,8 +233,8 @@ function normalizeElicitationPayload(payload) {
 }
 
 function buildElicitationHeaderText(payload) {
-  const parts = [payload.title];
-  if (payload.detail) parts.push(payload.detail);
+  const parts = [redactSecrets(payload.title)];
+  if (payload.detail) parts.push(redactSecrets(payload.detail));
   return parts.join("\n\n");
 }
 
@@ -418,6 +425,51 @@ function createTelegramNativeRunner({
       errorClass: compactMessageText(errorClass || "unknown", 48),
       at: Date.now(),
     };
+  }
+
+  async function deliverFormatted(method, basePayload, message, requestOptions = {}, deliveryOptions = {}) {
+    if (!isFormattedTelegramMessage(message)) {
+      throw new Error("Telegram formatted message contract is required");
+    }
+    const preferPlain = deliveryOptions.preferPlain === true;
+    const signal = requestOptions && requestOptions.signal;
+    const plainBasePayload = { ...basePayload };
+    delete plainBasePayload.parse_mode;
+    const sendPlain = () => {
+      if (typeof deliveryOptions.onPlainAttempt === "function") {
+        try { deliveryOptions.onPlainAttempt(); } catch {}
+      }
+      return client[method]({
+        ...plainBasePayload,
+        text: message.plainText,
+      }, requestOptions);
+    };
+    if (preferPlain) {
+      return { result: await sendPlain(), usedPlain: true };
+    }
+    try {
+      const result = await client[method]({
+        ...basePayload,
+        text: message.html,
+        parse_mode: "HTML",
+      }, requestOptions);
+      return { result, usedPlain: false };
+    } catch (err) {
+      if (!isTelegramHtmlParseError(err)) throw err;
+      if (signal && signal.aborted) throw err;
+      safeLog("warn", "native Telegram HTML rejected, retrying rendered plain text", {
+        operation: method === "editMessageText" ? "edit" : "send",
+      });
+      return { result: await sendPlain(), usedPlain: true };
+    }
+  }
+
+  async function sendFormattedMessage(basePayload, message, requestOptions, deliveryOptions) {
+    return deliverFormatted("sendMessage", basePayload, message, requestOptions, deliveryOptions);
+  }
+
+  async function editFormattedMessage(basePayload, message, requestOptions, deliveryOptions) {
+    return deliverFormatted("editMessageText", basePayload, message, requestOptions, deliveryOptions);
   }
 
   function resetPollRetryDelay() {
@@ -691,7 +743,7 @@ function createTelegramNativeRunner({
     };
   }
 
-  async function editSessionTrustPrompt(payload) {
+  async function editSessionTrustPrompt(basePayload, message) {
     const controller = typeof AbortController === "function" ? new AbortController() : null;
     const timeoutMs = Number.isFinite(sessionAutomationEditTimeoutMs)
       && sessionAutomationEditTimeoutMs > 0
@@ -709,10 +761,11 @@ function createTelegramNativeRunner({
     });
     try {
       return await Promise.race([
-        client.editMessageText(
-          payload,
+        editFormattedMessage(
+          basePayload,
+          message,
           controller ? { signal: controller.signal } : undefined
-        ),
+        ).then((delivery) => delivery.result),
         timeout,
       ]);
     } finally {
@@ -763,13 +816,17 @@ function createTelegramNativeRunner({
     }
     if (action === "open") {
       entry.trustConfirming = true;
+      const confirmationMessage = appendTelegramStatus(
+        entry.message,
+        t("telegramSessionTrustConfirmText"),
+        { maxLength: MAX_MESSAGE_TEXT },
+      );
       try {
         await editSessionTrustPrompt({
           chat_id: entry.chatId,
           message_id: entry.messageId,
-          text: `${entry.text}\n\n${t("telegramSessionTrustConfirmText")}`,
           reply_markup: sessionTrustKeyboard(id, t),
-        });
+        }, confirmationMessage);
         try {
           await client.answerCallbackQuery({
             callback_query_id: cb.id,
@@ -788,15 +845,23 @@ function createTelegramNativeRunner({
       return true;
     }
     if (action === "no") {
-      entry.trustConfirming = false;
       try {
         await editSessionTrustPrompt({
           chat_id: entry.chatId,
           message_id: entry.messageId,
-          text: entry.text,
           reply_markup: buildApprovalKeyboard(id, entry),
-        });
-      } catch {}
+        }, entry.message);
+        entry.trustConfirming = false;
+      } catch {
+        entry.trustConfirming = true;
+        try {
+          await client.answerCallbackQuery({
+            callback_query_id: cb.id,
+            text: t("telegramApprovalToastUnavailable"),
+          });
+        } catch {}
+        return true;
+      }
       try { await client.answerCallbackQuery({ callback_query_id: cb.id }); } catch {}
       return true;
     }
@@ -813,17 +878,19 @@ function createTelegramNativeRunner({
       chatId: entry.chatId,
       messageId: entry.messageId,
       text: entry.text,
+      message: entry.message,
     });
     if (!cardWork) {
-      entry.trustConfirming = false;
       try {
         await editSessionTrustPrompt({
           chat_id: entry.chatId,
           message_id: entry.messageId,
-          text: entry.text,
           reply_markup: buildApprovalKeyboard(id, entry),
-        });
-      } catch {}
+        }, entry.message);
+        entry.trustConfirming = false;
+      } catch {
+        entry.trustConfirming = true;
+      }
       try {
         await client.answerCallbackQuery({
           callback_query_id: cb.id,
@@ -837,6 +904,7 @@ function createTelegramNativeRunner({
       chatId: entry.chatId,
       messageId: entry.messageId,
       text: entry.text,
+      message: entry.message,
       routeSignature: sessionAutomationRouteSignature,
       cardWork,
     });
@@ -1054,38 +1122,46 @@ function createTelegramNativeRunner({
   function appendApprovalStatus(entry, status, messageId) {
     const chatId = entry && entry.chatId;
     if (!chatId || !messageId) return Promise.resolve();
-    if (!status || !entry.text) return stripApprovalKeyboard(chatId, messageId);
-    return client.editMessageText({
+    if (!status || !entry.message) return stripApprovalKeyboard(chatId, messageId);
+    const message = appendTelegramStatus(entry.message, status, { maxLength: MAX_MESSAGE_TEXT });
+    return editFormattedMessage({
       chat_id: chatId,
       message_id: messageId,
-      text: `${entry.text}\n\n${status}`,
-    }).catch(() => stripApprovalKeyboard(chatId, messageId));
+    }, message).catch(() => stripApprovalKeyboard(chatId, messageId));
   }
 
   function renderSessionTrustCard(cardRef, status, grantId, options = {}) {
     if (!cardRef || !cardRef.chatId || !cardRef.messageId || !grantId) {
       return Promise.reject(new Error("session trust card reference is unavailable"));
     }
-    return client.editMessageText({
+    const baseMessage = cardRef.message || plainTelegramText(cardRef.text || "", {
+      maxLength: MAX_MESSAGE_TEXT,
+      neutralizeMentions: true,
+    });
+    const message = appendTelegramStatus(baseMessage, status, { maxLength: MAX_MESSAGE_TEXT });
+    return editFormattedMessage({
       chat_id: cardRef.chatId,
       message_id: cardRef.messageId,
-      text: `${cardRef.text}\n\n${status}`,
       reply_markup: {
         inline_keyboard: [[{
           text: t("telegramSessionTrustRevokeButton"),
           callback_data: buildSessionGrantRevokeAction(grantId),
         }]],
       },
-    }, options);
+    }, message, options).then((delivery) => delivery.result);
   }
 
   function renderSessionTrustTerminal(cardRef, status, options = {}) {
     if (!cardRef || !cardRef.chatId || !cardRef.messageId) return Promise.resolve();
-    return client.editMessageText({
+    const baseMessage = cardRef.message || plainTelegramText(cardRef.text || "", {
+      maxLength: MAX_MESSAGE_TEXT,
+      neutralizeMentions: true,
+    });
+    const message = appendTelegramStatus(baseMessage, status, { maxLength: MAX_MESSAGE_TEXT });
+    return editFormattedMessage({
       chat_id: cardRef.chatId,
       message_id: cardRef.messageId,
-      text: `${cardRef.text}\n\n${status}`,
-    }, options);
+    }, message, options).then((delivery) => delivery.result);
   }
 
   function notifySessionAutomationRouteChange() {
@@ -1256,7 +1332,8 @@ function createTelegramNativeRunner({
   function requestApproval(payload, options = {}) {
     const chatId = getChatId();
     const allowedUser = getAllowedUserId();
-    const text = buildApprovalText(payload);
+    const message = buildTelegramApprovalMessage(payload, { maxLength: MAX_MESSAGE_TEXT });
+    const text = message && message.plainText;
     const suggestions = normalizeApprovalSuggestions(payload && payload.suggestions);
     const signal = options && options.signal;
     if (!polling || !chatId || !allowedUser || !text || (signal && signal.aborted)) {
@@ -1275,6 +1352,7 @@ function createTelegramNativeRunner({
         // Card body as sent, kept so a resolved-elsewhere edit can rebuild the
         // text with a status line appended (issue #457).
         text,
+        message,
         timer: null,
         signal,
         onAbort: null,
@@ -1293,13 +1371,13 @@ function createTelegramNativeRunner({
         signal.addEventListener("abort", entry.onAbort, { once: true });
       }
 
-      client.sendMessage({
+      sendFormattedMessage({
         chat_id: chatId,
-        text,
         reply_markup: {
           ...buildApprovalKeyboard(id, entry),
         },
-      }, signal ? { signal } : undefined).then((msg) => {
+      }, message, signal ? { signal } : undefined).then((delivery) => {
+        const msg = delivery.result;
         const current = pendingApprovals.get(id);
         if (!current || (signal && signal.aborted)) return;
         current.messageId = msg && msg.message_id;
@@ -1321,11 +1399,11 @@ function createTelegramNativeRunner({
   // next/previous question (with a fresh keyboard) or - when called without a
   // keyboard - to show a final status line with no keyboard, mirroring
   // appendApprovalStatus's fallback-to-stripped-keyboard behavior on failure.
-  function renderElicitationCard(entry, text, keyboard) {
+  function renderElicitationCard(entry, message, keyboard) {
     if (!entry.chatId || !entry.messageId) return Promise.resolve();
-    const payload = { chat_id: entry.chatId, message_id: entry.messageId, text };
+    const payload = { chat_id: entry.chatId, message_id: entry.messageId };
     if (keyboard) payload.reply_markup = { inline_keyboard: keyboard };
-    return client.editMessageText(payload).catch(() => {
+    return editFormattedMessage(payload, message).then((delivery) => delivery.result).catch(() => {
       if (!keyboard) return undefined;
       return stripApprovalKeyboard(entry.chatId, entry.messageId);
     });
@@ -1334,6 +1412,10 @@ function createTelegramNativeRunner({
   function renderElicitationQuestion(entry) {
     if (entry.awaitingOtherFor != null) {
       const text = buildElicitationOtherPromptText(entry.payload, entry.awaitingOtherFor, t);
+      const message = plainTelegramText(text, {
+        maxLength: MAX_MESSAGE_TEXT,
+        neutralizeMentions: true,
+      });
       const callbackBase = `cq:${entry.payload._id}`;
       // A dead end otherwise: without a way back to the option list, tapping
       // Other by mistake (or changing your mind) would force either typing
@@ -1343,11 +1425,15 @@ function createTelegramNativeRunner({
         [{ text: t("telegramElicitationCancelOtherButton"), callback_data: `${callbackBase}:z${entry.awaitingOtherFor}` }],
         [{ text: t("telegramElicitationTerminalButton"), callback_data: `${callbackBase}:t` }],
       ];
-      return renderElicitationCard(entry, text, keyboard);
+      return renderElicitationCard(entry, message, keyboard);
     }
     const text = buildElicitationQuestionText(entry.payload, entry.activeQuestionIndex, t);
+    const message = plainTelegramText(text, {
+      maxLength: MAX_MESSAGE_TEXT,
+      neutralizeMentions: true,
+    });
     const keyboard = buildElicitationKeyboard(entry.payload, entry.activeQuestionIndex, entry.multiSelectSelections, t);
-    return renderElicitationCard(entry, text, keyboard);
+    return renderElicitationCard(entry, message, keyboard);
   }
 
   // Single resolution point for an elicitation, used by every exit: a
@@ -1372,7 +1458,14 @@ function createTelegramNativeRunner({
       ? buildElicitationOtherPromptText(entry.payload, entry.awaitingOtherFor, t)
       : buildElicitationQuestionText(entry.payload, entry.activeQuestionIndex, t);
     if (!entry.chatId || !entry.messageId) return;
-    renderElicitationCard(entry, status ? `${baseText}\n\n${status}` : baseText, null);
+    const baseMessage = plainTelegramText(baseText, {
+      maxLength: MAX_MESSAGE_TEXT,
+      neutralizeMentions: true,
+    });
+    const message = status
+      ? appendTelegramStatus(baseMessage, status, { maxLength: MAX_MESSAGE_TEXT })
+      : baseMessage;
+    renderElicitationCard(entry, message, null);
   }
 
   function clearAllElicitations() {
@@ -1551,6 +1644,10 @@ function createTelegramNativeRunner({
     const id = randomId();
     normalized._id = id;
     const text = buildElicitationQuestionText(normalized, 0, t);
+    const message = plainTelegramText(text, {
+      maxLength: MAX_MESSAGE_TEXT,
+      neutralizeMentions: true,
+    });
     const keyboard = buildElicitationKeyboard(normalized, 0, null, t);
 
     return new Promise((resolve) => {
@@ -1578,11 +1675,11 @@ function createTelegramNativeRunner({
         signal.addEventListener("abort", entry.onAbort, { once: true });
       }
 
-      client.sendMessage({
+      sendFormattedMessage({
         chat_id: chatId,
-        text,
         reply_markup: { inline_keyboard: keyboard },
-      }, signal ? { signal } : undefined).then((msg) => {
+      }, message, signal ? { signal } : undefined).then((delivery) => {
+        const msg = delivery.result;
         const current = pendingElicitations.get(id);
         if (!current || (signal && signal.aborted)) return;
         current.messageId = msg && msg.message_id;
@@ -1636,18 +1733,45 @@ function createTelegramNativeRunner({
     }
   }
 
+  async function sendBoundedNotification(chatId, message, deliveryState) {
+    if (!isFormattedTelegramMessage(message)) {
+      return sendBoundedMessage(chatId, message);
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      try { controller.abort(); } catch {}
+    }, Math.max(1, notifyTimeoutMs));
+    if (timer && typeof timer.unref === "function") timer.unref();
+    try {
+      const delivery = await sendFormattedMessage(
+        { chat_id: chatId },
+        message,
+        { signal: controller.signal },
+        {
+          preferPlain: deliveryState.preferPlain === true,
+          onPlainAttempt: () => { deliveryState.preferPlain = true; },
+        },
+      );
+      return delivery.result;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   // Public R1a entry point. Best-effort: never throws, always resolves to a
   // structured result so callers (the snapshot fanout) can log without
   // branching on exceptions. One 429 retry honouring retry_after; everything
   // else (403 blocked, timeout, network) is logged and dropped.
-  async function sendNotification(text) {
+  async function sendNotification(value) {
     const chatId = getChatId();
-    const body = compactMessageText(text);
-    if (!polling || !chatId || !body) {
+    const body = isFormattedTelegramMessage(value) ? value : compactMessageText(value);
+    const hasBody = isFormattedTelegramMessage(body) ? !!body.plainText : !!body;
+    if (!polling || !chatId || !hasBody) {
       return { ok: false, errorClass: "not_active" };
     }
+    const deliveryState = { preferPlain: false };
     try {
-      const sent = await sendBoundedMessage(chatId, body);
+      const sent = await sendBoundedNotification(chatId, body, deliveryState);
       return { ok: true, messageId: extractTelegramMessageId(sent) };
     } catch (err) {
       const cls = classifyError(err);
@@ -1668,7 +1792,7 @@ function createTelegramNativeRunner({
           if (!polling || !retryChatId || retryChatId !== chatId) {
             return { ok: false, errorClass: "not_active" };
           }
-          const sent = await sendBoundedMessage(retryChatId, body);
+          const sent = await sendBoundedNotification(retryChatId, body, deliveryState);
           return { ok: true, messageId: extractTelegramMessageId(sent) };
         } catch (err2) {
           const cls2 = classifyError(err2);

--- a/test/permission-telegram-approval.test.js
+++ b/test/permission-telegram-approval.test.js
@@ -137,10 +137,17 @@ describe("permission telegram remote approval", () => {
     assert.match(requests[0].payload.detail, /Tool: Bash/);
     assert.match(requests[0].payload.detail, /Folder: project-alpha/);
     assert.match(requests[0].payload.detail, /Summary: Run project tests/);
+    assert.deepEqual(requests[0].payload.fields, [
+      { label: "Agent", value: "claude-code" },
+      { label: "Tool", value: "Bash" },
+      { label: "Folder", value: "project-alpha" },
+      { label: "Summary", value: "Run project tests for chat <redacted:id> and <redacted:id>" },
+    ]);
     assert.equal(requests[0].payload.detail.includes("npm test"), false);
     assert.equal(requests[0].payload.detail.includes("sk-1234567890123456"), false);
     assert.equal(requests[0].payload.detail.includes("987654321"), false);
     assert.equal(requests[0].payload.detail.includes("telegram:123456789"), false);
+    assert.equal(JSON.stringify(requests[0].payload.fields).includes("sk-1234567890123456"), false);
 
     resolveApproval("allow");
     await flush();

--- a/test/telegram-companion.test.js
+++ b/test/telegram-companion.test.js
@@ -6,11 +6,18 @@ const test = require("node:test");
 const {
   createTelegramCompanion,
   formatNotification,
+  formatTelegramNotificationMessage,
 } = require("../src/telegram-companion");
 
 function tick() {
   // Flush the fire-and-forget microtask chain in onSnapshot.
   return new Promise((resolve) => setImmediate(resolve));
+}
+
+function sentText(value) {
+  return value && typeof value === "object" && typeof value.plainText === "string"
+    ? value.plainText
+    : String(value || "");
 }
 
 function doneEntry(overrides = {}) {
@@ -38,7 +45,7 @@ function makeClient() {
   };
 }
 
-function makeCompanion({ enabled = true, client, getLang, getCompletionOutputMode, getNotifyOnComplete } = {}) {
+function makeCompanion({ enabled = true, client, getLang, getCompletionOutputMode, getNotifyOnComplete, formatText } = {}) {
   const sink = client || makeClient();
   const comp = createTelegramCompanion({
     getClient: () => sink.client,
@@ -46,6 +53,7 @@ function makeCompanion({ enabled = true, client, getLang, getCompletionOutputMod
     getLang,
     getCompletionOutputMode,
     getNotifyOnComplete,
+    formatText,
   });
   return { comp, sent: sink.sent };
 }
@@ -84,8 +92,9 @@ test("factory sends assistant output only when full output is explicit", async (
   });
   await tick();
   assert.equal(sent.length, 1);
-  assert.match(sent[0], /Assistant output:/);
-  assert.match(sent[0], /Implemented the fix/);
+  assert.match(sentText(sent[0]), /Assistant output:/);
+  assert.match(sentText(sent[0]), /Implemented the fix/);
+  assert.match(sent[0].html, /<b>Assistant output:<\/b>/);
 });
 
 test("notifies a fresh completion after priming", async () => {
@@ -94,8 +103,8 @@ test("notifies a fresh completion after priming", async () => {
   comp.onSnapshot({ sessions: [doneEntry()] });
   await tick();
   assert.equal(sent.length, 1);
-  assert.match(sent[0], /fix the bug/);
-  assert.match(sent[0], /done/);
+  assert.match(sentText(sent[0]), /fix the bug/);
+  assert.match(sentText(sent[0]), /done/);
 });
 
 test("registers completion notification message ids after successful sends", async () => {
@@ -195,7 +204,7 @@ test("notifies each completing session with identity fields", async () => {
   });
   await tick();
   assert.equal(sent.length, 2);
-  const joined = sent.join("\n---\n");
+  const joined = sent.map(sentText).join("\n---\n");
   assert.match(joined, /task A/);
   assert.match(joined, /projA/);
   assert.match(joined, /task B/);
@@ -226,7 +235,7 @@ test("interrupted badge uses the warning marker", async () => {
   });
   await tick();
   assert.equal(sent.length, 1);
-  assert.match(sent[0], /interrupted/);
+  assert.match(sentText(sent[0]), /interrupted/);
 });
 
 test("completion notification follows the current Clawd language", async () => {
@@ -236,14 +245,14 @@ test("completion notification follows the current Clawd language", async () => {
   comp.onSnapshot({ sessions: [doneEntry()] });
   await tick();
   assert.equal(sent.length, 1);
-  assert.match(sent[0], /已完成/);
-  assert.doesNotMatch(sent[0], /\(done\)/);
+  assert.match(sentText(sent[0]), /已完成/);
+  assert.doesNotMatch(sentText(sent[0]), /\(done\)/);
 
   lang = "ja";
   comp.onSnapshot({ sessions: [doneEntry({ lastEvent: { rawEvent: "Stop", at: 2000 } })] });
   await tick();
   assert.equal(sent.length, 2);
-  assert.match(sent[1], /完了/);
+  assert.match(sentText(sent[1]), /完了/);
 });
 
 test("output mode off keeps the R1a bare notification", async () => {
@@ -255,8 +264,8 @@ test("output mode off keeps the R1a bare notification", async () => {
   comp.onSnapshot({ sessions: [doneEntry({ assistantLastOutput: "assistant text" })] });
   await tick();
   assert.equal(sent.length, 1);
-  assert.doesNotMatch(sent[0], /assistant text/);
-  assert.doesNotMatch(sent[0], /Assistant output/);
+  assert.doesNotMatch(sentText(sent[0]), /assistant text/);
+  assert.doesNotMatch(sentText(sent[0]), /Assistant output/);
 });
 
 test("full output mode appends redacted assistant text", async () => {
@@ -271,11 +280,11 @@ test("full output mode appends redacted assistant text", async () => {
   });
   await tick();
   assert.equal(sent.length, 1);
-  assert.match(sent[0], /Assistant output \(truncated\):/);
-  assert.match(sent[0], /TAIL/);
-  assert.match(sent[0], /secret=<redacted>/);
-  assert.doesNotMatch(sent[0], /sk-1234567890abcdef/);
-  assert.doesNotMatch(sent[0], /Last output/);
+  assert.match(sentText(sent[0]), /Assistant output \(truncated\):/);
+  assert.match(sentText(sent[0]), /TAIL/);
+  assert.match(sentText(sent[0]), /secret=<redacted>/);
+  assert.doesNotMatch(sentText(sent[0]), /sk-1234567890abcdef/);
+  assert.doesNotMatch(sentText(sent[0]), /Last output/);
 });
 
 test("full output mode with bare ping disabled skips completions with no assistant text", async () => {
@@ -296,8 +305,8 @@ test("full output mode with bare ping disabled skips completions with no assista
   });
   await tick();
   assert.equal(sent.length, 1);
-  assert.match(sent[0], /Assistant output:/);
-  assert.match(sent[0], /Implemented the fix/);
+  assert.match(sentText(sent[0]), /Assistant output:/);
+  assert.match(sentText(sent[0]), /Implemented the fix/);
 });
 
 test("output mode off with bare ping disabled sends no completion message", async () => {
@@ -321,9 +330,9 @@ test("legacy tail output mode is treated as full output", async () => {
   });
   await tick();
   assert.equal(sent.length, 1);
-  assert.match(sent[0], /Assistant output:/);
-  assert.match(sent[0], /Implemented the fix/);
-  assert.doesNotMatch(sent[0], /Last output/);
+  assert.match(sentText(sent[0]), /Assistant output:/);
+  assert.match(sentText(sent[0]), /Implemented the fix/);
+  assert.doesNotMatch(sentText(sent[0]), /Last output/);
 });
 
 test("full output mode appends assistant text and marks extractor truncation", async () => {
@@ -339,9 +348,9 @@ test("full output mode appends assistant text and marks extractor truncation", a
   });
   await tick();
   assert.equal(sent.length, 1);
-  assert.match(sent[0], /Assistant output \(truncated\):/);
-  assert.match(sent[0], /Implemented X/);
-  assert.match(sent[0], /Tests pass/);
+  assert.match(sentText(sent[0]), /Assistant output \(truncated\):/);
+  assert.match(sentText(sent[0]), /Implemented X/);
+  assert.match(sentText(sent[0]), /Tests pass/);
 });
 
 test("full output mode with bare ping enabled degrades to R1a when no assistant text is available", async () => {
@@ -353,7 +362,7 @@ test("full output mode with bare ping enabled degrades to R1a when no assistant 
   comp.onSnapshot({ sessions: [doneEntry()] });
   await tick();
   assert.equal(sent.length, 1);
-  assert.doesNotMatch(sent[0], /Assistant output/);
+  assert.doesNotMatch(sentText(sent[0]), /Assistant output/);
 });
 
 test("forgets sessions that drop out of the snapshot", async () => {
@@ -369,4 +378,60 @@ test("formatNotification falls back to short id when title missing", () => {
   });
   assert.match(text, /sess-z/);
   assert.match(text, /#sess-z/);
+});
+
+test("formatted completion parses only Assistant output and escapes metadata", () => {
+  const message = formatTelegramNotificationMessage(doneEntry({
+    displayTitle: "<b>title</b> @username",
+    agentId: "agent<script>",
+    cwd: "/tmp/folder<a>",
+    assistantLastOutput: "**safe bold** <redacted:token>",
+  }), {
+    completionOutputMode: "full",
+    includeBare: true,
+    lang: "en",
+  });
+
+  assert.match(message.html, /<b>&lt;b&gt;title&lt;\/b&gt; ＠username<\/b>/);
+  assert.match(message.html, /agent&lt;script&gt;/);
+  assert.match(message.html, /folder&lt;a&gt;/);
+  assert.match(message.html, /<b>safe bold<\/b> &lt;redacted:token&gt;/);
+  assert.equal((message.html.match(/<a\b/g) || []).length, 0);
+  assert.ok(message.htmlVisibleLength <= 3600);
+  assert.ok(message.plainVisibleLength <= 3600);
+});
+
+test("formatted completion preserves the Assistant output budget and truncation state when composed", () => {
+  const horizontalRules = "---\n\n".repeat(180);
+  const source = horizontalRules + "word ".repeat(400).slice(0, 2599 - horizontalRules.length);
+  assert.equal(source.length, 2599, "fixture must stay below the pre-Markdown 2600 limit");
+
+  const message = formatTelegramNotificationMessage(doneEntry({
+    assistantLastOutput: source,
+  }), {
+    completionOutputMode: "full",
+    includeBare: true,
+    lang: "en",
+  });
+
+  const label = "Assistant output (truncated):\n";
+  const outputStart = message.plainText.indexOf(label);
+  assert.notEqual(outputStart, -1);
+  const renderedOutput = message.plainText.slice(outputStart + label.length);
+  assert.ok(renderedOutput.length <= 2600, "composed output must retain its inner budget");
+  assert.match(renderedOutput, /\n\.\.\. truncated$/);
+  assert.equal(message.truncated, true);
+  assert.ok(message.budgetLength <= 3600);
+});
+
+test("custom completion formatter keeps the legacy plain string contract", async () => {
+  const { comp, sent } = makeCompanion({
+    getNotifyOnComplete: () => true,
+    formatText: () => "<b>legacy wire</b>",
+  });
+  comp.onSnapshot({ sessions: [] });
+  comp.onSnapshot({ sessions: [doneEntry()] });
+  await tick();
+
+  assert.deepEqual(sent, ["<b>legacy wire</b>"]);
 });

--- a/test/telegram-elicitation.test.js
+++ b/test/telegram-elicitation.test.js
@@ -84,6 +84,7 @@ test("requestElicitation resolves elicitation-submit when a single-select questi
 
   server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
   server.enqueue("sendMessage", (payload) => {
+    assert.equal(payload.parse_mode, "HTML");
     optionData = payload.reply_markup.inline_keyboard[0][0].callback_data;
     return { ok: true, result: { message_id: 501, chat: { id: 123 } } };
   });
@@ -109,6 +110,7 @@ test("requestElicitation resolves elicitation-submit when a single-select questi
   const edit = server.calls.find((call) => call.method === "editMessageText");
   assert.ok(edit, "answering the last question rewrites the card with a submitted status");
   assert.match(edit.payload.text, /Submitted/);
+  assert.equal(edit.payload.parse_mode, "HTML");
   assert.equal(edit.payload.reply_markup, undefined);
 
   await runner.stop();
@@ -161,11 +163,13 @@ test("requestElicitation redacts secrets from the displayed question and returns
   const server = createFakeTelegramServer();
   let releaseFirstPoll;
   let sentText = "";
+  let sentParseMode = null;
   let optionData = "";
 
   server.enqueue("getUpdates", () => new Promise((resolve) => { releaseFirstPoll = resolve; }));
   server.enqueue("sendMessage", (payload) => {
     sentText = payload.text;
+    sentParseMode = payload.parse_mode;
     optionData = payload.reply_markup.inline_keyboard[0][0].callback_data;
     return { ok: true, result: { message_id: 601, chat: { id: 123 } } };
   });
@@ -180,7 +184,8 @@ test("requestElicitation redacts secrets from the displayed question and returns
   await runner.start();
   await tick();
   const decisionPromise = runner.requestElicitation({
-    title: "claude-code needs input",
+    title: "claude-code needs sk-titleabcdefghijklmnop",
+    detail: "detail sk-detailabcdefghijklmnop",
     questions: [
       { question: "Rotate sk-abcdefghijklmnop1234 from .env?", options: [{ label: "Yes" }, { label: "No" }] },
     ],
@@ -189,7 +194,10 @@ test("requestElicitation redacts secrets from the displayed question and returns
 
   // The card text sent to Telegram must not carry the key the agent quoted...
   assert.doesNotMatch(sentText, /sk-abcdefghijklmnop1234/);
+  assert.doesNotMatch(sentText, /sk-titleabcdefghijklmnop|sk-detailabcdefghijklmnop/);
   assert.match(sentText, /redacted:token/);
+  assert.doesNotMatch(sentText, /<a\b/);
+  assert.equal(sentParseMode, "HTML");
 
   releaseFirstPoll({ ok: true, result: [] });
   const decision = await decisionPromise;
@@ -771,4 +779,30 @@ test("requestElicitation resolves null when the initial card send fails", async 
   assert.equal(decision, null);
 
   await runner.stop();
+});
+
+test("requestElicitation plain-fallback preserves the initial keyboard and pending decision", async () => {
+  const server = createFakeTelegramServer();
+  server.enqueue("getUpdates", () => new Promise(() => {}));
+  server.enqueueError("sendMessage", {
+    status: 400,
+    description: "Bad Request: can't parse entities at byte offset 3",
+  });
+  server.enqueueOk("sendMessage", { message_id: 1401, chat: { id: 123 } });
+
+  const runner = makeRunner(server);
+  await runner.start();
+  await tick();
+  const decisionPromise = runner.requestElicitation(singleQuestionPayload());
+  await tick();
+
+  const sends = server.calls.filter((call) => call.method === "sendMessage");
+  assert.equal(sends.length, 2);
+  assert.equal(sends[0].payload.parse_mode, "HTML");
+  assert.equal(sends[1].payload.parse_mode, undefined);
+  assert.deepEqual(sends[1].payload.reply_markup, sends[0].payload.reply_markup);
+  assert.equal(runner._pendingElicitations.size, 1, "successful fallback must keep waiting for the answer");
+
+  await runner.stop();
+  assert.equal(await decisionPromise, null);
 });

--- a/test/telegram-message-format.test.js
+++ b/test/telegram-message-format.test.js
@@ -1,0 +1,212 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  appendTelegramStatus,
+  assertTelegramHtmlAllowlist,
+  buildTelegramApprovalMessage,
+  clipUtf16Safe,
+  isTelegramHtmlParseError,
+  neutralizeTelegramMentions,
+  plainTelegramText,
+  renderTelegramMarkdown,
+  sanitizeTelegramUrl,
+} = require("../src/telegram-message-format");
+
+test("renders a conservative Telegram HTML subset and readable plain fallback", () => {
+  const message = renderTelegramMarkdown([
+    "# Heading",
+    "",
+    "**bold** *italic* ~~strike~~ and `x < y`",
+    "",
+    "```js",
+    "const tag = '<b>not html</b>';",
+    "```",
+  ].join("\n"));
+
+  assert.match(message.html, /^<b>Heading<\/b>/);
+  assert.match(message.html, /<b>bold<\/b>/);
+  assert.match(message.html, /<i>italic<\/i>/);
+  assert.match(message.html, /<s>strike<\/s>/);
+  assert.match(message.html, /<code>x &lt; y<\/code>/);
+  assert.match(message.html, /<pre><code>const tag = '&lt;b&gt;not html&lt;\/b&gt;';<\/code><\/pre>/);
+  assert.match(message.plainText, /^Heading\n\nbold italic strike and x < y/);
+  assert.match(message.plainText, /const tag = '<b>not html<\/b>';/);
+  assert.equal(assertTelegramHtmlAllowlist(message.html), true);
+});
+
+test("redaction placeholders and raw Telegram tags remain escaped literal text", () => {
+  const markers = [
+    "<redacted:telegram-token>",
+    "<redacted:token>",
+    "<redacted:aws-key>",
+    "<redacted:secretish>",
+  ];
+  const message = renderTelegramMarkdown(`${markers.join(" ")} <tg-time unix="1">now</tg-time> <script>x</script>`);
+
+  for (const marker of markers) {
+    assert.match(message.html, new RegExp(marker.replace(/[<>]/g, (value) => value === "<" ? "&lt;" : "&gt;")));
+  }
+  assert.doesNotMatch(message.html, /<a\b/);
+  assert.match(message.html, /&lt;tg-time unix="1"&gt;now&lt;\/tg-time&gt;/);
+  assert.match(message.html, /&lt;script&gt;x&lt;\/script&gt;/);
+});
+
+test("allows only credential-free HTTP links and visibly degrades rejected links and images", () => {
+  const safe = renderTelegramMarkdown("[docs](https://example.com/a?x=1&y=2)");
+  assert.match(safe.html, /<a href="https:\/\/example\.com\/a\?x=1&amp;y=2">docs<\/a> \(example\.com\)/);
+  assert.match(safe.plainText, /docs \(https:\/\/example\.com\/a\?x=1&y=2\)/);
+
+  const mentionPath = renderTelegramMarkdown("[profile](https://example.com/@username)");
+  assert.match(mentionPath.html, /href="https:\/\/example\.com\/@username"/);
+  assert.match(mentionPath.plainText, /https:\/\/example\.com\/＠username/);
+  assert.doesNotMatch(mentionPath.plainText, /\/@username/);
+
+  const rejected = renderTelegramMarkdown([
+    "[script](javascript:alert(1))",
+    "[mention](tg://user?id=1)",
+    "[unsafe mention](javascript:@username)",
+    "[credential](https://user:secret@example.com/private)",
+    "![alt](https://example.com/@username/image.png)",
+  ].join("\n"));
+  assert.doesNotMatch(rejected.html, /<a\b/);
+  assert.match(rejected.plainText, /script \(javascript:alert\(1\)\)/);
+  assert.match(rejected.plainText, /mention \(tg:\/\/user\?id=1\)/);
+  assert.match(rejected.plainText, /unsafe mention \(javascript:＠username\)/);
+  assert.doesNotMatch(rejected.plainText, /user:secret/);
+  assert.match(rejected.plainText, /🖼 alt \(https:\/\/example\.com\/＠username\/image\.png\)/);
+
+  assert.equal(sanitizeTelegramUrl("https://example.com/x"), "https://example.com/x");
+  assert.equal(sanitizeTelegramUrl("mailto:user@example.com"), null);
+  assert.equal(sanitizeTelegramUrl("https://user:secret@example.com/x"), null);
+});
+
+test("maps breaks, tables, lists, and nested blockquotes without unsupported tags", () => {
+  const message = renderTelegramMarkdown([
+    "soft",
+    "break",
+    "",
+    "hard  ",
+    "break",
+    "",
+    "> outer",
+    "> > inner",
+    "",
+    "1. one",
+    "2. two",
+    "",
+    "| A | B |",
+    "|---|---|",
+    "| 1 | 2 |",
+  ].join("\n"));
+
+  assert.doesNotMatch(message.html, /<br\b/i);
+  assert.match(message.html, /soft\nbreak/);
+  assert.match(message.html, /hard\nbreak/);
+  assert.equal((message.html.match(/<blockquote>/g) || []).length, 1);
+  assert.equal((message.html.match(/<\/blockquote>/g) || []).length, 1);
+  assert.match(message.plainText, /> outer/);
+  assert.match(message.plainText, /> inner/);
+  assert.match(message.plainText, /1\. one\n2\. two/);
+  assert.match(message.html, /<pre>A \| B\n1 \| 2<\/pre>/);
+
+  const combined = renderTelegramMarkdown("> - item\n>\n> ```js\n> const x = '<tag>';\n> ```");
+  assert.equal((combined.html.match(/<blockquote>/g) || []).length, 1);
+  assert.doesNotMatch(combined.html, /<blockquote>[\s\S]*<pre>/, "block entities must not nest inside blockquotes");
+  assert.match(combined.html, /• item/);
+  assert.match(combined.html, /const x = '&lt;tag&gt;';/);
+});
+
+test("neutralizes username mentions only when requested and preserves code copy text", () => {
+  assert.equal(neutralizeTelegramMentions("ping @username, email test@example.com"), "ping ＠username, email test@example.com");
+  const message = renderTelegramMarkdown("ping @username, code `@username`, email test@example.com");
+  assert.match(message.html, /ping ＠username/);
+  assert.match(message.html, /<code>@username<\/code>/);
+  assert.match(message.plainText, /code @username/);
+
+  const fixed = plainTelegramText("fixed @username", { neutralizeMentions: false });
+  assert.equal(fixed.plainText, "fixed @username");
+});
+
+test("budgets HTML-visible and plain representations independently without splitting surrogate pairs", () => {
+  const quote = renderTelegramMarkdown("> one\n> two");
+  assert.ok(quote.plainVisibleLength > quote.htmlVisibleLength);
+  assert.equal(quote.budgetLength, quote.plainVisibleLength);
+
+  const dense = Array.from({ length: 20 }, (_, index) => (
+    `[L${index}](https://example.com/${"x".repeat(30)}/${index})`
+  )).join(" ");
+  const bounded = renderTelegramMarkdown(dense, { maxLength: 180, truncationMarker: "\n..." });
+  assert.equal(bounded.truncated, true);
+  assert.ok(bounded.htmlVisibleLength <= 180);
+  assert.ok(bounded.plainVisibleLength <= 180);
+  assert.equal(bounded.budgetLength, Math.max(bounded.htmlVisibleLength, bounded.plainVisibleLength));
+  assert.doesNotMatch(bounded.html, /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/u);
+
+  assert.equal(clipUtf16Safe("ab😀cd", 3), "ab");
+  assert.equal(clipUtf16Safe("ab😀cd", 4), "ab😀");
+});
+
+test("malformed Markdown and middle-cut fences always produce balanced allowlisted HTML", () => {
+  const fixtures = [
+    "**open [link](https://example.com",
+    "| table | without |\n| closing",
+    "```js\nconst x = '<tag>'",
+    "before\n```\ncut in the middle of a fence\n`",
+  ];
+  for (const fixture of fixtures) {
+    const message = renderTelegramMarkdown(fixture, { maxLength: 80 });
+    assert.equal(assertTelegramHtmlAllowlist(message.html), true);
+    for (const tag of ["b", "i", "s", "code", "pre", "blockquote", "a"]) {
+      assert.equal(
+        (message.html.match(new RegExp(`<${tag}(?:\\s[^>]*)?>`, "g")) || []).length,
+        (message.html.match(new RegExp(`</${tag}>`, "g")) || []).length,
+        `tag ${tag} must stay balanced`,
+      );
+    }
+  }
+});
+
+test("approval builder keeps dynamic fields escaped and appends status through the same contract", () => {
+  const message = buildTelegramApprovalMessage({
+    title: "Agent <b>asks</b> @username",
+    fields: [
+      { label: "Tool", value: "Bash <script>" },
+      { label: "Summary", value: "open tg://user?id=1" },
+    ],
+  });
+  assert.match(message.html, /^<b>Agent &lt;b&gt;asks&lt;\/b&gt; ＠username<\/b>/);
+  assert.match(message.html, /<b>Tool:<\/b> Bash &lt;script&gt;/);
+  assert.doesNotMatch(message.html, /<script>|<a\b/);
+
+  const resolved = appendTelegramStatus(message, "✅ Allowed");
+  assert.match(resolved.html, /<b>✅ Allowed<\/b>$/);
+  assert.match(resolved.plainText, /✅ Allowed$/);
+  assert.ok(resolved.budgetLength <= 3800);
+
+  const longBase = plainTelegramText("x".repeat(100), { maxLength: 100, truncationMarker: "..." });
+  const longResolved = appendTelegramStatus(longBase, "✅ Allowed", {
+    maxLength: 100,
+    truncationMarker: "...",
+  });
+  assert.equal(longResolved.truncated, true);
+  assert.ok(longResolved.budgetLength <= 100);
+  assert.match(longResolved.html, /<b>✅ Allowed<\/b>$/);
+  assert.match(longResolved.plainText, /✅ Allowed$/);
+});
+
+test("HTML parse fallback classifier is narrow", () => {
+  assert.equal(isTelegramHtmlParseError({ status: 400, description: "Bad Request: can't parse entities: Unsupported start tag" }), true);
+  assert.equal(isTelegramHtmlParseError({ code: "400", message: "BAD REQUEST: CAN'T PARSE ENTITIES at byte offset 7" }), true);
+  assert.equal(isTelegramHtmlParseError({ status: 400, description: "Bad Request: message is too long" }), false);
+  assert.equal(isTelegramHtmlParseError({ status: 400, description: "Bad Request: message is not modified" }), false);
+  assert.equal(isTelegramHtmlParseError({ status: 403, description: "can't parse entities" }), false);
+});
+
+test("hard allowlist assertion rejects unsupported tags and attributes", () => {
+  assert.throws(() => assertTelegramHtmlAllowlist("<br>"), /disallowed tag/);
+  assert.throws(() => assertTelegramHtmlAllowlist("<b class=\"x\">x</b>"), /attributes/);
+  assert.throws(() => assertTelegramHtmlAllowlist("<a onclick=\"x\">x</a>"), /link attribute/);
+});

--- a/test/telegram-native-runner.test.js
+++ b/test/telegram-native-runner.test.js
@@ -4,6 +4,7 @@ const assert = require("node:assert/strict");
 const test = require("node:test");
 
 const { createTelegramNativeRunner } = require("../src/telegram-native-runner");
+const { renderTelegramMarkdown } = require("../src/telegram-message-format");
 const { EVENTS } = require("../src/telegram-migration-state");
 const { createRemoteCardWorkRegistry } = require("../src/session-automation-remote");
 const { createFakeTelegramServer } = require("./fakes/telegram-server");
@@ -192,6 +193,7 @@ test("native runner requestApproval resolves allow for matching callback", async
   server.enqueue("sendMessage", (payload) => {
     assert.match(payload.text, /claude-code requests Bash/);
     assert.match(payload.text, /Summary: Run tests/);
+    assert.equal(payload.parse_mode, "HTML");
     const allCallbackData = payload.reply_markup.inline_keyboard
       .flatMap((row) => row)
       .map((button) => button.callback_data);
@@ -247,8 +249,9 @@ test("native runner requestApproval resolves allow for matching callback", async
   assert.ok(allowEdit, "tapping Allow rewrites the card body with the outcome");
   assert.equal(
     allowEdit.payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Allowed",
+    "<b>claude-code requests Bash</b>\n\nSummary: Run tests\n\n<b>\u2705 Allowed</b>",
   );
+  assert.equal(allowEdit.payload.parse_mode, "HTML");
   assert.equal(allowEdit.payload.reply_markup, undefined);
   await runner.stop();
 });
@@ -691,7 +694,9 @@ test("native runner aborts a hung session-trust confirmation edit at its deadlin
   let trustOpenData = "";
   let pollCount = 0;
   let editAborted = false;
+  const calls = [];
   const transport = async ({ method, payload, signal }) => {
+    calls.push({ method, payload, signal });
     if (method === "sendMessage") {
       trustOpenData = payload.reply_markup.inline_keyboard.at(-1)[0].callback_data;
       return { ok: true, result: { message_id: 503, chat: { id: 123 } } };
@@ -762,6 +767,90 @@ test("native runner aborts a hung session-trust confirmation edit at its deadlin
 
   assert.equal(editAborted, true);
   assert.equal(runner._pendingApprovals.size, 1, "the ordinary approval remains pending");
+  assert.equal(
+    Array.from(runner._pendingApprovals.values())[0].trustConfirming,
+    false,
+    "failed confirmation edit must roll back the hidden trust-confirming state",
+  );
+  assert.equal(
+    calls.some((call) => call.method === "answerCallbackQuery" && call.payload.text === "Unavailable"),
+    true,
+    "the user must receive existing unavailable feedback instead of losing the keyboard",
+  );
+  const confirmationEdit = calls.find((call) => call.method === "editMessageText");
+  assert.equal(confirmationEdit.payload.parse_mode, "HTML");
+  await runner.stop();
+  assert.equal(await decisionPromise, null);
+});
+
+test("session-trust return failure keeps confirmation state and shows unavailable feedback", async () => {
+  let releaseFirstPoll;
+  let trustOpenData = "";
+  let pollCount = 0;
+  let editCount = 0;
+  const calls = [];
+  const transport = async ({ method, payload, signal }) => {
+    calls.push({ method, payload, signal });
+    if (method === "sendMessage") {
+      trustOpenData = payload.reply_markup.inline_keyboard.at(-1)[0].callback_data;
+      return { ok: true, result: { message_id: 504, chat: { id: 123 } } };
+    }
+    if (method === "getUpdates") {
+      pollCount += 1;
+      if (pollCount === 1) return new Promise((resolve) => { releaseFirstPoll = resolve; });
+      if (pollCount === 2) {
+        const id = trustOpenData.match(/^ct:([a-z0-9]+):open$/)[1];
+        const message = { message_id: 504, chat: { id: 123 } };
+        const from = { id: 777 };
+        return {
+          ok: true,
+          result: [
+            { update_id: 1, callback_query: { id: "return-open", from, message, data: trustOpenData } },
+            { update_id: 2, callback_query: { id: "return-no", from, message, data: `ct:${id}:no` } },
+          ],
+        };
+      }
+      return new Promise((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(Object.assign(new Error("aborted"), { name: "AbortError" })), { once: true });
+      });
+    }
+    if (method === "editMessageText") {
+      editCount += 1;
+      if (editCount === 2) {
+        return { ok: false, status: 400, error_code: 400, description: "Bad Request: message can't be edited" };
+      }
+      return { ok: true, result: { message_id: 504 } };
+    }
+    return { ok: true, result: true };
+  };
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+
+  await runner.start();
+  await tick();
+  const decisionPromise = runner.requestApproval({
+    title: "claude-code requests Bash",
+    detail: "Summary: Run tests",
+    canOfferSessionTrust: true,
+  });
+  await tick();
+  releaseFirstPoll({ ok: true, result: [] });
+  await tick();
+  await tick();
+
+  const entry = Array.from(runner._pendingApprovals.values())[0];
+  assert.equal(entry.trustConfirming, true, "the visible confirmation card must remain the state truth");
+  assert.equal(
+    calls.some((call) => call.method === "answerCallbackQuery" && call.payload.text === "Unavailable"),
+    true,
+  );
+  assert.equal(calls.some((call) => call.method === "editMessageReplyMarkup"), false);
+
   await runner.stop();
   assert.equal(await decisionPromise, null);
 });
@@ -915,8 +1004,9 @@ test("native runner claims a Telegram tap atomically so a racing abort can't dro
   assert.equal(edits.length, 1, "the late abort must not fire a second, conflicting card rewrite");
   assert.equal(
     edits[0].payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Allowed",
+    "<b>claude-code requests Bash</b>\n\nSummary: Run tests\n\n<b>\u2705 Allowed</b>",
   );
+  assert.equal(edits[0].payload.parse_mode, "HTML");
   await runner.stop();
 });
 
@@ -1047,8 +1137,9 @@ test("native runner rejects forged suggestion callbacks and waits for a valid de
   assert.equal(edits.length, 1, "only the valid decision rewrites the card");
   assert.equal(
     edits[0].payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Applied",
+    "<b>claude-code requests Bash</b>\n\nSummary: Run tests\n\n<b>\u2705 Applied</b>",
   );
+  assert.equal(edits[0].payload.parse_mode, "HTML");
   await runner.stop();
 });
 
@@ -1120,8 +1211,9 @@ test("native runner requestApproval ignores wrong user and resolves later callba
   assert.ok(denyEdit, "tapping Deny rewrites the card body with the outcome");
   assert.equal(
     denyEdit.payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u274C Denied",
+    "<b>claude-code requests Bash</b>\n\nSummary: Run tests\n\n<b>\u274C Denied</b>",
   );
+  assert.equal(denyEdit.payload.parse_mode, "HTML");
   await runner.stop();
 });
 
@@ -1265,8 +1357,9 @@ test("native runner rewrites approval card with status when resolved outside Tel
   assert.equal(editCalls[0].payload.message_id, 99);
   assert.equal(
     editCalls[0].payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u2705 Resolved outside Telegram",
+    "<b>claude-code requests Bash</b>\n\nSummary: Run tests\n\n<b>\u2705 Resolved outside Telegram</b>",
   );
+  assert.equal(editCalls[0].payload.parse_mode, "HTML");
   assert.equal(
     editCalls[0].payload.reply_markup,
     undefined,
@@ -1315,8 +1408,9 @@ test("native runner appends timeout status when an approval expires", async () =
   assert.equal(editCalls[0].payload.message_id, 77);
   assert.equal(
     editCalls[0].payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u23F3 Timed out",
+    "<b>claude-code requests Bash</b>\n\nSummary: Run tests\n\n<b>\u23F3 Timed out</b>",
   );
+  assert.equal(editCalls[0].payload.parse_mode, "HTML");
 
   releaseFirstPoll({ ok: true, result: [] });
   await runner.stop();
@@ -1354,8 +1448,9 @@ test("native runner appends session-ended status when polling stops with a pendi
   assert.equal(editCalls[0].payload.message_id, 55);
   assert.equal(
     editCalls[0].payload.text,
-    "claude-code requests Bash\n\nSummary: Run tests\n\n\u23F9\uFE0F Session ended",
+    "<b>claude-code requests Bash</b>\n\nSummary: Run tests\n\n<b>\u23F9\uFE0F Session ended</b>",
   );
+  assert.equal(editCalls[0].payload.parse_mode, "HTML");
 });
 
 test("native runner falls back to stripping the keyboard when the status rewrite fails", async () => {
@@ -1414,6 +1509,84 @@ test("native runner requestApproval is disabled until polling with a valid paylo
   assert.equal(await runner.requestApproval({ title: "", detail: "y" }), null);
 });
 
+test("requestApproval plain-fallback preserves the keyboard and does not decide automatically", async () => {
+  const server = createFakeTelegramServer();
+  const controller = new AbortController();
+  server.enqueue("getUpdates", () => new Promise(() => {}));
+  server.enqueueError("sendMessage", {
+    status: 400,
+    description: "Bad Request: can't parse entities: Unsupported start tag",
+  });
+  server.enqueueOk("sendMessage", { message_id: 141, chat: { id: 123 } });
+  server.enqueueOk("editMessageText", { message_id: 141 });
+
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport: server.transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+  await runner.start();
+  await tick();
+
+  const decisionPromise = runner.requestApproval({
+    title: "claude-code requests Bash",
+    detail: "Summary: Run tests",
+  }, { signal: controller.signal });
+  await tick();
+
+  const sends = server.calls.filter((call) => call.method === "sendMessage");
+  assert.equal(sends.length, 2);
+  assert.equal(sends[0].payload.parse_mode, "HTML");
+  assert.equal(sends[1].payload.parse_mode, undefined);
+  assert.deepEqual(sends[1].payload.reply_markup, sends[0].payload.reply_markup);
+  assert.equal(runner._pendingApprovals.size, 1);
+
+  controller.abort();
+  assert.equal(await decisionPromise, null);
+  await runner.stop();
+});
+
+test("requestApproval does not start a plain fallback after the caller aborts on the HTML failure", async () => {
+  const controller = new AbortController();
+  const calls = [];
+  const transport = async ({ method, payload }) => {
+    calls.push({ method, payload });
+    if (method === "getUpdates") return new Promise(() => {});
+    if (method === "sendMessage") {
+      controller.abort();
+      return {
+        ok: false,
+        status: 400,
+        error_code: 400,
+        description: "Bad Request: can't parse entities: Unsupported start tag",
+      };
+    }
+    return { ok: true, result: true };
+  };
+  const runner = createTelegramNativeRunner({
+    tokenStore: tokenStore(),
+    transport,
+    getDispatch: () => async () => {},
+    getChatId: () => "123",
+    getAllowedUserId: () => "777",
+  });
+  await runner.start();
+  await tick();
+
+  const decision = await runner.requestApproval({
+    title: "claude-code requests Bash",
+    detail: "Summary: Run tests",
+  }, { signal: controller.signal });
+
+  assert.equal(decision, null);
+  const sends = calls.filter((call) => call.method === "sendMessage");
+  assert.equal(sends.length, 1, "aborted requests must not start the rendered-plain retry");
+  assert.equal(sends[0].payload.parse_mode, "HTML");
+  await runner.stop();
+});
+
 // ── R1a sendNotification ──────────────────────────────────────────────────
 
 // Start polling against a getUpdates that never resolves so `polling` stays
@@ -1443,7 +1616,82 @@ test("sendNotification posts a plain message with no inline keyboard", async () 
   const send = server.calls.find((c) => c.method === "sendMessage");
   assert.equal(send.payload.chat_id, "123");
   assert.equal(send.payload.text, "done: task X");
+  assert.equal(send.payload.parse_mode, undefined, "legacy strings must keep the existing wire contract");
   assert.equal(send.payload.reply_markup, undefined);
+  await runner.stop();
+});
+
+test("sendNotification sends formatted messages as HTML", async () => {
+  const server = createFakeTelegramServer();
+  const runner = await startPolling(server);
+  server.enqueueOk("sendMessage", { message_id: 8 });
+
+  const message = renderTelegramMarkdown("**done** <redacted:token>");
+  const res = await runner.sendNotification(message);
+  assert.deepEqual(res, { ok: true, messageId: 8 });
+  const send = server.calls.find((call) => call.method === "sendMessage");
+  assert.equal(send.payload.parse_mode, "HTML");
+  assert.equal(send.payload.text, "<b>done</b> &lt;redacted:token&gt;");
+  await runner.stop();
+});
+
+test("sendNotification retries rendered plain text only for entity-parser 400", async () => {
+  const server = createFakeTelegramServer();
+  const runner = await startPolling(server);
+  server.enqueueError("sendMessage", {
+    status: 400,
+    description: "Bad Request: can't parse entities: Unsupported start tag at byte offset 0",
+  });
+  server.enqueueOk("sendMessage", { message_id: 81 });
+
+  const message = renderTelegramMarkdown("**done**");
+  const res = await runner.sendNotification(message);
+  assert.deepEqual(res, { ok: true, messageId: 81 });
+  const sends = server.calls.filter((call) => call.method === "sendMessage");
+  assert.equal(sends.length, 2);
+  assert.equal(sends[0].payload.parse_mode, "HTML");
+  assert.equal(sends[0].payload.text, "<b>done</b>");
+  assert.equal(sends[1].payload.parse_mode, undefined);
+  assert.equal(sends[1].payload.text, "done");
+  await runner.stop();
+});
+
+test("sendNotification does not plain-retry unrelated 400 responses", async () => {
+  const server = createFakeTelegramServer();
+  const runner = await startPolling(server);
+  server.enqueueError("sendMessage", {
+    status: 400,
+    description: "Bad Request: message is too long",
+  });
+
+  const res = await runner.sendNotification(renderTelegramMarkdown("**done**"));
+  assert.deepEqual(res, { ok: false, errorClass: "400" });
+  assert.equal(server.calls.filter((call) => call.method === "sendMessage").length, 1);
+  await runner.stop();
+});
+
+test("sendNotification keeps the post-429 retry plain after HTML parse fallback", async () => {
+  const server = createFakeTelegramServer();
+  const slept = [];
+  const runner = await startPolling(server, {
+    sleep: async (ms) => { slept.push(ms); },
+  });
+  server.enqueueError("sendMessage", {
+    status: 400,
+    description: "Bad Request: CAN'T PARSE ENTITIES at byte offset 4",
+  });
+  server.enqueueError("sendMessage", { status: 429, parameters: { retry_after: 1 } });
+  server.enqueueOk("sendMessage", { message_id: 82 });
+
+  const res = await runner.sendNotification(renderTelegramMarkdown("**done**"));
+  assert.deepEqual(res, { ok: true, messageId: 82 });
+  assert.deepEqual(slept, [1000]);
+  const sends = server.calls.filter((call) => call.method === "sendMessage");
+  assert.equal(sends.length, 3);
+  assert.equal(sends[0].payload.parse_mode, "HTML");
+  assert.equal(sends[1].payload.parse_mode, undefined);
+  assert.equal(sends[2].payload.parse_mode, undefined);
+  assert.equal(sends[2].payload.text, "done");
   await runner.stop();
 });
 


### PR DESCRIPTION
## Summary

- render Assistant completion Markdown through a conservative Telegram HTML allowlist
- keep approval, session-trust, and elicitation cards structured while escaping dynamic values
- retry the already-rendered plain message only for Telegram entity-parse errors
- preserve legacy plain-string notifications, Direct Send, retry, authorization, and no-auto-decision behavior
- pin markdown-it 15.0.0 and document the formatting contract

## Verification

- focused Telegram suites: 158 passed, 0 failed
- full npm test: 6787 passed, 0 failed, 21 skipped
- macOS arm64 directory package built successfully
- packaged asar loads the pinned formatter dependency and passes the structural-expansion truncation repro

## Remaining manual validation

- [ ] packaged Windows app with a real Telegram bot
- [ ] completion notification fixture on Telegram Desktop and one mobile client
- [ ] approval and session-trust lifecycle edits
- [ ] elicitation navigation and answer-value fidelity
- [ ] mention neutralization and plain fallback behavior

Closes #766