### PR TITLE
fix(quota-ring): 读数跟着告警走 + 闪回，图标按素材占比缩放

### DIFF
--- a/src/preload-quota-ring.js
+++ b/src/preload-quota-ring.js
@@ -4,6 +4,7 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 const snapshotListeners = new Set();
 const langListeners = new Set();
+const visibilityListeners = new Set();
 
 ipcRenderer.on("quota-ring:snapshot", (_event, payload) => {
   for (const cb of snapshotListeners) {
@@ -14,6 +15,15 @@ ipcRenderer.on("quota-ring:snapshot", (_event, payload) => {
 ipcRenderer.on("quota-ring:lang-change", (_event, payload) => {
   for (const cb of langListeners) {
     try { cb(payload); } catch (err) { console.warn("quota ring lang listener threw:", err); }
+  }
+});
+
+// The renderer cannot detect this itself: an Electron window that is hidden
+// does not reliably flip document.visibilityState, and a pinned cluster never
+// hides at all.
+ipcRenderer.on("quota-ring:visibility", (_event, visible) => {
+  for (const cb of visibilityListeners) {
+    try { cb(visible); } catch (err) { console.warn("quota ring visibility listener threw:", err); }
   }
 });
 
@@ -31,5 +41,10 @@ contextBridge.exposeInMainWorld("quotaRingAPI", {
     if (typeof cb !== "function") return () => {};
     langListeners.add(cb);
     return () => langListeners.delete(cb);
+  },
+  onVisibility: (cb) => {
+    if (typeof cb !== "function") return () => {};
+    visibilityListeners.add(cb);
+    return () => visibilityListeners.delete(cb);
   },
 });

--- a/src/quota-ring-renderer.js
+++ b/src/quota-ring-renderer.js
@@ -79,10 +79,18 @@ const GLYPH_ZOOM = 1.35;
 // HUD and Dashboard surfaces; a coin already puts them on a light plate, so
 // here it is pure cost. test/session-hud-style.test.js pins this mapping
 // against the exporter's own manifest so a new provider cannot miss it.
+// Tiled marks get a little breathing room rather than a flush fit. Filling the
+// hole exactly (64/40) is geometrically "equal" to the plain marks but not
+// visually: OpenAI's six-blade spiral has thin interlocking strokes, and at the
+// coin's ~10.6px glyph circle its stroke gaps fall under a pixel and antialias
+// into a grey smudge. Claude's starburst survives flush because it is radial,
+// thick, and mostly empty. So 40 units of artwork are laid out at 90% of the
+// hole — 40 / 0.9 = 44.4 — which still pushes the plate past the clip (the
+// frame stays gone) without crowding the strokes.
 const GLYPH_ZOOM_BY_PROVIDER = {
   antigravityQuota: 64 / 56,
   claudeQuota: 64 / 56,
-  codexQuota: 64 / 40,
+  codexQuota: 64 / 44.4,
 };
 let coinClipSeq = 0;
 

--- a/src/quota-ring-renderer.js
+++ b/src/quota-ring-renderer.js
@@ -244,14 +244,18 @@ function buildCoinModel(source, def, now, multiSource) {
     providerKey: def.key,
     label: def.label,
     host: visibleHost || source.host || null,
+    // Stable identity from the store, distinct from the display label: two
+    // trusted remote profiles may share one host string, so anything keyed per
+    // source has to use this instead.
+    sourceKey: source.sourceKey === undefined ? null : source.sourceKey,
     sourceMarker: visibleHost,
     glyphUrl: payload.quotaAgentIcons && payload.quotaAgentIcons[def.key],
     windows,
     binding,
     displayWindow,
-    // Kept so the row can show the rolling number as a subline when the alert
-    // borrowed the headline — the reason to yield was that the two disagreed,
-    // and dropping the quiet one entirely trades one blind spot for another.
+    // Kept so the flashback can hand the readout back to the rolling number at
+    // the moments it is asked about — yielding the headline was right, but
+    // dropping the quiet number entirely trades one blind spot for another.
     restingWindow,
     state,
     near: !!near,
@@ -443,12 +447,17 @@ function buildOverflow(count) {
 // includes a window reset (70% -> 1%), which is exactly the kind of change
 // worth surfacing.
 const FLASH_MS = 1600;
-const flashState = new Map(); // coin key -> { lastPct, pending, until }
+const flashState = new Map(); // coin key -> { lastPct, dirty, until }
 let ringVisible = true; // main process tells us; assume visible until told
 let flashTimer = null;
 
+// Keyed on the store's sourceKey, never on `host`: host is a display label and
+// two trusted remote profiles are explicitly allowed to share one, which would
+// otherwise fuse their coins into a single state entry — each overwriting the
+// other's lastPct and manufacturing a change on every snapshot. JSON so no
+// separator can appear inside a component.
 function coinKey(model) {
-  return `${model.providerKey} ${model.host || ""}`;
+  return JSON.stringify([model.providerKey, model.sourceKey ?? null]);
 }
 
 // A coin only has something to flash back TO when the alert took the headline
@@ -462,9 +471,11 @@ function flashCandidate(model) {
 }
 
 function armFlash(entry, now) {
-  entry.pending = false;
+  entry.dirty = false;
   // Do not restart a flash already running: with several runs back to back the
-  // readout would otherwise sit on the rolling number indefinitely.
+  // readout would otherwise sit on the rolling number indefinitely and the
+  // alert would never get its headline back. (A newer value still paints
+  // immediately — the snapshot repaints — it just does not extend the window.)
   if (!(entry.until > now)) entry.until = now + FLASH_MS;
 }
 
@@ -478,23 +489,27 @@ function noteRestingWindows(coins, now) {
     seen.add(key);
     const resting = model.restingWindow;
     const pct = resting && !resting.reset ? resting.pct : null;
-    let entry = flashState.get(key);
+    const entry = flashState.get(key);
     if (!entry) {
       // First sighting establishes the baseline; a fresh window (or a rebuilt
       // one after the panel was destroyed) should not flash on arrival.
-      flashState.set(key, { lastPct: pct, pending: false, until: 0 });
+      flashState.set(key, { lastPct: pct, dirty: false, until: 0 });
       continue;
     }
-    if (pct !== entry.lastPct) {
-      entry.lastPct = pct;
-      if (flashCandidate(model)) {
-        // Hidden clusters bank the change instead of burning it: the flash is
-        // for whoever summons the ring next, and playing it to an empty screen
-        // would spend it on nobody.
-        if (ringVisible) armFlash(entry, now);
-        else entry.pending = true;
-      }
-    }
+    if (pct === entry.lastPct) continue;
+    entry.lastPct = pct;
+    // Record the movement itself, independently of whether an alert happens to
+    // hold the headline right now. Gating this on flashCandidate() lost the
+    // ordinary case: rolling moves while hidden and healthy, THEN the weekly
+    // window crosses the threshold — by the time anyone looks, the rolling
+    // number has changed unseen and nothing remembers it.
+    entry.dirty = true;
+    if (!ringVisible) continue;
+    // Visible: either play it now, or note that it is already on screen — the
+    // readout IS the rolling window when no alert took it, so there is nothing
+    // left to replay later.
+    if (flashCandidate(model)) armFlash(entry, now);
+    else entry.dirty = false;
   }
   for (const key of [...flashState.keys()]) if (!seen.has(key)) flashState.delete(key);
 }
@@ -510,20 +525,38 @@ function armPendingFlashes(coins, now) {
   let armed = false;
   for (const model of coins) {
     const entry = flashState.get(coinKey(model));
-    if (entry && entry.pending && flashCandidate(model)) {
+    if (!entry || !entry.dirty) continue;
+    if (flashCandidate(model)) {
       armFlash(entry, now);
       armed = true;
+    } else {
+      // No alert holds the headline any more, so the rolling number is already
+      // what the reader sees. Clear the debt rather than keeping it — otherwise
+      // the next alert would open with a replay of a change the reader has
+      // been looking at the whole time.
+      entry.dirty = false;
     }
   }
   return armed;
 }
 
-function scheduleFlashEnd() {
+// Fire at the EARLIEST pending expiry, not a fixed FLASH_MS from now: a second
+// coin flashing later would otherwise push the timer out and leave the first
+// one's handback to the 1s tick, stretching a 1.6s flash toward 2.6s.
+function scheduleFlashEnd(now) {
+  let earliest = Infinity;
+  for (const entry of flashState.values()) {
+    if (entry.until > now && entry.until < earliest) earliest = entry.until;
+  }
   if (flashTimer) clearTimeout(flashTimer);
+  flashTimer = null;
+  if (!Number.isFinite(earliest)) return;
   flashTimer = setTimeout(() => {
     flashTimer = null;
     render();
-  }, FLASH_MS + 30);
+    // Another coin may still be mid-flash with a later expiry.
+    scheduleFlashEnd(Date.now());
+  }, Math.max(0, earliest - now) + 30);
 }
 
 // Digest of everything time flips WITHOUT a new snapshot (bucket expiry, source
@@ -542,8 +575,9 @@ function fingerprint(now) {
         : 0;
       return `${w.ring}:${w.field}:${w.pct}:${w.reset ? 1 : 0}:${resetIn}:${w.stale ? 1 : 0}:${staleAge}`;
     }).join(",");
-    // Include the flash so the 1s tick repaints when one expires, even if the
-    // precise timer was lost (panel destroyed and rebuilt mid-flash).
+    // Include the flash so the 1s tick can repaint when one expires, as a
+    // backstop for the precise timer. (It cannot recover a panel that was
+    // destroyed and rebuilt mid-flash — that takes the whole Map with it.)
     return `${m.providerKey}:${m.host || ""}:${m.state}:${isFlashing(m, now) ? 1 : 0}:${windows}`;
   }).join("|");
   return `${quotaDisplayMode()}|${digest}`;
@@ -590,7 +624,7 @@ async function init() {
     const now = Date.now();
     const coins = collectCoins(now);
     noteRestingWindows(coins, now);
-    if (coins.some((model) => isFlashing(model, now))) scheduleFlashEnd();
+    if (coins.some((model) => isFlashing(model, now))) scheduleFlashEnd(now);
     render();
   });
 
@@ -604,7 +638,7 @@ async function init() {
       if (!ringVisible || wasVisible) return;
       const now = Date.now();
       if (!armPendingFlashes(collectCoins(now), now)) return;
-      scheduleFlashEnd();
+      scheduleFlashEnd(now);
       render();
     });
   }

--- a/src/quota-ring-renderer.js
+++ b/src/quota-ring-renderer.js
@@ -249,6 +249,10 @@ function buildCoinModel(source, def, now, multiSource) {
     windows,
     binding,
     displayWindow,
+    // Kept so the row can show the rolling number as a subline when the alert
+    // borrowed the headline — the reason to yield was that the two disagreed,
+    // and dropping the quiet one entirely trades one blind spot for another.
+    restingWindow,
     state,
     near: !!near,
   };
@@ -389,12 +393,16 @@ function buildCoinRow(model) {
   pct.className = "pct";
   const win = document.createElement("span");
   win.className = "win";
-  if (model.displayWindow && model.displayWindow.reset) {
+  // During a flashback the rolling window borrows the readout back. The rings
+  // never change — only which window the digits are reporting — so the alert
+  // stays on screen the whole time.
+  const shown = model.flashingResting ? model.restingWindow : model.displayWindow;
+  if (shown && shown.reset) {
     pct.textContent = quotaDisplayMode() === "remaining" ? "100%" : "0%";
     win.textContent = t("quotaRingReset");
-  } else if (model.displayWindow) {
-    pct.textContent = `${Math.round(quotaDisplayPercent(model.displayWindow.pct))}%`;
-    win.textContent = model.displayWindow.label;
+  } else if (shown) {
+    pct.textContent = `${Math.round(quotaDisplayPercent(shown.pct))}%`;
+    win.textContent = shown.label;
   } else {
     pct.textContent = "—";
     win.textContent = model.windows[0] ? model.windows[0].label : "";
@@ -419,6 +427,105 @@ function buildOverflow(count) {
   return el;
 }
 
+// ── Rolling-window flashback ──
+//
+// When an alert borrows the headline, the rolling number vanishes — but "what
+// did that last run cost me?" is still the question the ring gets opened for.
+// Rather than cycling the two forever (permanent motion in the corner of the
+// eye, and a glance can land on the wrong half), the rolling number is shown
+// only at the moments it is actually being asked about:
+//
+//   - the cluster becomes visible and the rolling number moved since it was
+//     last on screen — i.e. you summoned it right after using some quota;
+//   - it is pinned, and the rolling number moves under you.
+//
+// Both are events, not a timer: an idle desktop never animates. Movement
+// includes a window reset (70% -> 1%), which is exactly the kind of change
+// worth surfacing.
+const FLASH_MS = 1600;
+const flashState = new Map(); // coin key -> { lastPct, pending, until }
+let ringVisible = true; // main process tells us; assume visible until told
+let flashTimer = null;
+
+function coinKey(model) {
+  return `${model.providerKey} ${model.host || ""}`;
+}
+
+// A coin only has something to flash back TO when the alert took the headline
+// from a different window.
+function flashCandidate(model) {
+  return model.restingWindow
+    && model.displayWindow
+    && model.restingWindow !== model.displayWindow
+    ? model.restingWindow
+    : null;
+}
+
+function armFlash(entry, now) {
+  entry.pending = false;
+  // Do not restart a flash already running: with several runs back to back the
+  // readout would otherwise sit on the rolling number indefinitely.
+  if (!(entry.until > now)) entry.until = now + FLASH_MS;
+}
+
+// Fold the current snapshot into the flash state. Called only where the
+// snapshot is actually consumed — never from fingerprint(), which runs every
+// tick and must stay free of side effects.
+function noteRestingWindows(coins, now) {
+  const seen = new Set();
+  for (const model of coins) {
+    const key = coinKey(model);
+    seen.add(key);
+    const resting = model.restingWindow;
+    const pct = resting && !resting.reset ? resting.pct : null;
+    let entry = flashState.get(key);
+    if (!entry) {
+      // First sighting establishes the baseline; a fresh window (or a rebuilt
+      // one after the panel was destroyed) should not flash on arrival.
+      flashState.set(key, { lastPct: pct, pending: false, until: 0 });
+      continue;
+    }
+    if (pct !== entry.lastPct) {
+      entry.lastPct = pct;
+      if (flashCandidate(model)) {
+        // Hidden clusters bank the change instead of burning it: the flash is
+        // for whoever summons the ring next, and playing it to an empty screen
+        // would spend it on nobody.
+        if (ringVisible) armFlash(entry, now);
+        else entry.pending = true;
+      }
+    }
+  }
+  for (const key of [...flashState.keys()]) if (!seen.has(key)) flashState.delete(key);
+}
+
+function isFlashing(model, now) {
+  const entry = flashState.get(coinKey(model));
+  return !!(entry && entry.until > now && flashCandidate(model));
+}
+
+// Release whatever was banked while the cluster was hidden. Returns whether
+// anything actually fired, so the caller can skip a repaint.
+function armPendingFlashes(coins, now) {
+  let armed = false;
+  for (const model of coins) {
+    const entry = flashState.get(coinKey(model));
+    if (entry && entry.pending && flashCandidate(model)) {
+      armFlash(entry, now);
+      armed = true;
+    }
+  }
+  return armed;
+}
+
+function scheduleFlashEnd() {
+  if (flashTimer) clearTimeout(flashTimer);
+  flashTimer = setTimeout(() => {
+    flashTimer = null;
+    render();
+  }, FLASH_MS + 30);
+}
+
 // Digest of everything time flips WITHOUT a new snapshot (bucket expiry, source
 // staleness), so the 1s tick can re-render on change even for a pinned cluster
 // receiving no snapshots.
@@ -435,7 +542,9 @@ function fingerprint(now) {
         : 0;
       return `${w.ring}:${w.field}:${w.pct}:${w.reset ? 1 : 0}:${resetIn}:${w.stale ? 1 : 0}:${staleAge}`;
     }).join(",");
-    return `${m.providerKey}:${m.host || ""}:${m.state}:${windows}`;
+    // Include the flash so the 1s tick repaints when one expires, even if the
+    // precise timer was lost (panel destroyed and rebuilt mid-flash).
+    return `${m.providerKey}:${m.host || ""}:${m.state}:${isFlashing(m, now) ? 1 : 0}:${windows}`;
   }).join("|");
   return `${quotaDisplayMode()}|${digest}`;
 }
@@ -452,7 +561,10 @@ function render() {
   const visible = coins.slice(0, MAX_COINS);
   const overflow = coins.length - visible.length;
 
-  for (const model of visible) clusterEl.appendChild(buildCoinRow(model));
+  for (const model of visible) {
+    model.flashingResting = isFlashing(model, now);
+    clusterEl.appendChild(buildCoinRow(model));
+  }
   if (overflow > 0) clusterEl.appendChild(buildOverflow(overflow));
 }
 
@@ -475,11 +587,33 @@ async function init() {
       translations: payload.translations,
       lang: payload.lang,
     };
+    const now = Date.now();
+    const coins = collectCoins(now);
+    noteRestingWindows(coins, now);
+    if (coins.some((model) => isFlashing(model, now))) scheduleFlashEnd();
     render();
   });
 
+  // Visibility comes from the main process rather than the Page Visibility API:
+  // an Electron window that is merely hidden does not reliably flip
+  // document.visibilityState, and a pinned cluster never hides at all.
+  if (typeof window.quotaRingAPI.onVisibility === "function") {
+    window.quotaRingAPI.onVisibility((visible) => {
+      const wasVisible = ringVisible;
+      ringVisible = visible !== false;
+      if (!ringVisible || wasVisible) return;
+      const now = Date.now();
+      if (!armPendingFlashes(collectCoins(now), now)) return;
+      scheduleFlashEnd();
+      render();
+    });
+  }
+
   const i18n = await window.quotaRingAPI.getI18n();
   if (i18n) payload = { ...payload, translations: i18n.translations || {}, lang: i18n.lang };
+  // Establish the baseline before the first paint so a cold start never opens
+  // on a flashback.
+  noteRestingWindows(collectCoins(Date.now()), Date.now());
   render();
   setInterval(tick, 1000);
 }

--- a/src/quota-ring-renderer.js
+++ b/src/quota-ring-renderer.js
@@ -62,14 +62,28 @@ const INNER_C = 2 * Math.PI * INNER_R;
 // (avatar mask) and oversize past the clip so the mark fills the circle instead
 // of floating small inside the PNG's whitespace.
 const GLYPH_ZOOM = 1.35;
-// Per-provider override. The exporter already fits every glyph inside a 56x56
-// safe area on a 64x64 canvas, so 1.35 crops a second time on top of that —
-// tolerable for marks that carry their own slack, fatal for a radial one whose
-// arms end at the safe-area edge. Claude's starburst loses 17.9% of its ink at
-// 1.35 and 1.5% at 64/56, which is exactly the "circular clip lops the corners"
-// problem the icon swap set out to fix. Left at 1.35 elsewhere: those glyphs
-// have uneven padding and 1.35 is what makes them fill the hole.
-const GLYPH_ZOOM_BY_PROVIDER = { claudeQuota: 64 / 56 };
+// Per-provider override, because the exporter does not give every glyph the
+// same share of its canvas (see scripts/export-agent-icons.js):
+//
+//   plain marks           artwork fills 56 of 64  -> zoom 64/56
+//   contrast-tile marks   artwork fills 40 of 64, inside a 56px light plate
+//                         -> zoom 64/40
+//
+// A single 1.35 for both is what made the Codex mark look 29% smaller than
+// Claude's and wear a visible frame: 1.35 shows the middle 47 units, so a
+// 40-unit mark floats with 7 units of its plate still in frame. Zooming to
+// 64/40 fills the hole with the mark itself and pushes the plate past the clip,
+// which is also why the frame disappears — and the plate (#f4f4f4) is within a
+// couple of levels of the coin's own plate (#f6f6f8), so nothing shows at the
+// seam. The tile exists so these black-on-transparent marks survive the dark
+// HUD and Dashboard surfaces; a coin already puts them on a light plate, so
+// here it is pure cost. test/session-hud-style.test.js pins this mapping
+// against the exporter's own manifest so a new provider cannot miss it.
+const GLYPH_ZOOM_BY_PROVIDER = {
+  antigravityQuota: 64 / 56,
+  claudeQuota: 64 / 56,
+  codexQuota: 64 / 40,
+};
 let coinClipSeq = 0;
 
 let payload = {

--- a/src/quota-ring-renderer.js
+++ b/src/quota-ring-renderer.js
@@ -103,11 +103,16 @@ function formatWindowLabel(windowMinutes, fallbackLabel) {
   return `${Math.round(minutes)}m`;
 }
 
+// One definition of the thresholds: the ring's color, the pulse, and whether
+// the readout yields to the binding window all key off the same two numbers.
+const WARN_AT = 60; // >= this is amber
+const HOT_AT = 85; // > this is red (and pulses)
+
 function severityClass(usedPercent) {
   const p = Number(usedPercent);
   if (!Number.isFinite(p)) return "sev-ok";
-  if (p > 85) return "sev-hot";
-  if (p >= 60) return "sev-warn";
+  if (p > HOT_AT) return "sev-hot";
+  if (p >= WARN_AT) return "sev-warn";
   return "sev-ok";
 }
 
@@ -210,17 +215,27 @@ function buildCoinModel(source, def, now, multiSource) {
   for (const w of bindingCandidates) {
     if (!binding || w.pct > binding.pct) binding = w;
   }
-  // The compact readout answers the common "what is my rolling-window
-  // usage?" question. Keep it independent from binding: the weekly window
-  // can still own warning/pulse when it is more constrained. Prefer the
-  // rolling window while it is fresh, but never present an old rolling
-  // number as live when the weekly window has a newer confirmation.
-  const displayWindow = (outer && !outer.stale)
+  // The compact readout answers the common "what is my rolling-window usage?"
+  // question, so it prefers the rolling window while that is fresh — never
+  // presenting an old rolling number as live when the weekly window has a
+  // newer confirmation.
+  //
+  // But it yields to the binding window once that crosses a warning threshold.
+  // Otherwise the number and the alert describe different windows: 30% rolling
+  // over 90% weekly printed "30% 5h" — the most reassuring reading available —
+  // while the only thing reporting trouble was the inner ring's color. That
+  // left color as the sole carrier of the alert, which fails anyone with a
+  // color-vision deficiency, fails a glance that reads the digits, and (in the
+  // 60-85 band, where nothing pulses) has no other channel at all.
+  const restingWindow = (outer && !outer.stale)
     ? outer
     : ((inner && !inner.stale) ? inner : (outer || inner));
+  const displayWindow = (binding && binding.pct >= WARN_AT && binding !== restingWindow)
+    ? binding
+    : restingWindow;
   const stale = windows.every((w) => w.stale);
   const state = allReset ? "reset" : (stale ? "stale" : "live");
-  const near = state === "live" && binding && binding.pct > 85;
+  const near = state === "live" && binding && binding.pct > HOT_AT;
 
   const visibleHost = multiSource
     ? (source.host || t("dashboardQuotaSourceLocal"))

--- a/src/quota-ring.html
+++ b/src/quota-ring.html
@@ -29,15 +29,15 @@
    What hue does NOT carry: which quota family an Antigravity ring picked
    (Gemini vs third-party — the readout prefix says that).
 
-   Where color IS currently the sole carrier, stated plainly rather than wished
+   Where color IS still the sole carrier, stated plainly rather than wished
    away, because CVD flattens these six hues toward one axis:
-   - An INNER ring in warning. The readout follows displayWindow (outer first)
-     while the alert follows binding (the most-constrained window), so inner 90%
-     / outer 30% prints "30% 5h" and the red inner ring is the only signal.
    - Anything in the 60-85% band, which does not pulse at all.
    - Any alert under prefers-reduced-motion, which drops the pulse too.
-   The fix for the first one is to print binding's number once it crosses a
-   threshold, not to add more motion; tracked separately from this palette. */
+   - The ~1.6s of a flashback, while the digits are reporting the rolling
+     window instead of the alerting one.
+   The readout itself is no longer in that list: it hands its headline to the
+   most-constrained window once that crosses a threshold, so the digits and the
+   rings now name the same window. */
 :root {
   --sev-warn: #fbbf24;
   --sev-hot: #f87171;
@@ -61,9 +61,10 @@
   --track-alpha: 0.14;
   --track-alpha-reset: 0.2;
   /* Bed for a ring that somehow carries no identity class. Not reachable today
-     (buildCoinSvg always tags both tracks) and NOT a fallback for an invalid
-     color-mix — an invalid value resolves to `unset`, not to a lower-specificity
-     rule. The color-mix below carries its own var() fallback for that. */
+     (buildCoinSvg always tags both tracks). It is NOT a safety net for a bad
+     value further down either — an invalid declaration resolves to `unset`, not
+     to a lower-specificity rule — which is why the track rule splits hue and
+     alpha across two properties instead of relying on this. */
   --ring-track: rgba(140, 142, 152, 0.16);
   /* Healthy identity pairs: outer (rolling) → inner (weekly).
      Adding a provider to RING_PROVIDERS means adding a pair HERE too; the

--- a/src/quota-ring.html
+++ b/src/quota-ring.html
@@ -211,7 +211,11 @@ body { padding: 6px 6px 8px; }
 .coin .fill.sev-hot { stroke: var(--sev-hot); }
 .coin .fill.sev-reset { stroke: var(--sev-reset); opacity: 0.56; }
 .coin .plate { fill: rgba(246, 246, 248, 0.92); }
-.coin-row.is-stale .glyph { filter: grayscale(1); opacity: 0.8; }
+/* Staleness is carried by the row's own opacity above, not by desaturating the
+   glyph on top of it. Greyscale was doing uneven work anyway: it gutted the
+   colored marks (Claude, Antigravity) while doing nothing at all to a mark that
+   is already black and white (Codex), so the same state read as a much louder
+   warning on some coins than on others. */
 .coin-row.is-reset .glyph { opacity: 0.55; }
 
 /* Near-exhausted (hot) coin pulses gently to pull the eye; motion-safe only. */

--- a/src/session-hud.js
+++ b/src/session-hud.js
@@ -719,8 +719,12 @@ module.exports = function initSessionHud(ctx) {
   }
 
   function hideQuotaRing() {
-    if (ringWindow && !ringWindow.isDestroyed() && ringWindow.isVisible()) {
-      sendRingVisibility(false);
+    if (ringWindow && !ringWindow.isDestroyed()) {
+      // Only the notification is conditional. hide() stays unconditional and
+      // idempotent: isVisible() can report false while the window is merely
+      // occluded (app hidden on macOS, another Space, parent state), and
+      // skipping the real hide there would let the system surface it again.
+      if (ringWindow.isVisible()) sendRingVisibility(false);
       ringWindow.hide();
     }
     scheduleHiddenDestroy("ring");

--- a/src/session-hud.js
+++ b/src/session-hud.js
@@ -693,6 +693,10 @@ module.exports = function initSessionHud(ctx) {
       ringDidFinishLoad = true;
       applyZoomToWindow(ringWindow, getTextScale());
       sendI18n();
+      // Correct the renderer's optimistic default before any snapshot lands:
+      // the window is created hidden, and a flashback armed while nobody can
+      // see it would be spent on an empty screen.
+      sendRingVisibility(ringWindow.isVisible());
       syncSessionHud();
     });
     ringWindow.on("closed", () => {
@@ -704,8 +708,21 @@ module.exports = function initSessionHud(ctx) {
     return ringWindow;
   }
 
+  // The renderer replays the rolling-window number when the cluster appears
+  // after that number moved, so it needs the appear/disappear edges — which it
+  // cannot observe itself (a hidden Electron window does not reliably flip
+  // document.visibilityState, and a pinned cluster never hides).
+  function sendRingVisibility(visible) {
+    if (!ringWindow || ringWindow.isDestroyed() || !ringDidFinishLoad) return;
+    if (!ringWindow.webContents || ringWindow.webContents.isDestroyed()) return;
+    ringWindow.webContents.send("quota-ring:visibility", visible);
+  }
+
   function hideQuotaRing() {
-    if (ringWindow && !ringWindow.isDestroyed()) ringWindow.hide();
+    if (ringWindow && !ringWindow.isDestroyed() && ringWindow.isVisible()) {
+      sendRingVisibility(false);
+      ringWindow.hide();
+    }
     scheduleHiddenDestroy("ring");
   }
 
@@ -717,6 +734,7 @@ module.exports = function initSessionHud(ctx) {
       keepOutOfTaskbar(win);
       if (isMac) deferMacFloatingVisibility(ctx, win);
       else if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
+      sendRingVisibility(true);
     }
   }
 

--- a/src/state-account-quota.js
+++ b/src/state-account-quota.js
@@ -423,8 +423,13 @@ function createAccountQuotaStore(options = {}) {
     // Merge arbitration uses exact receive time, while snapshots expose only
     // minute-quantized stamps to avoid a broadcast on every statusline tick.
     const rawSeenByBucket = new WeakMap();
-    for (const record of sources.values()) {
-      const entry = { host: record.host };
+    for (const [sourceKey, record] of sources) {
+      // sourceKey, not host: `host` is a DISPLAY label and two trusted remote
+      // profiles are explicitly allowed to share one (see the "keeps trusted
+      // remote profile sources separate when display hosts match" test). Any
+      // renderer that keys per-source state off the label would collapse those
+      // two sources into one.
+      const entry = { sourceKey, host: record.host };
       let hasAny = false;
       for (const providerKey of QUOTA_PROVIDER_KEYS) {
         const stored = record[providerKey];
@@ -450,7 +455,8 @@ function createAccountQuotaStore(options = {}) {
     });
     if (options.mergeSources !== true || out.length <= 1) return out;
 
-    const merged = { host: null };
+    // The merged view is a single synthetic source; nothing can collide with it.
+    const merged = { sourceKey: null, host: null };
     let hasAny = false;
     for (const providerKey of QUOTA_PROVIDER_KEYS) {
       const providerCandidates = out

--- a/test/quota-ring-renderer.test.js
+++ b/test/quota-ring-renderer.test.js
@@ -611,3 +611,117 @@ describe("quota ring rolling-window flashback", () => {
     assert.strictEqual(flash.readout(NOW + 10 + FLASH_MS + 1).flashing, false);
   });
 });
+
+// Regressions found by review, each of which the suite above sailed past.
+describe("quota ring flashback — identity and bookkeeping", () => {
+  const NOW = 1_000_000;
+  const FLASH_MS = 1600;
+
+  const twoProfiles = (fiveA, fiveB, now) => [
+    {
+      // Two trusted remote profiles are explicitly allowed to share one display
+      // host (state-account-quota keeps them separate by sourceKey), so keying
+      // per-coin state on `host` fuses them into a single entry.
+      sourceKey: "remote:profile-a",
+      host: "shared.example",
+      claudeQuota: {
+        lastSeenAt: now,
+        group: {
+          claudeFiveHour: { usedPercent: fiveA, resetAt: now + 3_600_000, windowMinutes: 300, lastSeenAt: now },
+          claudeWeekly: { usedPercent: 61, resetAt: now + 3_600_000, windowMinutes: 10080, lastSeenAt: now },
+        },
+      },
+    },
+    {
+      sourceKey: "remote:profile-b",
+      host: "shared.example",
+      claudeQuota: {
+        lastSeenAt: now,
+        group: {
+          claudeFiveHour: { usedPercent: fiveB, resetAt: now + 3_600_000, windowMinutes: 300, lastSeenAt: now },
+          claudeWeekly: { usedPercent: 61, resetAt: now + 3_600_000, windowMinutes: 10080, lastSeenAt: now },
+        },
+      },
+    },
+  ];
+
+  it("keeps per-source state apart when two sources share a display host", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(true);
+    flash.push(twoProfiles(1, 10, NOW), NOW);
+    // Identical follow-up: nothing moved, so nothing may flash. Sharing one
+    // entry would make the two coins overwrite each other's lastPct and
+    // manufacture a change on every single snapshot.
+    flash.push(twoProfiles(1, 10, NOW), NOW + 10);
+    const flags = vm.runInContext(
+      "collectCoins(__now).map((m) => isFlashing(m, __now))",
+      Object.assign(context, { __now: NOW + 10 })
+    );
+    assert.deepStrictEqual([...flags], [false, false]);
+  });
+
+  it("replays a change that happened while hidden and healthy, before any alert existed", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(false);
+    // Hidden, weekly still healthy: no alert holds the headline yet.
+    flash.push(claudeSource(1, 30, NOW), NOW);
+    flash.push(claudeSource(4, 30, NOW), NOW + 10);
+    // Only now does the weekly window cross the threshold. The rolling number
+    // moved unseen; recording it must not have depended on an alert being up
+    // at that instant.
+    flash.push(claudeSource(4, 61, NOW), NOW + 20);
+    flash.setVisible(true);
+    assert.strictEqual(flash.reveal(NOW + 5000), true);
+    assert.deepStrictEqual(flash.readout(NOW + 5000), { pct: "4%", win: "5h", flashing: true });
+  });
+
+  it("drops the debt when the rolling number is already on screen at reveal", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(false);
+    flash.push(claudeSource(1, 61, NOW), NOW);
+    flash.push(claudeSource(4, 61, NOW), NOW + 10);
+    // The alert clears before anyone looks, so the readout is the rolling
+    // number again and the reader sees the new value directly.
+    flash.push(claudeSource(4, 30, NOW), NOW + 20);
+    flash.setVisible(true);
+    assert.strictEqual(flash.reveal(NOW + 5000), false);
+    // The debt has to be settled at that reveal, not merely left unplayed:
+    // hide again, let a new alert take the headline without the rolling number
+    // moving, and a stale debt would surface as a replay of something the
+    // reader already spent time looking at.
+    flash.setVisible(false);
+    flash.push(claudeSource(4, 61, NOW), NOW + 6000);
+    flash.setVisible(true);
+    assert.strictEqual(flash.reveal(NOW + 7000), false);
+    assert.deepStrictEqual(flash.readout(NOW + 7000), { pct: "61%", win: "7d", flashing: false });
+  });
+
+  it("hands over at exactly the warning threshold", () => {
+    // 59 and 61 both pass whether the comparison is >= or >; 60 is the value
+    // that pins it.
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(true);
+    flash.push(claudeSource(1, 60, NOW), NOW);
+    assert.deepStrictEqual(flash.readout(NOW), { pct: "60%", win: "7d", flashing: false });
+  });
+
+  it("ends each coin's flash on time when another starts later", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(true);
+    flash.push(twoProfiles(1, 1, NOW), NOW);
+    flash.push(twoProfiles(4, 1, NOW), NOW + 10);      // coin A flashes
+    flash.push(twoProfiles(4, 7, NOW), NOW + 900);     // coin B flashes later
+    const at = NOW + 10 + FLASH_MS + 1;
+    const flags = vm.runInContext(
+      "collectCoins(__now).map((m) => isFlashing(m, __now))",
+      Object.assign(context, { __now: at })
+    );
+    // A is done on its own schedule; B is still mid-flash.
+    assert.deepStrictEqual([...flags], [false, true]);
+  });
+});

--- a/test/quota-ring-renderer.test.js
+++ b/test/quota-ring-renderer.test.js
@@ -91,6 +91,55 @@ function loadRenderer() {
   return context;
 }
 
+// Drives the flashback state machine the way the real callbacks do: push a
+// snapshot, fold it in, then ask what the readout would print.
+function flashHarness(context) {
+  const run = (expr, vars = {}) => {
+    Object.assign(context, vars);
+    return vm.runInContext(expr, context);
+  };
+  return {
+    push(accountQuota, now) {
+      run("payload = { ...payload, accountQuota: __q };"
+        + " __coins = collectCoins(__now); noteRestingWindows(__coins, __now);",
+      { __q: accountQuota, __now: now });
+    },
+    setVisible(visible) {
+      run("ringVisible = __v", { __v: visible });
+    },
+    reveal(now) {
+      return run("armPendingFlashes(collectCoins(__now), __now)", { __now: now });
+    },
+    // What the coin's digits say at this instant. Rebuilt in this realm: an
+    // object returned straight out of the vm has a different Object prototype
+    // and deepStrictEqual compares prototypes.
+    readout(now) {
+      const out = run(`(() => {
+        const model = collectCoins(__now)[0];
+        model.flashingResting = isFlashing(model, __now);
+        const row = buildCoinRow(model);
+        return {
+          pct: row.children[0].children[0].textContent,
+          win: row.children[0].children[1].textContent,
+          flashing: model.flashingResting,
+        };
+      })()`, { __now: now });
+      return { pct: out.pct, win: out.win, flashing: out.flashing };
+    },
+  };
+}
+
+const claudeSource = (five, week, now) => [{
+  host: null,
+  claudeQuota: {
+    lastSeenAt: now,
+    group: {
+      claudeFiveHour: { usedPercent: five, resetAt: now + 3_600_000, windowMinutes: 300, lastSeenAt: now },
+      claudeWeekly: { usedPercent: week, resetAt: now + 3_600_000, windowMinutes: 10080, lastSeenAt: now },
+    },
+  },
+}];
+
 function modelFor(context, source, providerIndex, now, multiSource = false) {
   context.__source = source;
   context.__now = now;
@@ -466,5 +515,99 @@ describe("quota ring renderer model", () => {
     vm.runInContext("payload.accountQuota = __accountQuota", context);
     const coins = vm.runInContext("collectCoins(1000000)", context);
     assert.strictEqual(coins.length, 0);
+  });
+});
+
+// The readout hands its headline to whichever window is in trouble, which
+// leaves the rolling number invisible exactly when someone is most likely to
+// ask "what did that last run cost me?". Rather than cycling the two forever,
+// the rolling number is replayed at the moments it is actually being asked
+// about: the cluster appearing after it moved, or moving while pinned.
+describe("quota ring rolling-window flashback", () => {
+  const NOW = 1_000_000;
+  const FLASH_MS = 1600;
+
+  it("does not flash on the very first snapshot", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(true);
+    // 1% rolling under a 61% weekly: the alert already owns the headline, so a
+    // naive "value differs from nothing" check would fire on arrival.
+    flash.push(claudeSource(1, 61, NOW), NOW);
+    assert.deepStrictEqual(flash.readout(NOW), { pct: "61%", win: "7d", flashing: false });
+  });
+
+  it("replays the rolling number when it moves while the cluster is visible", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(true);
+    flash.push(claudeSource(1, 61, NOW), NOW);
+    flash.push(claudeSource(4, 61, NOW), NOW + 10);
+
+    assert.deepStrictEqual(flash.readout(NOW + 10), { pct: "4%", win: "5h", flashing: true });
+    // ...and hands the headline back on its own.
+    assert.deepStrictEqual(
+      flash.readout(NOW + 10 + FLASH_MS + 1),
+      { pct: "61%", win: "7d", flashing: false }
+    );
+  });
+
+  it("banks the change while hidden and spends it when the cluster appears", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(false);
+    flash.push(claudeSource(1, 61, NOW), NOW);
+    flash.push(claudeSource(4, 61, NOW), NOW + 10);
+    // Nothing plays to an empty screen.
+    assert.strictEqual(flash.readout(NOW + 10).flashing, false);
+
+    flash.setVisible(true);
+    assert.strictEqual(flash.reveal(NOW + 5000), true);
+    assert.deepStrictEqual(flash.readout(NOW + 5000), { pct: "4%", win: "5h", flashing: true });
+  });
+
+  it("spends a banked change only once", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(false);
+    flash.push(claudeSource(1, 61, NOW), NOW);
+    flash.push(claudeSource(4, 61, NOW), NOW + 10);
+    flash.setVisible(true);
+    flash.reveal(NOW + 5000);
+    // A second appearance with nothing new since should be quiet.
+    assert.strictEqual(flash.reveal(NOW + 5000 + FLASH_MS + 1), false);
+  });
+
+  it("stays quiet when the alert never took the headline", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(true);
+    // Weekly below the warning threshold: the readout is already the rolling
+    // window, so there is nothing to flash back to.
+    flash.push(claudeSource(1, 30, NOW), NOW);
+    flash.push(claudeSource(4, 30, NOW), NOW + 10);
+    assert.deepStrictEqual(flash.readout(NOW + 10), { pct: "4%", win: "5h", flashing: false });
+  });
+
+  it("treats a window reset as a change worth replaying", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(true);
+    flash.push(claudeSource(70, 61, NOW), NOW);
+    // 70% -> 1% is the rollover, and "the 5h window just came back" is exactly
+    // the kind of thing worth surfacing.
+    flash.push(claudeSource(1, 61, NOW), NOW + 10);
+    assert.deepStrictEqual(flash.readout(NOW + 10), { pct: "1%", win: "5h", flashing: true });
+  });
+
+  it("does not restart a flash already running", () => {
+    const context = loadRenderer();
+    const flash = flashHarness(context);
+    flash.setVisible(true);
+    flash.push(claudeSource(1, 61, NOW), NOW);
+    flash.push(claudeSource(4, 61, NOW), NOW + 10);
+    // Back-to-back runs must not pin the readout on the rolling number forever.
+    flash.push(claudeSource(7, 61, NOW), NOW + 900);
+    assert.strictEqual(flash.readout(NOW + 10 + FLASH_MS + 1).flashing, false);
   });
 });

--- a/test/quota-ring-renderer.test.js
+++ b/test/quota-ring-renderer.test.js
@@ -167,13 +167,62 @@ describe("quota ring renderer model", () => {
     assert.strictEqual(fills.length, 2);
     assert.doesNotMatch(fills[0].attributes.class, /is-near/);
     assert.match(fills[1].attributes.class, /sev-hot is-near/);
-    assert.strictEqual(model.displayWindow.field, "claudeFiveHour");
+    // The readout follows the alert instead of the rolling window here. Printing
+    // "20% 5h" over a 90% weekly ring was the most reassuring reading available
+    // while the only thing reporting trouble was the inner ring's color.
+    assert.strictEqual(model.displayWindow.field, "claudeWeekly");
     context.__model = model;
     context.__now = now;
     const row = vm.runInContext("buildCoinRow(__model, __now)", context);
     const readout = row.children[0];
-    assert.strictEqual(readout.children[0].textContent, "20%");
-    assert.strictEqual(readout.children[1].textContent, "5h");
+    assert.strictEqual(readout.children[0].textContent, "90%");
+    assert.strictEqual(readout.children[1].textContent, "7d");
+  });
+
+  it("keeps the rolling readout while the weekly window is merely busy", () => {
+    // The handover is scoped to alerts. Below the warning threshold the readout
+    // still answers "what am I using right now?", which is the common question;
+    // yielding on every higher number would bury the rolling window for good.
+    const context = loadRenderer();
+    const now = 1_000_000;
+    const model = modelFor(context, {
+      claudeQuota: {
+        group: {
+          claudeFiveHour: { usedPercent: 20, resetAt: now + 3_600_000, windowMinutes: 300 },
+          claudeWeekly: { usedPercent: 59, resetAt: now + 3_600_000, windowMinutes: 10080 },
+        },
+        lastSeenAt: now,
+      },
+    }, 1, now);
+    assert.strictEqual(model.binding.field, "claudeWeekly");
+    assert.strictEqual(model.displayWindow.field, "claudeFiveHour");
+    context.__model = model;
+    context.__now = now;
+    const row = vm.runInContext("buildCoinRow(__model, __now)", context);
+    assert.strictEqual(row.children[0].children[0].textContent, "20%");
+    assert.strictEqual(row.children[0].children[1].textContent, "5h");
+  });
+
+  it("hands the readout to an inner window that is merely in warning, not just critical", () => {
+    // The 60-85 band has no pulse at all, so without this the amber inner ring
+    // is the only signal — and the digits actively contradict it.
+    const context = loadRenderer();
+    const now = 1_000_000;
+    const model = modelFor(context, {
+      claudeQuota: {
+        group: {
+          claudeFiveHour: { usedPercent: 1, resetAt: now + 3_600_000, windowMinutes: 300 },
+          claudeWeekly: { usedPercent: 61, resetAt: now + 3_600_000, windowMinutes: 10080 },
+        },
+        lastSeenAt: now,
+      },
+    }, 1, now);
+    assert.strictEqual(model.displayWindow.field, "claudeWeekly");
+    context.__model = model;
+    context.__now = now;
+    const row = vm.runInContext("buildCoinRow(__model, __now)", context);
+    assert.strictEqual(row.children[0].children[0].textContent, "61%");
+    assert.strictEqual(row.children[0].children[1].textContent, "7d");
   });
 
   it("falls back to the weekly readout when the short window is absent", () => {

--- a/test/session-hud-style.test.js
+++ b/test/session-hud-style.test.js
@@ -249,3 +249,49 @@ describe("session HUD visual shell", () => {
     assert.match(sessionHudHtml, /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*\.unread-bell svg\s*\{[\s\S]*animation:\s*none;/);
   });
 });
+
+// The exporter gives a plain mark 56 of its 64px canvas but a contrast-tile
+// mark only 40 (the rest is the light plate that keeps a black-on-transparent
+// logo alive on dark HUD/Dashboard surfaces). A coin crops its glyph to a
+// circle, so one shared zoom makes tiled marks render visibly smaller and
+// framed. This pins the per-provider zoom against the exporter's own manifest,
+// so adding a ring provider cannot silently inherit the wrong one.
+describe("quota ring glyph zoom follows the exporter's artwork ratio", () => {
+  const manifest = JSON.parse(fs.readFileSync(
+    path.join(__dirname, "..", "assets", "source", "agent-icons", "source-manifest.json"), "utf8"
+  ));
+  const snapshotSource = fs.readFileSync(
+    path.join(__dirname, "..", "src", "state-session-snapshot.js"), "utf8"
+  );
+
+  it("zooms tiled marks to their artwork, not to the plate", () => {
+    // providerKey -> agent id, straight from the snapshot that feeds the ring.
+    const block = snapshotSource.match(/quotaAgentIcons: \(\(\) => \{[\s\S]*?\n    \}\)\(\)/);
+    assert.ok(block, "could not locate the quotaAgentIcons block");
+    const mapping = [...block[0].matchAll(/(\w+Quota):\s*iconFor\("([\w-]+)"\)/g)]
+      .map((m) => ({ providerKey: m[1], agentId: m[2] }));
+    assert.ok(mapping.length >= 3, `expected the ring providers, got ${JSON.stringify(mapping)}`);
+
+    const zoomBlock = quotaRingRenderer.match(/GLYPH_ZOOM_BY_PROVIDER = \{[\s\S]*?\}/);
+    assert.ok(zoomBlock, "no GLYPH_ZOOM_BY_PROVIDER");
+    const zooms = Object.fromEntries(
+      [...zoomBlock[0].matchAll(/(\w+Quota):\s*64\s*\/\s*(\d+)/g)].map((m) => [m[1], Number(m[2])])
+    );
+
+    // Only providers the ring actually draws; RING_PROVIDERS is the authority.
+    const drawn = new Set(
+      [...quotaRingRenderer.matchAll(/key:\s*"(\w+Quota)"/g)].map((m) => m[1])
+    );
+
+    for (const { providerKey, agentId } of mapping) {
+      if (!drawn.has(providerKey)) continue;
+      const tiled = !!(manifest.sources[agentId] || {}).contrastTreatment;
+      const expected = tiled ? 40 : 56;
+      assert.strictEqual(
+        zooms[providerKey], expected,
+        `${providerKey} (${agentId}) is ${tiled ? "" : "not "}contrast-tiled, so its glyph fills `
+        + `${expected} of 64 and the coin should zoom 64/${expected}`
+      );
+    }
+  });
+});

--- a/test/session-hud-style.test.js
+++ b/test/session-hud-style.test.js
@@ -275,7 +275,7 @@ describe("quota ring glyph zoom follows the exporter's artwork ratio", () => {
     const zoomBlock = quotaRingRenderer.match(/GLYPH_ZOOM_BY_PROVIDER = \{[\s\S]*?\}/);
     assert.ok(zoomBlock, "no GLYPH_ZOOM_BY_PROVIDER");
     const zooms = Object.fromEntries(
-      [...zoomBlock[0].matchAll(/(\w+Quota):\s*64\s*\/\s*(\d+)/g)].map((m) => [m[1], Number(m[2])])
+      [...zoomBlock[0].matchAll(/(\w+Quota):\s*64\s*\/\s*([\d.]+)/g)].map((m) => [m[1], Number(m[2])])
     );
 
     // Only providers the ring actually draws; RING_PROVIDERS is the authority.
@@ -286,12 +286,27 @@ describe("quota ring glyph zoom follows the exporter's artwork ratio", () => {
     for (const { providerKey, agentId } of mapping) {
       if (!drawn.has(providerKey)) continue;
       const tiled = !!(manifest.sources[agentId] || {}).contrastTreatment;
-      const expected = tiled ? 40 : 56;
-      assert.strictEqual(
-        zooms[providerKey], expected,
-        `${providerKey} (${agentId}) is ${tiled ? "" : "not "}contrast-tiled, so its glyph fills `
-        + `${expected} of 64 and the coin should zoom 64/${expected}`
+      const divisor = zooms[providerKey];
+      assert.ok(
+        divisor !== undefined,
+        `${providerKey} (${agentId}) has no entry in GLYPH_ZOOM_BY_PROVIDER; it would fall back to `
+        + "the shared zoom, which fits neither artwork size"
       );
+      if (tiled) {
+        // Artwork is 40 of 64, inside a 56px plate. The divisor may exceed 40 to
+        // leave breathing room, but must stay well under the 56 that would put
+        // the plate's edge back inside the clip as a visible frame.
+        assert.ok(
+          divisor >= 40 && divisor <= 46,
+          `${providerKey} (${agentId}) is contrast-tiled — its artwork fills 40 of 64, so the divisor `
+          + `should sit between 40 (flush) and ~46 (before the plate shows), got ${divisor}`
+        );
+      } else {
+        assert.strictEqual(
+          divisor, 56,
+          `${providerKey} (${agentId}) is not contrast-tiled, so its glyph fills 56 of 64`
+        );
+      }
     }
   });
 });


### PR DESCRIPTION
额度环的三个问题：币上的数字和变色的那圈不是同一个窗口；带底板的图标比别的小一圈还带框；长时间没上报的 agent 图标会被抽成灰的。

## 一、数字和告警各说各话

读数**永远显示外圈**（滚动窗口），但环变色跟的是**最紧张的那一圈**。两者独立，于是：

| | 外圈 5h | 内圈 7d | 币上写的 |
|---|---|---|---|
| 实际 | 30% | **90%** | **30% 5h** |

数字给出的是当下最令人安心的读数，而唯一在报警的是内圈变红。这让颜色成为告警的唯一载体，对色觉障碍用户、扫一眼看数字的人、以及 60–85% 那个不脉冲的档位统统失效。

**不是理论推演——是 dogfood 撞出来的**：改之前桌面上那枚币写着「1% 5h」，内圈是 61% 的琥珀色。

**改法**：读数仍优先滚动窗口，但最紧的那个窗口 ≥60%（同 `WARN_AT`）时，标题交给它。交接刻意只在告警时发生——改成"永远显示更高的那个"，滚动窗口就再也见不到了，而它才是日常最有用的数。顺带把 60/85 收成常量。

### 闪回：在你会问起它的时刻把滚动数字放回来

交出标题也带走了滚动数字，而"刚跑完一个任务"恰恰是最想看它的时刻。

先试的是**同时显示两行小字**，真机上否掉了：副行只有 6.5px，读出来是"这儿还有个数"而不是一个数。

所以改成**闪回**，触发条件是事件不是定时器：

1. **环出现时**，若滚动数字在它上次离开屏幕后变过 → 先播它，1.6 秒交还
2. **钉住时**，滚动数字在眼皮底下变了 → 立刻播，1.6 秒交还

**空闲的桌面永远不动**——这正是不做轮换的理由：轮换会在余光里留下永久动静，而且扫一眼可能正好撞上另一半、以为看到了全部。环在闪回期间**完全不变色**，告警始终在屏幕上。

边界：冷启动第一帧不播（没有基线）；藏着时发生的变化**存起来**等下次唤出兑现且只兑现一次；连着跑不重启计时（否则读数被钉死，告警拿不回标题）；窗口重置（70%→1%）算变化；周额度没越线不播。

可见性必须由主进程给：Electron 窗口被 `hide()` 后 `document.visibilityState` 不一定翻，钉住的环压根不隐藏。窗口创建即隐藏，所以 `did-finish-load` 时先推真实状态。

## 二、图标大小不一 + 带框

导出器不给每个标同样的画布份额：

| | 图形占 64px 画布 | |
|---|---|---|
| 普通标（Claude / Antigravity） | **56** | |
| 带底板的（Codex） | **40** | 外面还有 56px 浅色圆角板 |

底板是为了让纯黑白的厂商标在 `#202024` 的深色 HUD、`#18181b` 的 Dashboard 上不消失，有测试钉着 3:1 对比度。**但额度环里币中心本来就有固定的浅色 plate**，那份保险买不到任何东西，却付了 29% 的图形尺寸。

原来一个共用的 `1.35` 只露出中间 47 单位，于是 40 单位的 Codex 标浮在里面、四周剩 7 单位底板——**那就是"小一圈 + 有框"**。

**改法**：每个 provider 按自己素材的占比缩放。普通标 `64/56`；带底板的 `64/44.4`，即 40 单位的图形铺 90% 圆孔。

为什么不是铺满（`64/40`）：几何上"相等"不等于视觉上相等。OpenAI 的六瓣螺旋线条细且互相缠绕，在币的 ~10.6px 图标圆里，笔画间距会掉到 1px 以下、抗锯齿糊成一团灰；Claude 星芒放射状、线条粗、留白多，铺满反而清爽。留 10% 余白，框仍然消失（底板照样被挤出裁剪圈），但笔画不挤。

顺带修了上一轮漏的：**Antigravity 也是 56 单位的普通标，却还在用 1.35**，和 Claude 星芒被裁是同一个毛病。写测试时立刻被抓到。

**导出的素材一个字节都没动**——底板在 HUD 和 Dashboard 的深色主题下仍然必要，那边的大小差异是为深色主题付的费，要动就得动整套素材体系。

## 三、陈旧图标不再灰化

某个 agent 超过 5 分钟没上报，原来是**两层表达**叠加：整行淡到 0.72 **加上** 图标 `grayscale(1)`。

去掉灰化，只留整行淡化。除了观感，还有实打实的理由：**灰化对不同图标力度完全不一样**——它把 Claude 的橙星芒和 Antigravity 的彩色标抽干，却对本来就是黑白的 Codex 一点作用都没有。同一个状态在有些币上大喊大叫、在另一些币上悄无声息。

代价：陈旧信号比以前弱一点。整行 0.72 现在是唯一的载体。

## Review 发现的两个阻塞 bug

闪回的状态机被 Codex 审出两个真 bug，**而我随它一起写的 7 条测试一条都没抓到**。

**1. 两个 source 会共用同一份闪回状态。** 键用的是 `providerKey + host`，但 `host` 是**展示标签**不是身份——仓库里有一条测试专门保证两个远程 profile 可以共享同一个 `displayHost`（`keeps trusted remote profile sources separate when display hosts match`）。两枚币于是共用一个状态槽，互相覆盖 `lastPct`，**每份快照都被当成"变了"**，两枚币会永久乱闪。而 snapshot 压根没输出稳定身份，渲染侧无从区分。

修法：store 把自己的 `sourceKey` 一并输出，渲染侧改用它。（旧分隔符还是个**字面 NUL 字节**，让 ripgrep 把整个文件判为二进制；键改成 JSON 后顺带解决。）

**2. 变化只在"当时已经告警"时才记。** 于是丢掉了最普通的路径：藏着 + 健康时滚动数字变了 → 不记 → 之后周窗口才越线 → 打开环，那次变化被吞了。反方向也错：欠着的账在"告警已消失、滚动数字本来就在屏幕上"时不销账，下次告警回来会播一次**过期闪回**。

修法：**变化本身照记，播不播等有人看时再定**。

另外三条：定时器固定从"最后一次触发"算 1.6 秒，第二枚币晚一点闪就把第一枚的交还推给 1 秒 tick，把 1.6 秒拖到约 2.6 秒（改成瞄准最早到期）；`hide()` 不该有条件（`isVisible()` 在 macOS 应用隐藏/切换工作区时可能返回 false，跳过真正的 hide 会让窗口被系统恢复）；四处过期注释。

## 验证

- 全量 `node --test test/*.test.js`：**7703 通过 / 0 失败**，新增 14 条用例
- **变异验证**（不落盘）：每处修复单独回退成 bug 版本，确认对应断言变红。第一次跑时"过期闪回"那条**没红**——因为测试场景少了一步（过期闪回只在下一次唤出时才浮现），补上后四条全部拦住
- **端到端真机**：走完整链路 `POST /state` → 额度 store → 快照广播 → IPC → 渲染，CDP 高频轮询读数：

```
+0.00s   62% 7d     起始，告警占着标题
+0.01s    8% 5h     ← 5h 一变，立刻闪回
+1.66s   61% 7d     ← 1.65 秒后自己交还（设定 1.6s）
+3.29s    5% 5h     ← 第二次变化，再闪一次
+5.37s   61% 7d     ← 再次交还
```

- 图标缩放三档在真机上并排比过；`sourceKey` 确认传到渲染侧（flashState 的键变成 `["claudeQuota",""]`）；stale 场景确认 `filter: none` / 行 opacity 0.72

## 没有动的

- 告警阈值（≥60 警告 / >85 危险）、逐环接管、脉冲、`prefers-reduced-motion`
- 「已用 / 剩余」开关的语义
- 环的配色（上一个 PR 的身份色）
- 导出的图标素材

## 已知遗留

1. **HUD / Dashboard 里带底板的图标仍然小一圈且有框**。那是为深色主题付的费，改要动整套素材体系，不划算。
2. **闪回的 1.6 秒内，数值告警通道暂时让位**，色觉障碍用户那一小段只剩环色。窗口很短，接受为残余限制。
3. **低功耗模式下窗口隐藏 30 秒会被销毁**，重建后渲染侧状态归零，一次待兑现的闪回会被吞。默认关闭，属有限场景——"隐藏期间的变化一定兑现"这句话需要这条限定。
4. **陈旧信号只剩整行 0.72**，比以前弱。
5. 六个身份色在色觉障碍下会塌成一维（上个 PR 的已知限制，需要把内外区分挪到非颜色通道才能根治）。
