### PR TITLE
fix(opencode): avoid premature stale idle during long active work

### DIFF
--- a/src/state-stale-cleanup.js
+++ b/src/state-stale-cleanup.js
@@ -23,6 +23,7 @@ function isLocalOpencodeWorkingLikeSession(session) {
   return !!session
     && session.agentId === "opencode"
     && !session.host
+    && !session.headless
     && isWorkingLikeState(session.state);
 }
 

--- a/src/state-stale-cleanup.js
+++ b/src/state-stale-cleanup.js
@@ -6,6 +6,7 @@ const SESSION_STALE_MS = 600000;
 const WORKING_STALE_MS = 300000;
 const DETACHED_IDLE_STALE_MS = 30000;
 const CODEX_LOCAL_WORKING_STALE_FLOOR_MS = 20 * 60 * 1000;
+const OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS = 20 * 60 * 1000;
 
 function isWorkingLikeState(state) {
   return state === "working" || state === "juggling" || state === "thinking";
@@ -14,6 +15,13 @@ function isWorkingLikeState(state) {
 function isLocalCodexWorkingLikeSession(session) {
   return !!session
     && session.agentId === "codex"
+    && !session.host
+    && isWorkingLikeState(session.state);
+}
+
+function isLocalOpencodeWorkingLikeSession(session) {
+  return !!session
+    && session.agentId === "opencode"
     && !session.host
     && isWorkingLikeState(session.state);
 }
@@ -58,6 +66,21 @@ function getStaleSessionDecision(session, options = {}) {
     )
       ? config.codexLocalWorkingStaleFloorMs
       : CODEX_LOCAL_WORKING_STALE_FLOOR_MS;
+    workingStaleMs = Math.max(workingStaleMs, floor);
+    if (sessionStaleMs > 0) sessionStaleMs = Math.max(sessionStaleMs, floor);
+  }
+
+  if (isLocalOpencodeWorkingLikeSession(session)) {
+    // OpenCode tools can run silently for many minutes (for example, a long
+    // shell command). Keep the same bounded stale guard used for local Codex
+    // instead of letting the generic five-minute working timeout release the
+    // sleep blocker during a legitimate tool call.
+    const floor = (
+      Number.isFinite(config.opencodeLocalWorkingStaleFloorMs)
+      && config.opencodeLocalWorkingStaleFloorMs > 0
+    )
+      ? config.opencodeLocalWorkingStaleFloorMs
+      : OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS;
     workingStaleMs = Math.max(workingStaleMs, floor);
     if (sessionStaleMs > 0) sessionStaleMs = Math.max(sessionStaleMs, floor);
   }
@@ -154,8 +177,10 @@ module.exports = {
   WORKING_STALE_MS,
   DETACHED_IDLE_STALE_MS,
   CODEX_LOCAL_WORKING_STALE_FLOOR_MS,
+  OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS,
   isWorkingLikeState,
   isLocalCodexWorkingLikeSession,
+  isLocalOpencodeWorkingLikeSession,
   isLocalZcodeDesktopIdleSession,
   getStaleSessionDecision,
 };

--- a/test/opencode-family-core.test.js
+++ b/test/opencode-family-core.test.js
@@ -93,6 +93,26 @@ describe("opencode-family plugin factory", () => {
     oc.__test._sessionParentById.clear();
   });
 
+  it("keeps genuine root completion and deletion lifecycle events authoritative", async () => {
+    const { createOpencodeFamilyPlugin } = await loadCore();
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_PARAMS);
+
+    assert.deepStrictEqual(
+      plugin.__test.translateEvent({
+        type: "session.idle",
+        properties: { sessionID: "ses_root" },
+      }),
+      { state: "attention", event: "Stop" },
+    );
+    assert.deepStrictEqual(
+      plugin.__test.translateEvent({
+        type: "session.deleted",
+        properties: { sessionID: "ses_root" },
+      }),
+      { state: "sleeping", event: "SessionEnd" },
+    );
+  });
+
   it("isolates the FULL per-instance state bag (log path, dedup, port cache, bridge)", async () => {
     const { createOpencodeFamilyPlugin } = await loadCore();
     const oc = createOpencodeFamilyPlugin(OPENCODE_PARAMS);

--- a/test/state-session-snapshot.test.js
+++ b/test/state-session-snapshot.test.js
@@ -147,6 +147,12 @@ describe("isSessionInProgress state mapping", () => {
     assert.strictEqual(isSessionInProgress(session("sleeping")), false);
   });
 
+  it("keeps a local OpenCode working session in the blocker-facing in-progress set", () => {
+    const active = session("working", { agentId: "opencode" });
+    assert.strictEqual(isSessionInProgress(active), true);
+    assert.strictEqual(isSessionInProgress({ ...active, state: "idle" }), false);
+  });
+
   it("never counts headless sessions, even when active", () => {
     assert.strictEqual(isSessionInProgress(session("working", { headless: true })), false);
     assert.strictEqual(isSessionInProgress(session("thinking", { headless: true })), false);

--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -404,6 +404,14 @@ describe("state stale cleanup decisions", () => {
       }), { now });
       assert.deepStrictEqual(result, { action: "idle", reason: "working-timeout", updateTimestamp: true });
     }
+
+    const { result: headlessResult } = decision(session({
+      state: "working",
+      agentId: "opencode",
+      headless: true,
+      updatedAt: now - WORKING_STALE_MS - 1,
+    }), { now });
+    assert.deepStrictEqual(headlessResult, { action: "idle", reason: "working-timeout", updateTimestamp: true });
   });
 
   it("still downgrades local Codex working after the Codex floor expires", () => {

--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -8,6 +8,7 @@ const {
   WORKING_STALE_MS,
   DETACHED_IDLE_STALE_MS,
   CODEX_LOCAL_WORKING_STALE_FLOOR_MS,
+  OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS,
   isWorkingLikeState,
   isLocalCodexWorkingLikeSession,
   isLocalZcodeDesktopIdleSession,
@@ -322,6 +323,87 @@ describe("state stale cleanup decisions", () => {
       staleConfig: { sessionStaleMs: 60_000, workingStaleMs: 60_000 },
     });
     assert.deepStrictEqual(result, { action: null });
+  });
+
+  it("keeps a local OpenCode tool active at the captured 305-second failure point", () => {
+    const now = 2_000_000;
+    const { result } = decision(session({
+      state: "working",
+      agentId: "opencode",
+      agentPid: 10,
+      sourcePid: 20,
+      pidReachable: true,
+      updatedAt: now - 305_656,
+    }), {
+      now,
+      alivePids: new Set([10, 20]),
+      staleConfig: { sessionStaleMs: 600_000, workingStaleMs: 300_000 },
+    });
+
+    assert.deepStrictEqual(result, { action: null });
+  });
+
+  it("retains a hard stale ceiling for local OpenCode working sessions", () => {
+    const now = 2_000_000;
+    const { result } = decision(session({
+      state: "working",
+      agentId: "opencode",
+      agentPid: 10,
+      sourcePid: 20,
+      pidReachable: true,
+      updatedAt: now - OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS - 1,
+    }), {
+      now,
+      alivePids: new Set([10, 20]),
+    });
+
+    assert.deepStrictEqual(result, { action: "idle", reason: "session-timeout", updateTimestamp: false });
+  });
+
+  it("retires local OpenCode work immediately when its process dies", () => {
+    const now = 2_000_000;
+    assert.deepStrictEqual(
+      decision(session({
+        state: "working",
+        agentId: "opencode",
+        agentPid: 10,
+        sourcePid: 20,
+        pidReachable: true,
+        updatedAt: now - 305_656,
+      }), {
+        now,
+        alivePids: new Set([20]),
+      }).result,
+      { action: "delete", reason: "agent-exit" },
+    );
+
+    assert.deepStrictEqual(
+      decision(session({
+        state: "working",
+        agentId: "opencode",
+        agentPid: 10,
+        sourcePid: 20,
+        pidReachable: true,
+        updatedAt: now - OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS - 1,
+      }), {
+        now,
+        alivePids: new Set([10]),
+      }).result,
+      { action: "delete", reason: "source-exit" },
+    );
+  });
+
+  it("does not extend remote OpenCode or Claude working sessions", () => {
+    const now = 2_000_000;
+    for (const agentId of ["opencode", "claude-code"]) {
+      const { result } = decision(session({
+        state: "working",
+        agentId,
+        host: agentId === "opencode" ? "ssh:example.com" : null,
+        updatedAt: now - WORKING_STALE_MS - 1,
+      }), { now });
+      assert.deepStrictEqual(result, { action: "idle", reason: "working-timeout", updateTimestamp: true });
+    }
   });
 
   it("still downgrades local Codex working after the Codex floor expires", () => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -962,6 +962,29 @@ describe("cleanStaleSessions()", () => {
     assert.strictEqual(api.sessions.get("s1").state, "idle");
   });
 
+  it("genuine OpenCode session.idle completion still records normal Stop semantics", () => {
+    api = require("../src/state")(makeCtx({
+      processKill: makePidKill(new Set([1000, 2000])),
+    }));
+    api.updateSession("opencode:s1", "working", "PreToolUse", {
+      agentId: "opencode",
+      agentPid: 1000,
+      sourcePid: 2000,
+      cwd: "/tmp",
+    });
+    api.updateSession("opencode:s1", "attention", "Stop", {
+      agentId: "opencode",
+      agentPid: 1000,
+      sourcePid: 2000,
+      cwd: "/tmp",
+    });
+
+    const completed = api.sessions.get("opencode:s1");
+    assert.strictEqual(completed.state, "idle");
+    assert.strictEqual(completed.recentEvents.at(-1).event, "Stop");
+    assert.strictEqual(api.deriveSessionBadge(completed), "done");
+  });
+
   it("pidReachable false + stale → delete", () => {
     api = require("../src/state")(makeCtx());
     api.sessions.set("s1", rawSession("working", {


### PR DESCRIPTION
## Summary

OpenCode can legitimately spend more than five minutes in one silent tool/model segment. Clawd's generic five-minute working stale timeout incorrectly treated such a session as abandoned, forced it idle, and released `prevent-app-suspension`.

## Root cause

Live reproduction with:

```text
pwsh -NoProfile -Command "Start-Sleep -Seconds 420; Write-Output 'done'"
```

Before the fix:

- the tool started around 01:44:28;
- stale age crossed the generic `workingStaleMs=300000` threshold;
- at age `305656` ms Clawd returned `working-timeout`;
- the session was forced idle;
- `anyInProgress=0` and the power blocker stopped;
- the OpenCode tool continued running for about two more minutes.

Runtime evidence: https://github.com/rullerzhou-afk/clawd-on-desk/issues/850#issuecomment-5244153342

## Fix

Apply a bounded 20-minute stale floor to local, non-headless OpenCode working-like sessions, analogous to the existing local Codex protection for long silent active work.

- Process-death handling still takes precedence.
- Genuine OpenCode completion still transitions through `session.idle` / `Stop` immediately.
- Finite stale/session cleanup still provides a safety ceiling for abandoned work.
- Remote OpenCode, headless sessions, Codex, Claude, and other agents retain their existing policies.
- No tool-in-flight state machine or broader lifecycle redesign is introduced.

## Tests

Regression coverage includes:

- the exact pre-fix ~305-second OpenCode failure point;
- eventual stale retirement;
- dead agent/source process cleanup;
- genuine OpenCode completion;
- blocker-facing `isSessionInProgress` behavior;
- remote/headless OpenCode and other-agent isolation.

Final results: focused suites 530 passed, 0 failed, 0 skipped; broad `npm test` 7,521 passed, 0 failed, 35 platform-gated skips.

## Live verification

Windows 11 ARM64:

- reran the same 420-second silent tool;
- at about 5m30s OpenCode was still running and Clawd remained working;
- `powercfg /requests` showed Clawd's Electron request under `EXECUTION`;
- after the tool completed, Clawd returned idle normally.

## Scope

Broader OpenCode lifecycle hypotheses, tool-in-flight tracking, FIFO transport ordering, and unrelated issue work are intentionally out of scope.

Fixes #850
