### PR TITLE
feat(winget): prepare-only manifest generation with an architecture contract

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,212 @@
+name: Prepare WinGet manifest
+
+# PREPARE ONLY — this workflow submits nothing and holds no long-lived
+# credential. It uses the ephemeral job GITHUB_TOKEN with `contents: read`, which
+# cannot write to this repository or to winget-pkgs.
+#
+# Background: `rullerzhou-afk.clawd-on-desk` has existed in microsoft/winget-pkgs
+# since v0.6.0, submitted by a third-party release-tracking bot we never
+# configured. That bot forwards only the FIRST matching .exe, so from v0.6.2 —
+# the first release to ship -x64.exe and -arm64.exe side by side — every manifest
+# declared two `Architecture: x64` entries that both pointed at the arm64
+# installer. The NSIS stub is 32-bit x86 and runs anywhere, so the install
+# reported success and the app then failed to launch.
+#
+# Why this cannot yet submit automatically: `komac update` does not turn the URLs
+# it is given into installer entries. It reads the PREVIOUS manifest and emits one
+# entry per previous entry, matching each to its best new installer
+# (Komac src/commands/update_version.rs -> src/match_installers.rs). The live
+# v0.14.0 manifest has two entries, both `Architecture: x64` (they are the
+# user/machine scope split), so both match the new x64 installer and the arm64
+# one is discarded — confirmed by running komac v2.16.0 against both URLs.
+#
+# The upstream manifest must therefore be repaired by a hand-reviewed PR first —
+# to x64/arm64 x user/machine — before any automation can maintain it. Until then
+# this workflow generates the manifest komac WOULD submit and uploads it for
+# inspection.
+#
+# See docs/project/release-process.md for the staged plan.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      release-tag:
+        description: "Release tag to prepare, e.g. v0.15.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: winget-prepare
+  cancel-in-progress: false
+
+env:
+  # Single source of truth: the gate asserts our installer filenames match this,
+  # and that nothing else in the release does.
+  INSTALLERS_REGEX: '^Clawd-on-Desk-Setup-.*-(x64|arm64)\.exe$'
+  # Every architecture the package promises. Distinctness alone would still let a
+  # package.json edit that drops arm64 publish a single-architecture manifest.
+  REQUIRED_ARCHITECTURES: "x64,arm64"
+  KOMAC_VERSION: "2.16.0"
+  KOMAC_SHA256: "7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d"
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    # komac downloads both installers in full (~258 MB) to analyse them; it has
+    # no range or header-only mode. Bound the job so a stalled CDN cannot hold
+    # the concurrency group indefinitely.
+    timeout-minutes: 30
+    # `released` never fires for drafts or prereleases, but it DOES fire when an
+    # already-published prerelease is edited into a release, and
+    # workflow_dispatch can target any tag. The tag-shape check below closes both.
+    if: github.event_name == 'workflow_dispatch' || github.event.release.prerelease == false
+    steps:
+      - name: Resolve release tag
+        id: release
+        # Runs before any checkout: `gh` only needs the token and repository
+        # name, and the tag decides which tree the config is read from.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          INPUT_TAG: ${{ inputs.release-tag }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          tag="${INPUT_TAG:-$EVENT_TAG}"
+          if [ -z "$tag" ]; then
+            echo "No release tag to prepare." >&2
+            exit 1
+          fi
+          # git permits ' ; $ ( ) ` { } | & in a ref name, and the tag is
+          # interpolated into downstream commands. Constrain it to the shape
+          # this project actually tags before it leaves this step.
+          if ! printf '%s' "$tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Refusing tag with unexpected shape: $tag" >&2
+            echo "WinGet publishes release versions only (vMAJOR.MINOR.PATCH)." >&2
+            exit 1
+          fi
+          prerelease="$(gh release view "$tag" --repo "$GITHUB_REPOSITORY" --json isPrerelease --jq '.isPrerelease')"
+          if [ "$prerelease" != "false" ]; then
+            echo "Refusing to prepare prerelease $tag for WinGet." >&2
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Check out release tooling
+        # Pinned to the default branch on purpose. Without an explicit ref,
+        # actions/checkout takes the ref that triggered the run — for a release
+        # event that is the tag, which for older releases does not contain this
+        # tooling at all. The build config is read from the tag separately below.
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Fetch the tagged build configuration
+        # Installer filenames come from the package.json that produced the
+        # release's assets, which is the tag's, not the default branch's.
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh api "repos/$GITHUB_REPOSITORY/contents/package.json?ref=$TAG" \
+            --jq '.content' | base64 -d > tagged-package.json
+          echo "Tagged version: $(jq -r '.version' tagged-package.json)"
+
+      - name: Collect release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Carries name, digest and size, so the contract can pin content and
+          # not just filenames.
+          gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json assets \
+            --jq '.assets' > release-assets.json
+          jq -r '.[] | "  \(.name)  \(.digest // "no-digest")"' release-assets.json
+
+      - name: Verify WinGet architecture contract
+        # Guards komac's INPUT: the filename is the only correct architecture
+        # signal we ship, because electron-builder's NSIS stub is 32-bit x86 for
+        # both targets. This does not and cannot guarantee komac's OUTPUT; that
+        # is what the generated manifest below is for.
+        env:
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          npm run verify:winget-arch -- \
+            --package-json tagged-package.json \
+            --release-tag "$TAG" \
+            --assets-file release-assets.json \
+            --installers-regex "$INSTALLERS_REGEX" \
+            --require-architectures "$REQUIRED_ARCHITECTURES" \
+            --output winget-arch-contract.json
+
+      - name: Install komac
+        # Into the runner's temp dir, not /usr/local/bin: GitHub-hosted runners
+        # execute as a non-root user, and writing there would need sudo.
+        run: |
+          set -euo pipefail
+          archive="komac-${KOMAC_VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+          curl -fsSL --proto '=https' --tlsv1.2 -o "$archive" \
+            "https://github.com/russellbanks/Komac/releases/download/v${KOMAC_VERSION}/${archive}"
+          echo "${KOMAC_SHA256}  ${archive}" | sha256sum --check --strict
+          tar -xzf "$archive" komac
+          mkdir -p "$RUNNER_TEMP/bin"
+          install -m 0755 komac "$RUNNER_TEMP/bin/komac"
+          echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/bin/komac" --version
+
+      - name: Generate manifest (no submission)
+        # --dry-run writes the manifest and exits before any fork or PR is
+        # created. GITHUB_TOKEN here is the ambient job token, which can read
+        # public repositories and cannot write to winget-pkgs.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mapfile -t urls < <(jq -r '.komacUrls[]' winget-arch-contract.json)
+          if [ "${#urls[@]}" -eq 0 ]; then
+            echo "Contract produced no installer URLs; nothing to generate." >&2
+            exit 1
+          fi
+          printf 'Generating from:\n'
+          printf '  %s\n' "${urls[@]}"
+          mkdir -p generated
+          # Each URL carries an explicit |<architecture> suffix, which komac
+          # ranks above both its own filename inference and PE-header analysis.
+          komac update rullerzhou-afk.clawd-on-desk \
+            --version "${TAG#v}" \
+            --urls "${urls[@]}" \
+            --dry-run \
+            --output generated
+
+      - name: Summarize generated installers
+        if: always() && hashFiles('generated/**') != ''
+        run: |
+          # komac writes the winget-pkgs directory layout, so the installer
+          # manifest is several levels down.
+          echo "### Generated WinGet manifest" >> "$GITHUB_STEP_SUMMARY"
+          echo '```yaml' >> "$GITHUB_STEP_SUMMARY"
+          find generated -name '*installer.yaml' -exec cat {} + >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v4
+        if: always() && hashFiles('winget-arch-contract.json') != ''
+        with:
+          name: winget-arch-contract
+          path: winget-arch-contract.json
+
+      - uses: actions/upload-artifact@v4
+        if: always() && hashFiles('generated/**') != ''
+        with:
+          name: winget-generated-manifest
+          path: generated/

--- a/docs/project/release-process.md
+++ b/docs/project/release-process.md
@@ -227,3 +227,139 @@ The legacy Telegram sidecar was removed in v0.14.0. Release builds must run
 Windows x64/arm64, macOS x64/arm64, and Linux x64. The assertion scans both the
 outer resources tree and the real `app.asar`; a retired executable or runtime
 module is a hard failure.
+
+## WinGet Publishing
+
+Publishing the draft release fires `.github/workflows/winget.yml`. **It currently
+prepares only** — it generates the manifest komac would submit and uploads it as
+an artifact. It holds no long-lived PAT or repository secret; the ambient job
+`GITHUB_TOKEN` it uses has `contents: read` and cannot write to this repository or
+to winget-pkgs. Automatic submission is deliberately not enabled yet; see the
+staged plan below.
+
+**The workflow must already be on `main` before the tag is created.** For
+`release` events GitHub reads the workflow definition from the tagged ref, so a
+tag cut before this file landed can never trigger it — including v0.14.0, which
+was published on 2026-08-02.
+
+The workflow checks out the default branch **explicitly** for tooling, then reads
+the target tag's `package.json` through the API and passes it with
+`--package-json`. Without an explicit `ref:`, `actions/checkout` takes the ref
+that triggered the run — for a release event that is the tag, which for older
+releases does not contain this tooling at all. Splitting the two keeps the
+tooling current while the installer filenames stay tied to the tree that actually
+produced the release's assets.
+
+### Why submission is staged rather than immediate
+
+`komac update` does not turn the URLs it is given into installer entries. It
+reads the **previous** manifest and emits one entry per previous entry, matching
+each to its best new installer
+(`src/commands/update_version.rs` -> `src/match_installers.rs`, which iterates
+`previous_installers`). Passing correct URLs therefore does not produce a correct
+manifest: if the upstream shape is wrong, komac faithfully reproduces it.
+
+The live v0.14.0 manifest has two entries, both `Architecture: x64` — those two
+are the **user/machine scope split**, carrying `/currentuser` and `/allusers`,
+not two architectures. Scoring both against a correct pair of new installers
+gives the x64 installer 8 points and the arm64 installer 6, so both previous
+entries take x64 and the arm64 installer is discarded.
+
+So the upstream manifest has to be repaired by hand first, and the correct shape
+is **four** entries, not two:
+
+| Architecture | Scope | Installer | Custom |
+| --- | --- | --- | --- |
+| x64 | user | `...-x64.exe` | `/currentuser` |
+| x64 | machine | `...-x64.exe` | `/allusers` |
+| arm64 | user | `...-arm64.exe` | `/currentuser` |
+| arm64 | machine | `...-arm64.exe` | `/allusers` |
+
+Collapsing to two entries would drop the per-user/per-machine choice the NSIS
+installer supports (`build.nsis` sets `oneClick: false` and no `perMachine`).
+
+### Staged plan
+
+1. **Prepare only** (current state). Run the workflow, download the
+   `winget-generated-manifest` artifact, and compare it against the table above.
+   This is the first end-to-end run on a GitHub-hosted runner. The local komac
+   v2.16.0 dry-run already established the expected bad two-x64 output; this run
+   validates the hosted workflow, token, download, and artifact paths together.
+2. **Repair upstream.** One hand-reviewed PR to `microsoft/winget-pkgs` fixing
+   v0.14.0 to the four entries above and setting `License: AGPL-3.0-only`.
+3. **Validate komac's output.** Extend the gate to parse the generated YAML and
+   assert the exact `{x64, arm64} x {user, machine}` set, each entry's URL,
+   SHA256, `Custom` switch, and the license. Note that komac overwrites `License`
+   from the repository's current `licenseInfo.spdxId`, which GitHub reports as
+   `AGPL-3.0` — not the `AGPL-3.0-only` in `package.json` — so this must be
+   asserted or rewritten rather than assumed.
+4. **Enable submission.** Split into `prepare` and `submit` jobs so the PAT
+   exists only in the final step, and pin every `uses:` to a commit SHA at that
+   point. Prefer a dedicated account for the token: `public_repo` grants write
+   access to every public repository its owner can write to, this one included.
+
+### Why the installer filename is a contract
+
+electron-builder emits a **32-bit x86 NSIS stub for both the x64 and the arm64
+target**, so PE-header inspection reports `x86` for both installers. Komac
+resolves architecture from the URL and lets that value override whatever binary
+analysis produced, so the `${arch}` token in `build.win.artifactName` is the only
+correct architecture signal we publish.
+
+`npm run verify:winget-arch` enforces this. It ports the upstream
+`Architecture::from_url` delimiter algorithm and fails the release if a filename
+stops resolving to the architecture it was built for, if two targets collapse
+onto one architecture, if the published set is not exactly `x64` and `arm64`, if
+a filename stops matching the workflow's `INSTALLERS_REGEX`, if the release
+carries a stray asset that regex would also select, if the release tag disagrees
+with `package.json`, or if both installers share a digest.
+
+**This gate checks komac's input, not its output.** It cannot detect the
+shape-preservation problem described above; validating the generated YAML is a
+separate step (stage 3).
+
+This guard exists because the third-party bot that previously owned the manifest
+forwarded only the first matching `.exe`. That was harmless while we shipped one
+Windows installer; from **v0.6.2** (2026-04-27), the first release to publish
+`-x64.exe` and `-arm64.exe` side by side, through v0.14.0 — **12 versions** —
+every manifest declared two `Architecture: x64` entries that both pointed at the
+**arm64** installer. The NSIS stub runs on x64, so the install reported success
+and the app then failed to launch.
+
+### Why komac is invoked directly
+
+The obvious choice, `winget-releaser`, is a composite action whose own steps run
+`cargo-bins/cargo-binstall@main` (a mutable branch ref) and
+`cargo binstall komac -y` (an unpinned build) — both in the same job, both
+*before* the step that would receive a PAT. Pinning that action to a commit SHA
+freezes the wrapper and neither of those links, so the workflow installs komac
+itself from a release archive whose SHA-256 is pinned in `env`.
+
+Bumping `KOMAC_VERSION` requires bumping `KOMAC_SHA256` in the same edit; the
+checksum is asserted in `test/winget-arch-contract.test.js`.
+
+Note that `actions/checkout@v4` and friends are still mutable tags. That is
+acceptable while this workflow holds no secret, and matches the rest of the
+repository's workflows; it must be resolved to commit SHAs before stage 4 adds a
+token.
+
+### Setup, when stage 4 is reached
+
+1. Fork `microsoft/winget-pkgs` under the account that will own `WINGET_TOKEN`.
+2. Create a **classic** PAT for that account with `public_repo` scope and store
+   it as the `WINGET_TOKEN` repository secret. Fine-grained tokens do not work
+   with komac's fork flow.
+3. Ask `SpecterShell/Dumplings` to drop its
+   `Tasks/rullerzhou-afk.clawd-on-desk` tracker so the bot and this workflow do
+   not submit competing manifests.
+
+### Per-release checks
+
+- Download the `winget-generated-manifest` artifact and confirm it carries
+  **four** installer entries — `x64` and `arm64`, each in `user` and `machine`
+  scope — with the right filename and `Custom` switch in each.
+- Confirm `License` reads `AGPL-3.0-only`. Versions v0.6.2 through v0.14.0 carry
+  a stale `MIT` value: it was accurate for the initial v0.6.0 submission and was
+  never refreshed after `3b6277ff` relicensed the project on 2026-04-25.
+- `winget install rullerzhou-afk.clawd-on-desk` is not documented in the READMEs
+  until a corrected manifest has been verified live.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "audit:assets": "node scripts/audit-repository-assets.js",
     "audit:native-package": "node scripts/audit-packaged-native.js",
     "verify:updater-metadata": "node scripts/verify-updater-metadata.js",
+    "verify:winget-arch": "node scripts/verify-winget-arch-contract.js",
     "verify:release": "node scripts/verify-release-version.js",
     "create-theme": "node scripts/create-theme.js",
     "export-agent-icons": "node scripts/export-agent-icons.js",

--- a/scripts/verify-winget-arch-contract.js
+++ b/scripts/verify-winget-arch-contract.js
@@ -1,0 +1,519 @@
+#!/usr/bin/env node
+"use strict";
+
+// Verifies that a release can produce a correct WinGet manifest.
+//
+// Why this needs a dedicated gate: electron-builder emits a 32-bit x86 NSIS
+// stub for BOTH the x64 and the arm64 target, so PE-header inspection labels
+// both installers x86. Komac resolves architecture from the URL and lets that
+// value override whatever the binary analyzer derived, so the filename is the
+// only correct signal we ship. That makes `build.win.artifactName` a published
+// contract: drop the ${arch} token and every WinGet user silently receives the
+// wrong installer.
+//
+// SCOPE — this checks komac's INPUT, not its output. `komac update` reads the
+// previous manifest and emits one installer per PREVIOUS entry, matching each to
+// the best new installer (Komac src/match_installers.rs). A correct set of input
+// URLs therefore does NOT guarantee a correct manifest: if the previous manifest
+// is malformed, komac faithfully reproduces its shape. Validating the generated
+// YAML is a separate step; see docs/project/release-process.md.
+//
+// The URL algorithm below is ported from winget-types `Architecture::from_url`
+// (russellbanks/winget-types, src/manifests/installer/architecture.rs).
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const pkg = require("../package.json");
+
+// winget-types: const DELIMITERS: [u8; 8]
+const DELIMITERS = new Set([",", "/", "\\", ".", "_", "-", "(", ")"]);
+
+// winget-types: const ARCHITECTURES: [(&str, Architecture); 32]
+// Order is preserved from the source; the resolver is order-independent but a
+// faithful copy keeps future diffs against upstream readable.
+const ARCHITECTURES = [
+  ["x86-64", "x64"],
+  ["x86_64", "x64"],
+  ["x64", "x64"],
+  ["64-bit", "x64"],
+  ["64bit", "x64"],
+  ["win64a", "arm64"],
+  ["win64", "x64"],
+  ["winx64", "x64"],
+  ["ia64", "x64"],
+  ["amd64", "x64"],
+  ["x86", "x86"],
+  ["x32", "x86"],
+  ["32-bit", "x86"],
+  ["32bit", "x86"],
+  ["win32", "x86"],
+  ["winx86", "x86"],
+  ["ia32", "x86"],
+  ["i386", "x86"],
+  ["i486", "x86"],
+  ["i586", "x86"],
+  ["i686", "x86"],
+  ["386", "x86"],
+  ["486", "x86"],
+  ["586", "x86"],
+  ["686", "x86"],
+  ["arm64ec", "arm64"],
+  ["arm64", "arm64"],
+  ["aarch64", "arm64"],
+  ["arm", "arm"],
+  ["armv7", "arm"],
+  ["aarch", "arm"],
+  ["neutral", "neutral"],
+];
+
+// electron-builder arch id -> WinGet architecture.
+const BUILDER_ARCH_TO_WINGET = {
+  x64: "x64",
+  arm64: "arm64",
+  ia32: "x86",
+  armv7l: "arm",
+};
+
+const TARGET_EXTENSION = { nsis: "exe" };
+
+// winget-types: is_delimited_at.
+//
+// Upstream's `start` is a `usize`, so `start - 1` at index 0 is a wrapping
+// underflow rather than a bounds check: in a release build it wraps to
+// `usize::MAX`, `get` returns `None`, and the match is rejected — which is what
+// the `start === 0` branch below reproduces. (A debug build panics instead; no
+// JS port can mirror that, and it is not what ships.) Unreachable here either
+// way, since every URL we build starts with `https://`.
+function isDelimitedAt(url, start, length) {
+  if (start === 0) return false;
+  const before = url[start - 1];
+  const after = url[start + length];
+  if (before === undefined || after === undefined) return false;
+  return DELIMITERS.has(before) && DELIMITERS.has(after);
+}
+
+// winget-types: `url.rmatch_indices(name).find(properly delimited)` — the
+// rightmost delimited occurrence of `name`, or -1.
+function rightmostDelimitedIndex(url, name) {
+  let from = url.length;
+  for (;;) {
+    const index = url.lastIndexOf(name, from);
+    if (index === -1) return -1;
+    if (isDelimitedAt(url, index, name.length)) return index;
+    if (index === 0) return -1;
+    from = index - 1;
+  }
+}
+
+// Primary pass of winget-types `Architecture::from_url`: among all delimited
+// matches, prefer the one furthest right, then the longest name.
+//
+// Upstream uses `max_by_key`, which keeps the LAST maximum; the comparison
+// below keeps the FIRST. The two can only disagree on a tie of both index and
+// name length, which requires two distinct names to be the same substring at
+// the same offset — impossible, and the table has no duplicate names.
+//
+// NOT A GENERAL `from_url` PORT. Upstream has a second pass that resolves
+// `{arch}.{ext}` with no left delimiter (`installerx64.exe` -> x64); it is
+// deliberately omitted, so this function returns null on names upstream would
+// resolve. That narrowing is what makes the contract below strictly stronger
+// than upstream — requiring a primary-pass match rejects names that only the
+// fallback could rescue — but it means the function must not be reused as a
+// drop-in `Architecture::from_url`.
+function resolveArchitecture(rawUrl) {
+  const url = String(rawUrl).toLowerCase();
+  let best = null;
+  for (const [name, architecture] of ARCHITECTURES) {
+    const index = rightmostDelimitedIndex(url, name);
+    if (index === -1) continue;
+    if (
+      best === null ||
+      index > best.index ||
+      (index === best.index && name.length > best.name.length)
+    ) {
+      best = { name, architecture, index };
+    }
+  }
+  return best
+    ? { architecture: best.architecture, matched: best.name, index: best.index }
+    : { architecture: null, matched: null, index: -1 };
+}
+
+function readWindowsBuildConfig(config = pkg) {
+  const build = config.build || {};
+  const win = build.win || {};
+  const publish = Array.isArray(build.publish) ? build.publish[0] : build.publish;
+  const targets = Array.isArray(win.target) ? win.target : [];
+  const entries = [];
+  const implicitArchTargets = [];
+
+  for (const target of targets) {
+    const name = typeof target === "string" ? target : target && target.target;
+    if (!name) continue;
+    const arches = typeof target === "string" || !Array.isArray(target.arch) ? null : target.arch;
+    // A bare string target ("nsis") or a missing arch list leaves the built
+    // architecture up to electron-builder's default, which never reaches the
+    // filename — so WinGet would have nothing to resolve.
+    if (arches === null || arches.length === 0) {
+      implicitArchTargets.push(name);
+      continue;
+    }
+    for (const arch of arches) entries.push({ target: name, arch });
+  }
+
+  return {
+    version: config.version || "",
+    artifactName: win.artifactName || "",
+    owner: (publish && publish.owner) || "",
+    repo: (publish && publish.repo) || "",
+    entries,
+    implicitArchTargets,
+  };
+}
+
+function materializeName(template, { version, arch, ext }) {
+  return template
+    .replace(/\$\{version\}/g, version)
+    .replace(/\$\{arch\}/g, arch)
+    .replace(/\$\{ext\}/g, ext);
+}
+
+function downloadUrl({ owner, repo, version, filename }) {
+  return `https://github.com/${owner}/${repo}/releases/download/v${version}/${filename}`;
+}
+
+// GitHub reports release asset digests as `sha256:<64 lowercase hex>`. Anything
+// else is not a digest we can pin content with, and an unvalidated string would
+// satisfy the distinctness check with two arbitrary values.
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+// Accepts the `gh release view --json assets` payload, either bare or wrapped.
+function normalizeAssets(raw) {
+  const list = Array.isArray(raw) ? raw : Array.isArray(raw && raw.assets) ? raw.assets : null;
+  if (!list) throw new Error("assets file must be a JSON array or {assets: [...]}");
+  return list.map((asset, index) => {
+    if (!asset || typeof asset !== "object") {
+      throw new Error(`assets[${index}] is not an object`);
+    }
+    return {
+      name: String(asset.name || ""),
+      digest: asset.digest ? String(asset.digest) : "",
+      size: Number.isFinite(asset.size) ? asset.size : null,
+    };
+  });
+}
+
+function verifyWingetArchContract({
+  config = pkg,
+  assets = null,
+  installersRegex = null,
+  requiredArchitectures = null,
+  releaseTag = null,
+} = {}) {
+  const build = readWindowsBuildConfig(config);
+  const errors = [];
+  const installers = [];
+
+  // The submission selects assets with its own regex, which lives in the
+  // workflow and knows nothing about artifactName. Without this cross-check the
+  // two can desync while every other check here stays green.
+  let matcher = null;
+  if (installersRegex !== null) {
+    try {
+      matcher = new RegExp(installersRegex);
+    } catch {
+      errors.push(`installers-regex is not a valid regular expression: ${installersRegex}`);
+    }
+  }
+
+  // The manifest version comes from the release tag while the installer URLs are
+  // built from package.json. A tag cut without bumping package.json (or repointed
+  // afterwards) would publish one version's metadata against another's binaries.
+  if (releaseTag !== null) {
+    const expectedTag = `v${build.version}`;
+    if (releaseTag !== expectedTag) {
+      errors.push(
+        `Release tag ${releaseTag} does not match package.json version ` +
+          `(${build.version}, expected tag ${expectedTag}).`,
+      );
+    }
+  }
+
+  if (!build.artifactName) {
+    errors.push("build.win.artifactName is missing; WinGet cannot resolve an architecture.");
+  } else if (!build.artifactName.includes("${arch}")) {
+    errors.push(
+      `build.win.artifactName must contain the \${arch} token, got: ${build.artifactName}`,
+    );
+  }
+  if (!build.owner || !build.repo) {
+    errors.push("build.publish[0] must define owner and repo to derive release URLs.");
+  }
+  if (!build.entries.length) {
+    errors.push("build.win.target declares no architectures.");
+  }
+  for (const name of build.implicitArchTargets) {
+    errors.push(
+      `build.win.target "${name}" leaves arch implicit; WinGet needs it in the filename.`,
+    );
+  }
+
+  const assetByName = new Map((assets || []).map((asset) => [asset.name, asset]));
+
+  for (const entry of build.entries) {
+    const extension = TARGET_EXTENSION[entry.target];
+    if (!extension) {
+      errors.push(
+        `Unmapped Windows target "${entry.target}"; add it to TARGET_EXTENSION before shipping.`,
+      );
+      continue;
+    }
+    const expected = BUILDER_ARCH_TO_WINGET[entry.arch];
+    if (!expected) {
+      errors.push(
+        `Unmapped electron-builder arch "${entry.arch}"; add it to BUILDER_ARCH_TO_WINGET.`,
+      );
+      continue;
+    }
+    if (!build.artifactName) continue;
+
+    const filename = materializeName(build.artifactName, {
+      version: build.version,
+      arch: entry.arch,
+      ext: extension,
+    });
+    const url = downloadUrl({
+      owner: build.owner,
+      repo: build.repo,
+      version: build.version,
+      filename,
+    });
+    const resolved = resolveArchitecture(url);
+
+    if (resolved.architecture === null) {
+      errors.push(
+        `No delimited architecture token in ${filename}; WinGet would fall back to PE-header ` +
+          `detection, which reports x86 for every electron-builder NSIS stub.`,
+      );
+    } else if (resolved.architecture !== expected) {
+      errors.push(
+        `${filename} resolves to WinGet architecture "${resolved.architecture}" ` +
+          `(matched token "${resolved.matched}") but was built for electron-builder ` +
+          `arch "${entry.arch}", which must publish as "${expected}".`,
+      );
+    }
+
+    if (matcher && !matcher.test(filename)) {
+      errors.push(
+        `${filename} does not match the WinGet installers-regex ` +
+          `${installersRegex}; the submission would not pick it up.`,
+      );
+    }
+
+    const asset = assetByName.get(filename) || null;
+    installers.push({
+      target: entry.target,
+      builderArch: entry.arch,
+      expectedArchitecture: expected,
+      resolvedArchitecture: resolved.architecture,
+      matchedToken: resolved.matched,
+      filename,
+      url,
+      digest: asset ? asset.digest : null,
+      size: asset ? asset.size : null,
+    });
+  }
+
+  const resolvedArchitectures = installers.map((entry) => entry.resolvedArchitecture);
+  if (installers.length > 1 && new Set(resolvedArchitectures).size !== installers.length) {
+    errors.push(
+      `Windows installers do not resolve to distinct architectures: ` +
+        `${installers.map((entry) => `${entry.filename}=${entry.resolvedArchitecture}`).join(", ")}`,
+    );
+  }
+
+  // Distinctness alone still permits shipping a single architecture. The
+  // published manifest must carry every architecture the package promises, so
+  // the required set is asserted explicitly rather than inferred from whatever
+  // package.json happens to declare today.
+  if (requiredArchitectures !== null) {
+    const required = [...requiredArchitectures].sort();
+    const actual = [...new Set(resolvedArchitectures.filter(Boolean))].sort();
+    if (required.join(",") !== actual.join(",")) {
+      errors.push(
+        `Published architectures must be exactly [${required.join(", ")}], got ` +
+          `[${actual.join(", ") || "none"}].`,
+      );
+    }
+  }
+
+  if (assets) {
+    const names = assets.map((asset) => asset.name);
+    if (new Set(names).size !== names.length) {
+      errors.push("Release contains duplicate asset names; cannot bind an installer to content.");
+    }
+    for (const entry of installers) {
+      const asset = assetByName.get(entry.filename);
+      if (!asset) {
+        errors.push(`Release is missing the expected installer asset: ${entry.filename}`);
+        continue;
+      }
+      if (!asset.digest) {
+        errors.push(`Release asset ${entry.filename} has no digest to pin.`);
+      } else if (!DIGEST_PATTERN.test(asset.digest)) {
+        errors.push(
+          `Release asset ${entry.filename} has an unrecognized digest "${asset.digest}"; ` +
+            `expected sha256:<64 hex>.`,
+        );
+      }
+    }
+    const expectedNames = new Set(installers.map((entry) => entry.filename));
+    for (const asset of assets) {
+      if (expectedNames.has(asset.name)) continue;
+      if (matcher ? matcher.test(asset.name) : asset.name.endsWith(".exe")) {
+        errors.push(
+          `Unexpected asset "${asset.name}" would also match the WinGet installer regex.`,
+        );
+      }
+    }
+    // The shipped defect published one file under both entries. Identical
+    // digests mean the architectures are a naming fiction, and the explicit
+    // |arch override would then mislabel real content.
+    //
+    // Distinct digests still do NOT prove either file is the architecture its
+    // name claims — swapping the two binaries passes every check here. Nothing
+    // short of inspecting the payload can establish that; the generated
+    // manifest's SHA256 must be cross-checked against these values downstream.
+    const digests = installers
+      .map((entry) => entry.digest)
+      .filter((digest) => digest && DIGEST_PATTERN.test(digest));
+    if (digests.length > 1 && new Set(digests).size !== digests.length) {
+      errors.push(
+        `Installers share a digest; the same binary is published under more than one ` +
+          `architecture: ${installers.map((e) => `${e.filename}=${e.digest}`).join(", ")}`,
+      );
+    }
+  }
+
+  // Komac accepts `<url>|<architecture>` and gives that override the highest
+  // precedence — above its own filename inference and above PE-header analysis
+  // (Komac src/download/downloads.rs). Emitting the arguments from the same
+  // verified mapping that just passed the checks above means the submission
+  // cannot feed komac anything the contract did not check. It does NOT
+  // guarantee the manifest komac emits; see the SCOPE note at the top.
+  const komacUrls = errors.length
+    ? []
+    : installers.map((entry) => `${entry.url}|${entry.resolvedArchitecture}`);
+
+  return {
+    schemaVersion: 2,
+    version: build.version,
+    releaseTag,
+    artifactName: build.artifactName,
+    installersRegex,
+    requiredArchitectures: requiredArchitectures ? [...requiredArchitectures].sort() : null,
+    installers,
+    komacUrls,
+    assetsChecked: assets ? assets.length : 0,
+    errors,
+    summary: { installers: installers.length, errors: errors.length },
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    assetsFile: "",
+    output: "",
+    installersRegex: "",
+    requireArchitectures: "",
+    releaseTag: "",
+    packageJson: "",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--assets-file") options.assetsFile = argv[++index] || "";
+    else if (arg === "--output") options.output = argv[++index] || "";
+    else if (arg === "--installers-regex") options.installersRegex = argv[++index] || "";
+    else if (arg === "--require-architectures") options.requireArchitectures = argv[++index] || "";
+    else if (arg === "--release-tag") options.releaseTag = argv[++index] || "";
+    else if (arg === "--package-json") options.packageJson = argv[++index] || "";
+    else throw new Error(`Unknown argument: ${arg}`);
+  }
+  return options;
+}
+
+function readAssetsFile(assetsFile) {
+  return normalizeAssets(JSON.parse(fs.readFileSync(path.resolve(assetsFile), "utf8")));
+}
+
+// The release tooling lives on the default branch, but the build configuration
+// that produced a release's assets lives in that release's tag. Loading the
+// config separately keeps both correct instead of forcing one checkout to serve
+// both roles.
+function readPackageJson(packageJsonPath) {
+  return JSON.parse(fs.readFileSync(path.resolve(packageJsonPath), "utf8"));
+}
+
+function runCli(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const assets = options.assetsFile ? readAssetsFile(options.assetsFile) : null;
+  const report = verifyWingetArchContract({
+    config: options.packageJson ? readPackageJson(options.packageJson) : pkg,
+    assets,
+    installersRegex: options.installersRegex || null,
+    requiredArchitectures: options.requireArchitectures
+      ? options.requireArchitectures.split(",").map((value) => value.trim()).filter(Boolean)
+      : null,
+    releaseTag: options.releaseTag || null,
+  });
+  const json = `${JSON.stringify(report, null, 2)}\n`;
+
+  if (options.output) {
+    const outputPath = path.resolve(options.output);
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, json, "utf8");
+  } else {
+    process.stdout.write(json);
+  }
+
+  if (report.errors.length) {
+    process.stderr.write(
+      `WinGet architecture contract failed: ${report.errors.length} error(s).\n`,
+    );
+    for (const error of report.errors) process.stderr.write(`  - ${error}\n`);
+    return 1;
+  }
+  process.stderr.write(
+    `WinGet architecture contract passed for ${report.installers.length} installer(s).\n`,
+  );
+  return 0;
+}
+
+if (require.main === module) {
+  try {
+    process.exitCode = runCli();
+  } catch (err) {
+    process.stderr.write(`${err && err.message ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {
+  DELIMITERS,
+  ARCHITECTURES,
+  BUILDER_ARCH_TO_WINGET,
+  DIGEST_PATTERN,
+  readPackageJson,
+  isDelimitedAt,
+  rightmostDelimitedIndex,
+  resolveArchitecture,
+  readWindowsBuildConfig,
+  materializeName,
+  downloadUrl,
+  normalizeAssets,
+  readAssetsFile,
+  verifyWingetArchContract,
+  parseArgs,
+  runCli,
+};

--- a/test/winget-arch-contract.test.js
+++ b/test/winget-arch-contract.test.js
@@ -1,0 +1,870 @@
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+
+const pkg = require("../package.json");
+const {
+  BUILDER_ARCH_TO_WINGET,
+  isDelimitedAt,
+  resolveArchitecture,
+  readWindowsBuildConfig,
+  materializeName,
+  downloadUrl,
+  normalizeAssets,
+  verifyWingetArchContract,
+  parseArgs,
+  runCli,
+} = require("../scripts/verify-winget-arch-contract.js");
+
+const RELEASE_BASE =
+  "https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v0.14.0";
+
+const WORKFLOW_PATH = path.join(__dirname, "..", ".github", "workflows", "winget.yml");
+const WORKFLOW_RAW = fs.readFileSync(WORKFLOW_PATH, "utf8");
+
+// Assertions below run against the workflow with comments removed. Grepping the
+// raw text lets any assertion be satisfied by a comment that merely mentions the
+// right token while the executable YAML says something else.
+function stripComments(yaml) {
+  return yaml
+    .split("\n")
+    .map((line) => line.replace(/\s+#.*$/, ""))
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+}
+
+const WORKFLOW = stripComments(WORKFLOW_RAW);
+
+// Returns the body of a named step, up to the next step at the same indent.
+function stepBody(yaml, name) {
+  const start = yaml.indexOf(`- name: ${name}`);
+  if (start === -1) return null;
+  const rest = yaml.slice(start + 1);
+  const next = rest.indexOf("\n      - ");
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+// Asserts a CLI flag carries an exact value. Checking only that a flag appears
+// lets `--require-architectures ""` or `--version "9.9.9"` pass unnoticed, which
+// is how six semantic breaks survived an earlier revision of these tests.
+function assertFlag(body, flag, expected, message) {
+  const match = body.match(new RegExp(`${flag}\\s+(\\S+)`));
+  assert.ok(match, `${flag} must be passed${message ? ` (${message})` : ""}`);
+  assert.equal(match[1], expected, `${flag} must be ${expected}, got ${match[1]}`);
+}
+
+function configWith() {
+  return {
+    version: "0.14.0",
+    build: {
+      publish: [{ provider: "github", owner: "rullerzhou-afk", repo: "clawd-on-desk" }],
+      win: {
+        artifactName: "Clawd-on-Desk-Setup-${version}-${arch}.${ext}",
+        target: [{ target: "nsis", arch: ["x64", "arm64"] }],
+      },
+    },
+  };
+}
+
+const X64_ASSET = {
+  name: "Clawd-on-Desk-Setup-0.14.0-x64.exe",
+  digest: "sha256:3733d49f918d5dccbdeaf00daf926938c8bc657f1bea81caf6bfb43de3cb4efb",
+  size: 128223329,
+};
+const ARM64_ASSET = {
+  name: "Clawd-on-Desk-Setup-0.14.0-arm64.exe",
+  digest: "sha256:0e4d6527603a924394697ccb0648b09c146a5c39f8bd725c481d4bbca0177a42",
+  size: 129682958,
+};
+
+describe("winget architecture resolver (ported from winget-types from_url)", () => {
+  it("resolves our shipped installer names to distinct architectures", () => {
+    assert.equal(
+      resolveArchitecture(`${RELEASE_BASE}/Clawd-on-Desk-Setup-0.14.0-x64.exe`).architecture,
+      "x64",
+    );
+    assert.equal(
+      resolveArchitecture(`${RELEASE_BASE}/Clawd-on-Desk-Setup-0.14.0-arm64.exe`).architecture,
+      "arm64",
+    );
+  });
+
+  it("prefers arm64 over the shorter arm token", () => {
+    const resolved = resolveArchitecture(
+      `${RELEASE_BASE}/Clawd-on-Desk-Setup-0.14.0-arm64.exe`,
+    );
+    assert.equal(resolved.matched, "arm64");
+  });
+
+  it("prefers the longer name when two tokens start at the same offset", () => {
+    const resolved = resolveArchitecture(`${RELEASE_BASE}/app-x86_64.exe`);
+    assert.equal(resolved.matched, "x86_64");
+    assert.equal(resolved.architecture, "x64");
+  });
+
+  it("prefers the rightmost delimited token", () => {
+    assert.equal(
+      resolveArchitecture(`${RELEASE_BASE}/x64-tools/app-arm64.exe`).architecture,
+      "arm64",
+    );
+  });
+
+  it("narrows upstream: a token upstream would rescue resolves to null", () => {
+    // Real upstream resolves this to x64 through its `{arch}.{ext}` fallback,
+    // which is deliberately not ported.
+    assert.equal(resolveArchitecture("https://example.com/installerx64.exe").architecture, null);
+  });
+
+  it("treats a token at index 0 as undelimited", () => {
+    assert.equal(isDelimitedAt("x64.exe", 0, 3), false);
+    assert.equal(resolveArchitecture("x64.exe").architecture, null);
+  });
+
+  it("requires a delimiter on both sides", () => {
+    assert.equal(isDelimitedAt("app-x64.exe", 4, 3), true);
+    assert.equal(isDelimitedAt("app-x64", 4, 3), false, "token running to end of string");
+  });
+
+  it("is case insensitive", () => {
+    assert.equal(resolveArchitecture(`${RELEASE_BASE}/App-ARM64.EXE`).architecture, "arm64");
+  });
+});
+
+describe("winget architecture contract", () => {
+  it("passes for the current package.json", () => {
+    const report = verifyWingetArchContract();
+    assert.deepEqual(report.errors, [], report.errors.join("\n"));
+    assert.equal(report.installers.length, 2);
+  });
+
+  it("maps every shipped Windows target to the architecture it claims", () => {
+    for (const installer of verifyWingetArchContract().installers) {
+      assert.equal(
+        installer.resolvedArchitecture,
+        installer.expectedArchitecture,
+        `${installer.filename} must resolve to ${installer.expectedArchitecture}`,
+      );
+    }
+  });
+
+  it("detects two targets collapsing onto one architecture, in isolation", () => {
+    const config = configWith();
+    config.build.win.target = [{ target: "nsis", arch: ["x64", "x64"] }];
+    const report = verifyWingetArchContract({ config });
+    assert.equal(report.errors.length, 1, report.errors.join("\n"));
+    assert.match(report.errors[0], /do not resolve to distinct architectures/);
+  });
+
+  it("detects a filename resolving to the wrong architecture, in isolation", () => {
+    const config = configWith();
+    config.build.win.artifactName = "Clawd-on-Desk-Setup-${version}-${arch}-x64.${ext}";
+    config.build.win.target = [{ target: "nsis", arch: ["arm64"] }];
+    const report = verifyWingetArchContract({ config });
+    assert.equal(report.errors.length, 1, report.errors.join("\n"));
+    assert.match(report.errors[0], /resolves to WinGet architecture "x64"/);
+  });
+
+  it("fails when the ${arch} token is dropped from artifactName", () => {
+    const config = configWith();
+    config.build.win.artifactName = "Clawd-on-Desk-Setup-${version}.${ext}";
+    const report = verifyWingetArchContract({ config });
+    assert.ok(
+      report.errors.some((error) => error.includes("${arch} token")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails when ${arch} is present but produces an undelimited name", () => {
+    const config = configWith();
+    config.build.win.artifactName = "Clawd-on-Desk-Setup-${version}${arch}.${ext}";
+    const report = verifyWingetArchContract({ config });
+    assert.ok(
+      report.errors.some((error) => error.includes("No delimited architecture token")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails when artifactName is missing entirely", () => {
+    const config = configWith();
+    delete config.build.win.artifactName;
+    const report = verifyWingetArchContract({ config });
+    assert.ok(
+      report.errors.some((error) => error.includes("artifactName is missing")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails when a target leaves its architecture implicit", () => {
+    const config = configWith();
+    config.build.win.target = ["nsis"];
+    const report = verifyWingetArchContract({ config });
+    assert.ok(
+      report.errors.some((error) => error.includes("leaves arch implicit")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails when no architectures are declared at all", () => {
+    const config = configWith();
+    config.build.win.target = [];
+    const report = verifyWingetArchContract({ config });
+    assert.ok(
+      report.errors.some((error) => error.includes("declares no architectures")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails on an electron-builder arch with no WinGet mapping", () => {
+    const config = configWith();
+    config.build.win.target = [{ target: "nsis", arch: ["x64", "riscv64"] }];
+    const report = verifyWingetArchContract({ config });
+    assert.ok(
+      report.errors.some((error) => error.includes("BUILDER_ARCH_TO_WINGET")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails on a Windows target with no extension mapping", () => {
+    const config = configWith();
+    config.build.win.target = [{ target: "msi", arch: ["x64"] }];
+    const report = verifyWingetArchContract({ config });
+    assert.ok(
+      report.errors.some((error) => error.includes("TARGET_EXTENSION")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails when build.publish is missing", () => {
+    const config = configWith();
+    delete config.build.publish;
+    const report = verifyWingetArchContract({ config });
+    assert.ok(
+      report.errors.some((error) => error.includes("build.publish")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("pins the electron-builder to WinGet architecture mapping", () => {
+    assert.deepEqual(BUILDER_ARCH_TO_WINGET, {
+      x64: "x64",
+      arm64: "arm64",
+      ia32: "x86",
+      armv7l: "arm",
+    });
+  });
+});
+
+describe("winget contract required-architecture set", () => {
+  // Distinctness alone permits shipping a single architecture: with one entry
+  // the collision check is skipped and everything else passes.
+  it("rejects a build that would publish only x64", () => {
+    const config = configWith();
+    config.build.win.target = [{ target: "nsis", arch: ["x64"] }];
+    const report = verifyWingetArchContract({
+      config,
+      requiredArchitectures: ["x64", "arm64"],
+      assets: [X64_ASSET],
+    });
+    assert.ok(
+      report.errors.some((error) => error.includes("Published architectures must be exactly")),
+      report.errors.join("\n"),
+    );
+    assert.deepEqual(report.komacUrls, []);
+  });
+
+  it("rejects a build that would publish an extra architecture", () => {
+    const config = configWith();
+    config.build.win.target = [{ target: "nsis", arch: ["x64", "arm64", "ia32"] }];
+    const report = verifyWingetArchContract({
+      config,
+      requiredArchitectures: ["x64", "arm64"],
+    });
+    assert.ok(
+      report.errors.some((error) => error.includes("Published architectures must be exactly")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("accepts the required set regardless of declaration order", () => {
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      requiredArchitectures: ["arm64", "x64"],
+    });
+    assert.deepEqual(report.errors, [], report.errors.join("\n"));
+    assert.deepEqual(report.requiredArchitectures, ["arm64", "x64"]);
+  });
+});
+
+describe("winget contract release-tag binding", () => {
+  // Installer URLs come from package.json; the manifest version comes from the
+  // tag. A tag cut without bumping package.json would cross the two.
+  it("rejects a tag that does not match package.json", () => {
+    const report = verifyWingetArchContract({ config: configWith(), releaseTag: "v0.15.0" });
+    assert.ok(
+      report.errors.some((error) => error.includes("does not match package.json version")),
+      report.errors.join("\n"),
+    );
+    assert.deepEqual(report.komacUrls, []);
+  });
+
+  it("accepts the matching tag", () => {
+    const report = verifyWingetArchContract({ config: configWith(), releaseTag: "v0.14.0" });
+    assert.deepEqual(report.errors, [], report.errors.join("\n"));
+  });
+
+  it("rejects a bare version with no v prefix", () => {
+    const report = verifyWingetArchContract({ config: configWith(), releaseTag: "0.14.0" });
+    assert.ok(report.errors.length > 0, "expected a tag mismatch");
+  });
+});
+
+describe("winget contract komac arguments", () => {
+  it("emits one explicit |architecture override per installer", () => {
+    const report = verifyWingetArchContract({ config: configWith() });
+    assert.deepEqual(report.komacUrls, [
+      `${RELEASE_BASE}/Clawd-on-Desk-Setup-0.14.0-x64.exe|x64`,
+      `${RELEASE_BASE}/Clawd-on-Desk-Setup-0.14.0-arm64.exe|arm64`,
+    ]);
+  });
+
+  it("emits nothing when the contract fails", () => {
+    const config = configWith();
+    config.build.win.target = [{ target: "nsis", arch: ["x64", "x64"] }];
+    const report = verifyWingetArchContract({ config });
+    assert.ok(report.errors.length > 0);
+    assert.deepEqual(report.komacUrls, []);
+  });
+
+  it("builds each URL from the release tag and filename", () => {
+    assert.equal(
+      downloadUrl({
+        owner: "rullerzhou-afk",
+        repo: "clawd-on-desk",
+        version: "1.2.3",
+        filename: "x.exe",
+      }),
+      "https://github.com/rullerzhou-afk/clawd-on-desk/releases/download/v1.2.3/x.exe",
+    );
+  });
+});
+
+describe("winget contract release-asset cross-check", () => {
+  it("passes when the release carries exactly the expected installers", () => {
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      assets: [X64_ASSET, ARM64_ASSET, { name: "latest.yml", digest: "sha256:aa", size: 1 }],
+    });
+    assert.deepEqual(report.errors, [], report.errors.join("\n"));
+    assert.equal(report.assetsChecked, 3);
+  });
+
+  it("records each installer's digest and size in the report", () => {
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      assets: [X64_ASSET, ARM64_ASSET],
+    });
+    const byName = Object.fromEntries(report.installers.map((i) => [i.filename, i]));
+    assert.equal(byName[X64_ASSET.name].digest, X64_ASSET.digest);
+    assert.equal(byName[ARM64_ASSET.name].size, ARM64_ASSET.size);
+  });
+
+  it("fails when an expected installer is absent from the release", () => {
+    const report = verifyWingetArchContract({ config: configWith(), assets: [X64_ASSET] });
+    assert.ok(
+      report.errors.some((error) => error.includes("missing the expected installer")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails on a stray asset that would also match the installer regex", () => {
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      assets: [
+        X64_ASSET,
+        ARM64_ASSET,
+        { name: "Clawd-on-Desk-Portable-0.14.0.exe", digest: "sha256:bb", size: 1 },
+      ],
+    });
+    assert.ok(
+      report.errors.some((error) => error.includes("Unexpected asset")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails when both installers are the same binary", () => {
+    // Exactly what shipped: two names, one file, identical SHA256. The explicit
+    // |arch override would then label real arm64 content as x64.
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      assets: [X64_ASSET, { ...ARM64_ASSET, digest: X64_ASSET.digest }],
+    });
+    assert.ok(
+      report.errors.some((error) => error.includes("share a digest")),
+      report.errors.join("\n"),
+    );
+    assert.deepEqual(report.komacUrls, []);
+  });
+
+  it("fails when an installer asset carries no digest to pin", () => {
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      assets: [X64_ASSET, { ...ARM64_ASSET, digest: "" }],
+    });
+    assert.ok(
+      report.errors.some((error) => error.includes("no digest to pin")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("fails on a digest that is not sha256:<64 hex>", () => {
+    // Two arbitrary non-empty strings would otherwise satisfy distinctness and
+    // pin nothing at all.
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      assets: [
+        { ...X64_ASSET, digest: "a" },
+        { ...ARM64_ASSET, digest: "b" },
+      ],
+    });
+    assert.equal(
+      report.errors.filter((error) => error.includes("unrecognized digest")).length,
+      2,
+      report.errors.join("\n"),
+    );
+    assert.deepEqual(report.komacUrls, []);
+  });
+
+  it("fails when the release lists the same asset name twice", () => {
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      assets: [X64_ASSET, ARM64_ASSET, { ...X64_ASSET, digest: "sha256:" + "d".repeat(64) }],
+    });
+    assert.ok(
+      report.errors.some((error) => error.includes("duplicate asset names")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("does not claim a distinct digest proves the architecture", () => {
+    // Swapping the two binaries passes every check here. This test exists to
+    // record that limitation, not to assert a guarantee we do not have.
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      assets: [
+        { ...X64_ASSET, digest: ARM64_ASSET.digest },
+        { ...ARM64_ASSET, digest: X64_ASSET.digest },
+      ],
+    });
+    assert.deepEqual(report.errors, [], "content-swap is out of scope for this gate");
+  });
+});
+
+describe("winget contract installers-regex cross-check", () => {
+  const workflowRegex = (() => {
+    const match = WORKFLOW.match(/^\s*INSTALLERS_REGEX:\s*'(.+)'\s*$/m);
+    assert.ok(match, "workflow must define INSTALLERS_REGEX");
+    return match[1];
+  })();
+
+  it("matches every installer the contract expects", () => {
+    const report = verifyWingetArchContract({ installersRegex: workflowRegex });
+    assert.deepEqual(report.errors, [], report.errors.join("\n"));
+  });
+
+  it("selects both architectures, never a single one", () => {
+    const matcher = new RegExp(workflowRegex);
+    const matched = verifyWingetArchContract().installers.filter((installer) =>
+      matcher.test(installer.filename),
+    );
+    assert.equal(matched.length, 2, "a regex matching one installer republishes the bug");
+    assert.deepEqual(
+      matched.map((installer) => installer.resolvedArchitecture).sort(),
+      ["arm64", "x64"],
+    );
+  });
+
+  it("fails when the regex misses an expected installer", () => {
+    const report = verifyWingetArchContract({
+      installersRegex: "^Clawd-on-Desk-Setup-.*-x64\\.exe$",
+    });
+    assert.ok(
+      report.errors.some((error) => error.includes("does not match the WinGet installers-regex")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("uses the regex, not the .exe suffix, to spot stray assets", () => {
+    const report = verifyWingetArchContract({
+      config: configWith(),
+      installersRegex: "^Clawd-on-Desk-Setup-.*-(x64|arm64)\\.(exe|msi)$",
+      assets: [
+        X64_ASSET,
+        ARM64_ASSET,
+        { name: "Clawd-on-Desk-Setup-0.14.0-x64.msi", digest: "sha256:cc", size: 1 },
+      ],
+    });
+    assert.ok(
+      report.errors.some((error) => error.includes("Unexpected asset")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("reports an unusable regex rather than ignoring it", () => {
+    const report = verifyWingetArchContract({ installersRegex: "([" });
+    assert.ok(
+      report.errors.some((error) => error.includes("not a valid regular expression")),
+      report.errors.join("\n"),
+    );
+  });
+
+  it("declares the same required architectures the workflow does", () => {
+    const match = WORKFLOW.match(/^\s*REQUIRED_ARCHITECTURES:\s*"(.+)"\s*$/m);
+    assert.ok(match, "workflow must define REQUIRED_ARCHITECTURES");
+    assert.deepEqual(match[1].split(",").map((v) => v.trim()).sort(), ["arm64", "x64"]);
+  });
+});
+
+describe("winget contract helpers", () => {
+  it("reads the Windows build config from package.json", () => {
+    const build = readWindowsBuildConfig(pkg);
+    assert.equal(build.owner, "rullerzhou-afk");
+    assert.equal(build.repo, "clawd-on-desk");
+    assert.ok(build.entries.length >= 1);
+  });
+
+  it("materializes every artifactName token", () => {
+    assert.equal(
+      materializeName("Clawd-on-Desk-Setup-${version}-${arch}.${ext}", {
+        version: "1.2.3",
+        arch: "arm64",
+        ext: "exe",
+      }),
+      "Clawd-on-Desk-Setup-1.2.3-arm64.exe",
+    );
+  });
+
+  it("normalizes both bare and wrapped asset payloads", () => {
+    assert.deepEqual(normalizeAssets([X64_ASSET]), [X64_ASSET]);
+    assert.deepEqual(normalizeAssets({ assets: [X64_ASSET] }), [X64_ASSET]);
+  });
+
+  it("rejects an asset payload that is neither shape", () => {
+    assert.throws(() => normalizeAssets({ nope: 1 }), /JSON array/);
+  });
+
+  it("rejects a non-object asset entry by index", () => {
+    assert.throws(() => normalizeAssets([X64_ASSET, null]), /assets\[1\] is not an object/);
+  });
+
+  it("rejects unknown CLI arguments", () => {
+    assert.throws(() => parseArgs(["--nope"]), /Unknown argument/);
+  });
+
+  it("parses every supported CLI argument", () => {
+    assert.deepEqual(
+      parseArgs([
+        "--assets-file", "a.json",
+        "--output", "b.json",
+        "--installers-regex", "^x$",
+        "--require-architectures", "x64,arm64",
+        "--release-tag", "v1.0.0",
+        "--package-json", "tagged.json",
+      ]),
+      {
+        assetsFile: "a.json",
+        output: "b.json",
+        installersRegex: "^x$",
+        requireArchitectures: "x64,arm64",
+        releaseTag: "v1.0.0",
+        packageJson: "tagged.json",
+      },
+    );
+  });
+});
+
+describe("winget contract tagged build configuration", () => {
+  // The tooling checkout and the release's build config come from different
+  // trees; --package-json is what keeps the installer URLs tied to the tag.
+  it("reads the build config from the given file, not the repo's own", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "winget-cfg-"));
+    const configPath = path.join(dir, "tagged-package.json");
+    const output = path.join(dir, "report.json");
+    const tagged = configWith();
+    tagged.version = "0.9.9";
+    fs.writeFileSync(configPath, JSON.stringify(tagged), "utf8");
+
+    const code = runCli([
+      "--package-json", configPath,
+      "--release-tag", "v0.9.9",
+      "--output", output,
+    ]);
+    assert.equal(code, 0, "the tagged config must be the one that is checked");
+
+    const report = JSON.parse(fs.readFileSync(output, "utf8"));
+    assert.equal(report.version, "0.9.9");
+    assert.ok(
+      report.installers.every((installer) => installer.url.includes("/v0.9.9/")),
+      "installer URLs must come from the tagged version",
+    );
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("still catches a tag that disagrees with the tagged config", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "winget-cfg-"));
+    const configPath = path.join(dir, "tagged-package.json");
+    const output = path.join(dir, "report.json");
+    fs.writeFileSync(configPath, JSON.stringify(configWith()), "utf8");
+
+    const code = runCli([
+      "--package-json", configPath,
+      "--release-tag", "v0.9.9",
+      "--output", output,
+    ]);
+    assert.equal(code, 1);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("winget contract CLI", () => {
+  function scratch() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), "winget-arch-"));
+  }
+
+  it("writes a JSON evidence manifest and exits zero", () => {
+    const dir = scratch();
+    const output = path.join(dir, "winget-arch.json");
+    assert.equal(runCli(["--output", output]), 0);
+    const report = JSON.parse(fs.readFileSync(output, "utf8"));
+    assert.equal(report.schemaVersion, 2);
+    assert.equal(report.errors.length, 0);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("exits non-zero and records the failure when the release is incomplete", () => {
+    // Covers the whole CI path: --assets-file is read and fed into the contract,
+    // and the exit code the workflow gate relies on is actually non-zero.
+    const dir = scratch();
+    const assetsFile = path.join(dir, "assets.json");
+    const output = path.join(dir, "winget-arch.json");
+    const version = pkg.version;
+    fs.writeFileSync(
+      assetsFile,
+      JSON.stringify([
+        { name: `Clawd-on-Desk-Setup-${version}-x64.exe`, digest: "sha256:aa", size: 1 },
+        { name: "latest.yml", digest: "sha256:bb", size: 2 },
+      ]),
+      "utf8",
+    );
+
+    assert.equal(runCli(["--assets-file", assetsFile, "--output", output]), 1);
+
+    const report = JSON.parse(fs.readFileSync(output, "utf8"));
+    assert.equal(report.assetsChecked, 2);
+    assert.ok(
+      report.errors.some((error) => error.includes(`Setup-${version}-arm64.exe`)),
+      report.errors.join("\n"),
+    );
+    assert.deepEqual(report.komacUrls, []);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("passes every option through to the contract", () => {
+    const dir = scratch();
+    const output = path.join(dir, "winget-arch.json");
+    const code = runCli([
+      "--installers-regex", "^nope$",
+      "--require-architectures", "x64",
+      "--release-tag", "v9.9.9",
+      "--output", output,
+    ]);
+    assert.equal(code, 1);
+    const report = JSON.parse(fs.readFileSync(output, "utf8"));
+    assert.equal(report.installersRegex, "^nope$");
+    assert.deepEqual(report.requiredArchitectures, ["x64"]);
+    assert.equal(report.releaseTag, "v9.9.9");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+describe("winget prepare workflow", () => {
+  it("keeps the ambient GitHub token strictly read-only", () => {
+    // Mutable actions are acceptable during prepare-only only because the job
+    // token cannot write. Lock both the top-level value and the absence of a
+    // job-level override so that premise cannot silently drift.
+    // Matches the inline form too (`permissions: write-all`): a job-level
+    // override written that way is valid YAML, replaces the workflow-level grant
+    // outright, and would slip past a bare-`permissions:` pattern.
+    const declarations = WORKFLOW.match(/^[ \t]*permissions:/gm) || [];
+    assert.equal(declarations.length, 1, "workflow must declare permissions exactly once");
+
+    const topLevel = WORKFLOW.match(/^permissions:\s*\n((?:[ \t]+.*(?:\n|$))*)/m);
+    assert.ok(topLevel, "workflow must declare top-level permissions");
+    assert.equal(topLevel[1].trim(), "contents: read");
+  });
+
+  it("references no repository secret and submits nothing", () => {
+    // Phase 0 is prepare-only. The ambient github.token is still technically a
+    // secret, so this asserts the narrower true thing: no long-lived PAT or
+    // configured repository secret. Adding one would also reintroduce the
+    // requirement to pin every action to a commit SHA.
+    assert.doesNotMatch(WORKFLOW, /secrets\./, "workflow must reference no repository secret");
+    assert.doesNotMatch(WORKFLOW, /komac submit/, "workflow must not submit");
+    assert.doesNotMatch(WORKFLOW, /--submit\b/, "workflow must not submit");
+  });
+
+  it("runs komac in dry-run as a standalone flag", () => {
+    // `--dry-run=false` still matches a bare /--dry-run/ search but is rejected
+    // by clap, so the run would fail rather than being safely prepared.
+    const body = stepBody(WORKFLOW, "Generate manifest (no submission)");
+    assert.ok(body, "generate step must exist");
+    assert.match(body, /^\s*--dry-run\s*\\?\s*$/m, "--dry-run must take no value");
+  });
+
+  it("bounds the job so a stalled download cannot hold the concurrency group", () => {
+    // komac downloads both installers in full; there is no header-only mode.
+    assert.match(WORKFLOW, /timeout-minutes:\s*\d+/);
+  });
+
+  it("runs the architecture contract before invoking komac", () => {
+    const gate = WORKFLOW.indexOf("verify:winget-arch");
+    const generate = WORKFLOW.indexOf("komac update");
+    assert.ok(gate > -1, "workflow must run the architecture gate");
+    assert.ok(generate > -1, "workflow must generate via komac");
+    assert.ok(gate < generate, "the gate must run before generation");
+  });
+
+  it("gives the gate no way to be skipped or ignored", () => {
+    const body = stepBody(WORKFLOW, "Verify WinGet architecture contract");
+    assert.ok(body, "gate step must exist");
+    assert.doesNotMatch(body, /\bif:/, "gate must not be conditional");
+    assert.doesNotMatch(body, /continue-on-error/, "gate failure must fail the job");
+  });
+
+  it("passes the gate live values, not just the right flag names", () => {
+    const body = stepBody(WORKFLOW, "Verify WinGet architecture contract");
+    assertFlag(body, "--release-tag", '"$TAG"', "must track the resolved tag");
+    assertFlag(body, "--require-architectures", '"$REQUIRED_ARCHITECTURES"');
+    assertFlag(body, "--installers-regex", '"$INSTALLERS_REGEX"');
+    assertFlag(body, "--package-json", "tagged-package.json");
+    assertFlag(body, "--output", "winget-arch-contract.json");
+  });
+
+  it("reads the build config from the tag, not the tooling checkout", () => {
+    // Installer filenames come from the package.json that built the assets.
+    const body = stepBody(WORKFLOW, "Fetch the tagged build configuration");
+    assert.ok(body, "config fetch step must exist");
+    assert.match(body, /contents\/package\.json\?ref=\$TAG/);
+    assert.match(body, />\s*tagged-package\.json/);
+  });
+
+  it("checks the tooling out at the default branch explicitly", () => {
+    // Without an explicit ref, actions/checkout takes the triggering ref, which
+    // for a release event is the tag — and older tags lack this tooling.
+    const body = stepBody(WORKFLOW, "Check out release tooling");
+    assert.ok(body, "tooling checkout step must exist");
+    assert.match(body, /ref:\s*\$\{\{\s*github\.event\.repository\.default_branch\s*\}\}/);
+  });
+
+  it("collects whole asset objects, not just names", () => {
+    const body = stepBody(WORKFLOW, "Collect release assets");
+    assert.ok(body, "collect step must exist");
+    assert.match(body, /--json assets/);
+    // A `.assets[].name` filter would drop the digests the contract pins
+    // content with, and every other assertion here would still pass.
+    assert.doesNotMatch(body, /\.assets\[\]\.name/);
+  });
+
+  it("feeds the gate exactly the file the collect step writes", () => {
+    // Binding the two steps by value: asserting each mentions some filename
+    // passes even when they disagree, because a leftover reference elsewhere in
+    // the step satisfies the match.
+    const collect = stepBody(WORKFLOW, "Collect release assets");
+    const gate = stepBody(WORKFLOW, "Verify WinGet architecture contract");
+    const written = collect.match(/>\s*(\S+\.json)/);
+    const consumed = gate.match(/--assets-file\s+(\S+)/);
+    assert.ok(written, "collect step must redirect to a .json file");
+    assert.ok(consumed, "gate must be given an assets file");
+    assert.equal(consumed[1], written[1]);
+  });
+
+  it("feeds komac exactly the URLs the contract emitted", () => {
+    const body = stepBody(WORKFLOW, "Generate manifest (no submission)");
+    assert.ok(body, "generate step must exist");
+    assert.match(body, /\.komacUrls\[\]/, "URLs must come from the verified report");
+    assert.doesNotMatch(body, /releases\/download/, "URLs must not be rebuilt by hand");
+    assert.match(body, /--urls "\$\{urls\[@\]\}"/, "the resolved array must be passed");
+    assertFlag(body, "--version", '"${TAG#v}"', "must derive from the resolved tag");
+  });
+
+  it("writes komac output to the directory it uploads", () => {
+    const generate = stepBody(WORKFLOW, "Generate manifest (no submission)");
+    const output = generate.match(/--output\s+(\S+)/);
+    assert.ok(output, "generate step must pass --output");
+    assert.match(
+      WORKFLOW,
+      new RegExp(`name: winget-generated-manifest\\s*\\n\\s*path: ${output[1]}/?`),
+      `upload path must match komac --output (${output[1]})`,
+    );
+  });
+
+  it("summarizes the manifest from komac's nested layout", () => {
+    // komac writes the winget-pkgs directory tree, so a flat generated/*.yaml
+    // glob silently matches nothing and the summary renders empty.
+    const body = stepBody(WORKFLOW, "Summarize generated installers");
+    assert.ok(body, "summary step must exist");
+    assert.doesNotMatch(body, /cat generated\/\*/, "flat glob cannot match the nested layout");
+    assert.match(body, /find generated .*installer\.yaml/);
+  });
+
+  it("installs komac somewhere a non-root runner can write", () => {
+    // GitHub-hosted runners execute as a non-root user; /usr/local/bin needs sudo.
+    const body = stepBody(WORKFLOW, "Install komac");
+    assert.ok(body, "install step must exist");
+    assert.doesNotMatch(body, /\/usr\/local\/bin/);
+    assert.match(body, /\$RUNNER_TEMP\/bin/);
+    assert.match(body, />> "\$GITHUB_PATH"/, "the install dir must be added to PATH");
+  });
+
+  it("pins komac to a version and verifies its checksum", () => {
+    assert.match(WORKFLOW, /KOMAC_VERSION:\s*"2\.16\.0"/);
+    assert.match(
+      WORKFLOW,
+      /KOMAC_SHA256:\s*"7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d"/,
+    );
+    const body = stepBody(WORKFLOW, "Install komac");
+    assert.ok(body, "install step must exist");
+    assert.match(body, /sha256sum --check --strict/);
+  });
+
+  it("only prepares non-prerelease version tags", () => {
+    assert.match(WORKFLOW, /types:\s*\[released\]/);
+    assert.match(WORKFLOW, /github\.event\.release\.prerelease == false/);
+    const body = stepBody(WORKFLOW, "Resolve release tag");
+    assert.ok(body, "resolve step must exist");
+    // Polarity matters: a guard that publishes only prereleases would satisfy a
+    // naive "mentions isPrerelease" assertion.
+    assert.match(body, /\[ "\$prerelease" != "false" \]/);
+    assert.match(body, /\^v\[0-9\]\+\\\.\[0-9\]\+\\\.\[0-9\]\+\$/, "tag shape must be pinned");
+  });
+
+  it("serializes concurrent runs", () => {
+    assert.match(WORKFLOW, /concurrency:/);
+    assert.match(WORKFLOW, /cancel-in-progress:\s*false/);
+  });
+
+  it("declares the exact package identifier live in winget-pkgs", () => {
+    assert.match(WORKFLOW, /komac update rullerzhou-afk\.clawd-on-desk\s*\\?\s*$/m);
+  });
+
+  it("invokes an npm script that package.json actually defines", () => {
+    const invoked = WORKFLOW.match(/npm run ([\w:-]+)/g) || [];
+    assert.ok(invoked.length > 0, "workflow must invoke an npm script");
+    for (const entry of invoked) {
+      const name = entry.replace("npm run ", "");
+      assert.ok(pkg.scripts[name], `package.json is missing the "${name}" script`);
+    }
+    assert.equal(pkg.scripts["verify:winget-arch"], "node scripts/verify-winget-arch-contract.js");
+  });
+});


### PR DESCRIPTION
Stage 1 of #860 — generation only. This holds no long-lived credential, passes
no `--submit`, and cannot write to `microsoft/winget-pkgs`.

## Why generation and submission are split

`komac update` does not turn the URLs it is given into installer entries. It
reads the **previous** manifest and emits one entry per previous entry, matching
each to its best new installer (`src/commands/update_version.rs` →
`src/match_installers.rs`, which iterates `previous_installers`).

The live v0.14.0 manifest has two entries, both `Architecture: x64` — those are
the user/machine scope split, not two architectures. Scoring them against a
correct pair of new installers gives the x64 installer 8 points and the arm64
installer 6, so both take x64 and **the arm64 installer is discarded**. Verified
by running komac v2.16.0 locally against both URLs.

Correct input URLs therefore cannot produce a correct manifest while the upstream
shape is wrong. That has to be repaired by a hand-reviewed PR first, to four
entries (`x64`/`arm64` × `user`/`machine`), which is stage 2 in #860.

Running this workflow validates the hosted runner, token, download and artifact
paths end to end, and produces the generated manifest to check the repair
against.

## What is in here

- **`.github/workflows/winget.yml`** — prepare-only. Prerelease- and
  tag-shape-guarded, time-bounded, serialized by a concurrency group. komac is
  installed from a checksum-pinned release archive into `RUNNER_TEMP` (hosted
  runners are not root). Tooling is checked out at the default branch
  **explicitly** — `actions/checkout` otherwise takes the triggering ref, which
  for a release event is the tag, and older tags do not contain this tooling —
  while the build config is read from the tag itself, so installer filenames stay
  tied to the tree that produced the assets.

- **`scripts/verify-winget-arch-contract.js`** + `npm run verify:winget-arch` —
  ports the upstream `Architecture::from_url` delimiter algorithm from
  `winget-types`. Fails on a filename that stops resolving to its build
  architecture, two targets collapsing onto one architecture, a published set
  that is not exactly `{x64, arm64}`, a filename that stops matching
  `INSTALLERS_REGEX`, a stray asset that regex would select, a release tag
  disagreeing with the tagged `package.json`, a malformed or missing asset
  digest, duplicate asset names, or two installers sharing a digest. It emits the
  komac arguments, so the generation step cannot feed komac anything the contract
  did not check.

- **`test/winget-arch-contract.test.js`** — 77 tests. Workflow assertions run
  against a comment-stripped copy and bind flag **values**, not just flag names.

- **`docs/project/release-process.md`** — the four-entry target shape, why
  submission is staged, and the four stages.

## Why the filename is load-bearing

electron-builder emits a **32-bit x86 NSIS stub for both the x64 and the arm64
target** — verified against both published v0.14.0 assets. Any PE-header-based
detection labels both installers `x86`. komac resolves architecture from the URL
and lets that override binary analysis, so the `${arch}` token in
`build.win.artifactName` is the only correct architecture signal we publish, and
nothing previously stopped that template from changing.

## Scope limits, stated explicitly

- The gate checks komac's **input**, never its output. It cannot detect the
  shape-preservation problem above; that is stage 3.
- Distinct digests do not prove either binary is the architecture its name
  claims. Swapping the two files passes every check here, and generated-YAML
  validation alone would still pass. Before submission, stage 3 must extract
  each installer and verify the architecture of its packaged application and
  native inventory rather than the x86 NSIS stub.
- `actions/*@v4` are mutable tags. Acceptable while the job token is
  `contents: read` and no secret is referenced — both locked by tests — and must
  be resolved to commit SHAs before stage 4 adds a PAT.

## Verification

- 77 targeted tests pass. Adversarial mutations were caught, including every
  workflow edit that previously survived (`--require-architectures ""`,
  `--version "9.9.9"`, `--dry-run=false`, a job-level `permissions: write-all`).
- Full suite: 7609 tests, 7584 pass, 1 fail, 24 skipped. The failure is
  `state-session-snapshot.test.js` asserting a Windows path basename on macOS; it
  fails identically on `main`.
- Not yet run on a GitHub-hosted runner — that is the point of merging stage 1.

Closes nothing on its own; #860 tracks the remaining stages.
