### PR TITLE
Fix target-native Koffi packaging and audit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,6 +138,10 @@ jobs:
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root dist/linux-unpacked/resources --output dist/telegram-retirement-manifests/linux-x64.json
       - name: Audit packaged native payloads
         run: node scripts/audit-packaged-native.js --app-root dist/linux-unpacked --target linux-x64 --output dist/native-package-manifests/linux-x64.json
+      - name: Configure Linux Chromium sandbox
+        run: |
+          sudo chown root:root dist/linux-unpacked/chrome-sandbox
+          sudo chmod 4755 dist/linux-unpacked/chrome-sandbox
       - name: Run packaged Koffi smoke
         run: node scripts/run-packaged-koffi-smoke.js --executable dist/linux-unpacked/clawd-on-desk --target linux-x64 --output dist/koffi-smoke/linux-x64.json --xvfb
       - name: Verify Linux updater metadata

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,17 +30,25 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - run: npm install
+      - run: npm ci
       - run: npm test
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.artifact_validation_only }}
       - name: Run package validation tests
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact_validation_only }}
-        run: node --test test/assert-no-retired-telegram-sidecar.test.js test/package-build-config.test.js test/telegram-legacy-retirement.test.js test/telegram-migration-state.test.js test/telegram-migration-controller.test.js test/telegram-migration-user-data.test.js
+        run: node --test test/assert-no-retired-telegram-sidecar.test.js test/after-pack-koffi.test.js test/audit-packaged-native.test.js test/koffi-lockfile.test.js test/native-package-target.test.js test/package-koffi-smoke.test.js test/package-build-config.test.js test/telegram-legacy-retirement.test.js test/telegram-migration-state.test.js test/telegram-migration-controller.test.js test/telegram-migration-user-data.test.js test/verify-updater-metadata.test.js test/win-foreground-terminal.test.js test/win-fullscreen-detect.test.js
       - run: npx electron-builder --win --publish never
       - name: Assert retired Telegram sidecar is absent
         run: |
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root dist/win-unpacked/resources --output dist/telegram-retirement-manifests/windows-x64.json
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root dist/win-arm64-unpacked/resources --output dist/telegram-retirement-manifests/windows-arm64.json
+      - name: Audit packaged native payloads
+        run: |
+          node scripts/audit-packaged-native.js --app-root dist/win-unpacked --target windows-x64 --output dist/native-package-manifests/windows-x64.json
+          node scripts/audit-packaged-native.js --app-root dist/win-arm64-unpacked --target windows-arm64 --output dist/native-package-manifests/windows-arm64.json
+      - name: Run native-host packaged Koffi smoke
+        run: node scripts/run-packaged-koffi-smoke.js --executable "dist/win-unpacked/Clawd on Desk.exe" --target windows-x64 --output dist/koffi-smoke/windows-x64.json
+      - name: Verify Windows updater metadata
+        run: node scripts/verify-updater-metadata.js --metadata dist/latest.yml --artifact-root dist --contract windows --output dist/updater-metadata-manifests/windows.json
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -55,6 +63,16 @@ jobs:
           path: |
             dist/telegram-retirement-manifests/*.json
           if-no-files-found: warn
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: windows-native-package-audit
+          path: |
+            dist/koffi-prune-manifests/*.json
+            dist/koffi-smoke/*.json
+            dist/native-package-manifests/*.json
+            dist/updater-metadata-manifests/*.json
+          if-no-files-found: error
 
   build-mac:
     needs: validate-release
@@ -64,13 +82,21 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - run: npm install
+      - run: npm ci
       - run: npm test
       - run: npx electron-builder --mac --publish never
       - name: Assert retired Telegram sidecar is absent
         run: |
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root "dist/mac/Clawd on Desk.app/Contents/Resources" --output dist/telegram-retirement-manifests/darwin-x64.json
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root "dist/mac-arm64/Clawd on Desk.app/Contents/Resources" --output dist/telegram-retirement-manifests/darwin-arm64.json
+      - name: Audit packaged native payloads
+        run: |
+          node scripts/audit-packaged-native.js --app-root "dist/mac/Clawd on Desk.app" --target darwin-x64 --output dist/native-package-manifests/darwin-x64.json
+          node scripts/audit-packaged-native.js --app-root "dist/mac-arm64/Clawd on Desk.app" --target darwin-arm64 --output dist/native-package-manifests/darwin-arm64.json
+      - name: Run native-host packaged Koffi smoke
+        run: node scripts/run-packaged-koffi-smoke.js --executable "dist/mac-arm64/Clawd on Desk.app/Contents/MacOS/Clawd on Desk" --target darwin-arm64 --output dist/koffi-smoke/darwin-arm64.json
+      - name: Verify macOS updater metadata
+        run: node scripts/verify-updater-metadata.js --metadata dist/latest-mac.yml --artifact-root dist --contract mac --output dist/updater-metadata-manifests/mac.json
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -85,6 +111,16 @@ jobs:
           path: |
             dist/telegram-retirement-manifests/*.json
           if-no-files-found: warn
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: mac-native-package-audit
+          path: |
+            dist/koffi-prune-manifests/*.json
+            dist/koffi-smoke/*.json
+            dist/native-package-manifests/*.json
+            dist/updater-metadata-manifests/*.json
+          if-no-files-found: error
 
   build-linux:
     needs: validate-release
@@ -94,12 +130,18 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - run: npm install
+      - run: npm ci
       - run: npm test
       - run: npx electron-builder --linux --publish never
       - name: Assert retired Telegram sidecar is absent
         run: |
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root dist/linux-unpacked/resources --output dist/telegram-retirement-manifests/linux-x64.json
+      - name: Audit packaged native payloads
+        run: node scripts/audit-packaged-native.js --app-root dist/linux-unpacked --target linux-x64 --output dist/native-package-manifests/linux-x64.json
+      - name: Run packaged Koffi smoke
+        run: node scripts/run-packaged-koffi-smoke.js --executable dist/linux-unpacked/clawd-on-desk --target linux-x64 --output dist/koffi-smoke/linux-x64.json --xvfb
+      - name: Verify Linux updater metadata
+        run: node scripts/verify-updater-metadata.js --metadata dist/latest-linux.yml --artifact-root dist --contract linux --output dist/updater-metadata-manifests/linux.json
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -115,6 +157,16 @@ jobs:
           path: |
             dist/telegram-retirement-manifests/*.json
           if-no-files-found: warn
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: linux-native-package-audit
+          path: |
+            dist/koffi-prune-manifests/*.json
+            dist/koffi-smoke/*.json
+            dist/native-package-manifests/*.json
+            dist/updater-metadata-manifests/*.json
+          if-no-files-found: error
 
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/telegram-retirement-package-audit.yml
+++ b/.github/workflows/telegram-retirement-package-audit.yml
@@ -153,6 +153,11 @@ jobs:
           --app-root "${{ matrix.app_root }}"
           --target "${{ matrix.target }}"
           --output "dist/native-package-manifests/${{ matrix.target }}.json"
+      - name: Configure Linux Chromium sandbox
+        if: matrix.target == 'linux-x64'
+        run: |
+          sudo chown root:root dist/linux-unpacked/chrome-sandbox
+          sudo chmod 4755 dist/linux-unpacked/chrome-sandbox
       - name: Run packaged Koffi smoke
         run: >-
           node scripts/run-packaged-koffi-smoke.js

--- a/.github/workflows/telegram-retirement-package-audit.yml
+++ b/.github/workflows/telegram-retirement-package-audit.yml
@@ -1,4 +1,4 @@
-name: Telegram Legacy Retirement Package Audit
+name: Five-target Package Audit
 
 on:
   pull_request:
@@ -7,6 +7,13 @@ on:
       - "package.json"
       - "package-lock.json"
       - "src/main.js"
+      - "src/koffi-package-contract.js"
+      - "src/native-package-target.js"
+      - "src/package-koffi-smoke.js"
+      - "src/mac-window.js"
+      - "src/win-cloak-recovery.js"
+      - "src/win-foreground-terminal.js"
+      - "src/win-fullscreen-detect.js"
       - "src/settings-actions.js"
       - "src/settings-i18n.js"
       - "src/telegram-*"
@@ -14,8 +21,21 @@ on:
       - "src/settings.css"
       - "scripts/assert-no-retired-telegram-sidecar.js"
       - "scripts/audit-repository-assets.js"
+      - "scripts/after-pack-koffi.js"
+      - "scripts/audit-packaged-native.js"
+      - "scripts/native-package-policy.json"
+      - "scripts/run-packaged-koffi-smoke.js"
+      - "scripts/verify-updater-metadata.js"
       - "test/assert-no-retired-telegram-sidecar.test.js"
+      - "test/after-pack-koffi.test.js"
+      - "test/audit-packaged-native.test.js"
+      - "test/koffi-lockfile.test.js"
+      - "test/native-package-target.test.js"
+      - "test/package-koffi-smoke.test.js"
       - "test/package-build-config.test.js"
+      - "test/verify-updater-metadata.test.js"
+      - "test/win-foreground-terminal.test.js"
+      - "test/win-fullscreen-detect.test.js"
       - "test/settings-renderer-browser-env.test.js"
       - "test/telegram-legacy-retirement.test.js"
       - "test/telegram-migration-*.test.js"
@@ -34,15 +54,23 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - run: npm install
+      - run: npm ci
       - run: |
           node --test \
             test/assert-no-retired-telegram-sidecar.test.js \
+            test/after-pack-koffi.test.js \
+            test/audit-packaged-native.test.js \
+            test/koffi-lockfile.test.js \
+            test/native-package-target.test.js \
+            test/package-koffi-smoke.test.js \
             test/package-build-config.test.js \
             test/telegram-legacy-retirement.test.js \
             test/telegram-migration-state.test.js \
             test/telegram-migration-controller.test.js \
-            test/telegram-migration-user-data.test.js
+            test/telegram-migration-user-data.test.js \
+            test/verify-updater-metadata.test.js \
+            test/win-foreground-terminal.test.js \
+            test/win-fullscreen-detect.test.js
 
   package:
     needs: unit
@@ -54,30 +82,45 @@ jobs:
           - target: windows-x64
             runner: windows-latest
             build_script: build:win:x64
+            app_root: dist/win-unpacked
+            executable: dist/win-unpacked/Clawd on Desk.exe
+            smoke_extra: ""
             resources_root: dist/win-unpacked/resources
             artifact_check_glob: dist/Clawd-on-Desk-Setup-*-x64.exe
             artifact_glob: dist/Clawd-on-Desk-Setup-*-x64.exe
           - target: windows-arm64
-            runner: windows-latest
+            runner: windows-11-arm
             build_script: build:win:arm64
+            app_root: dist/win-arm64-unpacked
+            executable: dist/win-arm64-unpacked/Clawd on Desk.exe
+            smoke_extra: ""
             resources_root: dist/win-arm64-unpacked/resources
             artifact_check_glob: dist/Clawd-on-Desk-Setup-*-arm64.exe
             artifact_glob: dist/Clawd-on-Desk-Setup-*-arm64.exe
           - target: darwin-x64
-            runner: macos-latest
+            runner: macos-15-intel
             build_script: build:mac:x64
+            app_root: dist/mac/Clawd on Desk.app
+            executable: dist/mac/Clawd on Desk.app/Contents/MacOS/Clawd on Desk
+            smoke_extra: ""
             resources_root: dist/mac/Clawd on Desk.app/Contents/Resources
             artifact_check_glob: dist/Clawd-on-Desk-*-x64.dmg
             artifact_glob: dist/Clawd-on-Desk-*-x64.dmg
           - target: darwin-arm64
             runner: macos-latest
             build_script: build:mac:arm64
+            app_root: dist/mac-arm64/Clawd on Desk.app
+            executable: dist/mac-arm64/Clawd on Desk.app/Contents/MacOS/Clawd on Desk
+            smoke_extra: ""
             resources_root: dist/mac-arm64/Clawd on Desk.app/Contents/Resources
             artifact_check_glob: dist/Clawd-on-Desk-*-arm64.dmg
             artifact_glob: dist/Clawd-on-Desk-*-arm64.dmg
           - target: linux-x64
             runner: ubuntu-latest
             build_script: build:linux:x64
+            app_root: dist/linux-unpacked
+            executable: dist/linux-unpacked/clawd-on-desk
+            smoke_extra: "--xvfb"
             resources_root: dist/linux-unpacked/resources
             artifact_check_glob: dist/Clawd-on-Desk-*-x86_64.AppImage
             artifact_glob: |
@@ -89,7 +132,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
-      - run: npm install
+      - run: npm ci
       - run: npm run ${{ matrix.build_script }} -- --publish never
       - name: Assert installer exists
         shell: bash
@@ -104,12 +147,28 @@ jobs:
           node scripts/assert-no-retired-telegram-sidecar.js
           --resources-root "${{ matrix.resources_root }}"
           --output "dist/telegram-retirement-manifests/${{ matrix.target }}.json"
+      - name: Audit packaged native payloads
+        run: >-
+          node scripts/audit-packaged-native.js
+          --app-root "${{ matrix.app_root }}"
+          --target "${{ matrix.target }}"
+          --output "dist/native-package-manifests/${{ matrix.target }}.json"
+      - name: Run packaged Koffi smoke
+        run: >-
+          node scripts/run-packaged-koffi-smoke.js
+          --executable "${{ matrix.executable }}"
+          --target "${{ matrix.target }}"
+          --output "dist/koffi-smoke/${{ matrix.target }}.json"
+          ${{ matrix.smoke_extra }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: telegram-retirement-${{ matrix.target }}
+          name: package-audit-${{ matrix.target }}
           path: |
             ${{ matrix.artifact_glob }}
+            dist/koffi-prune-manifests/*.json
+            dist/koffi-smoke/*.json
+            dist/native-package-manifests/*.json
             dist/telegram-retirement-manifests/*.json
           if-no-files-found: error
           retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ docs/**
 !docs/investigations/codex-subagent-session-meta.md
 !docs/plans/
 !docs/plans/plan-issue-513-remote-ssh-isolation.md
+!docs/plans/plan-issue-763-koffi-target-native-packaging.md
 !docs/project/
 !docs/project/agent-runtime-architecture.md
 !docs/project/release-process.md
@@ -107,6 +108,11 @@ scripts/*
 !scripts/audit-repository-assets.js
 !scripts/assert-no-retired-telegram-sidecar.js
 !scripts/verify-release-version.js
+!scripts/after-pack-koffi.js
+!scripts/audit-packaged-native.js
+!scripts/native-package-policy.json
+!scripts/run-packaged-koffi-smoke.js
+!scripts/verify-updater-metadata.js
 
 # oh-my-cursor state
 .omc/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,7 @@ Copilot CLI 同步走 `<COPILOT_HOME 或 ~/.copilot>/hooks/hooks.json`，marker-
 - 禁用 agent 不应卸载 hooks / plugins / extensions：只停止对应 monitor、清理 session / bubble、让 HTTP hook 入口快速 fallback；重新启用未安装 agent 不触发本机 integration sync。卸载集成必须走 Settings Agent 页的 Uninstall / 对应 uninstall 命令，并同时清掉 `integrationInstalled`
 - Kiro 的 `sessionId="default"` 会复用；session alias key 必须按 cwd scope 区分，同时保留旧 `local|kiro-cli|default` 只读 fallback
 - Windows NSIS release 必须产出明确架构的 x64 / ARM64 安装包：`win.artifactName` 保留 `${arch}`，`nsis.buildUniversalInstaller` 保持 `false`
+- 每个 release target 只能保留一个匹配目标架构的 Koffi `koffi.node`；`afterPack` 只允许剪裁 `app.asar.unpacked` 的物理文件，禁止重写 `app.asar`，并必须通过完整 native inventory audit（唯一常设例外是 electron-builder 管理的 Windows ia32 `resources/elevate.exe`）
 - 资源路径统一用 `path.join(__dirname, ...)`
 - 需要编辑发布素材时，先复制到 `assets/source/` 再改，不要直接改工作素材来源不明的文件
 - `assets/source/cloudling-pointer-bridge/` 是 Cloudling 指针桥素材的保留源文件目录；运行时逻辑已内联进主题 SVG，不要把这个 source 目录当临时文件清理

--- a/docs/plans/plan-issue-763-koffi-target-native-packaging.md
+++ b/docs/plans/plan-issue-763-koffi-target-native-packaging.md
@@ -1,0 +1,628 @@
+# Plan: #763 Koffi target-native packaging and foreign-native audit
+
+> Status: **Draft v3 with second-review findings incorporated; no implementation is authorized by this document**
+> Date: 2026-08-07
+> Issue: https://github.com/rullerzhou-afk/clawd-on-desk/issues/763
+> Origin: follow-up deliberately excluded from PR #762
+> Scope: Windows x64/ARM64, macOS x64/ARM64, Linux x64 release artifacts
+
+---
+
+## 0. Decision summary
+
+The implementation should not begin by blindly deleting 17 directories from the packaged app.
+
+Koffi 3.x provides an upstream split-package answer, but its ABI layer is still receiving material fixes: 3.1.1 restored a missing Windows ARM64 package, and 3.1.4 fixed unused register/stack bytes for Win64 and i386 `bool` arguments. Clawd's FFI surface includes manual COM vtable dispatch, multiple `objc_msgSend` prototypes, and private SkyLight calls. Migrating that surface while also changing dependency provisioning and release-job topology would combine three independently risky changes.
+
+Both packaging routes can satisfy #763's acceptance condition: each release target contains exactly one target-native Koffi addon. The selected route for #763 is therefore **Route B**:
+
+1. pin the reviewed latest Koffi 2.16.x release, currently `2.16.3`, exactly;
+2. run real-library compatibility probes because 2.15.2 to 2.16.3 is not assumed to be behavior-neutral;
+3. use electron-builder's supported `afterPack` hook to retain only the target triplet's `koffi.node` and remove every other Koffi native payload before signing;
+4. add a post-package assertion that exactly the expected Koffi native payload is present;
+5. add a full extracted-app native audit with one narrow, documented exception for electron-builder's NSIS `resources/elevate.exe` helper;
+6. require positive packaged/runtime behavior evidence instead of treating a clean launch or lack of warnings as proof.
+
+Koffi 3 migration is deliberately deferred to a separate issue. That issue will own BigInt pointer adaptation, split-package lockfile/provisioning experiments, `process.resourcesPath` loading, multi-prototype `objc_msgSend` verification, and any release-job/updater-metadata topology change. Those topics do not gate #763.
+
+No release, tag, asset/history cleanup, Telegram retirement work, Remote SSH change, or unrelated FFI refactor belongs in this change.
+
+---
+
+## 1. Verified current state
+
+### 1.1 Package evidence
+
+The current repository declares `koffi: "^2.15.2"`; the lockfile resolves exactly 2.15.2. Koffi 2.15.2 installs all supported native targets into one package.
+
+The current source install contains:
+
+| Item | Count / bytes |
+|---|---:|
+| `koffi.node` files | 18 |
+| Total `koffi.node` bytes | 79,636,403 |
+| Total files under `node_modules/koffi/build/koffi` | 79,645,670 |
+
+The local v0.14.0 Windows x64 staged app built on 2026-08-05 still reproduces the issue:
+
+| Item | Count / bytes |
+|---|---:|
+| Packaged Koffi native modules | 18 / 79,636,403 bytes |
+| Foreign-to-win32-x64 modules | 17 / 76,446,131 bytes |
+| `resources/elevate.exe` | 107,520 bytes, PE ia32 |
+
+These local numbers are diagnosis evidence, not the canonical before/after benchmark. The implementation PR must produce same-commit, clean-run baselines as described in section 8.
+
+### 1.2 Runtime use of Koffi
+
+Koffi is not an incidental dependency. Clawd uses it in production paths:
+
+| Platform | Files / behavior |
+|---|---|
+| Windows | `src/main.js`: `AllowSetForegroundWindow`, console output code page |
+| Windows | `src/win-fullscreen-detect.js`: foreground fullscreen detection |
+| Windows | `src/win-foreground-terminal.js`: foreground Windows Terminal capture |
+| Windows | `src/win-cloak-recovery.js`: DWM cloak state and COM vtable calls |
+| macOS | `src/mac-window.js`: Objective-C/AppKit messaging and private SkyLight calls |
+| Linux | No current Clawd production FFI call, but the release contract will keep the matching linux-x64 Koffi package so `require("koffi")` remains valid and the five-target packaging rule stays uniform. Removing Linux Koffi entirely is a separate product/dependency decision. |
+
+The Windows cloak recovery path is the highest-risk compatibility area. It manually decodes COM vtable pointers and calls function pointers. Unit fakes cannot prove that its pointer widths, calling conventions, or behavior under a new Koffi native build are correct.
+
+### 1.3 Existing build topology
+
+The release workflow currently does the following:
+
+| Job | Host install | Outputs from the same dependency tree |
+|---|---|---|
+| Windows | `windows-latest`, one `npm install` | x64 NSIS + ARM64 NSIS and one combined `latest.yml` |
+| macOS | `macos-latest`, one `npm install` | x64 DMG + ARM64 DMG |
+| Linux | Ubuntu x64, one `npm install` | x64 AppImage + x64 deb |
+
+The published v0.14.0 `latest.yml` contains both Windows x64 and ARM64 installer entries. Route B preserves the single-job release topology and avoids introducing updater metadata merge/overwrite behavior merely to solve #763. The implementation still switches package/install jobs from `npm install` to clean, lockfile-driven `npm ci` as described in section 9.4.
+
+### 1.4 Upstream and package facts used by this plan
+
+- Koffi changelog: https://koffi.dev/changelog
+- Koffi pointer documentation: https://koffi.dev/pointers
+- Koffi 2.16.3 registry metadata: https://registry.npmjs.org/koffi/2.16.3
+- electron-builder build hooks: https://www.electron.build/docs/features/hooks/
+- electron-builder lifecycle: https://www.electron.build/docs/features/build-lifecycle/
+- npm clean install: https://docs.npmjs.com/cli/commands/npm-ci/
+- Published v0.14.0 updater metadata: [Windows](https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v0.14.0/latest.yml), [macOS](https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v0.14.0/latest-mac.yml), [Linux](https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v0.14.0/latest-linux.yml)
+- GitHub Windows ARM64 runner image migration notice: https://github.blog/changelog/2026-06-11-new-runner-images-in-public-preview/
+
+As of this plan, Koffi 2.16.3 is the selected candidate. It was released on 2026-07-20. Koffi 2.16.0 expanded `koffi.address()` to support Buffers and typed arrays, changed x86 SEH stack placement, and substantially reduced package size; 2.16.1 changed Windows callback stack/exception behavior. Do not assume API/ABI behavior solely from the unchanged major version. Do not leave a caret range that can silently change native code during a later lockfile refresh; pin `2.16.3` exactly.
+
+The published 2.16.3 tarball has an unpacked size of 28,750,096 bytes and integrity `sha512-E9y1AsgYGlaxMhcZzHr8y96QF2U5XzA12GGVAfbWqIubTwPNMXQarfBzePNXHe0xtIEtNd6ifAv3GAKYGUeBAQ==`. Its measured `build/koffi` layout contains 18 target directories and 18 `koffi.node` files. Each Windows triplet also contains `koffi.lib` and `koffi.exp`; those link artifacts are not needed at runtime. After pruning, the retained target triplet must contain exactly one file: `koffi.node`.
+
+Koffi 2.16.3 still has an install script (`node src/cnoke/cnoke.js -P . -D src/koffi --prebuild`). Phase 0 must prove that clean installs use the published prebuilds and do not silently fall back to a local source build.
+
+---
+
+## 2. Goals and non-goals
+
+### 2.1 Goals
+
+1. Each of the five release targets contains exactly one target-appropriate Koffi native addon and no foreign Koffi native addon.
+2. `require("koffi")` succeeds from the packaged Electron app on every target.
+3. Windows and macOS FFI behavior continues to work on the actual target architecture.
+4. A deterministic extracted-app audit reports every PE, ELF, and Mach-O payload and fails on an unexpected foreign architecture.
+5. The intentional electron-builder `resources/elevate.exe` helper is allowed by one exact-path, Windows-only, PE-ia32 exception with recorded provenance and reason.
+6. Installer/download bytes and staged/unpacked bytes are recorded independently from a same-commit baseline.
+7. Release CI cannot publish an artifact that skipped the Koffi/native audit.
+
+### 2.2 Non-goals
+
+1. Do not remove Koffi from Linux in this issue.
+2. Do not replace Koffi with another FFI library.
+3. Do not rewrite the Windows focus, fullscreen, cloak recovery, or macOS SkyLight feature design.
+4. Do not add universal Windows NSIS output; x64 and ARM64 remain separate.
+5. Do not remove `elevate.exe`. The task is to recognize its deliberate electron-builder provenance, not to disable an installer helper.
+6. Do not rewrite Git history or clean unrelated assets.
+7. Do not treat unit-test fakes as native ABI evidence.
+8. Do not migrate to Koffi 3, add `@koromix/koffi-*` provisioning, or split release jobs by architecture in #763.
+
+---
+
+## 3. Phase 0: Route B validation gate before production changes
+
+Phase 0 is a bounded spike. Its output is a checked-in evidence note or a clear section in the implementation PR. Route B is already selected; Phase 0 validates the selected version and pruning mechanics rather than reopening the Koffi 3 decision.
+
+### 3.1 Koffi 2.16.3 compatibility and install spike
+
+Use an isolated clean worktree or temporary project; do not mutate the user's active `node_modules` and call that reproducible evidence.
+
+Pin `koffi@2.16.3` and run the existing focused FFI tests plus new real-library probes on the applicable operating systems and architectures.
+
+Explicitly check:
+
+- all existing `lib.func(...)` declarations initialize;
+- `koffi.struct`, `koffi.sizeof`, output arrays, Buffers, and typed arrays behave unchanged;
+- `koffi.decode(buffer, "void *")` and offset decode return the pointers expected by `win-cloak-recovery.js`;
+- `koffi.proto` + `koffi.call` works for the manual COM vtable path;
+- `koffi.address()` returns the correct lossless BigInt for real pointer wrappers, Buffers/typed arrays where relevant, and the HWND path used by `win-foreground-terminal.js`;
+- Windows COM vtable decode/call succeeds against a real `IVirtualDesktopManager` instance far enough to obtain a non-null Boolean result for a real window;
+- macOS loads `libobjc` and SkyLight declarations, and multiple declarations of `objc_msgSend` with different prototypes each return plausible values;
+- Linux loads libc and a harmless call such as `getpid()` matches `process.pid`.
+
+Phase 0 fails if any real-library probe crashes, returns an implausible pointer, or requires weakening an existing runtime safety check.
+
+### 3.2 Install and package-layout evidence
+
+For Windows, macOS, and Linux CI hosts, start from the committed lockfile with `npm ci` and record:
+
+- the installed Koffi version and integrity;
+- the install-script result and whether any native source compilation or network download was attempted;
+- the actual `build/koffi` triplet inventory, file counts, and bytes;
+- successful `require("koffi")` plus one harmless native call;
+- successful execution of this repository's normal postinstall chain, including `scripts/verify-electron-install.js` and the host Electron binary.
+
+Any environment that falls back to local Koffi compilation or an install-time network download is rejected for release packaging until the cause is understood. The packaging hook itself must not download dependencies or run Koffi's build system.
+
+Build at least each unpacked target once and record the actual electron-builder 26.8.1 `afterPack` context platform/arch value. Normalize that value through the authoritative target map; do not hard-code unverified numeric enum values.
+
+### 3.3 Selected production route and pruning contract
+
+- Pin `koffi` to exactly `2.16.3`; do not remain on 2.15.2 or use a floating caret.
+- Register an electron-builder `afterPack` hook. Official lifecycle guarantees this runs after app files are packaged and before signing/distributable assembly.
+- Resolve the target triplet exclusively from the hook context's platform and architecture.
+- Re-measure the installed 2.16.3 layout in Phase 0 before freezing the prune implementation; do not copy a 2.15.2 directory list by assumption.
+- Under the resolved staged app only, retain the target triplet directory and remove every sibling target directory.
+- Remove **all** `.lib` and `.exp` files, including any inside the retained target triplet.
+- After pruning, require the retained target triplet to contain exactly `koffi.node` and no other file.
+- Fail closed on an unknown platform/arch, a missing expected directory, zero native modules, multiple native modules, or a path that resolves outside the staged Koffi subtree.
+- Never mutate source `node_modules`, shared caches, or another architecture's output directory.
+- Apply all audit, CI, size, and real-machine requirements below without weakening them because the major Koffi version remains 2.x.
+
+### 3.4 Deferred Koffi 3 issue
+
+Create a separate follow-up issue before or alongside implementation. Preserve the following research inputs there rather than implementing them in #763:
+
+- exact Koffi 3 version selection after ABI-fix frequency settles;
+- BigInt pointer migration and `koffi.address()` compatibility;
+- all five `@koromix/koffi-*` lockfile rows and clean cross-target provisioning;
+- Koffi 3's documented `process.resourcesPath` search roots and a possible `extraResources`-based target-native model;
+- full-Electron smoke when `ELECTRON_RUN_AS_NODE` cannot exercise `process.resourcesPath`;
+- Windows ARM64 COM vtable and macOS multi-prototype `objc_msgSend` probes;
+- updater metadata ownership/merge behavior before any release job is split by architecture.
+
+---
+
+## 4. Production design
+
+### 4.1 One authoritative target map
+
+Create one pure helper used by packaging, tests, and audits. Suggested responsibility:
+
+```text
+(electronPlatformName, electronBuilderArch)
+  -> releaseTargetId
+  -> expected process.platform/process.arch
+  -> Koffi package name or Koffi 2 triplet
+  -> expected native binary format and machine
+```
+
+Required mappings:
+
+| Release target | Runtime tuple | Koffi triplet | Binary format / machine | Artifact arch aliases |
+|---|---|---|---|---|
+| windows-x64 | `win32/x64` | `win32_x64` | PE x64 | `x64` |
+| windows-arm64 | `win32/arm64` | `win32_arm64` | PE ARM64 | `arm64` |
+| darwin-x64 | `darwin/x64` | `darwin_x64` | Mach-O x86_64 | `x64` |
+| darwin-arm64 | `darwin/arm64` | `darwin_arm64` | Mach-O arm64 | `arm64` |
+| linux-x64 | `linux/x64` | `linux_x64` | ELF x86_64 | AppImage `x86_64`, deb `amd64` |
+
+Do not duplicate this mapping in the build hook, audit CLI, workflow shell, and tests. Do not infer the audit target from artifact filenames; workflows pass the explicit release target ID. Do not use unreviewed numeric electron-builder arch constants in several files; normalize them once and test the actual hook context values emitted by electron-builder 26.8.1.
+
+### 4.2 Staged-app Koffi assertion
+
+The packaging hook or immediate post-pack assertion must:
+
+1. resolve the staged resources directory from `context.appOutDir` and platform conventions;
+2. inventory all physical `koffi.node` files in `app.asar.unpacked`;
+3. require exactly one target Koffi addon;
+4. parse its native header and verify the target machine, not merely trust its directory name;
+5. record relative path, byte size, SHA-256, Koffi version, package name/triplet, format, and machine in a JSON manifest;
+6. throw on missing, duplicate, malformed, or foreign Koffi payloads.
+
+The assertion must also list the logical ASAR entries for Koffi native files. `afterPack` physical deletion may leave stale `unpacked` header entries pointing at deleted foreign files. Do not accept those entries as harmless by reasoning alone: document the observed ASAR behavior, make the artifact audit count physical payloads correctly, and require packaged `require("koffi")` plus a native call to succeed.
+
+Do **not** attempt to eliminate stale logical entries by rewriting `app.asar` inside `afterPack` or any later hook. electron-builder 26.8.1 computes ASAR integrity during `beforeCopyExtraFiles`, before `afterPack`, and embeds it in the Windows executable resource and macOS `Info.plist` (`ElectronAsarIntegrity`). Rewriting the archive after that point produces a staged app whose integrity record no longer matches. On macOS this can make the packaged app fail at launch while an `ELECTRON_RUN_AS_NODE` smoke still passes. For Route B, stale logical entries are handled exclusively through the documented physical-inventory audit plus packaged `require("koffi")`/native-call smoke; the archive itself remains byte-for-byte unchanged after its integrity is recorded.
+
+### 4.3 Full extracted-app foreign-native audit
+
+Add a platform-neutral Node script, with its parser logic separated for unit tests. Suggested interface:
+
+```text
+node scripts/audit-packaged-native.js \
+  --app-root <extracted-app-root> \
+  --target windows-x64 \
+  --output <manifest.json>
+```
+
+Audit scope is the complete staged/extracted application directory used to create the installer:
+
+- Windows: `dist/win-unpacked` and `dist/win-arm64-unpacked`;
+- macOS: each `.app` bundle under the architecture-specific output directory;
+- Linux: `dist/linux-unpacked`.
+
+The script should identify binaries by magic/header, not extension alone:
+
+- PE: validate DOS and PE signatures, then read `Machine`;
+- ELF: validate class/endianness and read `e_machine`;
+- Mach-O: support thin and fat headers, enumerate slices, and report CPU types;
+- unknown or malformed executable-looking files: fail with path and reason rather than silently classifying them as assets.
+
+The first implementation should report every discovered native binary. It should not attempt to interpret arbitrary compressed archives. ASAR native payloads must be covered through ASAR listing plus `app.asar.unpacked` physical files.
+
+The manifest must be stable and sorted by normalized relative path. Include:
+
+- schema version;
+- release target;
+- app root identity;
+- each binary's path, size, SHA-256, format, architecture/slices;
+- disposition: `target`, `exception`, or `error`;
+- the exact policy entry used for an exception;
+- summary counts and bytes by disposition.
+
+### 4.4 Narrow `elevate.exe` policy
+
+electron-builder 26.8.1 copies the NSIS helper from its NSIS resources in `CopyElevateHelper` to `<appOutDir>/resources/elevate.exe`. The helper is intentionally PE ia32 even in x64 and ARM64 app directories.
+
+Represent this in a checked-in policy file rather than a broad code conditional. The exception must require all of:
+
+- normalized relative path is exactly `resources/elevate.exe`;
+- target platform is Windows;
+- parsed format is PE;
+- parsed machine is ia32;
+- reason names electron-builder NSIS `CopyElevateHelper`;
+- the audit manifest still records size and SHA-256 for review.
+
+Do not allow `**/elevate.exe`, every ia32 PE, every file under `resources`, or arbitrary electron-builder helpers.
+
+Do not pin only the unsigned file hash without accounting for release signing: electron-builder can sign the copied helper. If the implementation adds a hash or Authenticode condition, it must work for both unsigned validation builds and signed releases, and the review must explain how provenance remains verifiable after signing.
+
+The post-build extracted-app audit is required because electron-builder copies `elevate.exe` during NSIS target assembly, later than the normal `afterPack` stage.
+
+### 4.5 Fail-safe filesystem rules
+
+Any pruning implementation must:
+
+1. resolve and normalize the staged target directory;
+2. verify it is inside `context.appOutDir`;
+3. verify the deletion root is the exact Koffi native subtree;
+4. enumerate proposed deletions before applying them;
+5. reject symlinks/reparse points or any resolved path that leaves the subtree;
+6. never use the workspace root, user home, an unresolved environment variable, or a broad glob as a recursive-delete target;
+7. stop the build if the retained target fails post-prune verification.
+
+These guards require unit tests. A correct happy-path build is not evidence that the destructive boundary is safe.
+
+---
+
+## 5. Koffi 2.16.3 runtime compatibility checks
+
+The major version remains 2.x, but 2.16.0 changed `koffi.address()` behavior and Koffi's native build/ABI implementation. The following production paths require explicit source and real-library review.
+
+### 5.1 Windows foreground terminal
+
+`src/win-foreground-terminal.js` calls `koffi.address(hwnd)` and converts the result directly to a decimal string. Keep the lossless BigInt-to-decimal path and prove that 2.16.3 returns the actual foreground Windows Terminal handle rather than silently falling through the module's catch-to-`null` behavior.
+
+Tests must assert:
+
+- a real Koffi pointer wrapper converts to the expected BigInt address;
+- Buffer/typed-array address behavior added in 2.16.0 does not alter the HWND path;
+- decimal HWND output never passes through `Number`;
+- the real Windows probe returns a decimal HWND while a real Windows Terminal is foreground;
+- the real ABI smoke does not hard-code the text `koffi 2.15.2`.
+
+### 5.2 Windows cloak recovery
+
+Review and exercise every pointer boundary in `src/win-cloak-recovery.js`:
+
+- `CoCreateInstance` output `ppv[0]`;
+- vtable decode;
+- function-pointer decode at slots 2 and 3;
+- `koffi.proto` calling conventions;
+- `koffi.call` arguments and output array;
+- HWND decode from Electron's native window handle Buffer.
+
+Keep or strengthen explicit type/prototype declarations. The real probe must report `available=true`, obtain a non-null true/false result from `isOnCurrentVirtualDesktop()` for a real window, and dispose the COM manager cleanly. Initialization without a successful call is insufficient.
+
+### 5.3 macOS Objective-C and SkyLight
+
+`nativeHandleToPointer()` already returns BigInt. Verify on both Intel and Apple Silicon:
+
+- Objective-C selectors/classes initialize;
+- the existing multiple `objc_msgSend` declarations preserve their individual signatures and return widths (`long`/`ulong` on LP64);
+- SkyLight connection/space IDs remain plausible;
+- `applyStationaryCollectionBehavior()` returns true for a real Clawd window and the pet remains stationary during a Space switch;
+- de-delegation and restoration perform successful calls rather than merely avoiding warnings;
+- the optional de-delegation API still degrades safely when symbols are absent.
+
+### 5.4 Linux
+
+Run a packaged Koffi load smoke against libc (`getpid` or another harmless stable function). This is a package integrity test, not a new Clawd Linux runtime dependency.
+
+---
+
+## 6. Automated tests
+
+### 6.1 Pure/unit tests
+
+Add focused coverage for:
+
+- all five target mappings and unknown platform/arch rejection;
+- Koffi package/triplet inventory: exact one, zero, duplicate, wrong package, wrong arch;
+- PE x64/ARM64/ia32 parsing and malformed/truncated PE;
+- ELF x64/ARM64 parsing, class/endianness validation, malformed ELF;
+- thin Mach-O x86_64/arm64 and fat Mach-O slice parsing;
+- stable manifest sorting and path normalization across `\` and `/`;
+- exact `elevate.exe` exception and near-miss rejection:
+  - wrong directory;
+  - wrong filename case policy, if case normalization is used;
+  - non-Windows target;
+  - PE x64/ARM64 instead of ia32;
+  - malformed payload;
+- prune boundary safety: missing root, path escape, symlink/reparse point, unknown target, retained-file verification failure;
+- Koffi 2.16.3 pointer/address-to-decimal conversion and call-time failure detection;
+- `package-lock.json` contains exactly `koffi@2.16.3` with the reviewed official integrity;
+- `package.json` and workflow contract tests that prove the hook/audit cannot be omitted from release builds.
+
+Use tiny generated header fixtures where possible. Do not commit copied proprietary/system binaries just to test format parsing.
+
+### 6.2 Real-library ABI tests
+
+Keep existing fake-Koffi tests for branch behavior, but add/extend platform-gated real-library tests:
+
+- Windows host: load `kernel32`/`user32`, perform harmless calls, exercise foreground-terminal initialization, and exercise the COM vtable path far enough to prove pointer decoding without mutating desktop state;
+- macOS host: load `libobjc`, resolve a known class and selector, and run a harmless message send;
+- Linux host: load libc and compare native `getpid()` with `process.pid`.
+
+These tests prove the source install. The packaged smoke below separately proves the final ASAR/unpacked layout.
+
+### 6.3 Packaged module-load smoke
+
+Run a small script under the packaged Electron runtime with `ELECTRON_RUN_AS_NODE=1`, or another equally direct packaged-runtime entry that does not depend on the developer's source `node_modules`.
+
+The smoke must:
+
+1. require Koffi from `resources/app.asar`;
+2. prove the loaded `.node` path is inside the packaged app's physical `app.asar.unpacked` tree and matches the target package/triplet; obtain this evidence from the native `dlopen`/module-load layer rather than `require.cache` keys, which may retain the logical `app.asar` path;
+3. perform the platform's harmless native call and assert the expected return shape/value (`getpid() === process.pid` on Linux, and equivalent deterministic calls on Windows/macOS);
+4. initialize every platform-specific Clawd FFI probe that can run safely in CI, then perform at least one successful real call rather than only checking that construction did not throw;
+5. print a small JSON result containing runtime platform/arch, Koffi version, addon path, each probe's actual return value, and whether the call was positively validated;
+6. exit non-zero on any fallback to the source checkout/global module path, `null`/sentinel result where success is expected, or caught call-time failure.
+
+Route B keeps Koffi under `app.asar.unpacked`, so `ELECTRON_RUN_AS_NODE=1` is acceptable only after the smoke proves it resolves the same packaged addon path used by normal Electron. If a probe needs a real Electron window or if `ELECTRON_RUN_AS_NODE` is not reliable for a signed target, add a narrowly gated full-Electron self-test entry. The full-Electron path is also required to exercise normal application loading and the ASAR integrity check that `ELECTRON_RUN_AS_NODE` may bypass. It must not modify user preferences, install hooks, open the live HTTP port, or persist data. The future Koffi 3 `process.resourcesPath` packaging model must use full Electron and is out of scope here.
+
+---
+
+## 7. Real-machine behavior smoke
+
+Artifact-load success is necessary but insufficient. Record target-appropriate behavior evidence.
+
+| Target | Required real-machine checks |
+|---|---|
+| Windows x64 | App launches without Koffi warnings. With a real Windows Terminal foreground, the probe returns a base-10 HWND and the session's `wt_hwnd` is observed updating; HUD/session focus returns to that terminal. A real fullscreen app makes the fullscreen probe return true and Clawd yield. The cloak inspector reports `available=true`; `isOnCurrentVirtualDesktop()` returns true or false, never `null`, for a real window; disposal succeeds. |
+| Windows ARM64 | Repeat the same positive assertions on native ARM64 Windows hardware. x64 emulation is not ARM64 evidence. A native CI runner can cover packaged load/call but does not replace interactive focus/fullscreen/cloak evidence. |
+| macOS x64 | App launches on Intel. `applyStationaryCollectionBehavior()` returns true for the real pet window; the pet remains stationary across a Space switch; entering/leaving text editing successfully de-delegates and restores the window. Lack of Koffi/SkyLight warnings alone is not a pass. |
+| macOS ARM64 | Repeat the same positive assertions on Apple Silicon without Rosetta standing in for native ARM64 evidence. |
+| Linux x64 | App launches; packaged Koffi loads from the staged app; libc `getpid()` equals `process.pid`; normal pet window behavior has no regression. |
+
+For Windows Terminal cleanup, follow the repository safety rule: never terminate `WindowsTerminal.exe` or related shared processes. Test terminals exit only from the clearly owned test session with `exit`; otherwise preserve them for manual closure.
+
+Use the existing five-target PR matrix to reduce hardware gaps: evaluate `windows-11-arm` for the Windows ARM64 row and `macos-15-intel` for the macOS x64 row; keep `macos-latest` for Apple Silicon. These labels must be confirmed in Phase 0 and may be unavailable or preview-grade. If a native runner cannot support packaging, retain the cross-build row and document the remaining hardware block. Do not relabel a cross-build or headless native call as an interactive runtime smoke.
+
+GitHub plans to migrate the `windows-11-arm` label to its Visual Studio 2026 image in early September 2026. If implementation or later CI validation spans that migration window, rerun the runner viability and timeout check after the image changes rather than treating changed toolchain behavior as a product regression.
+
+---
+
+## 8. Size and audit evidence
+
+### 8.1 Same-commit baseline
+
+For each target, capture a baseline and candidate from the same source commit and equivalent clean runner/toolchain. The only intentional difference should be the packaging implementation under review.
+
+Record separately:
+
+- distributable bytes: NSIS, DMG, AppImage, deb;
+- staged/extracted app bytes;
+- `resources` bytes;
+- `app.asar` bytes;
+- `app.asar.unpacked` bytes;
+- Koffi main-package bytes;
+- Koffi native file count/bytes;
+- foreign-native count/bytes;
+- exception count/bytes.
+
+Do not infer installer savings by subtracting raw native bytes. Compression, signing, DMG/AppImage formats, and blockmaps make raw and distributable deltas different.
+
+### 8.2 Expected result shape
+
+The PR description should contain a table like:
+
+| Target | Artifact before | Artifact after | Staged before | Staged after | Koffi native before | Koffi native after | Audit |
+|---|---:|---:|---:|---:|---:|---:|---|
+| windows-x64 | TBD | TBD | TBD | TBD | TBD | 1 / TBD | pass + elevate exception |
+| windows-arm64 | TBD | TBD | TBD | TBD | TBD | 1 / TBD | pass + elevate exception |
+| darwin-x64 | TBD | TBD | TBD | TBD | TBD | 1 / TBD | pass |
+| darwin-arm64 | TBD | TBD | TBD | TBD | TBD | 1 / TBD | pass |
+| linux-x64 | TBD | TBD | TBD | TBD | TBD | 1 / TBD | pass |
+
+Do not copy the Windows local diagnosis into the other rows. Build and measure each target.
+
+### 8.3 Audit acceptance
+
+Each manifest must end with:
+
+- exactly one target Koffi `.node`;
+- zero foreign Koffi `.node` files;
+- zero unexpected foreign native binaries;
+- Windows only: exactly one approved `resources/elevate.exe` exception;
+- zero undeclared exceptions;
+- no missing or malformed native payload.
+
+Any additional legitimate helper discovered in fresh macOS/Linux builds must be investigated and documented individually. Do not broaden the policy to make the audit green.
+
+---
+
+## 9. CI and release integration
+
+### 9.1 Pull-request validation workflow
+
+Extend the existing five-target `.github/workflows/telegram-retirement-package-audit.yml` package matrix instead of adding a second five-target build. The same per-target build output must feed both the retired-sidecar assertion and the new Koffi/native audit. The workflow may be renamed to a general package-audit name only if all tests, path filters, artifact names, and references are updated atomically.
+
+Add relevant trigger paths:
+
+- `package.json`, `package-lock.json`;
+- Koffi/packaging/audit scripts and policy;
+- `.github/workflows/build.yml` and the audit workflow;
+- Koffi-using runtime files;
+- native audit/package config tests.
+
+It should also support `workflow_dispatch`. It must not create a tag or release.
+
+Evaluate native runner substitutions inside the existing rows, not as duplicate packaging jobs:
+
+- Windows ARM64: `windows-11-arm` public-preview runner, with fallback to the existing Windows cross-build if electron-builder or required tooling is unsupported;
+- macOS x64: `macos-15-intel`;
+- macOS ARM64: `macos-latest`/Apple Silicon;
+- Windows x64 and Linux x64: their existing native runners.
+
+Always upload, including on failure:
+
+- per-target Koffi manifest;
+- per-target full native manifest;
+- packaged load-smoke JSON;
+- size report;
+- relevant build logs.
+
+### 9.2 Release workflow
+
+The normal tag build must run the same assertions beside the existing retired-sidecar assertion after each platform build and before artifact upload/release. Reuse the same per-target manifest-upload pattern. The `release` job must depend on audited build jobs. A missing manifest is a failure, not a warning.
+
+Route B must retain the current single Windows release job that creates both x64 and ARM64 installers and one combined `latest.yml`; retain `${arch}` in Windows artifact names and `buildUniversalInstaller: false`. Do not split release jobs in #763.
+
+Add updater metadata validation before release publication:
+
+- `latest.yml` lists both Windows x64 and ARM64 installers;
+- `latest-mac.yml` and Linux metadata list every artifact expected by the current updater contract;
+- every metadata `url` resolves to an artifact selected for upload;
+- metadata `size` and `sha512` match the actual artifact;
+- no architecture entry is lost or overwritten.
+
+The current updater contract is anchored to the released v0.14.0 shape: `latest.yml` lists both Windows executables and its top-level `path` points at the x64 installer; `latest-mac.yml` lists both DMGs (no invented zip entry) and points at the x64 DMG; `latest-linux.yml` lists both the `x86_64` AppImage and `amd64` deb, points at the AppImage, and preserves the generated AppImage `blockMapSize`. Validate generated files against this shape and update the contract deliberately if the repository's configured release outputs change.
+
+### 9.3 Test command integration
+
+Add focused scripts only where they reduce ambiguity, for example:
+
+- `npm run audit:native-package -- ...` for an already-built app;
+- a focused package test list for `artifact_validation_only`;
+- no npm script that silently performs a full release or publishes artifacts.
+
+### 9.4 Install hygiene gates
+
+- Switch every install step in `.github/workflows/build.yml` and the existing five-target PR package-audit workflow, including its unit and package jobs, from `npm install` to `npm ci`. Do not restore `node_modules` across lockfile changes.
+- Add a checked-in unit/contract test that reads `package-lock.json` and asserts exactly `koffi@2.16.3`, the reviewed official integrity, and an install-script-bearing package row.
+- Keep the repository's existing registry topology out of scope; do not normalize hundreds of unrelated lockfile `resolved` URLs in #763. Whether the Koffi tarball resolves through npmjs or the existing mirror, its integrity must equal the official registry value and clean `npm ci` must succeed on all three CI operating systems.
+- If a future Koffi 3 issue adopts split optional packages, that issue must add a stronger lockfile test for all target `@koromix/koffi-*` `version`/`resolved`/`integrity`/`os`/`cpu` rows.
+
+---
+
+## 10. Implementation sequence
+
+1. Run the bounded Koffi 2.16.3 compatibility, install-script, layout, and `afterPack` context probes from Phase 0.
+2. Pin `koffi` to exactly 2.16.3, update the lockfile, and add the package/lock hygiene contract test.
+3. Implement the authoritative target map and binary parsers with unit tests.
+4. Implement the guarded `afterPack` pruning hook; delete all foreign triplets and every `.lib`/`.exp`, then verify the retained triplet contains exactly `koffi.node`.
+5. Implement the staged-app Koffi assertion and JSON manifest, including logical ASAR and physical unpacked inventory.
+6. Implement the full extracted-app audit and exact `elevate.exe` policy.
+7. Build and audit local Windows x64, then Windows ARM64; run packaged positive load/call smoke where the host can execute the target.
+8. Extend the existing five-target PR workflow and release workflow, switch packaging installs to `npm ci`, and retain all manifests/smoke JSON.
+9. Validate updater metadata coverage, sizes, and hashes against the built artifacts.
+10. Run all five target builds; use native Windows ARM64 and Intel macOS PR runners where Phase 0 proves them viable.
+11. Perform real-machine Windows x64/ARM64 and macOS x64/ARM64 positive behavior smoke; perform Linux x64 launch/load smoke.
+12. Record same-commit before/after bytes and behavior evidence in the PR.
+13. Create the separate Koffi 3 migration issue with the deferred research inputs from section 3.4.
+14. Update `docs/project/release-process.md` with the native audit requirement and add a short AGENTS.md invariant only after the implementation shape is final.
+15. Run focused tests, full `npm test`, `git diff --check`, and inspect the final diff for unrelated changes.
+
+Expected effort after review:
+
+- Phase 0: 1–3 focused hours;
+- code, parsers, and tests: 4–8 hours;
+- five-target CI and evidence: several hours of runner time;
+- real target smoke: dependent on device availability.
+
+Realistically this is one to two engineering days, not counting unavailable ARM64/Intel hardware waits.
+
+---
+
+## 11. Rollback and failure policy
+
+### 11.1 Before merge
+
+Do not merge when:
+
+- any target retains anything other than one correctly parsed target-architecture Koffi addon;
+- any packaged `require("koffi")` smoke uses the source checkout;
+- Koffi's install script falls back to an unexplained local source build or network download;
+- any Windows/macOS real FFI smoke lacks the required successful return value or is degraded;
+- the full native audit needs an unexplained exception;
+- signed and unsigned Windows builds disagree in a way the `elevate.exe` policy cannot explain;
+- local combined-arch build commands produce incomplete artifacts;
+- updater metadata omits an expected artifact or its size/hash does not match.
+
+### 11.2 Selected-route rollback
+
+If 2.16.3 fails Phase 0 or positive runtime smoke, stop before production pruning and record the failure. Re-evaluate a reviewed Koffi 2.x version or close #763 as blocked; do not silently switch to Koffi 3 inside the same implementation PR.
+
+If a post-merge regression is found before release, disable/remove the `afterPack` pruning hook and restore the last known exact Koffi version. The build must then intentionally fail the new one-target audit until the rollback decision also explicitly reverts that release gate. Keep independently valid audit parser work only if it remains truthful against the restored package. Never make the audit green with a broad exception for the old multi-target payload.
+
+### 11.3 Deferred migration isolation
+
+Do not ship a hybrid that carries Koffi 2's multi-target package and Koffi 3's split target packages. The future Koffi 3 issue must start from the post-#763 audited packaging contract and make its own migration/rollback decision.
+
+---
+
+## 12. Definition of done
+
+- [ ] Phase 0 proves Koffi 2.16.3 compatibility, lockfile-backed prebuilt installation without source-build/network fallback, actual layout, and `afterPack` target context.
+- [ ] Koffi is pinned exactly to 2.16.3; the lockfile integrity matches the reviewed official package.
+- [ ] Release and five-target PR package jobs use `npm ci`.
+- [ ] All five staged apps contain exactly one target-appropriate Koffi `.node`.
+- [ ] Every retained Koffi triplet contains exactly `koffi.node`; no `.lib` or `.exp` remains.
+- [ ] Packaged Electron loads and successfully calls Koffi on all five targets with actual return values recorded.
+- [ ] Windows x64 and ARM64 real focus/fullscreen/cloak smoke passes the positive assertions in section 7.
+- [ ] macOS x64 and ARM64 real ObjC/SkyLight behavior smoke passes the positive assertions in section 7.
+- [ ] Linux x64 launch and packaged libc call smoke passes.
+- [ ] Full native manifests contain zero unexpected foreign payloads.
+- [ ] Windows manifests contain exactly the narrow `resources/elevate.exe` exception.
+- [ ] Same-commit artifact and staged bytes are recorded for every target.
+- [ ] The existing five-target PR package workflow and release workflow both enforce the same audit without a duplicate matrix.
+- [ ] Updater metadata covers every expected architecture and matches artifact size/SHA-512.
+- [ ] Native `windows-11-arm` and `macos-15-intel` PR rows are used if Phase 0 proves them viable; otherwise the residual hardware gap is explicit.
+- [ ] The deferred Koffi 3 migration issue records the section 3.4 research inputs.
+- [ ] Focused tests, full `npm test`, and `git diff --check` pass.
+- [ ] Release process documentation and final packaging invariant are updated.
+- [ ] No unrelated cleanup or runtime behavior change is mixed into the PR.
+
+---
+
+## 13. Questions the external review must answer
+
+1. Is Route B now bounded tightly enough for #763, or does any remaining text accidentally reintroduce Koffi 3 migration/provisioning work?
+2. Does Phase 0 adequately detect 2.16.3 install-script fallback to local compilation or network download on Windows, macOS, and Linux?
+3. Do the proposed real-library probes cover every 2.15.2 to 2.16.3 behavior risk used by Clawd, especially `koffi.address`, COM vtable decode/call, Buffer-to-pointer decode, and multiple `objc_msgSend` declarations?
+4. Is `afterPack` the correct lifecycle point on Windows/macOS/Linux, including macOS signing, physical `app.asar.unpacked` deletion, and possible stale logical ASAR entries?
+5. Does requiring the retained triplet to contain exactly `koffi.node` correctly remove every runtime-unneeded `.lib`/`.exp` without deleting anything Koffi needs later?
+6. Is the full native audit scope well-defined? What legitimate fat Mach-O or foreign helper cases could produce false positives?
+7. Is the `elevate.exe` exception sufficiently narrow and provenance-aware for both unsigned CI and signed release builds, given that NSIS copies it after `afterPack`?
+8. Are the packaged smoke JSON and section 7 positive assertions sufficient to catch Clawd's fail-open/catch-to-null behavior?
+9. Can the existing five-target PR workflow safely substitute `windows-11-arm` and `macos-15-intel` without changing release metadata topology or duplicating expensive builds?
+10. Is the updater metadata gate complete for combined Windows x64/ARM64 `latest.yml`, macOS, and Linux artifacts?
+11. Is the scoped lockfile policy sufficient: exact version + official integrity + cross-OS `npm ci`, without normalizing hundreds of unrelated registry URLs?
+12. Are any planned deletes insufficiently constrained or capable of touching source `node_modules`, another architecture's output, a symlink/reparse target, or user data?
+13. Is any requirement excessive for #763, or is any release-critical acceptance condition still missing?

--- a/docs/project/release-process.md
+++ b/docs/project/release-process.md
@@ -18,7 +18,17 @@ npm run audit:assets
 
 Manual workflow dispatch builds Windows, macOS, and Linux artifacts, checks
 each unpacked resources tree for retired Telegram sidecar binaries/source, and
-uploads build artifacts. It does not publish a GitHub Release.
+gates every package on its target-native Koffi payload, a packaged positive-call
+smoke, and updater metadata matching the generated artifacts. It then uploads
+the installers plus JSON evidence manifests. It does not publish a GitHub
+Release.
+
+Each staged application must contain exactly one physical Koffi native addon at
+`app.asar.unpacked/node_modules/koffi/build/koffi/<target-triplet>/koffi.node`.
+The native inventory audit must reject every foreign-architecture binary except
+the exact electron-builder-managed Windows `resources/elevate.exe` ia32 helper.
+Do not rewrite `app.asar` from `afterPack`: electron-builder records ASAR
+integrity before that hook, so Koffi cleanup is physical-file pruning only.
 
 ## Draft Release
 
@@ -56,6 +66,9 @@ Before launching:
   `sidecars/cc-connect-clawd` nor any `cc-connect-clawd(.exe)` exists.
 - Confirm Windows artifacts are architecture-specific x64 / ARM64 installers,
   not a universal NSIS installer.
+- Download the native-package, Koffi prune/smoke, and updater metadata manifests.
+  Confirm the target has one matching `koffi.node`, no foreign native payload,
+  and no unreviewed exception.
 - For migration smoke, install v0.13.0 first and save a copy of the old
   `clawd-prefs.json` before upgrading.
 - For Reasonix smoke, prepare a machine with Reasonix initialized so

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "electron-updater": "^6.8.3",
         "htmlparser2": "^12.0.0",
         "jsonc-parser": "^3.3.1",
-        "koffi": "^2.15.2",
+        "koffi": "2.16.3",
         "markdown-it": "15.0.0",
         "ws": "^8.21.0"
       },
@@ -3464,9 +3464,9 @@
       }
     },
     "node_modules/koffi": {
-      "version": "2.15.2",
-      "resolved": "https://registry.npmmirror.com/koffi/-/koffi-2.15.2.tgz",
-      "integrity": "sha512-r9tjJLVRSOhCRWdVyQlF3/Ugzeg13jlzS4czS82MAgLff4W+BcYOW7g8Y62t9O5JYjYOLAjAovAZDNlDfZNu+g==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.3.tgz",
+      "integrity": "sha512-E9y1AsgYGlaxMhcZzHr8y96QF2U5XzA12GGVAfbWqIubTwPNMXQarfBzePNXHe0xtIEtNd6ifAv3GAKYGUeBAQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "postinstall": "node scripts/verify-electron-install.js --context postinstall",
     "test": "node test/run-tests.js",
     "audit:assets": "node scripts/audit-repository-assets.js",
+    "audit:native-package": "node scripts/audit-packaged-native.js",
+    "verify:updater-metadata": "node scripts/verify-updater-metadata.js",
     "verify:release": "node scripts/verify-release-version.js",
     "create-theme": "node scripts/create-theme.js",
     "export-agent-icons": "node scripts/export-agent-icons.js",
@@ -69,6 +71,7 @@
   "build": {
     "appId": "com.clawd.on-desk",
     "productName": "Clawd on Desk",
+    "afterPack": "scripts/after-pack-koffi.js",
     "protocols": [
       {
         "name": "Clawd Import Protocol",
@@ -189,7 +192,7 @@
     "electron-updater": "^6.8.3",
     "htmlparser2": "^12.0.0",
     "jsonc-parser": "^3.3.1",
-    "koffi": "^2.15.2",
+    "koffi": "2.16.3",
     "markdown-it": "15.0.0",
     "ws": "^8.21.0"
   }

--- a/scripts/after-pack-koffi.js
+++ b/scripts/after-pack-koffi.js
@@ -1,0 +1,257 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const asar = require("@electron/asar");
+const { resolveReleaseTarget } = require("../src/native-package-target");
+const { KOFFI_VERSION, KOFFI_TRIPLETS } = require("../src/koffi-package-contract");
+const { parseNativeFile, toPosix } = require("./audit-packaged-native");
+
+const KOFFI_2163_TRIPLETS = KOFFI_TRIPLETS;
+
+function isInside(parent, candidate) {
+  const relative = path.relative(path.resolve(parent), path.resolve(candidate));
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function assertDirectory(filename, label) {
+  if (!fs.existsSync(filename)) throw new Error(`${label} does not exist: ${filename}`);
+  const stat = fs.lstatSync(filename);
+  if (stat.isSymbolicLink()) throw new Error(`${label} must not be a symlink/reparse point: ${filename}`);
+  if (!stat.isDirectory()) throw new Error(`${label} is not a directory: ${filename}`);
+}
+
+function locateAppRoot(appOutDir, target) {
+  const resolved = path.resolve(appOutDir);
+  assertDirectory(resolved, "afterPack appOutDir");
+  if (target.runtimePlatform !== "darwin") return resolved;
+  if (resolved.toLowerCase().endsWith(".app")) return resolved;
+  const apps = fs.readdirSync(resolved, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.toLowerCase().endsWith(".app"))
+    .map((entry) => path.join(resolved, entry.name));
+  if (apps.length !== 1) {
+    throw new Error(`Expected exactly one macOS .app under ${resolved}, found ${apps.length}`);
+  }
+  return apps[0];
+}
+
+function locateResourcesRoot(appRoot, target) {
+  return target.runtimePlatform === "darwin"
+    ? path.join(appRoot, "Contents", "Resources")
+    : path.join(appRoot, "resources");
+}
+
+function walkTreeNoLinks(rootDir) {
+  const files = [];
+  function visit(current) {
+    const entries = fs.readdirSync(current, { withFileTypes: true })
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const absolutePath = path.join(current, entry.name);
+      const stat = fs.lstatSync(absolutePath);
+      if (stat.isSymbolicLink()) {
+        throw new Error(`Refusing to prune symlink/reparse point: ${absolutePath}`);
+      }
+      if (stat.isDirectory()) visit(absolutePath);
+      else if (stat.isFile()) files.push({ absolutePath, bytes: stat.size });
+      else throw new Error(`Refusing to prune non-file entry: ${absolutePath}`);
+    }
+  }
+  visit(rootDir);
+  return files;
+}
+
+function sha256File(filename) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filename)).digest("hex");
+}
+
+function listLogicalKoffiNative(archivePath, asarModule = asar) {
+  return asarModule.listPackage(archivePath)
+    .map(toPosix)
+    .filter((entry) => /(?:^|\/)node_modules\/koffi\/build\/koffi\/[^/]+\/koffi\.node$/i.test(entry))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function assertSafeKoffiRoot({ appOutDir, resourcesRoot, nativeRoot }) {
+  const resolvedAppOut = fs.realpathSync.native(path.resolve(appOutDir));
+  const resolvedResources = fs.realpathSync.native(path.resolve(resourcesRoot));
+  const resolvedNative = fs.realpathSync.native(path.resolve(nativeRoot));
+  if (!isInside(resolvedAppOut, resolvedResources)) {
+    throw new Error(`Resources root escaped appOutDir: ${resolvedResources}`);
+  }
+  if (!isInside(resolvedResources, resolvedNative)) {
+    throw new Error(`Koffi native root escaped packaged resources: ${resolvedNative}`);
+  }
+  const requiredSegment = toPosix(path.relative(resolvedResources, resolvedNative));
+  if (requiredSegment !== "app.asar.unpacked/node_modules/koffi/build/koffi") {
+    throw new Error(`Unexpected Koffi prune root: ${requiredSegment}`);
+  }
+}
+
+function pruneKoffiNative({ appOutDir, targetId, outputPath = "", asarModule = asar } = {}) {
+  if (!appOutDir) throw new TypeError("appOutDir is required");
+  const target = require("../src/native-package-target").getReleaseTarget(targetId);
+  const appRoot = locateAppRoot(appOutDir, target);
+  const resourcesRoot = locateResourcesRoot(appRoot, target);
+  const archivePath = path.join(resourcesRoot, "app.asar");
+  const unpackedRoot = path.join(resourcesRoot, "app.asar.unpacked");
+  const koffiRoot = path.join(unpackedRoot, "node_modules", "koffi");
+  const nativeRoot = path.join(koffiRoot, "build", "koffi");
+  const resolvedOutput = outputPath ? path.resolve(outputPath) : "";
+  if (resolvedOutput && isInside(appOutDir, resolvedOutput)) {
+    throw new Error(`Prune manifest must be outside appOutDir: ${resolvedOutput}`);
+  }
+
+  assertDirectory(resourcesRoot, "packaged resources root");
+  if (!fs.existsSync(archivePath) || !fs.statSync(archivePath).isFile()) {
+    throw new Error(`Required app.asar does not exist: ${archivePath}`);
+  }
+  assertDirectory(unpackedRoot, "app.asar.unpacked root");
+  assertDirectory(koffiRoot, "packaged Koffi root");
+  assertDirectory(nativeRoot, "packaged Koffi native root");
+  assertSafeKoffiRoot({ appOutDir, resourcesRoot, nativeRoot });
+
+  const packageJsonPath = path.join(koffiRoot, "package.json");
+  const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+  if (packageJson.version !== KOFFI_VERSION) {
+    throw new Error(`Refusing to prune unexpected Koffi version: ${packageJson.version || "<missing>"}`);
+  }
+
+  const rootEntries = fs.readdirSync(nativeRoot, { withFileTypes: true })
+    .slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+  if (rootEntries.some((entry) => !entry.isDirectory() || entry.isSymbolicLink())) {
+    throw new Error(`Koffi native root contains a non-directory or link: ${nativeRoot}`);
+  }
+  const actualTriplets = rootEntries.map((entry) => entry.name).sort();
+  const expectedTriplets = Array.from(KOFFI_2163_TRIPLETS).sort();
+  if (JSON.stringify(actualTriplets) !== JSON.stringify(expectedTriplets)) {
+    throw new Error(
+      `Unexpected Koffi 2.16.3 triplet layout. Expected ${KOFFI_2163_TRIPLETS.join(", ")}; ` +
+      `found ${actualTriplets.join(", ")}`
+    );
+  }
+
+  const targetDir = path.join(nativeRoot, target.koffiTriplet);
+  assertDirectory(targetDir, "target Koffi triplet");
+  const proposedDeletions = [];
+  for (const triplet of actualTriplets) {
+    const tripletDir = path.join(nativeRoot, triplet);
+    const resolvedTriplet = fs.realpathSync.native(tripletDir);
+    if (!isInside(nativeRoot, resolvedTriplet)) {
+      throw new Error(`Koffi triplet escaped native root: ${resolvedTriplet}`);
+    }
+    for (const file of walkTreeNoLinks(tripletDir)) {
+      proposedDeletions.push({
+        path: toPosix(path.relative(nativeRoot, file.absolutePath)),
+        bytes: file.bytes,
+        delete: triplet !== target.koffiTriplet || /\.(?:lib|exp)$/i.test(file.absolutePath),
+      });
+    }
+  }
+  proposedDeletions.sort((a, b) => a.path.localeCompare(b.path));
+
+  const targetEntries = fs.readdirSync(targetDir, { withFileTypes: true });
+  for (const entry of targetEntries) {
+    if (entry.isSymbolicLink() || !entry.isFile()) {
+      throw new Error(`Target Koffi triplet contains an unsupported entry: ${entry.name}`);
+    }
+    if (entry.name !== "koffi.node" && !/\.(?:lib|exp)$/i.test(entry.name)) {
+      throw new Error(`Target Koffi triplet contains an unexpected file: ${entry.name}`);
+    }
+  }
+  const retainedPath = path.join(targetDir, "koffi.node");
+  const parsed = parseNativeFile(retainedPath);
+  if (!parsed || parsed.format !== target.format ||
+      parsed.architectures.length !== 1 || parsed.architectures[0] !== target.architecture) {
+    throw new Error(
+      `Retained Koffi binary has wrong architecture: expected ${target.format}/${target.architecture}, ` +
+      `got ${parsed ? `${parsed.format}/${parsed.architectures.join(",")}` : "unknown"}`
+    );
+  }
+
+  for (const triplet of actualTriplets) {
+    if (triplet === target.koffiTriplet) continue;
+    const tripletDir = path.join(nativeRoot, triplet);
+    if (!isInside(nativeRoot, tripletDir)) throw new Error(`Unsafe triplet deletion path: ${tripletDir}`);
+    fs.rmSync(tripletDir, { recursive: true, force: false });
+  }
+  for (const entry of fs.readdirSync(targetDir, { withFileTypes: true })) {
+    if (/\.(?:lib|exp)$/i.test(entry.name)) fs.rmSync(path.join(targetDir, entry.name), { force: false });
+  }
+
+  const retainedEntries = fs.readdirSync(targetDir, { withFileTypes: true });
+  if (retainedEntries.length !== 1 || retainedEntries[0].name !== "koffi.node" || !retainedEntries[0].isFile()) {
+    throw new Error(`Post-prune target triplet must contain exactly koffi.node: ${targetDir}`);
+  }
+
+  const report = {
+    schemaVersion: 1,
+    target: target.id,
+    platform: target.runtimePlatform,
+    arch: target.runtimeArch,
+    koffiVersion: packageJson.version,
+    appOutDir: path.resolve(appOutDir),
+    appRoot: path.resolve(appRoot),
+    nativeRoot: path.resolve(nativeRoot),
+    proposedDeletions,
+    logicalKoffiNativeEntries: listLogicalKoffiNative(archivePath, asarModule),
+    retained: {
+      path: toPosix(path.relative(appRoot, retainedPath)),
+      bytes: fs.statSync(retainedPath).size,
+      sha256: sha256File(retainedPath),
+      format: parsed.format,
+      architectures: parsed.architectures,
+    },
+    summary: {
+      tripletsBefore: actualTriplets.length,
+      tripletsAfter: 1,
+      deletedFiles: proposedDeletions.filter((entry) => entry.delete).length,
+      deletedBytes: proposedDeletions.filter((entry) => entry.delete).reduce((sum, entry) => sum + entry.bytes, 0),
+    },
+  };
+
+  if (resolvedOutput) {
+    fs.mkdirSync(path.dirname(resolvedOutput), { recursive: true });
+    fs.writeFileSync(resolvedOutput, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  }
+  return report;
+}
+
+function getContextPlatform(context) {
+  return context.electronPlatformName ||
+    (context.packager && context.packager.platform && context.packager.platform.nodeName) || "";
+}
+
+async function afterPack(context) {
+  const target = resolveReleaseTarget(getContextPlatform(context), context.arch);
+  const outDir = path.resolve(context.outDir || path.dirname(context.appOutDir));
+  const outputPath = path.join(outDir, "koffi-prune-manifests", `${target.id}.json`);
+  const report = pruneKoffiNative({
+    appOutDir: context.appOutDir,
+    targetId: target.id,
+    outputPath,
+  });
+  const log = context.packager && context.packager.info && context.packager.info.log;
+  if (log && typeof log.info === "function") {
+    log.info({ target: target.id, deletedBytes: report.summary.deletedBytes }, "pruned foreign Koffi native payloads");
+  } else {
+    process.stdout.write(
+      `Clawd: pruned Koffi for ${target.id}; removed ${report.summary.deletedFiles} files ` +
+      `(${report.summary.deletedBytes} bytes).\n`
+    );
+  }
+}
+
+module.exports = afterPack;
+module.exports.KOFFI_2163_TRIPLETS = KOFFI_2163_TRIPLETS;
+module.exports.isInside = isInside;
+module.exports.locateAppRoot = locateAppRoot;
+module.exports.locateResourcesRoot = locateResourcesRoot;
+module.exports.walkTreeNoLinks = walkTreeNoLinks;
+module.exports.listLogicalKoffiNative = listLogicalKoffiNative;
+module.exports.assertSafeKoffiRoot = assertSafeKoffiRoot;
+module.exports.pruneKoffiNative = pruneKoffiNative;
+module.exports.getContextPlatform = getContextPlatform;

--- a/scripts/audit-packaged-native.js
+++ b/scripts/audit-packaged-native.js
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+const asar = require("@electron/asar");
+const { getReleaseTarget } = require("../src/native-package-target");
+const { KOFFI_TRIPLET_SET } = require("../src/koffi-package-contract");
+const defaultPolicy = require("./native-package-policy.json");
+
+const PE_MACHINES = new Map([
+  [0x014c, "ia32"],
+  [0x8664, "x64"],
+  [0xaa64, "arm64"],
+]);
+
+const ELF_MACHINES = new Map([
+  [0x0003, "ia32"],
+  [0x003e, "x86_64"],
+  [0x00b7, "arm64"],
+]);
+
+const MACH_CPU_TYPES = new Map([
+  [0x00000007, "ia32"],
+  [0x01000007, "x86_64"],
+  [0x0000000c, "arm"],
+  [0x0100000c, "arm64"],
+]);
+
+const KOFFI_NATIVE_PATH_RE = /(?:^|\/)node_modules\/koffi\/build\/koffi\/([^/]+)\/koffi\.node$/i;
+const LOGICAL_NATIVE_CANDIDATE_RE = /(?:\.node|\.dll|\.exe|\.dylib|\.so(?:\.\d+)*)$/i;
+
+function toPosix(value) {
+  return String(value || "").replace(/\\/g, "/").replace(/^\.\//, "");
+}
+
+function sha256File(filename) {
+  const hash = crypto.createHash("sha256");
+  hash.update(fs.readFileSync(filename));
+  return hash.digest("hex");
+}
+
+function readPrefix(filename, length = 4096) {
+  const fd = fs.openSync(filename, "r");
+  try {
+    const buffer = Buffer.alloc(length);
+    const bytesRead = fs.readSync(fd, buffer, 0, length, 0);
+    return buffer.subarray(0, bytesRead);
+  } finally {
+    fs.closeSync(fd);
+  }
+}
+
+function machineName(mapping, value) {
+  return mapping.get(value) || `unknown-0x${value.toString(16)}`;
+}
+
+function parsePe(buffer) {
+  if (buffer.length < 2 || buffer[0] !== 0x4d || buffer[1] !== 0x5a) return null;
+  if (buffer.length < 0x40) throw new Error("Truncated PE DOS header");
+  const peOffset = buffer.readUInt32LE(0x3c);
+  if (peOffset > 16 * 1024 * 1024) throw new Error(`Implausible PE header offset: ${peOffset}`);
+  if (buffer.length < peOffset + 6) throw new Error("Truncated PE signature/header");
+  if (buffer.readUInt32LE(peOffset) !== 0x00004550) throw new Error("Invalid PE signature");
+  const machine = buffer.readUInt16LE(peOffset + 4);
+  return {
+    format: "PE",
+    architectures: [machineName(PE_MACHINES, machine)],
+    machineValues: [machine],
+  };
+}
+
+function parseElf(buffer) {
+  if (buffer.length < 4 || !buffer.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))) return null;
+  if (buffer.length < 20) throw new Error("Truncated ELF header");
+  const elfClass = buffer[4];
+  const dataEncoding = buffer[5];
+  if (elfClass !== 1 && elfClass !== 2) throw new Error(`Unsupported ELF class: ${elfClass}`);
+  if (dataEncoding !== 1 && dataEncoding !== 2) throw new Error(`Unsupported ELF endianness: ${dataEncoding}`);
+  const machine = dataEncoding === 1 ? buffer.readUInt16LE(18) : buffer.readUInt16BE(18);
+  return {
+    format: "ELF",
+    architectures: [machineName(ELF_MACHINES, machine)],
+    machineValues: [machine],
+    class: elfClass === 2 ? "64" : "32",
+    endianness: dataEncoding === 1 ? "little" : "big",
+  };
+}
+
+function readMachCpu(buffer, offset, littleEndian) {
+  if (buffer.length < offset + 4) throw new Error("Truncated Mach-O CPU field");
+  return littleEndian ? buffer.readUInt32LE(offset) : buffer.readUInt32BE(offset);
+}
+
+function parseMachO(buffer) {
+  if (buffer.length < 4) return null;
+  const bytes = buffer.subarray(0, 4).toString("hex");
+  const thinMagics = new Map([
+    ["cefaedfe", { littleEndian: true, bits: 32 }],
+    ["cffaedfe", { littleEndian: true, bits: 64 }],
+    ["feedface", { littleEndian: false, bits: 32 }],
+    ["feedfacf", { littleEndian: false, bits: 64 }],
+  ]);
+  const fatMagics = new Map([
+    ["cafebabe", { littleEndian: false, entrySize: 20, bits: 32 }],
+    ["bebafeca", { littleEndian: true, entrySize: 20, bits: 32 }],
+    ["cafebabf", { littleEndian: false, entrySize: 32, bits: 64 }],
+    ["bfbafeca", { littleEndian: true, entrySize: 32, bits: 64 }],
+  ]);
+
+  const thin = thinMagics.get(bytes);
+  if (thin) {
+    const cpu = readMachCpu(buffer, 4, thin.littleEndian);
+    return {
+      format: "Mach-O",
+      architectures: [machineName(MACH_CPU_TYPES, cpu)],
+      machineValues: [cpu],
+      kind: "thin",
+      bits: thin.bits,
+    };
+  }
+
+  const fat = fatMagics.get(bytes);
+  if (!fat) return null;
+  if (buffer.length < 8) throw new Error("Truncated fat Mach-O header");
+  const count = fat.littleEndian ? buffer.readUInt32LE(4) : buffer.readUInt32BE(4);
+  if (count < 1 || count > 64) throw new Error(`Implausible fat Mach-O slice count: ${count}`);
+  const required = 8 + count * fat.entrySize;
+  if (buffer.length < required) throw new Error("Truncated fat Mach-O architecture table");
+  const machineValues = [];
+  for (let index = 0; index < count; index += 1) {
+    machineValues.push(readMachCpu(buffer, 8 + index * fat.entrySize, fat.littleEndian));
+  }
+  return {
+    format: "Mach-O",
+    architectures: machineValues.map((cpu) => machineName(MACH_CPU_TYPES, cpu)),
+    machineValues,
+    kind: "fat",
+    bits: fat.bits,
+  };
+}
+
+function parseNativeBuffer(buffer) {
+  return parsePe(buffer) || parseElf(buffer) || parseMachO(buffer);
+}
+
+function parseNativeFile(filename) {
+  let buffer = readPrefix(filename);
+  if (buffer.length >= 0x40 && buffer[0] === 0x4d && buffer[1] === 0x5a) {
+    const peOffset = buffer.readUInt32LE(0x3c);
+    if (peOffset <= 16 * 1024 * 1024 && peOffset + 6 > buffer.length) {
+      buffer = readPrefix(filename, peOffset + 6);
+    }
+  }
+  return parseNativeBuffer(buffer);
+}
+
+function walkPhysicalFiles(rootDir) {
+  const root = path.resolve(rootDir);
+  const files = [];
+
+  function visit(current) {
+    const entries = fs.readdirSync(current, { withFileTypes: true })
+      .slice()
+      .sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const absolutePath = path.join(current, entry.name);
+      const relativePath = toPosix(path.relative(root, absolutePath));
+      const stat = fs.lstatSync(absolutePath);
+      if (stat.isSymbolicLink()) continue;
+      if (stat.isDirectory()) {
+        visit(absolutePath);
+      } else if (stat.isFile()) {
+        files.push({ absolutePath, relativePath, bytes: stat.size });
+      }
+    }
+  }
+
+  visit(root);
+  return files;
+}
+
+function getException(policy, targetId, relativePath, parsed) {
+  const exceptions = policy && Array.isArray(policy.exceptions) ? policy.exceptions : [];
+  return exceptions.find((entry) => (
+    Array.isArray(entry.targets) && entry.targets.includes(targetId) &&
+    toPosix(entry.path) === relativePath &&
+    entry.format === parsed.format &&
+    Array.isArray(entry.architectures) &&
+    entry.architectures.length === parsed.architectures.length &&
+    entry.architectures.every((arch) => parsed.architectures.includes(arch))
+  )) || null;
+}
+
+function resourcesRootForTarget(appRoot, target) {
+  return target.runtimePlatform === "darwin"
+    ? path.join(appRoot, "Contents", "Resources")
+    : path.join(appRoot, "resources");
+}
+
+function listLogicalNativeEntries(appRoot, target, asarModule = asar) {
+  const archivePath = path.join(resourcesRootForTarget(appRoot, target), "app.asar");
+  if (!fs.existsSync(archivePath)) throw new Error(`Required app.asar does not exist: ${archivePath}`);
+  const resourcesRoot = resourcesRootForTarget(appRoot, target);
+  const unpackedRoot = path.join(resourcesRoot, "app.asar.unpacked");
+  return asarModule.listPackage(archivePath)
+    .map(toPosix)
+    .filter((entry) => LOGICAL_NATIVE_CANDIDATE_RE.test(entry))
+    .map((logicalPath) => {
+      const archiveRelativePath = logicalPath.replace(/^\/+/, "");
+      const physicalPath = path.join(unpackedRoot, ...archiveRelativePath.split("/"));
+      let physicalPresent = false;
+      if (fs.existsSync(physicalPath)) {
+        const stat = fs.lstatSync(physicalPath);
+        physicalPresent = stat.isFile() && !stat.isSymbolicLink();
+      }
+      const koffiMatch = logicalPath.match(KOFFI_NATIVE_PATH_RE);
+      let disposition = physicalPresent ? "physical-unpacked" : "error";
+      if (!physicalPresent && koffiMatch &&
+          KOFFI_TRIPLET_SET.has(koffiMatch[1]) && koffiMatch[1] !== target.koffiTriplet) {
+        disposition = "stale-koffi-logical";
+      }
+      return {
+        path: logicalPath,
+        physicalPath: toPosix(path.relative(appRoot, physicalPath)),
+        physicalPresent,
+        disposition,
+      };
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function listLogicalKoffiEntries(appRoot, target, asarModule = asar) {
+  return listLogicalNativeEntries(appRoot, target, asarModule)
+    .filter((entry) => KOFFI_NATIVE_PATH_RE.test(entry.path))
+    .map((entry) => entry.path);
+}
+
+function auditPackagedNative({ appRoot, targetId, policy = defaultPolicy, asarModule = asar } = {}) {
+  if (!appRoot) throw new TypeError("appRoot is required");
+  const target = getReleaseTarget(targetId);
+  const resolvedRoot = path.resolve(appRoot);
+  if (!fs.existsSync(resolvedRoot) || !fs.statSync(resolvedRoot).isDirectory()) {
+    throw new Error(`App root is not a directory: ${resolvedRoot}`);
+  }
+
+  const binaries = [];
+  const errors = [];
+  for (const file of walkPhysicalFiles(resolvedRoot)) {
+    let parsed;
+    try {
+      parsed = parseNativeFile(file.absolutePath);
+    } catch (err) {
+      errors.push({
+        code: "malformed-native-binary",
+        path: file.relativePath,
+        message: err && err.message ? err.message : String(err),
+      });
+      continue;
+    }
+    if (!parsed) continue;
+
+    const exception = getException(policy, target.id, file.relativePath, parsed);
+    const matchesTarget = parsed.format === target.format &&
+      parsed.architectures.every((arch) => arch === target.architecture);
+    let disposition = "target";
+    let policyId = null;
+    let reason = null;
+    if (exception) {
+      disposition = "exception";
+      policyId = exception.id;
+      reason = exception.reason;
+    } else if (!matchesTarget) {
+      disposition = "error";
+      errors.push({
+        code: "foreign-native-binary",
+        path: file.relativePath,
+        expected: `${target.format}/${target.architecture}`,
+        actual: `${parsed.format}/${parsed.architectures.join(",")}`,
+      });
+    }
+    binaries.push({
+      path: file.relativePath,
+      bytes: file.bytes,
+      sha256: sha256File(file.absolutePath),
+      format: parsed.format,
+      architectures: parsed.architectures,
+      disposition,
+      policyId,
+      reason,
+    });
+  }
+
+  binaries.sort((a, b) => a.path.localeCompare(b.path));
+  errors.sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code));
+
+  const physicalKoffi = binaries.filter((entry) => KOFFI_NATIVE_PATH_RE.test(entry.path));
+  const logicalNative = listLogicalNativeEntries(resolvedRoot, target, asarModule);
+  const logicalKoffi = logicalNative
+    .filter((entry) => KOFFI_NATIVE_PATH_RE.test(entry.path))
+    .map((entry) => entry.path);
+  for (const entry of logicalNative) {
+    if (entry.disposition === "error") {
+      errors.push({
+        code: "logical-native-without-physical-payload",
+        path: entry.path,
+        expectedPhysicalPath: entry.physicalPath,
+      });
+    }
+  }
+  if (physicalKoffi.length !== 1) {
+    errors.push({
+      code: "unexpected-koffi-native-count",
+      path: "resources/app.asar.unpacked/node_modules/koffi/build/koffi",
+      expected: 1,
+      actual: physicalKoffi.length,
+    });
+  } else {
+    const match = physicalKoffi[0].path.match(KOFFI_NATIVE_PATH_RE);
+    if (!match || match[1] !== target.koffiTriplet || physicalKoffi[0].disposition !== "target") {
+      errors.push({
+        code: "wrong-koffi-native-target",
+        path: physicalKoffi[0].path,
+        expectedTriplet: target.koffiTriplet,
+      });
+    }
+  }
+
+  const exceptionBinaries = binaries.filter((entry) => entry.disposition === "exception");
+  const expectedExceptionCount = target.runtimePlatform === "win32" ? 1 : 0;
+  if (exceptionBinaries.length !== expectedExceptionCount) {
+    errors.push({
+      code: "unexpected-native-exception-count",
+      path: "resources/elevate.exe",
+      expected: expectedExceptionCount,
+      actual: exceptionBinaries.length,
+    });
+  }
+
+  errors.sort((a, b) => a.path.localeCompare(b.path) || a.code.localeCompare(b.code));
+  const bytesByDisposition = { target: 0, exception: 0, error: 0 };
+  const countByDisposition = { target: 0, exception: 0, error: 0 };
+  for (const entry of binaries) {
+    bytesByDisposition[entry.disposition] += entry.bytes;
+    countByDisposition[entry.disposition] += 1;
+  }
+
+  return {
+    schemaVersion: 1,
+    target: target.id,
+    appRoot: resolvedRoot,
+    binaries,
+    logicalNative,
+    koffi: {
+      expectedTriplet: target.koffiTriplet,
+      physical: physicalKoffi.map((entry) => entry.path),
+      logical: logicalKoffi,
+    },
+    errors,
+    summary: {
+      binaries: binaries.length,
+      logicalNativeCandidates: logicalNative.length,
+      staleKoffiLogicalEntries: logicalNative.filter((entry) => entry.disposition === "stale-koffi-logical").length,
+      errors: errors.length,
+      countByDisposition,
+      bytesByDisposition,
+    },
+  };
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
+function parseArgs(argv) {
+  const options = { appRoot: "", targetId: "", output: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--app-root") options.appRoot = argv[++index] || "";
+    else if (arg === "--target") options.targetId = argv[++index] || "";
+    else if (arg === "--output") options.output = argv[++index] || "";
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!options.appRoot) throw new Error("--app-root is required");
+  if (!options.targetId) throw new Error("--target is required");
+  return options;
+}
+
+function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const report = auditPackagedNative(options);
+  const json = stableJson(report);
+  if (options.output) {
+    const outputPath = path.resolve(options.output);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, json, "utf8");
+  } else {
+    process.stdout.write(json);
+  }
+  if (report.errors.length) {
+    process.stderr.write(`Native package audit failed: ${report.errors.length} error(s).\n`);
+    return 1;
+  }
+  process.stderr.write(`Native package audit passed for ${report.target}.\n`);
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = runCli();
+  } catch (err) {
+    process.stderr.write(`${err && err.message ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  PE_MACHINES,
+  ELF_MACHINES,
+  MACH_CPU_TYPES,
+  KOFFI_NATIVE_PATH_RE,
+  LOGICAL_NATIVE_CANDIDATE_RE,
+  toPosix,
+  parsePe,
+  parseElf,
+  parseMachO,
+  parseNativeBuffer,
+  parseNativeFile,
+  walkPhysicalFiles,
+  getException,
+  resourcesRootForTarget,
+  listLogicalNativeEntries,
+  listLogicalKoffiEntries,
+  auditPackagedNative,
+  stableJson,
+  parseArgs,
+  runCli,
+};

--- a/scripts/native-package-policy.json
+++ b/scripts/native-package-policy.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "exceptions": [
+    {
+      "id": "electron-builder-nsis-elevate-helper",
+      "targets": [
+        "windows-x64",
+        "windows-arm64"
+      ],
+      "path": "resources/elevate.exe",
+      "format": "PE",
+      "architectures": [
+        "ia32"
+      ],
+      "reason": "electron-builder 26.8.1 NSIS CopyElevateHelper intentionally supplies a PE ia32 helper"
+    }
+  ]
+}

--- a/scripts/run-packaged-koffi-smoke.js
+++ b/scripts/run-packaged-koffi-smoke.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+"use strict";
+
+const { spawnSync } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const { getReleaseTarget } = require("../src/native-package-target");
+
+function parseArgs(argv) {
+  const options = { executable: "", targetId: "", output: "", timeoutMs: 60000, useXvfb: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--executable") options.executable = argv[++index] || "";
+    else if (arg === "--target") options.targetId = argv[++index] || "";
+    else if (arg === "--output") options.output = argv[++index] || "";
+    else if (arg === "--timeout-ms") options.timeoutMs = Number(argv[++index]);
+    else if (arg === "--xvfb") options.useXvfb = true;
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!options.executable) throw new Error("--executable is required");
+  if (!options.targetId) throw new Error("--target is required");
+  if (!options.output) throw new Error("--output is required");
+  if (!Number.isInteger(options.timeoutMs) || options.timeoutMs < 1000) throw new Error("--timeout-ms must be >= 1000");
+  getReleaseTarget(options.targetId);
+  options.executable = path.resolve(options.executable);
+  options.output = path.resolve(options.output);
+  return options;
+}
+
+function cleanupSmokeUserData(outputPath, report) {
+  const candidate = report && report.runtime && report.runtime.userDataPath;
+  if (!candidate) return { cleaned: false, reason: "not-reported" };
+  const resolvedOutputParent = path.dirname(path.resolve(outputPath));
+  const resolvedCandidate = path.resolve(candidate);
+  if (path.dirname(resolvedCandidate) !== resolvedOutputParent ||
+      !/^\.koffi-smoke-user-data-\d+$/.test(path.basename(resolvedCandidate))) {
+    throw new Error(`Refusing unsafe smoke user-data cleanup path: ${resolvedCandidate}`);
+  }
+  if (!fs.existsSync(resolvedCandidate)) return { cleaned: false, reason: "already-absent" };
+  const stat = fs.lstatSync(resolvedCandidate);
+  if (stat.isSymbolicLink() || !stat.isDirectory()) {
+    throw new Error(`Refusing non-directory smoke user-data cleanup path: ${resolvedCandidate}`);
+  }
+  fs.rmSync(resolvedCandidate, { recursive: true, force: false });
+  return { cleaned: true, reason: "removed" };
+}
+
+function runPackagedSmoke(options) {
+  if (!fs.existsSync(options.executable) || !fs.statSync(options.executable).isFile()) {
+    throw new Error(`Packaged executable does not exist: ${options.executable}`);
+  }
+  fs.mkdirSync(path.dirname(options.output), { recursive: true });
+  fs.rmSync(options.output, { force: true });
+  const appArgs = [
+    "--disable-gpu",
+    "--disable-gpu-compositing",
+    "--disable-software-rasterizer",
+    "--clawd-package-smoke",
+    `--clawd-package-smoke-target=${options.targetId}`,
+    `--clawd-package-smoke-output=${options.output}`,
+  ];
+  const command = options.useXvfb ? "xvfb-run" : options.executable;
+  const args = options.useXvfb ? ["-a", options.executable, ...appArgs] : appArgs;
+  const result = spawnSync(command, args, {
+    cwd: path.dirname(options.executable),
+    stdio: "inherit",
+    timeout: options.timeoutMs,
+    windowsHide: true,
+  });
+  if (result.error) throw result.error;
+  const report = fs.existsSync(options.output)
+    ? JSON.parse(fs.readFileSync(options.output, "utf8"))
+    : null;
+  if (report) {
+    try {
+      report.userDataCleanup = cleanupSmokeUserData(options.output, report);
+      fs.writeFileSync(options.output, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    } catch (err) {
+      process.stderr.write(`Packaged smoke user-data cleanup warning: ${err.message}\n`);
+    }
+  }
+  if (result.status !== 0) throw new Error(`Packaged smoke exited with status ${result.status}`);
+  if (!report) throw new Error(`Packaged smoke did not write: ${options.output}`);
+  if (report.ok !== true || report.target !== options.targetId) {
+    throw new Error(`Packaged smoke report failed: ${JSON.stringify(report)}`);
+  }
+  return report;
+}
+
+function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const report = runPackagedSmoke(options);
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = runCli();
+  } catch (err) {
+    process.stderr.write(`${err && err.stack ? err.stack : String(err)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { parseArgs, cleanupSmokeUserData, runPackagedSmoke, runCli };

--- a/scripts/verify-updater-metadata.js
+++ b/scripts/verify-updater-metadata.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function parseScalar(value) {
+  const trimmed = String(value || "").trim();
+  if ((trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+      (trimmed.startsWith('"') && trimmed.endsWith('"'))) {
+    return trimmed.slice(1, -1);
+  }
+  if (/^-?\d+$/.test(trimmed)) return Number(trimmed);
+  return trimmed;
+}
+
+function parseUpdaterYaml(text) {
+  const metadata = { files: [] };
+  let currentFile = null;
+  let inFiles = false;
+  for (const rawLine of String(text || "").split(/\r?\n/)) {
+    if (!rawLine.trim() || rawLine.trimStart().startsWith("#")) continue;
+    const indent = rawLine.match(/^\s*/)[0].length;
+    const trimmed = rawLine.trim();
+    if (indent === 0 && trimmed === "files:") {
+      inFiles = true;
+      currentFile = null;
+      continue;
+    }
+    if (inFiles && indent === 2 && trimmed.startsWith("- ")) {
+      const match = trimmed.slice(2).match(/^([^:]+):\s*(.*)$/);
+      if (!match) throw new Error(`Malformed updater file entry: ${rawLine}`);
+      currentFile = { [match[1]]: parseScalar(match[2]) };
+      metadata.files.push(currentFile);
+      continue;
+    }
+    if (inFiles && indent >= 4 && currentFile) {
+      const match = trimmed.match(/^([^:]+):\s*(.*)$/);
+      if (!match) throw new Error(`Malformed updater file field: ${rawLine}`);
+      currentFile[match[1]] = parseScalar(match[2]);
+      continue;
+    }
+    if (indent === 0) {
+      inFiles = false;
+      currentFile = null;
+      const match = trimmed.match(/^([^:]+):\s*(.*)$/);
+      if (!match) throw new Error(`Malformed updater metadata field: ${rawLine}`);
+      metadata[match[1]] = parseScalar(match[2]);
+      continue;
+    }
+    throw new Error(`Unsupported updater metadata structure: ${rawLine}`);
+  }
+  return metadata;
+}
+
+function sha512Base64(filename) {
+  return crypto.createHash("sha512").update(fs.readFileSync(filename)).digest("base64");
+}
+
+function validateContractShape(metadata, contract) {
+  const urls = metadata.files.map((entry) => String(entry.url || ""));
+  const errors = [];
+  if (contract === "windows") {
+    if (urls.length !== 2 || !urls.some((url) => /-x64\.exe$/i.test(url)) ||
+        !urls.some((url) => /-arm64\.exe$/i.test(url))) {
+      errors.push("latest.yml must list exactly the x64 and arm64 Windows executables");
+    }
+    if (!/-x64\.exe$/i.test(String(metadata.path || ""))) {
+      errors.push("latest.yml top-level path must point at the x64 installer");
+    }
+  } else if (contract === "mac") {
+    if (urls.length !== 2 || !urls.some((url) => /-x64\.dmg$/i.test(url)) ||
+        !urls.some((url) => /-arm64\.dmg$/i.test(url)) || urls.some((url) => /\.zip$/i.test(url))) {
+      errors.push("latest-mac.yml must list exactly the x64 and arm64 DMGs without a zip entry");
+    }
+    if (!/-x64\.dmg$/i.test(String(metadata.path || ""))) {
+      errors.push("latest-mac.yml top-level path must point at the x64 DMG");
+    }
+  } else if (contract === "linux") {
+    const appImage = metadata.files.find((entry) => /-x86_64\.AppImage$/.test(String(entry.url || "")));
+    const deb = metadata.files.find((entry) => /-amd64\.deb$/i.test(String(entry.url || "")));
+    if (urls.length !== 2 || !appImage || !deb) {
+      errors.push("latest-linux.yml must list exactly the x86_64 AppImage and amd64 deb");
+    }
+    if (!/-x86_64\.AppImage$/.test(String(metadata.path || ""))) {
+      errors.push("latest-linux.yml top-level path must point at the AppImage");
+    }
+    if (appImage && (!Number.isInteger(appImage.blockMapSize) || appImage.blockMapSize <= 0)) {
+      errors.push("latest-linux.yml AppImage entry must contain a positive blockMapSize");
+    }
+  } else {
+    throw new Error(`Unknown updater contract: ${contract || "<empty>"}`);
+  }
+  return errors;
+}
+
+function verifyUpdaterMetadata({ metadataPath, artifactRoot, contract } = {}) {
+  if (!metadataPath) throw new TypeError("metadataPath is required");
+  if (!artifactRoot) throw new TypeError("artifactRoot is required");
+  const resolvedMetadata = path.resolve(metadataPath);
+  const resolvedArtifacts = path.resolve(artifactRoot);
+  const metadata = parseUpdaterYaml(fs.readFileSync(resolvedMetadata, "utf8"));
+  const errors = validateContractShape(metadata, contract);
+  const files = [];
+
+  for (const entry of metadata.files) {
+    const url = String(entry.url || "");
+    if (!url || path.basename(url) !== url || url.includes("..")) {
+      errors.push(`Unsafe or missing updater artifact URL: ${url || "<empty>"}`);
+      continue;
+    }
+    const filename = path.join(resolvedArtifacts, url);
+    if (!fs.existsSync(filename) || !fs.statSync(filename).isFile()) {
+      errors.push(`Updater artifact does not exist: ${url}`);
+      continue;
+    }
+    const actualSize = fs.statSync(filename).size;
+    const actualSha512 = sha512Base64(filename);
+    if (entry.size !== actualSize) errors.push(`Updater size mismatch for ${url}: ${entry.size} != ${actualSize}`);
+    if (entry.sha512 !== actualSha512) errors.push(`Updater sha512 mismatch for ${url}`);
+    files.push({ url, path: filename, size: actualSize, sha512: actualSha512 });
+  }
+
+  const topLevel = metadata.files.find((entry) => entry.url === metadata.path);
+  if (!topLevel) errors.push(`Top-level updater path is absent from files[]: ${metadata.path || "<empty>"}`);
+  else {
+    if (metadata.sha512 !== topLevel.sha512) errors.push("Top-level updater sha512 must match the path entry");
+  }
+
+  return {
+    schemaVersion: 1,
+    contract,
+    metadataPath: resolvedMetadata,
+    artifactRoot: resolvedArtifacts,
+    files,
+    errors,
+    summary: { files: files.length, errors: errors.length },
+  };
+}
+
+function parseArgs(argv) {
+  const options = { metadataPath: "", artifactRoot: "", contract: "", output: "" };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--metadata") options.metadataPath = argv[++index] || "";
+    else if (arg === "--artifact-root") options.artifactRoot = argv[++index] || "";
+    else if (arg === "--contract") options.contract = argv[++index] || "";
+    else if (arg === "--output") options.output = argv[++index] || "";
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  if (!options.metadataPath) throw new Error("--metadata is required");
+  if (!options.artifactRoot) throw new Error("--artifact-root is required");
+  if (!options.contract) throw new Error("--contract is required");
+  return options;
+}
+
+function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const report = verifyUpdaterMetadata(options);
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.output) {
+    const outputPath = path.resolve(options.output);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, json, "utf8");
+  } else {
+    process.stdout.write(json);
+  }
+  if (report.errors.length) {
+    process.stderr.write(`Updater metadata verification failed: ${report.errors.length} error(s).\n`);
+    return 1;
+  }
+  process.stderr.write(`Updater metadata verification passed for ${report.contract}.\n`);
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = runCli();
+  } catch (err) {
+    process.stderr.write(`${err && err.message ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  parseUpdaterYaml,
+  sha512Base64,
+  validateContractShape,
+  verifyUpdaterMetadata,
+  parseArgs,
+  runCli,
+};

--- a/src/koffi-package-contract.js
+++ b/src/koffi-package-contract.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const KOFFI_VERSION = "2.16.3";
+
+const KOFFI_TRIPLETS = Object.freeze([
+  "darwin_arm64",
+  "darwin_x64",
+  "freebsd_arm64",
+  "freebsd_ia32",
+  "freebsd_x64",
+  "linux_arm64",
+  "linux_armhf",
+  "linux_ia32",
+  "linux_loong64",
+  "linux_riscv64d",
+  "linux_x64",
+  "musl_arm64",
+  "musl_x64",
+  "openbsd_ia32",
+  "openbsd_x64",
+  "win32_arm64",
+  "win32_ia32",
+  "win32_x64",
+]);
+
+const KOFFI_TRIPLET_SET = new Set(KOFFI_TRIPLETS);
+
+module.exports = { KOFFI_VERSION, KOFFI_TRIPLETS, KOFFI_TRIPLET_SET };

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,8 @@
 const { app, BrowserWindow, Notification, screen, ipcMain, globalShortcut, nativeTheme, dialog, shell, nativeImage, powerSaveBlocker, powerMonitor, clipboard, safeStorage } = require("electron");
+const { maybeRunPackageKoffiSmoke } = require("./package-koffi-smoke");
+if (maybeRunPackageKoffiSmoke({ app, BrowserWindow })) {
+  return;
+}
 // ── Linux/Wayland: relaunch under XWayland so the pet is draggable (issue #441) ──
 // Native Wayland ignores client-side window positioning and blocks global cursor
 // queries, so the pet spawns centered, can't be dragged, and has no tracking;

--- a/src/native-package-target.js
+++ b/src/native-package-target.js
@@ -1,0 +1,112 @@
+"use strict";
+
+const RELEASE_TARGETS = Object.freeze([
+  Object.freeze({
+    id: "windows-x64",
+    runtimePlatform: "win32",
+    runtimeArch: "x64",
+    koffiTriplet: "win32_x64",
+    format: "PE",
+    architecture: "x64",
+    artifactArchAliases: Object.freeze(["x64"]),
+  }),
+  Object.freeze({
+    id: "windows-arm64",
+    runtimePlatform: "win32",
+    runtimeArch: "arm64",
+    koffiTriplet: "win32_arm64",
+    format: "PE",
+    architecture: "arm64",
+    artifactArchAliases: Object.freeze(["arm64"]),
+  }),
+  Object.freeze({
+    id: "darwin-x64",
+    runtimePlatform: "darwin",
+    runtimeArch: "x64",
+    koffiTriplet: "darwin_x64",
+    format: "Mach-O",
+    architecture: "x86_64",
+    artifactArchAliases: Object.freeze(["x64"]),
+  }),
+  Object.freeze({
+    id: "darwin-arm64",
+    runtimePlatform: "darwin",
+    runtimeArch: "arm64",
+    koffiTriplet: "darwin_arm64",
+    format: "Mach-O",
+    architecture: "arm64",
+    artifactArchAliases: Object.freeze(["arm64"]),
+  }),
+  Object.freeze({
+    id: "linux-x64",
+    runtimePlatform: "linux",
+    runtimeArch: "x64",
+    koffiTriplet: "linux_x64",
+    format: "ELF",
+    architecture: "x86_64",
+    artifactArchAliases: Object.freeze(["x86_64", "amd64"]),
+  }),
+]);
+
+const TARGET_BY_ID = new Map(RELEASE_TARGETS.map((target) => [target.id, target]));
+
+const BUILDER_ARCH_BY_NUMBER = Object.freeze({
+  0: "ia32",
+  1: "x64",
+  2: "armv7l",
+  3: "arm64",
+  4: "universal",
+});
+
+function normalizePlatform(value) {
+  const platform = String(value == null ? "" : value).trim().toLowerCase();
+  if (platform === "windows" || platform === "win") return "win32";
+  if (platform === "mac" || platform === "macos" || platform === "osx") return "darwin";
+  return platform;
+}
+
+function normalizeBuilderArch(value) {
+  if (typeof value === "number" && Number.isInteger(value)) {
+    return BUILDER_ARCH_BY_NUMBER[value] || "";
+  }
+  const arch = String(value == null ? "" : value).trim().toLowerCase();
+  if (/^\d+$/.test(arch)) return BUILDER_ARCH_BY_NUMBER[Number(arch)] || "";
+  if (arch === "amd64" || arch === "x86_64") return "x64";
+  if (arch === "aarch64") return "arm64";
+  return arch;
+}
+
+function getReleaseTarget(targetId) {
+  const target = TARGET_BY_ID.get(String(targetId || ""));
+  if (!target) throw new Error(`Unknown release target: ${targetId || "<empty>"}`);
+  return target;
+}
+
+function resolveReleaseTarget(platformValue, archValue) {
+  const runtimePlatform = normalizePlatform(platformValue);
+  const runtimeArch = normalizeBuilderArch(archValue);
+  const target = RELEASE_TARGETS.find((candidate) => (
+    candidate.runtimePlatform === runtimePlatform && candidate.runtimeArch === runtimeArch
+  ));
+  if (!target) {
+    throw new Error(
+      `Unsupported package target: platform=${platformValue == null ? "<empty>" : platformValue} ` +
+      `arch=${archValue == null ? "<empty>" : archValue}`
+    );
+  }
+  return target;
+}
+
+function resolveRuntimeTarget(platformValue = process.platform, archValue = process.arch) {
+  return resolveReleaseTarget(platformValue, archValue);
+}
+
+module.exports = {
+  RELEASE_TARGETS,
+  BUILDER_ARCH_BY_NUMBER,
+  normalizePlatform,
+  normalizeBuilderArch,
+  getReleaseTarget,
+  resolveReleaseTarget,
+  resolveRuntimeTarget,
+};

--- a/src/package-koffi-smoke.js
+++ b/src/package-koffi-smoke.js
@@ -1,0 +1,266 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const { getReleaseTarget, resolveRuntimeTarget } = require("./native-package-target");
+
+const SMOKE_FLAG = "--clawd-package-smoke";
+const TARGET_PREFIX = "--clawd-package-smoke-target=";
+const OUTPUT_PREFIX = "--clawd-package-smoke-output=";
+
+function comparablePath(value) {
+  let resolved = path.resolve(String(value || ""));
+  if (process.platform === "win32" && resolved.startsWith("\\\\?\\UNC\\")) {
+    resolved = `\\\\${resolved.slice(8)}`;
+  } else if (process.platform === "win32" && resolved.startsWith("\\\\?\\")) {
+    resolved = resolved.slice(4);
+  }
+  return resolved;
+}
+
+function isInside(parent, candidate) {
+  const relative = path.relative(comparablePath(parent), comparablePath(candidate));
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative));
+}
+
+function parseSmokeArgs(argv) {
+  const args = Array.from(argv || [], String);
+  if (!args.includes(SMOKE_FLAG)) return null;
+  const targetArg = args.find((arg) => arg.startsWith(TARGET_PREFIX));
+  const outputArg = args.find((arg) => arg.startsWith(OUTPUT_PREFIX));
+  const targetId = targetArg ? targetArg.slice(TARGET_PREFIX.length) : "";
+  const outputPath = outputArg ? outputArg.slice(OUTPUT_PREFIX.length) : "";
+  if (!targetId) throw new Error(`${TARGET_PREFIX}<target> is required`);
+  if (!outputPath) throw new Error(`${OUTPUT_PREFIX}<path> is required`);
+  getReleaseTarget(targetId);
+  return { targetId, outputPath: path.resolve(outputPath) };
+}
+
+function physicalAddonPath(filename) {
+  const resolved = path.resolve(String(filename || ""));
+  if (/app\.asar\.unpacked(?:[\\/]|$)/i.test(resolved)) return resolved;
+  return resolved.replace(/app\.asar(?=[\\/])/i, "app.asar.unpacked");
+}
+
+function captureKoffiLoad() {
+  const originalDlopen = process.dlopen;
+  let dlopenPath = "";
+  process.dlopen = function patchedDlopen(module, filename, ...args) {
+    if (path.basename(String(filename || "")).toLowerCase() === "koffi.node") {
+      dlopenPath = String(filename);
+    }
+    return originalDlopen.call(this, module, filename, ...args);
+  };
+  try {
+    const koffi = require("koffi");
+    return { koffi, dlopenPath };
+  } finally {
+    process.dlopen = originalDlopen;
+  }
+}
+
+function callStableNativeFunction(koffi, platform = process.platform) {
+  if (platform === "win32") {
+    const kernel32 = koffi.load("kernel32.dll");
+    const getCurrentProcessId = kernel32.func("uint __stdcall GetCurrentProcessId()");
+    return { library: "kernel32.dll", symbol: "GetCurrentProcessId", value: getCurrentProcessId() };
+  }
+  if (platform === "darwin") {
+    const libSystem = koffi.load("/usr/lib/libSystem.B.dylib");
+    const getpid = libSystem.func("int getpid()");
+    return { library: "/usr/lib/libSystem.B.dylib", symbol: "getpid", value: getpid() };
+  }
+  if (platform === "linux") {
+    const libc = koffi.load("libc.so.6");
+    const getpid = libc.func("int getpid()");
+    return { library: "libc.so.6", symbol: "getpid", value: getpid() };
+  }
+  throw new Error(`Unsupported package smoke platform: ${platform}`);
+}
+
+async function runPlatformProbe({ BrowserWindow, target }) {
+  if (target.runtimePlatform === "win32") {
+    const win = new BrowserWindow({ show: false, width: 80, height: 80, skipTaskbar: true });
+    try {
+      win.showInactive();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      const { createCloakInspector } = require("./win-cloak-recovery");
+      const { createForegroundFullscreenProbe } = require("./win-fullscreen-detect");
+      const { createForegroundWindowsTerminalProbe } = require("./win-foreground-terminal");
+      const logs = [];
+      const cloak = createCloakInspector({ isWin: true, log: (line) => logs.push(line) });
+      try {
+        const onCurrentDesktop = cloak.isOnCurrentVirtualDesktop(win);
+        const fullscreenErrors = [];
+        const fullscreen = createForegroundFullscreenProbe({
+          isWin: true,
+          onError: (err) => fullscreenErrors.push(`init: ${err.message}`),
+          onCallError: (err) => fullscreenErrors.push(`call: ${err.message}`),
+        })();
+        if (fullscreenErrors.length) {
+          throw new Error(`Fullscreen probe failed: ${fullscreenErrors.join(" | ")}`);
+        }
+        if (typeof fullscreen !== "boolean") {
+          throw new Error(`Fullscreen probe returned ${typeof fullscreen}`);
+        }
+        const terminalErrors = [];
+        const foregroundTerminalHwnd = createForegroundWindowsTerminalProbe({
+          isWin: true,
+          onError: (err) => terminalErrors.push(`init: ${err.message}`),
+          onCallError: (err) => terminalErrors.push(`call: ${err.message}`),
+        })();
+        if (terminalErrors.length) {
+          throw new Error(`Foreground Windows Terminal probe failed: ${terminalErrors.join(" | ")}`);
+        }
+        if (foregroundTerminalHwnd !== null && !/^[1-9]\d*$/.test(foregroundTerminalHwnd)) {
+          throw new Error(`Foreground Windows Terminal probe returned ${foregroundTerminalHwnd}`);
+        }
+        if (!cloak.available) throw new Error(`Cloak inspector unavailable: ${logs.join(" | ")}`);
+        if (typeof onCurrentDesktop !== "boolean") {
+          throw new Error(
+            `Cloak inspector returned ${onCurrentDesktop} for a real packaged BrowserWindow ` +
+            `(visible=${win.isVisible()} logs=${logs.join(" | ") || "none"})`
+          );
+        }
+        return {
+          cloakAvailable: cloak.available,
+          cloakOnCurrentDesktop: onCurrentDesktop,
+          foregroundFullscreen: fullscreen,
+          foregroundTerminalHwnd,
+          foregroundTerminalExpectedMiss: foregroundTerminalHwnd === null,
+          logs,
+        };
+      } finally {
+        cloak.dispose();
+      }
+    } finally {
+      win.destroy();
+    }
+  }
+
+  if (target.runtimePlatform === "darwin") {
+    const win = new BrowserWindow({ show: false, width: 80, height: 80, skipTaskbar: true });
+    try {
+      const { applyStationaryCollectionBehavior } = require("./mac-window");
+      const applied = applyStationaryCollectionBehavior(win);
+      if (applied !== true) throw new Error("applyStationaryCollectionBehavior returned false");
+      return { stationaryCollectionBehaviorApplied: true };
+    } finally {
+      win.destroy();
+    }
+  }
+
+  return { windowProbe: "not-required" };
+}
+
+async function runPackageKoffiSmoke({ targetId, resourcesPath, BrowserWindow, userDataPath = "" } = {}) {
+  const target = getReleaseTarget(targetId);
+  const runtimeTarget = resolveRuntimeTarget();
+  if (runtimeTarget.id !== target.id) {
+    throw new Error(`Packaged runtime target mismatch: expected ${target.id}, got ${runtimeTarget.id}`);
+  }
+  if (!resourcesPath) throw new Error("Electron resourcesPath is unavailable");
+
+  const { koffi, dlopenPath } = captureKoffiLoad();
+  if (!dlopenPath) throw new Error("Koffi loaded without an observable process.dlopen path");
+  const physicalPath = physicalAddonPath(dlopenPath);
+  if (!fs.existsSync(physicalPath) || !fs.statSync(physicalPath).isFile()) {
+    throw new Error(`Physical Koffi addon does not exist: ${physicalPath}`);
+  }
+  if (!isInside(resourcesPath, physicalPath)) {
+    throw new Error(`Koffi addon loaded outside packaged resources: ${physicalPath}`);
+  }
+  const normalized = physicalPath.replace(/\\/g, "/");
+  if (!normalized.includes(`/app.asar.unpacked/node_modules/koffi/build/koffi/${target.koffiTriplet}/koffi.node`)) {
+    throw new Error(`Koffi addon path does not match ${target.koffiTriplet}: ${physicalPath}`);
+  }
+  const version = require("koffi/package.json").version;
+  if (version !== "2.16.3") throw new Error(`Unexpected packaged Koffi version: ${version}`);
+
+  const nativeCall = callStableNativeFunction(koffi, target.runtimePlatform);
+  if (nativeCall.value !== process.pid) {
+    throw new Error(`${nativeCall.symbol} returned ${nativeCall.value}; expected ${process.pid}`);
+  }
+  const addressType = typeof koffi.address(Buffer.alloc(8));
+  if (addressType !== "bigint") throw new Error(`koffi.address(Buffer) returned ${addressType}`);
+  const platformProbe = await runPlatformProbe({ BrowserWindow, target });
+
+  return {
+    schemaVersion: 1,
+    ok: true,
+    target: target.id,
+    runtime: { platform: process.platform, arch: process.arch, pid: process.pid, userDataPath },
+    koffi: {
+      version,
+      dlopenPath,
+      physicalPath,
+      addressType,
+    },
+    nativeCall,
+    platformProbe,
+  };
+}
+
+function writeResult(outputPath, result) {
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+}
+
+function maybeRunPackageKoffiSmoke({ app, BrowserWindow, argv = process.argv.slice(1) } = {}) {
+  let options;
+  try {
+    options = parseSmokeArgs(argv);
+  } catch (err) {
+    process.stderr.write(`${err && err.message ? err.message : String(err)}\n`);
+    app.exit(1);
+    return true;
+  }
+  if (!options) return false;
+
+  const smokeUserData = path.join(
+    path.dirname(options.outputPath),
+    `.koffi-smoke-user-data-${process.pid}`,
+  );
+  fs.mkdirSync(smokeUserData, { recursive: true });
+  app.setPath("userData", smokeUserData);
+  app.commandLine.appendSwitch("user-data-dir", smokeUserData);
+  app.disableHardwareAcceleration();
+  app.commandLine.appendSwitch("disable-gpu");
+  app.whenReady().then(async () => {
+    try {
+      const result = await runPackageKoffiSmoke({
+        targetId: options.targetId,
+        resourcesPath: process.resourcesPath,
+        BrowserWindow,
+        userDataPath: smokeUserData,
+      });
+      writeResult(options.outputPath, result);
+      app.exit(0);
+    } catch (err) {
+      writeResult(options.outputPath, {
+        schemaVersion: 1,
+        ok: false,
+        target: options.targetId,
+        error: err && err.stack ? err.stack : String(err),
+      });
+      app.exit(1);
+    }
+  });
+  return true;
+}
+
+module.exports = {
+  SMOKE_FLAG,
+  TARGET_PREFIX,
+  OUTPUT_PREFIX,
+  comparablePath,
+  isInside,
+  parseSmokeArgs,
+  physicalAddonPath,
+  captureKoffiLoad,
+  callStableNativeFunction,
+  runPlatformProbe,
+  runPackageKoffiSmoke,
+  writeResult,
+  maybeRunPackageKoffiSmoke,
+};

--- a/src/win-cloak-recovery.js
+++ b/src/win-cloak-recovery.js
@@ -138,7 +138,11 @@ function createCloakInspector(options = {}) {
       vdeskQuery = (hwnd) => {
         const out = [0];
         const hr = koffi.call(fnIsOnCurrent, IsOnCurrentProto, mgr, hwnd, out);
-        return hr === 0 ? !!out[0] : null;
+        if (hr !== 0) {
+          log(`cloak-recovery vdesk query failed (HRESULT=0x${(hr >>> 0).toString(16)})`);
+          return null;
+        }
+        return !!out[0];
       };
       const fnRelease = koffi.decode(vtbl, 2 * ptrSize, "void *");
       const ReleaseProto = koffi.proto("uint __stdcall CloakIUnknownRelease(void *self)");
@@ -184,7 +188,8 @@ function createCloakInspector(options = {}) {
       if (!hwnd) return null;
       try {
         return vdeskQuery(hwnd);
-      } catch {
+      } catch (err) {
+        log(`cloak-recovery vdesk query threw: ${err && err.message}`);
         return null;
       }
     },

--- a/src/win-foreground-terminal.js
+++ b/src/win-foreground-terminal.js
@@ -131,9 +131,11 @@ function createForegroundWindowsTerminalProbe(options = {}) {
       // through a JS Number.
       const addr = koffi.address(hwnd);
       return addr.toString(10);
-    } catch {
+    } catch (err) {
       // Any FFI hiccup at call time (not init) is an expected miss, not an
-      // error — onError is init-only (see above).
+      // error for production callers. Tests may opt into a separate diagnostic
+      // callback without changing the established init-only onError contract.
+      if (typeof options.onCallError === "function") options.onCallError(err);
       return null;
     }
   };

--- a/src/win-fullscreen-detect.js
+++ b/src/win-fullscreen-detect.js
@@ -119,9 +119,10 @@ function createForegroundFullscreenProbe(options = {}) {
         if (isDesktopShellWindowClass(className)) return false;
       }
       return true;
-    } catch {
+    } catch (err) {
       // Any FFI hiccup at call time: behave as "not fullscreen" so the
       // watchdog keeps the pet visible rather than hiding it on an error.
+      if (typeof options.onCallError === "function") options.onCallError(err);
       return false;
     }
   };

--- a/test/after-pack-koffi.test.js
+++ b/test/after-pack-koffi.test.js
@@ -1,0 +1,201 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const asar = require("@electron/asar");
+const {
+  KOFFI_2163_TRIPLETS,
+  isInside,
+  pruneKoffiNative,
+} = require("../scripts/after-pack-koffi");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "clawd-koffi-prune-"));
+}
+
+function fakePe(machine) {
+  const buffer = Buffer.alloc(256);
+  buffer.write("MZ", 0, "ascii");
+  buffer.writeUInt32LE(0x80, 0x3c);
+  buffer.write("PE\0\0", 0x80, "binary");
+  buffer.writeUInt16LE(machine, 0x84);
+  return buffer;
+}
+
+function fakeElf(machine) {
+  const buffer = Buffer.alloc(64);
+  Buffer.from([0x7f, 0x45, 0x4c, 0x46]).copy(buffer, 0);
+  buffer[4] = 2;
+  buffer[5] = 1;
+  buffer.writeUInt16LE(machine, 18);
+  return buffer;
+}
+
+function fakeMach(cpu) {
+  const buffer = Buffer.alloc(64);
+  Buffer.from("cffaedfe", "hex").copy(buffer, 0);
+  buffer.writeUInt32LE(cpu, 4);
+  return buffer;
+}
+
+function nativeForTarget(targetId) {
+  if (targetId === "windows-x64") return fakePe(0x8664);
+  if (targetId === "windows-arm64") return fakePe(0xaa64);
+  if (targetId === "linux-x64") return fakeElf(0x003e);
+  if (targetId === "darwin-x64") return fakeMach(0x01000007);
+  if (targetId === "darwin-arm64") return fakeMach(0x0100000c);
+  throw new Error(`Unsupported fixture target: ${targetId}`);
+}
+
+async function makePackagedKoffi(root, targetId) {
+  const target = require("../src/native-package-target").getReleaseTarget(targetId);
+  const appOutDir = target.runtimePlatform === "darwin" ? path.join(root, "out") : path.join(root, "app");
+  const appRoot = target.runtimePlatform === "darwin"
+    ? path.join(appOutDir, "Clawd on Desk.app")
+    : appOutDir;
+  const resources = target.runtimePlatform === "darwin"
+    ? path.join(appRoot, "Contents", "Resources")
+    : path.join(appRoot, "resources");
+  const unpackedKoffi = path.join(resources, "app.asar.unpacked", "node_modules", "koffi");
+  const nativeRoot = path.join(unpackedKoffi, "build", "koffi");
+  fs.mkdirSync(nativeRoot, { recursive: true });
+  fs.writeFileSync(path.join(unpackedKoffi, "package.json"), JSON.stringify({ version: "2.16.3" }));
+
+  const targetTriplet = target.koffiTriplet;
+  for (const triplet of KOFFI_2163_TRIPLETS) {
+    const tripletDir = path.join(nativeRoot, triplet);
+    fs.mkdirSync(tripletDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(tripletDir, "koffi.node"),
+      triplet === targetTriplet ? nativeForTarget(targetId) : Buffer.from("foreign"),
+    );
+    if (triplet.startsWith("win32_")) {
+      fs.writeFileSync(path.join(tripletDir, "koffi.lib"), "lib");
+      fs.writeFileSync(path.join(tripletDir, "koffi.exp"), "exp");
+    }
+  }
+
+  const asarSource = path.join(root, "asar-source");
+  for (const triplet of KOFFI_2163_TRIPLETS) {
+    const filename = path.join(asarSource, "node_modules", "koffi", "build", "koffi", triplet, "koffi.node");
+    fs.mkdirSync(path.dirname(filename), { recursive: true });
+    fs.writeFileSync(filename, "logical");
+  }
+  await asar.createPackage(asarSource, path.join(resources, "app.asar"));
+  return { appOutDir, appRoot, resources, nativeRoot, targetTriplet };
+}
+
+test("afterPack prune keeps one target addon and removes every lib/exp", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makePackagedKoffi(root, "windows-x64");
+  const output = path.join(root, "manifests", "windows-x64.json");
+  const report = pruneKoffiNative({
+    appOutDir: fixture.appRoot,
+    targetId: "windows-x64",
+    outputPath: output,
+  });
+
+  assert.equal(report.summary.tripletsBefore, 18);
+  assert.equal(report.summary.tripletsAfter, 1);
+  assert.equal(report.logicalKoffiNativeEntries.length, 18, "afterPack must not rewrite app.asar");
+  assert.deepEqual(fs.readdirSync(fixture.nativeRoot), [fixture.targetTriplet]);
+  assert.deepEqual(fs.readdirSync(path.join(fixture.nativeRoot, fixture.targetTriplet)), ["koffi.node"]);
+  assert.equal(report.retained.format, "PE");
+  assert.deepEqual(report.retained.architectures, ["x64"]);
+  assert.equal(fs.existsSync(output), true);
+});
+
+test("afterPack prune supports the Linux target without a platform exception", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makePackagedKoffi(root, "linux-x64");
+  const report = pruneKoffiNative({ appOutDir: fixture.appRoot, targetId: "linux-x64" });
+  assert.equal(report.retained.format, "ELF");
+  assert.deepEqual(report.retained.architectures, ["x86_64"]);
+  assert.deepEqual(fs.readdirSync(fixture.nativeRoot), ["linux_x64"]);
+});
+
+test("afterPack prune resolves a macOS app bundle and retains a thin Mach-O target", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makePackagedKoffi(root, "darwin-x64");
+  const report = pruneKoffiNative({ appOutDir: fixture.appOutDir, targetId: "darwin-x64" });
+  assert.equal(report.appRoot, path.resolve(fixture.appRoot));
+  assert.equal(report.retained.format, "Mach-O");
+  assert.deepEqual(report.retained.architectures, ["x86_64"]);
+  assert.deepEqual(fs.readdirSync(fixture.nativeRoot), ["darwin_x64"]);
+});
+
+test("prune fails closed on unknown layout and wrong version", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makePackagedKoffi(root, "windows-x64");
+  fs.mkdirSync(path.join(fixture.nativeRoot, "unexpected_triplet"));
+  assert.throws(
+    () => pruneKoffiNative({ appOutDir: fixture.appRoot, targetId: "windows-x64" }),
+    /Unexpected Koffi 2\.16\.3 triplet layout/,
+  );
+  fs.rmSync(path.join(fixture.nativeRoot, "unexpected_triplet"), { recursive: true });
+  fs.writeFileSync(
+    path.join(fixture.resources, "app.asar.unpacked", "node_modules", "koffi", "package.json"),
+    JSON.stringify({ version: "2.15.2" }),
+  );
+  assert.throws(
+    () => pruneKoffiNative({ appOutDir: fixture.appRoot, targetId: "windows-x64" }),
+    /unexpected Koffi version/i,
+  );
+});
+
+test("prune validates the retained architecture before deleting foreign triplets", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makePackagedKoffi(root, "windows-x64");
+  fs.writeFileSync(path.join(fixture.nativeRoot, fixture.targetTriplet, "koffi.node"), fakePe(0xaa64));
+  assert.throws(
+    () => pruneKoffiNative({ appOutDir: fixture.appRoot, targetId: "windows-x64" }),
+    /wrong architecture/i,
+  );
+  assert.equal(fs.readdirSync(fixture.nativeRoot).length, KOFFI_2163_TRIPLETS.length);
+});
+
+test("prune manifest is never written back inside the staged app", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makePackagedKoffi(root, "windows-x64");
+  assert.throws(
+    () => pruneKoffiNative({
+      appOutDir: fixture.appRoot,
+      targetId: "windows-x64",
+      outputPath: path.join(fixture.appRoot, "manifest.json"),
+    }),
+    /manifest must be outside appOutDir/i,
+  );
+});
+
+test("prune rejects junctions/reparse points before deleting anything", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makePackagedKoffi(root, "windows-x64");
+  const foreign = path.join(fixture.nativeRoot, "darwin_arm64");
+  fs.rmSync(foreign, { recursive: true });
+  const outside = path.join(root, "outside");
+  fs.mkdirSync(outside);
+  fs.writeFileSync(path.join(outside, "keep.txt"), "keep");
+  fs.symlinkSync(outside, foreign, process.platform === "win32" ? "junction" : "dir");
+  assert.throws(
+    () => pruneKoffiNative({ appOutDir: fixture.appRoot, targetId: "windows-x64" }),
+    /non-directory or link|symlink\/reparse/i,
+  );
+  assert.equal(fs.readFileSync(path.join(outside, "keep.txt"), "utf8"), "keep");
+});
+
+test("inside checks reject sibling-prefix and parent escapes", () => {
+  const base = path.resolve("C:/tmp/app");
+  assert.equal(isInside(base, path.join(base, "resources")), true);
+  assert.equal(isInside(base, path.resolve("C:/tmp/app-other")), false);
+  assert.equal(isInside(base, path.resolve("C:/tmp")), false);
+});

--- a/test/audit-packaged-native.test.js
+++ b/test/audit-packaged-native.test.js
@@ -1,0 +1,272 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const asar = require("@electron/asar");
+const {
+  parseNativeBuffer,
+  auditPackagedNative,
+  getException,
+  parseArgs,
+  stableJson,
+} = require("../scripts/audit-packaged-native");
+const policy = require("../scripts/native-package-policy.json");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "clawd-native-audit-"));
+}
+
+function fakePe(machine) {
+  const buffer = Buffer.alloc(256);
+  buffer.write("MZ", 0, "ascii");
+  buffer.writeUInt32LE(0x80, 0x3c);
+  buffer.write("PE\0\0", 0x80, "binary");
+  buffer.writeUInt16LE(machine, 0x84);
+  return buffer;
+}
+
+function fakeElf(machine, { endian = "little", elfClass = 2 } = {}) {
+  const buffer = Buffer.alloc(64);
+  Buffer.from([0x7f, 0x45, 0x4c, 0x46]).copy(buffer, 0);
+  buffer[4] = elfClass;
+  buffer[5] = endian === "little" ? 1 : 2;
+  if (endian === "little") buffer.writeUInt16LE(machine, 18);
+  else buffer.writeUInt16BE(machine, 18);
+  return buffer;
+}
+
+function fakeMachThin(cpu, littleEndian = true) {
+  const buffer = Buffer.alloc(64);
+  Buffer.from(littleEndian ? "cffaedfe" : "feedfacf", "hex").copy(buffer, 0);
+  if (littleEndian) buffer.writeUInt32LE(cpu, 4);
+  else buffer.writeUInt32BE(cpu, 4);
+  return buffer;
+}
+
+function fakeMachFat(cpus) {
+  const buffer = Buffer.alloc(8 + cpus.length * 20);
+  Buffer.from("cafebabe", "hex").copy(buffer, 0);
+  buffer.writeUInt32BE(cpus.length, 4);
+  cpus.forEach((cpu, index) => buffer.writeUInt32BE(cpu, 8 + index * 20));
+  return buffer;
+}
+
+async function makeAppRoot(root, targetId, {
+  logicalOnlyNative = false,
+  unknownKoffiLogical = false,
+} = {}) {
+  const target = require("../src/native-package-target").getReleaseTarget(targetId);
+  const appRoot = target.runtimePlatform === "darwin"
+    ? path.join(root, "Clawd on Desk.app")
+    : path.join(root, "app");
+  const resources = target.runtimePlatform === "darwin"
+    ? path.join(appRoot, "Contents", "Resources")
+    : path.join(appRoot, "resources");
+  const koffiNode = path.join(
+    resources,
+    "app.asar.unpacked",
+    "node_modules",
+    "koffi",
+    "build",
+    "koffi",
+    target.koffiTriplet,
+    "koffi.node",
+  );
+  fs.mkdirSync(path.dirname(koffiNode), { recursive: true });
+
+  let targetBinary;
+  if (target.format === "PE") targetBinary = fakePe(target.architecture === "x64" ? 0x8664 : 0xaa64);
+  else if (target.format === "ELF") targetBinary = fakeElf(0x003e);
+  else targetBinary = fakeMachThin(target.architecture === "x86_64" ? 0x01000007 : 0x0100000c);
+  fs.writeFileSync(koffiNode, targetBinary);
+  const executable = target.runtimePlatform === "darwin"
+    ? path.join(appRoot, "Contents", "MacOS", "Clawd on Desk")
+    : path.join(appRoot, target.runtimePlatform === "win32" ? "Clawd.exe" : "clawd");
+  fs.mkdirSync(path.dirname(executable), { recursive: true });
+  fs.writeFileSync(executable, targetBinary);
+  if (target.runtimePlatform === "win32") fs.writeFileSync(path.join(resources, "elevate.exe"), fakePe(0x014c));
+
+  const source = path.join(root, "asar-source");
+  const logicalNode = path.join(source, "node_modules", "koffi", "build", "koffi", target.koffiTriplet, "koffi.node");
+  fs.mkdirSync(path.dirname(logicalNode), { recursive: true });
+  fs.writeFileSync(logicalNode, "logical");
+  if (logicalOnlyNative) {
+    const orphan = path.join(source, "node_modules", "orphan-native", "orphan.node");
+    fs.mkdirSync(path.dirname(orphan), { recursive: true });
+    fs.writeFileSync(orphan, targetBinary);
+  }
+  if (unknownKoffiLogical) {
+    const unknown = path.join(
+      source,
+      "node_modules",
+      "koffi",
+      "build",
+      "koffi",
+      "evil_triplet",
+      "koffi.node",
+    );
+    fs.mkdirSync(path.dirname(unknown), { recursive: true });
+    fs.writeFileSync(unknown, targetBinary);
+  }
+  await asar.createPackage(source, path.join(resources, "app.asar"));
+  return { appRoot, resources, koffiNode, targetBinary };
+}
+
+test("native parsers identify PE, ELF, thin Mach-O, and fat Mach-O architectures", () => {
+  assert.deepEqual(parseNativeBuffer(fakePe(0x8664)).architectures, ["x64"]);
+  assert.deepEqual(parseNativeBuffer(fakePe(0xaa64)).architectures, ["arm64"]);
+  assert.deepEqual(parseNativeBuffer(fakeElf(0x003e)).architectures, ["x86_64"]);
+  assert.deepEqual(parseNativeBuffer(fakeElf(0x00b7, { endian: "big" })).architectures, ["arm64"]);
+  assert.deepEqual(parseNativeBuffer(fakeMachThin(0x01000007)).architectures, ["x86_64"]);
+  assert.deepEqual(
+    parseNativeBuffer(fakeMachFat([0x01000007, 0x0100000c])).architectures,
+    ["x86_64", "arm64"],
+  );
+  assert.equal(parseNativeBuffer(Buffer.from("plain text")), null);
+});
+
+test("malformed native-looking headers fail closed", () => {
+  assert.throws(() => parseNativeBuffer(Buffer.from("MZ")), /Truncated PE/);
+  assert.throws(() => parseNativeBuffer(Buffer.from([0x7f, 0x45, 0x4c, 0x46])), /Truncated ELF/);
+  assert.throws(() => parseNativeBuffer(Buffer.from("cafebabe00000002", "hex")), /Truncated fat Mach-O/);
+});
+
+test("Windows audit records the exact elevate exception and one Koffi addon", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makeAppRoot(root, "windows-x64");
+  const report = auditPackagedNative({ appRoot: fixture.appRoot, targetId: "windows-x64" });
+  assert.deepEqual(report.errors, []);
+  assert.equal(report.koffi.physical.length, 1);
+  assert.equal(report.koffi.logical.length, 1);
+  assert.equal(report.logicalNative.length, 1);
+  assert.equal(report.logicalNative[0].disposition, "physical-unpacked");
+  assert.equal(report.summary.countByDisposition.exception, 1);
+  const elevate = report.binaries.find((entry) => entry.path === "resources/elevate.exe");
+  assert.equal(elevate.policyId, "electron-builder-nsis-elevate-helper");
+  assert.equal(
+    report.binaries.some((entry) => entry.path.includes("\\")),
+    false,
+    "manifest-relative paths must be POSIX-normalized",
+  );
+  assert.equal(stableJson(report).endsWith("\n"), true);
+});
+
+test("logical native candidates inside app.asar require a physical unpacked payload", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makeAppRoot(root, "windows-x64", { logicalOnlyNative: true });
+  const report = auditPackagedNative({ appRoot: fixture.appRoot, targetId: "windows-x64" });
+  const orphan = report.logicalNative.find((entry) => /orphan\.node$/.test(entry.path));
+  assert.equal(orphan.physicalPresent, false);
+  assert.equal(orphan.disposition, "error");
+  assert.equal(
+    report.errors.some((entry) => entry.code === "logical-native-without-physical-payload"),
+    true,
+  );
+});
+
+test("unknown Koffi logical triplets never receive the known-stale exemption", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makeAppRoot(root, "windows-x64", { unknownKoffiLogical: true });
+  const report = auditPackagedNative({ appRoot: fixture.appRoot, targetId: "windows-x64" });
+  const unknown = report.logicalNative.find((entry) => /evil_triplet/.test(entry.path));
+  assert.equal(unknown.disposition, "error");
+  assert.equal(
+    report.errors.some((entry) => (
+      entry.code === "logical-native-without-physical-payload" && /evil_triplet/.test(entry.path)
+    )),
+    true,
+  );
+});
+
+test("zero, duplicate, and wrong-triplet physical Koffi payloads hard-fail", async (t) => {
+  const zeroRoot = tempDir();
+  const duplicateRoot = tempDir();
+  const wrongRoot = tempDir();
+  t.after(() => {
+    for (const root of [zeroRoot, duplicateRoot, wrongRoot]) {
+      fs.rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  const zero = await makeAppRoot(zeroRoot, "windows-x64");
+  fs.rmSync(zero.koffiNode);
+  const zeroReport = auditPackagedNative({ appRoot: zero.appRoot, targetId: "windows-x64" });
+  assert.equal(zeroReport.errors.some((entry) => entry.code === "unexpected-koffi-native-count"), true);
+
+  const duplicate = await makeAppRoot(duplicateRoot, "windows-x64");
+  const duplicateNode = path.join(
+    duplicate.resources,
+    "app.asar.unpacked",
+    "node_modules",
+    "koffi",
+    "build",
+    "koffi",
+    "win32_arm64",
+    "koffi.node",
+  );
+  fs.mkdirSync(path.dirname(duplicateNode), { recursive: true });
+  fs.copyFileSync(duplicate.koffiNode, duplicateNode);
+  const duplicateReport = auditPackagedNative({ appRoot: duplicate.appRoot, targetId: "windows-x64" });
+  assert.equal(duplicateReport.errors.some((entry) => entry.code === "unexpected-koffi-native-count"), true);
+
+  const wrong = await makeAppRoot(wrongRoot, "windows-x64");
+  const wrongNode = path.join(
+    wrong.resources,
+    "app.asar.unpacked",
+    "node_modules",
+    "koffi",
+    "build",
+    "koffi",
+    "win32_arm64",
+    "koffi.node",
+  );
+  fs.mkdirSync(path.dirname(wrongNode), { recursive: true });
+  fs.renameSync(wrong.koffiNode, wrongNode);
+  const wrongReport = auditPackagedNative({ appRoot: wrong.appRoot, targetId: "windows-x64" });
+  assert.equal(wrongReport.errors.some((entry) => entry.code === "wrong-koffi-native-target"), true);
+});
+
+test("macOS audit reads app.asar from Contents/Resources", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makeAppRoot(root, "darwin-x64");
+  const report = auditPackagedNative({ appRoot: fixture.appRoot, targetId: "darwin-x64" });
+  assert.deepEqual(report.errors, []);
+  assert.equal(report.koffi.logical.length, 1);
+  assert.match(report.koffi.physical[0], /^Contents\/Resources\/app\.asar\.unpacked\//);
+});
+
+test("foreign binaries and wrong Koffi triplets hard-fail", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const fixture = await makeAppRoot(root, "windows-x64");
+  fs.writeFileSync(path.join(fixture.resources, "foreign.exe"), fakePe(0xaa64));
+  const report = auditPackagedNative({ appRoot: fixture.appRoot, targetId: "windows-x64" });
+  assert.equal(report.errors.some((entry) => entry.code === "foreign-native-binary"), true);
+  assert.equal(report.binaries.find((entry) => entry.path === "resources/foreign.exe").disposition, "error");
+});
+
+test("near-miss elevate helpers never receive the exception", () => {
+  const parsed = parseNativeBuffer(fakePe(0x014c));
+  assert.equal(getException(policy, "windows-x64", "resources/elevate.exe", parsed).id, "electron-builder-nsis-elevate-helper");
+  assert.equal(getException(policy, "windows-x64", "other/elevate.exe", parsed), null);
+  assert.equal(getException(policy, "darwin-x64", "resources/elevate.exe", parsed), null);
+  assert.equal(getException(policy, "windows-x64", "resources/Elevate.exe", parsed), null);
+  assert.equal(getException(policy, "windows-x64", "resources/elevate.exe", parseNativeBuffer(fakePe(0x8664))), null);
+});
+
+test("audit CLI parser requires explicit app root and target", () => {
+  assert.throws(() => parseArgs([]), /--app-root is required/);
+  assert.throws(() => parseArgs(["--app-root", "dist/app"]), /--target is required/);
+  assert.throws(() => parseArgs(["--wat"]), /Unknown argument/);
+  assert.deepEqual(
+    parseArgs(["--app-root", "dist/app", "--target", "linux-x64", "--output", "out.json"]),
+    { appRoot: "dist/app", targetId: "linux-x64", output: "out.json" },
+  );
+});

--- a/test/koffi-lockfile.test.js
+++ b/test/koffi-lockfile.test.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const pkg = require("../package.json");
+const lock = require("../package-lock.json");
+
+const EXPECTED_VERSION = "2.16.3";
+const EXPECTED_INTEGRITY = "sha512-E9y1AsgYGlaxMhcZzHr8y96QF2U5XzA12GGVAfbWqIubTwPNMXQarfBzePNXHe0xtIEtNd6ifAv3GAKYGUeBAQ==";
+
+test("Koffi native code is pinned exactly in package and lock metadata", () => {
+  assert.equal(pkg.dependencies.koffi, EXPECTED_VERSION);
+  assert.equal(lock.packages[""].dependencies.koffi, EXPECTED_VERSION);
+  const entry = lock.packages["node_modules/koffi"];
+  assert.equal(entry.version, EXPECTED_VERSION);
+  assert.equal(entry.integrity, EXPECTED_INTEGRITY);
+  assert.equal(entry.hasInstallScript, true);
+  assert.match(entry.resolved, /^https:\/\/(?:registry\.npmjs\.org|registry\.npmmirror\.com)\/koffi\//);
+});
+
+test("electron-builder runs the reviewed safe afterPack hook", () => {
+  assert.equal(pkg.build.afterPack, "scripts/after-pack-koffi.js");
+  assert.equal(pkg.scripts["audit:native-package"], "node scripts/audit-packaged-native.js");
+  assert.equal(pkg.scripts["verify:updater-metadata"], "node scripts/verify-updater-metadata.js");
+});

--- a/test/native-package-target.test.js
+++ b/test/native-package-target.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+const {
+  RELEASE_TARGETS,
+  normalizePlatform,
+  normalizeBuilderArch,
+  getReleaseTarget,
+  resolveReleaseTarget,
+} = require("../src/native-package-target");
+
+test("native package target map covers the five release targets exactly", () => {
+  assert.deepEqual(
+    RELEASE_TARGETS.map((target) => target.id),
+    ["windows-x64", "windows-arm64", "darwin-x64", "darwin-arm64", "linux-x64"],
+  );
+  assert.equal(getReleaseTarget("windows-x64").koffiTriplet, "win32_x64");
+  assert.equal(getReleaseTarget("linux-x64").artifactArchAliases.includes("amd64"), true);
+});
+
+test("electron-builder numeric and textual architecture values normalize once", () => {
+  assert.equal(normalizeBuilderArch(1), "x64");
+  assert.equal(normalizeBuilderArch(3), "arm64");
+  assert.equal(normalizeBuilderArch("1"), "x64");
+  assert.equal(normalizeBuilderArch("amd64"), "x64");
+  assert.equal(normalizeBuilderArch("aarch64"), "arm64");
+  assert.equal(normalizePlatform("windows"), "win32");
+  assert.equal(normalizePlatform("mac"), "darwin");
+});
+
+test("target resolution rejects unsupported platform and architecture tuples", () => {
+  assert.equal(resolveReleaseTarget("win32", 1).id, "windows-x64");
+  assert.equal(resolveReleaseTarget("win32", 3).id, "windows-arm64");
+  assert.equal(resolveReleaseTarget("darwin", "x64").id, "darwin-x64");
+  assert.equal(resolveReleaseTarget("linux", "amd64").id, "linux-x64");
+  assert.throws(() => resolveReleaseTarget("linux", "arm64"), /Unsupported package target/);
+  assert.throws(() => resolveReleaseTarget("freebsd", "x64"), /Unsupported package target/);
+  assert.throws(() => getReleaseTarget("windows-ia32"), /Unknown release target/);
+});

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -388,6 +388,10 @@ describe("package build config", () => {
       assert.match(workflow, /scripts\/assert-no-retired-telegram-sidecar\.js/);
       assert.match(workflow, /scripts\/audit-packaged-native\.js/);
       assert.match(workflow, /scripts\/run-packaged-koffi-smoke\.js/);
+      assert.match(workflow, /name: Configure Linux Chromium sandbox/);
+      assert.match(workflow, /if: matrix\.target == 'linux-x64'/);
+      assert.match(workflow, /sudo chown root:root dist\/linux-unpacked\/chrome-sandbox/);
+      assert.match(workflow, /sudo chmod 4755 dist\/linux-unpacked\/chrome-sandbox/);
       assert.match(workflow, /dist\/koffi-prune-manifests\/\*\.json/);
       assert.match(workflow, /dist\/native-package-manifests\/\*\.json/);
       assert.match(workflow, /runner: windows-11-arm/);
@@ -403,6 +407,9 @@ describe("package build config", () => {
       assert.strictEqual((workflow.match(/scripts\/run-packaged-koffi-smoke\.js/g) || []).length, 3);
       assert.strictEqual((workflow.match(/scripts\/verify-updater-metadata\.js/g) || []).length, 3);
       assert.strictEqual((workflow.match(/if-no-files-found: error/g) || []).length, 3);
+      assert.strictEqual((workflow.match(/name: Configure Linux Chromium sandbox/g) || []).length, 1);
+      assert.match(workflow, /sudo chown root:root dist\/linux-unpacked\/chrome-sandbox/);
+      assert.match(workflow, /sudo chmod 4755 dist\/linux-unpacked\/chrome-sandbox/);
       for (const contract of ["windows", "mac", "linux"]) {
         assert.match(workflow, new RegExp(`--contract ${contract}`));
       }

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -119,6 +119,27 @@ describe("package build config", () => {
     );
   });
 
+  describe("target-native Koffi packaging", () => {
+    it("pins the reviewed Koffi line and prunes only through the afterPack hook", () => {
+      assert.strictEqual(pkg.dependencies.koffi, "2.16.3");
+      assert.strictEqual(pkg.build.afterPack, "scripts/after-pack-koffi.js");
+      assert.strictEqual(pkg.scripts["audit:native-package"], "node scripts/audit-packaged-native.js");
+      assert.strictEqual(pkg.scripts["verify:updater-metadata"], "node scripts/verify-updater-metadata.js");
+    });
+
+    it("uses reproducible installs in release and five-target package CI", () => {
+      const release = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
+      const packageAudit = fs.readFileSync(
+        path.join(ROOT, ".github", "workflows", "telegram-retirement-package-audit.yml"),
+        "utf8",
+      );
+      assert.strictEqual((release.match(/      - run: npm ci/g) || []).length, 3);
+      assert.strictEqual((packageAudit.match(/      - run: npm ci/g) || []).length, 2);
+      assert.doesNotMatch(release, /      - run: npm install(?:\s|$)/m);
+      assert.doesNotMatch(packageAudit, /      - run: npm install(?:\s|$)/m);
+    });
+  });
+
   describe("Windows architecture targets", () => {
     function getWindowsNsisTarget() {
       const targets = pkg.build.win && pkg.build.win.target;
@@ -324,9 +345,21 @@ describe("package build config", () => {
         "only the Windows job should substitute the package-validation tests in evidence mode"
       );
       assert.strictEqual(
-        (workflow.match(/node --test test\/assert-no-retired-telegram-sidecar\.test\.js test\/package-build-config\.test\.js test\/telegram-legacy-retirement\.test\.js test\/telegram-migration-state\.test\.js test\/telegram-migration-controller\.test\.js test\/telegram-migration-user-data\.test\.js/g) || []).length,
-        1
+        (workflow.match(/name: Run package validation tests/g) || []).length,
+        1,
       );
+      const focusedLine = workflow.split(/\r?\n/).find((line) => line.includes("node --test test/assert-no-retired"));
+      assert.ok(focusedLine, "Windows evidence mode should retain its focused test command");
+      for (const testFile of [
+        "after-pack-koffi.test.js",
+        "audit-packaged-native.test.js",
+        "koffi-lockfile.test.js",
+        "native-package-target.test.js",
+        "package-koffi-smoke.test.js",
+        "verify-updater-metadata.test.js",
+      ]) {
+        assert.match(focusedLine, new RegExp(`test/${testFile.replace(/\./g, "\\.")}`));
+      }
       assert.strictEqual(
         (workflow.match(/      - run: npm test/g) || []).length,
         3,
@@ -336,7 +369,7 @@ describe("package build config", () => {
 
     it("builds and uploads all five target artifacts in pull-request CI", () => {
       const workflowPath = path.join(ROOT, ".github", "workflows", "telegram-retirement-package-audit.yml");
-      assert.ok(fs.existsSync(workflowPath), "Telegram retirement package audit workflow should exist");
+      assert.ok(fs.existsSync(workflowPath), "five-target package audit workflow should exist");
       const workflow = fs.readFileSync(workflowPath, "utf8");
       assert.match(workflow, /pull_request:/);
       assert.match(workflow, /name: Assert installer exists/);
@@ -350,16 +383,29 @@ describe("package build config", () => {
         "linux-x64",
       ]) {
         assert.match(workflow, new RegExp(`target: ${target}`));
-        assert.match(
-          workflow,
-          new RegExp(`telegram-retirement-\\$\\{\\{ matrix\\.target \\}\\}`),
-          "five-target CI should upload target-specific artifacts and manifests"
-        );
       }
+      assert.match(workflow, /name: package-audit-\$\{\{ matrix\.target \}\}/);
       assert.match(workflow, /scripts\/assert-no-retired-telegram-sidecar\.js/);
+      assert.match(workflow, /scripts\/audit-packaged-native\.js/);
+      assert.match(workflow, /scripts\/run-packaged-koffi-smoke\.js/);
+      assert.match(workflow, /dist\/koffi-prune-manifests\/\*\.json/);
+      assert.match(workflow, /dist\/native-package-manifests\/\*\.json/);
+      assert.match(workflow, /runner: windows-11-arm/);
+      assert.match(workflow, /runner: macos-15-intel/);
       assert.doesNotMatch(workflow, /fetch:sidecars|verify-sidecar|assert:packaged-sidecar/);
       assert.match(workflow, /Clawd-on-Desk-\*-x86_64\.AppImage/);
       assert.match(workflow, /Clawd-on-Desk-\*-amd64\.deb/);
+    });
+
+    it("gates release artifacts on native payload, packaged calls, and updater metadata", () => {
+      const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
+      assert.strictEqual((workflow.match(/scripts\/audit-packaged-native\.js/g) || []).length, 5);
+      assert.strictEqual((workflow.match(/scripts\/run-packaged-koffi-smoke\.js/g) || []).length, 3);
+      assert.strictEqual((workflow.match(/scripts\/verify-updater-metadata\.js/g) || []).length, 3);
+      assert.strictEqual((workflow.match(/if-no-files-found: error/g) || []).length, 3);
+      for (const contract of ["windows", "mac", "linux"]) {
+        assert.match(workflow, new RegExp(`--contract ${contract}`));
+      }
     });
 
     it("publishes GitHub releases only for pushed version tags", () => {

--- a/test/package-koffi-smoke.test.js
+++ b/test/package-koffi-smoke.test.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  parseSmokeArgs,
+  physicalAddonPath,
+  comparablePath,
+  isInside,
+  callStableNativeFunction,
+} = require("../src/package-koffi-smoke");
+const {
+  parseArgs: parseRunnerArgs,
+  cleanupSmokeUserData,
+} = require("../scripts/run-packaged-koffi-smoke");
+
+test("packaged smoke mode is opt-in and requires target/output", () => {
+  assert.equal(parseSmokeArgs(["--unrelated"]), null);
+  assert.throws(() => parseSmokeArgs(["--clawd-package-smoke"]), /target.*required/i);
+  assert.throws(
+    () => parseSmokeArgs(["--clawd-package-smoke", "--clawd-package-smoke-target=windows-x64"]),
+    /output.*required/i,
+  );
+  const parsed = parseSmokeArgs([
+    "--clawd-package-smoke",
+    "--clawd-package-smoke-target=windows-x64",
+    "--clawd-package-smoke-output=dist/smoke.json",
+  ]);
+  assert.equal(parsed.targetId, "windows-x64");
+  assert.equal(path.isAbsolute(parsed.outputPath), true);
+});
+
+test("physical addon evidence maps logical ASAR path to unpacked storage", () => {
+  const logical = path.resolve("dist/resources/app.asar/node_modules/koffi/build/koffi/win32_x64/koffi.node");
+  const physical = physicalAddonPath(logical).replace(/\\/g, "/");
+  assert.match(physical, /resources\/app\.asar\.unpacked\/node_modules\/koffi/);
+  assert.equal(physicalAddonPath(physicalAddonPath(logical)), physicalAddonPath(logical));
+});
+
+test("Windows extended-length dlopen paths compare inside normal resources paths", () => {
+  if (process.platform !== "win32") return;
+  const resources = "D:\\app\\resources";
+  const addon = "\\\\?\\D:\\app\\resources\\app.asar.unpacked\\koffi.node";
+  assert.equal(comparablePath(addon), "D:\\app\\resources\\app.asar.unpacked\\koffi.node");
+  assert.equal(isInside(resources, addon), true);
+  assert.equal(isInside(resources, "\\\\?\\D:\\outside\\koffi.node"), false);
+});
+
+test("stable native call proves Koffi 2.16.3 works on the current Windows host", { skip: process.platform !== "win32" }, () => {
+  const koffi = require("koffi");
+  const result = callStableNativeFunction(koffi, "win32");
+  assert.equal(result.symbol, "GetCurrentProcessId");
+  assert.equal(result.value, process.pid);
+  assert.equal(typeof koffi.address(Buffer.alloc(8)), "bigint");
+});
+
+test("packaged smoke runner parser rejects incomplete invocations", () => {
+  assert.throws(() => parseRunnerArgs([]), /--executable is required/);
+  assert.throws(() => parseRunnerArgs(["--executable", "app.exe"]), /--target is required/);
+  assert.throws(
+    () => parseRunnerArgs(["--executable", "app.exe", "--target", "windows-x64"]),
+    /--output is required/,
+  );
+});
+
+test("packaged smoke cleanup removes only its exact adjacent temporary profile", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-smoke-cleanup-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const output = path.join(root, "windows-x64.json");
+  const profile = path.join(root, ".koffi-smoke-user-data-1234");
+  fs.mkdirSync(profile);
+  fs.writeFileSync(path.join(profile, "state"), "temporary");
+  assert.deepEqual(
+    cleanupSmokeUserData(output, { runtime: { userDataPath: profile } }),
+    { cleaned: true, reason: "removed" },
+  );
+  assert.equal(fs.existsSync(profile), false);
+  assert.throws(
+    () => cleanupSmokeUserData(output, { runtime: { userDataPath: path.join(root, "unrelated") } }),
+    /unsafe smoke user-data cleanup path/i,
+  );
+});

--- a/test/verify-updater-metadata.test.js
+++ b/test/verify-updater-metadata.test.js
@@ -1,0 +1,115 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const test = require("node:test");
+const {
+  parseUpdaterYaml,
+  sha512Base64,
+  verifyUpdaterMetadata,
+  parseArgs,
+} = require("../scripts/verify-updater-metadata");
+
+function tempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "clawd-updater-metadata-"));
+}
+
+function writeArtifact(root, name, content) {
+  const filename = path.join(root, name);
+  fs.writeFileSync(filename, content);
+  return {
+    name,
+    size: fs.statSync(filename).size,
+    sha512: sha512Base64(filename),
+  };
+}
+
+function yamlFor(files, topPath, { appImageBlockMap = false } = {}) {
+  const top = files.find((entry) => entry.name === topPath);
+  const lines = ["version: 0.14.0", "files:"];
+  for (const entry of files) {
+    lines.push(`  - url: ${entry.name}`);
+    lines.push(`    sha512: ${entry.sha512}`);
+    lines.push(`    size: ${entry.size}`);
+    if (appImageBlockMap && entry.name.endsWith(".AppImage")) lines.push("    blockMapSize: 123");
+  }
+  lines.push(`path: ${topPath}`);
+  lines.push(`sha512: ${top.sha512}`);
+  lines.push("releaseDate: '2026-08-02T00:00:00.000Z'");
+  return `${lines.join("\n")}\n`;
+}
+
+test("minimal updater YAML parser keeps files and top-level path separate", () => {
+  const parsed = parseUpdaterYaml([
+    "version: 1.2.3",
+    "files:",
+    "  - url: one.exe",
+    "    sha512: abc",
+    "    size: 10",
+    "path: one.exe",
+    "sha512: abc",
+  ].join("\n"));
+  assert.equal(parsed.version, "1.2.3");
+  assert.deepEqual(parsed.files, [{ url: "one.exe", sha512: "abc", size: 10 }]);
+  assert.equal(parsed.path, "one.exe");
+});
+
+test("Windows dual-architecture updater metadata verifies bytes and hashes", (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const x64 = writeArtifact(root, "Clawd-on-Desk-Setup-0.14.0-x64.exe", "x64");
+  const arm64 = writeArtifact(root, "Clawd-on-Desk-Setup-0.14.0-arm64.exe", "arm64");
+  const metadata = path.join(root, "latest.yml");
+  fs.writeFileSync(metadata, yamlFor([x64, arm64], x64.name));
+  const report = verifyUpdaterMetadata({ metadataPath: metadata, artifactRoot: root, contract: "windows" });
+  assert.deepEqual(report.errors, []);
+  assert.equal(report.files.length, 2);
+});
+
+test("macOS contract requires two DMGs and no invented zip", (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const x64 = writeArtifact(root, "Clawd-on-Desk-0.14.0-x64.dmg", "x64");
+  const arm64 = writeArtifact(root, "Clawd-on-Desk-0.14.0-arm64.dmg", "arm64");
+  const metadata = path.join(root, "latest-mac.yml");
+  fs.writeFileSync(metadata, yamlFor([x64, arm64], x64.name));
+  assert.deepEqual(
+    verifyUpdaterMetadata({ metadataPath: metadata, artifactRoot: root, contract: "mac" }).errors,
+    [],
+  );
+});
+
+test("Linux contract requires AppImage, deb, path, and blockMapSize", (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const appImage = writeArtifact(root, "Clawd-on-Desk-0.14.0-x86_64.AppImage", "appimage");
+  const deb = writeArtifact(root, "Clawd-on-Desk-0.14.0-amd64.deb", "deb");
+  const metadata = path.join(root, "latest-linux.yml");
+  fs.writeFileSync(metadata, yamlFor([appImage, deb], appImage.name, { appImageBlockMap: true }));
+  assert.deepEqual(
+    verifyUpdaterMetadata({ metadataPath: metadata, artifactRoot: root, contract: "linux" }).errors,
+    [],
+  );
+});
+
+test("metadata verification reports missing artifacts and tampered hashes", (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const x64 = writeArtifact(root, "Clawd-on-Desk-Setup-0.14.0-x64.exe", "x64");
+  const arm64 = { name: "Clawd-on-Desk-Setup-0.14.0-arm64.exe", size: 10, sha512: "wrong" };
+  const metadata = path.join(root, "latest.yml");
+  fs.writeFileSync(metadata, yamlFor([x64, arm64], x64.name));
+  const report = verifyUpdaterMetadata({ metadataPath: metadata, artifactRoot: root, contract: "windows" });
+  assert.equal(report.errors.some((error) => /does not exist/.test(error)), true);
+});
+
+test("updater CLI parser requires metadata, artifact root, and contract", () => {
+  assert.throws(() => parseArgs([]), /--metadata is required/);
+  assert.throws(() => parseArgs(["--metadata", "latest.yml"]), /--artifact-root is required/);
+  assert.throws(
+    () => parseArgs(["--metadata", "latest.yml", "--artifact-root", "dist"]),
+    /--contract is required/,
+  );
+});

--- a/test/win-foreground-terminal.test.js
+++ b/test/win-foreground-terminal.test.js
@@ -232,7 +232,17 @@ describe("createForegroundWindowsTerminalProbe — expected misses (no onError)"
   });
 
   it("a call-time throw anywhere in the chain degrades to null, not onError", () => {
-    assertExpectedMiss({ classNameThrows: true });
+    let initErrors = 0;
+    let callErrors = 0;
+    const probe = createForegroundWindowsTerminalProbe({
+      isWin: true,
+      koffi: fakeKoffi({ classNameThrows: true }),
+      onError: () => { initErrors++; },
+      onCallError: () => { callErrors++; },
+    });
+    assert.strictEqual(probe(), null);
+    assert.strictEqual(initErrors, 0);
+    assert.strictEqual(callErrors, 1);
   });
 
   it("still closes the handle when QueryFullProcessImageNameW throws (finally)", () => {

--- a/test/win-fullscreen-detect.test.js
+++ b/test/win-fullscreen-detect.test.js
@@ -23,6 +23,7 @@ function fakeKoffi(behavior) {
           }
           if (signature.includes("GetWindowRect")) {
             return (_hwnd, rectOut) => {
+              if (behavior.getWindowRectThrows) throw new Error("GetWindowRect exploded");
               if (behavior.winRect) Object.assign(rectOut, behavior.winRect);
               return behavior.getWindowRect !== false;
             };
@@ -151,6 +152,20 @@ describe("createForegroundFullscreenProbe", () => {
       koffi: fakeKoffi({ hwnd: {}, getWindowRect: false }),
     });
     assert.strictEqual(probe(), false);
+  });
+
+  it("reports thrown call-time failures through the opt-in diagnostic callback", () => {
+    let initErrors = 0;
+    let callErrors = 0;
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({ hwnd: {}, getWindowRectThrows: true }),
+      onError: () => { initErrors++; },
+      onCallError: () => { callErrors++; },
+    });
+    assert.strictEqual(probe(), false);
+    assert.strictEqual(initErrors, 0);
+    assert.strictEqual(callErrors, 1);
   });
 
   // #719: clicking the desktop makes the shell window (Progman, or a WorkerW


### PR DESCRIPTION
## Summary

- pin Koffi to the reviewed `2.16.3` release and prune foreign triplets plus all `.lib`/`.exp` files from staged apps in a guarded `afterPack` hook
- add one authoritative five-target map and a full PE/ELF/Mach-O physical inventory, plus ASAR logical-native inventory; the only standing foreign-binary exception is electron-builder's exact Windows ia32 `resources/elevate.exe`
- add an isolated full-Electron packaged smoke that proves the physical `koffi.node` load path, stable native call, `koffi.address()` behavior, and platform probes without starting normal Clawd services or touching real preferences
- gate the existing five-target PR matrix and release jobs with `npm ci`, native audit manifests, packaged smoke, and updater metadata size/SHA-512 verification
- document the release invariant and preserve the reviewed implementation plan

Closes #763.

Koffi 3 migration/provisioning remains separate in #823.

## Phase 0 and package evidence

- official Koffi 2.16.3 integrity is pinned in `package-lock.json`; its offline install script selected the bundled prebuild without source compilation or network fallback
- measured Koffi `build/koffi` before pruning: 18 native addons plus Windows link artifacts, **26,541,184 bytes**
- Windows x64 retained `win32_x64/koffi.node` (**1,612,288 bytes**) and removed **24,928,896 bytes**
- Windows ARM64 retained `win32_arm64/koffi.node` (**1,442,816 bytes**) and removed **25,098,368 bytes**
- both extracted Windows apps passed the updated full native inventory: 10 target binaries, one exact `elevate.exe` policy exception, 18 known Koffi ASAR logical candidates, 17 reviewed stale foreign-triplet entries, zero errors
- the single-invocation x64+ARM64 build produced `latest.yml` with both installers and matching size/SHA-512 metadata
- x64 packaged smoke loaded the physical pruned addon, matched `GetCurrentProcessId()` to the Electron PID, returned BigInt from `koffi.address(Buffer)`, and got a positive `IVirtualDesktopManager` result for its real test window

## Validation

- isolated clean-worktree `npm test`: 6,998 passed, 0 failed, 31 environment skips (7,029 total), including the final review and Linux sandbox hardening
- final focused afterPack/native-audit tests: 18 passed, including macOS bundle layout, ASAR orphan native candidates, unknown Koffi triplets, zero/duplicate/wrong-triplet payloads, and junction guards
- final Windows terminal/fullscreen diagnostic tests: 42 passed
- focused target/config/updater test runs: passed
- workflow YAML parse and `git diff --check`: passed
- `npm run build:win:all -- --publish never`: passed for x64 and ARM64 in one electron-builder invocation
- updated native audit: passed for `windows-x64` and `windows-arm64`
- Windows updater metadata verification: passed
- sandbox-external current-HEAD `windows-x64` rebuild, native audit, and packaged Koffi/COM smoke: passed
- Windows x64 real-machine positive probes: real Windows Terminal foreground returned base-10 HWND `788134`; after foregrounding an owned distractor window, the same production `focusTerminalWindow` path used by the HUD returned `target=788134`, `foreground=788134`, `reason=wt-hwnd-from-hook`, and a direct User32 read confirmed the OS foreground remained `788134`; an owned full-monitor test window returned `foregroundFullscreen=true`; cloak inspection returned `available=true` and `true` for a real packaged BrowserWindow; cleanup removed the exact isolated profile
- PR #824 rerun after Linux `chrome-sandbox` ownership/mode repair: unit, all five native package rows, repository audit, and all Wayland/XWayland checks passed

The main checkout still has a pre-existing development Electron instance actively loading its `node_modules/electron` tree, so it was left untouched. A new isolated worktree completed clean `npm ci`, the full test suite, current-HEAD x64 packaging, native audit, and packaged smoke; no user Electron or Windows Terminal process was terminated.

## Real-machine evidence boundary

Windows x64 real-machine validation is complete. In addition to the packaged FFI probes, a manual visual check confirmed that clicking the Session HUD row brings the correct Windows Terminal window to the foreground, the pet yields while a fullscreen window is active on the tested display, and the pet returns normally after leaving fullscreen without a restart. Rendering and animation remained stable throughout the smoke test.

Interactive Windows ARM64 and macOS x64/ARM64 focus/fullscreen/cloak/Space/de-delegation smoke still require matching hardware. The PR matrix has passed native Windows ARM64, Intel macOS, and Apple Silicon packaged load/call evidence, but this is intentionally not relabeled as interactive real-machine evidence.

## Review

An independent final review found two blockers (silent Windows probe degradation and an over-broad stale-ASAR Koffi exemption). Both were fixed with diagnostic callbacks and the exact shared Koffi 2.16.3 triplet allowlist; the reviewer rechecked the closures and returned **BLOCKER CLOSED — can open PR**.


