### PR TITLE
fix: harden npm dependency security and package validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         if: ${{ github.event_name != 'workflow_dispatch' || !inputs.artifact_validation_only }}
       - name: Run package validation tests
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.artifact_validation_only }}
-        run: node --test test/assert-no-retired-telegram-sidecar.test.js test/after-pack-koffi.test.js test/audit-packaged-native.test.js test/koffi-lockfile.test.js test/native-package-target.test.js test/package-koffi-smoke.test.js test/package-build-config.test.js test/telegram-legacy-retirement.test.js test/telegram-migration-state.test.js test/telegram-migration-controller.test.js test/telegram-migration-user-data.test.js test/verify-updater-metadata.test.js test/win-foreground-terminal.test.js test/win-fullscreen-detect.test.js
+        run: node --test test/assert-no-retired-telegram-sidecar.test.js test/after-pack-koffi.test.js test/audit-packaged-native.test.js test/koffi-lockfile.test.js test/native-package-target.test.js test/package-koffi-smoke.test.js test/package-build-config.test.js test/telegram-legacy-retirement.test.js test/telegram-migration-state.test.js test/telegram-migration-controller.test.js test/telegram-migration-user-data.test.js test/verify-updater-metadata.test.js test/win-foreground-terminal.test.js test/win-fullscreen-detect.test.js test/appimage-apprun.test.js test/dependency-security-floor.test.js
       - run: npx electron-builder --win --publish never
       - name: Assert retired Telegram sidecar is absent
         run: |
@@ -85,6 +85,26 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npx electron-builder --mac --publish never
+      - name: Verify macOS ad-hoc hardened signatures
+        shell: bash
+        run: |
+          set -euo pipefail
+          for app in \
+            "dist/mac/Clawd on Desk.app" \
+            "dist/mac-arm64/Clawd on Desk.app"; do
+            signature_details="$(codesign -dv --verbose=4 "$app" 2>&1)"
+            grep -q "Signature=adhoc" <<<"$signature_details"
+            grep -Eq "flags=.*\\(adhoc,runtime\\)" <<<"$signature_details"
+            codesign --verify --deep --strict --verbose=2 "$app"
+
+            entitlements="$(codesign -d --entitlements :- "$app" 2>/dev/null)"
+            for entitlement in \
+              com.apple.security.cs.allow-jit \
+              com.apple.security.cs.allow-unsigned-executable-memory \
+              com.apple.security.cs.disable-library-validation; do
+              grep -q "<key>$entitlement</key>" <<<"$entitlements"
+            done
+          done
       - name: Assert retired Telegram sidecar is absent
         run: |
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root "dist/mac/Clawd on Desk.app/Contents/Resources" --output dist/telegram-retirement-manifests/darwin-x64.json
@@ -133,6 +153,8 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npx electron-builder --linux --publish never
+      - name: Verify final AppImage AppRun search paths
+        run: node scripts/verify-appimage-apprun.js --artifact dist/*.AppImage --output dist/appimage-apprun-manifests/linux-x64.json
       - name: Assert retired Telegram sidecar is absent
         run: |
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root dist/linux-unpacked/resources --output dist/telegram-retirement-manifests/linux-x64.json
@@ -168,6 +190,7 @@ jobs:
           path: |
             dist/koffi-prune-manifests/*.json
             dist/koffi-smoke/*.json
+            dist/appimage-apprun-manifests/*.json
             dist/native-package-manifests/*.json
             dist/updater-metadata-manifests/*.json
           if-no-files-found: error

--- a/.github/workflows/telegram-retirement-package-audit.yml
+++ b/.github/workflows/telegram-retirement-package-audit.yml
@@ -59,7 +59,9 @@ jobs:
           node --test \
             test/assert-no-retired-telegram-sidecar.test.js \
             test/after-pack-koffi.test.js \
+            test/appimage-apprun.test.js \
             test/audit-packaged-native.test.js \
+            test/dependency-security-floor.test.js \
             test/koffi-lockfile.test.js \
             test/native-package-target.test.js \
             test/package-koffi-smoke.test.js \

--- a/.github/workflows/wayland-smoke.yml
+++ b/.github/workflows/wayland-smoke.yml
@@ -23,6 +23,9 @@ on:
       - .github/workflows/wayland-smoke.yml
       - package.json
       - package-lock.json
+      - scripts/verify-appimage-apprun.js
+      - test/appimage-apprun.test.js
+      - test/fixtures/appimage-apprun/**
 
 permissions:
   contents: read
@@ -46,6 +49,7 @@ jobs:
         run: |
           npm ci
           node --test test/linux-ozone.test.js
+          node --test test/appimage-apprun.test.js
 
       - name: Build the AppImage from this ref
         run: |
@@ -53,13 +57,18 @@ jobs:
           node scripts/assert-no-retired-telegram-sidecar.js --resources-root dist/linux-unpacked/resources --output dist/telegram-retirement-manifest.json
           ls -l dist/*.AppImage
 
+      - name: Verify final AppImage AppRun search paths
+        run: node scripts/verify-appimage-apprun.js --artifact dist/*.AppImage --output dist/appimage-apprun-manifests/linux-x64.json
+
       - name: Upload AppImage for isolated smoke jobs
         uses: actions/upload-artifact@v4
         with:
           # Preserve the established download name used by issue #441 field
           # testers and the regular Linux build workflow.
           name: linux-installer
-          path: dist/*.AppImage
+          path: |
+            dist/*.AppImage
+            dist/appimage-apprun-manifests/*.json
           if-no-files-found: error
           retention-days: 3
 

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ docs/**
 !docs/plans/
 !docs/plans/plan-issue-513-remote-ssh-isolation.md
 !docs/plans/plan-issue-763-koffi-target-native-packaging.md
+!docs/plans/plan-npm-dependency-security-hardening.md
 !docs/project/
 !docs/project/agent-runtime-architecture.md
 !docs/project/release-process.md
@@ -116,6 +117,7 @@ scripts/*
 !scripts/native-package-policy.json
 !scripts/run-packaged-koffi-smoke.js
 !scripts/verify-updater-metadata.js
+!scripts/verify-appimage-apprun.js
 
 # oh-my-cursor state
 .omc/

--- a/docs/plans/plan-npm-dependency-security-hardening.md
+++ b/docs/plans/plan-npm-dependency-security-hardening.md
@@ -372,6 +372,7 @@ macOS 两个架构都必须执行并保存：
 - `package-lock.json`
 - `test/dependency-security-floor.test.js`
 - AppImage verifier 及其 fixture/test
+- `scripts/after-pack-koffi.js` / `test/after-pack-koffi.test.js`（真实 CI 暴露 `/var` alias 与 Windows 短路径误报时，仅统一使用已校验的 canonical root，不放宽目录逃逸检查）
 - `.github/workflows/build.yml`
 - `.github/workflows/wayland-smoke.yml`
 - 有真实 Windows 证据时才更新 `scripts/native-package-policy.json`
@@ -379,4 +380,4 @@ macOS 两个架构都必须执行并保存：
 
 如果实际修复需要超出该范围，应先说明原因和回归面，再决定是否继续。
 
-本仓库当前通过 `.gitignore` 忽略 `docs/**`，因此本计划即使存在于本地，也不会出现在普通 `git status` 中。当前修改仅是本地、被忽略的计划文档；在未获得 staging/commit 授权前不纳入版本历史。若修复 PR 决定包含本计划，需要单独审阅后显式 `git add -f docs/plans/plan-npm-dependency-security-hardening.md`；否则必须在 PR 描述中保留经审阅的实施/验收摘要，不能让关键安全门只存在于维护者本机。
+本计划已通过精确 `.gitignore` 例外纳入本修复分支，普通 `git status` 可见；关键安全门和实施边界不会只存在于维护者本机。

--- a/docs/plans/plan-npm-dependency-security-hardening.md
+++ b/docs/plans/plan-npm-dependency-security-hardening.md
@@ -292,6 +292,8 @@ macOS 两个架构都必须执行并保存：
 4. 如果 helper 已消失，删除这条已失效例外，不能保留死规则。
 5. 如果 helper 的格式、架构或来源改变，保持 fail-closed；重新论证例外，不能只改 JSON 让 audit 通过。
 
+执行证据（GitHub Actions `31364225508`）：electron-builder 26.15.7 的真实 Windows x64 / ARM64 打包均仍产出唯一的 `resources/elevate.exe` 例外；两份 manifest 都记录为 PE ia32、107,520 bytes、SHA-256 `9b1fbf0c11c520ae714af8aa9af12cfd48503eedecd7398d8992ee94d1b4dc37`，且无其他未声明例外。已据此把 policy 的 provenance 版本说明更新为 26.15.7，target/path/format/architecture 匹配条件保持不变。
+
 ### Phase 7 — 最终复核与交付边界
 
 - 重新核对 exact HEAD/diff，确保只有计划内文件。

--- a/docs/plans/plan-npm-dependency-security-hardening.md
+++ b/docs/plans/plan-npm-dependency-security-hardening.md
@@ -1,0 +1,382 @@
+# Plan: npm 依赖安全修复与发布产物验证
+
+> 状态：已通过最终交叉审查，无 P0/P1 计划缺陷；等待实施授权。本文不授权修改依赖、提交、推送、创建 PR、合并或发版。
+>
+> 调查基线：`main` = `57073c986e3174ed07dca17a4d30bf1cea3b993b`，当时工作区干净且与 `origin/main` 一致。实施前必须重新核对，不能把这条历史记录当作当前状态。
+>
+> 日期：2026-08-10
+
+## 0. 决策摘要
+
+建议用 **一个独立依赖安全 PR** 处理当前 14 个独立 advisory（npm 汇总显示为 12 个 high package nodes），不拆成多个依赖 PR：
+
+- 直接依赖安全地板：
+  - `electron-builder`: `^26.8.1` → `^26.15.7`，本次候选 lockfile 预期锁定 `26.15.7`。
+  - `electron`: `^41.10.2` → `^41.10.4`，本次候选 lockfile 预期锁定 `41.10.4`。
+- 间接依赖必须做命名包定向刷新，不能假设两个直接升级会自动清掉所有旧物理副本：
+  - `app-builder-lib` → `26.15.7`；`builder-util` / `electron-publish` 预期为 `26.15.3`；`dmg-builder` 预期为 `26.15.7`。
+  - electron-builder 构建树中的 `builder-util-runtime` → `>=9.7.0`，当前解析预期为 `9.7.0`。
+  - `js-yaml` → `4.3.1`。
+  - `brace-expansion` → `1.1.18` / `2.1.4` / `5.0.9`（按各自 major 保持兼容）。
+  - `ip-address` 安全地板为 `10.3.1`；最终候选树已不再包含该包，若未来重新出现仍按该地板检查。
+  - `undici` → `7.29.0`；升级后的 `node-gyp 12.4.0` 另带来一份安全的 `undici 6.28.0`，两条已审阅 major 均纳入回归门。
+- `koffi` 必须继续保持精确版本 `2.16.3`。
+- 因 electron-builder 26.15.x 不再在无证书时自动为 ARM64/universal macOS 产物做 ad-hoc 签名，本 PR 应显式设置 `build.mac.identity: "-"`，把当前无 Developer ID 的发布策略固定为 x64/ARM64 均 ad-hoc 签名。
+- 不使用 `npm audit fix`、`--force`、`overrides`，不删除 lockfile，不做 major upgrade。
+- 安全修复和“允许发布”是两个门：audit 清零不能替代 Windows/macOS/Linux 真实打包验证。
+
+当前最高项目级风险定为 **P1，而不是 P0**：`app-builder-lib <26.15.0` 会把不安全的搜索路径写入最终 AppImage 的 `AppRun`。其官方 CVSS 向量为 `AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H`，利用要求本地低权限攻击者能向应用启动工作目录写入恶意动态库；它不是无需前提的远程接管或紧急全平台下架事件，但会阻断下一次 Linux AppImage 发布。
+
+本计划只修依赖、由该升级直接引起的 macOS 签名确定性问题，以及相应验证门；不顺带重构业务代码，也不在本 PR 决定是否发布 `v0.14.x`。当前 `main` 已明显超过 `v0.14.0` 的范围；若以后决定做真正的 `v0.14.1`，应另行评估从 `v0.14.0` tag 建维护分支，而不是直接把当前 `main` 称为补丁版。
+
+## 1. 已核实的风险模型
+
+### 1.1 “12 high”不是 12 个独立漏洞
+
+去重结果为 **14 个独立 GitHub Security Advisory：8 high + 6 moderate**。npm 报告的 12 个 high 是 package node 数，并将节点命中的最高严重度向上汇总：
+
+- electron-builder 家族的 2 个真实 advisory 被多个中间包节点重复计数。
+- `undici` 一个节点命中 5 个 advisory。
+- `ip-address` 一个节点命中 3 个 advisory。
+- `brace-expansion` 的多个物理版本命中 2 个 advisory。
+
+计划验收应按 advisory 和实际依赖树判断，不能只比较 npm 顶层计数。
+
+### 1.2 去重后的修复分组
+
+| 分组 | Advisory | 当前情况 | 项目可达性/产物影响 | 安全地板 / 当前预期解析 | 项目级优先级 |
+|---|---|---|---|---|---|
+| AppImage | [GHSA-7g7r-gx96-252g](https://github.com/advisories/GHSA-7g7r-gx96-252g) | `app-builder-lib 26.8.1`，经直接 devDependency `electron-builder` 引入 | 构建期把脆弱 `AppRun` 固化进 AppImage；需要攻击者可写启动 cwd | `>=26.15.0` / `26.15.7` | **P1；阻断下一次 AppImage** |
+| YAML | [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | production `js-yaml 4.3.0` | 已进入 `app.asar`，updater 的 YAML 解析路径可达；攻击前提是控制 Release 元数据或 TLS 路径 | `4.3.1` / `4.3.1` | P2 |
+| Electron | [GHSA-9f4c-93c8-jc8g](https://github.com/advisories/GHSA-9f4c-93c8-jc8g) | 直接 devDependency `electron 41.10.2` | Electron Framework 随应用发布，但仓库无命中条件所需的不可信 sandboxed iframe；当前不可达 | `>=41.10.4` / `41.10.4` | P3 |
+| 凭据重定向 | [GHSA-p2f4-r6v6-j797](https://github.com/advisories/GHSA-p2f4-r6v6-j797) | 构建树 `builder-util-runtime 9.5.1`；production 副本已修复 | dev-only；本项目用 `--publish never`，不从该路径携带 GitLab/custom redirect 凭据发布 | `>=9.7.0` / `9.7.0` | P3 |
+| Glob/ReDoS | [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | `brace-expansion` 多个 dev-only major | 不进应用，pattern 来自仓库受控构建配置 | `1.1.18` / `2.1.4` / `5.0.9` | P3 |
+| IP 分类 | [GHSA-mwp4-54f8-5fhr](https://github.com/advisories/GHSA-mwp4-54f8-5fhr), [GHSA-4xrf-jv44-h6hh](https://github.com/advisories/GHSA-4xrf-jv44-h6hh), [GHSA-22jq-vg5j-6vgg](https://github.com/advisories/GHSA-22jq-vg5j-6vgg) | `ip-address 10.2.0`，node-gyp/SOCKS 构建链 | dev-only，不进应用；本链路不依赖 advisory 涉及的 SSRF 安全分类结果 | `>=10.3.1` / `10.4.0` | P3 |
+| HTTP client | [GHSA-4cwx-7wf7-3272](https://github.com/advisories/GHSA-4cwx-7wf7-3272), [GHSA-8xcm-r25x-g524](https://github.com/advisories/GHSA-8xcm-r25x-g524), [GHSA-m8rv-5g2x-5cg5](https://github.com/advisories/GHSA-m8rv-5g2x-5cg5), [GHSA-jr45-8vmc-qm54](https://github.com/advisories/GHSA-jr45-8vmc-qm54), [GHSA-v3r7-h72x-cjcm](https://github.com/advisories/GHSA-v3r7-h72x-cjcm) | `undici 7.28.0`，由 `@electron/get` 引入 | 只用于安装期下载 Electron，不进应用；项目未调用命中的 interceptor/Blob/cookie 路径 | `7.29.0` / `7.29.0` | P3 |
+
+结论：**No P0 findings；存在一个 P1 发布目标 blocker。** 14 个 advisory 都已有同 major 修复版本，没有等待上游或长期接受风险的必要。
+
+### 1.3 与 PR #810 的边界
+
+PR #810 未修改 `package.json` 或 `package-lock.json`，也未引入新依赖。它新增的窗口没有 iframe，并显式拒绝新窗口和导航；当前 advisory 是既有依赖债务，不应归因给 PR #810。
+
+## 2. 目标与非目标
+
+### 2.1 目标
+
+1. 将直接依赖安全地板写进 `package.json`，并让 `package-lock.json` 精确解析到本次经过选择的版本。
+2. 对所有相关间接包做命名包定向刷新，清除每个脆弱物理副本，而不是依赖 npm 的偶然重解析。
+3. 当前完整依赖树和 production-only 依赖树中的原 14 个 advisory 全部关闭；实施当天新增 advisory 另行分级。
+4. 证明最终 AppImage 中的 `AppRun` 已消除空/相对搜索路径元素，而不是只证明 `node_modules` 里的生成器源码已更新。
+5. 明确保持无 Developer ID 的 macOS 发布策略，并让 x64/ARM64 产物都得到确定性的 ad-hoc hardened-runtime 签名。
+6. 证明 electron-builder 升级没有破坏五个常设 release targets：Windows x64、Windows ARM64、macOS x64、macOS ARM64、Linux x64。
+7. 保持 Koffi 2.16.3、native pruning、ASAR integrity、updater metadata 和现有发布命名契约不变。
+8. 增加离线、确定性的安全地板回归测试，防止未来 lockfile 回退到已知脆弱版本。
+
+### 2.2 非目标
+
+- 不修改业务功能、窗口安全模型、updater 行为或代理/网络配置。
+- 不升级任何 major，不引入 `overrides`。
+- 不引入 Developer ID 证书或 notarization；这些属于单独的签名发布策略变更。
+- 不建立新的独立 `.blockmap` 发布契约或硬门；只保留并复核现有 updater metadata/校验契约。
+- 不把上游 npm workspace 修复当作本仓库升级理由；本仓库当前不是 npm workspace。
+- 不重新设计 CI 或发布流程，只增加与本次依赖修复直接相关的 gate。
+- 不在本 PR 创建 tag、发布资产、修改已有 Release、发公告或下架 v0.14.0 AppImage。
+- 不把 `npm audit` 结果当成真实平台运行证明。
+
+## 3. 依赖、签名与 lockfile 契约
+
+### 3.1 直接依赖
+
+`package.json` 只提高两个直接 devDependency 的最低安全版本：
+
+```json
+{
+  "devDependencies": {
+    "electron": "^41.10.4",
+    "electron-builder": "^26.15.7"
+  }
+}
+```
+
+caret 表示允许未来在同 major 内正常解析；本次 PR 的候选 `package-lock.json` 必须精确锁到 `electron 41.10.4` 和 `electron-builder 26.15.7`。永久回归测试检查安全地板和同 major，不把这两个本次解析结果永久写死为唯一允许版本。
+
+选择 26.x 当前维护线版本，而不是只升到 advisory 下限 26.15.0，理由是：
+
+- 26.15.0 已包含不可回避的 Go → TypeScript 模块收集/构建内部迁移，停在下限并不能避开主要回归面。
+- [electron-builder 26.15.6](https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.15.6) 修复 NSIS 在 x64/ARM64 上可靠安装主程序和 native binaries 的问题，直接关系本仓库多架构产物。
+- 26.15.7 是当前 `v26` dist-tag 指向的版本；[26.15.7 release](https://github.com/electron-userland/electron-builder/releases/tag/electron-builder%4026.15.7) 的 locale 修复因本仓库未配置 `electronLanguages` 而不是本项目特有理由，但选择 v26 线最新已发布版本可以避免停在已知落后 patch。
+
+选择 [Electron 41.10.4](https://github.com/electron/electron/releases/tag/v41.10.4) 是为了关闭本 advisory 并保持 Electron 41.x，不改变 major。
+
+### 3.2 macOS 签名策略
+
+[electron-builder PR #9822](https://github.com/electron-userland/electron-builder/pull/9822) 移除了“无证书时仅 ARM64/universal 自动 ad-hoc 签名”的回退；在 26.15.x 中，不提供证书时默认跳过所有架构签名。无签名 ARM 应用仍可能由用户在 Privacy & Security 中手动批准后本地运行，因此不能绝对描述为“完全无法启动”，但失去 code seal、hardened-runtime 标志和既有 ARM64 行为仍是发布回归。
+
+本 PR 的最小确定性方案是在现有 `build.mac` 配置中显式加入：
+
+```json
+{
+  "identity": "-"
+}
+```
+
+契约如下：
+
+- `identity: "-"` 明确要求 ad-hoc 签名，不寻找 Developer ID；x64 会从当前的 unsigned 变为 ad-hoc，ARM64 则保持既有的 ad-hoc 意图。
+- 保留 electron-builder 默认 hardened runtime 和生成的 entitlement；不新增证书、keychain、notarization secret 或网络发布步骤。
+- electron-builder 26.15.x 在 `identity: "-"` 与默认 hardened runtime 同时启用时会输出建议性告警，提示检查 `com.apple.security.cs.disable-library-validation`。本项目必须以最终 entitlement 和实际启动验证为准；该告警属于预期，**不得通过增加 `hardenedRuntime: false` 来消除**。
+- 未来若引入 Developer ID，必须在单独变更中删除/覆盖此设置，并重新验证签名与 notarization，不能让 `"-"` 静默压过正式证书策略。
+- 本次必须同时检查 x64 和 ARM64 的签名结构；只有 ARM64 可在当前硬件上提供真实启动/Koffi smoke，Intel 真机证据仍按可用性单独声明。
+
+### 3.3 间接依赖
+
+实施时必须逐项检查 lockfile 的所有物理副本，而不是只看顶层 `npm ls` 输出：
+
+| 包 | 不允许残留 | 本轮当前预期解析 |
+|---|---|---|
+| `app-builder-lib` | `<26.15.0` | `26.15.7` |
+| `builder-util-runtime` | 构建树中的 `<9.7.0` | `9.7.0` |
+| `js-yaml` | `>=4.0.0 <4.3.1` | `4.3.1` |
+| `brace-expansion` | `<1.1.18`、`>=2 <2.1.4`、`>=5 <5.0.9` | `1.1.18` / `2.1.4` / `5.0.9` |
+| `ip-address` | 出现 `<10.3.1` 即失败；允许安全升级后不再存在 | 最终候选树中不存在 |
+| `undici` | `>=6 <6.28.0`、`>=7 <7.29.0` | `6.28.0` / `7.29.0` |
+
+`electron-builder 26.15.7` 当前依赖组合还预期解析为 `builder-util 26.15.3`、`electron-publish 26.15.3`、`dmg-builder 26.15.7`。这些是本次 lockfile 审阅证据，不是永久禁止后续同 major patch 的断言。
+
+`koffi` 的 manifest 和 lockfile 必须继续精确为 `2.16.3`。
+
+### 3.4 lockfile 更新方式
+
+以下命令只在用户另行授权实施后运行，本轮修改计划时不得运行：
+
+1. 从重新核实过的 exact HEAD 和干净工作区开始。
+2. 手工修改两个直接版本地板和 `build.mac.identity`，再以禁用 scripts/audit 的 package-lock-only 方式生成候选 lockfile。
+3. 无论初次解析看起来是否已清零，都执行一次命名包定向 refresh：
+
+   ```bash
+   npm update js-yaml undici ip-address brace-expansion --package-lock-only --ignore-scripts --no-audit
+   ```
+
+   npm 11 会更新命名包在树中的直接和间接副本，且该命令不会把它们写成新的直接依赖。
+4. 不使用 `npm install <transitive>@<version>`；这种写法可能把间接包误写成直接依赖。
+5. 不删除整个 lockfile、不使用 `--force`、不使用 `overrides` 掩盖上游约束。
+6. 审核 lockfile diff，确认没有无关直接依赖、major、registry、integrity 或 package-manager 元数据漂移。
+7. 用审阅后的 lockfile 做一次干净 `npm ci`，实际安装树必须与 lockfile 一致。
+
+不能预先声称两个直接升级会自动清掉多少 advisory：例如现有 `brace-expansion 5.0.7` 仍满足新上游的 `^5.0.5`，不做定向刷新就可能保留。最终数量只能以生成后的全部物理副本和两种 audit 为证据。
+
+## 4. 实施阶段
+
+### Phase 0 — 重新锁定基线
+
+- 核实 `HEAD`、branch、`git status`、`origin/main`。
+- 记录 Node/npm 版本以及现有 `npm audit --json`、`npm audit --omit=dev --json`、`npm ls --all` 基线。
+- 如果工作区不干净或 HEAD 漂移，停止并先重新评估；不要覆盖已有用户改动。
+
+### Phase 1 — 最小 manifest/lockfile/签名配置变更
+
+- 只提高 `electron`、`electron-builder` 两个直接地板，并显式设置 `build.mac.identity: "-"`。
+- 生成候选 lockfile，执行第三节的强制命名包定向 refresh，再逐段评审 diff。
+- 检查根 package entry 与 `package.json` 一致。
+- 核实第三节列出的所有实际版本；任何旧物理副本都必须解释或清除。
+- 确认 `koffi 2.16.3` 及其 target-native package layout 没有被顺带改动。
+- PR diff 不得新增 `overrides`；这一条作为本次变更审阅规则，不做成永久禁止仓库未来使用 overrides 的测试。
+
+### Phase 2 — 增加确定性安全回归门
+
+建议新增两个窄验证器，避免安全保证完全依赖联网的 advisory 数据库。
+
+#### 2A. `test/dependency-security-floor.test.js`
+
+- 解析 `package.json` 和 `package-lock.json` 的 `packages` 表。
+- 对两个直接依赖检查：manifest 最低版本不低于所选安全地板、仍在既定 major；lockfile 实际版本不低于 manifest 地板且仍在同 major。
+- 遍历所有物理副本，按已审阅 major 白名单拒绝脆弱区间：
+  - `js-yaml`: `{ 4: >=4.3.1 }`
+  - `brace-expansion`: `{ 1: >=1.1.18, 2: >=2.1.4, 5: >=5.0.9 }`
+  - `ip-address`: `{ 10: >=10.3.1 }`（允许该包不再存在）
+  - `undici`: `{ 6: >=6.28.0, 7: >=7.29.0 }`
+- 上述包出现未审阅 major 时 fail closed，要求人工确认后再更新白名单。
+- 检查 `app-builder-lib >=26.15.0` 和构建树中 `builder-util-runtime >=9.7.0`，但不永久写死本次预期 patch。
+- floor test 不实现任何 Koffi 版本或 integrity 断言，也不 `require` `test/koffi-lockfile.test.js`；Koffi 契约由该顶层测试文件独立注册和运行。
+- 这是已知安全地板回归测试，不替代实时 `npm audit`。
+
+#### 2B. `scripts/verify-appimage-apprun.js`
+
+- 只在 Linux CI 的最终 `.AppImage` 生成后运行；检查最终 artifact，不检查 `node_modules/app-builder-lib` 生成器源码。
+- 在临时目录中只提取 `AppRun`。首选 `<artifact> --appimage-extract AppRun`；该操作只执行 AppImage 的 ELF runtime stub 来完成临时提取，不得继续启动被提取的 `AppRun`。若 CI 环境不支持 AppImage 自提取，可用 `unsquashfs` 配合不执行 `AppRun` 的只读 offset 提取作为 fallback。
+- **绝不 `source`、`eval`、执行 `AppRun` 或执行从中提取的赋值语句。** 产物内容一律作为不可信数据处理。
+- 解析作用域严格限定为顶层 `export NAME="…"` 语句。函数、`trap` / `case` / `if`、普通参数展开，以及 `LD_LIBRARY_PATH="" zenity …` 这类命令前缀赋值不在解析范围内，不计入赋值数量，也不触发四条 export 右值的语法拒绝。
+- 对 `PATH`、`XDG_DATA_DIRS`、`LD_LIBRARY_PATH`、`GSETTINGS_SCHEMA_DIR` 各要求恰好一个顶层 export 赋值；缺失或重复都 fail closed。
+- 额外断言：所有顶层 export 中，右值含 `:` 分隔符的变量集合必须恰好等于上述四项。出现第五个未审阅 path-list export 时 fail closed，人工评估后才能扩充名单，不能因其不在既有名单中就默认安全。
+- 有限静态语法白名单只适用于上述四条 export 的右值，只允许已审阅的 literal、`${APPDIR}` 和 `${VAR:+:${VAR}}` 形式；在这些右值中拒绝命令替换、反引号、控制运算符、重定向和任何未识别 shell 语法。
+- 用验证器自己的字符串解释逻辑分别模拟继承变量未设置和设置为无害哨兵值的结果，不调用 shell。拒绝空的开头/结尾/连续 `:` 元素、相对 literal（如 `./share`），以及无条件继承变量展开造成的空路径元素。
+- 允许并记录 26.15.7 已审阅模板的条件展开。以后上游更改语法时应主动失败，要求显式复审，而不是宽松放过。
+- fixture 至少包含：真实 26.8.1 模板失败、真实 26.15.7 模板通过、`./share` 失败、双冒号失败、命令替换失败、重复顶层 export 失败、命令前缀 `LD_LIBRARY_PATH=""` 不计数、第五个 path-list export 失败。
+- 输出 artifact SHA-256、AppRun SHA-256、四条规范化赋值及模拟结果，便于 CI 审阅。
+
+将 AppRun gate 放在 `.github/workflows/build.yml` 的 Linux AppImage 构建后。现有失败产物上传使用 `if: always()`，应保留用于故障取证：gate 失败可以仍上传 CI artifact，但会让 Linux build job 失败，并通过 `release` job 的依赖关系阻止发布。在 `.github/workflows/wayland-smoke.yml` 中，将 gate 放在正常 artifact 上传和 smoke 之前，失败时不继续后续步骤。准确称呼它为 **release gate**，不是所有工作流中的绝对 upload gate。
+
+### Phase 3 — 安装树与 audit 验证
+
+用已审阅 lockfile 干净安装后执行并保存结果：
+
+```bash
+npm ci
+npm ls --all
+npm audit --json
+npm audit --omit=dev --json
+npm run verify:electron
+```
+
+验收要求：
+
+- `npm ls --all` 无 invalid/extraneous/missing。
+- 原 14 个 advisory 在完整和 production-only audit 中全部关闭。
+- 目标是在实施当日两种 audit 都为 0；若期间出现新 advisory，必须独立去重和分级。P0/P1 且与发布产物相关的项目可阻断本 PR；较低、dev-only 或不可达项目可以建独立 follow-up，不能为追求数字清零盲目扩大本 PR，也不能无解释忽略。
+- 本次 lockfile 证据应显示 Electron 41.10.4、electron-builder/app-builder-lib 26.15.7，以及第三节记录的预期间接版本；永久测试只执行安全地板/major 契约。
+- 实际 Koffi 仍为 2.16.3。
+
+### Phase 4 — 代码、配置与既有 package contract 回归
+
+先跑窄测试，再跑全套：
+
+```bash
+node --test test/dependency-security-floor.test.js
+node --test test/package-build-config.test.js
+node --test test/koffi-lockfile.test.js
+npm test
+```
+
+还必须运行仓库已有的 Electron install、native target、package native inventory、updater metadata、ASAR integrity 和 `scripts/assert-no-retired-telegram-sidecar.js` 相关验证。该 retired-sidecar 检查现已覆盖三个 build jobs、独立 package audit workflow 和 Wayland 路径；升级后应保留此覆盖，但不把上游 workspace PR 当成本仓库的直接适用依据。
+
+任何测试如果只检查配置或 fixture，报告中必须明确它没有替代真实安装包验证。
+
+### Phase 5 — 五目标真实打包矩阵
+
+electron-builder 26.15.x 同时包含模块收集、Windows package-manager 调用、macOS 签名和 Linux AppImage 生成路径的内部变化，因此合并前的硬门是实际打包。
+
+| 平台/目标 | 必须验证 | 允许保留的边界 |
+|---|---|---|
+| Windows x64 | `--publish never` 构建；native inventory；Koffi packaged smoke；NSIS 实际安装/启动；`clawd://` 注册 smoke；updater metadata；`app.asar`/unpacked 模块清单 | 必须有真实 x64 Windows 证据 |
+| Windows ARM64 | `--publish never` 构建；架构命名；native inventory；唯一 ARM64 `koffi.node`；NSIS 结构与 metadata | 若无 ARM64 真机，只能声明结构验证，不能声称运行通过 |
+| macOS ARM64 | 项目常规 DMG/zip target；ad-hoc/hardened 签名与 entitlement；ASAR integrity；native inventory；Koffi packaged smoke；实际启动；`clawd://` 安装后 smoke；metadata | 当前 Mac 可提供 ARM64 运行证据 |
+| macOS x64 | x64 产物；ad-hoc/hardened 签名与 entitlement；native inventory；唯一 x64 `koffi.node`；DMG/metadata/ASAR integrity | 若未在 Intel Mac 运行，只能声明结构验证 |
+| Linux x64 | AppImage + deb；最终 AppRun gate；在 disposable 环境实际安装/启动 `.deb`；native inventory；Koffi smoke；updater metadata；XWayland smoke 和现有 native-Wayland contract | CI/XWayland 不等同真实桌面环境全量手测 |
+
+macOS 两个架构都必须执行并保存：
+
+- `codesign -dv --verbose=4`：报告 `Signature=adhoc`，flags 含 `runtime`。
+- `codesign --verify --deep --strict`：通过。
+- entitlement 至少保留 `com.apple.security.cs.allow-jit`、`com.apple.security.cs.allow-unsigned-executable-memory`、`com.apple.security.cs.disable-library-validation`。
+- ARM64 运行现有 packaged Koffi smoke；x64 若无 Intel 机器，只报告结构签名验证。
+
+所有平台还需抽查：
+
+- 打包应用的 Electron runtime 是本次 lockfile 选择的 41.10.4。
+- `app.asar` 中 production `js-yaml` 是 4.3.1。
+- dev-only 的 `brace-expansion`、`ip-address`、`undici` 不进入运行时应用。
+- 每个 target 只保留目标架构的一个 `koffi.node`。
+- `afterPack` 仍只裁剪 `app.asar.unpacked` 的物理文件，不重写 `app.asar`。
+- 保留现有 updater metadata 校验，包括 artifact `sha512`/size 和 AppImage `blockMapSize`；不新增独立 blockmap 发布硬门。
+
+### Phase 6 — `elevate.exe` provenance 专项门
+
+`scripts/native-package-policy.json` 中的 `electron-builder 26.8.1` 目前只是 exception 的 `reason` 文本，不参与匹配；真正匹配依据是 target/path/format/architecture。
+
+因此：
+
+1. 不随版本号机械修改 `reason`。
+2. 先完成 26.15.7 的真实 Windows x64 和 ARM64 打包。
+3. 如果 `resources/elevate.exe` 仍存在，检查 `dist/native-package-manifests/windows-{x64,arm64}.json`，确认其来源、PE 格式和 ia32 架构仍符合 electron-builder 管理 helper 的既有例外，再更新 `reason` 的版本文本。
+4. 如果 helper 已消失，删除这条已失效例外，不能保留死规则。
+5. 如果 helper 的格式、架构或来源改变，保持 fail-closed；重新论证例外，不能只改 JSON 让 audit 通过。
+
+### Phase 7 — 最终复核与交付边界
+
+- 重新核对 exact HEAD/diff，确保只有计划内文件。
+- 复跑完整测试、两种 audit 和实际依赖树检查。
+- 汇总五目标证据，明确结构验证与真机运行验证的区别。
+- 做一次独立 post-fix 安全审查，重点复核最终 AppImage、macOS 签名和各平台打包内容。
+- 实施、commit、push、PR、merge、release/tag/资产处理分别等待授权；不得把本计划视为后续写操作的预授权。
+- 依赖 PR 处理完成后，记录 `v0.14.0` 旧 AppImage 风险的明确 follow-up；创建 Issue、公开说明或修改 Release 仍需单独授权。
+
+## 5. 验收标准
+
+只有同时满足以下条件，修复 PR 才可判定 ready：
+
+1. `package.json` 的 Electron/electron-builder 安全地板正确，本次 lockfile 精确解析到 41.10.4/26.15.7。
+2. 第三节列出的脆弱间接版本在所有 lockfile 物理副本中均不存在，且执行过强制命名包定向 refresh。
+3. `koffi` manifest、lockfile、打包产物都保持 2.16.3 和单目标架构契约。
+4. 原 14 个 advisory 全部关闭；实施日新增 advisory 已独立分级并有明确处置。
+5. 最终 AppImage 的 `AppRun` 通过 fail-closed 静态检查；验证器没有执行任何产物 shell；gate 能阻止 release job。
+6. macOS 明确使用 ad-hoc hardened-runtime 签名，x64/ARM64 均通过签名、entitlement 和严格验证；没有引入 Developer ID/notarization。
+7. Windows x64/ARM64、macOS x64/ARM64、Linux x64 五个 release targets 均完成最低证据矩阵。
+8. Windows module collection、Koffi pruning、`elevate.exe` provenance、macOS ASAR integrity、Linux AppImage/deb、updater metadata 均无回归。
+9. `scripts/native-package-policy.json` 如有更新，必须由真实 Windows manifest 证据支持；helper 消失时必须删除死例外。
+10. PR 不包含业务功能、无关依赖、代理配置、Release/tag、既有资产或新 blockmap 发布契约变更。
+
+## 6. 失败处理与回滚原则
+
+- 如果 electron-builder 26.15.7 破坏某一发布目标，先定位同 major 回归；不得降回 `<26.15.0` 后继续发布 AppImage。
+- 如果只能让其他平台通过，可暂时阻止 AppImage target，但这属于发布范围变更，需单独决定，不能在依赖 PR 中静默发生。
+- 如果显式 ad-hoc 签名不能在某一 macOS target 维持既有运行契约，先阻止该 target，不能静默发布 unsigned ARM64 应用。
+- 如果 lockfile 出现大量无关漂移，重新从干净基线做定向解析，不接受“audit 变绿即可”。
+- 如果新的 audit 项在实施期间出现，按新 advisory 单独分级；不能无上限扩张本 PR，也不能未经记录接受风险。
+- 回滚只撤销本轮候选改动，保留用户或并行工作的现有文件。
+
+## 7. 为什么不使用 `npm audit fix`
+
+根据 [npm audit 官方文档](https://docs.npmjs.com/cli/v11/commands/npm-audit)，`npm audit fix` 底层执行完整 install，会改依赖树和 lockfile，并运行适用的 lifecycle/install 行为。本仓库还会触发 Electron 下载和 postinstall 验证。
+
+本轮不使用它，原因不是“它一定会 major upgrade”，而是：
+
+- 它无法表达本项目对两个直接安全地板、macOS 签名策略和特定间接包物理副本的明确决策。
+- 它会把 electron-builder 的大型内部迁移和多组间接升级合成一次不透明解析，降低 diff 可审计性。
+- `npm audit fix --omit=dev` 会漏掉真正污染 AppImage 的 dev 构建依赖，也会漏掉随产物发布的 Electron runtime。
+- 本轮所有依赖修复都能通过显式同 major 版本选择和受控命名包 lock refresh 完成，不需要 `--force`。
+
+`npm audit fix --dry-run` 也不是必要验收项；最终应以 manifest/lockfile diff、实际依赖树、最终安装包和真实平台证据为准。
+
+## 8. 发布决策边界
+
+依赖 PR 合并后，是否立即发版仍需单独决定：
+
+- 下一次包含 AppImage 的发布必须先完成本修复。
+- 已发布 v0.14.0 AppImage 高置信度继承旧生成器缺陷，但尚未逐字节下载、提取并核对公开资产；现有证据来自 tag lockfile、无条件生成路径和 CI `npm ci`。
+- 该问题要求攻击者能写入启动 cwd，不建议仅凭 advisory 标签将其描述成无需前提的远程 RCE，也不自动触发全平台紧急下架。
+- 当前 `main` 已包含 v0.14.0 之后的大量功能，不能直接将 main 的下一版叫作 v0.14.1。真正 hotfix 需要维护分支、最小 backport、完整打包和独立授权。
+- Release note、用户提醒、旧资产处理和版本号选择都不属于本修复 PR；但合并后不能遗忘，应建立明确 follow-up。
+
+## 9. 静态审查无法单独证明的边界
+
+即使依赖和测试全部完成，以下内容仍必须在报告中保留限定：
+
+1. 未下载并逐字节检查的公开 v0.14.0 AppImage，只能高置信度推断受影响，不能声称已直接解包验证。
+2. 静态 `AppRun` 检查能证明本 advisory 的四个已知路径赋值已按受限语法安全生成，但不能证明 Linux 所有动态加载行为都无风险。
+3. CI 构建成功不能证明 Windows ARM64、Intel Mac 或各种 Linux 桌面环境的真实启动体验；没有真机就必须明确写“结构验证”。
+4. ARM64 Mac 的运行证据不能替代 Intel Mac；同样，Windows x64 不能替代 Windows ARM64 运行证明。
+5. `npm audit` 只覆盖其数据库和 npm 依赖图，不能覆盖未知漏洞、Electron 二进制全部风险、构建器生成物或业务逻辑漏洞。
+6. dependency floor test 只防止已知脆弱版本回退，不能替代联网复审；未审阅 major 只能 fail closed，不能自动判安全。
+7. js-yaml updater 路径的利用需要外部信任边界被突破；除非构造隔离测试，否则静态审查不能量化真实卡顿时长。
+8. Electron 41.10.2 advisory 当前不可达的结论依赖现有窗口/iframe 模型；未来新增不可信嵌入内容时仍需重新威胁建模。
+9. electron-builder 26.15.7 的 Windows 模块收集、签名和安装行为必须靠实际产物验证，不能只引用 changelog。
+10. ad-hoc 签名不提供 Developer ID 身份、notarization 或 Gatekeeper 信任；本轮只保持现有无证书发布策略的确定性。
+11. `.deb` disposable-environment smoke、XWayland smoke 和 AppImage 静态 gate 仍不能覆盖所有发行版、桌面环境、挂载选项和用户启动目录。
+
+## 10. 预计文件范围与计划文档状态
+
+实施后的合理 diff 应限于：
+
+- `package.json`（两个直接依赖地板和 `build.mac.identity: "-"`）
+- `package-lock.json`
+- `test/dependency-security-floor.test.js`
+- AppImage verifier 及其 fixture/test
+- `.github/workflows/build.yml`
+- `.github/workflows/wayland-smoke.yml`
+- 有真实 Windows 证据时才更新 `scripts/native-package-policy.json`
+- 本计划与必要的安全验证说明文档
+
+如果实际修复需要超出该范围，应先说明原因和回归面，再决定是否继续。
+
+本仓库当前通过 `.gitignore` 忽略 `docs/**`，因此本计划即使存在于本地，也不会出现在普通 `git status` 中。当前修改仅是本地、被忽略的计划文档；在未获得 staging/commit 授权前不纳入版本历史。若修复 PR 决定包含本计划，需要单独审阅后显式 `git add -f docs/plans/plan-npm-dependency-security-hardening.md`；否则必须在 PR 描述中保留经审阅的实施/验收摘要，不能让关键安全门只存在于维护者本机。

--- a/docs/plans/plan-npm-dependency-security-hardening.md
+++ b/docs/plans/plan-npm-dependency-security-hardening.md
@@ -68,7 +68,7 @@ PR #810 未修改 `package.json` 或 `package-lock.json`，也未引入新依赖
 2. 对所有相关间接包做命名包定向刷新，清除每个脆弱物理副本，而不是依赖 npm 的偶然重解析。
 3. 当前完整依赖树和 production-only 依赖树中的原 14 个 advisory 全部关闭；实施当天新增 advisory 另行分级。
 4. 证明最终 AppImage 中的 `AppRun` 已消除空/相对搜索路径元素，而不是只证明 `node_modules` 里的生成器源码已更新。
-5. 明确保持无 Developer ID 的 macOS 发布策略，并让 x64/ARM64 产物都得到确定性的 ad-hoc hardened-runtime 签名。
+5. 明确保持无 Developer ID 的 macOS 发布策略，并以最终产物 gate 确保 x64/ARM64 都得到 ad-hoc hardened-runtime 签名。
 6. 证明 electron-builder 升级没有破坏五个常设 release targets：Windows x64、Windows ARM64、macOS x64、macOS ARM64、Linux x64。
 7. 保持 Koffi 2.16.3、native pruning、ASAR integrity、updater metadata 和现有发布命名契约不变。
 8. 增加离线、确定性的安全地板回归测试，防止未来 lockfile 回退到已知脆弱版本。
@@ -113,7 +113,7 @@ caret 表示允许未来在同 major 内正常解析；本次 PR 的候选 `pack
 
 [electron-builder PR #9822](https://github.com/electron-userland/electron-builder/pull/9822) 移除了“无证书时仅 ARM64/universal 自动 ad-hoc 签名”的回退；在 26.15.x 中，不提供证书时默认跳过所有架构签名。无签名 ARM 应用仍可能由用户在 Privacy & Security 中手动批准后本地运行，因此不能绝对描述为“完全无法启动”，但失去 code seal、hardened-runtime 标志和既有 ARM64 行为仍是发布回归。
 
-本 PR 的最小确定性方案是在现有 `build.mac` 配置中显式加入：
+本 PR 的最小方案是在现有 `build.mac` 配置中显式加入：
 
 ```json
 {
@@ -123,10 +123,11 @@ caret 表示允许未来在同 major 内正常解析；本次 PR 的候选 `pack
 
 契约如下：
 
-- `identity: "-"` 明确要求 ad-hoc 签名，不寻找 Developer ID；x64 会从当前的 unsigned 变为 ad-hoc，ARM64 则保持既有的 ad-hoc 意图。
+- `identity: "-"` 表达 ad-hoc 签名意图；x64 会从当前的 unsigned 变为 ad-hoc，ARM64 则保持既有的 ad-hoc 意图。electron-builder 26.15.7 会先把该值作为证书名称 qualifier 做子串匹配，匹配不到时才构造 `"-"` ad-hoc identity，因此配置本身不能证明没有选中名称含连字符的证书。
+- `.github/workflows/build.yml` 必须对两个最终 `.app` 检查 `Signature=adhoc`、`adhoc,runtime`、严格签名和 entitlement；这道产物 gate 才是本发布流程的确定性保证，任何意外证书签名都会阻止 build job 和后续 release job。
 - 保留 electron-builder 默认 hardened runtime 和生成的 entitlement；不新增证书、keychain、notarization secret 或网络发布步骤。
 - electron-builder 26.15.x 在 `identity: "-"` 与默认 hardened runtime 同时启用时会输出建议性告警，提示检查 `com.apple.security.cs.disable-library-validation`。本项目必须以最终 entitlement 和实际启动验证为准；该告警属于预期，**不得通过增加 `hardenedRuntime: false` 来消除**。
-- 未来若引入 Developer ID，必须在单独变更中删除/覆盖此设置，并重新验证签名与 notarization，不能让 `"-"` 静默压过正式证书策略。
+- 未来若引入 Developer ID，必须在单独变更中删除/覆盖此设置，并重新验证签名与 notarization，不能依赖当前 qualifier 的隐式匹配行为。
 - 本次必须同时检查 x64 和 ARM64 的签名结构；只有 ARM64 可在当前硬件上提供真实启动/Koffi smoke，Intel 真机证据仍按可用性单独声明。
 
 ### 3.3 间接依赖
@@ -206,13 +207,13 @@ caret 表示允许未来在同 major 内正常解析；本次 PR 的候选 `pack
 - 只在 Linux CI 的最终 `.AppImage` 生成后运行；检查最终 artifact，不检查 `node_modules/app-builder-lib` 生成器源码。
 - 在临时目录中只提取 `AppRun`。首选 `<artifact> --appimage-extract AppRun`；该操作只执行 AppImage 的 ELF runtime stub 来完成临时提取，不得继续启动被提取的 `AppRun`。若 CI 环境不支持 AppImage 自提取，可用 `unsquashfs` 配合不执行 `AppRun` 的只读 offset 提取作为 fallback。
 - **绝不 `source`、`eval`、执行 `AppRun` 或执行从中提取的赋值语句。** 产物内容一律作为不可信数据处理。
-- 解析作用域严格限定为顶层 `export NAME="…"` 语句。函数、`trap` / `case` / `if`、普通参数展开，以及 `LD_LIBRARY_PATH="" zenity …` 这类命令前缀赋值不在解析范围内，不计入赋值数量，也不触发四条 export 右值的语法拒绝。
+- 验证器不构建 shell AST，也不猜测函数、`trap` / `case` / `if` 的控制流；它保守扫描每一行，只允许从行首开始的精确 `export NAME="…"` 语句。shell 缩进不表示嵌套，因此任何以空格或 Tab 开头、但仍会执行的 `export` 都 fail closed；普通参数展开和 `LD_LIBRARY_PATH="" zenity …` 这类命令前缀赋值不计入 export 数量，也不触发四条 export 右值的语法拒绝。
 - 对 `PATH`、`XDG_DATA_DIRS`、`LD_LIBRARY_PATH`、`GSETTINGS_SCHEMA_DIR` 各要求恰好一个顶层 export 赋值；缺失或重复都 fail closed。
-- 额外断言：所有顶层 export 中，右值含 `:` 分隔符的变量集合必须恰好等于上述四项。出现第五个未审阅 path-list export 时 fail closed，人工评估后才能扩充名单，不能因其不在既有名单中就默认安全。
+- 额外断言：所有从行首开始的 export 变量集合必须恰好等于上述四项。出现第五个未审阅 export 时，无论右值是否含 `:` 都 fail closed，人工评估后才能扩充名单，不能因其不在既有名单中就默认安全。
 - 有限静态语法白名单只适用于上述四条 export 的右值，只允许已审阅的 literal、`${APPDIR}` 和 `${VAR:+:${VAR}}` 形式；在这些右值中拒绝命令替换、反引号、控制运算符、重定向和任何未识别 shell 语法。
 - 用验证器自己的字符串解释逻辑分别模拟继承变量未设置和设置为无害哨兵值的结果，不调用 shell。拒绝空的开头/结尾/连续 `:` 元素、相对 literal（如 `./share`），以及无条件继承变量展开造成的空路径元素。
 - 允许并记录 26.15.7 已审阅模板的条件展开。以后上游更改语法时应主动失败，要求显式复审，而不是宽松放过。
-- fixture 至少包含：真实 26.8.1 模板失败、真实 26.15.7 模板通过、`./share` 失败、双冒号失败、命令替换失败、重复顶层 export 失败、命令前缀 `LD_LIBRARY_PATH=""` 不计数、第五个 path-list export 失败。
+- fixture 至少包含：真实 26.8.1 模板失败、真实 26.15.7 模板通过、`./share` 失败、双冒号失败、命令替换失败、重复顶层 export 失败、空格/Tab 缩进 export 失败、命令前缀 `LD_LIBRARY_PATH=""` 不计数、第五个 path-list export 和第五个无冒号 export 都失败。
 - 输出 artifact SHA-256、AppRun SHA-256、四条规范化赋值及模拟结果，便于 CI 审阅。
 
 将 AppRun gate 放在 `.github/workflows/build.yml` 的 Linux AppImage 构建后。现有失败产物上传使用 `if: always()`，应保留用于故障取证：gate 失败可以仍上传 CI artifact，但会让 Linux build job 失败，并通过 `release` job 的依赖关系阻止发布。在 `.github/workflows/wayland-smoke.yml` 中，将 gate 放在正常 artifact 上传和 smoke 之前，失败时不继续后续步骤。准确称呼它为 **release gate**，不是所有工作流中的绝对 upload gate。
@@ -312,7 +313,7 @@ macOS 两个架构都必须执行并保存：
 3. `koffi` manifest、lockfile、打包产物都保持 2.16.3 和单目标架构契约。
 4. 原 14 个 advisory 全部关闭；实施日新增 advisory 已独立分级并有明确处置。
 5. 最终 AppImage 的 `AppRun` 通过 fail-closed 静态检查；验证器没有执行任何产物 shell；gate 能阻止 release job。
-6. macOS 明确使用 ad-hoc hardened-runtime 签名，x64/ARM64 均通过签名、entitlement 和严格验证；没有引入 Developer ID/notarization。
+6. macOS 最终 x64/ARM64 产物均通过 ad-hoc hardened-runtime 签名、entitlement 和严格验证 gate；没有引入 Developer ID/notarization。
 7. Windows x64/ARM64、macOS x64/ARM64、Linux x64 五个 release targets 均完成最低证据矩阵。
 8. Windows module collection、Koffi pruning、`elevate.exe` provenance、macOS ASAR integrity、Linux AppImage/deb、updater metadata 均无回归。
 9. `scripts/native-package-policy.json` 如有更新，必须由真实 Windows manifest 证据支持；helper 消失时必须删除死例外。
@@ -363,8 +364,11 @@ macOS 两个架构都必须执行并保存：
 7. js-yaml updater 路径的利用需要外部信任边界被突破；除非构造隔离测试，否则静态审查不能量化真实卡顿时长。
 8. Electron 41.10.2 advisory 当前不可达的结论依赖现有窗口/iframe 模型；未来新增不可信嵌入内容时仍需重新威胁建模。
 9. electron-builder 26.15.7 的 Windows 模块收集、签名和安装行为必须靠实际产物验证，不能只引用 changelog。
-10. ad-hoc 签名不提供 Developer ID 身份、notarization 或 Gatekeeper 信任；本轮只保持现有无证书发布策略的确定性。
-11. `.deb` disposable-environment smoke、XWayland smoke 和 AppImage 静态 gate 仍不能覆盖所有发行版、桌面环境、挂载选项和用户启动目录。
+10. ad-hoc 签名不提供 Developer ID 身份、notarization 或 Gatekeeper 信任；`identity: "-"` 只表达配置意图，真正的发布保证来自最终 `.app` 的签名 gate。
+11. electron-builder 26.15.7 的 7zip 工具在 npm 安装树之外按平台下载，因此不受 lockfile 或 `npm audit` 覆盖；当前 app-builder-lib 将其固定为 `7zip@1.0.0` 并校验平台对应 SHA-256，但这仍是上游构建工具供应链边界。
+12. AppImage runtime 自提取失败时，`unsquashfs` fallback 会按 SquashFS magic offset 尝试提取；当前真实产物只有一个 offset 能成功提取 `AppRun`，但静态审查没有证明恶意双 SquashFS/诱饵布局不可构造。
+13. electron-builder 26.15.7 新增的 `desktopName is not set` 建议性告警没有在本安全 PR 中通过盲设配置消除；现有 Wayland CI 通过也不能替代真实 Linux 桌面集成验证。
+14. `.deb` disposable-environment smoke、XWayland smoke 和 AppImage 静态 gate 仍不能覆盖所有发行版、桌面环境、挂载选项和用户启动目录。
 
 ## 10. 预计文件范围与计划文档状态
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,29 +20,11 @@
       },
       "devDependencies": {
         "@electron/asar": "^3.4.1",
-        "electron": "^41.10.2",
-        "electron-builder": "^26.8.1"
+        "electron": "^41.10.4",
+        "electron-builder": "^26.15.7"
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@develar/schema-utils": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmmirror.com/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
-      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.12.0",
-        "ajv-keywords": "^3.4.1"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
@@ -81,9 +63,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -133,29 +115,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/@electron/fuses/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/fuses/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/@electron/get": {
@@ -223,29 +182,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@electron/notarize/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/notarize/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/osx-sign": {
       "version": "1.3.3",
       "resolved": "https://registry.npmmirror.com/@electron/osx-sign/-/osx-sign-1.3.3.tgz",
@@ -268,21 +204,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
       "version": "4.0.10",
       "resolved": "https://registry.npmmirror.com/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
@@ -296,49 +217,19 @@
         "url": "https://github.com/sponsors/gjtorikian/"
       }
     },
-    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/osx-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/rebuild": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmmirror.com/@electron/rebuild/-/rebuild-4.0.3.tgz",
-      "integrity": "sha512-u9vpTHRMkOYCs/1FLiSVAFZ7FbjsXK+bQuzviJZa+lG7BHZl1nz52/IcGvwa3sk80/fc3llutBkbCq10Vh8WQA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-4.2.0.tgz",
+      "integrity": "sha512-RKL/O+jGoXJMxrx/5771y1n0xTKmFuOYGO3gMmwypBM6rsH0kou0mswwdXA2JrhIkE4xyC7v9vGk0n6NPzgOxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@malept/cross-spawn-promise": "^2.0.0",
         "debug": "^4.1.1",
-        "detect-libc": "^2.0.1",
-        "got": "^11.7.0",
-        "graceful-fs": "^4.2.11",
         "node-abi": "^4.2.0",
         "node-api-version": "^0.2.1",
-        "node-gyp": "^11.2.0",
-        "ora": "^5.1.0",
-        "read-binary-file-arch": "^1.0.6",
-        "semver": "^7.3.5",
-        "tar": "^7.5.6",
-        "yargs": "^17.0.1"
+        "node-gyp": "^12.2.0",
+        "read-binary-file-arch": "^1.0.6"
       },
       "bin": {
         "electron-rebuild": "lib/cli.js"
@@ -374,9 +265,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -384,9 +275,9 @@
       }
     },
     "node_modules/@electron/universal/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -396,19 +287,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/universal/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@electron/universal/node_modules/minimatch": {
@@ -427,16 +305,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@electron/universal/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/@electron/windows-sign": {
       "version": "1.2.2",
       "resolved": "https://registry.npmmirror.com/@electron/windows-sign/-/windows-sign-1.2.2.tgz",
@@ -444,6 +312,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -459,12 +328,13 @@
       }
     },
     "node_modules/@electron/windows-sign/node_modules/fs-extra": {
-      "version": "11.3.4",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-11.3.4.tgz",
-      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -472,134 +342,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@electron/windows-sign/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmmirror.com/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-9.2.2.tgz",
-      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@isaacs/fs-minipass": {
@@ -685,75 +427,69 @@
         "node": ">=10"
       }
     },
-    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+    "node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@npmcli/agent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/@npmcli/agent/-/agent-3.0.0.tgz",
-      "integrity": "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "http-proxy-agent": "^7.0.0",
-        "https-proxy-agent": "^7.0.1",
-        "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.3"
+        "node": ">= 20.19.0"
       },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/@npmcli/fs": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/@npmcli/fs/-/fs-4.0.0.tgz",
-      "integrity": "sha512-/xGlezI6xfGO9NwuJlnwz/K14qD1kCSAGtacBHnGzeAIuJGazcp45KP5NuyARXoKb7cwulAGWVsbeSxdG/cb0Q==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmmirror.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+    "node_modules/@peculiar/asn1-schema": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
+      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
+      "dependencies": {
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/json-schema": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.12.tgz",
+      "integrity": "sha512-coUfuoMeIB7B8/NMekxaDzLhaYmp0HZNPEjYRm9goRou8UZIC3z21s0sL9AWoCw4EG876QyO3kYrc61WNF9B/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
       "engines": {
-        "node": ">=14"
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@peculiar/utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/utils/-/utils-2.0.3.tgz",
+      "integrity": "sha512-+oL3HPFRIZ1St2K50lWCXiioIgSoxzz7R1J3uF6neO2yl1sgmpgY6XXJH4BdpoDkMWznQTeYF6oWNDZLCdQ4eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/@peculiar/webcrypto": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.7.1.tgz",
+      "integrity": "sha512-ODOov0sGMJMf3jPonOkgGqPknTsu+DdQ7kD++gz8aI+aFMOMHFbWAA2taqXXVTdP+OTOQR/znGvSpmkeI0WTYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "tslib": "^2.8.1",
+        "webcrypto-core": "^1.9.2"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -853,9 +589,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "resolved": "https://registry.npmmirror.com/@types/debug/-/debug-4.1.12.tgz",
-      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -905,18 +641,6 @@
         "undici-types": "~7.16.0"
       }
     },
-    "node_modules/@types/plist": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmmirror.com/@types/plist/-/plist-3.0.5.tgz",
-      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*",
-        "xmlbuilder": ">=11.0.1"
-      }
-    },
     "node_modules/@types/responselike": {
       "version": "1.0.3",
       "resolved": "https://registry.npmmirror.com/@types/responselike/-/responselike-1.0.3.tgz",
@@ -926,14 +650,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/verror": {
-      "version": "1.10.11",
-      "resolved": "https://registry.npmmirror.com/@types/verror/-/verror-1.10.11.tgz",
-      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.13",
@@ -945,21 +661,14 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/7zip-bin": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmmirror.com/7zip-bin/-/7zip-bin-5.2.0.tgz",
-      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/abbrev": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmmirror.com/abbrev/-/abbrev-3.0.1.tgz",
-      "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+      "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/agent-base": {
@@ -973,31 +682,20 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmmirror.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
       }
     },
     "node_modules/ansi-regex": {
@@ -1026,40 +724,36 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/app-builder-bin": {
-      "version": "5.0.0-alpha.12",
-      "resolved": "https://registry.npmmirror.com/app-builder-bin/-/app-builder-bin-5.0.0-alpha.12.tgz",
-      "integrity": "sha512-j87o0j6LqPL3QRr8yid6c+Tt5gC7xNfYo6uQIQkorAC6MpeayVMZrEDzKmJJ/Hlv7EnOQpaRm53k6ktDYZyB6w==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/app-builder-lib": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmmirror.com/app-builder-lib/-/app-builder-lib-26.8.1.tgz",
-      "integrity": "sha512-p0Im/Dx5C4tmz8QEE1Yn4MkuPC8PrnlRneMhWJj7BBXQfNTJUshM/bp3lusdEsDbvvfJZpXWnYesgSLvwtM2Zw==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.7.tgz",
+      "integrity": "sha512-C7APoYISPExUmrEntNhDpz9Tccb4uWuEDfLaC0WPPc7/pwzz0WZGznCz/ycPfkkzw6tKOalceD8g6TgHmVz1QA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@develar/schema-utils": "~2.6.5",
         "@electron/asar": "3.4.1",
         "@electron/fuses": "^1.8.0",
         "@electron/get": "^3.0.0",
         "@electron/notarize": "2.5.0",
         "@electron/osx-sign": "1.3.3",
-        "@electron/rebuild": "^4.0.3",
+        "@electron/rebuild": "^4.0.4",
         "@electron/universal": "2.0.3",
         "@malept/flatpak-bundler": "^0.4.0",
+        "@noble/hashes": "^2.2.0",
+        "@peculiar/webcrypto": "^1.7.1",
         "@types/fs-extra": "9.0.13",
+        "ajv": "^8.18.0",
+        "asn1js": "^3.0.10",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.8.1",
-        "builder-util-runtime": "9.5.1",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
         "chromium-pickle-js": "^0.2.0",
         "ci-info": "4.3.1",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.8.1",
+        "electron-publish": "26.15.3",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -1067,7 +761,8 @@
         "js-yaml": "^4.1.0",
         "json5": "^2.2.3",
         "lazy-val": "^1.0.5",
-        "minimatch": "^10.0.3",
+        "minimatch": "^10.2.5",
+        "pkijs": "^3.4.0",
         "plist": "3.1.0",
         "proper-lockfile": "^4.1.2",
         "resedit": "^1.7.0",
@@ -1075,14 +770,15 @@
         "tar": "^7.5.7",
         "temp-file": "^3.4.0",
         "tiny-async-pool": "1.3.0",
+        "unzipper": "^0.12.3",
         "which": "^5.0.0"
       },
       "engines": {
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.8.1",
-        "electron-builder-squirrel-windows": "26.8.1"
+        "dmg-builder": "26.15.7",
+        "electron-builder-squirrel-windows": "26.15.7"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/get": {
@@ -1148,42 +844,14 @@
         "node": ">=8"
       }
     },
-    "node_modules/app-builder-lib/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/fs-extra/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/app-builder-lib/node_modules/fs-extra/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/app-builder-lib/node_modules/semver": {
@@ -1199,32 +867,35 @@
         "node": ">=10"
       }
     },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+    "node_modules/asn1js": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
+      "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.5",
+        "tslib": "^2.8.1"
+      },
       "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/astral-regex": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmmirror.com/astral-regex/-/astral-regex-2.0.0.tgz",
-      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/async": {
@@ -1259,6 +930,13 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.18.1",
@@ -1328,17 +1006,12 @@
       ],
       "license": "MIT"
     },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
+      "license": "MIT"
     },
     "node_modules/boolean": {
       "version": "3.2.0",
@@ -1350,41 +1023,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-from": {
@@ -1395,16 +1043,14 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmmirror.com/builder-util/-/builder-util-26.8.1.tgz",
-      "integrity": "sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
+      "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.1.6",
-        "7zip-bin": "~5.2.0",
-        "app-builder-bin": "5.0.0-alpha.12",
-        "builder-util-runtime": "9.5.1",
+        "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.4",
@@ -1417,13 +1063,15 @@
         "stat-mode": "^1.0.0",
         "temp-file": "^3.4.0",
         "tiny-async-pool": "1.3.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmmirror.com/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-      "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-      "dev": true,
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -1433,128 +1081,14 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/builder-util/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/builder-util/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/builder-util/node_modules/universalify": {
+    "node_modules/bytestreamjs": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "resolved": "https://registry.npmjs.org/bytestreamjs/-/bytestreamjs-2.0.1.tgz",
+      "integrity": "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ==",
       "dev": true,
-      "license": "MIT",
+      "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/cacache": {
-      "version": "19.0.1",
-      "resolved": "https://registry.npmmirror.com/cacache/-/cacache-19.0.1.tgz",
-      "integrity": "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/fs": "^4.0.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
-        "lru-cache": "^10.0.1",
-        "minipass": "^7.0.3",
-        "minipass-collect": "^2.0.1",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "p-map": "^7.0.2",
-        "ssri": "^12.0.0",
-        "tar": "^7.4.3",
-        "unique-filename": "^4.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/cacache/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cacache/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/cacache/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/cacache/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/cacache/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=6.0.0"
       }
     },
     "node_modules/cacheable-lookup": {
@@ -1665,50 +1199,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cli-spinners": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmmirror.com/cli-spinners/-/cli-spinners-2.9.2.tgz",
-      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cli-truncate": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/cli-truncate/-/cli-truncate-2.1.0.tgz",
-      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "slice-ansi": "^3.0.0",
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmmirror.com/cliui/-/cliui-8.0.1.tgz",
@@ -1722,16 +1212,6 @@
       },
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/clone-response": {
@@ -1807,23 +1287,11 @@
       "license": "MIT"
     },
     "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/crc": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmmirror.com/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer": "^5.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/cross-dirname": {
       "version": "0.1.0",
@@ -1831,7 +1299,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -1917,19 +1386,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/defaults/-/defaults-1.0.4.tgz",
-      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmmirror.com/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
@@ -1987,16 +1443,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmmirror.com/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/detect-node": {
       "version": "2.1.0",
       "resolved": "https://registry.npmmirror.com/detect-node/-/detect-node-2.1.0.tgz",
@@ -2024,9 +1470,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2048,86 +1494,16 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmmirror.com/dmg-builder/-/dmg-builder-26.8.1.tgz",
-      "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.7.tgz",
+      "integrity": "sha512-rfo1YyAWO0L3cZLKCqKQiLYbW6ZXebRUfK0kWp4oXxO7dDFLrf7alRkWImNuXvZVQhs6Idzy++cwOk8I+xPDhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
+        "app-builder-lib": "26.15.7",
+        "builder-util": "26.15.3",
         "fs-extra": "^10.1.0",
-        "iconv-lite": "^0.6.2",
         "js-yaml": "^4.1.0"
-      },
-      "optionalDependencies": {
-        "dmg-license": "^1.0.11"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/dmg-builder/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/dmg-license": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmmirror.com/dmg-license/-/dmg-license-1.0.11.tgz",
-      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "@types/plist": "^3.0.1",
-        "@types/verror": "^1.10.3",
-        "ajv": "^6.10.0",
-        "crc": "^3.8.0",
-        "iconv-corefoundation": "^1.1.7",
-        "plist": "^3.0.4",
-        "smart-buffer": "^4.0.2",
-        "verror": "^1.10.0"
-      },
-      "bin": {
-        "dmg-license": "bin/dmg-license.js"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/dom-serializer": {
@@ -2240,12 +1616,15 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmmirror.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
       "dev": true,
-      "license": "MIT"
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
     },
     "node_modules/ejs": {
       "version": "3.1.10",
@@ -2264,9 +1643,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "41.10.2",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.2.tgz",
-      "integrity": "sha512-vzSetbn05LPfg0gW0p9txpqmkkFyTXzdSHvKIXbtmsK362hkgUQJu+x19GSSS9v/VXeFi5UJI5TYJ1a+Os3CpA==",
+      "version": "41.10.4",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.4.tgz",
+      "integrity": "sha512-YUE5aRDz1M1d+1BX1G7SESkXup+1fqvrQ64ztVa/b1N+yXxXRUnbRlRNk70FI/n3O65JiQV9G3M0dxn5XldowQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -2283,18 +1662,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmmirror.com/electron-builder/-/electron-builder-26.8.1.tgz",
-      "integrity": "sha512-uWhx1r74NGpCagG0ULs/P9Nqv2nsoo+7eo4fLUOB8L8MdWltq9odW/uuLXMFCDGnPafknYLZgjNX0ZIFRzOQAw==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.7.tgz",
+      "integrity": "sha512-DBpaNzxsPs1BvEblzFoNriSbzsBqDCy/gseIngeEhYzQG1IxfB7Hvc2tBBVmpWE2BTQGP9J1RrAvDT+Vc/uAxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
-        "builder-util-runtime": "9.5.1",
+        "app-builder-lib": "26.15.7",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.8.1",
+        "dmg-builder": "26.15.7",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -2309,109 +1688,34 @@
       }
     },
     "node_modules/electron-builder-squirrel-windows": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmmirror.com/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.8.1.tgz",
-      "integrity": "sha512-o288fIdgPLHA76eDrFADHPoo7VyGkDCYbLV1GzndaMSAVBoZrGvM9m2IehdcVMzdAZJ2eV9bgyissQXHv5tGzA==",
+      "version": "26.15.7",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-26.15.7.tgz",
+      "integrity": "sha512-B4uvn2NzFSuf084udWqugludFull6CRJiWe2dLzMnZLl6G5hdAGk0fsBMGlBSpKjvQCJn8IPc+S7OnJ+GXqwLA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "app-builder-lib": "26.8.1",
-        "builder-util": "26.8.1",
+        "app-builder-lib": "26.15.7",
+        "builder-util": "26.15.3",
         "electron-winstaller": "5.4.0"
       }
     },
-    "node_modules/electron-builder/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-builder/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-builder/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/electron-publish": {
-      "version": "26.8.1",
-      "resolved": "https://registry.npmmirror.com/electron-publish/-/electron-publish-26.8.1.tgz",
-      "integrity": "sha512-q+jrSTIh/Cv4eGZa7oVR+grEJo/FoLMYBAnSL5GCtqwUpr1T+VgKB/dn1pnzxIxqD8S/jP1yilT9VrwCqINR4w==",
+      "version": "26.15.3",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
+      "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
-        "builder-util": "26.8.1",
-        "builder-util-runtime": "9.5.1",
+        "aws4": "^1.13.2",
+        "builder-util": "26.15.3",
+        "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "form-data": "^4.0.5",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "mime": "^2.5.2"
-      }
-    },
-    "node_modules/electron-publish/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-publish/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/electron-publish/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/electron-updater": {
@@ -2430,45 +1734,6 @@
         "tiny-typed-emitter": "^2.1.0"
       }
     },
-    "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.7.0",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/electron-updater/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/electron-updater/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/electron-updater/node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmmirror.com/semver/-/semver-7.7.4.tgz",
@@ -2481,15 +1746,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/electron-updater/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmmirror.com/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -2497,6 +1753,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -2517,6 +1774,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -2526,23 +1784,34 @@
         "node": ">=6 <7 || >=8"
       }
     },
+    "node_modules/electron-winstaller/node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-winstaller/node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmmirror.com/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
     },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
@@ -2667,17 +1936,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmmirror.com/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
-      "dev": true,
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2685,12 +1943,22 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
-      "license": "MIT"
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -2728,9 +1996,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2770,36 +2038,6 @@
         }
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmmirror.com/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
@@ -2816,17 +2054,18 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fs-minipass": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmmirror.com/fs-minipass/-/fs-minipass-3.0.3.tgz",
-      "integrity": "sha512-XUBA9XClHbnJWSfBzjkm6RvPsyg3sryZt06BEQoXcF7EK/xpGaQYJgQKDJSUH5SGZ76Y7pFx1QBnXz09rU5Fbw==",
-      "dev": true,
-      "license": "ISC",
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
       "dependencies": {
-        "minipass": "^7.0.3"
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -2938,9 +2177,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3189,68 +2428,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/iconv-corefoundation": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmmirror.com/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
-      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "dependencies": {
-        "cli-truncate": "^2.1.0",
-        "node-addon-api": "^1.6.3"
-      },
-      "engines": {
-        "node": "^8.11.2 || >=10"
-      }
-    },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmmirror.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmmirror.com/inflight/-/inflight-1.0.6.tgz",
@@ -3270,16 +2447,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -3290,28 +2457,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-interactive": {
+    "node_modules/isarray": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/is-interactive/-/is-interactive-1.0.0.tgz",
-      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmmirror.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "license": "MIT"
     },
     "node_modules/isbinaryfile": {
       "version": "5.0.7",
@@ -3336,22 +2487,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmmirror.com/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jake": {
       "version": "10.9.4",
       "resolved": "https://registry.npmmirror.com/jake/-/jake-10.9.4.tgz",
@@ -3371,9 +2506,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmmirror.com/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -3381,9 +2516,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -3410,9 +2545,9 @@
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true,
       "license": "MIT"
     },
@@ -3444,11 +2579,13 @@
       "license": "MIT"
     },
     "node_modules/jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -3536,23 +2673,6 @@
       "integrity": "sha512-AZV+GsS/6ckvPOVQPXSiFFacKvKB4kOQu6ynt9wz0F3LO4R9Ij4K1ddYsIytDpSgLz88JHd9P+oaLeej5/Sl7Q==",
       "license": "MIT"
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmmirror.com/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/long": {
       "version": "5.3.2",
       "resolved": "https://registry.npmmirror.com/long/-/long-5.3.2.tgz",
@@ -3580,29 +2700,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/make-fetch-happen": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmmirror.com/make-fetch-happen/-/make-fetch-happen-14.0.3.tgz",
-      "integrity": "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/agent": "^3.0.0",
-        "cacache": "^19.0.1",
-        "http-cache-semantics": "^4.1.1",
-        "minipass": "^7.0.2",
-        "minipass-fetch": "^4.0.0",
-        "minipass-flush": "^1.0.5",
-        "minipass-pipeline": "^1.2.4",
-        "negotiator": "^1.0.0",
-        "proc-log": "^5.0.0",
-        "promise-retry": "^2.0.1",
-        "ssri": "^12.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/markdown-it": {
@@ -3711,16 +2808,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmmirror.com/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/mimic-response": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/mimic-response/-/mimic-response-1.0.1.tgz",
@@ -3732,13 +2819,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -3767,115 +2854,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/minipass-collect": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/minipass-collect/-/minipass-collect-2.0.1.tgz",
-      "integrity": "sha512-D7V8PO9oaz7PWGLbCACuI1qEOsq7UKfLotx/C0Aet43fCUB/wfQ7DYeq2oR/svFJGYDHPr38SHATeaj/ZoKHKw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minipass-fetch": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmmirror.com/minipass-fetch/-/minipass-fetch-4.0.1.tgz",
-      "integrity": "sha512-j7U11C5HXigVuutxebFadoYBbd7VSdZWggSe64NVdvWNBqGAiXPL2QVCehjmw7lY1oF9gOllYbORh+hiNgfPgQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.0.3",
-        "minipass-sized": "^1.0.3",
-        "minizlib": "^3.0.1"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      },
-      "optionalDependencies": {
-        "encoding": "^0.1.13"
-      }
-    },
-    "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmmirror.com/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-pipeline": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmmirror.com/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
-      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-pipeline/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/minipass-sized/-/minipass-sized-1.0.3.tgz",
-      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmmirror.com/minipass/-/minipass-3.3.6.tgz",
-      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/minizlib": {
       "version": "3.1.0",
       "resolved": "https://registry.npmmirror.com/minizlib/-/minizlib-3.1.0.tgz",
@@ -3895,6 +2873,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -3908,20 +2887,10 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/node-abi": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmmirror.com/node-abi/-/node-abi-4.28.0.tgz",
-      "integrity": "sha512-Qfp5XZL1cJDOabOT8H5gnqMTmM4NjvYzHp4I/Kt/Sl76OVkOBBHRFlPspGV0hYvMoqQsypFjT/Yp7Km0beXW9g==",
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.33.0.tgz",
+      "integrity": "sha512-vLBWCKb+7LWsX+TbfzWOkw0W81m377tyx3hOweBTjO43CXZnRGS1/JPWs20fr0PgZyDXk6ROYrylsEycK8raDA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3930,14 +2899,6 @@
       "engines": {
         "node": ">=22.12.0"
       }
-    },
-    "node_modules/node-addon-api": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmmirror.com/node-addon-api/-/node-addon-api-1.7.2.tgz",
-      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/node-api-version": {
       "version": "0.2.1",
@@ -3950,44 +2911,87 @@
       }
     },
     "node_modules/node-gyp": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmmirror.com/node-gyp/-/node-gyp-11.5.0.tgz",
-      "integrity": "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-12.4.0.tgz",
+      "integrity": "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^14.0.3",
-        "nopt": "^8.0.0",
-        "proc-log": "^5.0.0",
+        "nopt": "^9.0.0",
+        "proc-log": "^6.0.0",
         "semver": "^7.3.5",
-        "tar": "^7.4.3",
+        "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
-        "which": "^5.0.0"
+        "undici": "^6.25.0",
+        "which": "^6.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/nopt": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmmirror.com/nopt/-/nopt-8.1.0.tgz",
-      "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+    "node_modules/node-gyp/node_modules/isexe": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+      "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/node-gyp/node_modules/undici": {
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/node-gyp/node_modules/which": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+      "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "abbrev": "^3.0.0"
+        "isexe": "^4.0.0"
+      },
+      "bin": {
+        "node-which": "bin/which.js"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nopt": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+      "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^4.0.0"
       },
       "bin": {
         "nopt": "bin/nopt.js"
       },
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/normalize-url": {
@@ -4036,46 +3040,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmmirror.com/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ora": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmmirror.com/ora/-/ora-5.4.1.tgz",
-      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.1.0",
-        "chalk": "^4.1.0",
-        "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.5.0",
-        "is-interactive": "^1.0.0",
-        "is-unicode-supported": "^0.1.0",
-        "log-symbols": "^4.1.0",
-        "strip-ansi": "^6.0.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-cancelable": {
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/p-cancelable/-/p-cancelable-2.1.1.tgz",
@@ -4102,26 +3066,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmmirror.com/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -4141,30 +3085,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/pe-library": {
       "version": "0.4.1",
@@ -4194,12 +3114,42 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkijs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pkijs/-/pkijs-3.4.0.tgz",
+      "integrity": "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@noble/hashes": "1.4.0",
+        "asn1js": "^3.0.6",
+        "bytestreamjs": "^2.0.1",
+        "pvtsutils": "^1.3.6",
+        "pvutils": "^1.1.3",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/plist": {
@@ -4224,6 +3174,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -4241,19 +3192,27 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/proc-log": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/proc-log/-/proc-log-5.0.0.tgz",
-      "integrity": "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.1.0.tgz",
+      "integrity": "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==",
       "dev": true,
       "license": "ISC",
       "engines": {
-        "node": "^18.17.0 || >=20.5.0"
+        "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
@@ -4334,16 +3293,6 @@
         "once": "^1.3.1"
       }
     },
-    "node_modules/punycode": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
-      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
@@ -4351,6 +3300,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pvtsutils": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
+      "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/pvutils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/qs": {
@@ -4395,24 +3364,35 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmmirror.com/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4457,20 +3437,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmmirror.com/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmmirror.com/retry/-/retry-0.12.0.tgz",
@@ -4488,6 +3454,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -4515,37 +3482,16 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmmirror.com/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/sanitize-filename": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmmirror.com/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
-      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
       "dev": true,
       "license": "WTFPL OR ISC",
       "dependencies": {
@@ -4714,63 +3660,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/slice-ansi": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmmirror.com/slice-ansi/-/slice-ansi-3.0.0.tgz",
-      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmmirror.com/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmmirror.com/socks/-/socks-2.8.7.tgz",
-      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ip-address": "^10.0.1",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks-proxy-agent": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmmirror.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
-      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "^4.3.4",
-        "socks": "^2.8.3"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmmirror.com/source-map/-/source-map-0.6.1.tgz",
@@ -4800,19 +3689,6 @@
       "license": "BSD-3-Clause",
       "optional": true
     },
-    "node_modules/ssri": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmmirror.com/ssri/-/ssri-12.0.0.tgz",
-      "integrity": "sha512-S7iGNosepx9RadX82oimUkvr0Ct7IjJbEbs4mJcTxst8um95J3sDYU1RBEOvdu6oL1Wek2ODI5i4MAw+dZ6cAQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/stat-mode": {
       "version": "1.0.0",
       "resolved": "https://registry.npmmirror.com/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -4824,13 +3700,13 @@
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmmirror.com/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-width": {
@@ -4848,37 +3724,7 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -4918,9 +3764,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.21",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
-      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -4950,6 +3796,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -4967,44 +3814,6 @@
       "dependencies": {
         "async-exit-hook": "^2.0.1",
         "fs-extra": "^10.0.0"
-      }
-    },
-    "node_modules/temp-file/node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/temp-file/node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/temp-file/node_modules/universalify": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
-      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
       }
     },
     "node_modules/tiny-async-pool": {
@@ -5034,14 +3843,14 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmmirror.com/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -5080,6 +3889,13 @@
         "utf8-byte-length": "^1.0.1"
       }
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
+    },
     "node_modules/type-fest": {
       "version": "0.13.1",
       "resolved": "https://registry.npmmirror.com/type-fest/-/type-fest-0.13.1.tgz",
@@ -5101,9 +3917,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5117,50 +3933,42 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
-    "node_modules/unique-filename": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmmirror.com/unique-filename/-/unique-filename-4.0.0.tgz",
-      "integrity": "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmmirror.com/unique-slug/-/unique-slug-5.0.0.tgz",
-      "integrity": "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^18.17.0 || >=20.5.0"
-      }
-    },
     "node_modules/universalify": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmmirror.com/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 10.0.0"
       }
     },
-    "node_modules/uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmmirror.com/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+    "node_modules/unzipper": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.5.tgz",
+      "integrity": "sha512-tXYOi9R57Uj/2Z25SOs5RRSzq886MBQj2gY8dPL+xl/kv6s6SvByoKfAtvfVeEuhntWDgjd2o9p2lb4TVPAz0A==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "punycode": "^2.1.0"
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "11.3.1",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/unzipper/node_modules/fs-extra": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
+      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/utf8-byte-length": {
@@ -5177,30 +3985,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/verror": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmmirror.com/verror/-/verror-1.10.1.tgz",
-      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
-    "node_modules/wcwidth": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmmirror.com/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+    "node_modules/webcrypto-core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.9.2.tgz",
+      "integrity": "sha512-gsXecm82UQNlTBURJGuqOWy1Ww08S3kZUcr3aOJS02Pk0xLtkfeUAVC0u0xhgdonFme80edSJUIJyuvL/7250Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "defaults": "^1.0.3"
+        "@peculiar/asn1-schema": "^2.7.0",
+        "@peculiar/json-schema": "^1.1.12",
+        "@peculiar/utils": "^2.0.2",
+        "asn1js": "^3.0.10",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/which": {
@@ -5220,25 +4016,6 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
       "version": "7.0.0",
       "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
@@ -5312,9 +4089,9 @@
       "license": "ISC"
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmmirror.com/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     ],
     "mac": {
       "icon": "assets/icon.png",
+      "identity": "-",
       "artifactName": "Clawd-on-Desk-${version}-${arch}.${ext}",
       "target": [
         {
@@ -184,8 +185,8 @@
   },
   "devDependencies": {
     "@electron/asar": "^3.4.1",
-    "electron": "^41.10.2",
-    "electron-builder": "^26.8.1"
+    "electron": "^41.10.4",
+    "electron-builder": "^26.15.7"
   },
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.71.1",

--- a/scripts/after-pack-koffi.js
+++ b/scripts/after-pack-koffi.js
@@ -88,6 +88,7 @@ function assertSafeKoffiRoot({ appOutDir, resourcesRoot, nativeRoot }) {
   if (requiredSegment !== "app.asar.unpacked/node_modules/koffi/build/koffi") {
     throw new Error(`Unexpected Koffi prune root: ${requiredSegment}`);
   }
+  return { resolvedAppOut, resolvedResources, resolvedNative };
 }
 
 function pruneKoffiNative({ appOutDir, targetId, outputPath = "", asarModule = asar } = {}) {
@@ -111,7 +112,7 @@ function pruneKoffiNative({ appOutDir, targetId, outputPath = "", asarModule = a
   assertDirectory(unpackedRoot, "app.asar.unpacked root");
   assertDirectory(koffiRoot, "packaged Koffi root");
   assertDirectory(nativeRoot, "packaged Koffi native root");
-  assertSafeKoffiRoot({ appOutDir, resourcesRoot, nativeRoot });
+  const { resolvedNative } = assertSafeKoffiRoot({ appOutDir, resourcesRoot, nativeRoot });
 
   const packageJsonPath = path.join(koffiRoot, "package.json");
   const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
@@ -140,7 +141,7 @@ function pruneKoffiNative({ appOutDir, targetId, outputPath = "", asarModule = a
   for (const triplet of actualTriplets) {
     const tripletDir = path.join(nativeRoot, triplet);
     const resolvedTriplet = fs.realpathSync.native(tripletDir);
-    if (!isInside(nativeRoot, resolvedTriplet)) {
+    if (!isInside(resolvedNative, resolvedTriplet)) {
       throw new Error(`Koffi triplet escaped native root: ${resolvedTriplet}`);
     }
     for (const file of walkTreeNoLinks(tripletDir)) {

--- a/scripts/native-package-policy.json
+++ b/scripts/native-package-policy.json
@@ -12,7 +12,7 @@
       "architectures": [
         "ia32"
       ],
-      "reason": "electron-builder 26.8.1 NSIS CopyElevateHelper intentionally supplies a PE ia32 helper"
+      "reason": "electron-builder 26.15.7 NSIS CopyElevateHelper intentionally supplies a PE ia32 helper"
     }
   ]
 }

--- a/scripts/verify-appimage-apprun.js
+++ b/scripts/verify-appimage-apprun.js
@@ -31,8 +31,12 @@ function parseTopLevelExports(content) {
 
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
-    if (!line.startsWith("export ")) {
+    if (!/^[ \t]*export(?:[ \t]|$)/.test(line)) {
       continue;
+    }
+
+    if (!line.startsWith("export ")) {
+      throw new Error(`unsupported export syntax at AppRun line ${index + 1}`);
     }
 
     const match = /^export ([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
@@ -120,14 +124,11 @@ function validateAppRunContent(content) {
     };
   }
 
-  const actualPathListExports = exports
-    .filter((entry) => entry.rhs.includes(":"))
-    .map((entry) => entry.name)
-    .sort();
-  const expectedPathListExports = [...REVIEWED_PATH_EXPORTS].sort();
-  if (JSON.stringify(actualPathListExports) !== JSON.stringify(expectedPathListExports)) {
+  const actualExports = exports.map((entry) => entry.name).sort();
+  const expectedExports = [...REVIEWED_PATH_EXPORTS].sort();
+  if (JSON.stringify(actualExports) !== JSON.stringify(expectedExports)) {
     throw new Error(
-      `top-level path-list exports changed; expected ${expectedPathListExports.join(", ")}, got ${actualPathListExports.join(", ") || "none"}`
+      `top-level exports changed; expected ${expectedExports.join(", ")}, got ${actualExports.join(", ") || "none"}`
     );
   }
 

--- a/scripts/verify-appimage-apprun.js
+++ b/scripts/verify-appimage-apprun.js
@@ -1,0 +1,274 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+const REVIEWED_PATH_EXPORTS = Object.freeze([
+  "PATH",
+  "XDG_DATA_DIRS",
+  "LD_LIBRARY_PATH",
+  "GSETTINGS_SCHEMA_DIR",
+]);
+
+const APPDIR_SENTINEL = "/__clawd_verified_appdir__";
+const INHERITED_SENTINEL = "/__clawd_inherited_one__:/__clawd_inherited_two__";
+const SQUASHFS_MAGIC = Buffer.from("hsqs", "ascii");
+
+function sha256File(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+function sha256Text(text) {
+  return crypto.createHash("sha256").update(text, "utf8").digest("hex");
+}
+
+function parseTopLevelExports(content) {
+  const exports = [];
+  const lines = content.split(/\r?\n/);
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!line.startsWith("export ")) {
+      continue;
+    }
+
+    const match = /^export ([A-Za-z_][A-Za-z0-9_]*)=(.*)$/.exec(line);
+    if (!match) {
+      throw new Error(`unsupported top-level export syntax at AppRun line ${index + 1}`);
+    }
+    exports.push({
+      name: match[1],
+      rhs: match[2],
+      line: index + 1,
+    });
+  }
+
+  return exports;
+}
+
+function assertSafePathList(value, label) {
+  const parts = value.split(":");
+  if (parts.some((part) => part.length === 0)) {
+    throw new Error(`${label} produces an empty search-path element: ${JSON.stringify(value)}`);
+  }
+  for (const part of parts) {
+    if (!path.posix.isAbsolute(part)) {
+      throw new Error(`${label} produces a non-absolute search-path element: ${JSON.stringify(part)}`);
+    }
+  }
+}
+
+function evaluateReviewedRightHandSide(rhs, variableName, inheritedValue) {
+  if (rhs.length < 2 || !rhs.startsWith('"') || !rhs.endsWith('"')) {
+    throw new Error(`${variableName} must use one double-quoted right-hand side`);
+  }
+
+  const source = rhs.slice(1, -1);
+  const appDirToken = "${APPDIR}";
+  const inheritedToken = "${" + variableName + ":+:${" + variableName + "}}";
+  let output = "";
+
+  for (let index = 0; index < source.length; ) {
+    if (source.startsWith(appDirToken, index)) {
+      output += APPDIR_SENTINEL;
+      index += appDirToken.length;
+      continue;
+    }
+    if (source.startsWith(inheritedToken, index)) {
+      if (inheritedValue) {
+        output += `:${inheritedValue}`;
+      }
+      index += inheritedToken.length;
+      continue;
+    }
+
+    const character = source[index];
+    if (character === "$" || !/[A-Za-z0-9_./:+-]/.test(character)) {
+      throw new Error(
+        `${variableName} contains unreviewed shell syntax at offset ${index}: ${JSON.stringify(source.slice(index))}`
+      );
+    }
+    output += character;
+    index += 1;
+  }
+
+  assertSafePathList(output, variableName);
+  return output;
+}
+
+function validateAppRunContent(content) {
+  const exports = parseTopLevelExports(content);
+  const results = {};
+
+  for (const variableName of REVIEWED_PATH_EXPORTS) {
+    const matches = exports.filter((entry) => entry.name === variableName);
+    if (matches.length !== 1) {
+      throw new Error(
+        `${variableName} must have exactly one top-level export assignment, found ${matches.length}`
+      );
+    }
+
+    const entry = matches[0];
+    results[variableName] = {
+      statement: `export ${entry.name}=${entry.rhs}`,
+      line: entry.line,
+      inheritedUnset: evaluateReviewedRightHandSide(entry.rhs, variableName, ""),
+      inheritedSet: evaluateReviewedRightHandSide(entry.rhs, variableName, INHERITED_SENTINEL),
+    };
+  }
+
+  const actualPathListExports = exports
+    .filter((entry) => entry.rhs.includes(":"))
+    .map((entry) => entry.name)
+    .sort();
+  const expectedPathListExports = [...REVIEWED_PATH_EXPORTS].sort();
+  if (JSON.stringify(actualPathListExports) !== JSON.stringify(expectedPathListExports)) {
+    throw new Error(
+      `top-level path-list exports changed; expected ${expectedPathListExports.join(", ")}, got ${actualPathListExports.join(", ") || "none"}`
+    );
+  }
+
+  return results;
+}
+
+function findSquashfsOffsets(artifactPath) {
+  const data = fs.readFileSync(artifactPath);
+  const offsets = [];
+  let offset = data.indexOf(SQUASHFS_MAGIC);
+  while (offset !== -1) {
+    offsets.push(offset);
+    offset = data.indexOf(SQUASHFS_MAGIC, offset + 1);
+  }
+  return offsets;
+}
+
+function extractWithUnsquashfs(artifactPath, tempDir) {
+  const offsets = findSquashfsOffsets(artifactPath);
+  const errors = [];
+
+  for (const offset of offsets) {
+    const outputDir = path.join(tempDir, `unsquashfs-${offset}`);
+    const result = spawnSync(
+      "unsquashfs",
+      ["-o", String(offset), "-d", outputDir, artifactPath, "AppRun"],
+      { encoding: "utf8", maxBuffer: 4 * 1024 * 1024 }
+    );
+    const appRunPath = path.join(outputDir, "AppRun");
+    if (result.status === 0 && fs.existsSync(appRunPath)) {
+      return {
+        content: fs.readFileSync(appRunPath, "utf8"),
+        method: `unsquashfs-offset-${offset}`,
+      };
+    }
+    errors.push(result.error ? result.error.message : (result.stderr || `exit ${result.status}`).trim());
+    fs.rmSync(outputDir, { recursive: true, force: true });
+  }
+
+  throw new Error(
+    `unsquashfs could not extract AppRun from ${offsets.length} SquashFS candidate(s): ${errors.filter(Boolean).join("; ") || "no SquashFS magic found"}`
+  );
+}
+
+function extractAppRun(artifactPath) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-apprun-"));
+  try {
+    const runtimeResult = spawnSync(
+      artifactPath,
+      ["--appimage-extract", "AppRun"],
+      { cwd: tempDir, encoding: "utf8", maxBuffer: 4 * 1024 * 1024 }
+    );
+    const runtimeExtractedPath = path.join(tempDir, "squashfs-root", "AppRun");
+    if (runtimeResult.status === 0 && fs.existsSync(runtimeExtractedPath)) {
+      return {
+        content: fs.readFileSync(runtimeExtractedPath, "utf8"),
+        method: "appimage-runtime-extract",
+      };
+    }
+
+    try {
+      return extractWithUnsquashfs(artifactPath, tempDir);
+    } catch (fallbackError) {
+      const runtimeError = runtimeResult.error
+        ? runtimeResult.error.message
+        : (runtimeResult.stderr || `exit ${runtimeResult.status}`).trim();
+      throw new Error(
+        `AppImage runtime extraction failed (${runtimeError || "unknown error"}); ${fallbackError.message}`
+      );
+    }
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+}
+
+function parseArguments(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--artifact" || argument === "--output") {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error(`${argument} requires a value`);
+      }
+      options[argument.slice(2)] = value;
+      index += 1;
+      continue;
+    }
+    throw new Error(`unknown argument: ${argument}`);
+  }
+  if (!options.artifact) {
+    throw new Error("usage: verify-appimage-apprun.js --artifact <file.AppImage> [--output <manifest.json>]");
+  }
+  return options;
+}
+
+function verifyArtifact(artifactPath) {
+  const resolvedArtifact = path.resolve(artifactPath);
+  const stat = fs.statSync(resolvedArtifact);
+  if (!stat.isFile()) {
+    throw new Error(`AppImage artifact is not a file: ${resolvedArtifact}`);
+  }
+
+  const extracted = extractAppRun(resolvedArtifact);
+  const exports = validateAppRunContent(extracted.content);
+  return {
+    schemaVersion: 1,
+    artifact: resolvedArtifact,
+    artifactSha256: sha256File(resolvedArtifact),
+    appRunSha256: sha256Text(extracted.content),
+    extractionMethod: extracted.method,
+    reviewedPathExports: exports,
+  };
+}
+
+function main(argv) {
+  const options = parseArguments(argv);
+  const manifest = verifyArtifact(options.artifact);
+  const output = `${JSON.stringify(manifest, null, 2)}\n`;
+
+  if (options.output) {
+    const outputPath = path.resolve(options.output);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, output);
+  }
+  process.stdout.write(output);
+}
+
+if (require.main === module) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    process.stderr.write(`AppRun verification failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  REVIEWED_PATH_EXPORTS,
+  evaluateReviewedRightHandSide,
+  parseTopLevelExports,
+  validateAppRunContent,
+  verifyArtifact,
+};

--- a/test/after-pack-koffi.test.js
+++ b/test/after-pack-koffi.test.js
@@ -109,6 +109,24 @@ test("afterPack prune keeps one target addon and removes every lib/exp", async (
   assert.equal(fs.existsSync(output), true);
 });
 
+test("afterPack containment checks canonicalize parent path aliases", async (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const actualRoot = path.join(root, "actual");
+  const aliasRoot = path.join(root, "alias");
+  fs.mkdirSync(actualRoot);
+  fs.symlinkSync(actualRoot, aliasRoot, process.platform === "win32" ? "junction" : "dir");
+
+  const fixture = await makePackagedKoffi(aliasRoot, "windows-x64");
+  const report = pruneKoffiNative({
+    appOutDir: fixture.appRoot,
+    targetId: "windows-x64",
+  });
+
+  assert.equal(report.retained.format, "PE");
+  assert.deepEqual(fs.readdirSync(fixture.nativeRoot), [fixture.targetTriplet]);
+});
+
 test("afterPack prune supports the Linux target without a platform exception", async (t) => {
   const root = tempDir();
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));

--- a/test/appimage-apprun.test.js
+++ b/test/appimage-apprun.test.js
@@ -1,0 +1,87 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const {
+  REVIEWED_PATH_EXPORTS,
+  validateAppRunContent,
+} = require("../scripts/verify-appimage-apprun");
+
+const ROOT = path.join(__dirname, "..");
+const FIXTURE_ROOT = path.join(__dirname, "fixtures", "appimage-apprun");
+const SAFE_FIXTURE = fs.readFileSync(
+  path.join(FIXTURE_ROOT, "electron-builder-26.15.7.AppRun"),
+  "utf8"
+);
+const VULNERABLE_FIXTURE = fs.readFileSync(
+  path.join(FIXTURE_ROOT, "electron-builder-26.8.1.AppRun"),
+  "utf8"
+);
+
+test("accepts the reviewed electron-builder 26.15.7 AppRun assignments", () => {
+  const result = validateAppRunContent(SAFE_FIXTURE);
+  assert.deepStrictEqual(Object.keys(result), [...REVIEWED_PATH_EXPORTS]);
+  for (const variableName of REVIEWED_PATH_EXPORTS) {
+    assert.match(result[variableName].inheritedUnset, /^\//);
+    assert.match(result[variableName].inheritedSet, /^\//);
+  }
+});
+
+test("rejects the vulnerable electron-builder 26.8.1 AppRun assignments", () => {
+  assert.throws(
+    () => validateAppRunContent(VULNERABLE_FIXTURE),
+    /exactly one top-level export|empty search-path|non-absolute|unreviewed shell syntax/
+  );
+});
+
+test("rejects a relative literal path component", () => {
+  const changed = SAFE_FIXTURE.replace(
+    "${APPDIR}/usr/share/",
+    "./share/"
+  );
+  assert.throws(() => validateAppRunContent(changed), /non-absolute/);
+});
+
+test("rejects an empty path element", () => {
+  const changed = SAFE_FIXTURE.replace(
+    "${APPDIR}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}",
+    "${APPDIR}/usr/lib::${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+  );
+  assert.throws(() => validateAppRunContent(changed), /empty search-path/);
+});
+
+test("rejects command substitution in a reviewed export", () => {
+  const changed = SAFE_FIXTURE.replace(
+    "${APPDIR}:${APPDIR}/usr/sbin",
+    "${APPDIR}:$(id):${APPDIR}/usr/sbin"
+  );
+  assert.throws(() => validateAppRunContent(changed), /unreviewed shell syntax/);
+});
+
+test("rejects a duplicate reviewed top-level export", () => {
+  const changed = `${SAFE_FIXTURE}\nexport PATH="\${APPDIR}"\n`;
+  assert.throws(() => validateAppRunContent(changed), /exactly one top-level export/);
+});
+
+test("does not count command-prefix LD_LIBRARY_PATH assignments", () => {
+  const result = validateAppRunContent(SAFE_FIXTURE);
+  assert.strictEqual(result.LD_LIBRARY_PATH.line > 0, true);
+});
+
+test("rejects a fifth unreviewed top-level path-list export", () => {
+  const changed = `${SAFE_FIXTURE}\nexport PYTHONPATH="\${APPDIR}/python\${PYTHONPATH:+:\${PYTHONPATH}}"\n`;
+  assert.throws(() => validateAppRunContent(changed), /path-list exports changed/);
+});
+
+test("release and Wayland workflows run the final-artifact AppRun gate", () => {
+  const release = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
+  const wayland = fs.readFileSync(path.join(ROOT, ".github", "workflows", "wayland-smoke.yml"), "utf8");
+  const command = /node scripts\/verify-appimage-apprun\.js --artifact dist\/\*\.AppImage/;
+
+  assert.match(release, command);
+  assert.match(wayland, command);
+  assert.match(release, /uses: actions\/upload-artifact@v4\n\s+if: always\(\)/);
+});

--- a/test/appimage-apprun.test.js
+++ b/test/appimage-apprun.test.js
@@ -21,6 +21,29 @@ const VULNERABLE_FIXTURE = fs.readFileSync(
   "utf8"
 );
 
+function workflowJob(workflow, jobName) {
+  const lines = workflow.split(/\r?\n/);
+  const start = lines.indexOf(`  ${jobName}:`);
+  assert.notStrictEqual(start, -1, `workflow must define the ${jobName} job`);
+
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^  [A-Za-z0-9_-]+:$/.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+function assertAppearsBefore(content, earlier, later, label) {
+  const earlierIndex = content.indexOf(earlier);
+  const laterIndex = content.indexOf(later);
+  assert.notStrictEqual(earlierIndex, -1, `${label} must contain ${earlier}`);
+  assert.notStrictEqual(laterIndex, -1, `${label} must contain ${later}`);
+  assert.ok(earlierIndex < laterIndex, `${earlier} must run before ${later} in ${label}`);
+}
+
 test("accepts the reviewed electron-builder 26.15.7 AppRun assignments", () => {
   const result = validateAppRunContent(SAFE_FIXTURE);
   assert.deepStrictEqual(Object.keys(result), [...REVIEWED_PATH_EXPORTS]);
@@ -66,6 +89,18 @@ test("rejects a duplicate reviewed top-level export", () => {
   assert.throws(() => validateAppRunContent(changed), /exactly one top-level export/);
 });
 
+test("rejects whitespace-prefixed export assignments that the shell would execute", async (t) => {
+  for (const indentation of ["  ", "\t"]) {
+    await t.test(JSON.stringify(indentation), () => {
+      const changed = SAFE_FIXTURE.replace(
+        "export LD_LIBRARY_PATH=",
+        `${indentation}export LD_LIBRARY_PATH=`
+      );
+      assert.throws(() => validateAppRunContent(changed), /unsupported export syntax/);
+    });
+  }
+});
+
 test("does not count command-prefix LD_LIBRARY_PATH assignments", () => {
   const result = validateAppRunContent(SAFE_FIXTURE);
   assert.strictEqual(result.LD_LIBRARY_PATH.line > 0, true);
@@ -73,15 +108,26 @@ test("does not count command-prefix LD_LIBRARY_PATH assignments", () => {
 
 test("rejects a fifth unreviewed top-level path-list export", () => {
   const changed = `${SAFE_FIXTURE}\nexport PYTHONPATH="\${APPDIR}/python\${PYTHONPATH:+:\${PYTHONPATH}}"\n`;
-  assert.throws(() => validateAppRunContent(changed), /path-list exports changed/);
+  assert.throws(() => validateAppRunContent(changed), /top-level exports changed/);
 });
 
-test("release and Wayland workflows run the final-artifact AppRun gate", () => {
+test("rejects a fifth unreviewed top-level export without a colon", () => {
+  const changed = `${SAFE_FIXTURE}\nexport LD_PRELOAD="/tmp/unreviewed.so"\n`;
+  assert.throws(() => validateAppRunContent(changed), /top-level exports changed/);
+});
+
+test("release and Wayland workflows gate the final AppImage before artifact handoff", () => {
   const release = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
   const wayland = fs.readFileSync(path.join(ROOT, ".github", "workflows", "wayland-smoke.yml"), "utf8");
-  const command = /node scripts\/verify-appimage-apprun\.js --artifact dist\/\*\.AppImage/;
+  const releaseLinux = workflowJob(release, "build-linux");
+  const releaseJob = workflowJob(release, "release");
+  const waylandBuild = workflowJob(wayland, "build-appimage");
+  const gateCommand = "node scripts/verify-appimage-apprun.js --artifact dist/*.AppImage";
+  const uploadAction = "uses: actions/upload-artifact@v4";
 
-  assert.match(release, command);
-  assert.match(wayland, command);
-  assert.match(release, /uses: actions\/upload-artifact@v4\r?\n\s+if: always\(\)/);
+  assertAppearsBefore(releaseLinux, gateCommand, uploadAction, "build-linux");
+  assertAppearsBefore(waylandBuild, gateCommand, uploadAction, "build-appimage");
+  assert.match(releaseLinux, /uses: actions\/upload-artifact@v4\n\s+if: always\(\)/);
+  assert.doesNotMatch(waylandBuild, /^\s+if: always\(\)\s*$/m);
+  assert.match(releaseJob, /needs: \[build-windows, build-mac, build-linux\]/);
 });

--- a/test/appimage-apprun.test.js
+++ b/test/appimage-apprun.test.js
@@ -83,5 +83,5 @@ test("release and Wayland workflows run the final-artifact AppRun gate", () => {
 
   assert.match(release, command);
   assert.match(wayland, command);
-  assert.match(release, /uses: actions\/upload-artifact@v4\n\s+if: always\(\)/);
+  assert.match(release, /uses: actions\/upload-artifact@v4\r?\n\s+if: always\(\)/);
 });

--- a/test/dependency-security-floor.test.js
+++ b/test/dependency-security-floor.test.js
@@ -1,0 +1,124 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const pkg = require("../package.json");
+const lock = require("../package-lock.json");
+
+const DIRECT_POLICIES = Object.freeze({
+  electron: { major: 41, floor: "41.10.4" },
+  "electron-builder": { major: 26, floor: "26.15.7" },
+});
+
+const TRANSITIVE_POLICIES = Object.freeze({
+  "js-yaml": Object.freeze({ 4: "4.3.1" }),
+  "brace-expansion": Object.freeze({
+    1: "1.1.18",
+    2: "2.1.4",
+    5: "5.0.9",
+  }),
+  "ip-address": Object.freeze({ 10: "10.3.1" }),
+  // node-gyp 12.x carries the reviewed v6 line; @electron/get carries v7.
+  undici: Object.freeze({
+    6: "6.28.0",
+    7: "7.29.0",
+  }),
+});
+
+function parseVersion(value, label) {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:-[0-9A-Za-z.-]+)?$/.exec(value);
+  assert.ok(match, `${label} must be a concrete semver, got ${JSON.stringify(value)}`);
+  return match.slice(1, 4).map(Number);
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < 3; index += 1) {
+    if (left[index] !== right[index]) {
+      return left[index] < right[index] ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+function assertAtLeast(actual, floor, label) {
+  const actualParts = parseVersion(actual, label);
+  const floorParts = parseVersion(floor, `${label} floor`);
+  assert.ok(
+    compareVersions(actualParts, floorParts) >= 0,
+    `${label} must be >= ${floor}, got ${actual}`
+  );
+  return actualParts;
+}
+
+function packageNameForEntry(packagePath, entry) {
+  if (entry && typeof entry.name === "string") {
+    return entry.name;
+  }
+  return packagePath.split("node_modules/").at(-1) || "";
+}
+
+function entriesFor(packageName) {
+  return Object.entries(lock.packages)
+    .filter(([packagePath, entry]) => packagePath && packageNameForEntry(packagePath, entry) === packageName)
+    .map(([packagePath, entry]) => ({ packagePath, entry }));
+}
+
+test("direct Electron build dependencies stay on reviewed majors and security floors", () => {
+  const lockRoot = lock.packages[""];
+  assert.ok(lockRoot, "package-lock.json must contain the root package entry");
+
+  for (const [name, policy] of Object.entries(DIRECT_POLICIES)) {
+    const range = pkg.devDependencies[name];
+    const match = /^\^(\d+\.\d+\.\d+)$/.exec(range || "");
+    assert.ok(match, `${name} must use a caret range with a concrete floor`);
+    assert.strictEqual(
+      lockRoot.devDependencies[name],
+      range,
+      `${name} root lock metadata must match package.json`
+    );
+
+    const manifestFloor = match[1];
+    const manifestParts = assertAtLeast(manifestFloor, policy.floor, `${name} manifest floor`);
+    assert.strictEqual(manifestParts[0], policy.major, `${name} manifest must remain on major ${policy.major}`);
+
+    const locked = lock.packages[`node_modules/${name}`];
+    assert.ok(locked, `${name} must have a top-level lock entry`);
+    const lockedParts = assertAtLeast(locked.version, manifestFloor, `${name} locked version`);
+    assert.strictEqual(lockedParts[0], policy.major, `${name} lock entry must remain on major ${policy.major}`);
+  }
+});
+
+test("all reviewed transitive package copies stay above their per-major security floors", () => {
+  for (const [name, majorPolicies] of Object.entries(TRANSITIVE_POLICIES)) {
+    for (const { packagePath, entry } of entriesFor(name)) {
+      const versionParts = parseVersion(entry.version, `${name} at ${packagePath}`);
+      const floor = majorPolicies[versionParts[0]];
+      assert.ok(
+        floor,
+        `${name} at ${packagePath} introduced unreviewed major ${versionParts[0]} (${entry.version})`
+      );
+      assertAtLeast(entry.version, floor, `${name} at ${packagePath}`);
+    }
+  }
+
+  assert.ok(entriesFor("js-yaml").length > 0, "the runtime YAML parser must remain visible in the lockfile");
+  assert.ok(entriesFor("brace-expansion").length > 0, "brace-expansion copies must remain auditable");
+  assert.ok(entriesFor("undici").length > 0, "undici copies must remain auditable");
+});
+
+test("electron-builder generated-artifact dependencies cannot regress below fixed lines", () => {
+  const appBuilderEntries = entriesFor("app-builder-lib");
+  assert.ok(appBuilderEntries.length > 0, "app-builder-lib must remain present");
+  for (const { packagePath, entry } of appBuilderEntries) {
+    const parts = assertAtLeast(entry.version, "26.15.0", `app-builder-lib at ${packagePath}`);
+    assert.strictEqual(parts[0], 26, "a new app-builder-lib major requires explicit review");
+  }
+
+  const runtimeEntries = entriesFor("builder-util-runtime");
+  assert.ok(runtimeEntries.length > 0, "builder-util-runtime must remain present");
+  for (const { packagePath, entry } of runtimeEntries) {
+    const parts = assertAtLeast(entry.version, "9.7.0", `builder-util-runtime at ${packagePath}`);
+    assert.strictEqual(parts[0], 9, "a new builder-util-runtime major requires explicit review");
+  }
+});

--- a/test/fixtures/appimage-apprun/electron-builder-26.15.7.AppRun
+++ b/test/fixtures/appimage-apprun/electron-builder-26.15.7.AppRun
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -e
+
+THIS="$0"
+args=("$@")
+
+if [ -z "$APPDIR" ] ; then
+  path="$(dirname "$(readlink -f "${THIS}")")"
+  APPDIR="$path"
+fi
+
+export PATH="${APPDIR}:${APPDIR}/usr/sbin${PATH:+:${PATH}}"
+export XDG_DATA_DIRS="${APPDIR}/usr/share/${XDG_DATA_DIRS:+:${XDG_DATA_DIRS}}:/usr/share/gnome:/usr/local/share/:/usr/share/"
+export LD_LIBRARY_PATH="${APPDIR}/usr/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+export GSETTINGS_SCHEMA_DIR="${APPDIR}/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:${GSETTINGS_SCHEMA_DIR}}"
+
+error()
+{
+  if [ -x /usr/bin/zenity ] ; then
+    LD_LIBRARY_PATH="" zenity --error --text "${1}" 2>/dev/null
+  elif [ -x /usr/bin/kdialog ] ; then
+    LD_LIBRARY_PATH="" kdialog --msgbox "${1}" 2>/dev/null
+  elif [ -x /usr/bin/Xdialog ] ; then
+    LD_LIBRARY_PATH="" Xdialog --msgbox "${1}" 2>/dev/null
+  fi
+}
+
+yesno()
+{
+  if [ -x /usr/bin/zenity ] ; then
+    LD_LIBRARY_PATH="" zenity --question --text "$TEXT" 2>/dev/null || exit 0
+  fi
+}

--- a/test/fixtures/appimage-apprun/electron-builder-26.8.1.AppRun
+++ b/test/fixtures/appimage-apprun/electron-builder-26.8.1.AppRun
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+THIS="$0"
+args=("$@")
+
+if [ -z "$APPDIR" ] ; then
+  path="$(dirname "$(readlink -f "${THIS}")")"
+  APPDIR="$path"
+fi
+
+export PATH="${APPDIR}:${APPDIR}/usr/sbin:${PATH}"
+export XDG_DATA_DIRS="./share/:/usr/share/gnome:/usr/local/share/:/usr/share/:${XDG_DATA_DIRS}"
+export LD_LIBRARY_PATH="${APPDIR}/usr/lib:${LD_LIBRARY_PATH}"
+export XDG_DATA_DIRS="${APPDIR}"/usr/share/:"${XDG_DATA_DIRS}":/usr/share/gnome/:/usr/local/share/:/usr/share/
+export GSETTINGS_SCHEMA_DIR="${APPDIR}/usr/share/glib-2.0/schemas:${GSETTINGS_SCHEMA_DIR}"
+
+error()
+{
+  if [ -x /usr/bin/zenity ] ; then
+    LD_LIBRARY_PATH="" zenity --error --text "${1}" 2>/dev/null
+  fi
+}

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -201,6 +201,36 @@ describe("package build config", () => {
       );
     });
 
+    it("uses explicit ad-hoc signing without disabling hardened runtime", () => {
+      assert.strictEqual(
+        pkg.build.mac && pkg.build.mac.identity,
+        "-",
+        "macOS x64 and ARM64 packages must opt into deterministic ad-hoc signing"
+      );
+      assert.notStrictEqual(
+        pkg.build.mac && pkg.build.mac.hardenedRuntime,
+        false,
+        "do not silence the ad-hoc signing warning by disabling hardened runtime"
+      );
+    });
+
+    it("gates both packaged apps on ad-hoc hardened signatures and required entitlements", () => {
+      const workflow = fs.readFileSync(path.join(ROOT, ".github", "workflows", "build.yml"), "utf8");
+      assert.match(workflow, /name: Verify macOS ad-hoc hardened signatures/);
+      assert.match(workflow, /dist\/mac\/Clawd on Desk\.app/);
+      assert.match(workflow, /dist\/mac-arm64\/Clawd on Desk\.app/);
+      assert.match(workflow, /Signature=adhoc/);
+      assert.match(workflow, /adhoc,runtime/);
+      assert.match(workflow, /codesign --verify --deep --strict/);
+      for (const entitlement of [
+        "com.apple.security.cs.allow-jit",
+        "com.apple.security.cs.allow-unsigned-executable-memory",
+        "com.apple.security.cs.disable-library-validation",
+      ]) {
+        assert.match(workflow, new RegExp(entitlement.replace(/\./g, "\\.")));
+      }
+    });
+
     it("uses architecture-specific macOS DMG names without spaces", () => {
       const artifactName = pkg.build.mac && pkg.build.mac.artifactName;
       assert.strictEqual(

--- a/test/package-build-config.test.js
+++ b/test/package-build-config.test.js
@@ -201,11 +201,11 @@ describe("package build config", () => {
       );
     });
 
-    it("uses explicit ad-hoc signing without disabling hardened runtime", () => {
+    it("requests explicit ad-hoc signing without disabling hardened runtime", () => {
       assert.strictEqual(
         pkg.build.mac && pkg.build.mac.identity,
         "-",
-        "macOS x64 and ARM64 packages must opt into deterministic ad-hoc signing"
+        "macOS x64 and ARM64 packages must express ad-hoc signing intent; CI gates the final signatures"
       );
       assert.notStrictEqual(
         pkg.build.mac && pkg.build.mac.hardenedRuntime,


### PR DESCRIPTION
## Summary

- upgrade Electron from 41.10.2 to 41.10.4 and electron-builder from 26.8.1 to 26.15.7, with a lockfile refresh that keeps Koffi pinned at 2.16.3
- add permanent dependency security floors and a final-artifact AppImage AppRun validation gate
- fail closed on whitespace-prefixed or additional unreviewed AppRun exports, and test that the AppRun gate runs before artifact handoff
- harden Koffi afterPack containment checks across canonical path aliases and cover CRLF workflow parsing
- update the narrow NSIS elevate.exe provenance text only after real Windows x64 and ARM64 package manifests confirmed the existing PE ia32 helper contract

## Security outcome

- `npm audit --json`: 0 vulnerabilities
- `npm audit --omit=dev --json`: 0 vulnerabilities
- no `npm audit fix`, `npm update`, proxy change, tag, or release was used
- packaged macOS inspection confirmed js-yaml 4.3.1 and Koffi 2.16.3 are present, while the reviewed build-only dependency chains are absent

## Validation

- post-review focused suite: 68/68 passed using `node --test test/audit-packaged-native.test.js test/package-build-config.test.js test/dependency-security-floor.test.js test/appimage-apprun.test.js test/after-pack-koffi.test.js`
- the exact unit command used by Five-target Package Audit passed 184 tests with 1 platform skip and 0 failures
- the local full suite reached 7,220 passes and 0 code failures, but the existing `mobile-preview-server.test.js` did not close its listener on this host; excluding only that unrelated file completed with 7,220/7,220 passes and 24 platform skips. A clean plain-`npm test` exit on the current head is therefore not claimed; the changed security/package scope is covered by the focused and five-target runs below
- release version contract passed
- pre-review five-target artifact evidence against exact head `5bbdc8e4cc894a4765d2f9886104d9e6d88b8dfd`:
  - Build & Release: https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/31365261240
  - Five-target Package Audit: https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/31365264958
  - Wayland smoke: https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/31365266069
- post-review automatic checks all completed successfully for exact head `0e964a85d60f1768189836403a4422e6a2e574c3`:
  - Five-target Package Audit: https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/31371903813
  - Repository Asset Audit: https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/31371903820
  - Wayland smoke: https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/31371903826
- updater sizes and SHA-512 values were recomputed for the downloaded Windows, macOS, and Linux artifacts
- both downloaded macOS DMGs passed checksum and content inspection; the extracted x64 and ARM64 `.app` bundles passed architecture, strict deep signature, hardened-runtime, entitlement, and one-target Koffi payload inspection
- Windows ARM64 ran the packaged Koffi smoke on a native ARM runner and successfully called `GetCurrentProcessId`

## Review closure

- AppRun exports with leading spaces or tabs are rejected because shell indentation does not prevent execution
- every exact line-start AppRun export must be one of the four reviewed variables, regardless of whether its value contains a colon
- tests require the release and Wayland AppRun gates to precede artifact upload; Wayland must not upload after a failed gate, while the release workflow may retain `if: always()` evidence uploads and still blocks the release job
- Five-target Package Audit now runs both the AppRun and dependency-floor tests in its unit job
- `build.mac.identity: "-"` is documented as signing intent rather than proof: electron-builder first treats it as a certificate-name qualifier, and the final `.app` signature gate is the release guarantee

## Remaining runtime boundaries

- CI does not replace an interactive Windows install, uninstall, or updater test on a normal user machine
- macOS CI uses ad-hoc hardened signatures, not Developer ID notarization or Gatekeeper trust
- Wayland coverage is isolated headless smoke rather than a physical desktop session; the new `desktopName` warning remains a separate real-desktop follow-up
- the AppImage runtime extraction path is preferred; the `unsquashfs` fallback has not been proven against a deliberately crafted multi-SquashFS decoy layout
- electron-builder's checksum-pinned `7zip@1.0.0` platform download is outside the npm lockfile and `npm audit` boundary
- this PR does not publish artifacts or alter the current user update channel
