### PR TITLE
test(opencode): harden stale-floor regressions

### DIFF
--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -8,7 +8,6 @@ const {
   WORKING_STALE_MS,
   DETACHED_IDLE_STALE_MS,
   CODEX_LOCAL_WORKING_STALE_FLOOR_MS,
-  OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS,
   isWorkingLikeState,
   isLocalCodexWorkingLikeSession,
   isLocalZcodeDesktopIdleSession,
@@ -370,7 +369,7 @@ describe("state stale cleanup decisions", () => {
       agentPid: 10,
       sourcePid: 20,
       pidReachable: true,
-      updatedAt: now - OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS - 1,
+      updatedAt: now - 20 * 60 * 1000 - 1,
     }), {
       now,
       alivePids: new Set([10, 20]),
@@ -378,6 +377,23 @@ describe("state stale cleanup decisions", () => {
         sessionStaleMs: configuredStaleMs,
         workingStaleMs: configuredStaleMs,
       },
+    });
+
+    assert.deepStrictEqual(result, { action: null });
+  });
+
+  it("keeps local OpenCode work active immediately before the fixed 20-minute stale floor", () => {
+    const now = 2_000_000;
+    const { result } = decision(session({
+      state: "working",
+      agentId: "opencode",
+      agentPid: 10,
+      sourcePid: 20,
+      pidReachable: true,
+      updatedAt: now - (20 * 60 * 1000 - 1),
+    }), {
+      now,
+      alivePids: new Set([10, 20]),
     });
 
     assert.deepStrictEqual(result, { action: null });
@@ -391,7 +407,7 @@ describe("state stale cleanup decisions", () => {
       agentPid: 10,
       sourcePid: 20,
       pidReachable: true,
-      updatedAt: now - OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS - 1,
+      updatedAt: now - 20 * 60 * 1000 - 1,
     }), {
       now,
       alivePids: new Set([10, 20]),
@@ -427,7 +443,7 @@ describe("state stale cleanup decisions", () => {
         agentPid: 10,
         sourcePid: 20,
         pidReachable: true,
-        updatedAt: now - OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS - 1,
+        updatedAt: now - 20 * 60 * 1000 - 1,
       }), {
         now,
         alivePids: new Set([10]),
@@ -455,6 +471,17 @@ describe("state stale cleanup decisions", () => {
       updatedAt: now - WORKING_STALE_MS - 1,
     }), { now });
     assert.deepStrictEqual(headlessResult, { action: "idle", reason: "working-timeout", updateTimestamp: true });
+  });
+
+  it("does not extend local MiMo Code working sessions", () => {
+    const now = 2_000_000;
+    const { result } = decision(session({
+      state: "working",
+      agentId: "mimocode",
+      updatedAt: now - WORKING_STALE_MS - 1,
+    }), { now });
+
+    assert.deepStrictEqual(result, { action: "idle", reason: "working-timeout", updateTimestamp: true });
   });
 
   it("still downgrades local Codex working after the Codex floor expires", () => {

--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -343,7 +343,47 @@ describe("state stale cleanup decisions", () => {
     assert.deepStrictEqual(result, { action: null });
   });
 
-  it("retains a hard stale ceiling for local OpenCode working sessions", () => {
+  it("keeps local OpenCode thinking active at the captured 305-second failure point", () => {
+    const now = 2_000_000;
+    const { result } = decision(session({
+      state: "thinking",
+      agentId: "opencode",
+      agentPid: 10,
+      sourcePid: 20,
+      pidReachable: true,
+      updatedAt: now - 305_656,
+    }), {
+      now,
+      alivePids: new Set([10, 20]),
+      staleConfig: { sessionStaleMs: 600_000, workingStaleMs: 300_000 },
+    });
+
+    assert.deepStrictEqual(result, { action: null });
+  });
+
+  it("preserves a longer configured stale timeout for local OpenCode work", () => {
+    const now = 2_000_000;
+    const configuredStaleMs = 30 * 60 * 1000;
+    const { result } = decision(session({
+      state: "working",
+      agentId: "opencode",
+      agentPid: 10,
+      sourcePid: 20,
+      pidReachable: true,
+      updatedAt: now - OPENCODE_LOCAL_WORKING_STALE_FLOOR_MS - 1,
+    }), {
+      now,
+      alivePids: new Set([10, 20]),
+      staleConfig: {
+        sessionStaleMs: configuredStaleMs,
+        workingStaleMs: configuredStaleMs,
+      },
+    });
+
+    assert.deepStrictEqual(result, { action: null });
+  });
+
+  it("retires local OpenCode work after the default 20-minute stale floor", () => {
     const now = 2_000_000;
     const { result } = decision(session({
       state: "working",
@@ -360,7 +400,7 @@ describe("state stale cleanup decisions", () => {
     assert.deepStrictEqual(result, { action: "idle", reason: "session-timeout", updateTimestamp: false });
   });
 
-  it("retires local OpenCode work immediately when its process dies", () => {
+  it("deletes local OpenCode work immediately when the agent process dies", () => {
     const now = 2_000_000;
     assert.deepStrictEqual(
       decision(session({
@@ -376,7 +416,10 @@ describe("state stale cleanup decisions", () => {
       }).result,
       { action: "delete", reason: "agent-exit" },
     );
+  });
 
+  it("deletes local OpenCode work after the stale floor when the source process dies", () => {
+    const now = 2_000_000;
     assert.deepStrictEqual(
       decision(session({
         state: "working",

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -12,6 +12,7 @@ const _defaultTheme = themeLoader.loadTheme("clawd");
 const _calicoTheme = themeLoader.loadTheme("calico");
 const { createTranslator } = require("../src/i18n");
 const { makeSessionKey } = require("../src/session-key");
+const { isSessionInProgress } = require("../src/state-session-snapshot");
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -960,6 +961,29 @@ describe("cleanStaleSessions()", () => {
     }));
     api.cleanStaleSessions();
     assert.strictEqual(api.sessions.get("s1").state, "idle");
+  });
+
+  it("keeps local OpenCode blocker-facing work active past the generic session cutoff", () => {
+    api = require("../src/state")(makeCtx({
+      processKill: makePidKill(new Set([1000, 2000])),
+      getStaleConfig: () => ({
+        sessionStaleMs: 600_000,
+        workingStaleMs: 300_000,
+      }),
+    }));
+    api.sessions.set("opencode:s1", rawSession("working", {
+      agentId: "opencode",
+      agentPid: 1000,
+      sourcePid: 2000,
+      pidReachable: true,
+      updatedAt: Date.now() - 600_001,
+    }));
+
+    api.cleanStaleSessions();
+
+    const active = api.sessions.get("opencode:s1");
+    assert.strictEqual(active.state, "working");
+    assert.strictEqual(isSessionInProgress(active), true);
   });
 
   it("genuine OpenCode session.idle completion still records normal Stop semantics", () => {


### PR DESCRIPTION
## Summary

- add mutation-sensitive coverage for local OpenCode work between the generic session cutoff and the 20-minute stale floor
- lock the fixed 20-minute boundary, cover `thinking`, and preserve longer configured stale timeouts
- exercise the real `cleanStaleSessions()` to `isSessionInProgress()` path used by blocker-facing consumers
- separate agent-exit and source-exit lifecycle expectations and keep MiMo Code on its original stale policy

## Context

This is a test-only maintainer follow-up to #853. The production fix from @PeterShanxin remains unchanged and fully credited to the original contribution.

## Verification

- `node --test test/opencode-family-core.test.js test/opencode-family-state-ordering-disposal.test.js test/state-stale-cleanup.test.js test/state.test.js`
- 349 tests passed, 0 failed
- mutation checks confirmed the tests fail if the OpenCode session floor is removed, the floor is shortened from 20 to 11 minutes, `thinking` is excluded, a longer configured timeout is overwritten, or MiMo Code is incorrectly included
- no production files changed