### PR TITLE
fix(codex): fence terminal turns across event sources

### DIFF
--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -29,6 +29,7 @@ const {
   isFreshCodexQuotaTimestamp,
 } = require("../hooks/codex-rate-limits");
 const { parseCodexUserInputRecord } = require("../hooks/codex-user-input");
+const { normalizeCodexTurnId } = require("../src/codex-turn-id");
 
 const MAX_TRACKED_FILES = 50;
 const MAX_RETIRED_TRACKED_FILES = 100;
@@ -865,6 +866,8 @@ class CodexLogMonitor {
       assistantLastOutput: null,
       assistantLastOutputTruncated: false,
       contextUsage: null,
+      activeTurnId: null,
+      turnBoundaryOpen: false,
       codexQuota: null,
       codexSparkQuota: null,
       pendingUserInputs: recentlyActive ? new Map() : pending,
@@ -1220,6 +1223,8 @@ class CodexLogMonitor {
         assistantLastOutput: retired ? retired.assistantLastOutput || null : null,
         assistantLastOutputTruncated: retired ? retired.assistantLastOutputTruncated === true : false,
         contextUsage: retired ? retired.contextUsage || null : null,
+        activeTurnId: retired ? retired.activeTurnId || null : null,
+        turnBoundaryOpen: retired ? retired.turnBoundaryOpen === true : false,
         codexQuota: retired ? retired.codexQuota || null : null,
         codexSparkQuota: retired ? retired.codexSparkQuota || null : null,
         pendingUserInputs: retired && retired.pendingUserInputs instanceof Map
@@ -1532,6 +1537,8 @@ class CodexLogMonitor {
       tracked.assistantLastOutput = null;
       tracked.assistantLastOutputTruncated = false;
       tracked.contextUsage = null;
+      tracked.activeTurnId = null;
+      tracked.turnBoundaryOpen = false;
       tracked.codexQuota = null;
       tracked.codexSparkQuota = null;
     }
@@ -1590,6 +1597,28 @@ class CodexLogMonitor {
     // Build lookup key
     const key = subtype ? type + ":" + subtype : type;
 
+    // Turn identity is file-order bookkeeping, not a live callback. Apply it
+    // before both replay guards so an old task_started seeds the active ID and
+    // an old terminal clears it even though neither historical record is
+    // allowed to replay visible state.
+    const recordTurnId = normalizeCodexTurnId(
+      payload && typeof payload === "object" ? payload.turn_id : null
+    );
+    const isTurnStart = key === "event_msg:task_started";
+    const isTurnTerminal = key === "event_msg:task_complete" || key === "event_msg:turn_aborted";
+    let effectiveTurnId = recordTurnId || tracked.activeTurnId || null;
+    if (isTurnStart) {
+      tracked.activeTurnId = recordTurnId;
+      tracked.turnBoundaryOpen = true;
+      effectiveTurnId = recordTurnId;
+    }
+    const finishTurnTerminal = () => {
+      if (!isTurnTerminal) return;
+      tracked.activeTurnId = null;
+      tracked.turnBoundaryOpen = false;
+    };
+    const turnExtra = effectiveTurnId ? { turnId: effectiveTurnId } : null;
+
     // Metadata is needed for future live writes even when the session_meta
     // record itself predates monitor start.
     if (type === "session_meta") {
@@ -1612,7 +1641,10 @@ class CodexLogMonitor {
     // storms on app restart from driving stale state transitions.
     if (obj && typeof obj.timestamp === "string") {
       const ts = Date.parse(obj.timestamp);
-      if (!tracked.backfilling && Number.isFinite(ts) && ts < this._startedAtMs - 1500) return;
+      if (!tracked.backfilling && Number.isFinite(ts) && ts < this._startedAtMs - 1500) {
+        finishTurnTerminal();
+        return;
+      }
     }
 
     const assistantText = extractAssistantTextFromRecord(obj);
@@ -1675,8 +1707,14 @@ class CodexLogMonitor {
     // Look up state mapping
     const map = this._config.logEventMap;
     const state = map[key];
-    if (state === undefined) return; // unmapped event, skip
-    if (state === null) return; // explicitly ignored
+    if (state === undefined) {
+      finishTurnTerminal();
+      return; // unmapped event, skip
+    }
+    if (state === null) {
+      finishTurnTerminal();
+      return; // explicitly ignored
+    }
     tracked.lastStateEvent = key;
 
     // Track tool use per turn — reset on task_started, set on function_call
@@ -1700,8 +1738,15 @@ class CodexLogMonitor {
       // task_complete means the turn that asked is over — any question still
       // open for it is moot; Codex will not act on an answer after this.
       this._clearPendingUserInputsForTrackedSession(tracked);
-      if (tracked.backfilling) return;
-      this._emitStateChange(tracked, resolved, key, this._assistantOutputExtra(tracked));
+      if (tracked.backfilling) {
+        finishTurnTerminal();
+        return;
+      }
+      this._emitStateChange(tracked, resolved, key, {
+        ...(this._assistantOutputExtra(tracked) || {}),
+        ...(turnExtra || {}),
+      });
+      finishTurnTerminal();
       return;
     }
 
@@ -1718,13 +1763,15 @@ class CodexLogMonitor {
     // that carry a timestamp field.
     if (tracked.backfilling) {
       tracked.lastState = state;
+      finishTurnTerminal();
       return;
     }
 
     // Avoid spamming same state
     if (state === tracked.lastState && state === "working") return;
     tracked.lastState = state;
-    this._emitStateChange(tracked, state, key);
+    this._emitStateChange(tracked, state, key, turnExtra);
+    finishTurnTerminal();
   }
 
   _applySessionMeta(payload, tracked) {
@@ -1856,6 +1903,8 @@ class CodexLogMonitor {
       assistantLastOutput: tracked.assistantLastOutput || null,
       assistantLastOutputTruncated: tracked.assistantLastOutputTruncated === true,
       contextUsage: tracked.contextUsage || null,
+      activeTurnId: tracked.activeTurnId || null,
+      turnBoundaryOpen: tracked.turnBoundaryOpen === true,
       codexQuota: tracked.codexQuota || null,
       codexSparkQuota: tracked.codexSparkQuota || null,
       pendingUserInputs: tracked.pendingUserInputs instanceof Map
@@ -1905,7 +1954,12 @@ class CodexLogMonitor {
       tracked,
       snapshotState,
       tracked.lastStateEvent || "session_meta",
-      hasQuota ? quotaExtra : null
+      {
+        ...(hasQuota ? quotaExtra : {}),
+        syntheticBackfill: true,
+        turnBoundaryOpen: tracked.turnBoundaryOpen === true,
+        ...(tracked.activeTurnId ? { turnId: tracked.activeTurnId } : {}),
+      }
     );
   }
 

--- a/agents/codex-log-monitor.js
+++ b/agents/codex-log-monitor.js
@@ -1975,6 +1975,7 @@ class CodexLogMonitor {
       sessionTitle: tracked.sessionTitle,
       codexOriginator: tracked.codexOriginator || null,
       codexSource: tracked.codexSource || null,
+      ...(tracked.contextUsage ? { contextUsage: tracked.contextUsage } : {}),
       headless: false,
     });
   }

--- a/docs/investigations/issue-821-windows-validation.md
+++ b/docs/investigations/issue-821-windows-validation.md
@@ -1,0 +1,58 @@
+# Issue #821 Windows validation evidence
+
+Date: 2026-08-09
+
+Host: Microsoft Windows NT 10.0.26200.0, AMD64
+
+Producer: Codex CLI 0.147.0 (`originator=codex-tui`, `source=cli`)
+
+This record is intentionally privacy-safe. It retains only time, source,
+event type, a SHA-256 prefix for the canonical session, and a SHA-256 prefix
+for the normalized opaque turn ID. Prompt text, assistant output, tool input,
+commands, and raw rollout lines are excluded.
+
+This is a real cross-channel Codex CLI capture. It validates the Draft v4
+Part A identity preflight, but it is **not** a ChatGPT Desktop or reporter-side
+reproduction of Issue #821.
+
+## Cross-channel identity capture
+
+Canonical session digest: `2e27af1e370fe2d2`
+
+```text
+2026-08-08T23:04:13.998Z sid=2e27af1e370fe2d2 source=jsonl    event=event_msg:task_started  turn=d4fe677e03ae2427
+2026-08-08T23:04:14.336Z sid=2e27af1e370fe2d2 source=official event=UserPromptSubmit        turn=d4fe677e03ae2427
+2026-08-08T23:32:25.008Z sid=2e27af1e370fe2d2 source=official event=Stop                    turn=d4fe677e03ae2427
+2026-08-08T23:32:25.083Z sid=2e27af1e370fe2d2 source=jsonl    event=event_msg:task_complete turn=d4fe677e03ae2427
+```
+
+Result: the normalized official and JSONL IDs are present and equal at both
+the start and terminal boundaries. The Part A single-ID fence preflight passes
+for this current CLI producer.
+
+## Local verification matrix
+
+| Draft v4 case | Result | Evidence / limitation |
+|---|---|---|
+| Tool-using turn completes normally | Pass (CLI) | The captured turn completed naturally; official `Stop` and JSONL `task_complete` matched. |
+| Stop during an active tool | Not run | A manual terminal injection followed by a real late tool event tested the fence, but does not count as a real user stop. |
+| Stop during model streaming without a tool | Not run | Requires an interactive Desktop/CLI smoke. |
+| Immediately start a new turn in the same thread | Pass (CLI) | The next real `UserPromptSubmit` reopened the same canonical session and admitted work immediately. |
+| Keep a completed Desktop thread focused through token refresh | Not run | Automated composition covers liveness separation; the required 20-minute Desktop observation remains outstanding. |
+| Run two Desktop threads and stop only one | Not run | Requires an interactive Desktop smoke. |
+| Restart while active; repeat for terminal/stuck state | Partial (CLI) | Active-rollout synthetic backfill was observed. The full active + terminal/stuck Desktop restart matrix remains outstanding. |
+
+## Fence diagnostic probe
+
+In an isolated local Clawd runtime, an official `Stop` boundary was injected
+for the active captured turn. A real official `PostToolUse` for the same turn
+arrived 321 ms later and was rejected with `reason=closed-turn-id`. The next
+real turn reopened the same session. This proves the late-tail fence path but
+is not represented as a real user-stop result in the matrix above.
+
+## Closure status
+
+The Issue #821 reporter has not yet supplied their OS, Codex/ChatGPT Desktop
+version, or a confirmation run. The PR must therefore reference the issue
+without auto-closing it until the reporter platform smoke in Draft v4 section
+10.2 is complete.

--- a/src/agent-runtime-main.js
+++ b/src/agent-runtime-main.js
@@ -217,23 +217,21 @@ function createAgentRuntimeMain(options = {}) {
             stateRuntime.updateAccountQuota(null, accountQuotas);
           }
         };
+        const annotateCodexContextUsage = () => {
+          if (!sessionOptions.contextUsage) return false;
+          const stateRuntime = getStateRuntime();
+          if (!stateRuntime || typeof stateRuntime.updateSessionMetadata !== "function") return false;
+          return stateRuntime.updateSessionMetadata(sessionId, {
+            contextUsage: sessionOptions.contextUsage,
+          });
+        };
         if (isCodexMonitorMetadataOnlyEvent(event, extra)) {
-          if (sessionOptions.contextUsage) {
-            updateSession(sessionId, state, event, {
-              ...sessionOptions,
-              preserveState: true,
-            });
-          }
+          annotateCodexContextUsage();
           annotateCodexAccountQuota();
           return;
         }
         if (shouldSuppressCodexLogEvent(sessionId, state, event)) {
-          if (sessionOptions.contextUsage) {
-            updateSession(sessionId, state, event, {
-              ...sessionOptions,
-              preserveState: true,
-            });
-          }
+          annotateCodexContextUsage();
           annotateCodexAccountQuota();
           return;
         }

--- a/src/agent-runtime-main.js
+++ b/src/agent-runtime-main.js
@@ -7,6 +7,9 @@ const {
   isCodexMonitorMetadataOnlyEvent,
 } = require("./codex-monitor-callback");
 const { resolveSessionIdentity } = require("./session-key");
+const { digestCodexTurnId } = require("./codex-turn-id");
+const createCodexTurnFence = require("./codex-turn-fence");
+const createCodexOfficialActivity = require("./codex-official-activity");
 
 const CODEX_OFFICIAL_LOG_SUPPRESS_TTL_MS = 10 * 60 * 1000;
 const CODEX_LOG_EVENTS_COVERED_BY_OFFICIAL_HOOKS = new Set([
@@ -25,6 +28,13 @@ const CODEX_LOG_EVENTS_COVERED_BY_OFFICIAL_HOOKS = new Set([
 // Local Codex turns that are still in flight sit in one of these states. Kept in
 // sync with isWorkingLikeState() in state-stale-cleanup.js.
 const CODEX_WORKING_LIKE_STATES = new Set(["working", "thinking", "juggling"]);
+const CODEX_TURN_CAPTURE_EVENTS = new Set([
+  "UserPromptSubmit",
+  "Stop",
+  "event_msg:task_started",
+  "event_msg:task_complete",
+  "event_msg:turn_aborted",
+]);
 
 function createProfileScopedClassifier(classifier, profileId) {
   const canonicalSessionId = (sessionId) =>
@@ -51,6 +61,7 @@ function createProfileScopedClassifier(classifier, profileId) {
 function createAgentRuntimeMain(options = {}) {
   const now = typeof options.now === "function" ? options.now : Date.now;
   const logWarn = typeof options.logWarn === "function" ? options.logWarn : console.warn;
+  const debugLog = typeof options.debugLog === "function" ? options.debugLog : () => {};
   const loadCodexLogMonitor = options.loadCodexLogMonitor || (() => require("../agents/codex-log-monitor"));
   const loadCodexAgent = options.loadCodexAgent || (() => require("../agents/codex"));
   const codexSubagentClassifier = options.codexSubagentClassifier || new DefaultCodexSubagentClassifier();
@@ -66,21 +77,28 @@ function createAgentRuntimeMain(options = {}) {
   const clearCodexUserInputBubbles = options.clearCodexUserInputBubbles || (() => {});
 
   let codexMonitor = null;
-  const codexOfficialHookSessions = new Map();
+  const codexTurnFence = createCodexTurnFence({ now, debugLog });
+  const codexOfficialActivity = createCodexOfficialActivity({
+    now,
+    debugLog,
+    ttlMs: CODEX_OFFICIAL_LOG_SUPPRESS_TTL_MS,
+  });
 
-  function markCodexOfficialHookSession(sessionId) {
-    if (!sessionId) return;
-    codexOfficialHookSessions.set(String(sessionId), now());
+  function recordCodexTurnIdCapture(sessionId, source, event, turnId) {
+    if (!CODEX_TURN_CAPTURE_EVENTS.has(event)) return;
+    const digest = digestCodexTurnId(turnId);
+    debugLog(
+      `codex-turn-id sid=${String(sessionId || "-").replace(/[\r\n]/g, "_")}`
+      + ` source=${source} event=${event} turn=${digest || "-"}`
+    );
   }
 
-  function hasRecentCodexOfficialHookSession(sessionId) {
-    const lastHookAt = codexOfficialHookSessions.get(String(sessionId));
-    if (!lastHookAt) return false;
-    if (now() - lastHookAt > CODEX_OFFICIAL_LOG_SUPPRESS_TTL_MS) {
-      codexOfficialHookSessions.delete(String(sessionId));
-      return false;
-    }
-    return true;
+  function markCodexOfficialHookSession(sessionId, turnId = null) {
+    codexOfficialActivity.mark(sessionId, turnId);
+  }
+
+  function hasRecentCodexOfficialHookSession(sessionId, turnId = null) {
+    return codexOfficialActivity.hasRecent(sessionId, turnId);
   }
 
   // JSONL fallback rescue. Official Codex hooks normally emit a Stop that closes
@@ -104,16 +122,27 @@ function createAgentRuntimeMain(options = {}) {
     return CODEX_WORKING_LIKE_STATES.has(session.state);
   }
 
-  function shouldSuppressCodexLogEvent(sessionId, state, event) {
+  function shouldSuppressCodexLogEvent(sessionId, state, event, turnId = null) {
     if (!CODEX_LOG_EVENTS_COVERED_BY_OFFICIAL_HOOKS.has(event)) return false;
-    if (!hasRecentCodexOfficialHookSession(sessionId)) return false;
+    if (!hasRecentCodexOfficialHookSession(sessionId, turnId)) return false;
     if (shouldAllowCodexJsonlCompletionFallback(sessionId, state, event)) return false;
     return true;
   }
 
   function updateSessionFromServer(sessionId, state, event, opts = {}) {
     if (opts && opts.agentId === "codex" && opts.hookSource === "codex-official") {
-      markCodexOfficialHookSession(sessionId);
+      markCodexOfficialHookSession(sessionId, opts.turnId);
+      if (opts.profileId === "local") {
+        recordCodexTurnIdCapture(sessionId, "official", event, opts.turnId);
+        const fenceDecision = codexTurnFence.observe({
+          sessionId,
+          source: "official",
+          event,
+          state,
+          turnId: opts.turnId,
+        });
+        if (!fenceDecision.accept) return false;
+      }
     }
     const result = updateSession(sessionId, state, event, opts);
     maybeCaptureGhosttyTerminalId(sessionId, event, opts);
@@ -165,6 +194,7 @@ function createAgentRuntimeMain(options = {}) {
   }
 
   function clearSessionsByAgent(agentId) {
+    if (agentId === "codex") resetLocalCodexLifecycleTracking();
     const state = getStateRuntime();
     return state && typeof state.clearSessionsByAgent === "function"
       ? state.clearSessionsByAgent(agentId)
@@ -210,6 +240,7 @@ function createAgentRuntimeMain(options = {}) {
           rawSessionId: sessionIdentity.rawSessionId,
         };
         const accountQuotas = normalizeCodexMonitorAccountQuotas(extra);
+        recordCodexTurnIdCapture(sessionId, "jsonl", event, extra && extra.turnId);
         const annotateCodexAccountQuota = () => {
           if (!accountQuotas) return;
           const stateRuntime = getStateRuntime();
@@ -230,7 +261,21 @@ function createAgentRuntimeMain(options = {}) {
           annotateCodexAccountQuota();
           return;
         }
-        if (shouldSuppressCodexLogEvent(sessionId, state, event)) {
+        const fenceDecision = codexTurnFence.observe({
+          sessionId,
+          source: "jsonl",
+          event,
+          state,
+          turnId: extra && extra.turnId,
+          syntheticBackfill: extra && extra.syntheticBackfill === true,
+          turnBoundaryOpen: extra && extra.turnBoundaryOpen === true,
+        });
+        if (!fenceDecision.accept) {
+          annotateCodexContextUsage();
+          annotateCodexAccountQuota();
+          return;
+        }
+        if (shouldSuppressCodexLogEvent(sessionId, state, event, extra && extra.turnId)) {
           annotateCodexContextUsage();
           annotateCodexAccountQuota();
           return;
@@ -274,7 +319,12 @@ function createAgentRuntimeMain(options = {}) {
 
   function cleanup() {
     if (codexMonitor && typeof codexMonitor.stop === "function") codexMonitor.stop();
-    codexOfficialHookSessions.clear();
+    resetLocalCodexLifecycleTracking();
+  }
+
+  function resetLocalCodexLifecycleTracking() {
+    codexTurnFence.clear();
+    codexOfficialActivity.clear();
   }
 
   return {
@@ -291,6 +341,9 @@ function createAgentRuntimeMain(options = {}) {
     updateSessionFromServer,
     markCodexOfficialHookSession,
     shouldSuppressCodexLogEvent,
+    resetLocalCodexLifecycleTracking,
+    getCodexTurnFenceSnapshot: (sessionId) => codexTurnFence.getSnapshot(sessionId),
+    getCodexOfficialActivitySnapshot: (sessionId) => codexOfficialActivity.getSnapshot(sessionId),
     cleanup,
   };
 }

--- a/src/codex-official-activity.js
+++ b/src/codex-official-activity.js
@@ -1,0 +1,117 @@
+"use strict";
+
+const { normalizeCodexTurnId, digestCodexTurnId } = require("./codex-turn-id");
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000;
+const DEFAULT_MAX_SESSIONS = 200;
+const DEFAULT_MAX_EXACT_MARKS = 8;
+
+function createCodexOfficialActivity(options = {}) {
+  const now = typeof options.now === "function" ? options.now : Date.now;
+  const debugLog = typeof options.debugLog === "function" ? options.debugLog : () => {};
+  const ttlMs = Number.isFinite(options.ttlMs) && options.ttlMs >= 0 ? options.ttlMs : DEFAULT_TTL_MS;
+  const maxSessions = Number.isInteger(options.maxSessions) && options.maxSessions > 0
+    ? options.maxSessions
+    : DEFAULT_MAX_SESSIONS;
+  const maxExactMarks = Number.isInteger(options.maxExactMarks) && options.maxExactMarks > 0
+    ? options.maxExactMarks
+    : DEFAULT_MAX_EXACT_MARKS;
+  const sessions = new Map();
+
+  function isRecent(timestamp) {
+    return Number.isFinite(timestamp) && now() - timestamp <= ttlMs;
+  }
+
+  function pruneRecord(record) {
+    for (const [turnId, timestamp] of record.exact) {
+      if (!isRecent(timestamp)) record.exact.delete(turnId);
+    }
+    if (!isRecent(record.lastIdlessOfficialAt)) record.lastIdlessOfficialAt = null;
+    if (!isRecent(record.lastAnyOfficialAt)) record.lastAnyOfficialAt = null;
+  }
+
+  function hasMarks(record) {
+    return record.lastAnyOfficialAt !== null
+      || record.lastIdlessOfficialAt !== null
+      || record.exact.size > 0;
+  }
+
+  function touch(sessionId, record) {
+    sessions.delete(sessionId);
+    sessions.set(sessionId, record);
+  }
+
+  function pruneAllExpired() {
+    for (const [sessionId, record] of sessions) {
+      pruneRecord(record);
+      if (!hasMarks(record)) sessions.delete(sessionId);
+    }
+  }
+
+  function mark(sessionId, rawTurnId) {
+    if (!sessionId) return;
+    const turnId = normalizeCodexTurnId(rawTurnId);
+    const timestamp = now();
+    let record = sessions.get(String(sessionId));
+    if (!record) record = { lastAnyOfficialAt: null, lastIdlessOfficialAt: null, exact: new Map() };
+    pruneRecord(record);
+    record.lastAnyOfficialAt = timestamp;
+    if (turnId) {
+      record.exact.delete(turnId);
+      record.exact.set(turnId, timestamp);
+      while (record.exact.size > maxExactMarks) record.exact.delete(record.exact.keys().next().value);
+    } else {
+      record.lastIdlessOfficialAt = timestamp;
+    }
+    touch(String(sessionId), record);
+    if (sessions.size > maxSessions) pruneAllExpired();
+    while (sessions.size > maxSessions) {
+      const evicted = sessions.keys().next().value;
+      sessions.delete(evicted);
+      debugLog(`codex-official-activity evict sid=${String(evicted).replace(/[\r\n]/g, "_")} reason=session-capacity`);
+    }
+  }
+
+  function hasRecent(sessionId, rawTurnId) {
+    const key = String(sessionId || "");
+    const record = sessions.get(key);
+    if (!record) return false;
+    pruneRecord(record);
+    if (!hasMarks(record)) {
+      sessions.delete(key);
+      return false;
+    }
+    touch(key, record);
+    const turnId = normalizeCodexTurnId(rawTurnId);
+    if (!turnId) return isRecent(record.lastAnyOfficialAt);
+    return isRecent(record.lastIdlessOfficialAt) || isRecent(record.exact.get(turnId));
+  }
+
+  function clear() {
+    sessions.clear();
+  }
+
+  function getSnapshot(sessionId) {
+    const record = sessions.get(String(sessionId || ""));
+    if (!record) return null;
+    return {
+      lastAnyOfficialAt: record.lastAnyOfficialAt,
+      lastIdlessOfficialAt: record.lastIdlessOfficialAt,
+      exact: [...record.exact.keys()].map((turnId) => digestCodexTurnId(turnId)),
+    };
+  }
+
+  return {
+    mark,
+    hasRecent,
+    clear,
+    getSnapshot,
+    get size() { return sessions.size; },
+  };
+}
+
+createCodexOfficialActivity.DEFAULT_TTL_MS = DEFAULT_TTL_MS;
+createCodexOfficialActivity.DEFAULT_MAX_SESSIONS = DEFAULT_MAX_SESSIONS;
+createCodexOfficialActivity.DEFAULT_MAX_EXACT_MARKS = DEFAULT_MAX_EXACT_MARKS;
+
+module.exports = createCodexOfficialActivity;

--- a/src/codex-turn-fence.js
+++ b/src/codex-turn-fence.js
@@ -1,0 +1,200 @@
+"use strict";
+
+const { normalizeCodexTurnId, digestCodexTurnId } = require("./codex-turn-id");
+
+const DEFAULT_MAX_SESSIONS = 200;
+const DEFAULT_MAX_CLOSED_TURNS = 512;
+
+const START_EVENTS = new Set(["UserPromptSubmit", "event_msg:task_started"]);
+const TERMINAL_EVENTS = new Set(["Stop", "event_msg:task_complete", "event_msg:turn_aborted"]);
+const WORKING_STATES = new Set(["thinking", "working", "juggling", "sweeping"]);
+
+function createCodexTurnFence(options = {}) {
+  const now = typeof options.now === "function" ? options.now : Date.now;
+  const debugLog = typeof options.debugLog === "function" ? options.debugLog : () => {};
+  const maxSessions = Number.isInteger(options.maxSessions) && options.maxSessions > 0
+    ? options.maxSessions
+    : DEFAULT_MAX_SESSIONS;
+  const maxClosedTurns = Number.isInteger(options.maxClosedTurns) && options.maxClosedTurns > 0
+    ? options.maxClosedTurns
+    : DEFAULT_MAX_CLOSED_TURNS;
+  const records = new Map();
+  const closedLru = new Map();
+
+  function safeSessionId(value) {
+    return String(value || "-").replace(/[\r\n]/g, "_");
+  }
+
+  function logDecision(kind, input, reason = null) {
+    const digest = digestCodexTurnId(input.turnId);
+    debugLog(
+      `codex-fence ${kind} sid=${safeSessionId(input.sessionId)}`
+      + ` source=${input.source || "-"} event=${input.event || "-"}`
+      + ` turn=${digest || "-"}${reason ? ` reason=${reason}` : ""}`
+    );
+  }
+
+  function closedKey(sessionId, turnId) {
+    return `${sessionId}\u0000${turnId}`;
+  }
+
+  function deleteRecord(sessionId, reason) {
+    const record = records.get(sessionId);
+    if (!record) return;
+    records.delete(sessionId);
+    for (const turnId of record.closedTurnIds.keys()) {
+      closedLru.delete(closedKey(sessionId, turnId));
+    }
+    if (reason) {
+      debugLog(`codex-fence evict sid=${safeSessionId(sessionId)} reason=${reason}`);
+    }
+  }
+
+  function touchRecord(sessionId, record) {
+    record.touchedAt = now();
+    records.delete(sessionId);
+    records.set(sessionId, record);
+    while (records.size > maxSessions) {
+      deleteRecord(records.keys().next().value, "session-capacity");
+    }
+  }
+
+  function getRecord(sessionId, create) {
+    let record = records.get(sessionId) || null;
+    if (!record && create) {
+      record = {
+        currentTurnId: null,
+        terminalLatch: null,
+        closedTurnIds: new Map(),
+        touchedAt: now(),
+      };
+    }
+    if (record) touchRecord(sessionId, record);
+    return record;
+  }
+
+  function addClosedTurn(sessionId, record, turnId, event) {
+    if (!turnId || record.closedTurnIds.has(turnId)) return;
+    const closedAt = now();
+    record.closedTurnIds.set(turnId, { terminalEvent: event, closedAt });
+    const key = closedKey(sessionId, turnId);
+    closedLru.set(key, { sessionId, turnId });
+    while (closedLru.size > maxClosedTurns) {
+      const oldestKey = closedLru.keys().next().value;
+      const oldest = closedLru.get(oldestKey);
+      closedLru.delete(oldestKey);
+      const owner = oldest && records.get(oldest.sessionId);
+      if (owner) owner.closedTurnIds.delete(oldest.turnId);
+      if (oldest) {
+        debugLog(
+          `codex-fence evict sid=${safeSessionId(oldest.sessionId)}`
+          + ` turn=${digestCodexTurnId(oldest.turnId) || "-"} reason=tombstone-capacity`
+        );
+      }
+    }
+  }
+
+  function observe(rawInput = {}) {
+    const sessionId = typeof rawInput.sessionId === "string" && rawInput.sessionId
+      ? rawInput.sessionId
+      : null;
+    if (!sessionId) return { accept: true, reason: "no-session" };
+    const input = {
+      ...rawInput,
+      sessionId,
+      turnId: normalizeCodexTurnId(rawInput.turnId),
+    };
+    const syntheticOpenStart = input.syntheticBackfill === true
+      && input.turnBoundaryOpen === true
+      && !!input.turnId;
+    const isStart = START_EVENTS.has(input.event) || syntheticOpenStart;
+    const isTerminal = TERMINAL_EVENTS.has(input.event);
+    const isWork = !isStart && !isTerminal && WORKING_STATES.has(input.state);
+    if (!isStart && !isTerminal && !isWork) {
+      return { accept: true, reason: "housekeeping" };
+    }
+
+    const record = getRecord(sessionId, true);
+    const isClosed = !!(input.turnId && record.closedTurnIds.has(input.turnId));
+
+    if (isClosed) {
+      const reason = isTerminal ? "duplicate-terminal" : "closed-turn-id";
+      logDecision("drop", input, reason);
+      return { accept: false, reason };
+    }
+
+    if (isStart) {
+      const hadLatch = !!record.terminalLatch;
+      record.currentTurnId = input.turnId;
+      record.terminalLatch = null;
+      touchRecord(sessionId, record);
+      if (!input.turnId) logDecision("ambiguity", input, "idless-start");
+      if (hadLatch || input.syntheticBackfill === true) logDecision("reopen", input);
+      return { accept: true, reason: "start" };
+    }
+
+    if (isWork) {
+      if (record.terminalLatch) {
+        logDecision("drop", input, input.syntheticBackfill ? "synthetic-ambiguous" : "terminal-latch");
+        return { accept: false, reason: input.syntheticBackfill ? "synthetic-ambiguous" : "terminal-latch" };
+      }
+      if (!record.currentTurnId && input.turnId) {
+        record.currentTurnId = input.turnId;
+        touchRecord(sessionId, record);
+      } else if (record.currentTurnId && input.turnId && record.currentTurnId !== input.turnId) {
+        logDecision("drop", input, "unexpected-distinct-work");
+        return { accept: false, reason: "unexpected-distinct-work" };
+      }
+      return { accept: true, reason: "work" };
+    }
+
+    if (input.turnId) addClosedTurn(sessionId, record, input.turnId, input.event);
+    if (input.turnId && record.currentTurnId && record.currentTurnId !== input.turnId) {
+      touchRecord(sessionId, record);
+      logDecision("drop", input, "stale-terminal");
+      return { accept: false, reason: "stale-terminal" };
+    }
+
+    record.currentTurnId = null;
+    record.terminalLatch = {
+      turnId: input.turnId,
+      terminalEvent: input.event,
+      closedAt: now(),
+    };
+    touchRecord(sessionId, record);
+    logDecision("terminal", input);
+    if (!input.turnId) logDecision("ambiguity", input, "idless-terminal");
+    return { accept: true, reason: "terminal" };
+  }
+
+  function clear() {
+    records.clear();
+    closedLru.clear();
+  }
+
+  function getSnapshot(sessionId) {
+    const record = records.get(sessionId);
+    if (!record) return null;
+    return {
+      currentTurnId: record.currentTurnId,
+      terminalLatch: record.terminalLatch ? { ...record.terminalLatch } : null,
+      closedTurnIds: [...record.closedTurnIds.keys()],
+      touchedAt: record.touchedAt,
+    };
+  }
+
+  return {
+    observe,
+    clear,
+    getSnapshot,
+    get size() { return records.size; },
+    get closedSize() { return closedLru.size; },
+  };
+}
+
+createCodexTurnFence.DEFAULT_MAX_SESSIONS = DEFAULT_MAX_SESSIONS;
+createCodexTurnFence.DEFAULT_MAX_CLOSED_TURNS = DEFAULT_MAX_CLOSED_TURNS;
+createCodexTurnFence.START_EVENTS = START_EVENTS;
+createCodexTurnFence.TERMINAL_EVENTS = TERMINAL_EVENTS;
+
+module.exports = createCodexTurnFence;

--- a/src/codex-turn-id.js
+++ b/src/codex-turn-id.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const crypto = require("node:crypto");
+
+const MAX_CODEX_TURN_ID_LENGTH = 256;
+
+function normalizeCodexTurnId(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  if (!normalized || normalized.length > MAX_CODEX_TURN_ID_LENGTH) return null;
+  return normalized;
+}
+
+function digestCodexTurnId(value) {
+  const normalized = normalizeCodexTurnId(value);
+  if (!normalized) return null;
+  return crypto.createHash("sha256").update(normalized, "utf8").digest("hex").slice(0, 16);
+}
+
+module.exports = {
+  MAX_CODEX_TURN_ID_LENGTH,
+  normalizeCodexTurnId,
+  digestCodexTurnId,
+};

--- a/src/main.js
+++ b/src/main.js
@@ -2265,6 +2265,7 @@ agentRuntime = createAgentRuntimeMain({
   getPermissionRuntime: () => _perm,
   isAgentEnabled: (agentId) => _isAgentEnabled(_settingsController.getSnapshot(), agentId),
   updateSession: (sessionId, state, event, opts) => updateSession(sessionId, state, event, opts),
+  debugLog: (msg) => sessionLog(msg),
   captureGhosttyTerminalId,
   clearCodexNotifyBubbles: (...args) => clearCodexNotifyBubbles(...args),
   showCodexUserInputBubble: (...args) => showCodexUserInputBubble(...args),

--- a/src/server-codex-official-turns.js
+++ b/src/server-codex-official-turns.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { normalizeCodexTurnId } = require("./codex-turn-id");
+
 const CODEX_OFFICIAL_HOOK_SOURCE = "codex-official";
 const MAX_CODEX_OFFICIAL_TURNS = 200;
 const CODEX_SESSION_ROLE_SUBAGENT = "subagent";
@@ -56,7 +58,7 @@ function resolveCodexOfficialHookState(
   }
 
   const event = typeof data.event === "string" ? data.event : "";
-  const turnId = typeof data.turn_id === "string" && data.turn_id ? data.turn_id : null;
+  const turnId = normalizeCodexTurnId(data.turn_id);
   const sessionId = typeof sessionIdOverride === "string" && sessionIdOverride
     ? sessionIdOverride
     : (typeof data.session_id === "string" && data.session_id ? data.session_id : "default");
@@ -67,7 +69,7 @@ function resolveCodexOfficialHookState(
 
   if (event === "Stop" && data.stop_hook_active === true) {
     if (turnKey && turns) turns.delete(turnKey);
-    return { state: requestedState, drop: true, ...headless };
+    return { state: requestedState, drop: true, ...(turnId ? { turnId } : {}), ...headless };
   }
 
   if (turnKey && turns) {
@@ -83,18 +85,23 @@ function resolveCodexOfficialHookState(
     } else if (event === "Stop") {
       const current = turns.get(turnKey);
       if (current) turns.delete(turnKey);
-      if (isSubagent) return { state: "idle", drop: false, headless: true };
-      return { state: resolveCodexOfficialStopState(current, data), drop: false };
+      if (isSubagent) return { state: "idle", drop: false, ...(turnId ? { turnId } : {}), headless: true };
+      return {
+        state: resolveCodexOfficialStopState(current, data),
+        drop: false,
+        ...(turnId ? { turnId } : {}),
+      };
     }
   } else if (event === "Stop") {
     return {
       state: isSubagent ? "idle" : resolveCodexOfficialStopState(null, data),
       drop: false,
+      ...(turnId ? { turnId } : {}),
       ...headless,
     };
   }
 
-  return { state: requestedState, drop: false, ...headless };
+  return { state: requestedState, drop: false, ...(turnId ? { turnId } : {}), ...headless };
 }
 
 module.exports = {

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -664,6 +664,7 @@ function handleStatePost(req, res, options) {
             permissionGateId,
             preserveState,
             hookSource,
+            ...(codexHookState.turnId ? { turnId: codexHookState.turnId } : {}),
             backgroundTasksCount,
             sessionCronsCount,
             stopHookActive,

--- a/src/state.js
+++ b/src/state.js
@@ -361,21 +361,43 @@ function resolveAwaitingInputSinceStop(existing, event) {
   return false;
 }
 
-function hasCompletionTailWithoutProgress(session) {
+function getCompletionTailWithoutProgress(session) {
   const events = Array.isArray(session && session.recentEvents) ? session.recentEvents : [];
   for (let i = events.length - 1; i >= 0; i--) {
-    const event = events[i] && events[i].event;
-    if (POST_COMPLETION_EVENTS.has(event)) return true;
+    const entry = events[i];
+    const event = entry && entry.event;
+    if (POST_COMPLETION_EVENTS.has(event)) return entry;
     if (event == null || COMPLETION_HOUSEKEEPING_EVENTS.has(event)) continue;
-    return false;
+    return null;
   }
-  return false;
+  return null;
+}
+
+function hasCompletionTailWithoutProgress(session) {
+  return !!getCompletionTailWithoutProgress(session);
+}
+
+function markCompletionTailPresented(recentEvents) {
+  const copy = recentEvents.slice();
+  for (let i = copy.length - 1; i >= 0; i--) {
+    const entry = copy[i];
+    const event = entry && entry.event;
+    if (POST_COMPLETION_EVENTS.has(event)) {
+      copy[i] = { ...entry, state: "attention" };
+      break;
+    }
+    if (event == null || COMPLETION_HOUSEKEEPING_EVENTS.has(event)) continue;
+    break;
+  }
+  return copy;
 }
 
 function shouldSuppressDuplicateCompletionVisual(existing, state, event) {
   if (state !== "attention" || !POST_COMPLETION_EVENTS.has(event)) return false;
   if (!existing || (existing.state !== "idle" && existing.state !== "sleeping")) return false;
-  return existing.awaitingInputSinceStop === true || hasCompletionTailWithoutProgress(existing);
+  const completionTail = getCompletionTailWithoutProgress(existing);
+  if (completionTail) return completionTail.state === "attention";
+  return existing.awaitingInputSinceStop === true;
 }
 
 function shouldKeepExistingCompletionEventTail(existing, state, event) {
@@ -1436,7 +1458,10 @@ function scheduleClaudeTranscriptCompletionProbe(sessionId, transcriptPath) {
 function promoteCompletion(sessionId) {
   const session = sessions.get(sessionId);
   if (!session) return;
-  session.recentEvents = pushRecentEvent(session, "idle", "Stop");
+  // The stored session settles idle, but this Stop consumed the completion
+  // attention cue. Record that distinction so a later duplicate Stop is
+  // suppressed while an earlier idle-only terminal can still be upgraded.
+  session.recentEvents = pushRecentEvent(session, "attention", "Stop");
   session.state = "idle";
   session.updatedAt = Date.now();
   session.displayHint = null;
@@ -1837,7 +1862,9 @@ function updateSession(sessionId, state, event, opts = {}) {
 
   const keepExistingCompletionEventTail = shouldKeepExistingCompletionEventTail(existing, state, event);
   const recentEvents = keepExistingCompletionEventTail && Array.isArray(existing.recentEvents)
-    ? existing.recentEvents.slice()
+    ? (duplicateCompletionVisualAtEntry
+      ? existing.recentEvents.slice()
+      : markCompletionTailPresented(existing.recentEvents))
     : pushRecentEvent(existing, preservedState || state, event);
   const preserveCompletionAck =
     existing

--- a/test/agent-runtime-main.test.js
+++ b/test/agent-runtime-main.test.js
@@ -9,6 +9,7 @@ const createAgentRuntimeMain = require("../src/agent-runtime-main");
 const CodexSubagentClassifier = require("../agents/codex-subagent-classifier");
 const { resolveCodexOfficialHookState } = require("../src/server-codex-official-turns");
 const { makeSessionKey } = require("../src/session-key");
+const { digestCodexTurnId } = require("../src/codex-turn-id");
 
 const SRC_DIR = path.join(__dirname, "..", "src");
 const localSessionKey = (rawSessionId) => makeSessionKey({
@@ -86,6 +87,44 @@ describe("agent-runtime-main", () => {
       runtime.shouldSuppressCodexLogEvent("codex-1", "working", "event_msg:guardian_assessment"),
       false
     );
+  });
+
+  it("records privacy-safe local cross-channel turn identity diagnostics", () => {
+    const instances = [];
+    const debugLines = [];
+    const FakeMonitor = makeFakeMonitorClass(instances);
+    const runtime = createAgentRuntimeMain({
+      loadCodexLogMonitor: () => FakeMonitor,
+      loadCodexAgent: () => ({ id: "codex" }),
+      isAgentEnabled: () => true,
+      updateSession: () => {},
+      debugLog: (line) => debugLines.push(line),
+      codexSubagentClassifier: {},
+    });
+    const monitor = runtime.startCodexLogMonitor();
+    const sessionId = localSessionKey("codex:abc");
+    const turnId = "019fffff-1111-7777-8888-123456789abc";
+
+    runtime.updateSessionFromServer(sessionId, "thinking", "UserPromptSubmit", {
+      agentId: "codex",
+      hookSource: "codex-official",
+      profileId: "local",
+      turnId,
+    });
+    monitor.emit("codex:abc", "thinking", "event_msg:task_started", { turnId });
+    runtime.updateSessionFromServer(sessionId, "idle", "Stop", {
+      agentId: "codex",
+      hookSource: "codex-official",
+      profileId: "remote-box",
+      turnId: "must-not-log",
+    });
+
+    const digest = digestCodexTurnId(turnId);
+    assert.deepStrictEqual(debugLines, [
+      `codex-turn-id sid=${sessionId} source=official event=UserPromptSubmit turn=${digest}`,
+      `codex-turn-id sid=${sessionId} source=jsonl event=event_msg:task_started turn=${digest}`,
+    ]);
+    assert.strictEqual(debugLines.some((line) => line.includes(turnId)), false);
   });
 
   it("routes suppressed JSONL context through no-lifecycle session metadata", () => {
@@ -196,17 +235,17 @@ describe("agent-runtime-main", () => {
   it("handles JSONL token_count as metadata without clearing bubbles or changing state", () => {
     const instances = [];
     const calls = [];
-    const FakeMonitor = makeFakeMonitorClass(instances);
     const metadataCalls = [];
+    const FakeMonitor = makeFakeMonitorClass(instances);
     const runtime = createAgentRuntimeMain({
       loadCodexLogMonitor: () => FakeMonitor,
       loadCodexAgent: () => ({ id: "codex" }),
       isAgentEnabled: (agentId) => agentId === "codex",
       updateSession: (...args) => calls.push(["update", ...args]),
-      clearCodexNotifyBubbles: (...args) => calls.push(["clear", ...args]),
       getStateRuntime: () => ({
         updateSessionMetadata: (...args) => metadataCalls.push(args),
       }),
+      clearCodexNotifyBubbles: (...args) => calls.push(["clear", ...args]),
       codexSubagentClassifier: {},
     });
     const monitor = runtime.startCodexLogMonitor();
@@ -683,5 +722,171 @@ describe("agent-runtime-main", () => {
       sessionTitle: "Codex turn",
     });
     assert.deepStrictEqual(calls, []);
+  });
+
+  it("fences a late official tail after a JSONL terminal and immediately admits turn B", () => {
+    const instances = [];
+    const updates = [];
+    const clears = [];
+    const sessions = new Map();
+    const FakeMonitor = makeFakeMonitorClass(instances);
+    const runtime = createAgentRuntimeMain({
+      loadCodexLogMonitor: () => FakeMonitor,
+      loadCodexAgent: () => ({ id: "codex" }),
+      codexSubagentClassifier: {},
+      isAgentEnabled: () => true,
+      getStateRuntime: () => ({ sessions }),
+      updateSession: (...args) => updates.push(args),
+      clearCodexNotifyBubbles: (...args) => clears.push(args),
+    });
+    const monitor = runtime.startCodexLogMonitor();
+    const sessionId = localSessionKey("codex:s1");
+    const official = (state, event, turnId) => runtime.updateSessionFromServer(sessionId, state, event, {
+      agentId: "codex",
+      hookSource: "codex-official",
+      profileId: "local",
+      rawSessionId: "codex:s1",
+      turnId,
+    });
+
+    official("thinking", "UserPromptSubmit", "A");
+    monitor.emit("codex:s1", "idle", "event_msg:turn_aborted", { turnId: "A" });
+    assert.strictEqual(official("working", "PostToolUse", "A"), false);
+    assert.deepStrictEqual(updates.map((call) => [call[1], call[2]]), [
+      ["thinking", "UserPromptSubmit"],
+      ["idle", "event_msg:turn_aborted"],
+    ]);
+
+    assert.notStrictEqual(official("thinking", "UserPromptSubmit", "B"), false);
+    assert.notStrictEqual(official("working", "PreToolUse", "B"), false);
+    assert.deepStrictEqual(updates.slice(-2).map((call) => [call[1], call[2]]), [
+      ["thinking", "UserPromptSubmit"],
+      ["working", "PreToolUse"],
+    ]);
+
+    // A fenced JSONL tail is rejected before notification bubbles are cleared.
+    const clearCount = clears.length;
+    monitor.emit("codex:s1", "working", "response_item:function_call", { turnId: "A" });
+    assert.strictEqual(clears.length, clearCount);
+  });
+
+  it("applies one completion for official Stop plus duplicate JSONL terminal", () => {
+    const instances = [];
+    const updates = [];
+    const sessions = new Map();
+    const FakeMonitor = makeFakeMonitorClass(instances);
+    const runtime = createAgentRuntimeMain({
+      loadCodexLogMonitor: () => FakeMonitor,
+      loadCodexAgent: () => ({ id: "codex" }),
+      codexSubagentClassifier: {},
+      isAgentEnabled: () => true,
+      getStateRuntime: () => ({ sessions }),
+      updateSession: (...args) => updates.push(args),
+    });
+    const monitor = runtime.startCodexLogMonitor();
+    const sessionId = localSessionKey("codex:s1");
+    const opts = {
+      agentId: "codex",
+      hookSource: "codex-official",
+      profileId: "local",
+      turnId: "A",
+    };
+    runtime.updateSessionFromServer(sessionId, "thinking", "UserPromptSubmit", opts);
+    runtime.updateSessionFromServer(sessionId, "attention", "Stop", opts);
+    sessions.set(sessionId, { agentId: "codex", state: "attention" });
+    monitor.emit("codex:s1", "attention", "event_msg:task_complete", { turnId: "A" });
+
+    assert.deepStrictEqual(updates.map((call) => call[2]), ["UserPromptSubmit", "Stop"]);
+  });
+
+  it("keeps official suppression turn-aware while retaining ID-less compatibility", () => {
+    const runtime = createAgentRuntimeMain({ codexSubagentClassifier: {} });
+    runtime.markCodexOfficialHookSession("codex:s1", "A");
+    assert.strictEqual(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "working", "response_item:function_call", "A"),
+      true
+    );
+    assert.strictEqual(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "working", "response_item:function_call", "B"),
+      false
+    );
+    assert.strictEqual(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "working", "response_item:function_call", null),
+      true
+    );
+    runtime.markCodexOfficialHookSession("codex:s1", null);
+    assert.strictEqual(
+      runtime.shouldSuppressCodexLogEvent("codex:s1", "working", "response_item:function_call", "B"),
+      true
+    );
+  });
+
+  it("keeps exact JSONL completion rescue and distinct-turn fallback working", () => {
+    const instances = [];
+    const updates = [];
+    const sessions = new Map();
+    const FakeMonitor = makeFakeMonitorClass(instances);
+    const runtime = createAgentRuntimeMain({
+      loadCodexLogMonitor: () => FakeMonitor,
+      loadCodexAgent: () => ({ id: "codex" }),
+      codexSubagentClassifier: {},
+      isAgentEnabled: () => true,
+      getStateRuntime: () => ({ sessions }),
+      updateSession: (...args) => updates.push(args),
+    });
+    const monitor = runtime.startCodexLogMonitor();
+    const sessionId = localSessionKey("codex:s1");
+    const official = (state, event, turnId) => runtime.updateSessionFromServer(sessionId, state, event, {
+      agentId: "codex",
+      hookSource: "codex-official",
+      profileId: "local",
+      turnId,
+    });
+
+    official("thinking", "UserPromptSubmit", "A");
+    sessions.set(sessionId, { agentId: "codex", state: "working", host: null, headless: false });
+    monitor.emit("codex:s1", "attention", "event_msg:task_complete", { turnId: "A" });
+    assert.deepStrictEqual(updates.map((call) => call[2]), ["UserPromptSubmit", "event_msg:task_complete"]);
+
+    // A late official tail refreshes only A's exact suppression mark. B's
+    // fallback start and work remain visible if its official hooks are absent.
+    official("working", "PostToolUse", "A");
+    monitor.emit("codex:s1", "thinking", "event_msg:task_started", { turnId: "B" });
+    monitor.emit("codex:s1", "working", "response_item:function_call", { turnId: "B" });
+    assert.deepStrictEqual(updates.slice(-2).map((call) => call[2]), [
+      "event_msg:task_started",
+      "response_item:function_call",
+    ]);
+  });
+
+  it("bypasses the local fence for remote official hooks and resets tracking on Codex clear", () => {
+    const updates = [];
+    const clearCalls = [];
+    const runtime = createAgentRuntimeMain({
+      codexSubagentClassifier: {},
+      updateSession: (...args) => updates.push(args),
+      getStateRuntime: () => ({
+        clearSessionsByAgent: (...args) => { clearCalls.push(args); return 1; },
+      }),
+    });
+
+    const remoteOpts = {
+      agentId: "codex",
+      hookSource: "codex-official",
+      profileId: "remote-box",
+      turnId: "A",
+    };
+    runtime.updateSessionFromServer("remote-session", "idle", "Stop", remoteOpts);
+    runtime.updateSessionFromServer("remote-session", "working", "PostToolUse", remoteOpts);
+    assert.deepStrictEqual(updates.map((call) => call[2]), ["Stop", "PostToolUse"]);
+
+    const localOpts = { ...remoteOpts, profileId: "local" };
+    runtime.updateSessionFromServer("local-session", "idle", "Stop", localOpts);
+    assert.ok(runtime.getCodexTurnFenceSnapshot("local-session"));
+    assert.ok(runtime.getCodexOfficialActivitySnapshot("local-session"));
+    assert.strictEqual(runtime.clearSessionsByAgent("codex"), 1);
+    assert.strictEqual(runtime.getCodexTurnFenceSnapshot("local-session"), null);
+    assert.strictEqual(runtime.getCodexOfficialActivitySnapshot("local-session"), null);
+    assert.deepStrictEqual(clearCalls, [["codex"]]);
   });
 });

--- a/test/agent-runtime-main.test.js
+++ b/test/agent-runtime-main.test.js
@@ -10,6 +10,8 @@ const CodexSubagentClassifier = require("../agents/codex-subagent-classifier");
 const { resolveCodexOfficialHookState } = require("../src/server-codex-official-turns");
 const { makeSessionKey } = require("../src/session-key");
 const { digestCodexTurnId } = require("../src/codex-turn-id");
+const { CODEX_LOCAL_WORKING_STALE_FLOOR_MS } = require("../src/state-stale-cleanup");
+const themeLoader = require("../src/theme-loader");
 
 const SRC_DIR = path.join(__dirname, "..", "src");
 const localSessionKey = (rawSessionId) => makeSessionKey({
@@ -40,6 +42,50 @@ function makeFakeMonitorClass(instances) {
       return this.callback(sessionId, state, event, extra);
     }
   };
+}
+
+function makeRealStateHarness() {
+  themeLoader.init(SRC_DIR);
+  const theme = JSON.parse(JSON.stringify(themeLoader.loadTheme("clawd")));
+  // Composition tests assert lifecycle effects synchronously; animation hold
+  // timers are state presentation policy and are covered in state.test.js.
+  theme.timings.minDisplay = {};
+  theme.timings.autoReturn = {};
+  const sounds = [];
+  const stateChanges = [];
+  const noop = () => {};
+  const state = require("../src/state")({
+    lang: "en",
+    theme,
+    doNotDisturb: false,
+    miniTransitioning: false,
+    miniMode: false,
+    mouseOverPet: false,
+    idlePaused: false,
+    forceEyeResend: false,
+    eyePauseUntil: 0,
+    mouseStillSince: Date.now(),
+    miniSleepPeeked: false,
+    playSound: (name) => sounds.push(name),
+    sendToRenderer: (channel, stateName) => {
+      if (channel === "state-change") stateChanges.push(stateName);
+    },
+    syncHitWin: noop,
+    sendToHitWin: noop,
+    miniPeekIn: noop,
+    miniPeekOut: noop,
+    buildContextMenu: noop,
+    buildTrayMenu: noop,
+    pendingPermissions: [],
+    resolvePermissionEntry: noop,
+    dismissPermissionsForDnd: noop,
+    focusTerminalWindow: noop,
+    focusHostPlatform: "win32",
+    processKill: () => true,
+    getCursorScreenPoint: () => ({ x: 100, y: 100 }),
+    t: (key) => key,
+  });
+  return { state, sounds, stateChanges };
 }
 
 describe("agent-runtime-main", () => {
@@ -797,6 +843,175 @@ describe("agent-runtime-main", () => {
     monitor.emit("codex:s1", "attention", "event_msg:task_complete", { turnId: "A" });
 
     assert.deepStrictEqual(updates.map((call) => call[2]), ["UserPromptSubmit", "Stop"]);
+  });
+
+  it("produces one real state completion for official Stop plus duplicate JSONL terminal", () => {
+    const instances = [];
+    const FakeMonitor = makeFakeMonitorClass(instances);
+    const harness = makeRealStateHarness();
+    const runtime = createAgentRuntimeMain({
+      loadCodexLogMonitor: () => FakeMonitor,
+      loadCodexAgent: () => ({ id: "codex" }),
+      codexSubagentClassifier: {},
+      isAgentEnabled: () => true,
+      getStateRuntime: () => harness.state,
+      updateSession: (...args) => harness.state.updateSession(...args),
+    });
+    try {
+      const monitor = runtime.startCodexLogMonitor();
+      const rawSessionId = "codex:real-state-completion";
+      const sessionId = localSessionKey(rawSessionId);
+      const opts = {
+        agentId: "codex",
+        hookSource: "codex-official",
+        profileId: "local",
+        rawSessionId,
+        sourcePid: 42,
+        turnId: "A",
+      };
+
+      runtime.updateSessionFromServer(sessionId, "thinking", "UserPromptSubmit", opts);
+      runtime.updateSessionFromServer(sessionId, "attention", "Stop", opts);
+      monitor.emit(rawSessionId, "attention", "event_msg:task_complete", { turnId: "A" });
+
+      const session = harness.state.sessions.get(sessionId);
+      assert.ok(session);
+      assert.strictEqual(harness.sounds.filter((name) => name === "complete").length, 1);
+      assert.strictEqual(harness.stateChanges.filter((name) => name === "attention").length, 1);
+      assert.strictEqual(
+        session.recentEvents.filter((entry) => entry.event === "Stop" || entry.event === "event_msg:task_complete").length,
+        1
+      );
+      assert.strictEqual(session.state, "idle");
+    } finally {
+      runtime.cleanup();
+      harness.state.cleanup();
+    }
+  });
+
+  it("upgrades an ID-less idle terminal to one real completion when the ID-bearing Stop arrives", () => {
+    const harness = makeRealStateHarness();
+    const runtime = createAgentRuntimeMain({
+      codexSubagentClassifier: {},
+      getStateRuntime: () => harness.state,
+      updateSession: (...args) => harness.state.updateSession(...args),
+    });
+    try {
+      const rawSessionId = "codex:idless-completion-upgrade";
+      const sessionId = localSessionKey(rawSessionId);
+      const base = {
+        agentId: "codex",
+        hookSource: "codex-official",
+        profileId: "local",
+        rawSessionId,
+        sourcePid: 42,
+      };
+
+      runtime.updateSessionFromServer(sessionId, "thinking", "UserPromptSubmit", {
+        ...base,
+        turnId: "B",
+      });
+      assert.notStrictEqual(
+        runtime.updateSessionFromServer(sessionId, "idle", "Stop", { ...base, turnId: null }),
+        false
+      );
+      assert.notStrictEqual(
+        runtime.updateSessionFromServer(sessionId, "attention", "Stop", { ...base, turnId: "B" }),
+        false
+      );
+      assert.strictEqual(
+        runtime.updateSessionFromServer(sessionId, "attention", "Stop", { ...base, turnId: "B" }),
+        false
+      );
+
+      const session = harness.state.sessions.get(sessionId);
+      const completionEvents = session.recentEvents.filter((entry) => entry.event === "Stop");
+      assert.strictEqual(harness.sounds.filter((name) => name === "complete").length, 1);
+      assert.strictEqual(harness.stateChanges.filter((name) => name === "attention").length, 1);
+      assert.strictEqual(completionEvents.length, 1);
+      assert.strictEqual(completionEvents[0].state, "attention");
+      assert.deepStrictEqual(runtime.getCodexTurnFenceSnapshot(sessionId).closedTurnIds, ["B"]);
+    } finally {
+      runtime.cleanup();
+      harness.state.cleanup();
+    }
+  });
+
+  it("keeps token telemetry outside liveness and restores stale-idled work on the next lifecycle event", () => {
+    const instances = [];
+    const FakeMonitor = makeFakeMonitorClass(instances);
+    const harness = makeRealStateHarness();
+    const runtime = createAgentRuntimeMain({
+      loadCodexLogMonitor: () => FakeMonitor,
+      loadCodexAgent: () => ({ id: "codex" }),
+      codexSubagentClassifier: {},
+      isAgentEnabled: () => true,
+      getStateRuntime: () => harness.state,
+      updateSession: (...args) => harness.state.updateSession(...args),
+    });
+    try {
+      const monitor = runtime.startCodexLogMonitor();
+      const rawSessionId = "codex:real-state-metadata";
+      const sessionId = localSessionKey(rawSessionId);
+      const lifecycleOpts = {
+        agentId: "codex",
+        hookSource: "codex-official",
+        profileId: "local",
+        rawSessionId,
+        sourcePid: 42,
+        cwd: "D:\\repo",
+        sessionTitle: "Lifecycle title",
+        codexOriginator: "codex_work_desktop",
+        turnId: "A",
+      };
+
+      runtime.updateSessionFromServer(sessionId, "working", "UserPromptSubmit", lifecycleOpts);
+      const staleUpdatedAt = Date.now() - CODEX_LOCAL_WORKING_STALE_FLOOR_MS - 1_000;
+      const before = harness.state.sessions.get(sessionId);
+      before.updatedAt = staleUpdatedAt;
+      assert.strictEqual(before.pidReachable, true);
+
+      monitor.emit(rawSessionId, "working", "event_msg:token_count", {
+        contextUsage: { used: 123, limit: 1_000, percent: 12, source: "codex" },
+        // Metadata-only traffic must not gain lifecycle ownership of these.
+        cwd: "D:\\wrong",
+        sessionTitle: "Wrong title",
+        codexOriginator: "codex_exec",
+        sourcePid: 999,
+        turnId: "A",
+      });
+
+      const afterMetadata = harness.state.sessions.get(sessionId);
+      assert.strictEqual(afterMetadata.updatedAt, staleUpdatedAt);
+      assert.ok(afterMetadata.metadataUpdatedAt > staleUpdatedAt);
+      assert.deepStrictEqual(afterMetadata.contextUsage, {
+        used: 123,
+        limit: 1_000,
+        percent: 12,
+        source: "codex",
+      });
+      assert.strictEqual(afterMetadata.cwd, "D:\\repo");
+      assert.strictEqual(afterMetadata.sessionTitle, "Lifecycle title");
+      assert.strictEqual(afterMetadata.codexOriginator, "codex_work_desktop");
+      assert.strictEqual(afterMetadata.sourcePid, 42);
+
+      harness.state.cleanStaleSessions();
+      const afterStaleSweep = harness.state.sessions.get(sessionId);
+      assert.strictEqual(afterStaleSweep.state, "idle");
+      assert.strictEqual(afterStaleSweep.updatedAt, staleUpdatedAt);
+
+      runtime.updateSessionFromServer(sessionId, "working", "UserPromptSubmit", {
+        ...lifecycleOpts,
+        turnId: "B",
+      });
+      const restored = harness.state.sessions.get(sessionId);
+      assert.strictEqual(restored.state, "working");
+      assert.ok(restored.updatedAt > staleUpdatedAt);
+      assert.strictEqual(restored.codexOriginator, "codex_work_desktop");
+    } finally {
+      runtime.cleanup();
+      harness.state.cleanup();
+    }
   });
 
   it("keeps official suppression turn-aware while retaining ID-less compatibility", () => {

--- a/test/agent-runtime-main.test.js
+++ b/test/agent-runtime-main.test.js
@@ -88,10 +88,11 @@ describe("agent-runtime-main", () => {
     );
   });
 
-  it("lets JSONL token_count update official-hook Codex session metadata during suppression", () => {
+  it("routes suppressed JSONL context through no-lifecycle session metadata", () => {
     let currentTime = 1000;
     const instances = [];
     const calls = [];
+    const metadataCalls = [];
     const FakeMonitor = makeFakeMonitorClass(instances);
     const runtime = createAgentRuntimeMain({
       now: () => currentTime,
@@ -99,6 +100,9 @@ describe("agent-runtime-main", () => {
       loadCodexAgent: () => ({ id: "codex" }),
       isAgentEnabled: (agentId) => agentId === "codex",
       updateSession: (...args) => calls.push(["update", ...args]),
+      getStateRuntime: () => ({
+        updateSessionMetadata: (...args) => metadataCalls.push(args),
+      }),
       clearCodexNotifyBubbles: (...args) => calls.push(["clear", ...args]),
       codexSubagentClassifier: {},
     });
@@ -124,22 +128,18 @@ describe("agent-runtime-main", () => {
         agentId: "codex",
         hookSource: "codex-official",
       }],
-      ["update", localSessionKey("codex:abc"), "idle", "event_msg:task_complete", {
-        cwd: "D:\\repo",
-        agentId: "codex",
-        sessionTitle: undefined,
+    ]);
+    assert.deepStrictEqual(metadataCalls, [[
+      localSessionKey("codex:abc"),
+      {
         contextUsage: {
           used: 49961,
           limit: 258400,
           percent: 19,
           source: "codex",
         },
-        headless: false,
-        profileId: "local",
-        rawSessionId: "codex:abc",
-        preserveState: true,
-      }],
-    ]);
+      },
+    ]]);
   });
 
   it("routes Codex user-input monitor callbacks to a passive card and transient state", () => {
@@ -161,7 +161,13 @@ describe("agent-runtime-main", () => {
       questions: [{ id: "q", header: "Choice", question: "Pick one", options: [] }],
       autoResolutionMs: null,
     };
-    const extra = { cwd: "/repo", sourcePid: 42, agentPid: 42, headless: false };
+    const extra = {
+      cwd: "/repo",
+      sourcePid: 42,
+      agentPid: 42,
+      headless: false,
+      contextUsage: { used: 10, limit: 100, percent: 10, source: "codex" },
+    };
 
     monitor.options.onUserInputRequest("codex:s1", request, extra);
     monitor.options.onUserInputResolved("codex:s1", "call_1");
@@ -191,12 +197,16 @@ describe("agent-runtime-main", () => {
     const instances = [];
     const calls = [];
     const FakeMonitor = makeFakeMonitorClass(instances);
+    const metadataCalls = [];
     const runtime = createAgentRuntimeMain({
       loadCodexLogMonitor: () => FakeMonitor,
       loadCodexAgent: () => ({ id: "codex" }),
       isAgentEnabled: (agentId) => agentId === "codex",
       updateSession: (...args) => calls.push(["update", ...args]),
       clearCodexNotifyBubbles: (...args) => calls.push(["clear", ...args]),
+      getStateRuntime: () => ({
+        updateSessionMetadata: (...args) => metadataCalls.push(args),
+      }),
       codexSubagentClassifier: {},
     });
     const monitor = runtime.startCodexLogMonitor();
@@ -211,29 +221,25 @@ describe("agent-runtime-main", () => {
       },
     });
 
-    assert.deepStrictEqual(calls, [
-      ["update", localSessionKey("codex:abc"), "working", "event_msg:token_count", {
-        cwd: "D:\\repo",
-        agentId: "codex",
-        sessionTitle: undefined,
+    assert.deepStrictEqual(calls, []);
+    assert.deepStrictEqual(metadataCalls, [[
+      localSessionKey("codex:abc"),
+      {
         contextUsage: {
           used: 23959,
           limit: 258400,
           percent: 9,
           source: "codex",
         },
-        headless: false,
-        profileId: "local",
-        rawSessionId: "codex:abc",
-        preserveState: true,
-      }],
-    ]);
+      },
+    ]]);
   });
 
   it("routes JSONL generic and Spark quota to the account store, never updateSession opts", () => {
     const instances = [];
     const calls = [];
     const quotaCalls = [];
+    const metadataCalls = [];
     const FakeMonitor = makeFakeMonitorClass(instances);
     const runtime = createAgentRuntimeMain({
       loadCodexLogMonitor: () => FakeMonitor,
@@ -243,6 +249,7 @@ describe("agent-runtime-main", () => {
       clearCodexNotifyBubbles: (...args) => calls.push(["clear", ...args]),
       getStateRuntime: () => ({
         updateAccountQuota: (...args) => quotaCalls.push(args),
+        updateSessionMetadata: (...args) => metadataCalls.push(args),
       }),
       codexSubagentClassifier: {},
     });
@@ -271,7 +278,11 @@ describe("agent-runtime-main", () => {
       assert.strictEqual(Object.prototype.hasOwnProperty.call(call[4], "codexQuota"), false);
       assert.strictEqual(Object.prototype.hasOwnProperty.call(call[4], "codexSparkQuota"), false);
     }
-    assert.strictEqual(calls.filter((c) => c[0] === "update").length, 1);
+    assert.strictEqual(calls.filter((c) => c[0] === "update").length, 0);
+    assert.deepStrictEqual(metadataCalls, [[
+      localSessionKey("codex:abc"),
+      { contextUsage: { used: 23959, limit: 258400, percent: 9, source: "codex" } },
+    ]]);
     // Local monitor reports as the local source (null host).
     assert.deepStrictEqual(quotaCalls, [
       [null, { codexQuota, codexSparkQuota }],

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -107,6 +107,16 @@ describe("CodexLogMonitor", () => {
     fs.writeFileSync(testFile, [
       JSON.stringify({ type: "session_meta", payload: { cwd: "/projects/foo", source: "cli" } }),
       JSON.stringify({
+        type: "event_msg",
+        payload: {
+          type: "token_count",
+          info: {
+            last_token_usage: { total_tokens: 24846 },
+            model_context_window: 258400,
+          },
+        },
+      }),
+      JSON.stringify({
         type: "response_item",
         payload: {
           type: "function_call",
@@ -132,6 +142,12 @@ describe("CodexLogMonitor", () => {
     assert.strictEqual(requests.length, 1);
     assert.strictEqual(requests[0][0], EXPECTED_SID);
     assert.strictEqual(requests[0][1].callId, "call_question");
+    assert.deepStrictEqual(requests[0][2].contextUsage, {
+      used: 24846,
+      limit: 258400,
+      percent: 10,
+      source: "codex",
+    });
     assert.strictEqual(requests[0][2].cwd, "/projects/foo");
 
     fs.appendFileSync(testFile, JSON.stringify({

--- a/test/codex-log-monitor.test.js
+++ b/test/codex-log-monitor.test.js
@@ -1856,6 +1856,78 @@ describe("CodexLogMonitor", () => {
     monitor.start();
   });
 
+  it("normalizes, inherits, and clears JSONL turn identity around terminal emission", () => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+      '{"type":"event_msg","payload":{"type":"task_started","turn_id":"  turn-A  "}}',
+      '{"type":"response_item","payload":{"type":"function_call","name":"shell_command"}}',
+      '{"type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-terminal"}}',
+    ].join("\n") + "\n");
+
+    const events = [];
+    let activeDuringTerminal = null;
+    monitor = new CodexLogMonitor(makeConfig(tmpDir), (sid, state, event, extra) => {
+      events.push({ sid, state, event, extra });
+      if (event === "event_msg:task_complete") {
+        activeDuringTerminal = monitor._tracked.get(testFile).activeTurnId;
+      }
+    });
+    monitor._pollFile(testFile, path.basename(testFile));
+
+    assert.strictEqual(events.find((entry) => entry.event === "event_msg:task_started").extra.turnId, "turn-A");
+    assert.strictEqual(events.find((entry) => entry.event === "response_item:function_call").extra.turnId, "turn-A");
+    assert.strictEqual(events.find((entry) => entry.event === "event_msg:task_complete").extra.turnId, "turn-terminal");
+    assert.strictEqual(activeDuringTerminal, "turn-A", "terminal callback must run before tracker clear");
+    assert.strictEqual(monitor._tracked.get(testFile).activeTurnId, null);
+    assert.strictEqual(monitor._tracked.get(testFile).turnBoundaryOpen, false);
+  });
+
+  it("applies skipped historical start and terminal bookkeeping before replay guard", () => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    const oldTimestamp = new Date(Date.now() - 60_000).toISOString();
+    const liveTimestamp = new Date().toISOString();
+    fs.writeFileSync(testFile, [
+      JSON.stringify({ type: "session_meta", timestamp: oldTimestamp, payload: { cwd: "/tmp" } }),
+      JSON.stringify({ type: "event_msg", timestamp: oldTimestamp, payload: { type: "task_started", turn_id: "old-turn" } }),
+      JSON.stringify({ type: "event_msg", timestamp: oldTimestamp, payload: { type: "task_complete", turn_id: "old-turn" } }),
+      JSON.stringify({ type: "response_item", timestamp: liveTimestamp, payload: { type: "function_call", name: "shell_command" } }),
+    ].join("\n") + "\n");
+
+    const events = [];
+    monitor = new CodexLogMonitor(makeConfig(tmpDir), (sid, state, event, extra) => {
+      events.push({ sid, state, event, extra });
+    });
+    monitor._pollFile(testFile, path.basename(testFile));
+
+    assert.deepStrictEqual(events.map((entry) => entry.event), ["response_item:function_call"]);
+    assert.strictEqual(events[0].extra.turnId, undefined);
+    assert.strictEqual(monitor._tracked.get(testFile).activeTurnId, null);
+    assert.strictEqual(monitor._tracked.get(testFile).turnBoundaryOpen, false);
+  });
+
+  it("marks an active-turn backfill snapshot with its recovered turn identity", () => {
+    const testFile = path.join(dateDir, TEST_FILENAME);
+    fs.writeFileSync(testFile, [
+      '{"type":"session_meta","payload":{"cwd":"/tmp"}}',
+      '{"type":"event_msg","payload":{"type":"task_started","turn_id":"turn-backfill"}}',
+    ].join("\n") + "\n");
+    const oldTime = new Date(Date.now() - 10_000);
+    fs.utimesSync(testFile, oldTime, oldTime);
+
+    const events = [];
+    monitor = new CodexLogMonitor(makeConfig(tmpDir), (sid, state, event, extra) => {
+      events.push({ sid, state, event, extra });
+    });
+    monitor._pollFile(testFile, path.basename(testFile));
+
+    assert.strictEqual(events.length, 1);
+    assert.strictEqual(events[0].state, "thinking");
+    assert.strictEqual(events[0].extra.syntheticBackfill, true);
+    assert.strictEqual(events[0].extra.turnBoundaryOpen, true);
+    assert.strictEqual(events[0].extra.turnId, "turn-backfill");
+  });
+
   it("should map function_call to working", (_, done) => {
     const testFile = path.join(dateDir, TEST_FILENAME);
     fs.writeFileSync(testFile, [

--- a/test/codex-turn-fence.test.js
+++ b/test/codex-turn-fence.test.js
@@ -71,8 +71,23 @@ describe("codex turn fence", () => {
     fence.observe(event({ source: "jsonl", event: "event_msg:turn_aborted", state: "idle", turnId: null }));
     assert.strictEqual(fence.observe(event({ turnId: null })).reason, "terminal-latch");
     assert.strictEqual(fence.observe(event({ turnId: "B" })).reason, "terminal-latch");
+    assert.strictEqual(fence.observe(event({
+      source: "jsonl",
+      event: "event_msg:user_message",
+      state: "thinking",
+      turnId: "B",
+    })).reason, "terminal-latch");
     assert.strictEqual(fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: "B" })).accept, true);
     assert.strictEqual(fence.observe(event({ turnId: "B" })).accept, true);
+  });
+
+  it("fails open when no canonical session id is available", () => {
+    const fence = createCodexTurnFence();
+    assert.deepStrictEqual(fence.observe(event({ sessionId: null })), {
+      accept: true,
+      reason: "no-session",
+    });
+    assert.strictEqual(fence.size, 0);
   });
 
   it("does not tombstone an inferred B on a delayed ID-less terminal", () => {
@@ -159,6 +174,45 @@ describe("codex turn fence", () => {
     assert.ok(fence.closedSize <= 2);
     assert.strictEqual(fence.getSnapshot("s1"), null);
     assert.ok(logs.some((line) => line.includes("session-capacity")));
+  });
+
+  it("keeps fallback protection after tombstone eviction until identity becomes ambiguous", () => {
+    const logs = [];
+    const fence = createCodexTurnFence({
+      maxClosedTurns: 1,
+      debugLog: (line) => logs.push(line),
+    });
+    fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: "A" }));
+    fence.observe(event({ event: "Stop", state: "attention", turnId: "A" }));
+    fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: "B" }));
+    fence.observe(event({ event: "Stop", state: "attention", turnId: "B" }));
+
+    assert.deepStrictEqual(fence.getSnapshot("codex:s1").closedTurnIds, ["B"]);
+    assert.ok(logs.some((line) => line.includes("reason=tombstone-capacity")));
+    assert.strictEqual(
+      fence.observe(event({ event: "PostToolUse", state: "working", turnId: "A" })).reason,
+      "terminal-latch"
+    );
+
+    // A real but ID-less start is the bounded-memory ambiguity boundary: it
+    // explicitly reopens lifecycle state without naming a current turn. Once
+    // A's tombstone has been evicted, later work can only fail open.
+    fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: null }));
+    assert.deepStrictEqual(
+      fence.observe(event({ event: "PostToolUse", state: "working", turnId: "A" })),
+      { accept: true, reason: "work" }
+    );
+  });
+
+  it("fails open for a tail whose entire session record was capacity-evicted", () => {
+    const fence = createCodexTurnFence({ maxSessions: 1 });
+    fence.observe(event({ sessionId: "s1", event: "Stop", state: "attention", turnId: "A" }));
+    fence.observe(event({ sessionId: "s2", event: "UserPromptSubmit", state: "thinking", turnId: "B" }));
+    assert.strictEqual(fence.getSnapshot("s1"), null);
+    assert.deepStrictEqual(
+      fence.observe(event({ sessionId: "s1", event: "PostToolUse", state: "working", turnId: "A" })),
+      { accept: true, reason: "work" }
+    );
   });
 });
 

--- a/test/codex-turn-fence.test.js
+++ b/test/codex-turn-fence.test.js
@@ -1,0 +1,198 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const createCodexTurnFence = require("../src/codex-turn-fence");
+const createCodexOfficialActivity = require("../src/codex-official-activity");
+
+function event(overrides = {}) {
+  return {
+    sessionId: "codex:s1",
+    source: "official",
+    event: "PreToolUse",
+    state: "working",
+    turnId: "A",
+    ...overrides,
+  };
+}
+
+describe("codex turn fence", () => {
+  it("drops a same-turn official work tail after Stop", () => {
+    const fence = createCodexTurnFence();
+    assert.strictEqual(fence.observe(event({ event: "UserPromptSubmit", state: "thinking" })).accept, true);
+    assert.strictEqual(fence.observe(event()).accept, true);
+    assert.strictEqual(fence.observe(event({ event: "Stop", state: "attention" })).accept, true);
+    assert.deepStrictEqual(
+      fence.observe(event({ event: "PostToolUse" })),
+      { accept: false, reason: "closed-turn-id" }
+    );
+  });
+
+  it("shares exact identity across JSONL terminal and official tail", () => {
+    const fence = createCodexTurnFence();
+    fence.observe(event({ event: "UserPromptSubmit", state: "thinking" }));
+    assert.strictEqual(fence.observe(event({
+      source: "jsonl",
+      event: "event_msg:turn_aborted",
+      state: "idle",
+    })).accept, true);
+    assert.strictEqual(fence.observe(event({ event: "PostToolUse" })).reason, "closed-turn-id");
+  });
+
+  it("opens B explicitly while retaining A's tombstone", () => {
+    const fence = createCodexTurnFence();
+    fence.observe(event({ event: "Stop", state: "idle" }));
+    assert.strictEqual(fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: "B" })).accept, true);
+    assert.strictEqual(fence.observe(event({ event: "PostToolUse", turnId: "B" })).accept, true);
+    assert.strictEqual(fence.observe(event({ event: "PostToolUse", turnId: "A" })).reason, "closed-turn-id");
+    assert.deepStrictEqual(fence.getSnapshot("codex:s1").closedTurnIds, ["A"]);
+  });
+
+  it("does not let a stale terminal A close active B", () => {
+    const fence = createCodexTurnFence();
+    fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: "B" }));
+    assert.strictEqual(fence.observe(event({ event: "Stop", state: "idle", turnId: "A" })).reason, "stale-terminal");
+    assert.strictEqual(fence.getSnapshot("codex:s1").currentTurnId, "B");
+    assert.strictEqual(fence.observe(event({ event: "PostToolUse", turnId: "B" })).accept, true);
+  });
+
+  it("rejects a delayed explicit start for an already closed turn", () => {
+    const fence = createCodexTurnFence();
+    fence.observe(event({ source: "jsonl", event: "event_msg:turn_aborted", state: "idle" }));
+    assert.strictEqual(
+      fence.observe(event({ event: "UserPromptSubmit", state: "thinking" })).reason,
+      "closed-turn-id"
+    );
+  });
+
+  it("uses an ID-less latch until an explicit start reopens it", () => {
+    const fence = createCodexTurnFence();
+    fence.observe(event({ source: "jsonl", event: "event_msg:turn_aborted", state: "idle", turnId: null }));
+    assert.strictEqual(fence.observe(event({ turnId: null })).reason, "terminal-latch");
+    assert.strictEqual(fence.observe(event({ turnId: "B" })).reason, "terminal-latch");
+    assert.strictEqual(fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: "B" })).accept, true);
+    assert.strictEqual(fence.observe(event({ turnId: "B" })).accept, true);
+  });
+
+  it("does not tombstone an inferred B on a delayed ID-less terminal", () => {
+    const fence = createCodexTurnFence();
+    fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: "B" }));
+    assert.strictEqual(fence.observe(event({ event: "Stop", state: "idle", turnId: null })).accept, true);
+    assert.deepStrictEqual(fence.getSnapshot("codex:s1").closedTurnIds, []);
+    assert.strictEqual(fence.observe(event({ event: "Stop", state: "attention", turnId: "B" })).accept, true);
+    assert.strictEqual(fence.observe(event({ event: "Stop", state: "attention", turnId: "B" })).reason, "duplicate-terminal");
+  });
+
+  it("does not let work replace a different known current turn", () => {
+    const fence = createCodexTurnFence();
+    fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId: "B" }));
+    assert.strictEqual(fence.observe(event({ turnId: "A" })).reason, "unexpected-distinct-work");
+    assert.strictEqual(fence.getSnapshot("codex:s1").currentTurnId, "B");
+  });
+
+  it("keeps consecutive tombstones and makes duplicate terminals idempotent", () => {
+    const fence = createCodexTurnFence();
+    for (const turnId of ["A", "B", "C"]) {
+      fence.observe(event({ event: "UserPromptSubmit", state: "thinking", turnId }));
+      fence.observe(event({ event: "Stop", state: "idle", turnId }));
+    }
+    for (const turnId of ["A", "B", "C"]) {
+      assert.strictEqual(fence.observe(event({ event: "PostToolUse", turnId })).reason, "closed-turn-id");
+      assert.strictEqual(fence.observe(event({ event: "Stop", state: "idle", turnId })).reason, "duplicate-terminal");
+    }
+  });
+
+  it("handles synthetic backfill as an explicit boundary only when it recovered an open ID", () => {
+    const fence = createCodexTurnFence();
+    assert.strictEqual(fence.observe(event({
+      source: "jsonl",
+      event: "response_item:function_call",
+      syntheticBackfill: true,
+      turnBoundaryOpen: true,
+      turnId: "A",
+    })).accept, true);
+    fence.observe(event({ event: "Stop", state: "idle", turnId: "A" }));
+    assert.strictEqual(fence.observe(event({
+      source: "jsonl",
+      event: "response_item:function_call",
+      syntheticBackfill: true,
+      turnBoundaryOpen: true,
+      turnId: "A",
+    })).reason, "closed-turn-id");
+    assert.strictEqual(fence.observe(event({
+      source: "jsonl",
+      event: "response_item:function_call",
+      syntheticBackfill: true,
+      turnBoundaryOpen: false,
+      turnId: null,
+    })).reason, "synthetic-ambiguous");
+    assert.strictEqual(fence.observe(event({
+      source: "jsonl",
+      event: "response_item:function_call",
+      syntheticBackfill: true,
+      turnBoundaryOpen: true,
+      turnId: "B",
+    })).accept, true);
+  });
+
+  it("isolates sessions and clears all lifecycle state explicitly", () => {
+    const fence = createCodexTurnFence();
+    fence.observe(event({ event: "Stop", state: "idle" }));
+    assert.strictEqual(fence.observe(event({ sessionId: "codex:s2", turnId: "A" })).accept, true);
+    fence.clear();
+    assert.strictEqual(fence.size, 0);
+    assert.strictEqual(fence.observe(event()).accept, true);
+  });
+
+  it("bounds session records and global tombstones deterministically", () => {
+    const logs = [];
+    const fence = createCodexTurnFence({
+      maxSessions: 2,
+      maxClosedTurns: 2,
+      debugLog: (line) => logs.push(line),
+    });
+    for (const [sessionId, turnId] of [["s1", "A"], ["s2", "B"], ["s3", "C"]]) {
+      fence.observe(event({ sessionId, event: "Stop", state: "idle", turnId }));
+    }
+    assert.strictEqual(fence.size, 2);
+    assert.ok(fence.closedSize <= 2);
+    assert.strictEqual(fence.getSnapshot("s1"), null);
+    assert.ok(logs.some((line) => line.includes("session-capacity")));
+  });
+});
+
+describe("codex official activity index", () => {
+  it("suppresses exact IDs independently and keeps ID-less fallback conservative", () => {
+    let currentTime = 1000;
+    const activity = createCodexOfficialActivity({ now: () => currentTime });
+    activity.mark("s1", "A");
+    assert.strictEqual(activity.hasRecent("s1", "A"), true);
+    assert.strictEqual(activity.hasRecent("s1", "B"), false);
+    assert.strictEqual(activity.hasRecent("s1", null), true);
+    activity.mark("s1", null);
+    assert.strictEqual(activity.hasRecent("s1", "B"), true);
+  });
+
+  it("expires marks without using them as lifecycle freshness", () => {
+    let currentTime = 0;
+    const activity = createCodexOfficialActivity({ now: () => currentTime, ttlMs: 100 });
+    activity.mark("s1", "A");
+    currentTime = 101;
+    assert.strictEqual(activity.hasRecent("s1", "A"), false);
+    assert.strictEqual(activity.size, 0);
+  });
+
+  it("bounds exact marks per session and session LRU capacity", () => {
+    const activity = createCodexOfficialActivity({ maxExactMarks: 2, maxSessions: 2 });
+    activity.mark("s1", "A");
+    activity.mark("s1", "B");
+    activity.mark("s1", "C");
+    assert.strictEqual(activity.hasRecent("s1", "A"), false);
+    assert.strictEqual(activity.hasRecent("s1", "B"), true);
+    activity.mark("s2", "A");
+    activity.mark("s3", "A");
+    assert.strictEqual(activity.size, 2);
+    assert.strictEqual(activity.getSnapshot("s1"), null);
+  });
+});

--- a/test/codex-turn-id.test.js
+++ b/test/codex-turn-id.test.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  MAX_CODEX_TURN_ID_LENGTH,
+  normalizeCodexTurnId,
+  digestCodexTurnId,
+} = require("../src/codex-turn-id");
+
+describe("codex turn identity", () => {
+  it("normalizes opaque bounded string IDs without interpreting their format", () => {
+    assert.strictEqual(normalizeCodexTurnId("  turn-A  "), "turn-A");
+    assert.strictEqual(normalizeCodexTurnId("x".repeat(MAX_CODEX_TURN_ID_LENGTH)), "x".repeat(MAX_CODEX_TURN_ID_LENGTH));
+    assert.strictEqual(normalizeCodexTurnId(""), null);
+    assert.strictEqual(normalizeCodexTurnId("   "), null);
+    assert.strictEqual(normalizeCodexTurnId(123), null);
+    assert.strictEqual(normalizeCodexTurnId("x".repeat(MAX_CODEX_TURN_ID_LENGTH + 1)), null);
+  });
+
+  it("uses a deterministic privacy-safe digest for diagnostics", () => {
+    const digest = digestCodexTurnId("  turn-A  ");
+    assert.match(digest, /^[a-f0-9]{16}$/);
+    assert.strictEqual(digest, digestCodexTurnId("turn-A"));
+    assert.notStrictEqual(digest, digestCodexTurnId("turn-B"));
+    assert.strictEqual(digestCodexTurnId(null), null);
+  });
+});

--- a/test/server-hook-management.test.js
+++ b/test/server-hook-management.test.js
@@ -1150,7 +1150,7 @@ describe("Codex official hook turn tracking", () => {
       turn_id: "turn-1",
     }, "idle", turns);
 
-    assert.deepStrictEqual(result, { state: "attention", drop: false });
+    assert.deepStrictEqual(result, { state: "attention", drop: false, turnId: "turn-1" });
     assert.strictEqual(turns.size, 0);
   });
 
@@ -1172,7 +1172,7 @@ describe("Codex official hook turn tracking", () => {
       turn_id: "turn-1",
     }, "idle", turns);
 
-    assert.deepStrictEqual(result, { state: "idle", drop: false });
+    assert.deepStrictEqual(result, { state: "idle", drop: false, turnId: "turn-1" });
   });
 
   it("resolves Stop to attention when a no-tool turn has assistant output", () => {
@@ -1194,7 +1194,7 @@ describe("Codex official hook turn tracking", () => {
       assistant_last_output: "Short answer.",
     }, "idle", turns);
 
-    assert.deepStrictEqual(result, { state: "attention", drop: false });
+    assert.deepStrictEqual(result, { state: "attention", drop: false, turnId: "turn-1" });
     assert.strictEqual(turns.size, 0);
   });
 
@@ -1222,7 +1222,7 @@ describe("Codex official hook turn tracking", () => {
       stop_hook_active: true,
     }, "idle", turns);
 
-    assert.deepStrictEqual(result, { state: "idle", drop: true });
+    assert.deepStrictEqual(result, { state: "idle", drop: true, turnId: "turn-1" });
     assert.strictEqual(turns.size, 0);
   });
 
@@ -1258,7 +1258,7 @@ describe("Codex official hook turn tracking", () => {
       codex_session_role: "subagent",
     }, "idle", turns, classifier);
 
-    assert.deepStrictEqual(result, { state: "idle", drop: false, headless: true });
+    assert.deepStrictEqual(result, { state: "idle", drop: false, turnId: "turn-1", headless: true });
     assert.strictEqual(turns.size, 0);
   });
 
@@ -1302,8 +1302,8 @@ describe("Codex official hook turn tracking", () => {
       turn_id: "same-turn",
     }, "idle", turns);
 
-    assert.deepStrictEqual(subStop, { state: "idle", drop: false });
-    assert.deepStrictEqual(rootStop, { state: "attention", drop: false });
+    assert.deepStrictEqual(subStop, { state: "idle", drop: false, turnId: "same-turn" });
+    assert.deepStrictEqual(rootStop, { state: "attention", drop: false, turnId: "same-turn" });
     assert.strictEqual(turns.size, 0);
   });
 
@@ -1355,10 +1355,33 @@ describe("Codex official hook turn tracking", () => {
       codex_session_role: "subagent",
     }, "idle", turns, classifier, a);
 
-    assert.deepStrictEqual(bStop, { state: "idle", drop: false });
-    assert.deepStrictEqual(aStop, { state: "idle", drop: false, headless: true });
+    assert.deepStrictEqual(bStop, { state: "idle", drop: false, turnId: "same-turn" });
+    assert.deepStrictEqual(aStop, { state: "idle", drop: false, turnId: "same-turn", headless: true });
     assert.deepStrictEqual([...roles.keys()].sort(), [a, b].sort());
     assert.strictEqual(turns.size, 0);
+  });
+
+  it("normalizes official turn ids before ledger and runtime propagation", () => {
+    const turns = new Map();
+    const result = resolveCodexOfficialHookState({
+      agent_id: "codex",
+      hook_source: "codex-official",
+      event: "UserPromptSubmit",
+      session_id: "codex:s1",
+      turn_id: "  turn-normalized  ",
+    }, "thinking", turns);
+
+    assert.strictEqual(result.turnId, "turn-normalized");
+    assert.strictEqual(turns.has("codex:s1|turn-normalized"), true);
+
+    const rejected = resolveCodexOfficialHookState({
+      agent_id: "codex",
+      hook_source: "codex-official",
+      event: "UserPromptSubmit",
+      session_id: "codex:s2",
+      turn_id: "x".repeat(257),
+    }, "thinking", turns);
+    assert.strictEqual(rejected.turnId, undefined);
   });
 
   it("prunes the oldest tracked turns when the cap is exceeded", () => {

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -16,6 +16,7 @@ const {
 const { classifyPermissionInteraction } = require("../src/permission-automation-policy");
 const { buildStateBody } = require("../hooks/clawd-hook");
 const { makeSessionKey } = require("../src/session-key");
+const createAgentRuntimeMain = require("../src/agent-runtime-main");
 const localSessionKey = (rawSessionId) => makeSessionKey({
   profileId: "local",
   rawSessionId,
@@ -678,6 +679,98 @@ describe("server-route-state POST", () => {
     assert.strictEqual(res.statusCode, 200);
     assert.strictEqual(res.calls.updateSession[0][1], "attention");
     assert.strictEqual(res.calls.updateSession[0][3].assistantLastOutput, "Short answer.");
+  });
+
+  it("passes only normalized official Codex turn identity to the runtime", async () => {
+    const accepted = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "codex:sid",
+      event: "UserPromptSubmit",
+      agent_id: "codex",
+      hook_source: "codex-official",
+      turn_id: "  turn-A  ",
+    }));
+    assert.strictEqual(accepted.statusCode, 200);
+    assert.strictEqual(accepted.calls.updateSession[0][3].turnId, "turn-A");
+
+    const rejected = await callStatePost(JSON.stringify({
+      state: "working",
+      session_id: "codex:sid",
+      event: "UserPromptSubmit",
+      agent_id: "codex",
+      hook_source: "codex-official",
+      turn_id: "x".repeat(257),
+    }));
+    assert.strictEqual(rejected.statusCode, 200);
+    assert.strictEqual(rejected.calls.updateSession[0][3].turnId, undefined);
+  });
+
+  it("keeps server side effects and HTTP success when the runtime fences a stale official tail", async () => {
+    const updates = [];
+    const sessions = new Map();
+    const runtime = createAgentRuntimeMain({
+      codexSubagentClassifier: {},
+      getStateRuntime: () => ({ sessions }),
+      updateSession: (...args) => updates.push(args),
+    });
+    const turns = new Map();
+    const rawSessionId = "codex:fence-composition";
+    const sessionId = localSessionKey(rawSessionId);
+    const base = {
+      session_id: rawSessionId,
+      agent_id: "codex",
+      hook_source: "codex-official",
+      turn_id: "turn-A",
+    };
+    const post = (body, pendingPermissions = []) => callStatePost(JSON.stringify({ ...base, ...body }), {
+      ctx: {
+        sessions,
+        pendingPermissions,
+        updateSession: (...args) => runtime.updateSessionFromServer(...args),
+      },
+      options: { codexOfficialTurns: turns },
+    });
+
+    assert.strictEqual((await post({ state: "working", event: "UserPromptSubmit" })).statusCode, 200);
+    assert.strictEqual((await post({ state: "attention", event: "Stop" })).statusCode, 200);
+    const pending = {
+      res: {},
+      sessionId,
+      agentId: "codex",
+      subagentId: null,
+      toolName: "shell_command",
+      toolUseId: "tool-1",
+      interaction: classifyPermissionInteraction({ agentId: "codex", toolName: "shell_command" }),
+    };
+    const latePost = await post({
+      state: "working",
+      event: "PostToolUse",
+      tool_name: "shell_command",
+      tool_use_id: "tool-1",
+    }, [pending]);
+
+    assert.strictEqual(latePost.statusCode, 200);
+    assert.strictEqual(latePost.calls.resolved.length, 1, "permission cleanup runs before the runtime fence");
+    assert.deepStrictEqual(updates.map((call) => call[2]), ["UserPromptSubmit", "Stop"]);
+    assert.strictEqual(turns.size, 1, "late Post may recreate the bounded server ledger entry");
+
+    const duplicateStop = await post({ state: "attention", event: "Stop" });
+    assert.strictEqual(duplicateStop.statusCode, 200);
+    assert.deepStrictEqual(updates.map((call) => call[2]), ["UserPromptSubmit", "Stop"]);
+    assert.strictEqual(turns.size, 0, "duplicate Stop still clears the upstream server ledger");
+
+    const vetoed = await callStatePost(JSON.stringify({
+      ...base,
+      session_id: "codex:vetoed",
+      event: "Stop",
+      state: "idle",
+      stop_hook_active: true,
+    }), {
+      ctx: { updateSession: (...args) => runtime.updateSessionFromServer(...args) },
+      options: { codexOfficialTurns: turns },
+    });
+    assert.strictEqual(vetoed.statusCode, 204);
+    assert.strictEqual(runtime.getCodexTurnFenceSnapshot(localSessionKey("codex:vetoed")), null);
   });
 
   it("normalizes and passes stdin_diag to updateSession (#583)", async () => {

--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -338,6 +338,24 @@ describe("state stale cleanup decisions", () => {
     assert.deepStrictEqual(result, { action: "idle", reason: "session-timeout", updateTimestamp: false });
   });
 
+  it("ignores fresh metadataUpdatedAt when lifecycle updatedAt crossed the Codex floor", () => {
+    const now = 2000000;
+    const lifecycleAt = now - CODEX_LOCAL_WORKING_STALE_FLOOR_MS - 1;
+    const { result } = decision(session({
+      state: "working",
+      agentId: "codex",
+      updatedAt: lifecycleAt,
+      metadataUpdatedAt: now,
+      agentPid: 10,
+      sourcePid: 20,
+    }), {
+      now,
+      alivePids: new Set([10, 20]),
+    });
+
+    assert.deepStrictEqual(result, { action: "idle", reason: "session-timeout", updateTimestamp: false });
+  });
+
   it("does not extend remote Codex working sessions", () => {
     const { result } = decision(session({
       state: "working",

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -2045,6 +2045,67 @@ describe("updateSession()", () => {
     assert.strictEqual(api.getCurrentState(), "idle");
   });
 
+  it("presents a later attention Stop when an earlier ID-less Stop only idled the session", () => {
+    const soundsPlayed = [];
+    const stateChanges = [];
+    api.cleanup();
+    ctx = makeCtx({
+      processKill: () => true,
+      playSound: (name) => soundsPlayed.push(name),
+      sendToRenderer: (channel, state) => {
+        if (channel === "state-change") stateChanges.push(state);
+      },
+    });
+    api = require("../src/state")(ctx);
+
+    update(api, {
+      id: "codex:s1",
+      state: "thinking",
+      event: "UserPromptSubmit",
+      agentId: "codex",
+    });
+    mock.timers.tick(1000);
+    stateChanges.length = 0;
+
+    // A terminal without identity may resolve idle because the server cannot
+    // associate it with the turn's tool ledger. It closes lifecycle state but
+    // has not presented completion UX yet.
+    update(api, {
+      id: "codex:s1",
+      state: "idle",
+      event: "Stop",
+      agentId: "codex",
+    });
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 0);
+    stateChanges.length = 0;
+
+    // The later ID-bearing Stop is authoritative and resolves attention. It
+    // must upgrade the existing completion tail and celebrate exactly once.
+    update(api, {
+      id: "codex:s1",
+      state: "attention",
+      event: "Stop",
+      agentId: "codex",
+    });
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 1);
+    assert.deepStrictEqual(stateChanges, ["attention"]);
+    const completionEvents = api.sessions.get("codex:s1").recentEvents.filter((entry) => entry.event === "Stop");
+    assert.strictEqual(completionEvents.length, 1);
+    assert.strictEqual(completionEvents[0].state, "attention");
+
+    mock.timers.tick(4000);
+    soundsPlayed.length = 0;
+    stateChanges.length = 0;
+    update(api, {
+      id: "codex:s1",
+      state: "attention",
+      event: "Stop",
+      agentId: "codex",
+    });
+    assert.strictEqual(soundsPlayed.filter((name) => name === "complete").length, 0);
+    assert.ok(!stateChanges.includes("attention"));
+  });
+
   it("Codex Stop followed by token_count and task_complete still auto-returns from attention", () => {
     const soundsPlayed = [];
     const stateChanges = [];


### PR DESCRIPTION
## Summary

- separate Codex JSONL context telemetry from lifecycle liveness so token-count refreshes cannot create sessions or postpone stale cleanup
- normalize and propagate opaque turn IDs across official hooks and JSONL, then arbitrate them with a bounded ID-first terminal fence
- make official-hook suppression turn-aware, preserve exact closed-turn tombstones, and retain conservative ID-less compatibility
- preserve restart recovery through active-turn synthetic backfill while keeping Remote SSH behavior unchanged
- distinguish an idle-only terminal from a completion cue already presented, so a later ID-bearing Stop can celebrate exactly once

## Review follow-up

- added real `agent-runtime -> state` composition coverage for exactly-once completion
- added real metadata/liveness composition coverage through the 20-minute stale floor and next lifecycle recovery
- added explicit `user_message`, no-session, tombstone-capacity, and session-capacity fence cases
- fixed the ID-less idle Stop -> ID-bearing attention Stop zero-celebration edge case
- checked in a privacy-safe cross-channel capture and an honest manual-matrix record

## Validation

- `npm test` — 7,117 tests, 7,086 passed, 31 skipped, 0 failed
- `npm run verify:electron` — Electron 41.10.2 verified
- focused Issue #821 regression matrix — 595 passed, 0 failed
- real Windows Codex CLI 0.147.0 capture:
  - official and JSONL start/terminal digests matched for the same real turn
  - an injected terminal boundary rejected a real late `PostToolUse` with `reason=closed-turn-id`
  - the next real `UserPromptSubmit` reopened the same session immediately
- sanitized evidence and the passed/not-run matrix: [issue-821-windows-validation.md](https://github.com/rullerzhou-afk/clawd-on-desk/blob/3ad6dad0/docs/investigations/issue-821-windows-validation.md)

## Scope and rollback

- local Codex lifecycle only; Remote SSH bypasses the fence
- metadata/liveness separation, lifecycle fencing, and completion-UX follow-up are separate commits for independent rollback

## Issue status

The captured producer was Windows Codex CLI (`originator=codex-tui`), not ChatGPT Desktop. The reporter platform and the remaining Desktop manual matrix are still unconfirmed, so this PR references #821 without auto-closing it. Reporter-side confirmation remains the closure gate from Draft v4 section 10.2.

Refs #821