### PR TITLE
fix(macOS): pin pet against physical display bounds

### DIFF
--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -1574,7 +1574,7 @@ function createPetWindowRuntime(options = {}) {
       && hasCompletePhysicalDisplayTopology(displays, physicalPrimaryBounds);
     const margins = getVisibleContentMargins({ x, y, width: w, height: h });
     const bottomInset = usePhysicalBounds
-      ? null
+      ? 0
       : getNearestDisplayBottomInset(x + w / 2, y + h / 2);
     return computeLooseClamp(
       usePhysicalBounds ? projectDisplaysToPhysicalBounds(displays) : displays,
@@ -1632,7 +1632,7 @@ function createPetWindowRuntime(options = {}) {
       : null;
     const clampArea = physicalBounds || nearestWorkArea;
     const bottomInset = physicalBounds
-      ? null
+      ? 0
       : getNearestDisplayBottomInset(insetProbeX, insetProbeY);
     const mLeft = Math.round(w * 0.25);
     const mRight = Math.round(w * 0.25);

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -376,20 +376,82 @@ function createPetWindowRuntime(options = {}) {
       : null;
   }
 
-  function getNearestDisplayBottomInset(cx, cy) {
+  function getDisplayNearestPoint(cx, cy) {
     const point = { x: Math.round(cx), y: Math.round(cy) };
-    let display = null;
     try {
       if (typeof screen.getDisplayNearestPoint === "function") {
-        display = screen.getDisplayNearestPoint(point);
+        return screen.getDisplayNearestPoint(point) || null;
       }
     } catch {}
-    if (!display || !display.bounds || !display.workArea) {
-      try {
-        if (typeof screen.getPrimaryDisplay === "function") display = screen.getPrimaryDisplay();
-      } catch {}
+    return null;
+  }
+
+  function getPrimaryDisplaySafe() {
+    try {
+      return typeof screen.getPrimaryDisplay === "function"
+        ? (screen.getPrimaryDisplay() || null)
+        : null;
+    } catch {
+      return null;
     }
+  }
+
+  function getDisplayForInsets(cx, cy) {
+    let display = getDisplayNearestPoint(cx, cy);
+    if (!display || !display.bounds || !display.workArea) {
+      display = getPrimaryDisplaySafe();
+    }
+    return display;
+  }
+
+  function getNearestDisplayBottomInset(cx, cy) {
+    const display = getDisplayForInsets(cx, cy);
     return getDisplayInsets(display).bottom;
+  }
+
+  function getNearestDisplayPhysicalBounds(cx, cy) {
+    // Do not fall back to primary here: callers may be mapping a forced
+    // secondary work area (mini exit). A failed lookup must preserve that
+    // work area, never jump the pet to another display.
+    const display = getDisplayNearestPoint(cx, cy);
+    return display && isValidWorkArea(display.bounds) ? display.bounds : null;
+  }
+
+  function getPrimaryDisplayPhysicalBounds() {
+    const display = getPrimaryDisplaySafe();
+    return display && isValidWorkArea(display.bounds) ? display.bounds : null;
+  }
+
+  function projectDisplaysToPhysicalBounds(displays) {
+    if (!Array.isArray(displays)) return displays;
+    return displays.map((display) => {
+      if (!display || !isValidWorkArea(display.bounds)) return display;
+      return { ...display, workArea: display.bounds };
+    });
+  }
+
+  function hasCompletePhysicalDisplayTopology(displays, primaryBounds) {
+    if (!Array.isArray(displays) || displays.length === 0) return !!primaryBounds;
+    return displays.every((display) => display && isValidWorkArea(display.bounds));
+  }
+
+  function getClampDisplaysSafe() {
+    let rawDisplays;
+    try {
+      rawDisplays = getAllDisplays();
+    } catch {
+      return { displays: [], physicalTopologyComplete: false };
+    }
+    if (!Array.isArray(rawDisplays)) {
+      return { displays: [], physicalTopologyComplete: false };
+    }
+    const displays = rawDisplays.filter(
+      (display) => display && isValidWorkArea(display.workArea)
+    );
+    return {
+      displays,
+      physicalTopologyComplete: displays.length === rawDisplays.length,
+    };
   }
 
   function setViewportOffsetY(offsetY) {
@@ -640,9 +702,28 @@ function createPetWindowRuntime(options = {}) {
   // resolveStartupPlacement() call this exact function so a Linux outer-edge
   // window can never be constructed off-screen and then reconciled — the
   // startup bounds are already correct on the first native write.
+  function resolveMaterializationWorkArea(bounds, workArea, opts = {}) {
+    const requestedWorkArea = isValidWorkArea(workArea)
+      ? workArea
+      : resolveWorkAreaFor(bounds);
+    const allowEdgePinning = "allowEdgePinning" in opts
+      ? !!opts.allowEdgePinning
+      : getAllowEdgePinning();
+    if (!isMac || !allowEdgePinning || getMiniMode()) return requestedWorkArea;
+
+    const probeArea = isValidWorkArea(workArea) ? workArea : null;
+    const probeX = probeArea
+      ? probeArea.x + probeArea.width / 2
+      : bounds.x + bounds.width / 2;
+    const probeY = probeArea
+      ? probeArea.y + probeArea.height / 2
+      : bounds.y + bounds.height / 2;
+    return getNearestDisplayPhysicalBounds(probeX, probeY) || requestedWorkArea;
+  }
+
   function materializeVirtualBounds(bounds, workArea, opts = {}) {
     if (!bounds) return null;
-    const resolvedWorkArea = isValidWorkArea(workArea) ? workArea : resolveWorkAreaFor(bounds);
+    const resolvedWorkArea = resolveMaterializationWorkArea(bounds, workArea, opts);
     const clampBounds = resolveHorizontalClampBounds(bounds, resolvedWorkArea, opts.edgeContext);
     const raw = materializeVirtualBoundsRaw(bounds, resolvedWorkArea, clampBounds);
     if (!raw) return null;
@@ -1149,6 +1230,9 @@ function createPetWindowRuntime(options = {}) {
   //    and topmost's nudge — see recoverVisiblePetAfterRendererLoad below).
   //  - workArea / edgeContext: let a caller that already resolved these
   //    (e.g. a future per-frame mini animation) skip re-resolving them here.
+  //    In normal macOS mode with edge pinning enabled, workArea is only a
+  //    display hint: Y materialization uses that display's physical bounds.
+  //    Mini mode remains explicitly work-area-contained.
   //  - assertNoYOffset: mini's future per-frame X-only entry point. When the
   //    materialize result still has a non-zero Y offset (it shouldn't, if the
   //    caller clamped Y first), refuse to forward it to the renderer and log
@@ -1157,8 +1241,7 @@ function createPetWindowRuntime(options = {}) {
     const win = getRenderWindow();
     if (!isLiveWindow(win) || !next) return null;
 
-    const wa = isValidWorkArea(opts.workArea) ? opts.workArea : resolveWorkAreaFor(next);
-    const m = materializeVirtualBounds(next, wa, { edgeContext: opts.edgeContext });
+    const m = materializeVirtualBounds(next, opts.workArea, opts);
     if (!m) return null;
 
     // Key ordering (this batch's inviolable contract): the storage
@@ -1174,7 +1257,7 @@ function createPetWindowRuntime(options = {}) {
     // says by the time it gets around to checking.
     expectedWrite = {
       physical: { ...m.bounds },
-      workArea: wa,
+      workArea: m.workArea,
       gen: writeGen,
       clampBounds: m.clampBounds,
       displayId: m.clampBounds.displayId,
@@ -1478,11 +1561,26 @@ function createPetWindowRuntime(options = {}) {
   }
 
   function looseClampPetToDisplays(x, y, w, h) {
+    const allowEdgePinning = getAllowEdgePinning();
+    const { displays, physicalTopologyComplete } = getClampDisplaysSafe();
+    // #241: macOS workArea excludes the Dock/menu bar. Edge pinning is visual,
+    // so its clamp topology must follow the physical display rectangle instead.
+    const physicalPrimaryBounds = isMac && allowEdgePinning
+      ? getPrimaryDisplayPhysicalBounds()
+      : null;
+    const usePhysicalBounds = isMac
+      && allowEdgePinning
+      && physicalTopologyComplete
+      && hasCompletePhysicalDisplayTopology(displays, physicalPrimaryBounds);
     const margins = getVisibleContentMargins({ x, y, width: w, height: h });
-    const bottomInset = getNearestDisplayBottomInset(x + w / 2, y + h / 2);
+    const bottomInset = usePhysicalBounds
+      ? null
+      : getNearestDisplayBottomInset(x + w / 2, y + h / 2);
     return computeLooseClamp(
-      getAllDisplays(),
-      getPrimaryWorkAreaSafe(),
+      usePhysicalBounds ? projectDisplaysToPhysicalBounds(displays) : displays,
+      usePhysicalBounds
+        ? (physicalPrimaryBounds || getPrimaryWorkAreaSafe())
+        : getPrimaryWorkAreaSafe(),
       x,
       y,
       w,
@@ -1491,7 +1589,7 @@ function createPetWindowRuntime(options = {}) {
         width: w,
         height: h,
         visibleMargins: margins,
-        allowEdgePinning: getAllowEdgePinning(),
+        allowEdgePinning,
         bottomInset,
       })
     );
@@ -1517,25 +1615,41 @@ function createPetWindowRuntime(options = {}) {
     const forcedWorkArea = isValidWorkArea(optionsArg.workArea)
       ? optionsArg.workArea
       : null;
-    const nearest = forcedWorkArea || getNearestWorkArea(x + w / 2, y + h / 2);
-    const insetProbeX = forcedWorkArea ? nearest.x + nearest.width / 2 : x + w / 2;
-    const insetProbeY = forcedWorkArea ? nearest.y + nearest.height / 2 : y + h / 2;
-    const bottomInset = getNearestDisplayBottomInset(insetProbeX, insetProbeY);
+    const nearestWorkArea = forcedWorkArea || getNearestWorkArea(x + w / 2, y + h / 2);
+    const insetProbeX = forcedWorkArea
+      ? nearestWorkArea.x + nearestWorkArea.width / 2
+      : x + w / 2;
+    const insetProbeY = forcedWorkArea
+      ? nearestWorkArea.y + nearestWorkArea.height / 2
+      : y + h / 2;
+    const allowEdgePinning = "allowEdgePinning" in optionsArg
+      ? !!optionsArg.allowEdgePinning
+      : getAllowEdgePinning();
+    // A forced work area (for example, mini-mode exit) still identifies the
+    // display; when pinning is enabled, clamp against that display's bounds.
+    const physicalBounds = isMac && allowEdgePinning
+      ? getNearestDisplayPhysicalBounds(insetProbeX, insetProbeY)
+      : null;
+    const clampArea = physicalBounds || nearestWorkArea;
+    const bottomInset = physicalBounds
+      ? null
+      : getNearestDisplayBottomInset(insetProbeX, insetProbeY);
     const mLeft = Math.round(w * 0.25);
     const mRight = Math.round(w * 0.25);
     const clampMargins = getRestClampMargins({
       height: h,
       visibleMargins: margins,
-      allowEdgePinning: "allowEdgePinning" in optionsArg
-        ? optionsArg.allowEdgePinning
-        : getAllowEdgePinning(),
+      allowEdgePinning,
       bottomInset,
     });
     return {
-      x: Math.max(nearest.x - mLeft, Math.min(x, nearest.x + nearest.width - w + mRight)),
+      x: Math.max(
+        clampArea.x - mLeft,
+        Math.min(x, clampArea.x + clampArea.width - w + mRight)
+      ),
       y: Math.max(
-        nearest.y - clampMargins.top,
-        Math.min(y, nearest.y + nearest.height - h + clampMargins.bottom)
+        clampArea.y - clampMargins.top,
+        Math.min(y, clampArea.y + clampArea.height - h + clampMargins.bottom)
       ),
     };
   }

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -114,14 +114,26 @@ function createRuntime(overrides = {}) {
   }];
   const runtime = createPetWindowRuntime({
     screen: {
-      getAllDisplays: () => displays,
+      getAllDisplays: () => (
+        typeof overrides.getAllDisplays === "function"
+          ? overrides.getAllDisplays()
+          : displays
+      ),
       getCursorScreenPoint: () => (
         typeof overrides.cursor === "function"
           ? overrides.cursor()
           : (overrides.cursor || { x: 100, y: 100 })
       ),
-      getDisplayNearestPoint: () => displays[0],
-      getPrimaryDisplay: () => displays[0],
+      getDisplayNearestPoint: (point) => (
+        typeof overrides.getDisplayNearestPoint === "function"
+          ? overrides.getDisplayNearestPoint(point)
+          : displays[0]
+      ),
+      getPrimaryDisplay: () => (
+        typeof overrides.getPrimaryDisplay === "function"
+          ? overrides.getPrimaryDisplay()
+          : displays[0]
+      ),
     },
     isWin: overrides.isWin ?? true,
     isMac: overrides.isMac ?? false,
@@ -142,8 +154,16 @@ function createRuntime(overrides = {}) {
     getCurrentPixelSize: () => overrides.currentPixelSize || { width: 100, height: 100 },
     getEffectiveCurrentPixelSize: () => overrides.effectivePixelSize || { width: 100, height: 100 },
     getAllowEdgePinning: () => overrides.allowEdgePinning || false,
-    getPrimaryWorkAreaSafe: () => displays[0].workArea,
-    getNearestWorkArea: () => displays[0].workArea,
+    getPrimaryWorkAreaSafe: () => (
+      typeof overrides.getPrimaryWorkAreaSafe === "function"
+        ? overrides.getPrimaryWorkAreaSafe()
+        : displays[0].workArea
+    ),
+    getNearestWorkArea: (x, y) => (
+      typeof overrides.getNearestWorkArea === "function"
+        ? overrides.getNearestWorkArea(x, y)
+        : displays[0].workArea
+    ),
     sendToRenderer: (...args) => calls.push(["sendToRenderer", ...args]),
     keepOutOfTaskbar: (win) => calls.push(["keepOutOfTaskbar", win]),
     repositionSessionHud: () => calls.push(["repositionSessionHud"]),
@@ -193,6 +213,374 @@ function createRuntime(overrides = {}) {
     setHitWin: (win) => { hitWin = win; },
   };
 }
+
+describe("macOS physical edge pinning (#241)", () => {
+  const dockDisplay = {
+    id: 1,
+    bounds: { x: 0, y: 0, width: 1710, height: 1107 },
+    workArea: { x: 0, y: 34, width: 1710, height: 983 },
+  };
+
+  it("uses physical bounds for both drag and rest clamps when edge pinning is enabled", () => {
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [dockDisplay],
+    });
+
+    const rest = runtime.clampToScreenVisual(200, 10_000, 205, 205);
+    const drag = runtime.looseClampPetToDisplays(200, 10_000, 205, 205);
+
+    // Physical bottom 1107, window 205, 25% edge overflow 51.
+    assert.equal(rest.y, 953);
+    assert.equal(drag.y, 953);
+    assert.equal(rest.y + 205, 1158);
+  });
+
+  it("keeps the work-area-safe rest clamp when macOS edge pinning is disabled", () => {
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: false,
+      displays: [dockDisplay],
+    });
+
+    const rest = runtime.clampToScreenVisual(200, 10_000, 205, 205);
+    assert.equal(rest.y, 812, "workArea bottom 1017 minus the 205px window");
+  });
+
+  it("keeps the full bottom edge overflow when the Dock is hidden", () => {
+    const display = {
+      id: 1,
+      bounds: { x: 0, y: 0, width: 1000, height: 800 },
+      workArea: { x: 0, y: 0, width: 1000, height: 800 },
+    };
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [display],
+    });
+
+    assert.equal(runtime.clampToScreenVisual(0, 10_000, 200, 200).y, 650);
+    assert.equal(runtime.looseClampPetToDisplays(0, 10_000, 200, 200).y, 650);
+  });
+
+  it("honors a call-site edge-pinning override instead of the global macOS setting", () => {
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [dockDisplay],
+    });
+
+    const rest = runtime.clampToScreenVisual(200, 10_000, 205, 205, {
+      allowEdgePinning: false,
+    });
+    assert.equal(rest.y, 812);
+  });
+
+  it("uses the physical rectangle consistently for top, bottom, left, and right edges", () => {
+    const display = {
+      id: 1,
+      bounds: { x: 100, y: 50, width: 1000, height: 800 },
+      workArea: { x: 160, y: 90, width: 900, height: 700 },
+    };
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [display],
+    });
+
+    assert.deepStrictEqual(
+      runtime.clampToScreenVisual(-10_000, -10_000, 200, 200),
+      { x: 50, y: -70 },
+    );
+    assert.deepStrictEqual(
+      runtime.clampToScreenVisual(10_000, 10_000, 200, 200),
+      { x: 950, y: 700 },
+    );
+  });
+
+  it("materializes a normal-mode top pin at the physical display top", () => {
+    const display = {
+      id: 1,
+      bounds: { x: 100, y: 50, width: 1000, height: 800 },
+      workArea: { x: 160, y: 90, width: 900, height: 700 },
+    };
+    const fixture = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [display],
+    });
+    const logical = fixture.runtime.clampToScreenVisual(200, -10_000, 200, 200);
+
+    const physical = fixture.runtime.applyPetWindowBounds({
+      ...logical,
+      width: 200,
+      height: 200,
+    });
+
+    assert.deepStrictEqual(logical, { x: 200, y: -70 });
+    assert.deepStrictEqual(physical, { x: 200, y: 50, width: 200, height: 200 });
+    assert.equal(fixture.renderWin.getBounds().y, 50);
+    assert.equal(fixture.runtime.getViewportOffsetY(), 120);
+  });
+
+  it("materializes a saved normal-mode top pin against physical bounds at startup", () => {
+    const display = {
+      id: 1,
+      bounds: { x: 100, y: 50, width: 1000, height: 800 },
+      workArea: { x: 160, y: 90, width: 900, height: 700 },
+    };
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [display],
+    });
+
+    const placement = runtime.resolveStartupPlacement({
+      positionSaved: true,
+      miniMode: false,
+      x: 200,
+      y: -70,
+      positionDisplay: display,
+    }, { width: 200, height: 200 });
+
+    assert.equal(placement.initialVirtualBounds.y, -70);
+    assert.equal(placement.initialWindowBounds.y, 50);
+  });
+
+  it("keeps mini-mode Y materialization inside the work area", () => {
+    const display = {
+      id: 1,
+      bounds: { x: 100, y: 50, width: 1000, height: 800 },
+      workArea: { x: 160, y: 90, width: 900, height: 700 },
+    };
+    const fixture = createRuntime({
+      isWin: false,
+      isMac: true,
+      miniMode: true,
+      allowEdgePinning: true,
+      displays: [display],
+    });
+
+    const physical = fixture.runtime.applyPetWindowBounds(
+      { x: 200, y: -70, width: 200, height: 200 },
+      { workArea: display.workArea },
+    );
+
+    assert.deepStrictEqual(physical, { x: 200, y: 90, width: 200, height: 200 });
+    assert.equal(fixture.runtime.getViewportOffsetY(), 160);
+  });
+
+  it("maps a forced mini work area back to the same display's physical bounds", () => {
+    const displays = [
+      {
+        id: 1,
+        bounds: { x: 0, y: 0, width: 1000, height: 900 },
+        workArea: { x: 0, y: 30, width: 1000, height: 820 },
+      },
+      {
+        id: 2,
+        bounds: { x: 1000, y: 0, width: 1200, height: 900 },
+        workArea: { x: 1060, y: 30, width: 1140, height: 800 },
+      },
+    ];
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays,
+      getDisplayNearestPoint: ({ x }) => (x >= 1000 ? displays[1] : displays[0]),
+    });
+
+    assert.deepStrictEqual(
+      runtime.clampToScreenVisual(10_000, 10_000, 200, 200, {
+        workArea: displays[1].workArea,
+      }),
+      { x: 2050, y: 750 },
+    );
+  });
+
+  it("does not jump a forced secondary work area to primary when nearest lookup fails", () => {
+    const displays = [
+      {
+        id: 1,
+        bounds: { x: 0, y: 0, width: 1000, height: 800 },
+        workArea: { x: 0, y: 30, width: 1000, height: 700 },
+      },
+      {
+        id: 2,
+        bounds: { x: 1000, y: 0, width: 1000, height: 800 },
+        workArea: { x: 1100, y: 30, width: 800, height: 700 },
+      },
+    ];
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays,
+      getDisplayNearestPoint: () => { throw new Error("nearest unavailable"); },
+      getPrimaryDisplay: () => displays[0],
+    });
+
+    const rest = runtime.clampToScreenVisual(10_000, 300, 200, 200, {
+      workArea: displays[1].workArea,
+    });
+    assert.equal(rest.x, 1750, "fallback stays within the forced secondary work area");
+  });
+
+  it("uses a forced work area as the display hint during vertical multi-display materialization", () => {
+    const displays = [
+      {
+        id: 1,
+        bounds: { x: 0, y: 0, width: 1000, height: 800 },
+        workArea: { x: 0, y: 30, width: 1000, height: 740 },
+      },
+      {
+        id: 2,
+        bounds: { x: 0, y: 800, width: 1000, height: 800 },
+        workArea: { x: 0, y: 830, width: 1000, height: 700 },
+      },
+    ];
+    const fixture = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays,
+      getDisplayNearestPoint: ({ y }) => (y >= 800 ? displays[1] : displays[0]),
+      getNearestWorkArea: (_x, y) => (y >= 800 ? displays[1] : displays[0]).workArea,
+    });
+
+    const logical = fixture.runtime.clampToScreenVisual(200, -10_000, 200, 200, {
+      workArea: displays[1].workArea,
+    });
+    const physical = fixture.runtime.applyPetWindowBounds(
+      { ...logical, width: 200, height: 200 },
+      { workArea: displays[1].workArea },
+    );
+
+    assert.deepStrictEqual(logical, { x: 200, y: 680 });
+    assert.deepStrictEqual(physical, { x: 200, y: 800, width: 200, height: 200 });
+    assert.equal(fixture.runtime.getViewportOffsetY(), 120);
+  });
+
+  it("does not change Windows work-area edge behavior", () => {
+    const { runtime } = createRuntime({
+      isWin: true,
+      isMac: false,
+      allowEdgePinning: true,
+      displays: [dockDisplay],
+    });
+
+    const rest = runtime.clampToScreenVisual(200, 10_000, 205, 205);
+    const drag = runtime.looseClampPetToDisplays(200, 10_000, 205, 205);
+    assert.equal(rest.y, 863, "workArea bottom plus the capped 51px inset allowance");
+    assert.equal(drag.y, 863, "drag must not leak macOS physical bounds onto Windows");
+  });
+
+  it("does not change Linux work-area edge behavior", () => {
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: false,
+      isLinux: true,
+      allowEdgePinning: true,
+      displays: [dockDisplay],
+    });
+
+    const rest = runtime.clampToScreenVisual(200, 10_000, 205, 205);
+    const drag = runtime.looseClampPetToDisplays(200, 10_000, 205, 205);
+    assert.equal(rest.y, 863, "workArea bottom plus the capped 51px inset allowance");
+    assert.equal(drag.y, 863, "drag must not leak macOS physical bounds onto Linux");
+  });
+
+  it("falls back to the existing work-area clamp when physical bounds are unavailable", () => {
+    const display = {
+      id: 1,
+      bounds: null,
+      workArea: { x: 0, y: 0, width: 800, height: 600 },
+    };
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [display],
+    });
+
+    assert.equal(runtime.clampToScreenVisual(0, 10_000, 200, 200).y, 400);
+    assert.equal(runtime.looseClampPetToDisplays(0, 10_000, 200, 200).y, 400);
+  });
+
+  it("falls back safely when Electron display lookup throws", () => {
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [dockDisplay],
+      getDisplayNearestPoint: () => { throw new Error("screen unavailable"); },
+      getPrimaryDisplay: () => { throw new Error("primary unavailable"); },
+    });
+
+    const rest = runtime.clampToScreenVisual(200, 10_000, 205, 205);
+    assert.deepStrictEqual(rest, { x: 200, y: 812 });
+  });
+
+  it("keeps drag clamping finite when display enumeration throws", () => {
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      getAllDisplays: () => { throw new Error("topology unavailable"); },
+    });
+
+    assert.deepStrictEqual(
+      runtime.looseClampPetToDisplays(10_000, 10_000, 200, 200),
+      { x: 850, y: 600 },
+    );
+  });
+
+  it("filters malformed display entries before the drag fallback", () => {
+    const workArea = { x: 0, y: 0, width: 800, height: 600 };
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [null],
+      getPrimaryDisplay: () => null,
+      getPrimaryWorkAreaSafe: () => workArea,
+      getNearestWorkArea: () => workArea,
+    });
+
+    assert.deepStrictEqual(
+      runtime.looseClampPetToDisplays(10_000, 10_000, 200, 200),
+      { x: 650, y: 400 },
+    );
+  });
+
+  it("uses primary physical bounds when the display list is temporarily empty", () => {
+    const primary = {
+      id: 1,
+      bounds: { x: 0, y: 0, width: 1000, height: 800 },
+      workArea: { x: 0, y: 30, width: 1000, height: 700 },
+    };
+    const { runtime } = createRuntime({
+      isWin: false,
+      isMac: true,
+      allowEdgePinning: true,
+      displays: [],
+      getPrimaryDisplay: () => primary,
+      getPrimaryWorkAreaSafe: () => primary.workArea,
+      getNearestWorkArea: () => primary.workArea,
+    });
+
+    assert.equal(runtime.looseClampPetToDisplays(0, 10_000, 200, 200).y, 650);
+  });
+});
 
 // ── #690 Phase 0 fixture — Fedora 44 / GNOME Shell 50.3 / Mutter reproduction ──
 // docs/plans/plan-issue-690-gnome-mini-edge-snap.md §1.2 and §5 Phase 0.

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -232,10 +232,10 @@ describe("macOS physical edge pinning (#241)", () => {
     const rest = runtime.clampToScreenVisual(200, 10_000, 205, 205);
     const drag = runtime.looseClampPetToDisplays(200, 10_000, 205, 205);
 
-    // Physical bottom 1107, window 205, 25% edge overflow 51.
-    assert.equal(rest.y, 953);
-    assert.equal(drag.y, 953);
-    assert.equal(rest.y + 205, 1158);
+    // Cross the 90px Dock inset, but keep the window on the physical display.
+    assert.equal(rest.y, 902);
+    assert.equal(drag.y, 902);
+    assert.equal(rest.y + 205, 1107);
   });
 
   it("keeps the work-area-safe rest clamp when macOS edge pinning is disabled", () => {
@@ -250,7 +250,7 @@ describe("macOS physical edge pinning (#241)", () => {
     assert.equal(rest.y, 812, "workArea bottom 1017 minus the 205px window");
   });
 
-  it("keeps the full bottom edge overflow when the Dock is hidden", () => {
+  it("aligns with the physical bottom when the Dock is hidden", () => {
     const display = {
       id: 1,
       bounds: { x: 0, y: 0, width: 1000, height: 800 },
@@ -263,8 +263,8 @@ describe("macOS physical edge pinning (#241)", () => {
       displays: [display],
     });
 
-    assert.equal(runtime.clampToScreenVisual(0, 10_000, 200, 200).y, 650);
-    assert.equal(runtime.looseClampPetToDisplays(0, 10_000, 200, 200).y, 650);
+    assert.equal(runtime.clampToScreenVisual(0, 10_000, 200, 200).y, 600);
+    assert.equal(runtime.looseClampPetToDisplays(0, 10_000, 200, 200).y, 600);
   });
 
   it("honors a call-site edge-pinning override instead of the global macOS setting", () => {
@@ -300,7 +300,7 @@ describe("macOS physical edge pinning (#241)", () => {
     );
     assert.deepStrictEqual(
       runtime.clampToScreenVisual(10_000, 10_000, 200, 200),
-      { x: 950, y: 700 },
+      { x: 950, y: 650 },
     );
   });
 
@@ -403,7 +403,7 @@ describe("macOS physical edge pinning (#241)", () => {
       runtime.clampToScreenVisual(10_000, 10_000, 200, 200, {
         workArea: displays[1].workArea,
       }),
-      { x: 2050, y: 750 },
+      { x: 2050, y: 700 },
     );
   });
 
@@ -578,7 +578,7 @@ describe("macOS physical edge pinning (#241)", () => {
       getNearestWorkArea: () => primary.workArea,
     });
 
-    assert.equal(runtime.looseClampPetToDisplays(0, 10_000, 200, 200).y, 650);
+    assert.equal(runtime.looseClampPetToDisplays(0, 10_000, 200, 200).y, 600);
   });
 });
 


### PR DESCRIPTION
## Summary

- use physical display bounds for normal-mode edge pinning on macOS
- let bottom pinning cross the Dock while keeping the pet window on the physical screen
- keep edge-pinning-off behavior and mini mode constrained to the work area
- preserve the selected display through mini exit and display lookup failures
- make drag clamping degrade safely when Electron returns an incomplete display topology

This reimplements the previously promised fix for #241 against the current window runtime. The historical commit references in the issue are no longer resolvable.

## Validation

- focused window/mini/edge suite: 224 passed, 0 failed
- real Mac bottom-edge mouse drag with the Dock visible:
  - display bounds: 1710x1107; work area: y=34, height=983; pet window: 205x205
  - drag/rest stop at y=902, so the window bottom is exactly 1107
  - the pet crosses the 90px Dock inset without extending past the physical display
  - visual result confirmed on-device after tightening the initial 51px overflow
- current Mac hidden BrowserWindow top probe:
  - logical y = -123, physical/native y = 0, viewport offset = 123
- full npm test: 7003 passed, 4 failed, 22 skipped
  - the 4 failures reproduce on the unchanged base and are confined to after-pack-koffi path canonicalization on macOS (`/var` vs `/private/var`)
- independent Codex review: no P0-P3 findings after the bottom-edge tightening
- independent Claude review: no blocking production findings; requested drag and forced-work-area mutation guards are included

## Remaining manual validation

- real transparent render-window + hit-window dragging at the top and side edges
- a real multi-display/negative-coordinate setup, including mini exit and display topology changes

Fixes #241
