### PR TITLE
fix(windows): cache Koffi bindings per registry

### DIFF
--- a/src/win-process-ancestry.js
+++ b/src/win-process-ancestry.js
@@ -12,8 +12,8 @@ const MAX_PATH = 260;
 const ERROR_BAD_LENGTH = 24;
 const ERROR_NO_MORE_FILES = 18;
 const DEFAULT_TOOLHELP_RETRIES = 3;
-let defaultProcessQueryFfi = null;
-let defaultToolhelpFfi = null;
+const processQueryFfiByKoffi = new WeakMap();
+const toolhelpFfiByKoffi = new WeakMap();
 
 function normalizePid(value) {
   let numeric = value;
@@ -177,6 +177,14 @@ function buildToolhelpKoffiFfi(koffi) {
   };
 }
 
+function getOrCreateKoffiBindings(cache, koffi, build) {
+  const cached = cache.get(koffi);
+  if (cached) return cached;
+  const ffi = build(koffi);
+  cache.set(koffi, ffi);
+  return ffi;
+}
+
 function expectedProcessQueryAbi(pointerSize) {
   if (pointerSize === 8) {
     return {
@@ -304,11 +312,11 @@ function createWindowsToolhelpSnapshot(options = {}) {
   let ffi;
   try {
     if (options.ffi) ffi = options.ffi;
-    else if (options.koffi) ffi = buildToolhelpKoffiFfi(options.koffi);
-    else {
-      if (!defaultToolhelpFfi) defaultToolhelpFfi = buildToolhelpKoffiFfi(require("koffi"));
-      ffi = defaultToolhelpFfi;
-    }
+    else ffi = getOrCreateKoffiBindings(
+      toolhelpFfiByKoffi,
+      options.koffi || require("koffi"),
+      buildToolhelpKoffiFfi,
+    );
   } catch (err) {
     if (typeof options.onInitError === "function") options.onInitError(err);
     return { status: "unavailable", reason: "ffi-unavailable", query: null, close() {}, abi: null };
@@ -450,16 +458,15 @@ function createWindowsProcessQuery(options = {}) {
   try {
     if (options.ffi) {
       ffi = options.ffi;
-    } else if (options.koffi) {
-      // Explicit injection remains isolated: callers using a test/dedicated
-      // Koffi instance must not inherit the production module cache.
-      ffi = buildKoffiFfi(options.koffi);
     } else {
-      // Koffi named structs are process-global. Re-registering them on a
-      // second server/resolver construction throws a duplicate-type error,
-      // so the production bindings are built once and reused.
-      if (!defaultProcessQueryFfi) defaultProcessQueryFfi = buildKoffiFfi(require("koffi"));
-      ffi = defaultProcessQueryFfi;
+      // Koffi named structs are scoped to the Koffi registry object. Reuse
+      // bindings for the same default or explicitly injected registry while
+      // keeping different test/dedicated registries isolated.
+      ffi = getOrCreateKoffiBindings(
+        processQueryFfiByKoffi,
+        options.koffi || require("koffi"),
+        buildKoffiFfi,
+      );
     }
   } catch (err) {
     if (typeof options.onInitError === "function") options.onInitError(err);

--- a/test/win-process-ancestry.test.js
+++ b/test/win-process-ancestry.test.js
@@ -128,21 +128,49 @@ describe("win-process-ancestry", () => {
     });
   });
 
-  it("reuses the default Koffi bindings across consecutive process-query factories", {
+  it("reuses per-instance Koffi bindings across explicit and default process-query factories", {
     skip: process.platform !== "win32",
   }, () => {
-    const first = createWindowsProcessQuery();
-    const second = createWindowsProcessQuery();
+    const koffi = require("koffi");
+    const explicitFirst = createWindowsProcessQuery({ koffi });
+    const explicitSecond = createWindowsProcessQuery({ koffi });
+    const defaultFirst = createWindowsProcessQuery();
+    const defaultSecond = createWindowsProcessQuery();
 
-    assert.strictEqual(first.available, true);
-    assert.strictEqual(second.available, true);
-    for (const query of [first, second]) {
+    for (const query of [explicitFirst, explicitSecond, defaultFirst, defaultSecond]) {
+      assert.strictEqual(query.available, true);
       const result = query(process.pid);
       assert.strictEqual(result.status, "ok");
       assert.strictEqual(result.pid, process.pid);
       assert.ok(result.parentPid > 0);
       assert.ok(result.name.endsWith(".exe"));
       assert.ok(result.creationTime);
+    }
+  });
+
+  it("reuses per-instance Koffi bindings across explicit and default Toolhelp factories", {
+    skip: process.platform !== "win32",
+  }, () => {
+    const koffi = require("koffi");
+    const snapshots = [
+      createWindowsToolhelpSnapshot({ koffi }),
+      createWindowsToolhelpSnapshot({ koffi }),
+      createWindowsToolhelpSnapshot(),
+      createWindowsToolhelpSnapshot(),
+    ];
+
+    try {
+      for (const snapshot of snapshots) {
+        assert.strictEqual(snapshot.status, "ok");
+        const result = snapshot.query(process.pid);
+        assert.strictEqual(result.status, "ok");
+        assert.strictEqual(result.pid, process.pid);
+        assert.ok(result.parentPid > 0);
+        assert.ok(result.name.endsWith(".exe"));
+        assert.ok(result.creationTime);
+      }
+    } finally {
+      for (const snapshot of snapshots) snapshot.close();
     }
   });
 


### PR DESCRIPTION
## Summary

- cache process-query and Toolhelp bindings by Koffi registry instance with WeakMap
- make repeated explicit options.koffi construction reentrant while keeping distinct registries isolated
- preserve the direct options.ffi bypass
- exercise explicit and default factories together against real Windows Koffi bindings

This closes the only non-blocking follow-up identified during the final review of #839.

## Validation

- node --test test/win-process-ancestry.test.js (14/14 pass)
- npm test (7202 total, 7171 pass, 0 fail, 31 skip)
- git diff --check