### PR TITLE
fix(permission): stop prompting in Claude Code bypassPermissions sessions

### DIFF
--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -271,13 +271,14 @@ CodeBuddy 的 PermissionRequest HTTP 所有权只认严格的本机 managed URL�
 - WorkBuddy 不进入 `/permission`：权限请求只以 Notification 驱动提醒，Allow / Deny 决策留在 WorkBuddy 原生 GUI
 - QwenWork 不进入 `/permission`：`PermissionRequest` / `PermissionDenied` 只被观察并映射成 `working`，hook stdout 恒为 `{}`，Clawd 不产生 allow/deny，也不在 permission automation eligibility 名单内
 - Codex 的 PermissionRequest 是 official command hook；hook 脚本挂起等待 `/permission`，再把 sanitized allow/deny JSON 写到 stdout
-- `POST /permission` 接收 `{ tool_name, tool_input, session_id, permission_suggestions }`；Codex 额外带 `turn_id`、`tool_input_description`、`tool_input_fingerprint`
+- `POST /permission` 接收 `{ tool_name, tool_input, session_id, permission_suggestions }`；Claude Code 与 Codex 还带 `permission_mode`（会话权限模式）；Codex 额外带 `turn_id`、`tool_input_description`、`tool_input_fingerprint`
 - 每个权限请求都会创建独立 `BrowserWindow`，多个 bubble 从右下向上堆叠
 - bubble 会通过 IPC `bubble-height` 回报真实高度，主进程据此重排
 - 支持 Allow / Deny / suggestion 决策，以及 `addRules` / `setMode` suggestion 类型
 - `permission-automation-policy.js` 的 off / auto-tools / unattended 与 `session-automation-coordinator.js` 的 per-session grant 会在 bubble 渲染前产生真实决定。auto-tools 对 Claude/Qwen 的未知 built-in（除有效 namespaced MCP）fail closed，但其他已知 adapter 对非空工具名不都使用逐工具 allowlist；unattended 在识别已知 decision tools 后仍有意对可作 Allow/Deny 的未知请求保留“handle every request”行为。新增 agent/tool/interaction 必须同时审查 policy 与 tests，不能笼统假设 unknown 一律 defer
 - Telegram 与飞书 / Lark 是和本地 bubble 并行的远程决策通道；关闭本地 bubble 不等于关闭远程审批。远程 client 超时、断连、未配置或启动失败不得产生决定或 deny：本地 bubble 存在时请求继续 pending；仅在 remote-only 且所有可用 client 都无决定时，整体请求才 no-decision 并让 agent 回原生 UI 重问
 - DND 只负责“不弹 bubble”，不替用户决定权限：opencode 与 MiMo Code 分支 silent drop，让 TUI 内置权限提示接管；Claude Code 分支 `res.destroy()`，让 CC 回到内置聊天/终端确认；Codex 分支返回 no-decision `{}`，让 Codex 原生审批接管
+- Claude Code 以 `--dangerously-skip-permissions` 启动时 `permission_mode` 为 `bypassPermissions`。该模式下 CC 仍会发 PermissionRequest，Clawd 在 headless auto-deny 与 `PASSTHROUGH_TOOLS` 之后、各 bubble gate 之前 `res.destroy()`，让 CC 回内置流程自行处理，绝不替用户 allow/deny；`ExitPlanMode` / `AskUserQuestion` 照旧例外。该模式下已无待决审批，远程审批通道因此也不参与。这段路径与 codebuddy 共用，destroy 回退与该段既有分支一致
 - Codex 审批只认 official `PermissionRequest` hook；JSONL fallback 不再根据 shell function_call 猜测审批，也不再创建 Codex passive approval notify bubble
 - 涉及 Claude Code 权限 payload 的改动（`permission_suggestions`、`updatedPermissions`、elicitation 输入等）必须至少用一次真实 Claude Code 验证；`curl` 自编请求历史上掩盖过字段结构 bug
 

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -1432,6 +1432,7 @@ function handlePermissionPost(req, res, options) {
       // silent drop (95cbfc7).
       const ccAgentId = agentId;
       const toolName = typeof data.tool_name === "string" ? data.tool_name : "Unknown";
+      const ccPermissionMode = typeof data.permission_mode === "string" ? data.permission_mode : "";
       const interaction = classifyPermissionInteraction({
         agentId: ccAgentId,
         eventKind: "permission",
@@ -1489,6 +1490,13 @@ function handlePermissionPost(req, res, options) {
         recordRequestHookEvent.accepted();
         ctx.permLog(`PASSTHROUGH: tool=${toolName} session=${sessionId}`);
         ctx.sendPermissionResponse(res, "allow");
+        return;
+      }
+
+      if (isCCBypassPermissions(ccPermissionMode, interaction)) {
+        recordRequestHookEvent.accepted();
+        ctx.permLog(`bypassPermissions session → destroy connection, chat fallback (tool=${toolName} session=${sessionId})`);
+        res.destroy();
         return;
       }
 

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -44,6 +44,19 @@ const { sanitizeShadowRecord } = require("./windows-process-chain-shadow-log");
 
 const MAX_PERMISSION_BODY_BYTES = 524288;
 
+// A session started with --dangerously-skip-permissions reports
+// permission_mode "bypassPermissions". CC still fires the PermissionRequest
+// hook there, so Clawd would pop a bubble for a session whose owner
+// explicitly asked not to be asked. Drop the connection and let CC resolve
+// it natively, exactly like the bubble toggles below. Never answer
+// allow/deny on the user's behalf. ExitPlanMode / AskUserQuestion stay
+// exempt: they are UX flows, not approvals, and CC sends them regardless of
+// the permission mode.
+function isCCBypassPermissions(permissionMode, interaction) {
+  if (permissionMode !== "bypassPermissions") return false;
+  return !isDecisionInteraction(interaction);
+}
+
 // ExitPlanMode (Plan Review) and AskUserQuestion (elicitation) happen to
 // travel through /permission, but they're UX flows — not approvals the
 // sub-gate is named for. Silencing them would break plan-mode and leave
@@ -1677,6 +1690,7 @@ function handlePermissionPost(req, res, options) {
 
 module.exports = {
   MAX_PERMISSION_BODY_BYTES,
+  isCCBypassPermissions,
   shouldBypassCCBubble,
   shouldBypassCCSubagentBubble,
   shouldBypassCodexBubble,

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -52,6 +52,14 @@ const MAX_PERMISSION_BODY_BYTES = 524288;
 // allow/deny on the user's behalf. ExitPlanMode / AskUserQuestion stay
 // exempt: they are UX flows, not approvals, and CC sends them regardless of
 // the permission mode.
+//
+// Two consequences of sitting above the bubble gates, both intended:
+// - remote approval (Telegram / Lark) is skipped. The session's owner opted
+//   out of being asked at all, so keeping a remote channel alive would just
+//   reintroduce the prompt they turned off, on another device.
+// - the check is not agent-scoped. This block is shared with codebuddy (see
+//   permAgentId below), and res.destroy() is already what the block falls
+//   back to for every agent that reaches it.
 function isCCBypassPermissions(permissionMode, interaction) {
   if (permissionMode !== "bypassPermissions") return false;
   return !isDecisionInteraction(interaction);

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -1097,6 +1097,33 @@ describe("server-route-permission POST", () => {
     assert.deepStrictEqual(res.recorder.map((item) => item.outcome).filter(Boolean), ["accepted"]);
   });
 
+  it("handles a verbatim CC 2.1.228 bypassPermissions payload (live capture 2026-08-12)", async () => {
+    // Captured from a real Claude Code 2.1.228 session started with
+    // --dangerously-skip-permissions, through an isolated PermissionRequest
+    // command hook (paths anonymized). Ground truth for the two facts this
+    // branch rests on: CC still fires the hook in that mode, and the body
+    // carries permission_mode with the literal "bypassPermissions". A
+    // main-thread request has no agent_id, unlike the #451 subagent capture.
+    const realBody = {
+      session_id: "3d182efb-8a48-4bb2-973b-4546d1eaa90c",
+      transcript_path: "/Users/tester/.claude/projects/-Users-tester-repo/3d182efb-8a48-4bb2-973b-4546d1eaa90c.jsonl",
+      cwd: "/Users/tester/repo",
+      prompt_id: "85d97bf5-7195-42a7-bad6-c227c1f1aea2",
+      permission_mode: "bypassPermissions",
+      effort: { level: "xhigh" },
+      hook_event_name: "PermissionRequest",
+      tool_name: "Bash",
+      tool_input: { command: "echo hi", description: "Print hi" },
+    };
+
+    const res = await callPermissionPost(JSON.stringify(realBody));
+
+    assert.strictEqual(res.destroyed, true);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+    assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, []);
+  });
+
   it("still shows a bubble for ExitPlanMode in bypassPermissions sessions", async () => {
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "claude-code",

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -1080,6 +1080,38 @@ describe("server-route-permission POST", () => {
     assert.deepStrictEqual(res.recorder.map((item) => item.outcome).filter(Boolean), ["accepted"]);
   });
 
+  it("destroys the Claude connection for bypassPermissions sessions without creating a bubble", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "sid",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+      tool_use_id: "tool-1",
+      permission_mode: "bypassPermissions",
+    }));
+
+    assert.strictEqual(res.destroyed, true);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+    assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, []);
+    assert.deepStrictEqual(res.recorder.map((item) => item.outcome).filter(Boolean), ["accepted"]);
+  });
+
+  it("still shows a bubble for ExitPlanMode in bypassPermissions sessions", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "sid",
+      tool_name: "ExitPlanMode",
+      tool_input: { plan: "do the thing" },
+      tool_use_id: "tool-2",
+      permission_mode: "bypassPermissions",
+    }));
+
+    assert.strictEqual(res.destroyed, false);
+    assert.strictEqual(res.ctx.pendingPermissions.length, 1);
+    assert.strictEqual(res.ctx.calls.showPermissionBubble.length, 1);
+  });
+
   it("returns no-decision for a currently registered state-only custom AI", async () => {
     const id = "custom-nova-ai-0123456789ab";
     const res = await callPermissionPost(JSON.stringify({

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -14,6 +14,7 @@ const {
 const {
   MAX_PERMISSION_BODY_BYTES,
   handlePermissionPost,
+  isCCBypassPermissions,
   shouldBypassCCBubble,
   shouldBypassCCSubagentBubble,
   shouldBypassCodexBubble,
@@ -226,6 +227,17 @@ describe("server-route-permission helpers", () => {
     assert.strictEqual(shouldBypassCopilotBubble({
       isAgentPermissionsEnabled: () => true,
     }), false);
+  });
+
+  it("bypasses the CC bubble for bypassPermissions sessions except decision interactions", () => {
+    assert.strictEqual(isCCBypassPermissions("bypassPermissions", interaction("claude-code", "Bash")), true);
+    assert.strictEqual(isCCBypassPermissions("bypassPermissions", interaction("claude-code", "Edit")), true);
+    assert.strictEqual(isCCBypassPermissions("bypassPermissions", interaction("claude-code", "ExitPlanMode")), false);
+    assert.strictEqual(isCCBypassPermissions("bypassPermissions", interaction("claude-code", "AskUserQuestion")), false);
+    assert.strictEqual(isCCBypassPermissions("default", interaction("claude-code", "Bash")), false);
+    assert.strictEqual(isCCBypassPermissions("acceptEdits", interaction("claude-code", "Bash")), false);
+    assert.strictEqual(isCCBypassPermissions("", interaction("claude-code", "Bash")), false);
+    assert.strictEqual(isCCBypassPermissions(undefined, interaction("claude-code", "Bash")), false);
   });
 
   it("bypasses CC subagent bubbles only for subagent-origin requests with the sub-gate off", () => {

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -1112,6 +1112,50 @@ describe("server-route-permission POST", () => {
     assert.strictEqual(res.ctx.calls.showPermissionBubble.length, 1);
   });
 
+  it("lets the headless guard win over the bypassPermissions step-aside (auto-deny, no destroy)", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "sid",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+      tool_use_id: "tool-1",
+      permission_mode: "bypassPermissions",
+    }), {
+      ctx: {
+        sessions: new Map([[localSessionKey("sid"), { headless: true }]]),
+      },
+    });
+
+    assert.strictEqual(res.destroyed, false);
+    assert.deepStrictEqual(res.ctx.calls.sendPermissionResponse, [{
+      behavior: "deny",
+      message: "Non-interactive session; auto-denied",
+    }]);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+  });
+
+  it("lets PASSTHROUGH tools auto-allow before the bypassPermissions step-aside", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "sid",
+      tool_name: "Bash",
+      tool_input: { command: "npm test" },
+      tool_use_id: "tool-1",
+      permission_mode: "bypassPermissions",
+    }), {
+      ctx: {
+        PASSTHROUGH_TOOLS: new Set(["Bash"]),
+      },
+    });
+
+    assert.strictEqual(res.destroyed, false);
+    assert.deepStrictEqual(res.ctx.calls.sendPermissionResponse, [{
+      behavior: "allow",
+      message: undefined,
+    }]);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+  });
+
   it("returns no-decision for a currently registered state-only custom AI", async () => {
     const id = "custom-nova-ai-0123456789ab";
     const res = await callPermissionPost(JSON.stringify({


### PR DESCRIPTION
## Problem

Claude Code fires the `PermissionRequest` hook even in sessions started with
`--dangerously-skip-permissions`. Clawd's handler pops an approval bubble for those
requests, so a user who explicitly asked never to be asked still has to click through
every tool call.

## What this does

The hook payload already carries the session's mode in `permission_mode`. When that value
is `bypassPermissions` and the request is not a decision interaction, Clawd drops the
connection and lets Claude Code resolve the request natively, exactly like the existing
bubble-disabled paths in the same handler.

Clawd never answers `allow` or `deny` on the user's behalf here. It does not decide
anything, and it does not compensate for Claude Code's behavior. It reads a value it is
already being sent, and steps out of the way.

## Placement

The new branch sits after the two rules that must keep winning:

1. the headless auto-deny rule
2. the `PASSTHROUGH_TOOLS` auto-allow rule

Both still run first. Two regression tests pin that order, modeled on the ones that
already pin it for the subagent sub-gate (#451): moving the new branch above either rule
fails the suite.

`ExitPlanMode` and `AskUserQuestion` stay exempt through `isDecisionInteraction`. They are
UX flows rather than approvals, and Claude Code sends them regardless of permission mode.

## Two effects worth calling out

Both follow from the branch sitting above the bubble gates, and both are deliberate.

**Remote approval does not run for these requests.** No code in the Telegram / Lark path
changed, but a `bypassPermissions` request now returns before `tryRemoteOnlyApproval`.
That is the intent: the session's owner opted out of being asked, so keeping a remote
channel alive would reintroduce the same prompt on another device. If you would rather
these requests still reach remote approvers, that is a small move and I am happy to make
it.

**The check is not agent-scoped.** This block is shared with codebuddy, and `res.destroy()`
is already what it falls back to for every agent that reaches it, so an agent gate would
add a condition that cannot change today's outcome. Codex never reaches this branch: it
returns earlier in the handler under its own no-decision contract.

## Why only `bypassPermissions`

Claude Code's bundle enumerates six modes: `acceptEdits`, `auto`, `bypassPermissions`,
`default`, `dontAsk`, `plan`. Only `bypassPermissions` is described as bypassing all
permission checks. The neighbour that looks similar is not equivalent: `dontAsk` is "don't
prompt for permissions, deny if not pre-approved", so a bubble there is still the user's
only chance to approve something. Widening the check would change behavior the user never
asked to change, so this PR leaves the other five modes alone.

## Why `accepted()` rather than a `dropped-*` counter

`evaluateConnectionTest` in `doctor-hook-activity.js` reports `http-dropped` at warning
level as soon as any event carries a `dropped-*` outcome. Recording these as dropped would
make Doctor warn about a healthy bypass session. The two adjacent bubble-gate branches
record `accepted()` for the same reason.

## Evidence for `permission_mode`

`AGENTS.md` asks for at least one real Claude Code run behind any change touching the
`/permission` payload, so I captured one rather than writing a `curl` body by hand.

The setup was a scratch directory containing nothing but a `PermissionRequest` command
hook, pointed at a script that appends stdin to a file and prints `{}` — it records, it
never decides. A Claude Code 2.1.228 session started there with
`--dangerously-skip-permissions`, then one `Bash` call. The hook fired at all, which is
the first fact this PR rests on, and the body it wrote carries the second:

```json
{
  "session_id": "3d182efb-8a48-4bb2-973b-4546d1eaa90c",
  "transcript_path": "<local path>",
  "cwd": "<local path>",
  "prompt_id": "85d97bf5-7195-42a7-bad6-c227c1f1aea2",
  "permission_mode": "bypassPermissions",
  "effort": { "level": "xhigh" },
  "hook_event_name": "PermissionRequest",
  "tool_name": "Bash",
  "tool_input": { "command": "echo hi", "description": "Print hi" }
}
```

That body is now a test, with the two local paths anonymized the way the #451 subagent
fixture anonymizes its own. It runs through `handlePermissionPost` and asserts the
connection is destroyed with no pending permission, no bubble, and no remote approval
started. Worth noting: there is no `agent_id`, because this is a main-thread request
rather than the subagent request #451 captured.

The capture and the handler's behaviour on it, side by side:

![live Claude Code payload and the resulting handler behaviour](https://raw.githubusercontent.com/Praesentia-YKM/clawd-on-desk/evidence/pr-865/evidence/pr-865-live-capture.png)

## Scope

Three files, 147 added lines, one line changed. No new config option, no UI or translation
string, no new dependency.

`docs/project/agent-runtime-architecture.md` did not list `permission_mode` in the
`POST /permission` receive contract, so this PR adds it there along with a bullet for the
new gate under Permission Bubble.

Tests: `test/server-route-permission.test.js` passes 94/94. The full-suite failure count is
unchanged from the base commit (44 pre-existing failures on my machine, all in unrelated
telegram and native-pointer suites).
