### PR TITLE
feat(dashboard): persist Sessions/Dashboard window bounds

### DIFF
--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -246,15 +246,16 @@ module.exports = function initDashboard(ctx) {
     const placement = getDashboardPlacement(options);
     if (isUsableBounds(placement.bounds) && typeof dashboardWindow.setBounds === "function") {
       dashboardWindow.setBounds(placement.bounds);
+      // The anchored placement can land the window on a display with a
+      // different textScale; re-zoom right away (memoized — cheap no-op when
+      // nothing changed). This can grow the window to that display's scaled
+      // minimum, so it must run before the baseline capture below.
+      applyTextScaleToWindow();
       // Programmatic anchoring is not user geometry: rebase the persistence
       // baseline (and drop any pending save) so re-anchoring never overwrites
       // the user's saved standalone position.
       clearSaveBoundsTimer();
       lastSavedBounds = getNormalWindowBounds(dashboardWindow) || placement.bounds;
-      // The anchored placement can land the window on a display with a
-      // different textScale; re-zoom right away (memoized — cheap no-op when
-      // nothing changed).
-      applyTextScaleToWindow();
     }
   }
 

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -396,6 +396,13 @@ module.exports = function initDashboard(ctx) {
   function showDashboard(options = {}) {
     if (dashboardWindow && !dashboardWindow.isDestroyed()) {
       if (dashboardWindow.isMinimized()) dashboardWindow.restore();
+      // A debounce still pending on an open window holds the user's own last
+      // move. The re-anchor below drops that timer and rebases the baseline,
+      // so without flushing first the placement is lost for good — the close
+      // flush cannot recover it once the baseline matches the anchor.
+      if (options.source === "settings" && saveBoundsTimer) {
+        persistWindowBoundsNow(dashboardWindow);
+      }
       applySettingsPlacement(options);
       dashboardWindow.show();
       scheduleSettingsPlacementSync(options);

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -8,6 +8,7 @@ const DEFAULT_WIDTH = 480;
 const DEFAULT_HEIGHT = 600;
 const MIN_WIDTH = 320;
 const MIN_HEIGHT = 400;
+const BOUNDS_SAVE_DEBOUNCE_MS = 500;
 const LIGHT_BACKGROUND = "#f5f5f7";
 const DARK_BACKGROUND = "#1c1c1f";
 
@@ -40,9 +41,105 @@ function clampBoundsToWorkArea(bounds, workArea) {
   };
 }
 
+function roundedBounds(bounds) {
+  if (!isUsableBounds(bounds)) return null;
+  const normalized = {
+    x: Math.round(bounds.x),
+    y: Math.round(bounds.y),
+    width: Math.round(bounds.width),
+    height: Math.round(bounds.height),
+  };
+  return isUsableBounds(normalized) ? normalized : null;
+}
+
+function sameBounds(a, b) {
+  return !!a
+    && !!b
+    && a.x === b.x
+    && a.y === b.y
+    && a.width === b.width
+    && a.height === b.height;
+}
+
 module.exports = function initDashboard(ctx) {
   let dashboardWindow = null;
+  let saveBoundsTimer = null;
+  let lastSavedBounds = null;
   const scheduleLater = typeof ctx.setTimeout === "function" ? ctx.setTimeout : setTimeout;
+  const clearScheduled = typeof ctx.clearTimeout === "function" ? ctx.clearTimeout : clearTimeout;
+
+  function scheduleTimer(callback, delayMs) {
+    const timer = scheduleLater(callback, delayMs);
+    if (timer && typeof timer.unref === "function") timer.unref();
+    return timer;
+  }
+
+  function clearSaveBoundsTimer() {
+    if (!saveBoundsTimer) return;
+    clearScheduled(saveBoundsTimer);
+    saveBoundsTimer = null;
+  }
+
+  function getSavedDashboardBounds() {
+    if (typeof ctx.getSavedBounds !== "function") return null;
+    try { return roundedBounds(ctx.getSavedBounds()); } catch { return null; }
+  }
+
+  function getNormalWindowBounds(win) {
+    if (!win || (typeof win.isDestroyed === "function" && win.isDestroyed())) return null;
+    try {
+      if (typeof win.getNormalBounds === "function") {
+        const bounds = roundedBounds(win.getNormalBounds());
+        if (bounds) return bounds;
+      }
+    } catch {}
+    try {
+      return typeof win.getBounds === "function" ? roundedBounds(win.getBounds()) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function persistWindowBoundsNow(win) {
+    clearSaveBoundsTimer();
+    if (typeof ctx.onSaveBounds !== "function") return false;
+    const bounds = getNormalWindowBounds(win);
+    if (!bounds || sameBounds(bounds, lastSavedBounds)) return false;
+    try {
+      const result = ctx.onSaveBounds(bounds);
+      if (result && typeof result.then === "function") {
+        const attemptedBounds = bounds;
+        Promise.resolve(result).then(
+          (response) => {
+            if (!response || response.status !== "error") return;
+            if (sameBounds(lastSavedBounds, attemptedBounds)) lastSavedBounds = null;
+            console.warn("Clawd: failed to persist Dashboard window bounds:", response.message);
+          },
+          (err) => {
+            if (sameBounds(lastSavedBounds, attemptedBounds)) lastSavedBounds = null;
+            console.warn("Clawd: failed to persist Dashboard window bounds:", err && err.message);
+          },
+        );
+      } else if (result && result.status === "error") {
+        console.warn("Clawd: failed to persist Dashboard window bounds:", result.message);
+        return false;
+      }
+      lastSavedBounds = bounds;
+      return true;
+    } catch (err) {
+      console.warn("Clawd: failed to persist Dashboard window bounds:", err && err.message);
+      return false;
+    }
+  }
+
+  function scheduleWindowBoundsSave(win) {
+    if (typeof ctx.onSaveBounds !== "function") return;
+    clearSaveBoundsTimer();
+    saveBoundsTimer = scheduleTimer(() => {
+      saveBoundsTimer = null;
+      persistWindowBoundsNow(win);
+    }, BOUNDS_SAVE_DEBOUNCE_MS);
+  }
 
   function getCurrentSnapshot() {
     return typeof ctx.getSessionSnapshot === "function"
@@ -66,15 +163,24 @@ module.exports = function initDashboard(ctx) {
   }
 
   function computeInitialBounds() {
-    const petBounds = typeof ctx.getPetWindowBounds === "function"
+    const savedBounds = getSavedDashboardBounds();
+    const petBounds = !savedBounds && typeof ctx.getPetWindowBounds === "function"
       ? ctx.getPetWindowBounds()
       : null;
-    const cx = petBounds ? petBounds.x + petBounds.width / 2 : 0;
-    const cy = petBounds ? petBounds.y + petBounds.height / 2 : 0;
+    const anchor = savedBounds || petBounds;
+    const cx = anchor ? anchor.x + anchor.width / 2 : 0;
+    const cy = anchor ? anchor.y + anchor.height / 2 : 0;
     const workArea = typeof ctx.getNearestWorkArea === "function"
       ? ctx.getNearestWorkArea(cx, cy)
       : { x: 0, y: 0, width: 1280, height: 800 };
     const metrics = getScaledMetrics();
+    if (savedBounds) {
+      return clampBoundsToWorkArea({
+        ...savedBounds,
+        width: Math.max(savedBounds.width, metrics.minWidth),
+        height: Math.max(savedBounds.height, metrics.minHeight),
+      }, workArea);
+    }
     const width = Math.min(metrics.defaultWidth, Math.max(metrics.minWidth, workArea.width));
     const height = Math.min(metrics.defaultHeight, Math.max(metrics.minHeight, workArea.height));
     return {
@@ -140,6 +246,11 @@ module.exports = function initDashboard(ctx) {
     const placement = getDashboardPlacement(options);
     if (isUsableBounds(placement.bounds) && typeof dashboardWindow.setBounds === "function") {
       dashboardWindow.setBounds(placement.bounds);
+      // Programmatic anchoring is not user geometry: rebase the persistence
+      // baseline (and drop any pending save) so re-anchoring never overwrites
+      // the user's saved standalone position.
+      clearSaveBoundsTimer();
+      lastSavedBounds = getNormalWindowBounds(dashboardWindow) || placement.bounds;
       // The anchored placement can land the window on a display with a
       // different textScale; re-zoom right away (memoized — cheap no-op when
       // nothing changed).
@@ -195,18 +306,42 @@ module.exports = function initDashboard(ctx) {
     if (ctx.iconPath) opts.icon = ctx.iconPath;
 
     dashboardWindow = new BrowserWindow(opts);
+    // BrowserWindow's constructor can quantize framed window geometry at
+    // fractional Windows DPI. Re-apply the requested outer bounds before
+    // listeners are attached, and treat the post-correction rectangle as the
+    // persistence baseline: closing an untouched window must not rewrite
+    // prefs, and native frame drift must not accumulate across reopens.
+    try {
+      const createdBounds = typeof dashboardWindow.getBounds === "function"
+        ? roundedBounds(dashboardWindow.getBounds())
+        : null;
+      if (
+        createdBounds
+        && !sameBounds(createdBounds, placement.bounds)
+        && typeof dashboardWindow.setBounds === "function"
+      ) {
+        dashboardWindow.setBounds(placement.bounds);
+      }
+    } catch {}
+    lastSavedBounds = getNormalWindowBounds(dashboardWindow) || placement.bounds;
     dashboardWindow.setMenuBarVisibility(false);
     dashboardWindow.loadFile(path.join(__dirname, "dashboard.html"));
     // textScale is per-display: re-resolve after the user drags the window
     // somewhere else (debounced — "move" fires continuously during drags).
     let moveTextScaleTimer = null;
+    const createdWindow = dashboardWindow;
     dashboardWindow.on("move", () => {
       if (moveTextScaleTimer) clearTimeout(moveTextScaleTimer);
       moveTextScaleTimer = scheduleLater(() => {
         moveTextScaleTimer = null;
         applyTextScaleToWindow();
       }, 350);
+      scheduleWindowBoundsSave(createdWindow);
     });
+    dashboardWindow.on("resize", () => scheduleWindowBoundsSave(createdWindow));
+    // `closed` is too late to query native geometry. Flush while the window
+    // is still live so a pending debounce cannot lose the user's last move.
+    dashboardWindow.on("close", () => persistWindowBoundsNow(createdWindow));
     dashboardWindow.webContents.once("did-finish-load", () => {
       applyZoomToWindow(dashboardWindow, getTextScale());
       sendI18n();
@@ -220,6 +355,7 @@ module.exports = function initDashboard(ctx) {
       dashboardWindow.focus();
     });
     dashboardWindow.on("closed", () => {
+      clearSaveBoundsTimer();
       dashboardWindow = null;
     });
     return dashboardWindow;

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -16,6 +16,8 @@ function getDashboardBackgroundColor() {
   return nativeTheme.shouldUseDarkColors ? DARK_BACKGROUND : LIGHT_BACKGROUND;
 }
 
+const FALLBACK_WORK_AREA = { x: 0, y: 0, width: 1280, height: 800 };
+
 function isUsableBounds(bounds) {
   return !!bounds
     && Number.isFinite(bounds.x)
@@ -24,6 +26,12 @@ function isUsableBounds(bounds) {
     && Number.isFinite(bounds.height)
     && bounds.width > 0
     && bounds.height > 0;
+}
+
+// Displays can transiently report zero-size work areas during unplug or
+// session reconnect; a degenerate rect would collapse the window to nothing.
+function normalizeWorkArea(workArea) {
+  return isUsableBounds(workArea) ? workArea : FALLBACK_WORK_AREA;
 }
 
 function clampBoundsToWorkArea(bounds, workArea) {
@@ -83,6 +91,15 @@ module.exports = function initDashboard(ctx) {
   function getSavedDashboardBounds() {
     if (typeof ctx.getSavedBounds !== "function") return null;
     try { return roundedBounds(ctx.getSavedBounds()); } catch { return null; }
+  }
+
+  function getWorkAreaNear(cx, cy) {
+    if (typeof ctx.getNearestWorkArea !== "function") return FALLBACK_WORK_AREA;
+    try {
+      return normalizeWorkArea(ctx.getNearestWorkArea(cx, cy));
+    } catch {
+      return FALLBACK_WORK_AREA;
+    }
   }
 
   function getNormalWindowBounds(win) {
@@ -166,15 +183,14 @@ module.exports = function initDashboard(ctx) {
 
   function computeInitialBounds() {
     const savedBounds = getSavedDashboardBounds();
-    const petBounds = !savedBounds && typeof ctx.getPetWindowBounds === "function"
-      ? ctx.getPetWindowBounds()
-      : null;
+    let petBounds = null;
+    if (!savedBounds && typeof ctx.getPetWindowBounds === "function") {
+      try { petBounds = ctx.getPetWindowBounds(); } catch { petBounds = null; }
+    }
     const anchor = savedBounds || petBounds;
     const cx = anchor ? anchor.x + anchor.width / 2 : 0;
     const cy = anchor ? anchor.y + anchor.height / 2 : 0;
-    const workArea = typeof ctx.getNearestWorkArea === "function"
-      ? ctx.getNearestWorkArea(cx, cy)
-      : { x: 0, y: 0, width: 1280, height: 800 };
+    const workArea = getWorkAreaNear(cx, cy);
     const metrics = getScaledMetrics(savedBounds || workArea);
     if (savedBounds) {
       return clampBoundsToWorkArea({
@@ -211,9 +227,7 @@ module.exports = function initDashboard(ctx) {
   function computeSettingsAnchoredBounds(settingsBounds) {
     const cx = settingsBounds.x + settingsBounds.width / 2;
     const cy = settingsBounds.y + settingsBounds.height / 2;
-    const workArea = typeof ctx.getNearestWorkArea === "function"
-      ? ctx.getNearestWorkArea(cx, cy)
-      : { x: 0, y: 0, width: 1280, height: 800 };
+    const workArea = getWorkAreaNear(cx, cy);
     const metrics = getScaledMetrics(settingsBounds);
     const width = Math.max(metrics.minWidth, Math.min(metrics.defaultWidth, settingsBounds.width, workArea.width));
     const height = Math.max(metrics.minHeight, Math.min(settingsBounds.height, workArea.height));
@@ -288,8 +302,10 @@ module.exports = function initDashboard(ctx) {
     const metrics = getScaledMetrics(placement.bounds);
     const opts = {
       ...placement.bounds,
-      minWidth: metrics.minWidth,
-      minHeight: metrics.minHeight,
+      // Electron enforces the minimum over the requested size, so an uncapped
+      // minimum would undo the work-area clamp and overflow small displays.
+      minWidth: Math.min(metrics.minWidth, placement.bounds.width),
+      minHeight: Math.min(metrics.minHeight, placement.bounds.height),
       show: false,
       frame: true,
       transparent: false,
@@ -334,7 +350,7 @@ module.exports = function initDashboard(ctx) {
     let moveTextScaleTimer = null;
     const createdWindow = dashboardWindow;
     dashboardWindow.on("move", () => {
-      if (moveTextScaleTimer) clearTimeout(moveTextScaleTimer);
+      if (moveTextScaleTimer) clearScheduled(moveTextScaleTimer);
       moveTextScaleTimer = scheduleLater(() => {
         moveTextScaleTimer = null;
         applyTextScaleToWindow();
@@ -359,6 +375,10 @@ module.exports = function initDashboard(ctx) {
     });
     dashboardWindow.on("closed", () => {
       clearSaveBoundsTimer();
+      if (moveTextScaleTimer) {
+        clearScheduled(moveTextScaleTimer);
+        moveTextScaleTimer = null;
+      }
       dashboardWindow = null;
     });
     return dashboardWindow;

--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -147,13 +147,15 @@ module.exports = function initDashboard(ctx) {
       : { sessions: [], groups: [], orderedIds: [], menuOrderedIds: [] };
   }
 
-  function getTextScale() {
-    return clampTextScale(typeof ctx.getTextScale === "function" ? ctx.getTextScale() : 1);
+  // textScale is per-display; `bounds` selects the display the metrics are
+  // for. Without it the host falls back to the current window, then the pet.
+  function getTextScale(bounds = null) {
+    return clampTextScale(typeof ctx.getTextScale === "function" ? ctx.getTextScale(bounds) : 1);
   }
 
   // DEFAULT_*/MIN_* are CSS px; windows are sized in DIP.
-  function getScaledMetrics() {
-    const scale = getTextScale();
+  function getScaledMetrics(bounds = null) {
+    const scale = getTextScale(bounds);
     return {
       defaultWidth: scaleWidth(DEFAULT_WIDTH, scale),
       defaultHeight: scaleHeight(DEFAULT_HEIGHT, scale),
@@ -173,7 +175,7 @@ module.exports = function initDashboard(ctx) {
     const workArea = typeof ctx.getNearestWorkArea === "function"
       ? ctx.getNearestWorkArea(cx, cy)
       : { x: 0, y: 0, width: 1280, height: 800 };
-    const metrics = getScaledMetrics();
+    const metrics = getScaledMetrics(savedBounds || workArea);
     if (savedBounds) {
       return clampBoundsToWorkArea({
         ...savedBounds,
@@ -212,7 +214,7 @@ module.exports = function initDashboard(ctx) {
     const workArea = typeof ctx.getNearestWorkArea === "function"
       ? ctx.getNearestWorkArea(cx, cy)
       : { x: 0, y: 0, width: 1280, height: 800 };
-    const metrics = getScaledMetrics();
+    const metrics = getScaledMetrics(settingsBounds);
     const width = Math.max(metrics.minWidth, Math.min(metrics.defaultWidth, settingsBounds.width, workArea.width));
     const height = Math.max(metrics.minHeight, Math.min(settingsBounds.height, workArea.height));
     return clampBoundsToWorkArea({
@@ -283,7 +285,7 @@ module.exports = function initDashboard(ctx) {
 
   function createDashboardWindow(options = {}) {
     const placement = getDashboardPlacement(options);
-    const metrics = getScaledMetrics();
+    const metrics = getScaledMetrics(placement.bounds);
     const opts = {
       ...placement.bounds,
       minWidth: metrics.minWidth,

--- a/src/main.js
+++ b/src/main.js
@@ -2100,6 +2100,8 @@ const _dashboard = require("./dashboard")({
   getTextScale: () => effectiveTextScaleForKey(
     getWindowDisplayKey(_dashboard ? _dashboard.getWindow() : null) || getPetDisplayKey()
   ),
+  getSavedBounds: () => _settingsController.get("dashboardWindowBounds"),
+  onSaveBounds: (bounds) => _settingsController.applyUpdate("dashboardWindowBounds", bounds),
   iconPath: settingsWindowRuntime.getIconPath(),
 });
 showDashboard = _dashboard.showDashboard;

--- a/src/main.js
+++ b/src/main.js
@@ -2097,8 +2097,10 @@ const _dashboard = require("./dashboard")({
   getPetWindowBounds,
   getNearestWorkArea,
   getSettingsWindow: () => settingsWindowRuntime.getWindow(),
-  getTextScale: () => effectiveTextScaleForKey(
-    getWindowDisplayKey(_dashboard ? _dashboard.getWindow() : null) || getPetDisplayKey()
+  getTextScale: (bounds) => effectiveTextScaleForKey(
+    getDisplayKeyForBounds(bounds)
+    || getWindowDisplayKey(_dashboard ? _dashboard.getWindow() : null)
+    || getPetDisplayKey()
   ),
   getSavedBounds: () => _settingsController.get("dashboardWindowBounds"),
   onSaveBounds: (bounds) => _settingsController.applyUpdate("dashboardWindowBounds", bounds),

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -56,7 +56,7 @@ const {
   PET_ACCESSORY_IDS,
 } = require("./pet-customization-catalog");
 
-const CURRENT_VERSION = 13;
+const CURRENT_VERSION = 14;
 const DEFAULT_INTEGRATION_INSTALLED_IDS = Object.freeze(["claude-code", "codex"]);
 const DEFAULT_INTEGRATION_INSTALLED_SET = new Set(DEFAULT_INTEGRATION_INSTALLED_IDS);
 
@@ -107,6 +107,14 @@ const SCHEMA = {
   // The Settings runtime prefers Electron's normal bounds so maximized,
   // minimized, and fullscreen rectangles are not stored here.
   settingsWindowBounds: {
+    type: "object",
+    defaultFactory: () => null,
+    normalize: normalizeSettingsWindowBounds,
+  },
+  // Normal-state geometry for the resizable Sessions/Dashboard window. Same
+  // contract as settingsWindowBounds: `null` means the user has not placed it
+  // yet, so the runtime keeps the computed pet/Settings-anchored placement.
+  dashboardWindowBounds: {
     type: "object",
     defaultFactory: () => null,
     normalize: normalizeSettingsWindowBounds,
@@ -750,6 +758,11 @@ function migrate(raw) {
   // an absent/null value intentionally keeps the existing centered placement.
   if (out.version < 13) {
     out.version = 13;
+  }
+  // v13 -> v14: Dashboard-window geometry persistence, same contract as the
+  // Settings step above.
+  if (out.version < 14) {
+    out.version = 14;
   }
   if ((typeof out.version === "number" ? out.version : 0) < CURRENT_VERSION) {
     out.version = CURRENT_VERSION;

--- a/src/settings-actions.js
+++ b/src/settings-actions.js
@@ -247,6 +247,13 @@ const updateRegistry = {
       message: "settingsWindowBounds must be null or integer { x, y, width, height } with positive dimensions",
     };
   },
+  dashboardWindowBounds: (value) => {
+    if (value === null || isValidSettingsWindowBounds(value)) return { status: "ok" };
+    return {
+      status: "error",
+      message: "dashboardWindowBounds must be null or integer { x, y, width, height } with positive dimensions",
+    };
+  },
   // #408: frozen-origin work area for keepSizeAcrossDisplays. null = unknown
   // (legacy prefs / never seeded); otherwise positive width+height.
   savedPixelWorkArea: (value) => {

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -50,7 +50,7 @@
   // Runtime-only geometry belongs in the snapshot for consistency, but has no
   // mounted Settings control. Re-rendering for it would destroy focused inputs
   // and reset the active tab's scroll position after every window move/resize.
-  const RENDERER_INERT_SETTINGS_KEYS = new Set(["settingsWindowBounds"]);
+  const RENDERER_INERT_SETTINGS_KEYS = new Set(["settingsWindowBounds", "dashboardWindowBounds"]);
 
   const state = {
     snapshot: null,

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -43,6 +43,8 @@ describe("dashboard window", () => {
         this.parentWindows = [];
         this.setBoundsCalls = [];
         this.onceCallbacks = new Map();
+        this.onCallbacks = new Map();
+        this.normalBounds = null;
         this.webContents = {
           isDestroyed: () => false,
           once: () => {},
@@ -58,7 +60,16 @@ describe("dashboard window", () => {
       setMenuBarVisibility() {}
       loadFile() {}
       once(eventName, callback) { this.onceCallbacks.set(eventName, callback); }
-      on() {}
+      on(eventName, callback) {
+        const list = this.onCallbacks.get(eventName) || [];
+        list.push(callback);
+        this.onCallbacks.set(eventName, list);
+      }
+      emit(eventName) {
+        for (const callback of this.onCallbacks.get(eventName) || []) callback();
+      }
+      getBounds() { return { ...this.bounds }; }
+      getNormalBounds() { return { ...(this.normalBounds || this.bounds) }; }
       setBackgroundColor(color) { this.backgroundColors.push(color); }
       setBounds(bounds) {
         this.bounds = { ...bounds };
@@ -81,9 +92,15 @@ describe("dashboard window", () => {
       getPetWindowBounds: () => ({ x: 100, y: 100, width: 120, height: 120 }),
       getNearestWorkArea: options.getNearestWorkArea || (() => ({ x: 0, y: 0, width: 1280, height: 800 })),
       getSettingsWindow: options.getSettingsWindow,
+      getSavedBounds: options.getSavedBounds,
+      onSaveBounds: options.onSaveBounds,
       setTimeout: options.setTimeout || ((callback, delay) => {
-        timers.push({ callback, delay });
+        timers.push({ callback, delay, cleared: false });
         return timers.length;
+      }),
+      clearTimeout: options.clearTimeout || ((id) => {
+        const timer = timers[id - 1];
+        if (timer) timer.cleared = true;
       }),
       getSessionSnapshot: () => ({ sessions: [], groups: [] }),
       getI18n: () => ({ lang: "en", translations: {} }),
@@ -234,6 +251,180 @@ describe("dashboard window", () => {
       { x: 260, y: 50, width: 480, height: 520 },
     ]);
     assert.deepStrictEqual(timers.map((timer) => timer.delay), [0, 80]);
+  });
+
+  it("restores saved dashboard bounds instead of pet centering", () => {
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSavedBounds: () => ({ x: 40, y: 60, width: 500, height: 520 }),
+    });
+
+    dashboard.showDashboard();
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 40,
+      y: 60,
+      width: 500,
+      height: 520,
+    });
+  });
+
+  it("clamps restored bounds to the work area and scaled minimum", () => {
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSavedBounds: () => ({ x: 2000, y: 700, width: 200, height: 300 }),
+    });
+
+    dashboard.showDashboard();
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 960,
+      y: 400,
+      width: 320,
+      height: 400,
+    });
+  });
+
+  it("ignores invalid saved bounds and falls back to pet centering", () => {
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSavedBounds: () => ({ x: NaN, y: 0, width: 480, height: 600 }),
+    });
+
+    dashboard.showDashboard();
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 400,
+      y: 100,
+      width: 480,
+      height: 600,
+    });
+  });
+
+  it("keeps settings-anchored placement even when saved bounds exist", () => {
+    const settingsWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      getBounds: () => ({ x: 100, y: 50, width: 800, height: 560 }),
+    };
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+      getSavedBounds: () => ({ x: 10, y: 20, width: 500, height: 500 }),
+    });
+
+    dashboard.showDashboard({ source: "settings" });
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 260,
+      y: 50,
+      width: 480,
+      height: 560,
+    });
+  });
+
+  it("persists moved and resized normal bounds with a shared debounce", () => {
+    const saved = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.bounds = { x: 300, y: 200, width: 640, height: 700 };
+    win.emit("move");
+    win.emit("resize");
+
+    const saveTimers = timers.filter((timer) => timer.delay === 500);
+    assert.strictEqual(saveTimers.length, 2);
+    assert.strictEqual(saveTimers[0].cleared, true);
+    assert.strictEqual(saveTimers[1].cleared, false);
+    assert.deepStrictEqual(saved, []);
+
+    saveTimers[1].callback();
+    assert.deepStrictEqual(saved, [
+      { x: 300, y: 200, width: 640, height: 700 },
+    ]);
+
+    // A duplicate native event after the same geometry must not rewrite prefs.
+    win.emit("resize");
+    timers.filter((timer) => timer.delay === 500).at(-1).callback();
+    assert.strictEqual(saved.length, 1);
+  });
+
+  it("flushes pending geometry on close and skips untouched windows", () => {
+    const saved = [];
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.emit("close");
+    assert.deepStrictEqual(saved, []);
+
+    win.bounds = { x: 5, y: 6, width: 700, height: 500 };
+    win.emit("move");
+    win.emit("close");
+    assert.deepStrictEqual(saved, [
+      { x: 5, y: 6, width: 700, height: 500 },
+    ]);
+  });
+
+  it("saves normal bounds, not the maximized rectangle", () => {
+    const saved = [];
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.normalBounds = { x: 15, y: 25, width: 600, height: 500 };
+    win.bounds = { x: 0, y: 0, width: 1280, height: 800 };
+    win.emit("close");
+
+    assert.deepStrictEqual(saved, [
+      { x: 15, y: 25, width: 600, height: 500 },
+    ]);
+  });
+
+  it("does not persist the programmatic settings re-anchor", () => {
+    const saved = [];
+    const settingsWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      getBounds: () => ({ x: 100, y: 50, width: 800, height: 560 }),
+    };
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard({ source: "settings" });
+    const win = getCreatedWindow();
+    win.emitReadyToShow();
+    // Electron reports programmatic setBounds through the same move event.
+    win.emit("move");
+    for (const timer of timers.filter((t) => !t.cleared && t.delay === 500)) {
+      timer.callback();
+    }
+    assert.deepStrictEqual(saved, []);
+
+    // A real user drag afterwards still persists.
+    win.bounds = { x: 900, y: 300, width: 520, height: 560 };
+    win.emit("move");
+    timers.filter((t) => !t.cleared && t.delay === 500).at(-1).callback();
+    assert.deepStrictEqual(saved, [
+      { x: 900, y: 300, width: 520, height: 560 },
+    ]);
   });
 
   it("exposes a Clawd-only hide action instead of a terminal close action", () => {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -548,6 +548,46 @@ describe("dashboard window", () => {
     ]);
   });
 
+  it("saves a still-debounced user move before the settings re-anchor drops it", () => {
+    let persisted = { x: 40, y: 60, width: 520, height: 520 };
+    const settingsWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      getBounds: () => ({ x: 100, y: 50, width: 800, height: 560 }),
+    };
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+      getSavedBounds: () => persisted,
+      onSaveBounds: (bounds) => {
+        persisted = bounds;
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    const moved = { x: 700, y: 180, width: 520, height: 560 };
+    win.bounds = { ...moved };
+    win.emit("move");
+
+    // Re-opening from Settings before the 500ms debounce fires.
+    dashboard.showDashboard({ source: "settings" });
+    assert.deepStrictEqual(persisted, moved);
+
+    // The anchor itself still must not be persisted.
+    assert.deepStrictEqual(win.bounds, { x: 260, y: 50, width: 480, height: 560 });
+    win.emit("move");
+    for (const timer of timers.filter((t) => !t.cleared && t.delay === 500)) {
+      timer.callback();
+    }
+    assert.deepStrictEqual(persisted, moved);
+
+    win.emit("close");
+    win.emit("closed");
+    dashboard.showDashboard();
+    assert.deepStrictEqual(getCreatedWindow().bounds, moved);
+  });
+
   it("does not persist anchor growth to the scaled minimum on a short display", () => {
     const saved = [];
     const settingsWindow = {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -99,7 +99,8 @@ describe("dashboard window", () => {
       nativeTheme,
     });
     const dashboard = initDashboard({
-      getPetWindowBounds: () => ({ x: 100, y: 100, width: 120, height: 120 }),
+      getPetWindowBounds: options.getPetWindowBounds
+        || (() => ({ x: 100, y: 100, width: 120, height: 120 })),
       getNearestWorkArea: options.getNearestWorkArea || (() => ({ x: 0, y: 0, width: 1280, height: 800 })),
       getSettingsWindow: options.getSettingsWindow,
       getSavedBounds: options.getSavedBounds,
@@ -319,6 +320,66 @@ describe("dashboard window", () => {
     });
     assert.strictEqual(win.opts.minWidth, 512);
     assert.strictEqual(win.opts.minHeight, 640);
+  });
+
+  it("a tiny work area caps both restored bounds and window minimums", () => {
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSavedBounds: () => ({ x: 1000, y: 800, width: 900, height: 700 }),
+      getNearestWorkArea: () => ({ x: 50, y: 60, width: 500, height: 400 }),
+      getTextScale: () => 1.6,
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+
+    assert.deepStrictEqual(win.bounds, { x: 50, y: 60, width: 500, height: 400 });
+    assert.strictEqual(win.opts.minWidth, 500);
+    assert.strictEqual(win.opts.minHeight, 400);
+  });
+
+  it("falls back to a sane work area when the display reports a degenerate one", () => {
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSavedBounds: () => ({ x: 40, y: 60, width: 500, height: 520 }),
+      getNearestWorkArea: () => ({ x: 0, y: 0, width: 0, height: 0 }),
+    });
+
+    dashboard.showDashboard();
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 40,
+      y: 60,
+      width: 500,
+      height: 520,
+    });
+  });
+
+  it("tolerates a throwing pet-bounds lookup", () => {
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getPetWindowBounds: () => { throw new Error("display teardown"); },
+    });
+
+    dashboard.showDashboard();
+
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      x: 400,
+      y: 100,
+      width: 480,
+      height: 600,
+    });
+  });
+
+  it("clears the pending move text-scale timer on closed", () => {
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness();
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.emit("move");
+    const scaleTimer = timers.filter((t) => t.delay === 350).at(-1);
+    assert.strictEqual(scaleTimer.cleared, false);
+
+    win.emit("close");
+    win.emit("closed");
+    assert.strictEqual(scaleTimer.cleared, true);
   });
 
   it("uses persisted bounds when the dashboard window is recreated", () => {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -32,13 +32,17 @@ describe("dashboard window", () => {
 
     class FakeBrowserWindow {
       constructor(opts) {
+        // Models native frame quantization: the WM may hand back a slightly
+        // different rectangle than the one requested.
+        const offset = options.constructorBoundsOffset || {};
         this.opts = opts;
         this.bounds = {
-          x: opts.x,
-          y: opts.y,
-          width: opts.width,
-          height: opts.height,
+          x: opts.x + (offset.x || 0),
+          y: opts.y + (offset.y || 0),
+          width: opts.width + (offset.width || 0),
+          height: opts.height + (offset.height || 0),
         };
+        this.destroyed = false;
         this.backgroundColors = [opts.backgroundColor];
         this.parentWindows = [];
         this.setBoundsCalls = [];
@@ -52,7 +56,7 @@ describe("dashboard window", () => {
         };
         createdWindow = this;
       }
-      isDestroyed() { return false; }
+      isDestroyed() { return this.destroyed; }
       isMinimized() { return false; }
       restore() {}
       show() {}
@@ -72,7 +76,13 @@ describe("dashboard window", () => {
       getNormalBounds() { return { ...(this.normalBounds || this.bounds) }; }
       setBackgroundColor(color) { this.backgroundColors.push(color); }
       setBounds(bounds) {
-        this.bounds = { ...bounds };
+        const offset = options.setBoundsOffset || {};
+        this.bounds = {
+          x: bounds.x + (offset.x || 0),
+          y: bounds.y + (offset.y || 0),
+          width: bounds.width + (offset.width || 0),
+          height: bounds.height + (offset.height || 0),
+        };
         this.setBoundsCalls.push({ ...bounds });
       }
       setParentWindow(parentWindow) {
@@ -94,6 +104,7 @@ describe("dashboard window", () => {
       getSettingsWindow: options.getSettingsWindow,
       getSavedBounds: options.getSavedBounds,
       onSaveBounds: options.onSaveBounds,
+      getTextScale: options.getTextScale,
       setTimeout: options.setTimeout || ((callback, delay) => {
         timers.push({ callback, delay, cleared: false });
         return timers.length;
@@ -425,6 +436,170 @@ describe("dashboard window", () => {
     assert.deepStrictEqual(saved, [
       { x: 900, y: 300, width: 520, height: 560 },
     ]);
+  });
+
+  it("does not persist anchor growth to the scaled minimum on a short display", () => {
+    const saved = [];
+    const settingsWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      getBounds: () => ({ x: 100, y: 50, width: 800, height: 560 }),
+    };
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      getSettingsWindow: () => settingsWindow,
+      // Work area height (600) sits below the scaled minimum height (640 at
+      // 1.6), so the anchored placement is clamped short and the text-scale
+      // pass grows the window right after placement.
+      getNearestWorkArea: () => ({ x: 0, y: 0, width: 1280, height: 600 }),
+      getTextScale: () => 1.6,
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard({ source: "settings" });
+    const win = getCreatedWindow();
+    win.emitReadyToShow();
+    assert.strictEqual(win.bounds.height, 640);
+    win.emit("resize");
+    for (const timer of timers.filter((t) => !t.cleared && t.delay === 500)) {
+      timer.callback();
+    }
+    assert.deepStrictEqual(saved, []);
+
+    // A real user drag afterwards still persists.
+    win.bounds = { x: 200, y: 20, width: 900, height: 640 };
+    win.emit("move");
+    timers.filter((t) => !t.cleared && t.delay === 500).at(-1).callback();
+    assert.deepStrictEqual(saved, [
+      { x: 200, y: 20, width: 900, height: 640 },
+    ]);
+  });
+
+  it("keeps a failed synchronous persistence retryable", () => {
+    const attempts = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        attempts.push(bounds);
+        return attempts.length === 1
+          ? { status: "error", message: "read only" }
+          : { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.bounds = { x: 310, y: 220, width: 880, height: 620 };
+    win.emit("resize");
+    timers.filter((t) => t.delay === 500).at(-1).callback();
+    win.emit("resize");
+    timers.filter((t) => t.delay === 500).at(-1).callback();
+
+    assert.strictEqual(attempts.length, 2);
+  });
+
+  it("keeps a failed asynchronous persistence retryable", async () => {
+    const attempts = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        attempts.push(bounds);
+        return Promise.resolve(attempts.length === 1
+          ? { status: "error", message: "disk full" }
+          : { status: "ok" });
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.bounds = { x: 310, y: 220, width: 880, height: 620 };
+    win.emit("resize");
+    timers.filter((t) => t.delay === 500).at(-1).callback();
+    await Promise.resolve();
+    await Promise.resolve();
+    win.emit("resize");
+    timers.filter((t) => t.delay === 500).at(-1).callback();
+
+    assert.strictEqual(attempts.length, 2);
+  });
+
+  it("destroyed windows and closed cleanup cannot fire a pending bounds save", () => {
+    const saved = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.bounds = { x: 310, y: 220, width: 880, height: 620 };
+    win.emit("resize");
+    const pendingSave = timers.filter((t) => t.delay === 500).at(-1);
+    win.destroyed = true;
+    win.emit("closed");
+
+    assert.strictEqual(pendingSave.cleared, true);
+    pendingSave.callback();
+    assert.deepStrictEqual(saved, []);
+  });
+
+  it("normal-bounds lookup falls back to current bounds when unavailable", () => {
+    const saved = [];
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.bounds = { x: 330, y: 240, width: 860, height: 610 };
+    win.getNormalBounds = () => { throw new Error("unsupported"); };
+    win.emit("close");
+
+    assert.deepStrictEqual(saved, [
+      { x: 330, y: 240, width: 860, height: 610 },
+    ]);
+  });
+
+  it("saved bounds override native constructor frame drift", () => {
+    const savedBounds = { x: 40, y: 60, width: 500, height: 520 };
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      constructorBoundsOffset: { width: 2 },
+      getSavedBounds: () => savedBounds,
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+
+    assert.deepStrictEqual(win.bounds, savedBounds);
+    assert.deepStrictEqual(win.setBoundsCalls, [savedBounds]);
+  });
+
+  it("an untouched window does not persist native frame quantization on close", () => {
+    const saved = [];
+    const savedBounds = { x: 40, y: 60, width: 500, height: 520 };
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      constructorBoundsOffset: { width: 2 },
+      // Simulate a WM that cannot adopt the requested outer width exactly
+      // even when the runtime follows up with setBounds().
+      setBoundsOffset: { width: 1 },
+      getSavedBounds: () => savedBounds,
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    assert.deepStrictEqual(win.getBounds(), { ...savedBounds, width: 501 });
+
+    win.emit("close");
+    assert.deepStrictEqual(saved, []);
   });
 
   it("exposes a Clawd-only hide action instead of a terminal close action", () => {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -294,6 +294,55 @@ describe("dashboard window", () => {
     });
   });
 
+  it("applies the saved display's scaled minimum when restoring bounds", () => {
+    const scaleBounds = [];
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSavedBounds: () => ({ x: 2100, y: 80, width: 480, height: 600 }),
+      getNearestWorkArea: () => ({ x: 2000, y: 0, width: 1280, height: 800 }),
+      // The saved rect lives on a 1.6-scale display; the pet (no bounds
+      // argument) does not.
+      getTextScale: (bounds) => {
+        scaleBounds.push(bounds);
+        return bounds && bounds.x >= 2000 ? 1.6 : 1;
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+
+    assert.deepStrictEqual(scaleBounds[0], { x: 2100, y: 80, width: 480, height: 600 });
+    assert.deepStrictEqual(win.bounds, {
+      x: 2100,
+      y: 80,
+      width: 512,
+      height: 640,
+    });
+    assert.strictEqual(win.opts.minWidth, 512);
+    assert.strictEqual(win.opts.minHeight, 640);
+  });
+
+  it("uses persisted bounds when the dashboard window is recreated", () => {
+    let persisted = null;
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      getSavedBounds: () => persisted,
+      onSaveBounds: (bounds) => {
+        persisted = bounds;
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const first = getCreatedWindow();
+    first.normalBounds = { x: 420, y: 230, width: 640, height: 500 };
+    first.emit("close");
+    first.emit("closed");
+
+    dashboard.showDashboard();
+    const reopened = getCreatedWindow();
+    assert.notStrictEqual(reopened, first);
+    assert.deepStrictEqual(reopened.bounds, { x: 420, y: 230, width: 640, height: 500 });
+  });
+
   it("ignores invalid saved bounds and falls back to pet centering", () => {
     const { dashboard, getCreatedWindow } = createWindowHarness({
       getSavedBounds: () => ({ x: NaN, y: 0, width: 480, height: 600 }),

--- a/test/prefs.test.js
+++ b/test/prefs.test.js
@@ -70,6 +70,7 @@ describe("prefs.getDefaults", () => {
     assert.strictEqual(d.savedPixelHeight, 0);
     assert.strictEqual(d.savedPixelWorkArea, null);
     assert.strictEqual(d.settingsWindowBounds, null);
+    assert.strictEqual(d.dashboardWindowBounds, null);
     assert.strictEqual(d.permissionBubblesEnabled, true);
     assert.strictEqual(d.notificationBubbleAutoCloseSeconds, 6);
     assert.strictEqual(d.updateBubbleAutoCloseSeconds, 9);
@@ -1241,6 +1242,23 @@ describe("prefs.migrate v11 → v12 (showDock default off for fresh installs)", 
   });
 });
 
+describe("prefs.migrate v13 → v14 (Dashboard window bounds)", () => {
+  it("advances the schema without inventing geometry for existing users", () => {
+    const upgraded = prefs.validate(prefs.migrate({ version: 13, lang: "zh" }));
+    assert.strictEqual(upgraded.version, prefs.CURRENT_VERSION);
+    assert.strictEqual(upgraded.dashboardWindowBounds, null);
+  });
+
+  it("preserves valid geometry from an early v13 build or hand-edited file", () => {
+    const bounds = { x: -1180, y: 90, width: 920, height: 680 };
+    const upgraded = prefs.validate(prefs.migrate({
+      version: 13,
+      dashboardWindowBounds: bounds,
+    }));
+    assert.deepStrictEqual(upgraded.dashboardWindowBounds, bounds);
+  });
+});
+
 describe("prefs.migrate v12 → v13 (Settings window bounds)", () => {
   it("advances the schema without inventing geometry for existing users", () => {
     const upgraded = prefs.validate(prefs.migrate({ version: 12, lang: "zh" }));
@@ -1483,22 +1501,22 @@ describe("prefs.load", () => {
     }
   });
 
-  it("accepts the restored v13 schema and locks an explicit v14 file", () => {
-    const currentPath = makeTempPath("v13.json");
-    fs.writeFileSync(currentPath, JSON.stringify({ version: 13, lang: "zh" }), "utf8");
+  it("accepts the restored v14 schema and locks an explicit v15 file", () => {
+    const currentPath = makeTempPath("v14.json");
+    fs.writeFileSync(currentPath, JSON.stringify({ version: 14, lang: "zh" }), "utf8");
     const current = prefs.load(currentPath);
     assert.strictEqual(current.locked, false);
-    assert.strictEqual(current.snapshot.version, 13);
+    assert.strictEqual(current.snapshot.version, 14);
     assert.strictEqual(current.snapshot.lang, "zh");
 
-    const futurePath = makeTempPath("v14.json");
-    fs.writeFileSync(futurePath, JSON.stringify({ version: 14, lang: "ja" }), "utf8");
+    const futurePath = makeTempPath("v15.json");
+    fs.writeFileSync(futurePath, JSON.stringify({ version: 15, lang: "ja" }), "utf8");
     const originalWarn = console.warn;
     console.warn = () => {};
     try {
       const future = prefs.load(futurePath);
       assert.strictEqual(future.locked, true);
-      assert.strictEqual(future.snapshot.version, 14);
+      assert.strictEqual(future.snapshot.version, 15);
       assert.strictEqual(future.snapshot.lang, "ja");
     } finally {
       console.warn = originalWarn;

--- a/test/settings-actions.test.js
+++ b/test/settings-actions.test.js
@@ -233,6 +233,24 @@ describe("updateRegistry pure-data validators", () => {
     }
   });
 
+  it("Dashboard window bounds accept normal integer geometry or null", () => {
+    const validate = updateRegistry.dashboardWindowBounds;
+    assert.strictEqual(validate(null).status, "ok");
+    assert.strictEqual(
+      validate({ x: -1200, y: 80, width: 900, height: 640 }).status,
+      "ok",
+    );
+    for (const value of [
+      { x: 0.5, y: 0, width: 800, height: 560 },
+      { x: 0, y: 0, width: 0, height: 560 },
+      { x: 0, y: 0, width: 800 },
+      [],
+      "800x560",
+    ]) {
+      assert.strictEqual(validate(value).status, "error");
+    }
+  });
+
   it("object-form boolean fields validate via entry.validate", () => {
     const deps = { snapshot: baseSnapshot };
     for (const key of ["autoStartWithClaude", "manageClaudeHooksAutomatically", "openAtLogin"]) {

--- a/test/settings-controller.test.js
+++ b/test/settings-controller.test.js
@@ -576,6 +576,16 @@ describe("applyUpdate", () => {
   });
 
 
+  it("persists Dashboard window bounds through the controller-only write path", async () => {
+    const p = makeTempPath();
+    const ctrl = createSettingsController({ prefsPath: p });
+    const bounds = { x: 240, y: 130, width: 640, height: 720 };
+    const r = await ctrl.applyUpdate("dashboardWindowBounds", bounds);
+    assert.strictEqual(r.status, "ok");
+    assert.deepStrictEqual(ctrl.get("dashboardWindowBounds"), bounds);
+    assert.deepStrictEqual(prefs.load(p).snapshot.dashboardWindowBounds, bounds);
+  });
+
   it("persists Codex hook health notification prefs through applyUpdate", async () => {
     const p = makeTempPath();
     const ctrl = createSettingsController({ prefsPath: p });

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -5386,6 +5386,17 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(harness.getContentRenderCount(), 1);
     assert.strictEqual(harness.getSwitch("sessionHudEnabled"), mountedControl);
     assert.strictEqual(harness.content.scrollTop, 317);
+
+    const dashboardBounds = { x: 220, y: 140, width: 640, height: 720 };
+    harness.core.ops.applyChanges({
+      changes: { dashboardWindowBounds: dashboardBounds },
+      snapshot: { ...initialSnapshot, settingsWindowBounds: bounds, dashboardWindowBounds: dashboardBounds },
+    });
+
+    assert.deepStrictEqual(harness.core.state.snapshot.dashboardWindowBounds, dashboardBounds);
+    assert.strictEqual(harness.getContentRenderCount(), 1);
+    assert.strictEqual(harness.getSwitch("sessionHudEnabled"), mountedControl);
+    assert.strictEqual(harness.content.scrollTop, 317);
   });
 
   it("patches the Session HUD master switch without rebuilding General content", async () => {


### PR DESCRIPTION
Fixes #801.

The Sessions/Dashboard window recomputed its placement from the pet or Settings window on every open, so a user-chosen position/size never survived a close. This persists normal-state geometry the same way the Settings window does since the #765 fix:

- New nullable `dashboardWindowBounds` pref (schema v13 → v14, no backfill — absent/null keeps today's computed placement), validated/normalized with the same helpers as `settingsWindowBounds`.
- Restore path: saved bounds win over pet-centering, clamped to the nearest work area with scaled minimums resolved from the saved rect's own display; invalid saved bounds fall back to the existing logic.
- Save path: debounced (500 ms) saves on move/resize of normal (not maximized) bounds, flush on `close` while native geometry is still queryable, dedupe against the last saved rectangle.
- `options.source === "settings"` anchored placement is kept, and programmatic re-anchoring (including any text-scale growth it triggers) rebases the persistence baseline, so it is never written over the user's saved standalone position — only a real user move after anchoring persists, matching the behavior requested in the issue.
- Constructor frame-quantization correction and the untouched-close-no-write baseline mirror the Settings window, and constructor minimums are capped to the clamped placement so a work area smaller than the scaled minimum can't force the window to overflow the display.
- Geometry reads are hardened like the sibling: degenerate work areas fall back to a sane rect, a throwing pet-bounds lookup can't kill the window open, and the move text-scale timer is cleared on close.
- `dashboardWindowBounds` joins `RENDERER_INERT_SETTINGS_KEYS` so bounds saves don't rebuild an open Settings tab.

Note: the persistence helpers are intentionally duplicated from `settings-window.js` rather than extracted, matching the existing duplication of `isUsableBounds`/`clampBoundsToWorkArea` between these two files. Happy to extract a shared module instead if you prefer.

Tested: full suite green (13 new dashboard tests, each verified to fail against the pre-fix code); live-verified on Windows — move/resize/close/reopen and full app restart restore the window, Settings-anchored opens still attach to Settings without clobbering the saved standalone position, a manual drag after anchoring persists, and maximize → close → reopen restores the normal rectangle.
