### PR TITLE
fix(hermes): support WSL Pair and Unpair

### DIFF
--- a/docs/guides/setup-guide.md
+++ b/docs/guides/setup-guide.md
@@ -173,7 +173,11 @@ macOS Claude Keychain auth. See the dedicated guide for the exact boundary.
 
 > This section mainly covers Claude Code and other hook-based agents inside WSL. For the official `Codex CLI + WSL` status, Codex hook feature-flag behavior, and why Clawd does not auto-detect Codex logs under WSL's Linux home by default, see: [codex-wsl-clarification.md](codex-wsl-clarification.md)
 
-If you run Claude Code inside WSL while Clawd runs on the Windows host, hooks can POST directly to `127.0.0.1:23333` — no SSH tunnel needed, because WSL2 shares localhost with Windows by default.
+If an agent runs inside WSL while Clawd runs on the Windows host, its integration posts to `127.0.0.1:23333-23337`. WSL1 shares that loopback. WSL2 normally needs mirrored networking; default NAT does not make the Windows loopback server reachable from Linux. The in-app Pair flow probes this path and warns when installation succeeded but connectivity did not.
+
+For supported agents, open **Settings → Agents**, use **WSL Scan** from the Connected section, then find the matching distro row and choose **Pair**. A WSL-only agent can remain under the **Unavailable** collapsible section because local installation status and WSL pairing are separate. Pairing enables Clawd's event ingress but does not mark or install a Windows-local integration.
+
+**Hermes Agent in WSL:** Hermes must already be installed in the selected distro. Pair copies a private, temporary installer payload into WSL, installs and enables `clawd-on-desk` in the primary Hermes home and its discovered profiles, then removes the temporary payload. **Unpair** disables/removes only Clawd's Hermes plugin from that distro; it preserves unrelated plugins and does not disable Hermes events globally when another local or WSL source may still be active. Custom WSL `HERMES_HOME` is resolved from the distro's login shell.
 
 **Setup:**
 
@@ -199,8 +203,6 @@ After setup, start Clawd on Windows and run Claude Code in WSL — Clawd reacts 
 The in-app WSL deploy path intentionally runs the Claude installer without `--statusline`, so it provides transcript fallback only and does not claim an authoritative custom-provider window. The manual `--remote` command above does install a visible statusline in WSL's separate home, but the Windows app accepts its context/quota metadata only while **Collect local Claude usage** is enabled. With the switch off, those POSTs are successful no-ops. Windows startup reconciliation cannot remove a statusline from WSL's separate home.
 
 For Codex in WSL, official hooks work when Codex runs inside the WSL environment and `~/.codex` exists there. If you prefer sharing the Windows Codex home, set `CODEX_HOME=/mnt/c/Users/<windows-user>/.codex` inside WSL before running Codex.
-
-> **Note:** WSL2 localhost forwarding requires Windows 10 build 18945+ (enabled by default). If it doesn't work, check that `localhostForwarding=true` is not disabled in `%USERPROFILE%\.wslconfig`.
 
 ### WSL Networking & Hook Registration (Alternative Approach)
 

--- a/docs/guides/setup-guide.zh-CN.md
+++ b/docs/guides/setup-guide.zh-CN.md
@@ -103,7 +103,11 @@ Keychain 登录。准确边界见专门指南。
 
 > 本节的主线是 Claude Code / 其他 hook 型 agent 的 WSL 配置。关于 `Codex CLI + WSL` 的官方支持现状、Codex hooks feature flag 行为、以及 Clawd 当前为什么默认扫不到 WSL Linux home 下的 Codex 日志，见：[codex-wsl-clarification.zh-CN.md](codex-wsl-clarification.zh-CN.md)
 
-如果你在 WSL 里跑 Claude Code，而 Clawd 跑在 Windows 宿主上，hook 可以直接 POST 到 `127.0.0.1:23333` —— 不需要 SSH 隧道，因为 WSL2 默认与 Windows 共享 localhost。
+如果 agent 跑在 WSL 里、Clawd 跑在 Windows 宿主上，集成会向 `127.0.0.1:23333-23337` 上报。WSL1 天然共享这条 loopback；WSL2 通常需要镜像网络，默认 NAT 并不能让 Linux 访问 Windows 的 loopback 服务。应用内 Pair 会探测这条链路，并在安装成功但网络不可达时给出警告。
+
+对于已支持的 agent，请在 **Settings → Agents** 的 Connected 区执行 **WSL Scan**，再找到对应发行版并点击 **Pair**。仅存在于 WSL 的 agent 仍可能位于 **Unavailable** 折叠区，因为本机安装状态与 WSL 配对是两套状态。Pair 会打开 Clawd 的事件入口，但不会把它标记为 Windows 本机集成，也不会在 Windows 安装文件。
+
+**WSL 中的 Hermes Agent：** 请先在目标发行版里安装 Hermes。Pair 会把一份私有临时安装 payload 传入 WSL，在 Hermes 主 home 和已发现 profiles 中安装并启用 `clawd-on-desk`，随后删除临时 payload。**Unpair** 只禁用/移除该发行版里的 Clawd Hermes plugin，保留其他 plugin；如果本机或其他 WSL 来源仍可能使用 Hermes，也不会关闭全局 Hermes 事件入口。自定义 WSL `HERMES_HOME` 会从该发行版的 login shell 中解析。
 
 **配置步骤：**
 
@@ -129,8 +133,6 @@ node ~/.claude/hooks/copilot-install.js --remote
 应用内 WSL 部署路径会故意以不带 `--statusline` 的方式运行 Claude installer，因此只提供 transcript fallback，不宣称能拿到自定义 provider 的权威窗口。上面的手动 `--remote` 命令会在 WSL 的独立 home 中安装一条可见 statusline，但 Windows 端应用只有在 **采集本机 Claude 使用信息** 开启时才接受它的 context/quota metadata；开关关闭时这些 POST 会被当作成功 no-op。Windows 本机启动 reconcile 也无法移除 WSL 独立 home 里的 statusline。
 
 如果 Codex 运行在 WSL 里，official hooks 需要安装到 WSL 自己的 `~/.codex` 下。如果你希望 WSL 与 Windows 共用同一份 Codex home，也可以在 WSL 里先设置 `CODEX_HOME=/mnt/c/Users/<windows-user>/.codex` 再运行 Codex。
-
-> **注意：** WSL2 的 localhost 转发需要 Windows 10 build 18945+（默认开启）。如果不生效，检查 `%USERPROFILE%\.wslconfig` 中 `localhostForwarding=true` 是否被禁用。
 
 ### WSL 网络与 Hook 注册（替代方案）
 

--- a/docs/plans/plan-issue-540-hermes-wsl-deploy.md
+++ b/docs/plans/plan-issue-540-hermes-wsl-deploy.md
@@ -1,0 +1,468 @@
+# Plan: fix Hermes installation in WSL (#540)
+
+> Status: **Implemented; automated, isolated, and active-home real-WSL verification complete**
+> Date: 2026-08-09
+> Origin: GitHub issue #540, “hermes在wsl下无法安装”
+> Scope: Hermes-specific WSL detection, Pair/Unpair deployment, agent gating, installer symmetry, packaging, and regression coverage
+> Verification: `npm test` — 7,198 passed, 0 failed, 31 skipped; Ubuntu WSL isolated Pair → detector → Unpair passed without warnings, and active-home Pair → real Hermes lifecycle → Unpair → repeated Pair upgraded `0.1.0` to `0.2.0`, reached the production Clawd state route, preserved sibling configuration, and left no staging directory.
+
+---
+
+## 1. Decision summary
+
+Yes, #540 is fixable in Clawd. The failure is deterministic rather than an unconfirmed environment problem.
+
+`src/wsl-deploy.js` deliberately omits `hermes` because the current WSL deployer copies only flat `hooks/*.js` files. The Hermes installer also needs `hooks/hermes-plugin/plugin.yaml` and `hooks/hermes-plugin/__init__.py`, so Settings rejects Pair before touching WSL:
+
+```text
+WSL deploy is not supported for hermes
+```
+
+The reviewed solution is:
+
+1. add Hermes to WSL support with an explicit, complete six-file payload;
+2. upload that payload through the existing `wsl.exe` stdin boundary into a unique private temporary directory, preserving validated relative paths;
+3. run the existing Hermes installer and connectivity probe from that temporary directory, then always clean it up;
+4. resolve and detect Hermes from WSL-native paths rather than rebasing a Windows `%LOCALAPPDATA%` path;
+5. make Hermes profile uninstall symmetric with profile install;
+6. propagate structured install/uninstall warnings and failures to Settings;
+7. after a successful WSL Pair, enable the Hermes event gate while leaving local `integrationInstalled` unchanged;
+8. send Hermes loopback `/state` and `/permission` requests through an explicit no-proxy opener, because a real WSL shell proxy returned 502 for `127.0.0.1` even though the Node connectivity probe succeeded.
+
+This is preferable to tar, `/mnt/<drive>` access, Remote SSH reuse, or a recursive directory copy. It also avoids rewriting the shared live `~/.claude/hooks` tree for an integration that does not need persistent command-hook scripts.
+
+## 2. Reproduction and verified cause
+
+### 2.1 Underlying action call chain
+
+The current renderer does not expose a Hermes WSL Pair button because `refreshWslDetection()` filters out agents with no WSL install-script mapping. The unsupported result below is therefore reproduced by invoking the same Settings action dependency directly; after Hermes is added to the supported map, this becomes the production button path.
+
+```text
+Settings action `deployToWsl`
+  → `src/settings-actions-agents.js::deployToWsl()`
+  → main-process `deployHooksToWsl`
+  → `src/wsl-deploy.js::deployToWsl()`
+  → install-script lookup returns null
+  → `step: "unsupported"`
+```
+
+On the inspected Ubuntu WSL2 instance, the Settings chain returned:
+
+```json
+{"status":"error","message":"WSL deploy is not supported for hermes"}
+```
+
+A direct `deployToWsl("Ubuntu", { agentId: "hermes" })` call returned the same unsupported result.
+
+### 2.2 Hermes itself works in WSL
+
+The distro has a normal Hermes installation under `~/.hermes`, including `config.yaml` and `~/.hermes/hermes-agent/venv/bin/hermes`. A manually staged Clawd plugin is recognized by `hermes plugins list`. That copy is plugin version `0.1.0`, while the checked-in source is `0.2.0`, so the existing installer also has a real upgrade to perform once Settings can deliver its source assets.
+
+The current focused tests pass because `test/wsl-deploy.test.js` explicitly asserts that Hermes is unsupported. That assertion protects the bug and must become a support regression test.
+
+### 2.3 Additional blockers found during review
+
+Supporting the two nested files alone would still leave three user-visible failures:
+
+- fresh preferences have `agents.hermes.enabled=false`; WSL Pair currently returns no settings commit, and `/state` drops disabled Hermes events with HTTP 204, so Pair could appear successful while the pet never reacts;
+- the Windows Hermes descriptor can resolve to `%LOCALAPPDATA%\hermes` or host `HERMES_HOME`; rebasing that path does not locate WSL `~/.hermes`, so the Hermes WSL row can remain hidden;
+- `registerHermesPlugin()` installs into the primary home and every discovered Hermes profile, while `unregisterHermesPlugin()` currently removes only the primary copy.
+
+The implementation must address these blockers as part of #540 rather than documenting a false success.
+
+## 3. Required behavior
+
+The fix is complete only when all of the following hold:
+
+1. A Hermes installation in a selected WSL distro produces a Hermes WSL row even when Windows Hermes uses `%LOCALAPPDATA%` or a different host `HERMES_HOME`. Under the current cross-agent categorization, a WSL-only Hermes card remains in the **Unavailable** collapsible section; this issue does not redefine section membership.
+2. Pair uploads only the audited Hermes deployment payload and never depends on `/mnt/<drive>` or a repo clone inside WSL.
+3. Pair runs `hermes-install.js` in the selected distro, installs/upgrades the primary and profile plugin copies, and enables them through the real Hermes CLI without hand-editing YAML.
+4. The temporary deployment directory is cleaned after success, failure, timeout, or partial upload; persistent Hermes files remain only under Hermes-managed homes.
+5. A successful Pair sets the selected agent's global `enabled=true` but preserves its existing `integrationInstalled` value. In particular, a WSL-only fresh install remains `integrationInstalled=false`, so startup does not install a Windows-local Hermes plugin.
+6. Pair failure makes no settings commit. Unpair does not automatically disable the global agent gate because another distro or local source may still use it.
+7. Repeating Pair is idempotent and upgrades stale managed files without deleting unrelated plugin files.
+8. Unpair re-stages the audited uninstaller payload, then disables/removes Clawd from the primary Hermes home and all discovered profiles; it does not depend on historical `~/.claude/hooks` staging.
+9. Missing CLI, primary enable failure, profile partial failure, disable warning, missing packaged asset, upload error, and uninstall error produce distinct, user-visible results rather than a generic success.
+10. A successful install with failed WSL-to-Windows reachability keeps the existing actionable connectivity warning.
+11. Development and packaged builds use the same manifest and contain every required source file.
+
+## 4. Implementation plan
+
+### 4.1 Add a narrow Hermes WSL deployment option
+
+Keep the existing install-script map and behavior for current hook-based WSL integrations. Add:
+
+- `hermes: "hermes-install.js"` to the supported install-script lookup;
+- a frozen Hermes-specific WSL option describing ephemeral staging, structured results, WSL-native detection, and the exact payload.
+
+The payload is:
+
+```text
+hermes-install.js
+json-utils.js
+wsl-connectivity-probe.js
+server-config.js
+hermes-plugin/plugin.yaml
+hermes-plugin/__init__.py
+```
+
+The first four entries are the complete local JavaScript closure for install/uninstall plus connectivity probing; the last two are exactly `MANAGED_PLUGIN_FILES` under the source directory expected by `hermes-install.js`.
+
+Do not move CodeBuddy arguments or Claude's uninstall override merely to make a larger generic spec. Preserve those existing code paths. Do not enable OpenCode, MiMo Code, Pi, OpenClaw, or WorkBuddy as a side effect: nested-file transport is not proof that their WSL runtime contracts are valid.
+
+Do not couple this option to `src/remote-ssh-deploy.js`. Remote SSH uses SCP plus identity, lease, fencing, ownership, and secure-layout rules that do not belong in local WSL deployment.
+
+### 4.2 Preflight and validate the exact payload
+
+Add a collector such as `collectAgentWslFiles(hooksDir, agentId)` which returns normalized `relativePath`, absolute source path, and a `Buffer` for each entry.
+
+Before starting or mutating WSL, it must:
+
+- find every manifest entry, including the install script and nested plugin assets;
+- reject an empty or absolute relative path, `..`, backslashes, NUL, duplicate normalized destinations, and any resolved source outside `hooksDir`;
+- reject directories, symlinks, or other non-regular source entries;
+- read bytes as `Buffer` rather than converting them to UTF-8 strings;
+- report the exact missing/invalid relative path through `step: "verify-files"`.
+
+Add a manifest-consistency test asserting that the basenames under `hermes-plugin/` exactly equal the exported `MANAGED_PLUGIN_FILES`. If the Hermes installer later manages another asset, WSL support must fail CI until its explicit payload is updated.
+
+Also reuse the repository's Remote SSH manifest-test pattern to audit the JavaScript closure transitively: every relative `require()` reached from the listed JavaScript entries must resolve to another listed payload entry, and every bare import must be a Node builtin. This must catch future dependencies as well as the current `wsl-connectivity-probe.js → server-config.js` edge.
+
+Existing agents may continue using the current top-level JavaScript collector in this issue. Hermes must use its exact manifest and must not overwrite all shared top-level scripts merely because older integrations do.
+
+### 4.3 Upload into a private ephemeral directory
+
+Create a unique WSL directory with restrictive permissions using the explicit template `mktemp -d /tmp/clawd-hermes-XXXXXXXX`. Do not honor `TMPDIR` for this operation. The expected parent is therefore exactly `/tmp`; parse and validate the returned absolute POSIX path and `clawd-hermes-` basename before using it or attempting cleanup.
+
+Refactor `pipeFileToWsl()` (or add a narrowly named equivalent) so it:
+
+- accepts only a previously validated POSIX relative destination;
+- creates nested parents under the private staging root;
+- uses the existing `wsl.exe -d <distro> -- bash -c` stdin boundary;
+- passes a `Buffer` to `stdin.end()` without an encoding argument;
+- retains `windowsHide`, timeout handling, `close`-based completion, stderr capture, and the stdin `EPIPE` listener;
+- never follows a destination outside the validated staging root;
+- reports nested relative paths in copy errors.
+
+No consumer reads this private directory before all uploads succeed, so a partial upload cannot truncate another agent's live hook script or create a cross-version shared payload. If any upload fails, skip the installer and clean the temporary directory in `finally`.
+
+Use one exact, validated cleanup target. Never run recursive removal against `$HOME`, `~`, `/tmp`, an empty string, a glob, or unvalidated command output.
+
+Accept a temp path only when it has exactly one non-empty output marker, its parent is exactly `/tmp`, and its basename has the generated `clawd-hermes-` prefix and expected random suffix. Empty, multi-line, polluted, wrong-parent, wrong-prefix, `$HOME`, and `/` results must abort without cleanup. Cleanup is part of the operation result: if install/uninstall succeeded but cleanup returns non-zero or times out, downgrade the response to success-with-warning; if the primary operation already failed, preserve that error and attach a secondary cleanup warning. Never claim that no staging remains when cleanup was unverified.
+
+### 4.4 Run install, probe, and uninstall from fresh staging
+
+For Pair, run from the private directory with the existing login/interactive shell behavior so Node and Hermes environment managers resolve:
+
+```text
+CLAWD_WSL_DISTRO='<distro>' node hermes-install.js --json
+node wsl-connectivity-probe.js
+```
+
+Hermes does not currently consume `CLAWD_WSL_DISTRO`; a shared command builder may retain it for consistency, but neither correctness nor tests may depend on it. It may be omitted from a Hermes-specific command.
+
+The staged sibling layout lets `hermes-install.js` resolve `json-utils.js` and `hermes-plugin/` unchanged. The connectivity probe resolves `server-config.js` unchanged.
+
+For Unpair:
+
+1. resolve the packaged/development hooks source exactly as Pair does;
+2. preflight and upload the same audited payload to a new private directory;
+3. run `node hermes-install.js --uninstall --json` in the selected distro;
+4. parse the result and clean staging in `finally`.
+
+Update `src/main.js` so the remove dependency passes `isPackaged: app.isPackaged`; otherwise packaged Unpair cannot re-stage its installer.
+
+This makes Unpair work after a normal Pair, after an older/manual install, and after the previous staging directory has disappeared. Existing hook-based agent removal can retain its shared-staging behavior.
+
+### 4.5 Add a stable structured Hermes CLI result
+
+Add a `--json` mode to `hooks/hermes-install.js`. Normal local CLI output remains unchanged. In JSON mode, suppress human progress output and print one versioned sentinel line containing a bounded JSON result. A sentinel is required because an interactive login shell may add unrelated stdout/stderr.
+
+The result contract must distinguish:
+
+- `ok`: primary and profiles installed/removed cleanly;
+- `warning`: primary succeeded but one or more profiles failed to enable, or files were removed but a CLI disable step failed;
+- `error`: the primary plugin could not be enabled, a managed directory could not be removed, required source files were absent, or the installer itself failed.
+
+Include only bounded fields needed by Settings: schema version, operation, status, message, reason, and counts of profile warnings/errors. Do not expose arbitrary config content or unbounded CLI output.
+
+`src/wsl-deploy.js` must require and parse the sentinel for the fresh Hermes payload. Process exit status remains authoritative for hard failure, while the sentinel carries warning detail. Do not treat arbitrary login-shell stderr as a Hermes warning.
+
+Propagate the normalized warning/error through `src/settings-actions-agents.js` into `src/settings-tab-agents.js` so the user receives a warning toast or an error toast. The current `onProgress` emitter is not wired by the production Settings dependency and is not sufficient.
+
+At the Settings command boundary, success-with-warning must still use top-level `status: "ok"` plus a structured warning field; the controller applies commits only for `status: "ok"`. Do not map an installer warning to top-level `status: "warning"`, or the required `enabled=true` commit will be silently skipped.
+
+### 4.6 Make Hermes uninstall symmetric across profiles
+
+Refactor `unregisterHermesPlugin()` to enumerate the union of:
+
+- the primary Hermes home;
+- every config-bearing home returned by `hermesHomesForSync()`;
+- every profile home that still contains at least one Clawd managed plugin file, even if that profile's `config.yaml` has since been deleted.
+
+Then:
+
+- resolve the primary Hermes CLI once;
+- for each target that still has `config.yaml`, reuse that command with target-specific `HERMES_HOME` and run `plugins disable clawd-on-desk`;
+- for a configless residual profile, skip the CLI so cleanup cannot create a new config, and remove only Clawd's owned plugin directory;
+- remove only that target's `plugins/clawd-on-desk` directory;
+- aggregate per-home results into the structured result;
+- treat CLI disable failures as warnings when managed files were still removed;
+- treat a managed-directory removal failure as an error.
+
+Preserve `pluginDir` and `syncProfiles:false` test overrides. Do not remove sibling plugins or manually rewrite `config.yaml`. Hermes CLI may semantically change Clawd's own enabled entry; all unrelated YAML keys and plugin entries must remain intact.
+
+While touching managed-file copying, harden the final destination rather than relying on private source staging alone: reject an existing `plugins/clawd-on-desk` leaf that is a symlink, reject a managed destination that is a symlink or non-regular file, and update each managed file through a unique same-directory temporary file plus atomic rename with best-effort temp cleanup. This prevents an interrupted update from truncating the active Python plugin or following a managed leaf outside the intended directory. Preserve legitimate parent-home layouts and test the supported Windows/POSIX behavior.
+
+### 4.7 Resolve Hermes from WSL-native state
+
+Do not derive the WSL Hermes directory from the Windows descriptor's already-resolved `parentDir` or `configPath`. On Windows those frozen, module-load-time values may point to `%LOCALAPPDATA%\hermes` or a host-only custom location. The Hermes branch in `refreshWslDetection()` must bypass the existing `rebaseHomePathPosix(descriptor.parentDir, ...)` path completely.
+
+For each scanned distro that supports Hermes:
+
+1. resolve the ordinary WSL home as today;
+2. resolve `${HERMES_HOME:-$HOME/.hermes}` inside that distro using the same bounded login-shell environment used by installation and a unique sentinel line;
+3. validate that the result is an absolute POSIX path with no NUL/newline; if custom resolution fails, fall back only to the known `${wslHome}/.hermes` default and record that custom-home detection is unknown;
+4. use that WSL-native path for Hermes parent detection and UI detail.
+
+The normal case must never contain a Windows drive, backslash, `%LOCALAPPDATA%`, or host home suffix. Add an explicit regression where Windows Hermes resolves under LocalAppData while WSL Hermes exists at `/home/tester/.hermes`.
+
+### 4.8 Add per-agent cleanup evidence without claiming enabled truth
+
+The existing `hooksFilesPresent` and `hooksDeployed` fields are distro/Claude staging signals. They are not Hermes pairing truth and can make a Hermes row show Unpair or “Deployed” merely because Claude was paired.
+
+For Hermes, extend the batched WSL detector with one indexed tri-state field:
+
+```text
+integrationFilesPresent: true | false | null
+```
+
+`true` means at least one Clawd managed file exists in the primary Hermes plugin directory or any discovered `profiles/*/plugins/clawd-on-desk` directory. `false` means the scan completed and found none. `null` means the check was unavailable or incomplete. This is cleanup evidence, not proof that `plugins.enabled` contains Clawd.
+
+Parser requirements:
+
+- require exactly one unambiguous indexed marker for every expected check;
+- treat missing, duplicate, conflicting, or truncated markers as an untrustworthy distro scan and preserve the previous committed cache;
+- keep the current generation/commit arbitration and stopped-distro behavior.
+
+Renderer rules:
+
+- for entries with per-agent evidence, show Unpair only when `integrationFilesPresent === true`;
+- on a fresh scan with `integrationFilesPresent === null`, conservatively hide Unpair and keep Pair available; do not fall back to Claude's shared marker;
+- use the legacy `hooksFilesPresent` fallback only when per-agent evidence is not applicable, not when Hermes explicitly reports `false`;
+- do not show the Claude `hooksDeployed` badge on Hermes rows;
+- keep Pair available as repair/upgrade;
+- refresh WSL hints after both successful and failed Pair/Unpair attempts, so a partial installer result exposes a cleanup path.
+
+Do not parse Hermes YAML or run `hermes plugins list` during every scan merely to manufacture an enabled badge. Per-agent enabled-state truth is a separate design problem.
+
+### 4.9 Open the runtime gate without claiming a local install
+
+On successful WSL Pair, `_wslCommand()` must return a settings commit built from the existing agent entry with only:
+
+```js
+{ enabled: true }
+```
+
+The merge must preserve `integrationInstalled` and every other flag. In a fresh WSL-only setup, `integrationInstalled` therefore remains `false`, satisfying the repository rule that WSL registration must not trigger Windows-local automatic synchronization.
+
+On Pair failure, return no commit. On Unpair, do not set `enabled=false` and do not clear `integrationInstalled`; the gate is global while Pair/Unpair targets one distro, and other Hermes sources may still be active.
+
+For #540, apply this success-gate rule only to Hermes. Existing non-default WSL agents may have the same latent gate problem, but changing all of them requires a separate compatibility audit and follow-up. No local installer side effect is authorized by the Hermes commit.
+
+### 4.10 Documentation
+
+Update `docs/guides/setup-guide.md`:
+
+- Hermes must already be installed in the target distro;
+- under the current UI, open the Connected section to run WSL Scan, then open the **Unavailable** collapsible section to find the WSL-only Hermes card and its Pair row;
+- Clawd installs/enables only its plugin and does not install Hermes itself;
+- Pair opens the Clawd event gate but does not mark or install a Windows-local integration;
+- Unpair removes Clawd from the primary Hermes home and discovered profiles without disabling other Hermes sources globally;
+- the distro must reach Windows Clawd on `127.0.0.1:23333-23337`.
+
+While editing the WSL section, remove the existing localhost contradiction: one paragraph says WSL2 shares localhost by default, while the later networking section correctly explains that default NAT normally requires mirrored networking for this loopback-only server. Keep one accurate statement plus the existing connectivity-warning behavior.
+
+## 5. Automated test plan
+
+### 5.1 Payload and transport
+
+Extend `test/wsl-deploy.test.js` or add one focused companion file:
+
+1. Hermes maps to `hermes-install.js`; its uninstall command is `hermes-install.js --uninstall`.
+2. The Hermes payload contains exactly the six listed relative files.
+3. Its plugin asset basenames exactly match `MANAGED_PLUGIN_FILES`.
+4. A missing asset fails before WSL home lookup, temp creation, upload, or any other WSL mutation.
+5. Nested upload creates parents and sends byte-identical `Buffer` data.
+6. Empty, absolute, traversal, backslash, NUL, duplicate, symlink, non-file, and hooks-root escape entries are rejected.
+7. Upload failure prevents install and still cleans the exact temp directory.
+8. Pair runs install before connectivity probe and removes staging on success, installer failure, probe failure, timeout, and thrown error.
+9. Unpair resolves the packaged/development source, creates fresh staging, runs `--uninstall --json`, and cleans up.
+10. Hermes Pair/Unpair never writes or removes the persistent shared `~/.claude/hooks` directory.
+11. Empty, multi-line, polluted, `/`, `$HOME`, wrong-parent, or wrong-prefix temp output is rejected without recursive cleanup.
+12. Cleanup non-zero/timeout downgrades success to warning; a pre-existing primary error stays primary and carries a secondary cleanup warning.
+13. The relative-require and builtin-only audit proves that the exact payload is transitively closed.
+
+Add narrow dependency-injection seams for `isWindows`, home/temp resolution, WSL execution, upload, and packaged `resourcesPath`, or export pure command builders. The orchestration tests must run identically on Windows, macOS, and Linux without booting a real distro or relying on require-cache mutation.
+
+### 5.2 Hermes installer
+
+Extend `test/hermes-install.test.js`:
+
+1. JSON/sentinel success, warning, and error output is stable and bounded.
+2. Primary plus multiple profiles install and uninstall symmetrically.
+3. The primary CLI is reused with the correct `HERMES_HOME` for every profile.
+4. A profile enable failure returns success-with-warning when primary succeeds.
+5. A profile disable failure removes managed files and returns warning.
+6. A managed-directory removal failure returns error.
+7. A configless profile containing only one residual managed file is cleaned without invoking the CLI or creating `config.yaml`.
+8. `syncProfiles:false` and explicit `pluginDir` retain their current single-target behavior.
+9. Unrelated plugin directories and unrelated config semantics survive install/uninstall.
+10. A symlinked plugin leaf or managed destination is rejected, and an injected write/rename failure preserves the previous complete file while cleaning the owned temp file.
+
+Keep the existing missing-CLI, timeout, idempotence, upgrade, and unmanaged-file tests.
+
+### 5.3 Detection and renderer
+
+Extend `test/agent-installation-detector-wsl-refresh.test.js` and `test/settings-renderer-browser-env.test.js`:
+
+1. Hermes is not filtered out of WSL results.
+2. Host `%LOCALAPPDATA%\hermes` or host `HERMES_HOME` cannot redirect WSL detection away from `~/.hermes`.
+3. A valid WSL `HERMES_HOME` sentinel is honored; invalid/failed custom resolution follows the documented fallback.
+4. Managed files in the primary home or only in a profile produce `integrationFilesPresent: true`.
+5. No managed files produce `false`; malformed/missing/conflicting markers preserve previous cache rather than silently producing false.
+6. Claude deployed plus Hermes never paired does not show a Hermes badge or Unpair.
+7. Hermes evidence true shows Unpair even without shared Claude staging.
+8. A failed Pair that left managed files triggers a hint refresh and exposes Unpair.
+9. A configless profile-only residual produces evidence true; after Unpair the next scan produces false.
+10. A fresh `integrationFilesPresent: null` hides Unpair, keeps Pair, and never falls back to Claude's `hooksFilesPresent`.
+
+### 5.4 Settings action and gate
+
+Extend `test/settings-actions-agents.test.js` and route/gate coverage:
+
+1. successful Hermes Pair commits `enabled=true`;
+2. the commit preserves fresh `integrationInstalled=false` and preserves `true` if a local installation already exists;
+3. Pair warning still commits enabled and returns the warning;
+4. Pair failure returns no commit;
+5. Unpair never disables the global gate;
+6. structured install/uninstall warnings reach the renderer toast;
+7. after Pair, a Hermes `/state` event is accepted instead of dropped by the disabled-agent gate.
+
+### 5.5 Packaging
+
+Keep the existing `hooks/**/*` `files` and `asarUnpack` assertions. Add a temporary packaged-layout test under `app.asar.unpacked/hooks` and run the real packaged resolver plus Hermes manifest collector against it. The release gate must also inspect or smoke a real Windows artifact; checking `package.json` globs alone is not enough.
+
+### 5.6 Commands
+
+Run the focused suite first:
+
+```powershell
+node --test test/wsl-deploy.test.js test/hermes-install.test.js test/agent-installation-detector-wsl-refresh.test.js test/settings-actions-agents.test.js test/settings-renderer-browser-env.test.js test/package-build-config.test.js
+```
+
+Then run:
+
+```powershell
+npm test
+```
+
+## 6. Real WSL acceptance smoke
+
+Use a disposable distro/user or a separately backed-up Hermes test home. Do not mutate the developer's active `~/.hermes` during automated work.
+
+1. Install a supported Hermes CLI in Ubuntu WSL2 and record the WSL, Hermes, Node, and Clawd versions plus networking mode.
+2. Test the standard `~/.hermes` layout, then repeat with a disposable custom WSL `HERMES_HOME` resolved through the login shell.
+3. Start Windows Clawd from the same development revision. Run WSL Scan from the Connected section, then open the Unavailable collapsible section and confirm the WSL-only Hermes card contains the expected distro row even if Windows Hermes exists under LocalAppData.
+4. Pair and confirm no Hermes staging remains afterward and the shared `~/.claude/hooks` tree is unchanged.
+5. Verify the current managed files exist in the primary home and every config-bearing profile; verify `hermes plugins list` reports Clawd enabled for each applicable home.
+6. Verify Settings enabled Hermes without changing its local `integrationInstalled` value.
+7. Run a real Hermes prompt/tool lifecycle and verify Clawd accepts a Hermes `/state` event and animates.
+8. Repeat Pair and verify idempotence. Put an old `0.1.0` fixture only in the disposable target plugin directory, Pair, and verify it upgrades to `0.2.0` without deleting an unrelated file.
+9. Force one profile enable failure and confirm Pair reports a warning while the primary integration remains usable and cleanup remains available.
+10. Unpair and confirm primary/profile Clawd plugin directories are removed, the Clawd enabled entry is disabled where the CLI succeeds, unrelated YAML semantics and sibling plugins remain, and the global Hermes gate stays enabled.
+11. Test the mirrored/reachable path and the NAT/unreachable warning path where practical.
+12. Repeat Pair and Unpair from a packaged Windows artifact, not only the source tree.
+
+Attach the sanitized Settings result, plugin-list output, relevant managed-file hashes, and before/after semantic config checks to the PR or issue comment.
+
+Executed on the active Ubuntu WSL home on 2026-08-09:
+
+- production Pair upgraded the installed Clawd plugin from `0.1.0` to `0.2.0`; a second Pair returned `Hermes plugin already installed`;
+- a real Hermes CLI session produced `SessionStart → idle` and `UserPromptSubmit → thinking` through the production `src/server.js` route, and the deployed plugin's `pre_tool_call` produced `PreToolUse → working`;
+- the first real lifecycle exposed inherited proxy variables sending Python `urllib` loopback traffic to a proxy and returning HTTP 502; the explicit no-proxy opener fixed that path, and a regression test now runs with every proxy variable pointed at a failing endpoint;
+- production Unpair disabled Clawd through Hermes and removed only `plugins/clawd-on-desk`; the CLI's `plugins.disabled` history entry is intentionally left to Hermes rather than rewriting user YAML directly;
+- final state is `clawd-on-desk enabled 0.2.0`; deployed managed-file hashes match the repository, the Windows runtime remains on port 23333, and private staging/backup directories were removed.
+
+The existing desktop process was intentionally not restarted during this smoke. Production route events were captured directly; visual animation in the already-running GUI was not claimed because that process had loaded the pre-change disabled Hermes gate.
+
+## 7. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Windows-local paths hide the WSL installation | Resolve Hermes home inside WSL; test LocalAppData/host-HERMES_HOME isolation |
+| Pair succeeds but runtime drops events | Commit only `enabled=true` after success; route-level regression test |
+| WSL Pair accidentally triggers Windows-local install | Preserve `integrationInstalled`; do not call local sync |
+| Nested path escapes the staging root | Explicit manifest, POSIX normalization, containment checks, and adversarial tests |
+| Partial upload corrupts another integration | Private ephemeral staging; install only after all uploads; exact cleanup in `finally` |
+| Package omits a required file | Manifest/managed-file consistency, packaged-layout test, real artifact smoke |
+| A future helper is omitted from the exact payload | Transitive relative-require and builtin-only manifest audit |
+| Profiles remain active after Unpair | Symmetric root/profile enumeration and removal tests |
+| Settings reports false success or hides warnings | Versioned installer sentinel propagated through deploy, action, and renderer |
+| Claude pairing makes Hermes look paired | Per-agent Hermes evidence overrides legacy distro-level hook markers |
+| WSL plugin installs but cannot reach Windows | Preserve connectivity probe/warning, bypass inherited proxies for loopback `/state` and `/permission`, test hostile proxy env, and document mirrored networking |
+| Cleanup removes too broad a target or silently fails | Strict temp marker/prefix/parent validation, exact quoted target, structured cleanup warning |
+| Managed plugin update follows a symlink or is interrupted | Reject symlinked managed leaves; same-directory temporary write plus atomic rename |
+
+## 8. Non-goals
+
+- Installing or upgrading Hermes itself.
+- Enabling WSL support for OpenCode, MiMo Code, Pi, OpenClaw, or WorkBuddy.
+- Refactoring existing persistent hook-based WSL deployments into ephemeral staging.
+- Reusing or changing Remote SSH deployment.
+- Parsing Hermes YAML on every Settings scan or claiming verified enabled-state truth from file presence.
+- Redesigning WSL networking, port discovery, Hermes permissions, session source labels, or terminal focus.
+- Broad hardening of all existing installer destination writes or all shared WSL hook uploads; those should receive separate threat-modelled changes.
+- Moving WSL-only agents into the Connected section or otherwise redesigning Settings agent categorization; record that cross-agent UX issue as a follow-up.
+
+If real smoke proves Hermes events arrive but lack useful WSL source/focus metadata, record that as a separate follow-up rather than expanding #540 without a concrete acceptance requirement.
+
+## 9. Rollback
+
+The feature is additive. If release smoke uncovers a regression:
+
+1. remove the Hermes WSL support option and its detector/UI evidence path;
+2. retain independently correct Hermes profile-uninstall and structured-result fixes;
+3. leave local Hermes integration behavior intact;
+4. use the audited Hermes uninstaller in the affected disposable/user-approved WSL home.
+
+No migration or direct user-YAML rewrite is introduced, and no persistent staging directory needs rollback.
+
+## 10. Independent review outcome
+
+Three read-only sub-agent reviews covered implementation correctness, safety/testing, and alternative architectures. Their shared conclusions were incorporated:
+
+- explicit file allowlisting is better than tar here;
+- WSL-native Hermes path resolution, runtime gate activation, and profile-symmetric cleanup are required;
+- the original shared-staging/Claude-marker plan was too weak for Hermes and could create false success or false UI state;
+- structured results and cross-platform orchestration seams are necessary for reliable tests.
+
+A subsequent independent Claude review also found no blocker. It prompted the final specification closures: the current Unavailable-section location for WSL-only Hermes, fixed `/tmp` staging parent, conservative `integrationFilesPresent: null` UI behavior, packaged `resourcesPath` injection, and the resolved decisions in §11.
+
+Rejected alternatives:
+
+- **tar stream:** unnecessary dependency and archive-extraction attack surface for six small files;
+- **Remote SSH reuse:** wrong transport and security lifecycle;
+- **`/mnt` source execution:** depends on drvfs/automount, `wslpath`, drive letters, and packaged paths with spaces;
+- **recursive plugin copy:** silently widens the managed asset boundary;
+- **Hermes-only control-flow `if` statements without data:** cheap initially but harder to audit and extend than one narrow option/manifest.
+
+## 11. Resolved implementation decisions
+
+External review raised five final design questions. They are closed as follows so implementation has no optional branch:
+
+1. Use private ephemeral staging for Hermes and future asset-backed integrations only when they do not need persistent command-hook files.
+2. Resolve custom WSL `HERMES_HOME` through the same bounded login/interactive shell used by installation, with sentinel parsing and the explicit `~/.hermes` fallback. Correct path agreement takes priority over the extra scan latency.
+3. Use the versioned Hermes sentinel directly in v1. Extract a shared installer-result helper only when a second integration needs the contract.
+4. Enable only Hermes after successful Pair in #540. Audit other non-default WSL agents in a separate follow-up.
+5. Use `integrationFilesPresent` only as cleanup evidence. Enabled-state truth remains explicitly deferred and must not be inferred from managed files.

--- a/hooks/hermes-install.js
+++ b/hooks/hermes-install.js
@@ -16,8 +16,11 @@ const { asarUnpackedPath } = require("./json-utils");
 const PLUGIN_ID = "clawd-on-desk";
 const PLUGIN_SOURCE_DIR_NAME = "hermes-plugin";
 const MANAGED_PLUGIN_FILES = ["plugin.yaml", "__init__.py"];
+const HERMES_RESULT_SCHEMA_VERSION = 1;
+const HERMES_RESULT_SENTINEL = "CLAWD_HERMES_RESULT_V1=";
 const DEFAULT_PARENT_DIR = path.join(os.homedir(), ".hermes");
 const DEFAULT_PLUGIN_DIR = path.join(DEFAULT_PARENT_DIR, "plugins", PLUGIN_ID);
+let _atomicWriteCounter = 0;
 
 function resolvePluginSourceDir(baseDir = __dirname) {
   return asarUnpackedPath(path.resolve(baseDir, PLUGIN_SOURCE_DIR_NAME));
@@ -75,6 +78,31 @@ function discoverHermesProfileHomes(hermesHome) {
   return homes;
 }
 
+// Uninstall must also find profile-owned plugin remnants after a profile's
+// config.yaml was deleted. Registration intentionally ignores those profiles,
+// but leaving their managed plugin directory behind would make Settings offer
+// an Unpair action that can never finish.
+function discoverHermesManagedPluginHomes(hermesHome) {
+  const profilesDir = path.join(hermesHome, "profiles");
+  let entries = [];
+  try {
+    entries = fs.readdirSync(profilesDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const homes = [];
+  for (const entry of entries) {
+    if (!entry || !entry.isDirectory()) continue;
+    const profileHome = path.join(profilesDir, entry.name);
+    const pluginDir = path.join(profileHome, "plugins", PLUGIN_ID);
+    if (!MANAGED_PLUGIN_FILES.some((name) => pathExists(path.join(pluginDir, name)))) continue;
+    homes.push(profileHome);
+  }
+  homes.sort((a, b) => a.localeCompare(b));
+  return homes;
+}
+
 function hermesHomesForSync(options = {}) {
   const hermesHome = resolveHermesHome(options);
   const homes = [hermesHome];
@@ -82,6 +110,25 @@ function hermesHomesForSync(options = {}) {
 
   const seen = new Set(homes.map((home) => path.resolve(home)));
   for (const profileHome of discoverHermesProfileHomes(hermesHome)) {
+    const resolved = path.resolve(profileHome);
+    if (seen.has(resolved)) continue;
+    seen.add(resolved);
+    homes.push(resolved);
+  }
+  return homes;
+}
+
+function hermesHomesForRemoval(options = {}) {
+  const hermesHome = resolveHermesHome(options);
+  const homes = [hermesHome];
+  if (options.syncProfiles === false || options.pluginDir) return homes;
+
+  const seen = new Set(homes.map((home) => path.resolve(home)));
+  const candidates = [
+    ...discoverHermesProfileHomes(hermesHome),
+    ...discoverHermesManagedPluginHomes(hermesHome),
+  ];
+  for (const profileHome of candidates) {
     const resolved = path.resolve(profileHome);
     if (seen.has(resolved)) continue;
     seen.add(resolved);
@@ -156,12 +203,56 @@ function formatHermesCommand(command, args) {
   return [quoteCommandToken(base), ...args].join(" ");
 }
 
+function lstatIfPresent(filePath) {
+  try {
+    return fs.lstatSync(filePath);
+  } catch (err) {
+    if (err && err.code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+function assertSafeManagedLeaf(filePath, expectedType) {
+  const stat = lstatIfPresent(filePath);
+  if (!stat) return null;
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Refusing to manage symlink: ${filePath}`);
+  }
+  if (expectedType === "directory" && !stat.isDirectory()) {
+    throw new Error(`Managed plugin path is not a directory: ${filePath}`);
+  }
+  if (expectedType === "file" && !stat.isFile()) {
+    throw new Error(`Managed plugin file is not a regular file: ${filePath}`);
+  }
+  return stat;
+}
+
+function writeManagedFileAtomic(filePath, content, options = {}) {
+  const base = path.basename(filePath);
+  const dir = path.dirname(filePath);
+  const suffix = `${process.pid}.${Date.now()}.${++_atomicWriteCounter}`;
+  const tempPath = path.join(dir, `.${base}.clawd-${suffix}.tmp`);
+  const writeFileSync = options.writeFileSync || fs.writeFileSync;
+  const renameSync = options.renameSync || fs.renameSync;
+  const unlinkSync = options.unlinkSync || fs.unlinkSync;
+
+  try {
+    writeFileSync(tempPath, content, { flag: "wx", mode: 0o600 });
+    renameSync(tempPath, filePath);
+  } catch (err) {
+    try { unlinkSync(tempPath); } catch {}
+    throw err;
+  }
+}
+
 function copyManagedPluginFiles(options = {}) {
   const sourceDir = options.sourcePluginDir || resolvePluginSourceDir(options.baseDir);
   const pluginDir = options.pluginDir;
   if (!pluginDir) throw new Error("copyManagedPluginFiles requires pluginDir");
 
+  assertSafeManagedLeaf(pluginDir, "directory");
   fs.mkdirSync(pluginDir, { recursive: true });
+  assertSafeManagedLeaf(pluginDir, "directory");
 
   let installed = 0;
   let updated = 0;
@@ -170,15 +261,12 @@ function copyManagedPluginFiles(options = {}) {
     const sourcePath = path.join(sourceDir, file);
     const destPath = path.join(pluginDir, file);
     const source = fs.readFileSync(sourcePath);
+    const destStat = assertSafeManagedLeaf(destPath, "file");
     let current = null;
-    try {
-      current = fs.readFileSync(destPath);
-    } catch (err) {
-      if (err.code !== "ENOENT") throw err;
-    }
+    if (destStat) current = fs.readFileSync(destPath);
 
     if (!current) {
-      fs.writeFileSync(destPath, source);
+      writeManagedFileAtomic(destPath, source, options);
       installed++;
       continue;
     }
@@ -186,7 +274,7 @@ function copyManagedPluginFiles(options = {}) {
       skipped++;
       continue;
     }
-    fs.writeFileSync(destPath, source);
+    writeManagedFileAtomic(destPath, source, options);
     updated++;
   }
   return { installed, updated, skipped };
@@ -364,67 +452,149 @@ function registerHermesPlugin(options = {}) {
 
 function unregisterHermesPlugin(options = {}) {
   const hermesHome = resolveHermesHome(options);
-  const pluginDir = options.pluginDir || path.join(hermesHome, "plugins", PLUGIN_ID);
+  const targetHomes = options.pluginDir
+    ? [hermesHome]
+    : hermesHomesForRemoval({ ...options, hermesHome });
+  const primaryCommand = resolveHermesCommand({ ...options, hermesHome });
   const warnings = [];
-  const disableResult = runHermesCli(["plugins", "disable", PLUGIN_ID], {
-    ...options,
-    hermesHome,
-  });
-  const disableCommand = disableResult.displayCommand
-    || formatHermesCommand(resolveHermesCommand({ ...options, hermesHome }) || "hermes", ["plugins", "disable", PLUGIN_ID]);
+  const profileResults = [];
+  let removedCount = 0;
+  let firstError = null;
 
-  if (!disableResult.ok) {
-    warnings.push(
-      disableResult.unavailable
-        ? `Hermes CLI was not found; skipped disable. If Hermes keeps a stale enabled entry, run: ${disableCommand}`
-        : `Hermes CLI disable failed: ${disableResult.message}`
-    );
-  }
+  for (const targetHome of targetHomes) {
+    const pluginDir = options.pluginDir && targetHome === hermesHome
+      ? options.pluginDir
+      : path.join(targetHome, "plugins", PLUGIN_ID);
+    const hasConfig = pathExists(path.join(targetHome, "config.yaml"));
+    const targetWarnings = [];
+    let disableCommand = null;
 
-  let removed = false;
-  try {
-    if (fs.existsSync(pluginDir)) {
-      fs.rmSync(pluginDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-      removed = true;
+    // A configless residual profile has no enabled allow-list left to edit.
+    // Do not invoke Hermes there: some CLI versions create a fresh config.
+    if (targetHome === hermesHome || hasConfig) {
+      const disableResult = runHermesCli(["plugins", "disable", PLUGIN_ID], {
+        ...options,
+        hermesHome: targetHome,
+        hermesCommand: options.hermesCommand || primaryCommand,
+      });
+      disableCommand = disableResult.displayCommand
+        || formatHermesCommand(
+          resolveHermesCommand({ ...options, hermesHome: targetHome }) || "hermes",
+          ["plugins", "disable", PLUGIN_ID]
+        );
+      if (!disableResult.ok) {
+        targetWarnings.push(
+          disableResult.unavailable
+            ? `Hermes CLI was not found; skipped disable. If Hermes keeps a stale enabled entry, run: ${disableCommand}`
+            : `Hermes CLI disable failed: ${disableResult.message}`
+        );
+      }
     }
-  } catch (err) {
-    return {
-      status: "error",
+
+    let removed = false;
+    let removeError = null;
+    try {
+      const pluginStat = assertSafeManagedLeaf(pluginDir, "directory");
+      if (pluginStat) {
+        const rmSync = options.rmSync || fs.rmSync;
+        rmSync(pluginDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+        removed = true;
+        removedCount++;
+      }
+    } catch (err) {
+      removeError = err;
+      if (!firstError) firstError = { err, pluginDir, hermesHome: targetHome };
+    }
+
+    const entry = {
+      status: removeError ? "error" : (targetWarnings.length ? "warning" : "ok"),
+      hermesHome: targetHome,
       pluginDir,
-      hermesHome,
       disableCommand,
       removed,
-      warnings,
-      message: `Failed to remove Hermes plugin directory: ${err.message}`,
+      warnings: targetWarnings,
+      message: removeError
+        ? `Failed to remove Hermes plugin directory: ${removeError.message}`
+        : (targetWarnings.length ? "Hermes plugin removed with warnings" : "Hermes plugin removed"),
+    };
+    profileResults.push(entry);
+    warnings.push(...targetWarnings.map((warning) => `${targetHome}: ${warning}`));
+  }
+
+  const pluginDir = options.pluginDir || path.join(hermesHome, "plugins", PLUGIN_ID);
+  const base = {
+    pluginDir,
+    hermesHome,
+    removed: removedCount > 0,
+    removedCount,
+    warnings,
+    profileResults,
+  };
+
+  if (firstError) {
+    return {
+      ...base,
+      status: "error",
+      reason: "hermes-plugin-remove-failed",
+      message: `Failed to remove Hermes plugin directory ${firstError.pluginDir}: ${firstError.err.message}`,
     };
   }
 
   if (!options.silent) {
     console.log(`Clawd Hermes plugin removed -> ${pluginDir}`);
+    if (profileResults.length > 1) console.log(`  Profiles cleaned: ${profileResults.length - 1}`);
     for (const warning of warnings) console.warn(`  Warning: ${warning}`);
   }
 
   return {
+    ...base,
     status: "ok",
-    pluginDir,
-    hermesHome,
-    disableCommand,
-    removed,
-    warnings,
     message: warnings.length
       ? "Hermes plugin removed with warnings"
       : "Hermes plugin removed",
   };
 }
 
+function boundedResultText(value, fallback = "") {
+  const text = typeof value === "string" && value.trim() ? value.trim() : fallback;
+  return text.slice(0, 1000);
+}
+
+function toHermesCliResult(result, operation) {
+  const source = result && typeof result === "object" ? result : {};
+  const warningCount = Array.isArray(source.warnings)
+    ? source.warnings.length
+    : (Number.isInteger(source.profileErrorCount) ? source.profileErrorCount : 0);
+  const warningText = Array.isArray(source.warnings) && source.warnings.length
+    ? source.warnings.join("\n")
+    : source.profileWarning;
+  const status = source.status === "error"
+    ? "error"
+    : ((source.profileStatus === "partial" || warningCount > 0) ? "warning" : "ok");
+  return {
+    schemaVersion: HERMES_RESULT_SCHEMA_VERSION,
+    operation,
+    status,
+    message: boundedResultText(source.message, status === "error" ? "Hermes plugin operation failed" : "Hermes plugin operation completed"),
+    reason: boundedResultText(source.reason, "") || null,
+    warning: boundedResultText(warningText, "") || null,
+    profileWarningCount: warningCount,
+    profileErrorCount: Number.isInteger(source.profileErrorCount) ? source.profileErrorCount : 0,
+  };
+}
+
 module.exports = {
   DEFAULT_PARENT_DIR,
   DEFAULT_PLUGIN_DIR,
+  HERMES_RESULT_SCHEMA_VERSION,
+  HERMES_RESULT_SENTINEL,
   MANAGED_PLUGIN_FILES,
   PLUGIN_ID,
   copyManagedPluginFiles,
+  discoverHermesManagedPluginHomes,
   discoverHermesProfileHomes,
   formatHermesCommand,
+  hermesHomesForRemoval,
   hermesHomesForSync,
   isHermesInstalled,
   registerHermesPlugin,
@@ -432,14 +602,31 @@ module.exports = {
   resolveHermesHome,
   resolvePluginSourceDir,
   runHermesCli,
+  toHermesCliResult,
   unregisterHermesPlugin,
+  writeManagedFileAtomic,
 };
 
 if (require.main === module) {
   const uninstall = process.argv.includes("--uninstall");
-  const result = uninstall ? unregisterHermesPlugin({}) : registerHermesPlugin({});
+  const jsonMode = process.argv.includes("--json");
+  let result;
+  try {
+    result = uninstall
+      ? unregisterHermesPlugin({ silent: jsonMode })
+      : registerHermesPlugin({ silent: jsonMode });
+  } catch (err) {
+    result = {
+      status: "error",
+      reason: "hermes-plugin-operation-threw",
+      message: err && err.message ? err.message : "Hermes plugin operation failed",
+    };
+  }
+  if (jsonMode) {
+    console.log(`${HERMES_RESULT_SENTINEL}${JSON.stringify(toHermesCliResult(result, uninstall ? "uninstall" : "install"))}`);
+  }
   if (result && result.status === "error") {
-    console.error(result.message || "Hermes plugin install failed");
-    process.exit(1);
+    if (!jsonMode) console.error(result.message || "Hermes plugin install failed");
+    process.exitCode = 1;
   }
 }

--- a/hooks/hermes-plugin/__init__.py
+++ b/hooks/hermes-plugin/__init__.py
@@ -94,6 +94,18 @@ _process_meta_started = False
 _process_meta_resolved = False
 _process_meta: Dict[str, Any] = {}
 
+# Clawd only listens on 127.0.0.1. urllib.request.urlopen() inherits
+# HTTP_PROXY/HTTPS_PROXY from the user's shell, and some proxy environments do
+# not exempt loopback even when the destination is explicit. Sending local
+# state or a blocking permission request through that proxy produces false
+# 502s (verified in a real WSL Hermes run for #540). Use one explicit no-proxy
+# opener for every Clawd request; this must cover both /state and /permission.
+_LOCAL_URL_OPENER = request.build_opener(request.ProxyHandler({}))
+
+
+def _local_urlopen(req: request.Request, timeout: float):
+    return _LOCAL_URL_OPENER.open(req, timeout=timeout)
+
 
 def _debug_enabled() -> bool:
     value = os.environ.get("CLAWD_HERMES_DEBUG", "").strip().lower()
@@ -227,7 +239,7 @@ def _post_state(body: Dict[str, Any]) -> None:
             method="POST",
         )
         try:
-            with request.urlopen(req, timeout=POST_TIMEOUT_SECONDS) as response:
+            with _local_urlopen(req, timeout=POST_TIMEOUT_SECONDS) as response:
                 if response.headers.get(CLAWD_SERVER_HEADER) == CLAWD_SERVER_ID:
                     _cached_port = port
                     _no_server_until = 0.0
@@ -309,7 +321,7 @@ def _post_permission(tool_name: str, tool_input: dict, session_id: str, platform
             method="GET",
         )
         try:
-            with request.urlopen(probe_req, timeout=POST_TIMEOUT_SECONDS) as probe_resp:
+            with _local_urlopen(probe_req, timeout=POST_TIMEOUT_SECONDS) as probe_resp:
                 if probe_resp.headers.get(CLAWD_SERVER_HEADER) != CLAWD_SERVER_ID:
                     continue
         except Exception:
@@ -323,7 +335,7 @@ def _post_permission(tool_name: str, tool_input: dict, session_id: str, platform
             method="POST",
         )
         try:
-            with request.urlopen(req, timeout=PERMISSION_POST_TIMEOUT_SECONDS) as response:
+            with _local_urlopen(req, timeout=PERMISSION_POST_TIMEOUT_SECONDS) as response:
                 if response.status == 204:
                     _cached_port = port
                     return None

--- a/src/agent-installation-detector.js
+++ b/src/agent-installation-detector.js
@@ -607,6 +607,43 @@ function detectAgentInstallations(options = {}) {
 // fails (timeout, broken wsl.exe), the previous results survive.
 // Also batches dir-exists checks into one wsl.exe spawn per distro
 // instead of one per (distro × agent).
+const HERMES_WSL_HOME_SENTINEL = "CLAWD_HERMES_HOME_V1=";
+
+function quoteWslPath(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
+
+function parseHermesWslHome(stdout) {
+  const lines = (typeof stdout === "string" ? stdout : "")
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith(HERMES_WSL_HOME_SENTINEL));
+  if (lines.length !== 1) return null;
+  const value = lines[0].slice(HERMES_WSL_HOME_SENTINEL.length);
+  if (!value.startsWith("/") || value.includes("\0") || value.includes("\r") || value.includes("\n") || value.includes("\\")) {
+    return null;
+  }
+  if (path.posix.normalize(value) !== value) return null;
+  return value;
+}
+
+async function resolveHermesWslHome(distro, wslHome, execInWsl, options = {}) {
+  // wsl.exe may add an outer shell around the requested login bash. Escape
+  // both dollars so HERMES_HOME/HOME are resolved by that login shell, after
+  // the user's profile has run, rather than by the outer launcher shell.
+  const command = "printf '" + HERMES_WSL_HOME_SENTINEL
+    + "%s\\n' \"\\${HERMES_HOME:-\\$HOME/.hermes}\"";
+  const result = await execInWsl(
+    distro,
+    command,
+    { ...options, shell: "bash", shellFlags: ["-l", "-i", "-c"], timeout: 15000 }
+  );
+  const resolved = result && result.code === 0 ? parseHermesWslHome(result.stdout) : null;
+  return {
+    path: resolved || `${wslHome.replace(/\/+$/, "")}/.hermes`,
+    customHomeUnknown: !resolved,
+  };
+}
+
 async function refreshWslDetection(options = {}) {
   if (process.platform !== "win32") {
     _cachedDetected = true;
@@ -644,6 +681,16 @@ async function refreshWslDetection(options = {}) {
         continue;
       }
 
+      const supportsHermes = descriptors.some((descriptor) =>
+        descriptor
+        && descriptor.agentId === "hermes"
+        && (!skipDefaultIntegrations || !DEFAULT_SKIPPED_AGENT_IDS.has("hermes"))
+        && getAgentInstallScriptName("hermes")
+      );
+      const hermesWslHome = supportsHermes
+        ? await resolveHermesWslHome(distro.name, wslHome, execInWsl, options)
+        : null;
+
       // Collect all directories to check for this distro. Only agents that
       // WSL deploy actually supports get entries — the UI renders a Pair
       // button per entry, and a guaranteed-to-fail Pair is worse than none.
@@ -652,9 +699,21 @@ async function refreshWslDetection(options = {}) {
         if (!descriptor || typeof descriptor.agentId !== "string") continue;
         if (skipDefaultIntegrations && DEFAULT_SKIPPED_AGENT_IDS.has(descriptor.agentId)) continue;
         if (!getAgentInstallScriptName(descriptor.agentId)) continue;
-        const wslParentDir = rebaseHomePathPosix(descriptor.parentDir, wslHome, homeDir);
+        // Hermes' descriptor was resolved in the Windows process and can point
+        // at LOCALAPPDATA or a host-only HERMES_HOME. Never rebase that value
+        // into WSL; resolve the distro's own environment above.
+        const wslParentDir = descriptor.agentId === "hermes" && hermesWslHome
+          ? hermesWslHome.path
+          : rebaseHomePathPosix(descriptor.parentDir, wslHome, homeDir);
         if (!wslParentDir) continue;
-        checks.push({ descriptor, wslParentDir });
+        checks.push({
+          descriptor,
+          wslParentDir,
+          integrationEvidence: descriptor.agentId === "hermes" ? "hermes-plugin-files" : null,
+          customHomeUnknown: descriptor.agentId === "hermes" && hermesWslHome
+            ? hermesWslHome.customHomeUnknown
+            : false,
+        });
       }
 
       if (checks.length === 0) continue;
@@ -667,6 +726,19 @@ async function refreshWslDetection(options = {}) {
         const escaped = c.wslParentDir.replace(/'/g, "'\\''");
         return `test -d '${escaped}' && echo "OK ${i}" || echo "NO ${i}"`;
       });
+      for (let i = 0; i < checks.length; i++) {
+        const check = checks[i];
+        if (check.integrationEvidence !== "hermes-plugin-files") continue;
+        const primaryPlugin = `${check.wslParentDir.replace(/\/+$/, "")}/plugins/clawd-on-desk`;
+        const profilesDir = `${check.wslParentDir.replace(/\/+$/, "")}/profiles`;
+        batchLines.push(
+          `if { test -f ${quoteWslPath(`${primaryPlugin}/plugin.yaml`)} || `
+          + `test -f ${quoteWslPath(`${primaryPlugin}/__init__.py`)} || `
+          + `find ${quoteWslPath(profilesDir)} -mindepth 4 -maxdepth 4 -type f `
+          + `\\( -path '*/plugins/clawd-on-desk/plugin.yaml' -o -path '*/plugins/clawd-on-desk/__init__.py' \\) `
+          + `-print -quit 2>/dev/null | grep -q .; }; then echo "INTFILE ${i} 1"; else echo "INTFILE ${i} 0"; fi`
+        );
+      }
       // Two independent deployment signals, because they answer different
       // UI questions:
       //   DEPFILE — hook files exist in the distro. Pairing ANY agent copies
@@ -702,23 +774,56 @@ async function refreshWslDetection(options = {}) {
         continue;
       }
 
-      // Parse: collect indices of "OK" lines and the two DEP markers.
-      const foundIndices = new Set();
-      let hooksFilesPresent = false;
-      let hooksRegistered = false;
+      // Parse every expected marker strictly. Truncated, duplicate, or
+      // conflicting output is not a trustworthy negative result.
+      const dirStates = new Map();
+      const integrationStates = new Map();
+      let hooksFilesPresent = null;
+      let hooksRegistered = null;
+      let markerError = false;
       const stdout = (batchResult && batchResult.stdout) || "";
       for (const line of stdout.split("\n")) {
         const trimmed = line.trim();
-        const m = trimmed.match(/^OK (\d+)$/);
-        if (m) foundIndices.add(parseInt(m[1], 10));
-        else if (trimmed === "DEPFILE 1") hooksFilesPresent = true;
-        else if (trimmed === "DEPREG 1") hooksRegistered = true;
+        let match = trimmed.match(/^(OK|NO) (\d+)$/);
+        if (match) {
+          const index = parseInt(match[2], 10);
+          const value = match[1] === "OK";
+          if (dirStates.has(index)) markerError = true;
+          else dirStates.set(index, value);
+          continue;
+        }
+        match = trimmed.match(/^INTFILE (\d+) ([01])$/);
+        if (match) {
+          const index = parseInt(match[1], 10);
+          const value = match[2] === "1";
+          if (integrationStates.has(index)) markerError = true;
+          else integrationStates.set(index, value);
+          continue;
+        }
+        if (trimmed === "DEPFILE 1" || trimmed === "DEPFILE 0") {
+          if (hooksFilesPresent !== null) markerError = true;
+          else hooksFilesPresent = trimmed.endsWith("1");
+        } else if (trimmed === "DEPREG 1" || trimmed === "DEPREG 0") {
+          if (hooksRegistered !== null) markerError = true;
+          else hooksRegistered = trimmed.endsWith("1");
+        }
+      }
+
+      if (dirStates.size !== checks.length || hooksFilesPresent === null || hooksRegistered === null) markerError = true;
+      for (let i = 0; i < checks.length; i++) {
+        if (!dirStates.has(i)) markerError = true;
+        if (checks[i].integrationEvidence && !integrationStates.has(i)) markerError = true;
+      }
+      if (markerError) {
+        console.warn("Clawd: WSL batch marker output was incomplete or ambiguous in", distro.name);
+        keepPreviousEntries(distro.name);
+        continue;
       }
 
       for (let i = 0; i < checks.length; i++) {
-        const { descriptor, wslParentDir } = checks[i];
-        const hasParentDir = foundIndices.has(i);
-        wslAgents.push({
+        const { descriptor, wslParentDir, integrationEvidence, customHomeUnknown } = checks[i];
+        const hasParentDir = dirStates.get(i) === true;
+        const entry = {
           agentId: descriptor.agentId,
           agentName: descriptor.agentName,
           distro: distro.name,
@@ -732,7 +837,12 @@ async function refreshWslDetection(options = {}) {
           wslParentDir,
           hooksDeployed: hooksFilesPresent && hooksRegistered,
           hooksFilesPresent,
-        });
+        };
+        if (integrationEvidence) {
+          entry.integrationFilesPresent = integrationStates.get(i) === true;
+          entry.hermesHomeResolutionUnknown = customHomeUnknown;
+        }
+        wslAgents.push(entry);
       }
     }
 

--- a/src/main.js
+++ b/src/main.js
@@ -440,11 +440,11 @@ const _settingsController = createSettingsController({
     writeCodexAutoStartGate: _persistCodexAutoStartGate,
     deployHooksToWsl: async (distro, agentId) => {
       const { deployToWsl } = require("./wsl-deploy");
-      return deployToWsl(distro, { agentId, isPackaged: app.isPackaged });
+      return deployToWsl(distro, { agentId, isPackaged: app.isPackaged, resourcesPath: process.resourcesPath });
     },
     removeHooksFromWsl: async (distro, agentId) => {
       const { removeFromWsl } = require("./wsl-deploy");
-      return removeFromWsl(distro, { agentId });
+      return removeFromWsl(distro, { agentId, isPackaged: app.isPackaged, resourcesPath: process.resourcesPath });
     },
     cleanupIntegrations: async (options = {}) => {
       // Claude hooks + statusline unregister as one queue task, awaited here so

--- a/src/settings-actions-agents.js
+++ b/src/settings-actions-agents.js
@@ -835,10 +835,20 @@ async function _wslCommand(payload, deps, { commandName, depName, action }) {
   try {
     const result = await deps[depName](distro, agentId);
     if (result && result.ok) {
-      const okResult = { status: "ok", message: `${action} WSL ${distro}` };
+      const okResult = {
+        status: "ok",
+        message: (typeof result.message === "string" && result.message) || `${action} WSL ${distro}`,
+      };
       // deploy-only: false = hooks installed but Clawd is unreachable from
       // the distro (NAT networking) — renderer shows a localized warning.
       if (result.connectivity === false) okResult.wslConnectivity = false;
+      if (typeof result.warning === "string" && result.warning) okResult.warning = result.warning;
+      if (commandName === "deployToWsl" && agentId === "hermes") {
+        // WSL pairing opens the shared ingress gate but is not a Windows-local
+        // integration install. Preserve integrationInstalled and every sibling
+        // flag so startup cannot auto-sync Hermes onto the host by accident.
+        okResult.commit = buildAgentCommit(deps.snapshot || {}, agentId, { enabled: true });
+      }
       return okResult;
     }
     return {

--- a/src/settings-tab-agents.js
+++ b/src/settings-tab-agents.js
@@ -1326,12 +1326,26 @@
     label.textContent = `WSL: ${wslEntry.distro}`;
     text.appendChild(label);
 
+    const hasIntegrationEvidence = Object.prototype.hasOwnProperty.call(
+      wslEntry,
+      "integrationFilesPresent"
+    );
+
+    function refreshWslHints() {
+      if (typeof ops.fetchAgentInstallationHints !== "function") return;
+      ops.fetchAgentInstallationHints({ refreshWsl: true }).then(() => {
+        ops.requestRender({ content: true });
+      }).catch(() => {
+        // DOM may be torn down if the user navigated away before refresh.
+      });
+    }
+
     // Distro-level marker: hook files are present AND claude-code's
     // settings.json references them (hooksDeployed = DEPFILE && DEPREG).
     // Not per-agent pairing truth — that would require inspecting each
     // agent's config inside WSL — but enough to show Pair took effect and
     // to go dark after a claude-code Unpair.
-    if (wslEntry.hooksDeployed) {
+    if (!hasIntegrationEvidence && wslEntry.hooksDeployed) {
       const deployed = document.createElement("span");
       deployed.className = "agent-instance-deployed";
       deployed.textContent = t("agentInstanceDeployedBadge");
@@ -1362,20 +1376,17 @@
             distro: wslEntry.distro,
           });
           if (result && result.status === "ok") {
+            const warnings = [];
+            if (typeof result.warning === "string" && result.warning) warnings.push(result.warning);
             if (result.wslConnectivity === false) {
               // Hooks installed, but the distro cannot reach Clawd (NAT
               // networking) — sessions would silently never appear.
-              ops.showToast(t("agentInstancePairedNoConnectivity"), { error: true });
+              warnings.push(t("agentInstancePairedNoConnectivity"));
+            }
+            if (warnings.length) {
+              ops.showToast(warnings.join("\n"), { error: true });
             } else {
               ops.showToast(result.message || t("agentInstancePaired"));
-            }
-            // Refresh hints so the UI updates (and Pair button may disappear)
-            if (typeof ops.fetchAgentInstallationHints === "function") {
-              ops.fetchAgentInstallationHints({ refreshWsl: true }).then(() => {
-                ops.requestRender({ content: true });
-              }).catch(() => {
-                // DOM may be torn down if user navigated away before refresh completes
-              });
             }
           } else {
             const msg = (result && result.message) || "WSL deploy failed";
@@ -1388,19 +1399,23 @@
           { error: true }
         );
       } finally {
+        // Refresh after both success and failure: an installer can leave
+        // managed files that the user must be able to Unpair/repair.
+        refreshWslHints();
         button.disabled = false;
         button.textContent = t("agentInstancePair");
       }
     });
     ctrl.appendChild(button);
 
-    // Unpair — offered whenever hook FILES are present (hooksFilesPresent),
-    // not gated on the registration-based badge (hooksDeployed): a distro
-    // paired with only a non-claude agent registers in that agent's own
-    // config, so the claude-settings badge is off, yet the user still needs
-    // an unpair entry point. Runs the agent's uninstall inside the distro;
-    // hook files stay (shared by other agents).
-    if (wslEntry.hooksFilesPresent) {
+    // Asset-backed integrations provide per-agent cleanup evidence. Only
+    // legacy persistent-hook agents fall back to the distro-level shared
+    // hooksFilesPresent marker; an explicit false/null must never inherit a
+    // Claude pairing and expose a fake Unpair action.
+    const canUnpair = hasIntegrationEvidence
+      ? wslEntry.integrationFilesPresent === true
+      : wslEntry.hooksFilesPresent === true;
+    if (canUnpair) {
       const unpairBtn = document.createElement("button");
       unpairBtn.className = "soft-btn agent-instance-action";
       unpairBtn.textContent = t("agentInstanceUnpair");
@@ -1415,14 +1430,10 @@
               distro: wslEntry.distro,
             });
             if (result && result.status === "ok") {
-              ops.showToast(result.message || t("agentInstanceUnpaired"));
-              if (typeof ops.fetchAgentInstallationHints === "function") {
-                ops.fetchAgentInstallationHints({ refreshWsl: true }).then(() => {
-                  ops.requestRender({ content: true });
-                }).catch(() => {
-                  // DOM may be torn down if user navigated away before refresh completes
-                });
-              }
+              ops.showToast(
+                result.warning || result.message || t("agentInstanceUnpaired"),
+                result.warning ? { error: true } : undefined
+              );
             } else {
               ops.showToast((result && result.message) || "WSL unpair failed", { error: true });
             }
@@ -1430,6 +1441,7 @@
         } catch (err) {
           ops.showToast(String(err && err.message ? err.message : err), { error: true });
         } finally {
+          refreshWslHints();
           unpairBtn.disabled = false;
           unpairBtn.textContent = t("agentInstanceUnpair");
         }

--- a/src/wsl-deploy.js
+++ b/src/wsl-deploy.js
@@ -1,25 +1,37 @@
 "use strict";
 
-// One-click WSL hook deployment — copies hook scripts from the Windows-side
-// Clawd into a WSL distro and runs the agent-specific install script.
-//
-// The user never needs to clone the repo inside WSL. Hook files are piped
-// through wsl.exe stdin to avoid /mnt/ path assumptions and command-line
-// length limits.
-//
-// Conceptually mirrors src/remote-ssh-deploy.js: both deploy hook scripts
-// to a remote environment and run agent-specific install scripts. Step
-// lists differ (wsl.exe stdin pipe vs scp) but new deploy requirements
-// should be addressed in both paths.
+// One-click WSL integration deployment. Persistent command-hook integrations
+// keep their historical ~/.claude/hooks payload. Asset-backed integrations
+// such as Hermes use a private, exact, ephemeral payload instead.
 
 const childProcess = require("child_process");
 const fs = require("fs");
 const path = require("path");
-const { execInWsl, getWslHomeDir, isWindows } = require("./wsl-utils");
+const wslUtils = require("./wsl-utils");
 
-// All .js files in the hooks/ directory — the full set is needed because
-// different agent install scripts have different dependencies
-// (e.g. codex-install.js requires codex-hook.js, codex-install-utils.js, etc.).
+const HERMES_RESULT_SENTINEL = "CLAWD_HERMES_RESULT_V1=";
+const HERMES_TEMP_SENTINEL = "CLAWD_HERMES_TMP_V1=";
+const HERMES_TEMP_PARENT = "/tmp";
+const HERMES_TEMP_TEMPLATE = "/tmp/clawd-hermes-XXXXXXXX";
+const HERMES_TEMP_BASENAME_RE = /^clawd-hermes-[A-Za-z0-9]{8}$/;
+const HERMES_WSL_FILES = Object.freeze([
+  "hermes-install.js",
+  "json-utils.js",
+  "wsl-connectivity-probe.js",
+  "server-config.js",
+  "hermes-plugin/plugin.yaml",
+  "hermes-plugin/__init__.py",
+]);
+
+const AGENT_WSL_OPTIONS = Object.freeze({
+  hermes: Object.freeze({
+    staging: "ephemeral",
+    structuredResult: true,
+    files: HERMES_WSL_FILES,
+  }),
+});
+
+// All top-level .js files are retained for existing persistent hook agents.
 function collectHookFiles(hooksDir) {
   const files = [];
   try {
@@ -27,21 +39,67 @@ function collectHookFiles(hooksDir) {
       if (!name.endsWith(".js")) continue;
       const full = path.join(hooksDir, name);
       if (!fs.statSync(full).isFile()) continue;
-      files.push({ name, path: full, content: fs.readFileSync(full, "utf8") });
+      files.push({ name, relativePath: name, path: full, content: fs.readFileSync(full, "utf8") });
     }
   } catch (err) {
-    // Permission denied, I/O error, or other FS failure — throw so the
-    // deploy fails with the real error rather than "No hook files found".
     console.warn("Clawd: collectHookFiles failed:", err && err.message ? err.message : err);
     throw err;
   }
   return files;
 }
 
+function validateDeployRelativePath(value) {
+  if (typeof value !== "string" || !value) throw new Error("deploy path must be a non-empty string");
+  if (value.includes("\0") || value.includes("\\") || value.includes("\r") || value.includes("\n")) {
+    throw new Error(`invalid deploy path: ${JSON.stringify(value)}`);
+  }
+  if (path.posix.isAbsolute(value)) throw new Error(`absolute deploy path is not allowed: ${value}`);
+  const parts = value.split("/");
+  if (parts.some((part) => !part || part === "." || part === "..")) {
+    throw new Error(`unsafe deploy path: ${value}`);
+  }
+  const normalized = path.posix.normalize(value);
+  if (normalized !== value) throw new Error(`non-canonical deploy path: ${value}`);
+  return normalized;
+}
+
+function collectAgentWslFiles(hooksDir, agentId) {
+  const agentOptions = AGENT_WSL_OPTIONS[agentId];
+  if (!agentOptions || !Array.isArray(agentOptions.files)) return collectHookFiles(hooksDir);
+
+  const root = path.resolve(hooksDir);
+  const seen = new Set();
+  const files = [];
+  for (const configuredPath of agentOptions.files) {
+    const relativePath = validateDeployRelativePath(configuredPath);
+    if (seen.has(relativePath)) throw new Error(`duplicate deploy destination: ${relativePath}`);
+    seen.add(relativePath);
+
+    const sourcePath = path.resolve(root, ...relativePath.split("/"));
+    if (sourcePath !== root && !sourcePath.startsWith(`${root}${path.sep}`)) {
+      throw new Error(`deploy source escapes hooks directory: ${relativePath}`);
+    }
+    let stat;
+    try {
+      stat = fs.lstatSync(sourcePath);
+    } catch (err) {
+      if (err && err.code === "ENOENT") throw new Error(`required WSL deploy file is missing: ${relativePath}`);
+      throw err;
+    }
+    if (stat.isSymbolicLink() || !stat.isFile()) {
+      throw new Error(`WSL deploy source must be a regular non-symlink file: ${relativePath}`);
+    }
+    files.push({
+      name: relativePath,
+      relativePath,
+      path: sourcePath,
+      content: fs.readFileSync(sourcePath),
+    });
+  }
+  return files;
+}
+
 // Map agentId to the install script that runs in WSL.
-// Register: node <script>.js
-// Unregister: node <script>.js --uninstall — EXCEPT claude-code (see
-// AGENT_UNINSTALL_COMMAND below).
 const AGENT_INSTALL_SCRIPT = {
   "claude-code": "install.js",
   codex: "codex-install.js",
@@ -50,25 +108,23 @@ const AGENT_INSTALL_SCRIPT = {
   "gemini-cli": "gemini-install.js",
   "antigravity-cli": "antigravity-install.js",
   codebuddy: "codebuddy-install.js",
-  // workbuddy is intentionally absent: WorkBuddy ships only as a macOS/Windows
-  // Electron desktop app with no standalone Linux/WSL CLI runtime, so there is
-  // no in-WSL settings.json for hooks to deploy into. (Its installer is a plain
-  // .js and would transfer fine — the blocker is the missing WSL runtime, not
-  // the asset limitation noted below.) Re-add once a Linux/WSL build exists.
+  // WorkBuddy has no standalone Linux/WSL runtime.
   "kiro-cli": "kiro-install.js",
   "kimi-cli": "kimi-install.js",
   "qwen-code": "qwen-code-install.js",
   zcode: "zcode-install.js",
   codewhale: "codewhale-install.js",
-  // opencode / mimocode / pi / openclaw / hermes are intentionally absent: their
-  // install scripts need non-.js assets (pi-extension.ts, hermes-plugin/,
-  // opencode-plugin/, mimocode-plugin/, openclaw-plugin/) that the flat stdin
-  // file pipe cannot transfer. Re-add them
-  // once deploy supports directory transfer (e.g. tar over stdin).
+  // OpenCode / MiMo / Pi / OpenClaw remain unsupported until their complete
+  // WSL runtime behavior is independently validated.
+  hermes: "hermes-install.js",
   qoder: "qoder-install.js",
   reasonix: "reasonix-install.js",
   qoderwork: "qoderwork-install.js",
 };
+
+function getAgentWslOptions(agentId) {
+  return AGENT_WSL_OPTIONS[agentId] || null;
+}
 
 function getInstallScript(agentId) {
   return getAgentInstallScriptName(agentId);
@@ -78,11 +134,7 @@ function getAgentInstallArgs(agentId) {
   return agentId === "codebuddy" ? "--permission-url preserve" : "";
 }
 
-// install.js does NOT understand --uninstall: it ignores unknown argv and
-// RE-REGISTERS hooks, so "node install.js --uninstall" re-installs 12 hook
-// entries and the subsequent rm -rf leaves them pointing at deleted files
-// (verified on a real Windows+WSL Ubuntu machine). Claude's uninstall lives
-// in the separate uninstall.js; every other agent installer handles the flag.
+// install.js does not implement --uninstall; Claude uses uninstall.js.
 const AGENT_UNINSTALL_COMMAND = {
   "claude-code": "uninstall.js",
 };
@@ -93,27 +145,63 @@ function getAgentUninstallCommand(agentId) {
   return installScript ? `${installScript} --uninstall` : null;
 }
 
-// Resolve hooks directory for both dev (source tree) and packaged.
-function resolveHooksDir({ isPackaged } = {}) {
+function resolveHooksDir({ isPackaged, resourcesPath } = {}) {
   if (isPackaged) {
-    return path.join(process.resourcesPath, "app.asar.unpacked", "hooks");
+    const root = resourcesPath || process.resourcesPath;
+    if (typeof root !== "string" || !root) throw new Error("resourcesPath is required for packaged WSL deploy");
+    return path.join(root, "app.asar.unpacked", "hooks");
   }
   return path.join(__dirname, "..", "hooks");
 }
 
-// Pipe a file's content into WSL via stdin → cat > file.
-// More reliable than /mnt/ paths (user may have custom mount configs)
-// and avoids command-line length limits.
-function pipeFileToWsl(distro, wslDestDir, fileName, content, options = {}) {
-  return new Promise((resolve) => {
-    const safePath = `${wslDestDir.replace(/\/$/, "")}/${fileName}`;
-    const cmd = `cat > '${safePath.replace(/'/g, "'\\''")}'`;
+function quotePosix(value) {
+  return `'${String(value).replace(/'/g, "'\\''")}'`;
+}
 
-    const child = childProcess.spawn("wsl.exe", ["-d", distro, "--", "bash", "-c", cmd], {
-      env: { ...process.env, LANG: "C.UTF-8", LC_ALL: "C.UTF-8" },
-      stdio: ["pipe", "pipe", "pipe"],
-      windowsHide: true,
-    });
+function isSafeAbsolutePosixPath(value) {
+  return typeof value === "string"
+    && value.startsWith("/")
+    && !value.includes("\0")
+    && !value.includes("\r")
+    && !value.includes("\n")
+    && !value.includes("\\");
+}
+
+function getDependency(options, name, fallback) {
+  return options && typeof options[name] === "function" ? options[name] : fallback;
+}
+
+function isWindowsFor(options) {
+  return getDependency(options, "isWindows", wslUtils.isWindows)();
+}
+
+// Pipe bytes into a validated path below one WSL directory.
+function pipeFileToWsl(distro, wslDestDir, fileName, content, options = {}) {
+  let relativePath;
+  try {
+    relativePath = validateDeployRelativePath(fileName);
+    if (!isSafeAbsolutePosixPath(wslDestDir)) throw new Error("invalid WSL destination directory");
+  } catch (err) {
+    return Promise.resolve({ ok: false, fileName, error: err.message });
+  }
+
+  return new Promise((resolve) => {
+    const root = wslDestDir.replace(/\/+$/, "");
+    const safePath = `${root}/${relativePath}`;
+    const parentDir = path.posix.dirname(safePath);
+    const cmd = `mkdir -p -- ${quotePosix(parentDir)} && cat > ${quotePosix(safePath)}`;
+    const spawn = getDependency(options, "spawn", childProcess.spawn);
+    let child;
+    try {
+      child = spawn("wsl.exe", ["-d", distro, "--", "bash", "-c", cmd], {
+        env: { ...process.env, LANG: "C.UTF-8", LC_ALL: "C.UTF-8" },
+        stdio: ["pipe", "pipe", "pipe"],
+        windowsHide: true,
+      });
+    } catch (err) {
+      resolve({ ok: false, fileName: relativePath, error: err && err.message ? err.message : "spawn failed" });
+      return;
+    }
 
     const stderrChunks = [];
     let done = false;
@@ -121,271 +209,445 @@ function pipeFileToWsl(distro, wslDestDir, fileName, content, options = {}) {
       if (done) return;
       done = true;
       try { child.kill(); } catch {}
-      resolve({ ok: false, fileName, error: "timeout" });
+      resolve({ ok: false, fileName: relativePath, error: "timeout" });
     }, options.timeout || 30000);
 
     child.on("error", (err) => {
       if (done) return;
       done = true;
       clearTimeout(timer);
-      resolve({ ok: false, fileName, error: err && err.message ? err.message : "spawn failed" });
+      resolve({ ok: false, fileName: relativePath, error: err && err.message ? err.message : "spawn failed" });
     });
-
-    if (child.stderr) {
-      child.stderr.on("data", (d) => { stderrChunks.push(d); });
-    }
-
-    // Use 'close' not 'exit' — only 'close' guarantees stdio streams are
-    // fully drained. 'exit' can fire while OS buffers still hold data.
+    if (child.stderr) child.stderr.on("data", (data) => { stderrChunks.push(data); });
     child.on("close", (code) => {
       if (done) return;
       done = true;
       clearTimeout(timer);
       const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
       resolve(code === 0
-        ? { ok: true, fileName, stderr: stderr || null }
-        : { ok: false, fileName, error: stderr || `exit code ${code}` }
-      );
+        ? { ok: true, fileName: relativePath, stderr: stderr || null }
+        : { ok: false, fileName: relativePath, error: stderr || `exit code ${code}` });
     });
 
-    if (child.stdin) {
-      // EPIPE when wsl.exe dies before draining stdin (stopped/broken
-      // distro). Without a listener the stream 'error' event is unhandled
-      // and crashes the main process; 'close' already reports the failure.
-      child.stdin.on("error", () => {});
-      child.stdin.end(content, "utf8");
-    } else {
-      if (done) return;
+    if (!child.stdin) {
       done = true;
       clearTimeout(timer);
-      resolve({ ok: false, fileName, error: "no stdin" });
+      resolve({ ok: false, fileName: relativePath, error: "no stdin" });
+      return;
     }
+    child.stdin.on("error", () => {});
+    if (Buffer.isBuffer(content)) child.stdin.end(content);
+    else child.stdin.end(content, "utf8");
   });
 }
 
-// ── Deploy ────────────────────────────────────────────────────────────
+function parseConnectivityProbe(stdout) {
+  const text = typeof stdout === "string" ? stdout : "";
+  const match = text.match(/^REACHABLE (\d+)$/m);
+  if (match) return { reachable: true, port: parseInt(match[1], 10) };
+  if (/^UNREACHABLE$/m.test(text)) return { reachable: false, port: null };
+  return { reachable: null, port: null };
+}
 
-async function deployToWsl(distro, options = {}) {
-  if (!isWindows()) {
-    return { ok: false, step: "platform", message: "WSL deploy only runs on Windows" };
+function parseHermesInstallerResult(stdout, expectedOperation) {
+  const text = typeof stdout === "string" ? stdout : "";
+  const lines = text.split(/\r?\n/).filter((line) => line.startsWith(HERMES_RESULT_SENTINEL));
+  if (lines.length !== 1) return { ok: false, error: "Hermes installer did not return exactly one result sentinel" };
+  let result;
+  try {
+    result = JSON.parse(lines[0].slice(HERMES_RESULT_SENTINEL.length));
+  } catch (err) {
+    return { ok: false, error: `Hermes installer returned invalid JSON: ${err.message}` };
   }
-  if (!distro) {
-    return { ok: false, step: "args", message: "distro name is required" };
+  if (!result || result.schemaVersion !== 1) return { ok: false, error: "Unsupported Hermes installer result schema" };
+  if (!["ok", "warning", "error"].includes(result.status)) return { ok: false, error: "Invalid Hermes installer result status" };
+  if (expectedOperation && result.operation !== expectedOperation) return { ok: false, error: "Hermes installer returned the wrong operation" };
+  return { ok: true, result };
+}
+
+function parseHermesTempDir(stdout) {
+  const text = typeof stdout === "string" ? stdout.trim() : "";
+  if (!text || text.includes("\n") || text.includes("\r") || !text.startsWith(HERMES_TEMP_SENTINEL)) return null;
+  const value = text.slice(HERMES_TEMP_SENTINEL.length);
+  if (!isSafeAbsolutePosixPath(value)) return null;
+  if (path.posix.dirname(value) !== HERMES_TEMP_PARENT) return null;
+  if (!HERMES_TEMP_BASENAME_RE.test(path.posix.basename(value))) return null;
+  return value;
+}
+
+async function createHermesTempDir(distro, options = {}) {
+  const execInWsl = getDependency(options, "execInWsl", wslUtils.execInWsl);
+  // wsl.exe can subject the command string to an outer Linux shell before
+  // the requested bash -c. Avoid a local shell variable here: the outer
+  // shell would expand it before mktemp assigns it in the inner shell.
+  const command = `set -o pipefail; umask 077; mktemp -d ${HERMES_TEMP_TEMPLATE} | sed 's#^#${HERMES_TEMP_SENTINEL}#'`;
+  let result;
+  try {
+    result = await execInWsl(distro, command, { ...options, timeout: 15000 });
+  } catch (err) {
+    return { ok: false, error: err && err.message ? err.message : "Could not create Hermes WSL staging directory" };
   }
-
-  const hooksDir = options.hooksDir || resolveHooksDir({ isPackaged: options.isPackaged });
-  const agentId = options.agentId || "claude-code";
-  const installScript = getInstallScript(agentId);
-
-  if (!installScript) {
-    return { ok: false, step: "unsupported", message: `WSL deploy is not supported for ${agentId}` };
+  if (!result || result.code !== 0) {
+    return { ok: false, error: (result && result.stderr) || "Could not create Hermes WSL staging directory" };
   }
+  const tempDir = parseHermesTempDir(result.stdout);
+  if (!tempDir) return { ok: false, error: "WSL returned an unsafe Hermes staging directory" };
+  return { ok: true, tempDir };
+}
 
-  function emit(step, status, message, hint) {
+async function cleanupHermesTempDir(distro, tempDir, options = {}) {
+  if (parseHermesTempDir(`${HERMES_TEMP_SENTINEL}${tempDir}`) !== tempDir) {
+    return { ok: false, error: "Refusing to clean an unsafe Hermes staging directory" };
+  }
+  const execInWsl = getDependency(options, "execInWsl", wslUtils.execInWsl);
+  let result;
+  try {
+    result = await execInWsl(distro, `rm -rf -- ${quotePosix(tempDir)}`, { ...options, timeout: 30000 });
+  } catch (err) {
+    return { ok: false, error: err && err.message ? err.message : "Hermes staging cleanup failed" };
+  }
+  return result && result.code === 0
+    ? { ok: true }
+    : { ok: false, error: (result && (result.stderr || (result.error && result.error.message))) || "Hermes staging cleanup failed" };
+}
+
+function appendWarning(result, warning, field = "warning") {
+  if (!warning) return result;
+  const warnings = Array.isArray(result.warnings) ? [...result.warnings, warning] : [warning];
+  return { ...result, [field]: field === "warning" ? warnings.join("\n") : warning, warnings };
+}
+
+function mergeCleanupResult(operation, cleanup) {
+  if (cleanup && cleanup.ok) return { ...operation, stagingRemoved: true };
+  const warning = `Hermes WSL staging cleanup failed: ${(cleanup && cleanup.error) || "unknown error"}`;
+  if (operation && operation.ok) return { ...appendWarning(operation, warning), stagingRemoved: false };
+  return { ...appendWarning(operation || { ok: false }, warning, "cleanupWarning"), stagingRemoved: false };
+}
+
+async function copyEntriesToWsl(distro, targetDir, entries, options, emit) {
+  const upload = getDependency(options, "pipeFileToWsl", pipeFileToWsl);
+  let copied = 0;
+  const errors = [];
+  emit("copy-files", "start");
+  for (const entry of entries) {
+    const relativePath = entry.relativePath || entry.name;
+    let result;
+    try {
+      result = await upload(distro, targetDir, relativePath, entry.content, options);
+    } catch (err) {
+      result = { ok: false, fileName: relativePath, error: err && err.message ? err.message : String(err) };
+    }
+    if (result && result.ok) {
+      copied++;
+      if (result.stderr) emit("copy-files", "stderr", null, { fileName: relativePath, stderr: result.stderr.slice(0, 200) });
+    } else {
+      errors.push(result || { fileName: relativePath, error: "upload failed" });
+    }
+  }
+  if (errors.length) {
+    const names = errors.map((entry) => entry.fileName).join(", ");
+    const message = `Failed to copy ${errors.length} file(s): ${names}`;
+    emit("copy-files", "fail", message);
+    return { ok: false, copied, errors, message };
+  }
+  emit("copy-files", "ok", null, { copied, total: entries.length });
+  return { ok: true, copied };
+}
+
+function progressEmitter(distro, options) {
+  return (step, status, message, hint) => {
     if (typeof options.onProgress === "function") {
       options.onProgress({ distro, step, status, message: message || null, hint: hint || null });
     }
+  };
+}
+
+async function deployHermesToWsl(distro, hooksDir, entries, options, emit) {
+  const execInWsl = getDependency(options, "execInWsl", wslUtils.execInWsl);
+  emit("prepare-dir", "start");
+  const prepared = await createHermesTempDir(distro, options);
+  if (!prepared.ok) {
+    emit("prepare-dir", "fail", prepared.error);
+    return { ok: false, step: "prepare-dir", message: prepared.error };
+  }
+  emit("prepare-dir", "ok", null, { staging: "ephemeral" });
+
+  const tempDir = prepared.tempDir;
+  const escapedDir = quotePosix(tempDir);
+  let operation;
+  try {
+    const copied = await copyEntriesToWsl(distro, tempDir, entries, options, emit);
+    if (!copied.ok) {
+      operation = { ok: false, step: "copy-files", message: copied.message, errors: copied.errors };
+    } else {
+      emit("run-install", "start");
+      const runResult = await execInWsl(
+        distro,
+        `cd ${escapedDir} && node hermes-install.js --json`,
+        { ...options, shell: "bash", shellFlags: ["-l", "-i", "-c"], timeout: 60000 }
+      );
+      const parsed = parseHermesInstallerResult(runResult && runResult.stdout, "install");
+      if (!parsed.ok || !runResult || runResult.code !== 0 || parsed.result.status === "error") {
+        const message = parsed.ok
+          ? parsed.result.message
+          : (parsed.error || (runResult && runResult.stderr) || "Hermes installer failed");
+        emit("run-install", "fail", message);
+        operation = { ok: false, step: "run-install", message };
+      } else {
+        emit("run-install", parsed.result.status === "warning" ? "warn" : "ok", parsed.result.message);
+        emit("verify-connectivity", "start");
+        const probeResult = await execInWsl(
+          distro,
+          `cd ${escapedDir} && node wsl-connectivity-probe.js`,
+          { ...options, shell: "bash", shellFlags: ["-l", "-i", "-c"], timeout: 20000 }
+        );
+        const connectivity = parseConnectivityProbe(probeResult && probeResult.stdout);
+        if (connectivity.reachable === true) emit("verify-connectivity", "ok", null, { port: connectivity.port });
+        else if (connectivity.reachable === false) emit("verify-connectivity", "warn", "Clawd HTTP server unreachable from WSL (NAT networking?)");
+        else emit("verify-connectivity", "skip", (probeResult && probeResult.stderr) || null);
+
+        operation = {
+          ok: true,
+          distro,
+          agentId: "hermes",
+          message: parsed.result.message,
+          filesCopied: copied.copied,
+          connectivity: connectivity.reachable,
+          connectivityPort: connectivity.port,
+          installerResult: parsed.result,
+        };
+        if (parsed.result.status === "warning") {
+          operation = appendWarning(operation, parsed.result.warning || parsed.result.message);
+        }
+      }
+    }
+  } catch (err) {
+    operation = { ok: false, step: "exception", message: err && err.message ? err.message : String(err) };
   }
 
-  // 1. Verify local hook files exist.
-  emit("verify-files", "start");
-  const fileEntries = collectHookFiles(hooksDir);
-  if (fileEntries.length === 0) {
-    const msg = `No hook files found in ${hooksDir}`;
-    emit("verify-files", "fail", msg);
-    return { ok: false, step: "verify-files", message: msg };
-  }
-  // Ensure the target install script is present.
-  if (!fileEntries.some((f) => f.name === installScript)) {
-    const msg = `Install script ${installScript} not found in ${hooksDir}`;
-    emit("verify-files", "fail", msg);
-    return { ok: false, step: "verify-files", message: msg };
-  }
-  emit("verify-files", "ok", null, { fileCount: fileEntries.length });
+  const cleanup = await cleanupHermesTempDir(distro, tempDir, options);
+  return mergeCleanupResult(operation, cleanup);
+}
 
-  // 2. Resolve WSL home and create hooks directory.
+async function deployPersistentToWsl(distro, agentId, installScript, entries, options, emit) {
+  const getWslHomeDir = getDependency(options, "getWslHomeDir", wslUtils.getWslHomeDir);
+  const execInWsl = getDependency(options, "execInWsl", wslUtils.execInWsl);
   emit("prepare-dir", "start");
   const wslHome = await getWslHomeDir(distro, options);
   if (!wslHome) {
-    const msg = `Could not resolve $HOME in WSL ${distro}`;
-    emit("prepare-dir", "fail", msg);
-    return { ok: false, step: "prepare-dir", message: msg };
+    const message = `Could not resolve $HOME in WSL ${distro}`;
+    emit("prepare-dir", "fail", message);
+    return { ok: false, step: "prepare-dir", message };
   }
   const hooksTargetDir = `${wslHome}/.claude/hooks`;
-  const hooksTargetDirEscaped = hooksTargetDir.replace(/'/g, "'\\''");
-
-  const mkdirResult = await execInWsl(distro, `mkdir -p '${hooksTargetDirEscaped}'`, options);
-  if (mkdirResult.code !== 0) {
-    const msg = mkdirResult.stderr || `mkdir failed with code ${mkdirResult.code}`;
-    emit("prepare-dir", "fail", msg);
-    return { ok: false, step: "prepare-dir", message: msg };
+  const mkdirResult = await execInWsl(distro, `mkdir -p ${quotePosix(hooksTargetDir)}`, options);
+  if (!mkdirResult || mkdirResult.code !== 0) {
+    const message = (mkdirResult && mkdirResult.stderr) || "mkdir failed";
+    emit("prepare-dir", "fail", message);
+    return { ok: false, step: "prepare-dir", message };
   }
   emit("prepare-dir", "ok", null, { hooksTargetDir });
 
-  // 3. Copy hook files into WSL.
-  emit("copy-files", "start");
-  let copied = 0;
-  const copyErrors = [];
-  for (const entry of fileEntries) {
-    const result = await pipeFileToWsl(distro, hooksTargetDir, entry.name, entry.content, options);
-    if (result.ok) {
-      copied++;
-      if (result.stderr) {
-        emit("copy-files", "stderr", null, { fileName: entry.name, stderr: result.stderr.slice(0, 200) });
-      }
-    } else {
-      copyErrors.push(result);
-    }
-  }
-  if (copyErrors.length > 0) {
-    const names = copyErrors.map((e) => e.fileName).join(", ");
-    const msg = `Failed to copy ${copyErrors.length} file(s): ${names}`;
-    emit("copy-files", "fail", msg);
-    return { ok: false, step: "copy-files", message: msg, errors: copyErrors };
-  }
-  emit("copy-files", "ok", null, { copied, total: fileEntries.length });
+  const copied = await copyEntriesToWsl(distro, hooksTargetDir, entries, options, emit);
+  if (!copied.ok) return { ok: false, step: "copy-files", message: copied.message, errors: copied.errors };
 
-  // 4. Run agent-specific install script inside WSL.
-  // Pass CLAWD_WSL_DISTRO so install.js's buildCommandHookSpec detects WSL
-  // and emits plain (unquoted) command format. Without this, the hook runner
-  // treats quotes as part of the executable name → silent hook failure.
-  //
-  // Use bash -l -i -c so version managers (nvm/volta/fnm) are initialised
-  // and `node` resolves to the user's managed version, not a stale system one.
   emit("run-install", "start");
   const distroEscaped = distro.replace(/'/g, "'\\''");
   const installArgs = getAgentInstallArgs(agentId);
   const runResult = await execInWsl(
     distro,
-    `cd '${hooksTargetDirEscaped}' && CLAWD_WSL_DISTRO='${distroEscaped}' node ${installScript}${installArgs ? ` ${installArgs}` : ""}`,
+    `cd ${quotePosix(hooksTargetDir)} && CLAWD_WSL_DISTRO='${distroEscaped}' node ${installScript}${installArgs ? ` ${installArgs}` : ""}`,
     { ...options, shell: "bash", shellFlags: ["-l", "-i", "-c"], timeout: 60000 }
   );
-  if (runResult.code !== 0) {
-    const msg = runResult.stderr || `${installScript} failed with code ${runResult.code}`;
-    emit("run-install", "fail", msg);
-    return { ok: false, step: "run-install", message: msg };
+  if (!runResult || runResult.code !== 0) {
+    const message = (runResult && runResult.stderr) || `${installScript} failed`;
+    emit("run-install", "fail", message);
+    return { ok: false, step: "run-install", message };
   }
   emit("run-install", "ok");
 
-  // 5. Probe Windows-side Clawd reachability from inside the distro.
-  // Under default NAT networking, localhost belongs to the WSL VM, so hooks
-  // install fine but every report silently fails (verified on a real NAT
-  // machine). Deploy still succeeds — the UI turns connectivity=false into
-  // an actionable warning instead of a fake success.
   emit("verify-connectivity", "start");
   const probeResult = await execInWsl(
     distro,
-    `cd '${hooksTargetDirEscaped}' && node wsl-connectivity-probe.js`,
+    `cd ${quotePosix(hooksTargetDir)} && node wsl-connectivity-probe.js`,
     { ...options, shell: "bash", shellFlags: ["-l", "-i", "-c"], timeout: 20000 }
   );
   const connectivity = parseConnectivityProbe(probeResult && probeResult.stdout);
-  if (connectivity.reachable === true) {
-    emit("verify-connectivity", "ok", null, { port: connectivity.port });
-  } else if (connectivity.reachable === false) {
-    emit("verify-connectivity", "warn", "Clawd HTTP server unreachable from WSL (NAT networking?)");
-  } else {
-    // Probe itself failed to produce a verdict (crashed, killed) — do not
-    // alarm the user on an unknown; hooks may still work.
-    emit("verify-connectivity", "skip", (probeResult && probeResult.stderr) || null);
-  }
+  if (connectivity.reachable === true) emit("verify-connectivity", "ok", null, { port: connectivity.port });
+  else if (connectivity.reachable === false) emit("verify-connectivity", "warn", "Clawd HTTP server unreachable from WSL (NAT networking?)");
+  else emit("verify-connectivity", "skip", (probeResult && probeResult.stderr) || null);
 
   return {
     ok: true,
     distro,
     agentId,
     hooksTargetDir,
-    filesCopied: copied,
+    filesCopied: copied.copied,
     connectivity: connectivity.reachable,
     connectivityPort: connectivity.port,
   };
 }
 
-// Parse wsl-connectivity-probe.js output: "REACHABLE <port>" / "UNREACHABLE".
-// Anything else (probe crashed, empty output) → reachable: null = unknown.
-function parseConnectivityProbe(stdout) {
-  const text = typeof stdout === "string" ? stdout : "";
-  const m = text.match(/^REACHABLE (\d+)$/m);
-  if (m) return { reachable: true, port: parseInt(m[1], 10) };
-  if (/^UNREACHABLE$/m.test(text)) return { reachable: false, port: null };
-  return { reachable: null, port: null };
+async function deployToWsl(distro, options = {}) {
+  if (!isWindowsFor(options)) return { ok: false, step: "platform", message: "WSL deploy only runs on Windows" };
+  if (!distro) return { ok: false, step: "args", message: "distro name is required" };
+
+  const agentId = options.agentId || "claude-code";
+  const installScript = getInstallScript(agentId);
+  if (!installScript) return { ok: false, step: "unsupported", message: `WSL deploy is not supported for ${agentId}` };
+
+  const emit = progressEmitter(distro, options);
+  emit("verify-files", "start");
+  let hooksDir;
+  let entries;
+  try {
+    hooksDir = options.hooksDir || resolveHooksDir(options);
+    entries = collectAgentWslFiles(hooksDir, agentId);
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    emit("verify-files", "fail", message);
+    return { ok: false, step: "verify-files", message };
+  }
+  if (!entries.length || !entries.some((entry) => entry.relativePath === installScript)) {
+    const message = !entries.length ? `No hook files found in ${hooksDir}` : `Install script ${installScript} not found in ${hooksDir}`;
+    emit("verify-files", "fail", message);
+    return { ok: false, step: "verify-files", message };
+  }
+  emit("verify-files", "ok", null, { fileCount: entries.length });
+
+  return agentId === "hermes"
+    ? deployHermesToWsl(distro, hooksDir, entries, options, emit)
+    : deployPersistentToWsl(distro, agentId, installScript, entries, options, emit);
 }
 
-// ── Remove ────────────────────────────────────────────────────────────
-
-async function removeFromWsl(distro, options = {}) {
-  if (!isWindows()) {
-    return { ok: false, step: "platform", message: "WSL remove only runs on Windows" };
+async function removeHermesFromWsl(distro, options, emit) {
+  emit("verify-files", "start");
+  let entries;
+  try {
+    const hooksDir = options.hooksDir || resolveHooksDir(options);
+    entries = collectAgentWslFiles(hooksDir, "hermes");
+  } catch (err) {
+    const message = err && err.message ? err.message : String(err);
+    emit("verify-files", "fail", message);
+    return { ok: false, step: "verify-files", message };
   }
-  if (!distro) {
-    return { ok: false, step: "args", message: "distro name is required" };
-  }
+  emit("verify-files", "ok", null, { fileCount: entries.length });
 
+  emit("prepare-dir", "start");
+  const prepared = await createHermesTempDir(distro, options);
+  if (!prepared.ok) {
+    emit("prepare-dir", "fail", prepared.error);
+    return { ok: false, step: "prepare-dir", message: prepared.error };
+  }
+  emit("prepare-dir", "ok", null, { staging: "ephemeral" });
+
+  const tempDir = prepared.tempDir;
+  let operation;
+  try {
+    const copied = await copyEntriesToWsl(distro, tempDir, entries, options, emit);
+    if (!copied.ok) {
+      operation = { ok: false, step: "copy-files", message: copied.message, errors: copied.errors };
+    } else {
+      emit("remove", "start");
+      const execInWsl = getDependency(options, "execInWsl", wslUtils.execInWsl);
+      const result = await execInWsl(
+        distro,
+        `cd ${quotePosix(tempDir)} && node hermes-install.js --uninstall --json`,
+        { ...options, shell: "bash", shellFlags: ["-l", "-i", "-c"], timeout: 60000 }
+      );
+      const parsed = parseHermesInstallerResult(result && result.stdout, "uninstall");
+      if (!parsed.ok || !result || result.code !== 0 || parsed.result.status === "error") {
+        const message = parsed.ok ? parsed.result.message : (parsed.error || (result && result.stderr) || "Hermes uninstaller failed");
+        emit("remove", "fail", message);
+        operation = { ok: false, step: "remove", message };
+      } else {
+        emit("remove", parsed.result.status === "warning" ? "warn" : "ok", parsed.result.message);
+        operation = {
+          ok: true,
+          distro,
+          agentId: "hermes",
+          message: parsed.result.message,
+          filesRemoved: true,
+          installerResult: parsed.result,
+        };
+        if (parsed.result.status === "warning") {
+          operation = appendWarning(operation, parsed.result.warning || parsed.result.message);
+        }
+      }
+    }
+  } catch (err) {
+    operation = { ok: false, step: "exception", message: err && err.message ? err.message : String(err) };
+  }
+  const cleanup = await cleanupHermesTempDir(distro, tempDir, options);
+  return mergeCleanupResult(operation, cleanup);
+}
+
+async function removePersistentFromWsl(distro, options, emit) {
+  const getWslHomeDir = getDependency(options, "getWslHomeDir", wslUtils.getWslHomeDir);
+  const execInWsl = getDependency(options, "execInWsl", wslUtils.execInWsl);
   const wslHome = await getWslHomeDir(distro, options);
-  if (!wslHome) {
-    return { ok: false, step: "home", message: `Could not resolve $HOME in WSL ${distro}` };
-  }
+  if (!wslHome) return { ok: false, step: "home", message: `Could not resolve $HOME in WSL ${distro}` };
 
   const hooksDir = `${wslHome}/.claude/hooks`;
-  const hooksDirEscaped = hooksDir.replace(/'/g, "'\\''");
   const agentId = options.agentId || "claude-code";
-
-  function emit(step, status, message, hint) {
-    if (typeof options.onProgress === "function") {
-      options.onProgress({ distro, step, status, message: message || null, hint: hint || null });
-    }
-  }
-
   emit("remove", "start");
-
-  // Run the agent's uninstall script — best-effort, may fail if Node or
-  // hooks were already removed. Use bash -l -i -c so version managers
-  // (nvm/volta/fnm) are initialised and `node` resolves correctly.
   const uninstallCommand = getAgentUninstallCommand(agentId);
   if (uninstallCommand) {
     const uninstallResult = await execInWsl(
       distro,
-      `cd '${hooksDirEscaped}' && node ${uninstallCommand}`,
+      `cd ${quotePosix(hooksDir)} && node ${uninstallCommand}`,
       { ...options, shell: "bash", shellFlags: ["-l", "-i", "-c"], timeout: 30000 }
     );
-    if (uninstallResult.code !== 0) {
-      emit("remove", "stderr", uninstallResult.stderr || `uninstall exited ${uninstallResult.code}`);
+    if (!uninstallResult || uninstallResult.code !== 0) {
+      emit("remove", "stderr", (uninstallResult && uninstallResult.stderr) || "uninstall failed");
     }
   }
 
-  // Remove the hook FILES only when explicitly asked: ~/.claude/hooks is
-  // shared by every paired agent in the distro, so a per-agent unpair from
-  // the UI must not delete files other agents' registered commands point at.
   if (options.removeFiles === true) {
-    const rmResult = await execInWsl(
-      distro,
-      `rm -rf '${hooksDirEscaped}'`,
-      { ...options, timeout: 30000 }
-    );
-    if (rmResult.code !== 0) {
-      const msg = rmResult.stderr || `rm failed with code ${rmResult.code}`;
-      emit("remove", "fail", msg);
-      return { ok: false, step: "remove", message: msg };
+    const rmResult = await execInWsl(distro, `rm -rf ${quotePosix(hooksDir)}`, { ...options, timeout: 30000 });
+    if (!rmResult || rmResult.code !== 0) {
+      const message = (rmResult && rmResult.stderr) || "rm failed";
+      emit("remove", "fail", message);
+      return { ok: false, step: "remove", message };
     }
   }
-
   emit("remove", "ok");
   return { ok: true, distro, agentId, filesRemoved: options.removeFiles === true };
 }
 
-// ── Agent-specific install script name lookup ─────────────────────────
+async function removeFromWsl(distro, options = {}) {
+  if (!isWindowsFor(options)) return { ok: false, step: "platform", message: "WSL remove only runs on Windows" };
+  if (!distro) return { ok: false, step: "args", message: "distro name is required" };
+  const agentId = options.agentId || "claude-code";
+  const emit = progressEmitter(distro, options);
+  return agentId === "hermes"
+    ? removeHermesFromWsl(distro, options, emit)
+    : removePersistentFromWsl(distro, options, emit);
+}
 
 function getAgentInstallScriptName(agentId) {
   return AGENT_INSTALL_SCRIPT[agentId] || null;
 }
 
 module.exports = {
-  deployToWsl,
-  removeFromWsl,
-  getAgentInstallScriptName,
-  getAgentInstallArgs,
-  getAgentUninstallCommand,
-  parseConnectivityProbe,
-  resolveHooksDir,
-  pipeFileToWsl,
+  HERMES_RESULT_SENTINEL,
+  HERMES_TEMP_SENTINEL,
+  HERMES_WSL_FILES,
+  cleanupHermesTempDir,
+  collectAgentWslFiles,
   collectHookFiles,
+  createHermesTempDir,
+  deployToWsl,
+  getAgentInstallArgs,
+  getAgentInstallScriptName,
+  getAgentUninstallCommand,
+  getAgentWslOptions,
+  mergeCleanupResult,
+  parseConnectivityProbe,
+  parseHermesInstallerResult,
+  parseHermesTempDir,
+  pipeFileToWsl,
+  removeFromWsl,
+  resolveHooksDir,
+  validateDeployRelativePath,
 };

--- a/test/agent-installation-detector-wsl-refresh.test.js
+++ b/test/agent-installation-detector-wsl-refresh.test.js
@@ -132,3 +132,94 @@ test("DEPFILE/DEPREG signals map to hooksFilesPresent and hooksDeployed", async 
   assert.strictEqual(entry.hooksFilesPresent, false);
   assert.strictEqual(entry.hooksDeployed, false);
 });
+
+test("Hermes uses its WSL-native home and per-agent plugin evidence", async () => {
+  const hermesDescriptors = [{
+    agentId: "hermes",
+    agentName: "Hermes Agent",
+    parentDir: path.join(homeDir, "AppData", "Local", "hermes"),
+    configPath: path.join(homeDir, "AppData", "Local", "hermes", "plugins", "clawd-on-desk"),
+  }];
+  const commands = [];
+  wslUtils.getWslDistributions = async () => [{ name: "HermesUbuntu" }];
+  wslUtils.getWslHomeDir = async () => "/home/tester";
+  wslUtils.execInWsl = async (_distro, command) => {
+    commands.push(command);
+    if (command.includes("CLAWD_HERMES_HOME_V1=")) {
+      return { code: 0, stdout: "shell noise\nCLAWD_HERMES_HOME_V1=/home/tester/.hermes\n", stderr: "" };
+    }
+    return { code: 0, stdout: "OK 0\nINTFILE 0 1\nDEPFILE 1\nDEPREG 1\n", stderr: "" };
+  };
+
+  const result = await refreshWslDetection({
+    descriptors: hermesDescriptors,
+    homeDir,
+    skipDefaultIntegrations: false,
+  });
+  const entry = result.wslAgents.find((item) => item.distro === "HermesUbuntu" && item.agentId === "hermes");
+
+  assert.ok(entry);
+  assert.strictEqual(entry.detectedInstalled, true);
+  assert.strictEqual(entry.wslParentDir, "/home/tester/.hermes");
+  assert.strictEqual(entry.integrationFilesPresent, true);
+  assert.strictEqual(entry.hermesHomeResolutionUnknown, false);
+  assert.ok(commands[0].includes("\\${HERMES_HOME:-\\$HOME/.hermes}"),
+    "the login shell, not wsl.exe's outer launcher shell, resolves Hermes home");
+  assert.ok(commands[1].includes("/home/tester/.hermes"));
+  assert.ok(!commands[1].includes("AppData"));
+});
+
+test("Hermes honors custom WSL HERMES_HOME and falls back safely when resolution fails", async () => {
+  const descriptors = [{
+    agentId: "hermes",
+    agentName: "Hermes Agent",
+    parentDir: path.join(homeDir, ".hermes"),
+  }];
+  wslUtils.getWslHomeDir = async () => "/home/tester";
+  let resolverSucceeds = true;
+  wslUtils.getWslDistributions = async () => [{ name: "HermesCustom" }];
+  wslUtils.execInWsl = async (_distro, command) => {
+    if (command.includes("CLAWD_HERMES_HOME_V1=")) {
+      return resolverSucceeds
+        ? { code: 0, stdout: "CLAWD_HERMES_HOME_V1=/srv/hermes-home\n", stderr: "" }
+        : { code: 1, stdout: "", stderr: "profile failed" };
+    }
+    return { code: 0, stdout: "OK 0\nINTFILE 0 0\nDEPFILE 0\nDEPREG 0\n", stderr: "" };
+  };
+  const options = { descriptors, homeDir, skipDefaultIntegrations: false };
+
+  let entry = (await refreshWslDetection(options)).wslAgents.find((item) => item.distro === "HermesCustom");
+  assert.strictEqual(entry.wslParentDir, "/srv/hermes-home");
+  assert.strictEqual(entry.hermesHomeResolutionUnknown, false);
+
+  resolverSucceeds = false;
+  entry = (await refreshWslDetection(options)).wslAgents.find((item) => item.distro === "HermesCustom");
+  assert.strictEqual(entry.wslParentDir, "/home/tester/.hermes");
+  assert.strictEqual(entry.hermesHomeResolutionUnknown, true);
+});
+
+test("incomplete Hermes evidence preserves the previous committed distro result", async () => {
+  const descriptors = [{ agentId: "hermes", agentName: "Hermes Agent", parentDir: path.join(homeDir, ".hermes") }];
+  const options = { descriptors, homeDir, skipDefaultIntegrations: false };
+  wslUtils.getWslDistributions = async () => [{ name: "HermesMarkers" }];
+  wslUtils.getWslHomeDir = async () => "/home/tester";
+  let complete = true;
+  wslUtils.execInWsl = async (_distro, command) => {
+    if (command.includes("CLAWD_HERMES_HOME_V1=")) {
+      return { code: 0, stdout: "CLAWD_HERMES_HOME_V1=/home/tester/.hermes\n", stderr: "" };
+    }
+    return {
+      code: 0,
+      stdout: complete
+        ? "OK 0\nINTFILE 0 1\nDEPFILE 0\nDEPREG 0\n"
+        : "OK 0\nDEPFILE 0\nDEPREG 0\n",
+      stderr: "",
+    };
+  };
+
+  let entry = (await refreshWslDetection(options)).wslAgents.find((item) => item.distro === "HermesMarkers");
+  assert.strictEqual(entry.integrationFilesPresent, true);
+  complete = false;
+  entry = (await refreshWslDetection(options)).wslAgents.find((item) => item.distro === "HermesMarkers");
+  assert.strictEqual(entry.integrationFilesPresent, true, "ambiguous scan must keep the prior evidence");
+});

--- a/test/hermes-install.test.js
+++ b/test/hermes-install.test.js
@@ -3,14 +3,18 @@ const assert = require("node:assert");
 const fs = require("fs");
 const path = require("path");
 const os = require("os");
+const { spawnSync: spawnProcessSync } = require("node:child_process");
 
 const {
+  HERMES_RESULT_SCHEMA_VERSION,
   PLUGIN_ID,
   MANAGED_PLUGIN_FILES,
+  copyManagedPluginFiles,
   hermesHomesForSync,
   isHermesInstalled,
   registerHermesPlugin,
   resolveHermesHome,
+  toHermesCliResult,
   unregisterHermesPlugin,
 } = require("../hooks/hermes-install");
 
@@ -387,5 +391,151 @@ describe("Hermes plugin installer", () => {
     ]);
     assert.strictEqual(fs.existsSync(pluginDir), false);
     assert.strictEqual(fs.existsSync(siblingDir), true);
+  });
+
+  it("uninstalls primary, configured profiles, and configless managed remnants symmetrically", () => {
+    const hermesHome = makeTempDir();
+    const configured = path.join(hermesHome, "profiles", "ops");
+    const residual = path.join(hermesHome, "profiles", "old");
+    fs.mkdirSync(path.join(hermesHome, "plugins", PLUGIN_ID), { recursive: true });
+    fs.mkdirSync(path.join(configured, "plugins", PLUGIN_ID), { recursive: true });
+    fs.mkdirSync(path.join(residual, "plugins", PLUGIN_ID), { recursive: true });
+    fs.writeFileSync(path.join(hermesHome, "config.yaml"), "plugins: {}\n", "utf8");
+    fs.writeFileSync(path.join(configured, "config.yaml"), "plugins: {}\n", "utf8");
+    fs.writeFileSync(path.join(hermesHome, "plugins", PLUGIN_ID, "plugin.yaml"), "root\n", "utf8");
+    fs.writeFileSync(path.join(configured, "plugins", PLUGIN_ID, "__init__.py"), "# configured\n", "utf8");
+    fs.writeFileSync(path.join(residual, "plugins", PLUGIN_ID, "plugin.yaml"), "residual\n", "utf8");
+    const spawnSync = makeSpawn();
+
+    const result = unregisterHermesPlugin({
+      silent: true,
+      hermesHome,
+      hermesCommand: "hermes",
+      spawnSync,
+      env: {},
+    });
+
+    assert.strictEqual(result.status, "ok");
+    assert.strictEqual(result.removedCount, 3);
+    assert.deepStrictEqual(
+      spawnSync.calls.map((call) => call.options.env.HERMES_HOME).sort(),
+      [hermesHome, configured].sort(),
+      "configless residual must be removed without invoking Hermes CLI"
+    );
+    assert.strictEqual(fs.existsSync(path.join(hermesHome, "plugins", PLUGIN_ID)), false);
+    assert.strictEqual(fs.existsSync(path.join(configured, "plugins", PLUGIN_ID)), false);
+    assert.strictEqual(fs.existsSync(path.join(residual, "plugins", PLUGIN_ID)), false);
+    assert.strictEqual(fs.existsSync(path.join(residual, "config.yaml")), false);
+  });
+
+  it("removes managed files but returns warnings when one profile cannot disable", () => {
+    const hermesHome = makeTempDir();
+    const profileHome = path.join(hermesHome, "profiles", "ops");
+    for (const targetHome of [hermesHome, profileHome]) {
+      fs.mkdirSync(path.join(targetHome, "plugins", PLUGIN_ID), { recursive: true });
+      fs.writeFileSync(path.join(targetHome, "config.yaml"), "plugins: {}\n", "utf8");
+      fs.writeFileSync(path.join(targetHome, "plugins", PLUGIN_ID, "plugin.yaml"), "managed\n", "utf8");
+    }
+    const calls = [];
+    const spawnSync = (command, args, options) => {
+      calls.push({ command, args, options });
+      return options.env.HERMES_HOME === profileHome
+        ? { status: 1, stdout: "", stderr: "profile disable failed" }
+        : { status: 0, stdout: "", stderr: "" };
+    };
+
+    const result = unregisterHermesPlugin({ silent: true, hermesHome, hermesCommand: "hermes", spawnSync, env: {} });
+
+    assert.strictEqual(result.status, "ok");
+    assert.strictEqual(result.warnings.length, 1);
+    assert.match(result.warnings[0], /profile disable failed/);
+    assert.strictEqual(fs.existsSync(path.join(profileHome, "plugins", PLUGIN_ID)), false);
+    assert.strictEqual(calls.length, 2);
+  });
+
+  it("returns an error when a managed plugin directory cannot be removed", () => {
+    const hermesHome = makeTempDir();
+    const pluginDir = path.join(hermesHome, "plugins", PLUGIN_ID);
+    fs.mkdirSync(pluginDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginDir, "plugin.yaml"), "managed\n", "utf8");
+    const result = unregisterHermesPlugin({
+      silent: true,
+      hermesHome,
+      hermesCommand: "hermes",
+      spawnSync: makeSpawn(),
+      rmSync: () => { throw new Error("locked"); },
+      env: {},
+    });
+    assert.strictEqual(result.status, "error");
+    assert.strictEqual(result.reason, "hermes-plugin-remove-failed");
+    assert.match(result.message, /locked/);
+    assert.strictEqual(fs.existsSync(pluginDir), true);
+  });
+
+  it("preserves the old managed file when atomic replacement fails", () => {
+    const sourcePluginDir = makeSourcePlugin();
+    const pluginDir = makeTempDir();
+    const dest = path.join(pluginDir, "plugin.yaml");
+    fs.writeFileSync(dest, "old\n", "utf8");
+
+    assert.throws(() => copyManagedPluginFiles({
+      sourcePluginDir,
+      pluginDir,
+      renameSync: () => { throw new Error("rename failed"); },
+    }), /rename failed/);
+    assert.strictEqual(fs.readFileSync(dest, "utf8"), "old\n");
+    assert.deepStrictEqual(
+      fs.readdirSync(pluginDir).filter((name) => name.includes(".clawd-") && name.endsWith(".tmp")),
+      []
+    );
+  });
+
+  it("normalizes install and uninstall outcomes for the versioned CLI contract", () => {
+    assert.deepStrictEqual(toHermesCliResult({ status: "ok", message: "done" }, "install"), {
+      schemaVersion: HERMES_RESULT_SCHEMA_VERSION,
+      operation: "install",
+      status: "ok",
+      message: "done",
+      reason: null,
+      warning: null,
+      profileWarningCount: 0,
+      profileErrorCount: 0,
+    });
+    const warning = toHermesCliResult({
+      status: "ok",
+      profileStatus: "partial",
+      profileErrorCount: 2,
+      message: "partial",
+    }, "install");
+    assert.strictEqual(warning.status, "warning");
+    assert.strictEqual(warning.profileWarningCount, 2);
+    assert.strictEqual(warning.warning, null);
+    assert.match(toHermesCliResult({
+      status: "ok",
+      warnings: ["profile disable failed"],
+      message: "removed with warnings",
+    }, "uninstall").warning, /profile disable failed/);
+    assert.strictEqual(toHermesCliResult({ status: "error", reason: "bad", message: "failed" }, "uninstall").status, "error");
+  });
+
+  it("prints one structured error sentinel when JSON-mode installation throws", () => {
+    const hermesHome = makeTempDir();
+    const pluginsDir = path.join(hermesHome, "plugins");
+    fs.mkdirSync(pluginsDir, { recursive: true });
+    fs.writeFileSync(path.join(pluginsDir, PLUGIN_ID), "blocks plugin directory creation\n", "utf8");
+
+    const run = spawnProcessSync(process.execPath, [path.join(__dirname, "..", "hooks", "hermes-install.js"), "--json"], {
+      encoding: "utf8",
+      env: { ...process.env, HERMES_HOME: hermesHome },
+      timeout: 10000,
+      windowsHide: true,
+    });
+
+    assert.strictEqual(run.status, 1);
+    const sentinelLines = run.stdout.split(/\r?\n/).filter((line) => line.startsWith("CLAWD_HERMES_RESULT_V1="));
+    assert.strictEqual(sentinelLines.length, 1);
+    const result = JSON.parse(sentinelLines[0].slice("CLAWD_HERMES_RESULT_V1=".length));
+    assert.strictEqual(result.status, "error");
+    assert.strictEqual(result.reason, "hermes-plugin-operation-threw");
   });
 });

--- a/test/hermes-plugin.test.js
+++ b/test/hermes-plugin.test.js
@@ -620,7 +620,7 @@ def fake_urlopen(req, timeout=None):
         )
     raise AssertionError(req.full_url)
 
-mod.request.urlopen = fake_urlopen
+mod._local_urlopen = fake_urlopen
 mod._port_candidates = lambda: [23333]
 mod._add_process_meta = lambda payload: None
 mod._runtime_cwd = lambda: "/repo"
@@ -638,6 +638,58 @@ print(json.dumps({"result": result, "calls": calls, "cached_port": mod._cached_p
       ["GET", "http://127.0.0.1:23333/state", 0.25],
       ["POST", "http://127.0.0.1:23333/permission", 600],
     ]);
+  });
+
+  it("bypasses inherited HTTP proxies for Clawd loopback state posts", () => {
+    const output = runPluginPython(String.raw`
+import importlib.util
+import json
+import os
+import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+sys.dont_write_bytecode = True
+for key in ("NO_PROXY", "no_proxy"):
+    os.environ.pop(key, None)
+for key in ("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "ALL_PROXY", "all_proxy"):
+    os.environ[key] = "http://127.0.0.1:1"
+
+spec = importlib.util.spec_from_file_location("hermes_plugin", r"hooks/hermes-plugin/__init__.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+received = []
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        received.append(json.loads(self.rfile.read(length).decode("utf-8")))
+        self.send_response(200)
+        self.send_header(mod.CLAWD_SERVER_HEADER, mod.CLAWD_SERVER_ID)
+        self.end_headers()
+    def log_message(self, *args):
+        pass
+
+server = HTTPServer(("127.0.0.1", 0), Handler)
+thread = threading.Thread(target=server.serve_forever, daemon=True)
+thread.start()
+try:
+    mod._port_candidates = lambda: [server.server_port]
+    mod._append_log = lambda *args, **kwargs: None
+    mod._cached_port = None
+    mod._no_server_until = 0.0
+    mod._post_state({"agent_id": "hermes", "state": "thinking", "session_id": "proxy-smoke"})
+finally:
+    server.shutdown()
+    thread.join(timeout=2)
+    server.server_close()
+
+print(json.dumps({"received": received, "cached_port": mod._cached_port}, sort_keys=True))
+`);
+    const result = JSON.parse(output);
+    assert.strictEqual(result.received.length, 1);
+    assert.strictEqual(result.received[0].agent_id, "hermes");
+    assert.strictEqual(result.cached_port > 0, true);
   });
 
   it("skips process metadata on WebUI permission posts", () => {
@@ -685,7 +737,7 @@ def fake_add_process_meta(payload):
     payload["source_pid"] = 1234
     payload["editor"] = "code"
 
-mod.request.urlopen = fake_urlopen
+mod._local_urlopen = fake_urlopen
 mod._port_candidates = lambda: [23333]
 mod._add_process_meta = fake_add_process_meta
 mod._runtime_cwd = lambda: "/repo"
@@ -725,7 +777,7 @@ def fake_urlopen(*args, **kwargs):
     calls.append([str(args), kwargs])
     raise AssertionError("urlopen should not run during cooldown")
 
-mod.request.urlopen = fake_urlopen
+mod._local_urlopen = fake_urlopen
 mod._append_log = lambda payload, **kwargs: logs.append(payload)
 mod._cached_port = None
 mod._no_server_until = time.monotonic() + 10
@@ -793,7 +845,7 @@ def fake_urlopen(req, timeout=None):
     assert req.full_url.endswith("/state"), "permission POST should not be attempted after probe mismatch"
     return FakeResponse()
 
-mod.request.urlopen = fake_urlopen
+mod._local_urlopen = fake_urlopen
 mod._port_candidates = lambda: [23333]
 mod._append_log = lambda *args, **kwargs: None
 mod._cached_port = None

--- a/test/settings-actions-agents.test.js
+++ b/test/settings-actions-agents.test.js
@@ -970,3 +970,64 @@ test("every opencode-family member is installable AND auto-repairable (R10 P3)",
     );
   }
 });
+
+test("successful Hermes WSL Pair opens ingress without claiming a local install", async () => {
+  const snapshot = prefs.getDefaults();
+  snapshot.agents.hermes = {
+    integrationInstalled: false,
+    enabled: false,
+    permissionsEnabled: true,
+    notificationHookEnabled: true,
+  };
+  const result = await agentCommands.deployToWsl({ agentId: "hermes", distro: "Ubuntu" }, {
+    snapshot,
+    deployHooksToWsl: async (distro, agentId) => ({
+      ok: true,
+      distro,
+      agentId,
+      message: "Hermes plugin installed",
+      warning: "one profile failed",
+    }),
+  });
+
+  assert.strictEqual(result.status, "ok", "warning must stay top-level ok so controller applies commit");
+  assert.strictEqual(result.warning, "one profile failed");
+  assert.strictEqual(result.commit.agents.hermes.enabled, true);
+  assert.strictEqual(result.commit.agents.hermes.integrationInstalled, false);
+  assert.strictEqual(result.commit.agents.hermes.permissionsEnabled, true);
+});
+
+test("Hermes WSL Pair preserves an existing local installation flag", async () => {
+  const snapshot = prefs.getDefaults();
+  snapshot.agents.hermes.integrationInstalled = true;
+  snapshot.agents.hermes.enabled = false;
+  const result = await agentCommands.deployToWsl({ agentId: "hermes", distro: "Ubuntu" }, {
+    snapshot,
+    deployHooksToWsl: async () => ({ ok: true }),
+  });
+  assert.strictEqual(result.commit.agents.hermes.integrationInstalled, true);
+  assert.strictEqual(result.commit.agents.hermes.enabled, true);
+});
+
+test("failed Hermes WSL Pair does not open ingress", async () => {
+  const result = await agentCommands.deployToWsl({ agentId: "hermes", distro: "Ubuntu" }, {
+    snapshot: prefs.getDefaults(),
+    deployHooksToWsl: async () => ({ ok: false, message: "enable failed" }),
+  });
+  assert.strictEqual(result.status, "error");
+  assert.strictEqual(result.commit, undefined);
+  assert.match(result.message, /enable failed/);
+});
+
+test("Hermes WSL Unpair propagates warnings without disabling the global gate", async () => {
+  const snapshot = prefs.getDefaults();
+  snapshot.agents.hermes.enabled = true;
+  const result = await agentCommands.removeFromWsl({ agentId: "hermes", distro: "Ubuntu" }, {
+    snapshot,
+    removeHooksFromWsl: async () => ({ ok: true, message: "removed", warning: "disable failed" }),
+  });
+  assert.strictEqual(result.status, "ok");
+  assert.strictEqual(result.warning, "disable failed");
+  assert.strictEqual(result.commit, undefined);
+  assert.strictEqual(snapshot.agents.hermes.enabled, true);
+});

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -10920,6 +10920,61 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(harness.content.querySelectorAll(".agent-instance-action").length, 1,
       "only Pair when nothing is deployed");
   });
+
+  it("Hermes WSL rows use per-agent evidence instead of Claude staging markers", () => {
+    function renderHermes(integrationFilesPresent) {
+      const detectionResult = {
+        checkedAt: 3,
+        agents: [{ agentId: "hermes", detectedInstalled: false, confidence: "low" }],
+        skippedAgentIds: [],
+        wslAgents: [{
+          agentId: "hermes",
+          agentName: "Hermes Agent",
+          distro: "Ubuntu",
+          detectedInstalled: true,
+          confidence: "high",
+          reason: "parent-dir",
+          detail: "",
+          wslHome: "/home/u",
+          wslParentDir: "/home/u/.hermes",
+          hooksDeployed: true,
+          hooksFilesPresent: true,
+          integrationFilesPresent,
+        }],
+        wslDistros: [{ name: "Ubuntu", default: true }],
+        wslPending: false,
+        wslSupported: true,
+      };
+      const harness = loadAgentsTabForTest({
+        snapshot: {
+          agents: { hermes: { integrationInstalled: false, enabled: false } },
+          dismissedAgentInstallHints: {},
+        },
+        agentMetadata: [
+          { id: "hermes", name: "Hermes Agent", eventSource: "plugin", capabilities: {} },
+        ],
+        settingsAPI: { detectAgentInstallations: () => Promise.resolve(detectionResult) },
+      });
+      harness.core.runtime.agentInstallationHints = detectionResult;
+      harness.core.runtime.agentInstallationHintsFetched = true;
+      harness.core.ops.requestRender({ content: true });
+      return harness;
+    }
+
+    let harness = renderHermes(true);
+    assert.strictEqual(harness.content.querySelectorAll(".agent-instance-deployed").length, 0,
+      "Claude registration must never render a Hermes deployed badge");
+    assert.strictEqual(harness.content.querySelectorAll(".agent-instance-action").length, 2,
+      "Hermes managed files expose Pair and Unpair without shared staging");
+
+    harness = renderHermes(false);
+    assert.strictEqual(harness.content.querySelectorAll(".agent-instance-action").length, 1,
+      "explicit false must not inherit Claude hooksFilesPresent");
+
+    harness = renderHermes(null);
+    assert.strictEqual(harness.content.querySelectorAll(".agent-instance-action").length, 1,
+      "unknown evidence conservatively keeps Pair but hides Unpair");
+  });
 });
 
 describe("macOS platform detection (Settings shortcut labels)", () => {

--- a/test/wsl-deploy.test.js
+++ b/test/wsl-deploy.test.js
@@ -5,13 +5,31 @@
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
 const path = require("path");
+const { builtinModules } = require("node:module");
+const { EventEmitter } = require("node:events");
+const { PassThrough } = require("node:stream");
 
 const {
+  HERMES_RESULT_SENTINEL,
+  HERMES_TEMP_SENTINEL,
+  HERMES_WSL_FILES,
+  collectAgentWslFiles,
+  createHermesTempDir,
+  deployToWsl,
   getAgentInstallArgs,
   getAgentInstallScriptName,
+  parseHermesInstallerResult,
+  parseHermesTempDir,
+  pipeFileToWsl,
+  removeFromWsl,
   resolveHooksDir,
+  validateDeployRelativePath,
 } = require("../src/wsl-deploy");
+
+const HOOKS_DIR = path.join(__dirname, "..", "hooks");
 
 describe("wsl-deploy", () => {
   describe("getAgentInstallScriptName", () => {
@@ -40,11 +58,9 @@ describe("wsl-deploy", () => {
       assert.strictEqual(getAgentInstallScriptName(""), null);
     });
 
-    it("excludes agents whose install scripts need non-.js assets", () => {
-      // The stdin file pipe only transfers flat .js files; these installers
-      // need pi-extension.ts / *-plugin/ directories. See AGENT_INSTALL_SCRIPT.
+    it("supports Hermes without enabling other unvalidated asset-backed agents", () => {
       assert.strictEqual(getAgentInstallScriptName("pi"), null);
-      assert.strictEqual(getAgentInstallScriptName("hermes"), null);
+      assert.strictEqual(getAgentInstallScriptName("hermes"), "hermes-install.js");
       assert.strictEqual(getAgentInstallScriptName("opencode"), null);
       assert.strictEqual(getAgentInstallScriptName("openclaw"), null);
     });
@@ -77,6 +93,7 @@ describe("wsl-deploy", () => {
     it("uses <install-script> --uninstall for other agents", () => {
       assert.strictEqual(getAgentUninstallCommand("codex"), "codex-install.js --uninstall");
       assert.strictEqual(getAgentUninstallCommand("kimi-cli"), "kimi-install.js --uninstall");
+      assert.strictEqual(getAgentUninstallCommand("hermes"), "hermes-install.js --uninstall");
     });
 
     it("returns null for unsupported agents", () => {
@@ -125,6 +142,243 @@ describe("wsl-deploy", () => {
     it("defaults to dev path when no options", () => {
       const dir = resolveHooksDir();
       assert.ok(typeof dir === "string" && dir.length > 0);
+    });
+
+    it("accepts an injected packaged resources path", () => {
+      assert.strictEqual(
+        resolveHooksDir({ isPackaged: true, resourcesPath: "C:\\Clawd\\resources" }),
+        path.join("C:\\Clawd\\resources", "app.asar.unpacked", "hooks")
+      );
+    });
+  });
+
+  describe("Hermes exact WSL payload", () => {
+    it("contains exactly the audited six files as Buffers", () => {
+      const entries = collectAgentWslFiles(HOOKS_DIR, "hermes");
+      assert.deepStrictEqual(entries.map((entry) => entry.relativePath), [...HERMES_WSL_FILES]);
+      assert.ok(entries.every((entry) => Buffer.isBuffer(entry.content)));
+    });
+
+    it("matches the installer managed-file manifest", () => {
+      const { MANAGED_PLUGIN_FILES } = require("../hooks/hermes-install");
+      const pluginFiles = HERMES_WSL_FILES
+        .filter((name) => name.startsWith("hermes-plugin/"))
+        .map((name) => path.posix.basename(name));
+      assert.deepStrictEqual(pluginFiles.sort(), [...MANAGED_PLUGIN_FILES].sort());
+    });
+
+    it("is transitively closed over relative requires and uses only Node builtins", () => {
+      const deployed = new Set(HERMES_WSL_FILES);
+      const builtinRoots = new Set(builtinModules.map((name) => name.replace(/^node:/, "").split("/")[0]));
+      for (const relativePath of HERMES_WSL_FILES.filter((name) => name.endsWith(".js"))) {
+        const source = fs.readFileSync(path.join(HOOKS_DIR, ...relativePath.split("/")), "utf8");
+        for (const match of source.matchAll(/require\(["']([^"']+)["']\)/g)) {
+          const specifier = match[1];
+          if (specifier.startsWith(".")) {
+            const resolved = path.posix.normalize(path.posix.join(path.posix.dirname(relativePath), specifier));
+            const withExtension = resolved.endsWith(".js") ? resolved : `${resolved}.js`;
+            assert.ok(deployed.has(withExtension), `${relativePath} requires missing ${withExtension}`);
+          } else {
+            const root = specifier.replace(/^node:/, "").split("/")[0];
+            assert.ok(builtinRoots.has(root), `${relativePath} requires non-builtin ${specifier}`);
+          }
+        }
+      }
+    });
+
+    it("rejects unsafe relative paths", () => {
+      for (const value of ["", "/tmp/x", "../x", "a/../x", "a\\x", "a\0x", "a//x"]) {
+        assert.throws(() => validateDeployRelativePath(value));
+      }
+      assert.strictEqual(validateDeployRelativePath("hermes-plugin/plugin.yaml"), "hermes-plugin/plugin.yaml");
+    });
+
+    it("pipes nested payload bytes without text conversion", async () => {
+      const calls = [];
+      const payload = Buffer.from([0x00, 0xff, 0x41, 0x0a]);
+      const spawn = (_command, args) => {
+        const child = new EventEmitter();
+        child.stdin = new PassThrough();
+        child.stderr = new PassThrough();
+        const chunks = [];
+        child.stdin.on("data", (chunk) => chunks.push(chunk));
+        child.stdin.on("finish", () => {
+          calls.push({ args, content: Buffer.concat(chunks) });
+          queueMicrotask(() => child.emit("close", 0));
+        });
+        child.kill = () => {};
+        return child;
+      };
+
+      const result = await pipeFileToWsl(
+        "Ubuntu",
+        "/tmp/clawd-hermes-Ab12Cd34",
+        "hermes-plugin/plugin.yaml",
+        payload,
+        { spawn, timeout: 1000 }
+      );
+
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(calls.length, 1);
+      assert.deepStrictEqual(calls[0].content, payload);
+      assert.match(calls[0].args.at(-1), /mkdir -p -- '\/tmp\/clawd-hermes-Ab12Cd34\/hermes-plugin'/);
+      assert.match(calls[0].args.at(-1), /cat > '\/tmp\/clawd-hermes-Ab12Cd34\/hermes-plugin\/plugin.yaml'/);
+    });
+  });
+
+  describe("Hermes staging/result parsing", () => {
+    it("accepts only the fixed /tmp template result", () => {
+      assert.strictEqual(
+        parseHermesTempDir(`${HERMES_TEMP_SENTINEL}/tmp/clawd-hermes-Ab12Cd34\n`),
+        "/tmp/clawd-hermes-Ab12Cd34"
+      );
+      for (const output of [
+        "",
+        `${HERMES_TEMP_SENTINEL}/`,
+        `${HERMES_TEMP_SENTINEL}/home/tester`,
+        `${HERMES_TEMP_SENTINEL}/var/tmp/clawd-hermes-Ab12Cd34`,
+        `${HERMES_TEMP_SENTINEL}/tmp/wrong-Ab12Cd34`,
+        `noise\n${HERMES_TEMP_SENTINEL}/tmp/clawd-hermes-Ab12Cd34`,
+      ]) assert.strictEqual(parseHermesTempDir(output), null);
+    });
+
+    it("parses one versioned installer result and rejects ambiguity", () => {
+      const wire = { schemaVersion: 1, operation: "install", status: "warning", message: "partial" };
+      const parsed = parseHermesInstallerResult(`${HERMES_RESULT_SENTINEL}${JSON.stringify(wire)}\n`, "install");
+      assert.strictEqual(parsed.ok, true);
+      assert.deepStrictEqual(parsed.result, wire);
+      assert.strictEqual(parseHermesInstallerResult("", "install").ok, false);
+      assert.strictEqual(
+        parseHermesInstallerResult(`${HERMES_RESULT_SENTINEL}${JSON.stringify(wire)}\n${HERMES_RESULT_SENTINEL}${JSON.stringify(wire)}`, "install").ok,
+        false
+      );
+    });
+
+    it("creates staging without a shell-local variable that wsl.exe can pre-expand", async () => {
+      let command = null;
+      const result = await createHermesTempDir("Ubuntu", {
+        execInWsl: async (_distro, value) => {
+          command = value;
+          return { code: 0, stdout: `${HERMES_TEMP_SENTINEL}/tmp/clawd-hermes-Ab12Cd34\n`, stderr: "" };
+        },
+      });
+      assert.strictEqual(result.ok, true);
+      assert.doesNotMatch(command, /\$[A-Za-z_]/);
+      assert.match(command, /set -o pipefail/);
+      assert.match(command, /mktemp -d \/tmp\/clawd-hermes-XXXXXXXX/);
+    });
+  });
+
+  describe("Hermes ephemeral orchestration", () => {
+    it("pairs and unpairs from fresh private staging without resolving WSL home", async () => {
+      const calls = [];
+      const uploads = [];
+      const execInWsl = async (_distro, command) => {
+        calls.push(command);
+        if (command.includes("mktemp -d")) {
+          return { code: 0, stdout: `${HERMES_TEMP_SENTINEL}/tmp/clawd-hermes-Ab12Cd34\n`, stderr: "" };
+        }
+        if (command.includes("--uninstall --json")) {
+          return { code: 0, stdout: `${HERMES_RESULT_SENTINEL}{"schemaVersion":1,"operation":"uninstall","status":"ok","message":"removed"}\n`, stderr: "" };
+        }
+        if (command.includes("hermes-install.js --json")) {
+          return { code: 0, stdout: `${HERMES_RESULT_SENTINEL}{"schemaVersion":1,"operation":"install","status":"ok","message":"installed"}\n`, stderr: "" };
+        }
+        if (command.includes("wsl-connectivity-probe.js")) return { code: 0, stdout: "REACHABLE 23333\n", stderr: "" };
+        if (command.startsWith("rm -rf --")) return { code: 0, stdout: "", stderr: "" };
+        throw new Error(`unexpected command: ${command}`);
+      };
+      const common = {
+        agentId: "hermes",
+        hooksDir: HOOKS_DIR,
+        isWindows: () => true,
+        execInWsl,
+        getWslHomeDir: async () => { throw new Error("Hermes must not resolve shared WSL home staging"); },
+        pipeFileToWsl: async (_distro, targetDir, relativePath, content) => {
+          uploads.push({ targetDir, relativePath, content });
+          return { ok: true, fileName: relativePath };
+        },
+      };
+
+      const paired = await deployToWsl("Ubuntu", common);
+      assert.strictEqual(paired.ok, true);
+      assert.strictEqual(paired.connectivity, true);
+      assert.strictEqual(paired.stagingRemoved, true);
+      assert.strictEqual(uploads.length, HERMES_WSL_FILES.length);
+      assert.ok(uploads.every((entry) => entry.targetDir === "/tmp/clawd-hermes-Ab12Cd34"));
+      assert.ok(uploads.every((entry) => Buffer.isBuffer(entry.content)));
+      assert.ok(calls.every((command) => !command.includes("/.claude/hooks")));
+
+      uploads.length = 0;
+      const removed = await removeFromWsl("Ubuntu", common);
+      assert.strictEqual(removed.ok, true);
+      assert.strictEqual(removed.stagingRemoved, true);
+      assert.strictEqual(uploads.length, HERMES_WSL_FILES.length);
+      assert.ok(calls.some((command) => command.includes("--uninstall --json")));
+    });
+
+    it("fails missing assets before any WSL mutation", async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-wsl-hermes-missing-"));
+      try {
+        fs.writeFileSync(path.join(tempDir, "hermes-install.js"), "", "utf8");
+        let mutated = false;
+        const result = await deployToWsl("Ubuntu", {
+          agentId: "hermes",
+          hooksDir: tempDir,
+          isWindows: () => true,
+          execInWsl: async () => { mutated = true; return { code: 0, stdout: "", stderr: "" }; },
+        });
+        assert.strictEqual(result.ok, false);
+        assert.strictEqual(result.step, "verify-files");
+        assert.strictEqual(mutated, false);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    it("turns cleanup failure into a warning without hiding successful install", async () => {
+      const execInWsl = async (_distro, command) => {
+        if (command.includes("mktemp -d")) return { code: 0, stdout: `${HERMES_TEMP_SENTINEL}/tmp/clawd-hermes-Ab12Cd34\n`, stderr: "" };
+        if (command.includes("hermes-install.js --json")) return { code: 0, stdout: `${HERMES_RESULT_SENTINEL}{"schemaVersion":1,"operation":"install","status":"ok","message":"installed"}\n`, stderr: "" };
+        if (command.includes("wsl-connectivity-probe.js")) return { code: 1, stdout: "UNREACHABLE\n", stderr: "" };
+        if (command.startsWith("rm -rf --")) return { code: 1, stdout: "", stderr: "busy" };
+        throw new Error(`unexpected command: ${command}`);
+      };
+      const result = await deployToWsl("Ubuntu", {
+        agentId: "hermes",
+        hooksDir: HOOKS_DIR,
+        isWindows: () => true,
+        execInWsl,
+        pipeFileToWsl: async () => ({ ok: true }),
+      });
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.stagingRemoved, false);
+      assert.match(result.warning, /cleanup failed/i);
+    });
+
+    it("surfaces structured Hermes warning detail instead of only the summary", async () => {
+      const execInWsl = async (_distro, command) => {
+        if (command.includes("mktemp -d")) return { code: 0, stdout: `${HERMES_TEMP_SENTINEL}/tmp/clawd-hermes-Ab12Cd34\n`, stderr: "" };
+        if (command.includes("--uninstall --json")) {
+          return {
+            code: 0,
+            stdout: `${HERMES_RESULT_SENTINEL}{"schemaVersion":1,"operation":"uninstall","status":"warning","message":"removed with warnings","warning":"profile disable failed"}\n`,
+            stderr: "",
+          };
+        }
+        if (command.startsWith("rm -rf --")) return { code: 0, stdout: "", stderr: "" };
+        throw new Error(`unexpected command: ${command}`);
+      };
+      const result = await removeFromWsl("Ubuntu", {
+        agentId: "hermes",
+        hooksDir: HOOKS_DIR,
+        isWindows: () => true,
+        execInWsl,
+        pipeFileToWsl: async () => ({ ok: true }),
+      });
+      assert.strictEqual(result.ok, true);
+      assert.strictEqual(result.warning, "profile disable failed");
+      assert.strictEqual(result.message, "removed with warnings");
     });
   });
 });


### PR DESCRIPTION
## Summary

- add Hermes to Settings WSL Pair/Unpair with an exact six-file payload and private ephemeral staging
- resolve Hermes from the distro-native login-shell HERMES_HOME and expose per-agent cleanup evidence
- make Hermes profile uninstall symmetric, harden managed-file writes, and propagate structured warnings/errors
- enable Hermes ingress after successful WSL Pair without claiming a Windows-local integration install
- bypass inherited WSL proxy variables for Clawd loopback state and permission requests
- document Hermes WSL setup and correct the WSL2 localhost/NAT guidance

## Verification

- `npm test`: 7,198 passed, 0 failed, 31 skipped
- isolated Ubuntu WSL Pair -> detector -> Unpair passed without warnings and did not touch the active Hermes home
- active-home production Pair upgraded `clawd-on-desk` 0.1.0 -> 0.2.0; real Hermes lifecycle events reached production `src/server.js` as idle/thinking, and the deployed pre-tool callback mapped to working
- the real lifecycle exposed HTTP 502 from inherited proxy variables for `127.0.0.1`; the no-proxy opener fixed it and is covered with a hostile-proxy regression test
- production Unpair disabled Clawd and removed only its owned plugin directory; repeated final Pair returned `Hermes plugin already installed`
- final real state is `clawd-on-desk enabled 0.2.0`; deployed hashes match the repository, Clawd remains on port 23333, and staging/smoke backups are clean

Fixes #540