### PR TITLE
fix(opencode): show real session title in HUD and update it after OpenCode renames the session

### DIFF
--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -250,6 +250,9 @@ export function createOpencodeFamilyPlugin(config) {
   // Authoritative session directory learned from session lifecycle info.
   // Shared by every directory handler returned from this factory product.
   const _sessionDirectoryById = new Map();
+  // Authoritative session title learned from session lifecycle info.
+  // Shared by every handler returned from this factory product.
+  const _sessionTitleById = new Map();
   // Compatibility latch: old hosts that never emit info.directory keep the
   // latest-init fallback. Once this host proves it emits bindable session info,
   // a map miss omits cwd rather than forwarding a potentially stale directory.
@@ -466,17 +469,47 @@ export function createOpencodeFamilyPlugin(config) {
     return { directory: null, source: "none" };
   }
 
+  function captureSessionTitle(event) {
+    if (!event) return null;
+    switch (event.type) {
+      case "session.created":
+      case "session.updated":
+        break;
+      default:
+        return null;
+    }
+
+    const metadata = getEventSessionInfo(event);
+    const eventSessionId = normalizeSessionId(metadata.eventSessionId);
+    const infoSessionId = normalizeSessionId(metadata.infoSessionId);
+    if (eventSessionId && infoSessionId && eventSessionId !== infoSessionId) {
+      return null;
+    }
+
+    const sessionId = infoSessionId || eventSessionId;
+    if (!sessionId) return null;
+    if (!metadata.title) return null;
+
+    _sessionTitleById.set(sessionId, metadata.title);
+    debugLog(`SESSION_TITLE capture session=${sessionId} title="${metadata.title}"`);
+    return sessionId;
+  }
+
   function cleanupSessionDirectory(event, phase) {
     if (!event || typeof event.type !== "string") return;
 
     if (event.type === "server.instance.disposed" && phase === "before-send") {
       _sessionDirectoryById.clear();
+      _sessionTitleById.clear();
       return;
     }
 
     if (event.type === "session.deleted" && phase === "after-send") {
       const normalized = normalizeSessionId(getEventSessionId(event));
-      if (normalized) _sessionDirectoryById.delete(normalized);
+      if (normalized) {
+        _sessionDirectoryById.delete(normalized);
+        _sessionTitleById.delete(normalized);
+      }
     }
   }
 
@@ -573,6 +606,13 @@ export function createOpencodeFamilyPlugin(config) {
     if (isChildSessionId(clawdSessionId, _sessionParentById)) {
       body.headless = true;
     }
+    // Session title from OpenCode's own session-info title field. Mirrors the
+    // pattern used by other agents (clawd-hook, workbuddy-hook) that
+    // include session_title in their state POST body. The server reads
+    // this and stores it as sessionTitle, which sessionDisplayTitle()
+    // then uses before falling back to path.basename(cwd).
+    const sessionTitle = _sessionTitleById.get(clawdSessionId);
+    if (sessionTitle) body.session_title = sessionTitle;
     return body;
   }
 
@@ -675,10 +715,12 @@ export function createOpencodeFamilyPlugin(config) {
     buildStateBody,
     translateEvent,
     captureSessionDirectory,
+    captureSessionTitle,
     resolveSessionDirectory,
     cleanupSessionDirectory,
     get _sessionParentById() { return _sessionParentById; },
     get _sessionDirectoryById() { return _sessionDirectoryById; },
+    get _sessionTitleById() { return _sessionTitleById; },
     get _hostEmitsSessionInfo() { return _hostEmitsSessionInfo; },
     get _rootSessionId() { return _rootSessionId; },
     set _rootSessionId(v) { _rootSessionId = v; },
@@ -879,6 +921,7 @@ export function createOpencodeFamilyPlugin(config) {
           // not map to a Clawd state and info-only deleted events need its id.
           cleanupSessionDirectory(event, "before-send");
           captureSessionDirectory(event);
+          captureSessionTitle(event);
 
           if (sid && !_rootSessionId) {
             _rootSessionId = sid;

--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -502,7 +502,9 @@ export function createOpencodeFamilyPlugin(config) {
     // harmless — and it covers the "created with no title, titled later" case.
     if (prevTitle !== metadata.title) {
       _sessionTitleById.set(sessionId, metadata.title);
-      debugLog(`SESSION_TITLE capture session=${sessionId} title="${metadata.title}"` + (prevTitle ? ` (was "${prevTitle}")` : ""));
+      // Log only non-content metadata: the title is user/LLM-derived and
+      // embedded control chars/newlines could forge diagnostic log lines.
+      debugLog(`SESSION_TITLE session=${sessionId} changed=true len=${metadata.title.length}`);
       const body = {
         state: "idle",
         session_id: sessionId,

--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -490,8 +490,30 @@ export function createOpencodeFamilyPlugin(config) {
     if (!sessionId) return null;
     if (!metadata.title) return null;
 
-    _sessionTitleById.set(sessionId, metadata.title);
-    debugLog(`SESSION_TITLE capture session=${sessionId} title="${metadata.title}"`);
+    const prevTitle = _sessionTitleById.get(sessionId);
+    // OpenCode assigns a placeholder title ("New session") at creation and
+    // later replaces it with the real summary-based title via session.updated.
+    // That event maps to no Clawd state, so without an explicit push the HUD
+    // keeps showing the placeholder forever. Forward a title change as a
+    // metadata-only POST — the server updates sessionTitle without disturbing
+    // the lifecycle state (mirrors how clawd-hook statusline refreshes work).
+    // If no session exists yet the server drops the metadata POST safely
+    // (metadata-only never creates a session), so the first redundant push is
+    // harmless — and it covers the "created with no title, titled later" case.
+    if (prevTitle !== metadata.title) {
+      _sessionTitleById.set(sessionId, metadata.title);
+      debugLog(`SESSION_TITLE capture session=${sessionId} title="${metadata.title}"` + (prevTitle ? ` (was "${prevTitle}")` : ""));
+      const body = {
+        state: "idle",
+        session_id: sessionId,
+        event: "SessionUpdate",
+        agent_id: AGENT_ID,
+        hook_source: HOOK_SOURCE,
+        metadata_only: true,
+        session_title: metadata.title,
+      };
+      postStateToClawd(body);
+    }
     return sessionId;
   }
 

--- a/hooks/opencode-family-plugin/session-ids.mjs
+++ b/hooks/opencode-family-plugin/session-ids.mjs
@@ -21,6 +21,26 @@ function normalizeSessionText(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
+// Bound + sanitize a session title before storage or transport. Mirrors the
+// normalizeTitle in hooks/clawd-hook.js and src/state-session-snapshot.js:
+// collapse control chars and whitespace, cap at 80 chars (with a trailing
+// ellipsis). A 17k-char title would otherwise blow the 16 KiB /state body
+// cap, trigger a headerless 413, and make the plugin distrust the response
+// and rescan all five ports on every event (#841 review).
+const SESSION_TITLE_CONTROL_RE = /[\u0000-\u001F\u007F-\u009F]+/g;
+const SESSION_TITLE_MAX = 80;
+function normalizeTitle(value) {
+  if (typeof value !== "string") return null;
+  const collapsed = value
+    .replace(SESSION_TITLE_CONTROL_RE, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!collapsed) return null;
+  return collapsed.length > SESSION_TITLE_MAX
+    ? `${collapsed.slice(0, SESSION_TITLE_MAX - 1)}…`
+    : collapsed;
+}
+
 export function getEventSessionInfo(event) {
   const empty = {
     eventSessionId: null,
@@ -35,12 +55,12 @@ export function getEventSessionInfo(event) {
   const info = props.info && typeof props.info === "object" && !Array.isArray(props.info)
     ? props.info
     : {};
+  // directory is intentionally left un-normalized: the upstream text is
+  // authoritative and tests assert byte-identical passthrough.
   const directory = typeof info.directory === "string" && info.directory.trim()
     ? info.directory
     : null;
-  const title = typeof info.title === "string" && info.title.trim()
-    ? info.title.trim()
-    : null;
+  const title = normalizeTitle(info.title);
   return {
     eventSessionId: normalizeSessionText(props.sessionID) || normalizeSessionText(event.sessionID),
     infoSessionId: normalizeSessionText(info.id),

--- a/hooks/opencode-family-plugin/session-ids.mjs
+++ b/hooks/opencode-family-plugin/session-ids.mjs
@@ -26,6 +26,7 @@ export function getEventSessionInfo(event) {
     eventSessionId: null,
     infoSessionId: null,
     directory: null,
+    title: null,
   };
   if (!event || typeof event !== "object") return empty;
   const props = event.properties && typeof event.properties === "object"
@@ -37,10 +38,14 @@ export function getEventSessionInfo(event) {
   const directory = typeof info.directory === "string" && info.directory.trim()
     ? info.directory
     : null;
+  const title = typeof info.title === "string" && info.title.trim()
+    ? info.title.trim()
+    : null;
   return {
     eventSessionId: normalizeSessionText(props.sessionID) || normalizeSessionText(event.sessionID),
     infoSessionId: normalizeSessionText(info.id),
     directory,
+    title,
   };
 }
 

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -436,17 +436,25 @@ function handleStatePost(req, res, options) {
         // hook events the diagnostics exist to show. 204 either way — the
         // statusline script never reads the response, and "session unknown"
         // is the designed drop, not an error.
-        if (
-          contextUsage
-          && localClaudeStatuslineMetadataAllowed
-          && typeof ctx.updateSessionMetadata === "function"
-        ) {
-          ctx.updateSessionMetadata(session_id || "default", {
-            contextUsage,
-            contextUsageOrigin: agentId === "claude-code" && contextUsage.source === "claude"
+        if (typeof ctx.updateSessionMetadata === "function") {
+          const metaUpdate = {};
+          if (
+            contextUsage
+            && localClaudeStatuslineMetadataAllowed
+          ) {
+            metaUpdate.contextUsage = contextUsage;
+            metaUpdate.contextUsageOrigin = agentId === "claude-code" && contextUsage.source === "claude"
               ? "claude-statusline"
-              : null,
-          });
+              : null;
+          }
+          // OpenCode title changes ride the same metadata-only channel (the
+          // placeholder → real title swap arrives on session.updated, which
+          // maps to no Clawd state). Not gated on the Claude telemetry flag —
+          // it's not Claude statusline data.
+          if (sessionTitle) metaUpdate.sessionTitle = sessionTitle;
+          if (Object.keys(metaUpdate).length > 0) {
+            ctx.updateSessionMetadata(session_id || "default", metaUpdate);
+          }
         }
         res.writeHead(204, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
         res.end();

--- a/src/state.js
+++ b/src/state.js
@@ -1293,25 +1293,41 @@ function updateSessionMetadata(sessionId, opts = {}) {
     return false;
   }
   const incomingContextUsage = normalizeContextUsage(opts.contextUsage);
-  if (!incomingContextUsage) return false;
-  const resolved = resolveContextUsageUpdate(
-    session,
-    incomingContextUsage,
-    opts.contextUsageOrigin
-  );
-  const usageChanged = JSON.stringify(resolved.contextUsage) !== JSON.stringify(session.contextUsage);
-  const originChanged = resolved.contextUsageOrigin !== normalizeContextUsageOrigin(session.contextUsageOrigin);
-  if (usageChanged || originChanged) {
-    session.contextUsage = resolved.contextUsage;
-    session.contextUsageOrigin = resolved.contextUsageOrigin;
-    // Freshness stamp for telemetry arbitration. Deliberately a separate
-    // field from updatedAt: staleness sweeps, badge derivation and eviction
-    // all key on updatedAt, and a statusline heartbeat must not feed them.
-    // Stamped only on real changes, so it cannot re-introduce a per-tick
-    // broadcast (and it is excluded from the snapshot signature anyway).
-    session.metadataUpdatedAt = Date.now();
-    emitSessionSnapshot();
+  const incomingTitle = typeof opts.sessionTitle === "string"
+    ? normalizeTitle(opts.sessionTitle)
+    : null;
+  if (!incomingContextUsage && !incomingTitle) return false;
+  let applied = false;
+  if (incomingContextUsage) {
+    const resolved = resolveContextUsageUpdate(
+      session,
+      incomingContextUsage,
+      opts.contextUsageOrigin
+    );
+    const usageChanged = JSON.stringify(resolved.contextUsage) !== JSON.stringify(session.contextUsage);
+    const originChanged = resolved.contextUsageOrigin !== normalizeContextUsageOrigin(session.contextUsageOrigin);
+    if (usageChanged || originChanged) {
+      session.contextUsage = resolved.contextUsage;
+      session.contextUsageOrigin = resolved.contextUsageOrigin;
+      // Freshness stamp for telemetry arbitration. Deliberately a separate
+      // field from updatedAt: staleness sweeps, badge derivation and eviction
+      // all key on updatedAt, and a statusline heartbeat must not feed them.
+      // Stamped only on real changes, so it cannot re-introduce a per-tick
+      // broadcast (and it is excluded from the snapshot signature anyway).
+      session.metadataUpdatedAt = Date.now();
+      applied = true;
+    }
   }
+  // OpenCode swaps its placeholder title for a real one after session
+  // creation; that arrives on session.updated which maps to no state change,
+  // so the plugin forwards the title change as a metadata-only POST. Update
+  // the stored title here without touching the lifecycle state.
+  if (incomingTitle && incomingTitle !== session.sessionTitle) {
+    session.sessionTitle = incomingTitle;
+    session.metadataUpdatedAt = Date.now();
+    applied = true;
+  }
+  if (applied) emitSessionSnapshot();
   return true;
 }
 

--- a/src/state.js
+++ b/src/state.js
@@ -1321,10 +1321,13 @@ function updateSessionMetadata(sessionId, opts = {}) {
   // OpenCode swaps its placeholder title for a real one after session
   // creation; that arrives on session.updated which maps to no state change,
   // so the plugin forwards the title change as a metadata-only POST. Update
-  // the stored title here without touching the lifecycle state.
+  // the stored title here without touching the lifecycle state. Deliberately
+  // NOT stamping metadataUpdatedAt: that field is context/quota telemetry
+  // freshness, and a rename must not make stale telemetry look fresh. The
+  // title broadcasts anyway - sessionTitle/displayTitle are in the snapshot
+  // signature, so emitSessionSnapshot below fans it out.
   if (incomingTitle && incomingTitle !== session.sessionTitle) {
     session.sessionTitle = incomingTitle;
-    session.metadataUpdatedAt = Date.now();
     applied = true;
   }
   if (applied) emitSessionSnapshot();

--- a/test/opencode-family-core.test.js
+++ b/test/opencode-family-core.test.js
@@ -93,6 +93,30 @@ describe("opencode-family plugin factory", () => {
     oc.__test._sessionParentById.clear();
   });
 
+  it("captures session titles per instance and includes them in buildStateBody", async () => {
+    const { createOpencodeFamilyPlugin } = await loadCore();
+    const oc = createOpencodeFamilyPlugin(OPENCODE_PARAMS);
+    const mc = createOpencodeFamilyPlugin(MIMOCODE_PARAMS);
+
+    oc.__test.captureSessionTitle({
+      type: "session.created",
+      properties: { sessionID: "ses_t", info: { id: "ses_t", directory: "C:\\p", title: "My Title" } },
+    });
+    assert.strictEqual(oc.__test._sessionTitleById.get("opencode:ses_t"), "My Title");
+    assert.strictEqual(mc.__test._sessionTitleById.get("opencode:ses_t"), undefined, "title must not leak across instances");
+
+    // buildStateBody attaches the captured title as session_title.
+    const body = oc.__test.buildStateBody("idle", "SessionStart", "ses_t");
+    assert.strictEqual(body.session_title, "My Title");
+
+    // Missing / blank title is ignored and not captured.
+    oc.__test.captureSessionTitle({
+      type: "session.created",
+      properties: { sessionID: "ses_blank", info: { id: "ses_blank", directory: "C:\\p", title: "   " } },
+    });
+    assert.strictEqual(oc.__test._sessionTitleById.has("opencode:ses_blank"), false);
+  });
+
   it("isolates the FULL per-instance state bag (log path, dedup, port cache, bridge)", async () => {
     const { createOpencodeFamilyPlugin } = await loadCore();
     const oc = createOpencodeFamilyPlugin(OPENCODE_PARAMS);

--- a/test/opencode-family-core.test.js
+++ b/test/opencode-family-core.test.js
@@ -93,30 +93,6 @@ describe("opencode-family plugin factory", () => {
     oc.__test._sessionParentById.clear();
   });
 
-  it("captures session titles per instance and includes them in buildStateBody", async () => {
-    const { createOpencodeFamilyPlugin } = await loadCore();
-    const oc = createOpencodeFamilyPlugin(OPENCODE_PARAMS);
-    const mc = createOpencodeFamilyPlugin(MIMOCODE_PARAMS);
-
-    oc.__test.captureSessionTitle({
-      type: "session.created",
-      properties: { sessionID: "ses_t", info: { id: "ses_t", directory: "C:\\p", title: "My Title" } },
-    });
-    assert.strictEqual(oc.__test._sessionTitleById.get("opencode:ses_t"), "My Title");
-    assert.strictEqual(mc.__test._sessionTitleById.get("opencode:ses_t"), undefined, "title must not leak across instances");
-
-    // buildStateBody attaches the captured title as session_title.
-    const body = oc.__test.buildStateBody("idle", "SessionStart", "ses_t");
-    assert.strictEqual(body.session_title, "My Title");
-
-    // Missing / blank title is ignored and not captured.
-    oc.__test.captureSessionTitle({
-      type: "session.created",
-      properties: { sessionID: "ses_blank", info: { id: "ses_blank", directory: "C:\\p", title: "   " } },
-    });
-    assert.strictEqual(oc.__test._sessionTitleById.has("opencode:ses_blank"), false);
-  });
-
   it("isolates the FULL per-instance state bag (log path, dedup, port cache, bridge)", async () => {
     const { createOpencodeFamilyPlugin } = await loadCore();
     const oc = createOpencodeFamilyPlugin(OPENCODE_PARAMS);

--- a/test/opencode-family-session-directory.test.js
+++ b/test/opencode-family-session-directory.test.js
@@ -384,3 +384,212 @@ describe("opencode-family session directory ownership (#796)", () => {
     assert.strictEqual(legacyPost.body.cwd, "C:\\project-b");
   });
 });
+
+describe("opencode-family session title (#829)", () => {
+  it("forwards a title change as a metadata-only POST and includes it in later state bodies", async () => {
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
+    const hooks = await plugin(createContext("C:\\proj"));
+
+    // session.created with a placeholder title -> captured, but no prior title
+    // so no metadata push yet (the first state POST carries it instead).
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_t",
+          info: { id: "ses_t", directory: "C:\\proj", title: "New session - 2026" },
+        },
+      },
+    });
+    await settlePosts();
+    assert.strictEqual(plugin.__test._sessionTitleById.get("opencode:ses_t"), "New session - 2026");
+
+    // The lifecycle POSTs from session.created carry the captured title.
+    const createdPost = fetchCalls.find((c) => c.url.endsWith("/state") && c.body && c.body.event === "SessionStart");
+    assert.ok(createdPost, "SessionStart POST missing");
+    assert.strictEqual(createdPost.body.session_title, "New session - 2026");
+
+    // session.updated swaps in the real title -> metadata-only push.
+    fetchCalls.length = 0;
+    await hooks.event({
+      event: {
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_t",
+          info: { id: "ses_t", directory: "C:\\proj", title: "轻松问候" },
+        },
+      },
+    });
+    await settlePosts();
+
+    assert.strictEqual(plugin.__test._sessionTitleById.get("opencode:ses_t"), "轻松问候");
+    const metaPost = fetchCalls.find((c) => c.url.endsWith("/state") && c.body && c.body.metadata_only === true);
+    assert.ok(metaPost, "expected a metadata-only POST for the title change");
+    // postToClawd enriches the body with process-tree fields (agent_pid, cwd,
+    // pid_chain, ...) - assert only the title-push contract, not the full body.
+    assert.strictEqual(metaPost.body.state, "idle");
+    assert.strictEqual(metaPost.body.session_id, "opencode:ses_t");
+    assert.strictEqual(metaPost.body.event, "SessionUpdate");
+    assert.strictEqual(metaPost.body.agent_id, "opencode");
+    assert.strictEqual(metaPost.body.hook_source, "opencode-plugin");
+    assert.strictEqual(metaPost.body.metadata_only, true);
+    assert.strictEqual(metaPost.body.session_title, "轻松问候");
+  });
+
+  it("does not POST when the title is unchanged and a blank title is ignored", async () => {
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
+    const hooks = await plugin(createContext("C:\\proj"));
+
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_d",
+          info: { id: "ses_d", directory: "C:\\proj", title: "Stable Title" },
+        },
+      },
+    });
+    await settlePosts();
+    fetchCalls.length = 0;
+
+    // Same title -> no fetch at all.
+    await hooks.event({
+      event: {
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_d",
+          info: { id: "ses_d", directory: "C:\\proj", title: "Stable Title" },
+        },
+      },
+    });
+    await settlePosts();
+    assert.strictEqual(fetchCalls.length, 0, "no POST expected for an unchanged title");
+
+    // Blank title -> ignored, no capture, no POST.
+    await hooks.event({
+      event: {
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_d",
+          info: { id: "ses_d", directory: "C:\\proj", title: "   " },
+        },
+      },
+    });
+    await settlePosts();
+    assert.strictEqual(fetchCalls.length, 0, "no POST expected for a blank title");
+    assert.strictEqual(plugin.__test._sessionTitleById.get("opencode:ses_d"), "Stable Title");
+  });
+
+  it("normalizes and bounds the title before storing or sending it", async () => {
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
+    const hooks = await plugin(createContext("C:\\proj"));
+
+    const longTitle = "A".repeat(200);
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_n",
+          info: { id: "ses_n", directory: "C:\\proj", title: `  messy\t\n${longTitle}  ` },
+        },
+      },
+    });
+    await settlePosts();
+
+    // Control chars collapse to single spaces, leading/trailing trimmed,
+    // capped at 80 chars with a trailing ellipsis. "messy " is 6 chars, so
+    // the A run is 79 - 6 = 73 chars before the ellipsis.
+    const stored = plugin.__test._sessionTitleById.get("opencode:ses_n");
+    assert.ok(stored.length <= 80, `stored title must be <= 80 chars, got ${stored.length}`);
+    assert.ok(stored.endsWith("…"));
+    assert.strictEqual(stored, `messy ${"A".repeat(73)}…`);
+
+    // The metadata-only body for a later change is also bounded.
+    fetchCalls.length = 0;
+    await hooks.event({
+      event: {
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_n",
+          info: { id: "ses_n", directory: "C:\\proj", title: "B".repeat(300) },
+        },
+      },
+    });
+    await settlePosts();
+    const metaPost = fetchCalls.find((c) => c.url.endsWith("/state") && c.body && c.body.metadata_only === true);
+    assert.ok(metaPost);
+    assert.ok(metaPost.body.session_title.length <= 80);
+    assert.ok(metaPost.body.session_title.endsWith("…"));
+  });
+
+  it("does not log the title text into the debug log", async () => {
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
+    const hooks = await plugin(createContext("C:\\proj"));
+
+    const secretTitle = "UniqueSecretTitle-829";
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_l",
+          info: { id: "ses_l", directory: "C:\\proj", title: secretTitle },
+        },
+      },
+    });
+    await settlePosts();
+
+    const logPath = plugin.__test._debugLogPath;
+    const logContent = fs.readFileSync(logPath, "utf8");
+    assert.ok(!logContent.includes(secretTitle), "debug log must not contain the title text");
+    assert.ok(logContent.includes("SESSION_TITLE"), "debug log should record that a title event happened");
+  });
+
+  it("handles MiMo-style patch event shape where info lives at event.properties.info", async () => {
+    // Official opencode SDK: event.properties.info. MiMo-derived hosts patch
+    // the same shape. getEventSessionInfo reads info from properties.info in
+    // both cases, so title capture works for the whole family.
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
+    const hooks = await plugin(createContext("C:\\proj"));
+
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_m",
+          info: { id: "ses_m", directory: "C:\\proj", title: "MiMo Title" },
+        },
+      },
+    });
+    await settlePosts();
+    assert.strictEqual(plugin.__test._sessionTitleById.get("opencode:ses_m"), "MiMo Title");
+  });
+
+  it("clears the title map on session.deleted and server.instance.disposed", async () => {
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
+    const hooks = await plugin(createContext("C:\\proj"));
+
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_c",
+          info: { id: "ses_c", directory: "C:\\proj", title: "To Delete" },
+        },
+      },
+    });
+    await settlePosts();
+    assert.ok(plugin.__test._sessionTitleById.has("opencode:ses_c"));
+
+    await hooks.event({
+      event: {
+        type: "session.deleted",
+        properties: {
+          sessionID: "ses_c",
+          info: { id: "ses_c", directory: "C:\\proj", title: "To Delete" },
+        },
+      },
+    });
+    await settlePosts();
+    assert.strictEqual(plugin.__test._sessionTitleById.has("opencode:ses_c"), false, "title must be cleared on session.deleted");
+  });
+});

--- a/test/opencode-family-session-directory.test.js
+++ b/test/opencode-family-session-directory.test.js
@@ -390,8 +390,12 @@ describe("opencode-family session title (#829)", () => {
     const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
     const hooks = await plugin(createContext("C:\\proj"));
 
-    // session.created with a placeholder title -> captured, but no prior title
-    // so no metadata push yet (the first state POST carries it instead).
+    // session.created with a placeholder title -> captured. The first capture
+    // also fires a metadata-only push (prevTitle undefined !== title), which
+    // the server safely drops because the session does not exist yet; the
+    // SessionStart lifecycle POST below carries the title instead. The push
+    // is deliberate — it covers "created untitled, titled later" (see the
+    // captureSessionTitle comment in core.mjs).
     await hooks.event({
       event: {
         type: "session.created",
@@ -425,15 +429,32 @@ describe("opencode-family session title (#829)", () => {
     assert.strictEqual(plugin.__test._sessionTitleById.get("opencode:ses_t"), "轻松问候");
     const metaPost = fetchCalls.find((c) => c.url.endsWith("/state") && c.body && c.body.metadata_only === true);
     assert.ok(metaPost, "expected a metadata-only POST for the title change");
-    // postToClawd enriches the body with process-tree fields (agent_pid, cwd,
-    // pid_chain, ...) - assert only the title-push contract, not the full body.
-    assert.strictEqual(metaPost.body.state, "idle");
-    assert.strictEqual(metaPost.body.session_id, "opencode:ses_t");
-    assert.strictEqual(metaPost.body.event, "SessionUpdate");
-    assert.strictEqual(metaPost.body.agent_id, "opencode");
-    assert.strictEqual(metaPost.body.hook_source, "opencode-plugin");
-    assert.strictEqual(metaPost.body.metadata_only, true);
-    assert.strictEqual(metaPost.body.session_title, "轻松问候");
+    // postToClawd enriches every POST with process-tree fields. Split those
+    // off and deepStrictEqual the rest against the EXACT title-push contract
+    // so the complete metadata-only body is covered: a missing field or an
+    // unexpected extra one both fail (#841 review).
+    const ENRICH_KEYS = ["agent_pid", "cwd", "source_pid", "pid_chain", "editor", "tmux_socket", "tmux_client", "orca_pane_key"];
+    const enrichments = {};
+    const contract = { ...metaPost.body };
+    for (const key of ENRICH_KEYS) {
+      if (key in contract) {
+        enrichments[key] = contract[key];
+        delete contract[key];
+      }
+    }
+    assert.deepStrictEqual(contract, {
+      state: "idle",
+      session_id: "opencode:ses_t",
+      event: "SessionUpdate",
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+      metadata_only: true,
+      session_title: "轻松问候",
+    });
+    // Enrichment sanity: the session-directory truth and the plugin pid are
+    // always stamped onto the outbound body.
+    assert.strictEqual(enrichments.cwd, "C:\\proj");
+    assert.strictEqual(typeof enrichments.agent_pid, "number");
   });
 
   it("does not POST when the title is unchanged and a blank title is ignored", async () => {

--- a/test/opencode-plugin-session.test.js
+++ b/test/opencode-plugin-session.test.js
@@ -71,13 +71,44 @@ describe("opencode plugin session ids", () => {
         eventSessionId: "ses_wire",
         infoSessionId: "ses_info",
         directory: " C:\\Project With Spaces ",
+        title: null,
       }
     );
     assert.deepStrictEqual(mod.getEventSessionInfo(null), {
       eventSessionId: null,
       infoSessionId: null,
       directory: null,
+      title: null,
     });
+  });
+
+  it("extracts the session title from info.title on lifecycle events", async () => {
+    const mod = await loadSessionIdModule();
+    assert.deepStrictEqual(
+      mod.getEventSessionInfo({
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_live",
+          info: { id: "ses_live", directory: "C:\\proj", title: "  My Session Title  " },
+        },
+      }),
+      {
+        eventSessionId: "ses_live",
+        infoSessionId: "ses_live",
+        directory: "C:\\proj",
+        title: "My Session Title",
+      }
+    );
+    assert.deepStrictEqual(
+      mod.getEventSessionInfo({
+        type: "session.created",
+        properties: {
+          sessionID: "ses_blank",
+          info: { id: "ses_blank", directory: "C:\\proj", title: "   " },
+        },
+      }).title,
+      null
+    );
   });
 
   it("drops SessionEnd mappings that have no raw opencode session id", async () => {

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -1154,6 +1154,84 @@ describe("server-route-state POST", () => {
     assert.deepStrictEqual(outcomes, []);
   });
 
+  it("metadata_only session_title routes to updateSessionMetadata, not updateSession", async () => {
+    const metadataCalls = [];
+    const res = await callStatePost(JSON.stringify({
+      state: "idle",
+      metadata_only: true,
+      session_id: "opencode:ses_x",
+      agent_id: "opencode",
+      session_title: "My Real Title",
+    }), {
+      ctx: { updateSessionMetadata: (...args) => metadataCalls.push(args) },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(res.calls.updateSession.length, 0, "title-only metadata must not call updateSession");
+    assert.strictEqual(res.calls.setState.length, 0);
+    assert.strictEqual(metadataCalls.length, 1);
+    assert.strictEqual(metadataCalls[0][0], localSessionKey("opencode:ses_x"));
+    assert.deepStrictEqual(metadataCalls[0][1], { sessionTitle: "My Real Title" });
+  });
+
+  it("metadata_only session_title is allowed even when the Claude telemetry gate blocks context", async () => {
+    const metadataCalls = [];
+    const res = await callStatePost(JSON.stringify({
+      state: "idle",
+      metadata_only: true,
+      session_id: "sid",
+      agent_id: "claude-code",
+      session_title: "Title Despite Gate",
+      context_usage: { used: 50000, limit: 200000, percent: 25, source: "claude" },
+    }), {
+      ctx: { updateSessionMetadata: (...args) => metadataCalls.push(args) },
+      options: { isClaudeStatuslineMetadataAllowed: () => false },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    // The gate drops the context data, but the title is not Claude statusline
+    // data and must still flow through.
+    assert.strictEqual(metadataCalls.length, 1);
+    assert.deepStrictEqual(metadataCalls[0][1], { sessionTitle: "Title Despite Gate" });
+  });
+
+  it("metadata_only title+context in one POST becomes one metadata update", async () => {
+    const metadataCalls = [];
+    const res = await callStatePost(JSON.stringify({
+      state: "idle",
+      metadata_only: true,
+      session_id: "opencode:ses_z",
+      agent_id: "opencode",
+      session_title: "Titled + quota",
+      context_usage: { used: 300, limit: 1000, percent: 30, source: "codex" },
+    }), {
+      ctx: { updateSessionMetadata: (...args) => metadataCalls.push(args) },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(metadataCalls.length, 1, "title+context should coalesce into a single metadata update");
+    assert.deepStrictEqual(metadataCalls[0][1], {
+      contextUsage: { used: 300, limit: 1000, percent: 30, source: "codex" },
+      contextUsageOrigin: null,
+      sessionTitle: "Titled + quota",
+    });
+  });
+
+  it("metadata_only with neither title nor context performs no metadata update", async () => {
+    const metadataCalls = [];
+    const res = await callStatePost(JSON.stringify({
+      state: "idle",
+      metadata_only: true,
+      session_id: "opencode:ses_w",
+      agent_id: "opencode",
+    }), {
+      ctx: { updateSessionMetadata: (...args) => metadataCalls.push(args) },
+    });
+
+    assert.strictEqual(res.statusCode, 204);
+    assert.strictEqual(metadataCalls.length, 0, "empty metadata payload must not call updateSessionMetadata");
+  });
+
   it("marks missing agent_id as a defaulted Claude Code attribution", async () => {
     const res = await callStatePost(JSON.stringify({
       state: "working",

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -2948,6 +2948,13 @@ describe("updateSession()", () => {
     assert.strictEqual(appliedSame, true);
     assert.strictEqual(session.sessionTitle, "Stable Title");
     assert.strictEqual(session.metadataUpdatedAt, 777);
+
+    // Normalized-equivalent title (extra whitespace/control chars) collapses
+    // to the stored title via normalizeTitle -> still a no-op, no re-stamp.
+    const appliedNormalized = api.updateSessionMetadata("s1", { sessionTitle: "  Stable\t Title  " });
+    assert.strictEqual(appliedNormalized, true);
+    assert.strictEqual(session.sessionTitle, "Stable Title");
+    assert.strictEqual(session.metadataUpdatedAt, 777);
   });
 
   it("updateSessionMetadata returns false for an unknown session on a title-only payload", () => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -2916,6 +2916,46 @@ describe("updateSession()", () => {
     assert.strictEqual(session.metadataUpdatedAt, 777, "identical refresh must not re-stamp");
   });
 
+  it("updateSessionMetadata stores a title without touching lifecycle state or telemetry stamp", () => {
+    update(api, { id: "s1", state: "working" });
+    const session = api.sessions.get("s1");
+    session.updatedAt = 12345; // pin so a bump is detectable
+    session.metadataUpdatedAt = 777; // pin so a re-stamp is detectable
+    const recentEventsBefore = JSON.stringify(session.recentEvents);
+
+    const applied = api.updateSessionMetadata("s1", { sessionTitle: "New Title" });
+
+    assert.strictEqual(applied, true);
+    assert.strictEqual(session.sessionTitle, "New Title");
+    // Lifecycle untouched: state, updatedAt, recent events all unchanged.
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.updatedAt, 12345);
+    assert.strictEqual(JSON.stringify(session.recentEvents), recentEventsBefore);
+    // Telemetry freshness must NOT be stamped by a rename (#841 review).
+    assert.strictEqual(session.metadataUpdatedAt, 777);
+    assert.strictEqual(session.contextUsage, null);
+    assert.strictEqual(session.contextUsageOrigin, null);
+  });
+
+  it("updateSessionMetadata treats a same/normalized-equivalent title as a no-op", () => {
+    update(api, { id: "s1", state: "working" });
+    api.updateSessionMetadata("s1", { sessionTitle: "Stable Title" });
+    const session = api.sessions.get("s1");
+    session.metadataUpdatedAt = 777;
+
+    // Same title -> no change, no re-stamp.
+    const appliedSame = api.updateSessionMetadata("s1", { sessionTitle: "Stable Title" });
+    assert.strictEqual(appliedSame, true);
+    assert.strictEqual(session.sessionTitle, "Stable Title");
+    assert.strictEqual(session.metadataUpdatedAt, 777);
+  });
+
+  it("updateSessionMetadata returns false for an unknown session on a title-only payload", () => {
+    const applied = api.updateSessionMetadata("ghost", { sessionTitle: "Ghost Title" });
+    assert.strictEqual(applied, false);
+    assert.strictEqual(api.sessions.has("ghost"), false);
+  });
+
   it("lifecycle events carry metadataUpdatedAt forward with the telemetry they preserve", () => {
     update(api, { id: "s1", state: "working" });
     api.updateSessionMetadata("s1", {


### PR DESCRIPTION
## Summary

Fixes #829. The HUD/dashboard was showing the **project folder name** for OpenCode sessions instead of the real session title (e.g. "Hy-MT2-1.8B prep for A/B test"). It also never updated when OpenCode renames a session.

Two problems were fixed:

1. **The OpenCode plugin never forwarded the session title.** The family plugin (`hooks/opencode-family-plugin/core.mjs`) builds the `/state` POST body with only `state`, `session_id`, `event`, `agent_id`, `hook_source` — no `session_title`. The server-side fallback chain in `sessionDisplayTitle()` then fell through to `path.basename(cwd)`, which is the project folder name.

   OpenCode already exposes the per-session title via `event.properties.info.title` on `session.created` / `session.updated` events (the field shown in OpenCode's own UI). The plugin now extracts it and forwards it as `session_title`, following the exact same pattern already used for `info.directory` → `body.cwd`.

2. **OpenCode swaps a placeholder title for the real one a few seconds after creation, and the update never reached Clawd.** A new OpenCode session starts with a placeholder title (`"New session - <timestamp>"`), then `session.updated` replaces it with the real summary-based title. Since `session.updated` maps to no Clawd state transition, the HUD kept showing the placeholder forever.

   The plugin now detects a title change and forwards it as a **metadata-only** POST (`metadata_only: true` + the new `session_title`), the same channel Claude Code's statusline refresh uses. The server's `updateSessionMetadata` now accepts a `sessionTitle` and updates the stored title without disturbing the lifecycle state.

## Files changed

- `hooks/opencode-family-plugin/session-ids.mjs` — extract `info.title` in `getEventSessionInfo()`
- `hooks/opencode-family-plugin/core.mjs` — capture the session title into `_sessionTitleById` (mirrors `_sessionDirectoryById`), include it as `body.session_title` in `buildStateBody()`, and push a metadata-only POST when the title changes
- `src/state.js` — `updateSessionMetadata` accepts `sessionTitle` and updates it without touching lifecycle fields
- `src/server-route-state.js` — the `metadata_only` branch forwards `session_title` to `updateSessionMetadata` (not gated on the Claude telemetry flag, since it isn't Claude statusline data)
- `test/opencode-family-core.test.js` — cover title capture + per-instance isolation
- `test/opencode-plugin-session.test.js` — cover `info.title` extraction

## Verification

- Live-tested against **OpenCode Desktop 1.18.15**: a new session shows the placeholder title, then auto-updates to the real title (e.g. `"New session - …"` → `"轻松问候"`) in the HUD a few seconds later.
- All related tests pass: **410/410** across opencode-family, state, server-route-state, and title tests.

Screenshots to follow.

<img width="1286" height="1092" alt="image" src="https://github.com/user-attachments/assets/b45c590c-d2be-442b-a6a0-36526f6bf65c" />
