### PR TITLE
fix(dashboard): harden window bounds persistence

### DIFF
--- a/src/dashboard.js
+++ b/src/dashboard.js
@@ -73,6 +73,10 @@ module.exports = function initDashboard(ctx) {
   let dashboardWindow = null;
   let saveBoundsTimer = null;
   let lastSavedBounds = null;
+  let programmaticEventBounds = null;
+  let programmaticBoundsMutationDepth = 0;
+  let pendingUserBounds = null;
+  let pendingUserBoundsRevision = 0;
   const scheduleLater = typeof ctx.setTimeout === "function" ? ctx.setTimeout : setTimeout;
   const clearScheduled = typeof ctx.clearTimeout === "function" ? ctx.clearTimeout : clearTimeout;
 
@@ -117,18 +121,114 @@ module.exports = function initDashboard(ctx) {
     }
   }
 
+  function getCurrentWindowBounds(win) {
+    if (!win || (typeof win.isDestroyed === "function" && win.isDestroyed())) return null;
+    try {
+      return typeof win.getBounds === "function" ? roundedBounds(win.getBounds()) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function hasTransientWindowBounds(win) {
+    if (!win || (typeof win.isDestroyed === "function" && win.isDestroyed())) return true;
+    try {
+      if (
+        (typeof win.isMaximized === "function" && win.isMaximized())
+        || (typeof win.isFullScreen === "function" && win.isFullScreen())
+      ) {
+        return true;
+      }
+      // macOS's green-button "Zoom" can keep isMaximized() false. During that
+      // transition getBounds() exposes the transient zoom rectangle while
+      // getNormalBounds() retains the restorable user rectangle.
+      const currentBounds = getCurrentWindowBounds(win);
+      const normalBounds = getNormalWindowBounds(win);
+      return !!currentBounds && !!normalBounds && !sameBounds(currentBounds, normalBounds);
+    } catch {
+      return false;
+    }
+  }
+
+  // Programmatic placement and text-scale growth can emit the same native
+  // move/resize events as a user drag. Rebase both persistence and event
+  // baselines after the change: synchronous events are cancelled here, while
+  // matching asynchronous events are ignored by isProgrammaticBoundsEvent().
+  function rebaseProgrammaticBounds(win, fallbackBounds = null) {
+    clearSaveBoundsTimer();
+    const persistenceBaseline = getNormalWindowBounds(win) || roundedBounds(fallbackBounds);
+    if (persistenceBaseline) lastSavedBounds = persistenceBaseline;
+    programmaticEventBounds = getCurrentWindowBounds(win) || persistenceBaseline;
+  }
+
+  function isProgrammaticBoundsEvent(win) {
+    if (programmaticBoundsMutationDepth > 0) return true;
+    if (!programmaticEventBounds) return false;
+    const currentBounds = getCurrentWindowBounds(win);
+    if (sameBounds(currentBounds, programmaticEventBounds)) return true;
+    programmaticEventBounds = null;
+    return false;
+  }
+
+  function runProgrammaticBoundsMutation(callback) {
+    programmaticBoundsMutationDepth += 1;
+    try {
+      return callback();
+    } finally {
+      programmaticBoundsMutationDepth -= 1;
+    }
+  }
+
+  function rememberPendingUserBounds(bounds) {
+    // Keep the latest user rectangle as retry debt until persistence confirms
+    // success. Programmatic rebases may change lastSavedBounds, but must never
+    // consume geometry that has not reached prefs yet.
+    const normalized = roundedBounds(bounds);
+    if (!normalized) return null;
+    if (!sameBounds(normalized, pendingUserBounds)) {
+      pendingUserBounds = normalized;
+      pendingUserBoundsRevision += 1;
+    }
+    return {
+      bounds: pendingUserBounds,
+      revision: pendingUserBoundsRevision,
+    };
+  }
+
+  function clearPersistedUserBounds(attempt) {
+    if (!attempt || attempt.revision === null) return;
+    if (
+      pendingUserBoundsRevision === attempt.revision
+      && sameBounds(pendingUserBounds, attempt.bounds)
+    ) {
+      pendingUserBounds = null;
+    }
+  }
+
   function persistWindowBoundsNow(win) {
     clearSaveBoundsTimer();
+    if (!win || (typeof win.isDestroyed === "function" && win.isDestroyed())) return false;
     if (typeof ctx.onSaveBounds !== "function") return false;
-    const bounds = getNormalWindowBounds(win);
-    if (!bounds || sameBounds(bounds, lastSavedBounds)) return false;
+    const currentBounds = getNormalWindowBounds(win);
+    const bounds = pendingUserBounds || currentBounds;
+    // A retry debt can equal a later programmatic baseline (for example when a
+    // scale change only updates zoom and minimum size), so only dedupe geometry
+    // that has no outstanding user write behind it.
+    if (!bounds || (!pendingUserBounds && sameBounds(bounds, lastSavedBounds))) return false;
+    const attempt = {
+      bounds,
+      revision: pendingUserBounds ? pendingUserBoundsRevision : null,
+    };
     try {
       const result = ctx.onSaveBounds(bounds);
       if (result && typeof result.then === "function") {
         const attemptedBounds = bounds;
         Promise.resolve(result).then(
           (response) => {
-            if (!response || response.status !== "error") return;
+            if (!response || response.status !== "error") {
+              clearPersistedUserBounds(attempt);
+              return;
+            }
             if (sameBounds(lastSavedBounds, attemptedBounds)) lastSavedBounds = null;
             console.warn("Clawd: failed to persist Dashboard window bounds:", response.message);
           },
@@ -141,6 +241,8 @@ module.exports = function initDashboard(ctx) {
         console.warn("Clawd: failed to persist Dashboard window bounds:", result.message);
         return false;
       }
+      if (!result || typeof result.then !== "function") clearPersistedUserBounds(attempt);
+      programmaticEventBounds = null;
       lastSavedBounds = bounds;
       return true;
     } catch (err) {
@@ -151,6 +253,9 @@ module.exports = function initDashboard(ctx) {
 
   function scheduleWindowBoundsSave(win) {
     if (typeof ctx.onSaveBounds !== "function") return;
+    const bounds = getNormalWindowBounds(win);
+    if (!pendingUserBounds && sameBounds(bounds, lastSavedBounds)) return;
+    rememberPendingUserBounds(bounds);
     clearSaveBoundsTimer();
     saveBoundsTimer = scheduleTimer(() => {
       saveBoundsTimer = null;
@@ -261,17 +366,20 @@ module.exports = function initDashboard(ctx) {
     if (!dashboardWindow || dashboardWindow.isDestroyed()) return;
     const placement = getDashboardPlacement(options);
     if (isUsableBounds(placement.bounds) && typeof dashboardWindow.setBounds === "function") {
-      dashboardWindow.setBounds(placement.bounds);
-      // The anchored placement can land the window on a display with a
-      // different textScale; re-zoom right away (memoized — cheap no-op when
-      // nothing changed). This can grow the window to that display's scaled
-      // minimum, so it must run before the baseline capture below.
-      applyTextScaleToWindow();
-      // Programmatic anchoring is not user geometry: rebase the persistence
-      // baseline (and drop any pending save) so re-anchoring never overwrites
-      // the user's saved standalone position.
-      clearSaveBoundsTimer();
-      lastSavedBounds = getNormalWindowBounds(dashboardWindow) || placement.bounds;
+      runProgrammaticBoundsMutation(() => {
+        dashboardWindow.setBounds(placement.bounds);
+        // The anchored placement can land the window on a display with a
+        // different textScale; re-zoom right away (memoized — cheap no-op when
+        // nothing changed). This can grow the window to that display's scaled
+        // minimum; the helper rebases after that growth has settled.
+        applyTextScaleToWindow({
+          flushPendingUserBounds: false,
+          fallbackBounds: placement.bounds,
+        });
+      });
+      // Programmatic anchoring is not user geometry. The helper's rebase keeps
+      // it from overwriting the user's saved standalone position, even if
+      // move/resize is delivered later.
     }
   }
 
@@ -355,9 +463,18 @@ module.exports = function initDashboard(ctx) {
         moveTextScaleTimer = null;
         applyTextScaleToWindow();
       }, 350);
+      // Every move can cross into a display with a different text scale, even
+      // while maximized/fullscreen or when native delivery follows setBounds().
+      // The guards below only decide whether the rectangle is user geometry.
+      if (hasTransientWindowBounds(createdWindow)) return;
+      if (isProgrammaticBoundsEvent(createdWindow)) return;
       scheduleWindowBoundsSave(createdWindow);
     });
-    dashboardWindow.on("resize", () => scheduleWindowBoundsSave(createdWindow));
+    dashboardWindow.on("resize", () => {
+      if (hasTransientWindowBounds(createdWindow)) return;
+      if (isProgrammaticBoundsEvent(createdWindow)) return;
+      scheduleWindowBoundsSave(createdWindow);
+    });
     // `closed` is too late to query native geometry. Flush while the window
     // is still live so a pending debounce cannot lose the user's last move.
     dashboardWindow.on("close", () => persistWindowBoundsNow(createdWindow));
@@ -379,6 +496,7 @@ module.exports = function initDashboard(ctx) {
         clearScheduled(moveTextScaleTimer);
         moveTextScaleTimer = null;
       }
+      programmaticEventBounds = null;
       dashboardWindow = null;
     });
     return dashboardWindow;
@@ -421,22 +539,30 @@ module.exports = function initDashboard(ctx) {
   // textScale changed while the dashboard is open: re-zoom, raise the minimum
   // size, and only grow the window if it now sits below that minimum — never
   // touch a user-chosen size otherwise.
-  function applyTextScaleToWindow() {
+  function applyTextScaleToWindow(options = {}) {
     if (!dashboardWindow || dashboardWindow.isDestroyed()) return;
-    const metrics = getScaledMetrics();
-    applyZoomToWindow(dashboardWindow, getTextScale());
-    if (typeof dashboardWindow.setMinimumSize === "function") {
-      dashboardWindow.setMinimumSize(metrics.minWidth, metrics.minHeight);
+    // A pending debounce represents the user's pre-scale geometry. Flush it
+    // before minimum-size enforcement can grow the native window; otherwise
+    // the timer would later read and persist the programmatic rectangle.
+    if (options.flushPendingUserBounds !== false && saveBoundsTimer) {
+      persistWindowBoundsNow(dashboardWindow);
     }
-    if (typeof dashboardWindow.getBounds !== "function") return;
-    const bounds = dashboardWindow.getBounds();
-    if (bounds.width < metrics.minWidth || bounds.height < metrics.minHeight) {
-      dashboardWindow.setBounds({
-        ...bounds,
-        width: Math.max(bounds.width, metrics.minWidth),
-        height: Math.max(bounds.height, metrics.minHeight),
-      });
-    }
+    runProgrammaticBoundsMutation(() => {
+      const metrics = getScaledMetrics();
+      applyZoomToWindow(dashboardWindow, getTextScale());
+      if (typeof dashboardWindow.setMinimumSize === "function") {
+        dashboardWindow.setMinimumSize(metrics.minWidth, metrics.minHeight);
+      }
+      const bounds = getCurrentWindowBounds(dashboardWindow);
+      if (bounds && (bounds.width < metrics.minWidth || bounds.height < metrics.minHeight)) {
+        dashboardWindow.setBounds({
+          ...bounds,
+          width: Math.max(bounds.width, metrics.minWidth),
+          height: Math.max(bounds.height, metrics.minHeight),
+        });
+      }
+      rebaseProgrammaticBounds(dashboardWindow, options.fallbackBounds || bounds);
+    });
   }
 
   return {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -43,9 +43,12 @@ describe("dashboard window", () => {
           height: opts.height + (offset.height || 0),
         };
         this.destroyed = false;
+        this.maximized = false;
+        this.fullScreen = false;
         this.backgroundColors = [opts.backgroundColor];
         this.parentWindows = [];
         this.setBoundsCalls = [];
+        this.setMinimumSizeCalls = [];
         this.onceCallbacks = new Map();
         this.onCallbacks = new Map();
         this.normalBounds = null;
@@ -58,6 +61,8 @@ describe("dashboard window", () => {
       }
       isDestroyed() { return this.destroyed; }
       isMinimized() { return false; }
+      isMaximized() { return this.maximized; }
+      isFullScreen() { return this.fullScreen; }
       restore() {}
       show() {}
       focus() {}
@@ -75,7 +80,9 @@ describe("dashboard window", () => {
       getBounds() { return { ...this.bounds }; }
       getNormalBounds() { return { ...(this.normalBounds || this.bounds) }; }
       setBackgroundColor(color) { this.backgroundColors.push(color); }
+      setMinimumSize(width, height) { this.setMinimumSizeCalls.push({ width, height }); }
       setBounds(bounds) {
+        const previous = { ...this.bounds };
         const offset = options.setBoundsOffset || {};
         this.bounds = {
           x: bounds.x + (offset.x || 0),
@@ -84,6 +91,10 @@ describe("dashboard window", () => {
           height: bounds.height + (offset.height || 0),
         };
         this.setBoundsCalls.push({ ...bounds });
+        if (options.emitSetBoundsEvents) {
+          if (previous.x !== this.bounds.x || previous.y !== this.bounds.y) this.emit("move");
+          if (previous.width !== this.bounds.width || previous.height !== this.bounds.height) this.emit("resize");
+        }
       }
       setParentWindow(parentWindow) {
         this.parentWindows.push(parentWindow);
@@ -297,9 +308,15 @@ describe("dashboard window", () => {
 
   it("applies the saved display's scaled minimum when restoring bounds", () => {
     const scaleBounds = [];
+    const workAreaQueries = [];
     const { dashboard, getCreatedWindow } = createWindowHarness({
       getSavedBounds: () => ({ x: 2100, y: 80, width: 480, height: 600 }),
-      getNearestWorkArea: () => ({ x: 2000, y: 0, width: 1280, height: 800 }),
+      getNearestWorkArea: (cx, cy) => {
+        workAreaQueries.push({ cx, cy });
+        return cx >= 2000
+          ? { x: 2000, y: 0, width: 1280, height: 800 }
+          : { x: 0, y: 0, width: 1280, height: 800 };
+      },
       // The saved rect lives on a 1.6-scale display; the pet (no bounds
       // argument) does not.
       getTextScale: (bounds) => {
@@ -312,6 +329,7 @@ describe("dashboard window", () => {
     const win = getCreatedWindow();
 
     assert.deepStrictEqual(scaleBounds[0], { x: 2100, y: 80, width: 480, height: 600 });
+    assert.deepStrictEqual(workAreaQueries[0], { cx: 2340, cy: 380 });
     assert.deepStrictEqual(win.bounds, {
       x: 2100,
       y: 80,
@@ -380,6 +398,54 @@ describe("dashboard window", () => {
     win.emit("close");
     win.emit("closed");
     assert.strictEqual(scaleTimer.cleared, true);
+  });
+
+  it("re-resolves text scale after a maximized window moves without persisting transient bounds", () => {
+    let scale = 1;
+    const saved = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      getTextScale: () => scale,
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.normalBounds = { ...win.bounds };
+    win.maximized = true;
+    win.bounds = { x: 1280, y: 0, width: 1280, height: 800 };
+    scale = 1.6;
+    win.emit("move");
+
+    const scaleTimer = timers.filter((timer) => !timer.cleared && timer.delay === 350).at(-1);
+    assert.ok(scaleTimer);
+    assert.strictEqual(timers.filter((timer) => !timer.cleared && timer.delay === 500).length, 0);
+    scaleTimer.callback();
+    assert.deepStrictEqual(win.setMinimumSizeCalls.at(-1), { width: 512, height: 640 });
+    assert.deepStrictEqual(saved, []);
+  });
+
+  it("does not persist fullscreen move or resize events when current and normal bounds match", () => {
+    const saved = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.fullScreen = true;
+    win.bounds = { x: 0, y: 0, width: 1280, height: 800 };
+    win.normalBounds = { ...win.bounds };
+    win.emit("move");
+    win.emit("resize");
+
+    assert.strictEqual(timers.filter((timer) => !timer.cleared && timer.delay === 500).length, 0);
+    assert.deepStrictEqual(saved, []);
   });
 
   it("uses persisted bounds when the dashboard window is recreated", () => {
@@ -627,6 +693,261 @@ describe("dashboard window", () => {
     ]);
   });
 
+  it("does not persist programmatic text-scale growth as user geometry", () => {
+    let scale = 1;
+    const saved = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      emitSetBoundsEvents: true,
+      getTextScale: () => scale,
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    scale = 1.6;
+    dashboard.applyTextScaleToWindow();
+
+    assert.deepStrictEqual(win.bounds, { x: 400, y: 100, width: 512, height: 640 });
+    // Some WMs deliver the setBounds events after the call returns. Matching
+    // late events are still programmatic geometry: a move may re-resolve the
+    // display's text scale, but neither event may arm bounds persistence.
+    win.emit("resize");
+    win.emit("move");
+    assert.strictEqual(timers.filter((t) => !t.cleared && t.delay === 500).length, 0);
+    const scaleTimer = timers.filter((t) => !t.cleared && t.delay === 350).at(-1);
+    assert.ok(scaleTimer);
+    scaleTimer.callback();
+    for (const timer of timers.filter((t) => !t.cleared && t.delay === 500)) timer.callback();
+    assert.deepStrictEqual(saved, []);
+
+    const userBounds = { x: 240, y: 180, width: 760, height: 680 };
+    win.bounds = { ...userBounds };
+    win.emit("resize");
+    timers.filter((t) => !t.cleared && t.delay === 500).at(-1).callback();
+    assert.deepStrictEqual(saved, [userBounds]);
+  });
+
+  it("flushes pending user geometry before text-scale growth rebases the window", () => {
+    let scale = 1;
+    const saved = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      emitSetBoundsEvents: true,
+      getTextScale: () => scale,
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    const moved = { x: 2100, y: 80, width: 480, height: 600 };
+    win.bounds = { ...moved };
+    win.emit("move");
+    scale = 1.6;
+    timers.filter((t) => !t.cleared && t.delay === 350).at(-1).callback();
+
+    assert.deepStrictEqual(saved, [moved]);
+    assert.deepStrictEqual(win.bounds, { ...moved, width: 512, height: 640 });
+    for (const timer of timers.filter((t) => !t.cleared && t.delay === 500)) timer.callback();
+    assert.deepStrictEqual(saved, [moved]);
+  });
+
+  async function assertFailedPreScaleFlushRetries({ asyncFailure, moved }) {
+    let scale = 1;
+    let persisted = { x: 40, y: 60, width: 480, height: 600 };
+    const attempts = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      emitSetBoundsEvents: true,
+      getSavedBounds: () => persisted,
+      getTextScale: () => scale,
+      onSaveBounds: (bounds) => {
+        attempts.push(bounds);
+        const response = attempts.length === 1
+          ? { status: "error", message: asyncFailure ? "disk full" : "read only" }
+          : { status: "ok" };
+        if (attempts.length > 1) persisted = bounds;
+        if (asyncFailure) return Promise.resolve(response);
+        return response;
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.bounds = { ...moved };
+    win.emit("move");
+    scale = 1.6;
+    timers.filter((t) => !t.cleared && t.delay === 350).at(-1).callback();
+    if (asyncFailure) {
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+
+    win.emit("close");
+    if (asyncFailure) {
+      await Promise.resolve();
+      await Promise.resolve();
+    }
+    assert.deepStrictEqual(attempts, [moved, moved]);
+    win.emit("closed");
+    dashboard.showDashboard();
+    assert.deepStrictEqual(getCreatedWindow().bounds, {
+      ...moved,
+      width: Math.max(moved.width, 512),
+      height: Math.max(moved.height, 640),
+    });
+  }
+
+  it("retries a synchronously failed pre-scale flush after growth", async () => {
+    await assertFailedPreScaleFlushRetries({
+      asyncFailure: false,
+      moved: { x: 600, y: 100, width: 480, height: 600 },
+    });
+  });
+
+  it("retries an asynchronously failed pre-scale flush after growth", async () => {
+    await assertFailedPreScaleFlushRetries({
+      asyncFailure: true,
+      moved: { x: 600, y: 100, width: 480, height: 600 },
+    });
+  });
+
+  it("retries a synchronously failed pre-scale flush without growth", async () => {
+    await assertFailedPreScaleFlushRetries({
+      asyncFailure: false,
+      moved: { x: 300, y: 100, width: 800, height: 650 },
+    });
+  });
+
+  it("retries an asynchronously failed pre-scale flush without growth", async () => {
+    await assertFailedPreScaleFlushRetries({
+      asyncFailure: true,
+      moved: { x: 300, y: 100, width: 800, height: 650 },
+    });
+  });
+
+  async function assertOlderAsyncCompletionPreservesNewerDebt(firstResponse) {
+    let settleFirstSave;
+    const attempts = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        attempts.push(bounds);
+        if (attempts.length === 1) {
+          return new Promise((resolve) => {
+            settleFirstSave = () => resolve(firstResponse);
+          });
+        }
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    const olderBounds = { x: 560, y: 100, width: 520, height: 620 };
+    const newerBounds = { x: 760, y: 180, width: 620, height: 680 };
+    win.bounds = { ...olderBounds };
+    win.emit("move");
+    timers.filter((timer) => !timer.cleared && timer.delay === 500).at(-1).callback();
+
+    win.bounds = { ...newerBounds };
+    win.emit("move");
+    // Model a later programmatic operation rebasing the native rectangle before
+    // the older asynchronous write completes. The newer user debt must survive.
+    dashboard.applyTextScaleToWindow({ flushPendingUserBounds: false });
+    settleFirstSave();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    win.emit("close");
+    assert.deepStrictEqual(attempts, [olderBounds, newerBounds]);
+  }
+
+  it("does not let an older asynchronous success clear newer user geometry", async () => {
+    await assertOlderAsyncCompletionPreservesNewerDebt({ status: "ok" });
+  });
+
+  it("does not let an older asynchronous failure revive older user geometry", async () => {
+    await assertOlderAsyncCompletionPreservesNewerDebt({ status: "error", message: "disk full" });
+  });
+
+  it("keeps failed user geometry retryable across dashboard window recreation", () => {
+    const persisted = { x: 40, y: 60, width: 480, height: 600 };
+    const moved = { x: 700, y: 220, width: 620, height: 660 };
+    const attempts = [];
+    const { dashboard, getCreatedWindow, timers } = createWindowHarness({
+      getSavedBounds: () => persisted,
+      onSaveBounds: (bounds) => {
+        attempts.push(bounds);
+        return attempts.length < 3
+          ? { status: "error", message: "read only" }
+          : { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const first = getCreatedWindow();
+    first.bounds = { ...moved };
+    first.emit("move");
+    timers.filter((timer) => !timer.cleared && timer.delay === 500).at(-1).callback();
+    first.emit("close");
+    first.emit("closed");
+
+    dashboard.showDashboard();
+    const second = getCreatedWindow();
+    assert.deepStrictEqual(second.bounds, persisted);
+    second.emit("close");
+    assert.deepStrictEqual(attempts, [moved, moved, moved]);
+  });
+
+  it("keeps failed user geometry through settings re-anchor and transient window cycles", () => {
+    for (const exposeMaximizedFlag of [true, false]) {
+      let persisted = { x: 40, y: 60, width: 520, height: 520 };
+      const attempts = [];
+      const settingsWindow = {
+        isDestroyed: () => false,
+        isMinimized: () => false,
+        getBounds: () => ({ x: 100, y: 50, width: 800, height: 560 }),
+      };
+      const { dashboard, getCreatedWindow } = createWindowHarness({
+        getSettingsWindow: () => settingsWindow,
+        getSavedBounds: () => persisted,
+        onSaveBounds: (bounds) => {
+          attempts.push(bounds);
+          if (attempts.length === 1) return { status: "error", message: "read only" };
+          persisted = bounds;
+          return { status: "ok" };
+        },
+      });
+
+      dashboard.showDashboard();
+      const win = getCreatedWindow();
+      const moved = { x: 700, y: 180, width: 520, height: 560 };
+      win.bounds = { ...moved };
+      win.emit("move");
+      dashboard.showDashboard({ source: "settings" });
+      assert.deepStrictEqual(win.bounds, { x: 260, y: 50, width: 480, height: 560 });
+
+      win.normalBounds = { ...win.bounds };
+      win.maximized = exposeMaximizedFlag;
+      win.bounds = { x: 0, y: 0, width: 1280, height: 800 };
+      win.emit("resize");
+      win.emit("move");
+      win.maximized = false;
+      win.bounds = { ...win.normalBounds };
+      win.emit("resize");
+      win.emit("move");
+
+      win.emit("close");
+      assert.deepStrictEqual(attempts, [moved, moved]);
+      win.emit("closed");
+      dashboard.showDashboard();
+      assert.deepStrictEqual(getCreatedWindow().bounds, moved);
+    }
+  });
+
   it("keeps a failed synchronous persistence retryable", () => {
     const attempts = [];
     const { dashboard, getCreatedWindow, timers } = createWindowHarness({
@@ -715,6 +1036,25 @@ describe("dashboard window", () => {
     ]);
   });
 
+  it("rounds fractional native bounds before handing them to persistence", () => {
+    const saved = [];
+    const { dashboard, getCreatedWindow } = createWindowHarness({
+      onSaveBounds: (bounds) => {
+        saved.push(bounds);
+        return { status: "ok" };
+      },
+    });
+
+    dashboard.showDashboard();
+    const win = getCreatedWindow();
+    win.bounds = { x: 10.6, y: -20.6, width: 801.7, height: 559.8 };
+    win.emit("close");
+
+    assert.deepStrictEqual(saved, [
+      { x: 11, y: -21, width: 802, height: 560 },
+    ]);
+  });
+
   it("saved bounds override native constructor frame drift", () => {
     const savedBounds = { x: 40, y: 60, width: 500, height: 520 };
     const { dashboard, getCreatedWindow } = createWindowHarness({
@@ -762,6 +1102,24 @@ describe("dashboard window", () => {
     assert.match(rendererSource, /dashboardOpenCodexSession/);
     assert.doesNotMatch(rendererSource, /session\.platform === "webui"/);
     assert.match(preloadSource, /dashboard:hide-session/);
+  });
+
+  it("wires Dashboard persistence to the Dashboard bounds key in main", () => {
+    const mainSource = fs.readFileSync(path.join(__dirname, "..", "src", "main.js"), "utf8");
+    const start = mainSource.indexOf('const _dashboard = require("./dashboard")({');
+    const end = mainSource.indexOf("\n});", start);
+    assert.ok(start >= 0 && end > start, "Dashboard runtime wiring block must exist");
+    const wiring = mainSource.slice(start, end);
+
+    assert.match(
+      wiring,
+      /getSavedBounds:\s*\(\)\s*=>\s*_settingsController\.get\("dashboardWindowBounds"\)/,
+    );
+    assert.match(
+      wiring,
+      /onSaveBounds:\s*\(bounds\)\s*=>\s*_settingsController\.applyUpdate\("dashboardWindowBounds", bounds\)/,
+    );
+    assert.doesNotMatch(wiring, /settingsWindowBounds/);
   });
 
   it("wires account quota (including Dashboard-only Spark) into the dashboard header", () => {

--- a/test/prefs.test.js
+++ b/test/prefs.test.js
@@ -1532,6 +1532,7 @@ describe("prefs.save", () => {
     snap.bubbleFollowPet = true;
     snap.x = 42;
     snap.settingsWindowBounds = { x: -1200, y: 80, width: 900, height: 640 };
+    snap.dashboardWindowBounds = { x: 1440, y: 120, width: 720, height: 620 };
     prefs.save(p, snap);
     const { snapshot } = prefs.load(p);
     assert.strictEqual(snapshot.lang, "zh");
@@ -1542,6 +1543,12 @@ describe("prefs.save", () => {
       y: 80,
       width: 900,
       height: 640,
+    });
+    assert.deepStrictEqual(snapshot.dashboardWindowBounds, {
+      x: 1440,
+      y: 120,
+      width: 720,
+      height: 620,
     });
     assert.strictEqual(snapshot.version, prefs.CURRENT_VERSION);
   });
@@ -1569,6 +1576,32 @@ describe("prefs.save", () => {
       "800x560",
     ]) {
       assert.strictEqual(prefs.validate({ settingsWindowBounds: value }).settingsWindowBounds, null);
+    }
+  });
+
+  it("normalizes Dashboard window bounds and drops invalid geometry", () => {
+    assert.deepStrictEqual(
+      prefs.validate({
+        dashboardWindowBounds: {
+          x: 10.6,
+          y: -20.6,
+          width: 801.7,
+          height: 559.8,
+          ignored: true,
+        },
+      }).dashboardWindowBounds,
+      { x: 11, y: -21, width: 802, height: 560 },
+    );
+
+    for (const value of [
+      { x: 0, y: 0, width: 0, height: 560 },
+      { x: Infinity, y: 0, width: 800, height: 560 },
+      { x: "0", y: 0, width: 800, height: 560 },
+      { x: 0, y: 0, width: 800 },
+      [],
+      "800x560",
+    ]) {
+      assert.strictEqual(prefs.validate({ dashboardWindowBounds: value }).dashboardWindowBounds, null);
     }
   });
 


### PR DESCRIPTION
## Summary

- preserve pending user window geometry before programmatic Settings placement or text-scale growth can rebase native bounds
- suppress synchronous and delayed programmatic move/resize events, plus maximized and fullscreen transient geometry
- keep per-display text-scale refresh active while preventing transient bounds persistence
- keep newer user geometry safe from older asynchronous save completion and make failed writes retryable
- add regression coverage for schema wiring, event timing, retries, fullscreen, and cross-display text scale

## Context

Thank you @KaiC5504 for #807, which added the core Dashboard bounds persistence and the original pending-save flush. This maintainer follow-up keeps that behavior while hardening the native Electron event-ordering and failure paths found during exact-head review and macOS validation.

## Validation

- Dashboard tests: 47/47 passed
- Related settings/persistence tests: 676/676 passed
- Full suite: 6904 total, 6883 passed, 0 failed, 21 Windows-only skipped
- Mutation checks confirmed the new regressions fail if text-scale refresh is gated, fullscreen protection is removed, async revision protection is removed, or retry debt is cleared on window close
- macOS real-machine smoke: Settings anchoring plus 100% to 160% text scale did not overwrite saved geometry; fullscreen enter/exit did not persist transient bounds; green-button Zoom remained a normal user resize and persisted

## Platform boundary

Windows DWM plus fractional-DPI dual-display behavior and Linux Wayland were not independently real-machine validated in this follow-up.