### PR TITLE
docs: fix AGENTS references and credit contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,9 +69,7 @@ Copilot CLI 同步走 `<COPILOT_HOME 或 ~/.copilot>/hooks/hooks.json`，marker-
 
 ## Read These Docs
 
-- `docs/project/project-introduction.md`：5 分钟了解项目定位、状态映射和目录结构
-- `docs/project/agent-runtime-architecture.md`：集成方式、数据流、多 agent、permission bubble、opencode、终端聚焦、自动同步
-- `docs/project/project-architecture.md`：更完整的模块边界和启动/运行时分层
+- `docs/project/agent-runtime-architecture.md`：运行时架构、模块边界、启动与数据流、多 agent、permission bubble、终端聚焦和自动同步
 - `docs/project/theme-state-ui.md`：状态机、主题系统、settings、mini mode、素材规则、平台限制、待落地 UI 决策
 - `docs/project/release-process.md`：发版 checklist、release note 核对、tag 触发 GitHub 打包和资产确认
 - `docs/guides/copilot-setup.md`：Copilot CLI 自动同步说明、`COPILOT_HOME` 兼容性、手动配置备选模板

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -345,6 +345,8 @@ Clawd をより良くしてくれたすべての方に感謝します。
   </tr>
   <tr>
     <td align="center" valign="top" width="110"><a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /><br /><sub>anthonyonazure</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /><br /><sub>weed33834</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /><br /><sub>arismarioneves</sub></a></td>
   </tr>
 </table>
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -341,6 +341,8 @@ Clawd를 더 좋게 만드는 데 도움을 준 모든 분들께 감사합니다
   </tr>
   <tr>
     <td align="center" valign="top" width="110"><a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /><br /><sub>anthonyonazure</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /><br /><sub>weed33834</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /><br /><sub>arismarioneves</sub></a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -351,6 +351,8 @@ Thanks to everyone who has helped make Clawd better:
   </tr>
   <tr>
     <td align="center" valign="top" width="110"><a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /><br /><sub>anthonyonazure</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /><br /><sub>weed33834</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /><br /><sub>arismarioneves</sub></a></td>
   </tr>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -319,6 +319,8 @@ Clawd on Desk 是一个社区驱动的项目。欢迎提 Bug、提需求、提 P
 <a href="https://github.com/YOOGOMJA"><img src="https://github.com/YOOGOMJA.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/anupamme"><img src="https://github.com/anupamme.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /></a>
+<a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /></a>
+<a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /></a>
 
 ## 致谢
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -321,6 +321,8 @@ Clawd on Desk 是社群驅動的專案。歡迎提 Bug、提需求、提 PR —�
 <a href="https://github.com/YOOGOMJA"><img src="https://github.com/YOOGOMJA.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/anupamme"><img src="https://github.com/anupamme.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /></a>
+<a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /></a>
+<a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /></a>
 
 ## 致謝
 

--- a/src/settings-i18n.js
+++ b/src/settings-i18n.js
@@ -5216,7 +5216,8 @@
     "zhaoxv210", "serenNan", "IatomicreactorI", "quantai1314", "Git-creat7", "undownding", "chrono-meta",
     "Yike-Ye", "xiaoshidefeng", "yanguibao1997", "JasonZH6600", "V1staz", "royhuang91", "Schlaflied", "KaiC5504",
     "jiaxuan1101", "kkirito16", "200780381", "Dxy2326", "lurui1997", "JesmonX", "chen86860",
-    "LinYsssss", "He-wei-gui", "liugou27", "YOOGOMJA", "anupamme", "anthonyonazure",
+    "LinYsssss", "He-wei-gui", "liugou27", "YOOGOMJA", "anupamme", "anthonyonazure", "weed33834",
+    "arismarioneves",
   ];
 
   root.ClawdSettingsI18n = {

--- a/test/readme-contributors.test.js
+++ b/test/readme-contributors.test.js
@@ -53,6 +53,8 @@ const VERIFIED_GITHUB_CONTRIBUTORS = [
   "YOOGOMJA",
   "anupamme",
   "anthonyonazure",
+  "weed33834",
+  "arismarioneves",
 ];
 
 function loadSettingsContributors() {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -54,6 +54,8 @@ const VERIFIED_GITHUB_CONTRIBUTORS = [
   "YOOGOMJA",
   "anupamme",
   "anthonyonazure",
+  "weed33834",
+  "arismarioneves",
 ];
 
 function createDeferred() {


### PR DESCRIPTION
## Summary
- remove two AGENTS.md references to project documents that have never existed
- expand the existing runtime architecture entry to cover module boundaries, startup, and data flow
- credit weed33834 and arismarioneves in all localized READMEs and the Settings About page
- extend contributor regression coverage for both GitHub accounts

## Validation
- verified all 15 docs/*.md paths referenced by AGENTS.md exist
- compared contributors since v0.14.0 across commits, merged PR authors, and co-author trailers
- confirmed GitHub contributor accounts are covered by the maintainer/contributor lists
- node --test test/readme-contributors.test.js
- node --test test/settings-renderer-browser-env.test.js
- git diff --check