### PR TITLE
fix(focus): raise Cursor/Code when window title lacks project folder

### DIFF
--- a/src/focus.js
+++ b/src/focus.js
@@ -289,6 +289,10 @@ function makeFocusCmd(sourcePid, cwdCandidates, focusCacheKey = null, wtHwnd = n
                 }
             }
         } elseif ($editorProcessNames -contains $proc.ProcessName) {
+            # Cursor / VS Code: prefer a window whose title contains the project
+            # folder. Glass / Agents windows often title themselves "Cursor Agents"
+            # (or a chat name) with no cwd — falling back to the process's visible
+            # window / MainWindowHandle is what users expect from a HUD click.
             $matches = @([WinFocus]::FindByPidTitles([uint32]$curPid, [string[]]$cacheTitleNames))
             if ($matches.Count -eq 1) {
                 [WinFocus]::Focus($matches[0])
@@ -299,7 +303,22 @@ function makeFocusCmd(sourcePid, cwdCandidates, focusCacheKey = null, wtHwnd = n
             } elseif ($matches.Count -gt 1) {
                 $reason = 'editor-parent-title-ambiguous'
             } else {
-                $reason = 'editor-parent-no-title-match'
+                $pidWindows = @(Get-ClawdVisiblePidWindows -pids @([int]$curPid))
+                if ($pidWindows.Count -eq 1) {
+                    [WinFocus]::Focus($pidWindows[0])
+                    $selectedTargetHwnd = $pidWindows[0]
+                    $focused = $true
+                    $reason = 'editor-parent-pid-window'
+                } elseif ($pidWindows.Count -gt 1) {
+                    $reason = 'editor-parent-pid-window-ambiguous'
+                } elseif ($proc.MainWindowHandle -ne [IntPtr]::Zero) {
+                    [WinFocus]::Focus($proc.MainWindowHandle)
+                    $selectedTargetHwnd = $proc.MainWindowHandle
+                    $focused = $true
+                    $reason = 'editor-parent-main-window'
+                } else {
+                    $reason = 'editor-parent-no-title-match'
+                }
             }
         } else {
             [WinFocus]::Focus($proc.MainWindowHandle)
@@ -310,7 +329,25 @@ function makeFocusCmd(sourcePid, cwdCandidates, focusCacheKey = null, wtHwnd = n
         }
         break` : `
         if ($editorProcessNames -contains $proc.ProcessName) {
-            $reason = 'editor-parent-no-title'
+            # No cwd title candidates: still raise the IDE window. Clicking a
+            # Cursor / Claude-in-Cursor session should bring the app forward even
+            # when we cannot pick a project-specific window by title.
+            $pidWindows = @(Get-ClawdVisiblePidWindows -pids @([int]$curPid))
+            if ($pidWindows.Count -eq 1) {
+                [WinFocus]::Focus($pidWindows[0])
+                $selectedTargetHwnd = $pidWindows[0]
+                $focused = $true
+                $reason = 'editor-parent-pid-window-no-title'
+            } elseif ($pidWindows.Count -gt 1) {
+                $reason = 'editor-parent-pid-window-ambiguous-no-title'
+            } elseif ($proc.MainWindowHandle -ne [IntPtr]::Zero) {
+                [WinFocus]::Focus($proc.MainWindowHandle)
+                $selectedTargetHwnd = $proc.MainWindowHandle
+                $focused = $true
+                $reason = 'editor-parent-main-window-no-title'
+            } else {
+                $reason = 'editor-parent-no-title'
+            }
         } elseif ($wtProcessNames -notcontains $proc.ProcessName) {
             [WinFocus]::Focus($proc.MainWindowHandle)
             $selectedTargetHwnd = $proc.MainWindowHandle
@@ -636,6 +673,10 @@ const WINDOWS_FOCUS_POSITIVE_REASONS = new Set([
   "parent-direct",
   "parent-direct-no-title",
   "editor-parent-title-match",
+  "editor-parent-pid-window",
+  "editor-parent-main-window",
+  "editor-parent-pid-window-no-title",
+  "editor-parent-main-window-no-title",
   "wt-parent-title-match",
   "wt-title-match",
 ]);

--- a/test/focus-windows.test.js
+++ b/test/focus-windows.test.js
@@ -86,8 +86,27 @@ describe("Windows terminal focus", () => {
       assert.match(cmd, /\$editorProcessNames = @\('Code', 'Cursor'\)/);
       assert.match(cmd, /editor-parent-title-match/);
       assert.match(cmd, /editor-parent-title-ambiguous/);
+      // Cursor/Code windows often lack the project folder in the title
+      // ("Cursor Agents"); fall back to the process window instead of no-op.
+      assert.match(cmd, /editor-parent-pid-window/);
+      assert.match(cmd, /editor-parent-main-window/);
       assert.match(cmd, /editor-parent-no-title-match/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("raises Cursor/Code MainWindowHandle when no cwd title candidates exist", () => {
+    const { initFocus, cleanup } = loadFocusWithMock();
+    try {
+      const focus = initFocus({});
+      const cmd = focus.__test.makeFocusCmd(1234, []);
+
+      assert.match(cmd, /\$editorProcessNames = @\('Code', 'Cursor'\)/);
+      assert.match(cmd, /editor-parent-pid-window-no-title/);
+      assert.match(cmd, /editor-parent-main-window-no-title/);
       assert.match(cmd, /editor-parent-no-title/);
+      assert.doesNotMatch(cmd, /editor-parent-title-match/);
     } finally {
       cleanup();
     }


### PR DESCRIPTION
## Summary
- Clicking a Cursor Agent session in the HUD/Dashboard currently dispatches focus but ends in `editor-parent-no-title-match` (no-op).
- Cursor Glass windows often use titles like `Cursor Agents` instead of the project folder name (`siga-horas`), so title matching never hits.
- Fall back to the editor process visible window / `MainWindowHandle` for `Code` / `Cursor` parents — same idea as Windows Terminal's pid-window fallback.

## Evidence
From `%APPDATA%\clawd-on-desk\focus-debug.log`:
```
agent=cursor-agent sourcePid=28040 cwdTail=...\siga-horas
reason=editor-parent-no-title-match status=unconfirmed
```
Process 28040's `MainWindowTitle` is `Cursor Agents`.

## Test plan
- [x] `node --test test/focus-windows.test.js`
- [ ] Manual (Windows): click Cursor Agent row in Session HUD → Cursor comes to front
- [ ] Manual: VS Code / Claude-in-editor session with mismatched title still raises the IDE