### PR TITLE
chore(release): prepare v0.15.0 and address release review findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run native-host packaged Koffi smoke
         run: node scripts/run-packaged-koffi-smoke.js --executable "dist/win-unpacked/Clawd on Desk.exe" --target windows-x64 --output dist/koffi-smoke/windows-x64.json
       - name: Verify Windows updater metadata
-        run: node scripts/verify-updater-metadata.js --metadata dist/latest.yml --artifact-root dist --contract windows --output dist/updater-metadata-manifests/windows.json
+        run: node scripts/verify-updater-metadata.js --metadata dist/latest.yml --artifact-root dist --contract windows --package-json package.json --output dist/updater-metadata-manifests/windows.json
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -116,7 +116,7 @@ jobs:
       - name: Run native-host packaged Koffi smoke
         run: node scripts/run-packaged-koffi-smoke.js --executable "dist/mac-arm64/Clawd on Desk.app/Contents/MacOS/Clawd on Desk" --target darwin-arm64 --output dist/koffi-smoke/darwin-arm64.json
       - name: Verify macOS updater metadata
-        run: node scripts/verify-updater-metadata.js --metadata dist/latest-mac.yml --artifact-root dist --contract mac --output dist/updater-metadata-manifests/mac.json
+        run: node scripts/verify-updater-metadata.js --metadata dist/latest-mac.yml --artifact-root dist --contract mac --package-json package.json --output dist/updater-metadata-manifests/mac.json
       - uses: actions/upload-artifact@v4
         if: always()
         with:
@@ -167,7 +167,7 @@ jobs:
       - name: Run packaged Koffi smoke
         run: node scripts/run-packaged-koffi-smoke.js --executable dist/linux-unpacked/clawd-on-desk --target linux-x64 --output dist/koffi-smoke/linux-x64.json --xvfb
       - name: Verify Linux updater metadata
-        run: node scripts/verify-updater-metadata.js --metadata dist/latest-linux.yml --artifact-root dist --contract linux --output dist/updater-metadata-manifests/linux.json
+        run: node scripts/verify-updater-metadata.js --metadata dist/latest-linux.yml --artifact-root dist --contract linux --package-json package.json --output dist/updater-metadata-manifests/linux.json
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ docs/**
 !docs/releases/release-v0.12.0.md
 !docs/releases/release-v0.13.0.md
 !docs/releases/release-v0.14.0.md
+!docs/releases/release-v0.15.0.md
 
 # Temp files from testing
 .tmp_*

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ docs/**
 !docs/plans/plan-issue-513-remote-ssh-isolation.md
 !docs/plans/plan-issue-763-koffi-target-native-packaging.md
 !docs/plans/plan-npm-dependency-security-hardening.md
+!docs/plans/plan-opencode-family-state-ordering-and-instance-disposal-hardening.md
 !docs/project/
 !docs/project/agent-runtime-architecture.md
 !docs/project/release-process.md
@@ -131,3 +132,26 @@ scripts/manual/*
 
 # Cursor local config (MCP, rules from omc setup)
 .cursor/
+
+# VS Code local config
+.vscode/
+
+# Local agent/skill definitions (machine-specific)
+.agents/
+
+# Local git worktrees used for PR review
+.worktrees/
+
+# Playwright MCP session artifacts (screenshots, downloaded installers — hundreds of MB)
+.playwright-mcp/
+
+# Retired Telegram sidecar binaries. The sidecar was removed in v0.14.0 and every
+# release build asserts it is absent (scripts/assert-no-retired-telegram-sidecar.js);
+# stale local copies must never re-enter the repository.
+bin/
+
+# PowerShell module analysis cache that Windows sometimes drops at the repo root
+Microsoft/
+
+# Emoji export scratch
+clawd-emoji-final/

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -267,7 +267,7 @@ Clawd をより良くしてくれたすべての方に感謝します。
     <td align="center" valign="top" width="110"><a href="https://github.com/TVpoet"><img src="https://github.com/TVpoet.png" width="50" style="border-radius:50%" /><br /><sub>TVpoet</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/zeus6768"><img src="https://github.com/zeus6768.png" width="50" style="border-radius:50%" /><br /><sub>zeus6768</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/anhtrinh919"><img src="https://github.com/anhtrinh919.png" width="50" style="border-radius:50%" /><br /><sub>anhtrinh919</sub></a></td>
-    <td align="center" valign="top" width="110"><a href="https://github.com/tomaioo"><img src="https://github.com/tomaioo.png" width="50" style="border-radius:50%" /><br /><sub>tomaioo</sub></a></td>
+    <td align="center" valign="top" width="110"><sub>tomaioo</sub></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/v-avuso"><img src="https://github.com/v-avuso.png" width="50" style="border-radius:50%" /><br /><sub>v-avuso</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/livlign"><img src="https://github.com/livlign.png" width="50" style="border-radius:50%" /><br /><sub>livlign</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/tongguang2"><img src="https://github.com/tongguang2.png" width="50" style="border-radius:50%" /><br /><sub>tongguang2</sub></a></td>
@@ -348,6 +348,7 @@ Clawd をより良くしてくれたすべての方に感謝します。
     <td align="center" valign="top" width="110"><a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /><br /><sub>anthonyonazure</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /><br /><sub>weed33834</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /><br /><sub>arismarioneves</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/aaronWool"><img src="https://github.com/aaronWool.png" width="50" style="border-radius:50%" /><br /><sub>aaronWool</sub></a></td>
   </tr>
 </table>
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -263,7 +263,7 @@ Clawd를 더 좋게 만드는 데 도움을 준 모든 분들께 감사합니다
     <td align="center" valign="top" width="110"><a href="https://github.com/TVpoet"><img src="https://github.com/TVpoet.png" width="50" style="border-radius:50%" /><br /><sub>TVpoet</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/zeus6768"><img src="https://github.com/zeus6768.png" width="50" style="border-radius:50%" /><br /><sub>zeus6768</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/anhtrinh919"><img src="https://github.com/anhtrinh919.png" width="50" style="border-radius:50%" /><br /><sub>anhtrinh919</sub></a></td>
-    <td align="center" valign="top" width="110"><a href="https://github.com/tomaioo"><img src="https://github.com/tomaioo.png" width="50" style="border-radius:50%" /><br /><sub>tomaioo</sub></a></td>
+    <td align="center" valign="top" width="110"><sub>tomaioo</sub></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/v-avuso"><img src="https://github.com/v-avuso.png" width="50" style="border-radius:50%" /><br /><sub>v-avuso</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/livlign"><img src="https://github.com/livlign.png" width="50" style="border-radius:50%" /><br /><sub>livlign</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/tongguang2"><img src="https://github.com/tongguang2.png" width="50" style="border-radius:50%" /><br /><sub>tongguang2</sub></a></td>
@@ -344,6 +344,7 @@ Clawd를 더 좋게 만드는 데 도움을 준 모든 분들께 감사합니다
     <td align="center" valign="top" width="110"><a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /><br /><sub>anthonyonazure</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /><br /><sub>weed33834</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /><br /><sub>arismarioneves</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/aaronWool"><img src="https://github.com/aaronWool.png" width="50" style="border-radius:50%" /><br /><sub>aaronWool</sub></a></td>
   </tr>
 </table>
 

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ Thanks to everyone who has helped make Clawd better:
     <td align="center" valign="top" width="110"><a href="https://github.com/TVpoet"><img src="https://github.com/TVpoet.png" width="50" style="border-radius:50%" /><br /><sub>TVpoet</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/zeus6768"><img src="https://github.com/zeus6768.png" width="50" style="border-radius:50%" /><br /><sub>zeus6768</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/anhtrinh919"><img src="https://github.com/anhtrinh919.png" width="50" style="border-radius:50%" /><br /><sub>anhtrinh919</sub></a></td>
-    <td align="center" valign="top" width="110"><a href="https://github.com/tomaioo"><img src="https://github.com/tomaioo.png" width="50" style="border-radius:50%" /><br /><sub>tomaioo</sub></a></td>
+    <td align="center" valign="top" width="110"><sub>tomaioo</sub></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/v-avuso"><img src="https://github.com/v-avuso.png" width="50" style="border-radius:50%" /><br /><sub>v-avuso</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/livlign"><img src="https://github.com/livlign.png" width="50" style="border-radius:50%" /><br /><sub>livlign</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/tongguang2"><img src="https://github.com/tongguang2.png" width="50" style="border-radius:50%" /><br /><sub>tongguang2</sub></a></td>
@@ -356,6 +356,7 @@ Thanks to everyone who has helped make Clawd better:
     <td align="center" valign="top" width="110"><a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /><br /><sub>anthonyonazure</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /><br /><sub>weed33834</sub></a></td>
     <td align="center" valign="top" width="110"><a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /><br /><sub>arismarioneves</sub></a></td>
+    <td align="center" valign="top" width="110"><a href="https://github.com/aaronWool"><img src="https://github.com/aaronWool.png" width="50" style="border-radius:50%" /><br /><sub>aaronWool</sub></a></td>
   </tr>
 </table>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -261,7 +261,7 @@ Clawd on Desk 是一个社区驱动的项目。欢迎提 Bug、提需求、提 P
 <a href="https://github.com/TVpoet"><img src="https://github.com/TVpoet.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/zeus6768"><img src="https://github.com/zeus6768.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/anhtrinh919"><img src="https://github.com/anhtrinh919.png" width="50" style="border-radius:50%" /></a>
-<a href="https://github.com/tomaioo"><img src="https://github.com/tomaioo.png" width="50" style="border-radius:50%" /></a>
+<sub>tomaioo</sub>
 <a href="https://github.com/v-avuso"><img src="https://github.com/v-avuso.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/livlign"><img src="https://github.com/livlign.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/tongguang2"><img src="https://github.com/tongguang2.png" width="50" style="border-radius:50%" /></a>
@@ -324,6 +324,7 @@ Clawd on Desk 是一个社区驱动的项目。欢迎提 Bug、提需求、提 P
 <a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /></a>
+<a href="https://github.com/aaronWool"><img src="https://github.com/aaronWool.png" width="50" style="border-radius:50%" /></a>
 
 ## 致谢
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -261,7 +261,7 @@ Clawd on Desk 是社群驅動的專案。歡迎提 Bug、提需求、提 PR —�
 <a href="https://github.com/TVpoet"><img src="https://github.com/TVpoet.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/zeus6768"><img src="https://github.com/zeus6768.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/anhtrinh919"><img src="https://github.com/anhtrinh919.png" width="50" style="border-radius:50%" /></a>
-<a href="https://github.com/tomaioo"><img src="https://github.com/tomaioo.png" width="50" style="border-radius:50%" /></a>
+<sub>tomaioo</sub>
 <a href="https://github.com/v-avuso"><img src="https://github.com/v-avuso.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/livlign"><img src="https://github.com/livlign.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/tongguang2"><img src="https://github.com/tongguang2.png" width="50" style="border-radius:50%" /></a>
@@ -324,6 +324,7 @@ Clawd on Desk 是社群驅動的專案。歡迎提 Bug、提需求、提 PR —�
 <a href="https://github.com/anthonyonazure"><img src="https://github.com/anthonyonazure.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/weed33834"><img src="https://github.com/weed33834.png" width="50" style="border-radius:50%" /></a>
 <a href="https://github.com/arismarioneves"><img src="https://github.com/arismarioneves.png" width="50" style="border-radius:50%" /></a>
+<a href="https://github.com/aaronWool"><img src="https://github.com/aaronWool.png" width="50" style="border-radius:50%" /></a>
 
 ## 致謝
 

--- a/docs/plans/plan-issue-244-low-power-idle.md
+++ b/docs/plans/plan-issue-244-low-power-idle.md
@@ -1,7 +1,11 @@
 # Plan: Issue #244 Low Power Idle Mouse-Follow CPU
 
-> Status: Draft v1, revised after Claude review and Codex code check.
-> Date: 2026-05-07
+> Status: **Implemented and shipped.** `lowPowerIdleMode` lives in `src/prefs.js`, and
+> the release smoke checklist carries a Low-power idle item
+> (`docs/project/release-process.md`). Issue #244 closed 2026-07-12. The draft below is
+> kept as the design record — it was written as "Draft v1, revised after Claude review
+> and Codex code check".
+> Date: 2026-05-07 (status refreshed 2026-08-12)
 > Issue: https://github.com/rullerzhou-afk/clawd-on-desk/issues/244
 > Scope: Fix the existing Low power idle behavior so passive mouse-follow does not keep idle rendering active. Do not add a new Settings toggle in this pass.
 

--- a/docs/plans/plan-issue-763-koffi-target-native-packaging.md
+++ b/docs/plans/plan-issue-763-koffi-target-native-packaging.md
@@ -1,7 +1,13 @@
 # Plan: #763 Koffi target-native packaging and foreign-native audit
 
-> Status: **Draft v3 with second-review findings incorporated; no implementation is authorized by this document**
-> Date: 2026-08-07
+> Status: **Implemented.** Shipped by PR #824 (`fix: package only target-native Koffi
+> binaries`, 2026-08-07); issue #763 closed the same day. The packaging rule and the
+> foreign-native audit gate are now part of the release process — see
+> `docs/project/release-process.md`. Follow-up: the Koffi 3 split-package migration is
+> tracked separately in #823. The plan below is kept as the design record; it was
+> drafted as "Draft v3 with second-review findings incorporated; no implementation is
+> authorized by this document", and that authorization was given separately.
+> Date: 2026-08-07 (status refreshed 2026-08-12)
 > Issue: https://github.com/rullerzhou-afk/clawd-on-desk/issues/763
 > Origin: follow-up deliberately excluded from PR #762
 > Scope: Windows x64/ARM64, macOS x64/ARM64, Linux x64 release artifacts

--- a/docs/plans/plan-opencode-family-shared-integration.md
+++ b/docs/plans/plan-opencode-family-shared-integration.md
@@ -1,11 +1,20 @@
 # Design: collapse mimocode + opencode into a shared "opencode-family" path
 
-Status: **v4 — final review round absorbed** (codex 2026-07-17, three rounds:
-v1 BLOCK 4 blockers → v2; 3 contract gaps → v3; 1 blocker + 2 pinned contracts →
-this v4, reviewer verdict "APPROVE once absorbed". Every finding was verified
+Status: **Implemented — both PRs merged.** PR A landed as #706
+(`refactor/opencode-family-core`, 2026-07-17), which introduced
+`hooks/opencode-family-plugin/core.mjs`; the rebased #607 followed on 2026-07-18. The
+end state matches §10: a 1252-line shared core with `hooks/opencode-plugin/index.mjs`
+and `hooks/mimocode-plugin/index.mjs` reduced to 19-line entries that import it.
+Deferred hardening from a later review is planned separately in
+`plan-opencode-family-state-ordering-and-instance-disposal-hardening.md`.
+The design below is kept as the record. (Status refreshed 2026-08-12.)
+
+Design review history: **v4 — final review round absorbed** (codex 2026-07-17, three
+rounds: v1 BLOCK 4 blockers → v2; 3 contract gaps → v3; 1 blocker + 2 pinned contracts
+→ this v4, reviewer verdict "APPROVE once absorbed". Every finding was verified
 against real code before absorbing. Changelog in §11.)
-PR shape: **two independent PRs** — PR A (opencode-only refactor, merges first) + a
-rebased #607 (mimocode as a thin member). See §10.
+PR shape as planned: **two independent PRs** — PR A (opencode-only refactor, merges
+first) + a rebased #607 (mimocode as a thin member). See §10.
 Authorship: PR A is maintainer work; the rebased #607 keeps @jiaxuan1101's authorship
 with maintainer commits `Co-authored-by`.
 

--- a/docs/plans/plan-opencode-family-state-ordering-and-instance-disposal-hardening.md
+++ b/docs/plans/plan-opencode-family-state-ordering-and-instance-disposal-hardening.md
@@ -1,0 +1,131 @@
+# Plan: OpenCode-family state ordering and instance-disposal hardening
+
+> Status: **Implemented.** Both problems were fixed by PR #855
+> (`fix(opencode): serialize state delivery and scope disposal`, merged 2026-08-11),
+> with follow-up regression coverage in #858. Written as a deferred follow-up that was
+> explicitly not a merge requirement for PR #841.
+> Date: 2026-08-09 (status refreshed 2026-08-12)
+> Origin: Review of https://github.com/rullerzhou-afk/clawd-on-desk/pull/841
+> Scope: The shared OpenCode/MiMo plugin core in `hooks/opencode-family-plugin/`
+
+---
+
+## 1. Decision summary
+
+PR #841 should remain focused on forwarding, normalizing, and safely applying session-title updates. Two verified hardening problems are intentionally deferred:
+
+1. `/state` requests for one session are fire-and-forget and have no causal ordering. An older lifecycle request can arrive after a newer metadata-only rename and restore the older title.
+2. `server.instance.disposed` is directory-scoped, but the shared plugin factory currently clears process-wide session maps. Disposing one directory can remove cached ownership data for sessions in another directory.
+
+These problems are real, but neither needs to expand PR #841 into a transport/ownership refactor. They should be implemented and reviewed together with their own failure-injection tests.
+
+## 2. Verified current behavior
+
+### 2.1 Same-session requests can complete out of order
+
+`postToClawd()` starts an independent asynchronous port-discovery loop for every request and returns immediately. A normal lifecycle body and a metadata-only title body therefore have no ordering relationship.
+
+A reproducible sequence is:
+
+1. lifecycle request `L` captures title `A` and waits on a stale cached port;
+2. another request discovers the live port and refreshes the shared port cache;
+3. rename request `M` captures title `B`, uses the refreshed port, and applies `B`;
+4. `L` falls through to the live port and applies its older title `A`;
+5. if no later lifecycle event arrives, the HUD/Dashboard remains on `A`.
+
+The next lifecycle event normally self-heals because new bodies use the latest title map. That reduces frequency and persistence; it does not establish causal correctness.
+
+### 2.2 Disposal is scoped more narrowly than the maps
+
+One entry-module factory can return handlers for several directory instances. Those handlers share closure state, including:
+
+- `_sessionDirectoryById`;
+- `_sessionTitleById` after PR #841;
+- `_sessionParentById`;
+- `_lastStatePerSession` and root/latest-session fallback state.
+
+OpenCode's `server.instance.disposed` event identifies one directory through `event.properties.directory`. Existing cleanup treats it as process-wide and clears maps that can also contain sessions owned by other active directories.
+
+The directory clear predates PR #841. PR #841 only makes the same ownership assumption for the title map, so the complete fix belongs in this follow-up rather than a title-only patch.
+
+## 3. Workstream A: per-session FIFO for `/state`
+
+### 3.1 Required contract
+
+1. `/state` deliveries for the same canonical `session_id` settle in enqueue order.
+2. Lifecycle and metadata-only state updates share the same per-session queue.
+3. Different sessions remain concurrent; one slow session must not block another.
+4. `/permission` must not enter the state queue or wait behind state retries.
+5. A failed or exhausted request must not poison the queue; the next queued state must still run.
+6. Completed queue tails must be removed so the map cannot grow for the lifetime of the host.
+7. The event hook remains non-blocking from the host's perspective.
+
+### 3.2 Implementation constraints
+
+- Key the queue by the already canonicalized `body.session_id` so OpenCode and MiMo namespaces remain isolated.
+- Make the state delivery primitive return a promise representing the complete cached-port/runtime-port/fallback scan.
+- Chain each state delivery behind the prior tail for that session, swallowing the prior failure before starting the next delivery.
+- Delete a tail only if it is still the current tail for that session; an older completion must not delete a newer queued tail.
+- Snapshot and serialize mutable request data at enqueue time. In particular, `SessionEnd` must retain its title and directory even if session maps are cleaned before the queued network delivery begins.
+- Keep shared port-cache self-healing. FIFO governs state causality, not global port discovery.
+- Do not serialize every agent/session behind one global chain.
+
+### 3.3 Required tests
+
+Use a temp HOME, fake Bun bridge, and controllable fake fetch/server model.
+
+1. Delay a placeholder `SessionStart`, enqueue a real-title metadata update, and assert the final server title is real.
+2. Delay rename/lifecycle body `A`, enqueue rename `B`, and assert the final title is `B`.
+3. Exhaust all ports for one queued request and assert the next request for that session still executes.
+4. Block session A and assert session B can deliver concurrently.
+5. Block a state request and assert `/permission` is sent immediately through its independent path.
+6. Assert `session.deleted` serializes `SessionEnd` with its final title/directory, cleans ownership only after capture, and leaves no queue tail after settlement.
+7. Assert the queue-tail map returns to its baseline size after success and failure.
+
+## 4. Workstream B: directory-scoped disposal
+
+### 4.1 Required contract
+
+1. When `event.properties.directory` is present and valid, dispose only sessions owned by that directory.
+2. Preserve directory, title, parent, dedup, and fallback state belonging to every other active directory handler from the same factory.
+3. A legacy disposal event with no usable directory may retain a documented conservative fallback, but the fallback must be tested explicitly.
+4. Single-session `session.deleted` behavior remains unchanged: serialize the final `SessionEnd` first, then remove that session's ownership state.
+5. Cleanup must not synthesize an anonymous `SessionEnd` for another session.
+
+### 4.2 Ownership design
+
+Before mutating any map, derive the disposed session set from the authoritative directory ownership data. Normalize the directory using the same platform/path semantics used when it was captured; do not compare unrelated raw spellings ad hoc.
+
+For every disposed session ID, audit and clean all session-scoped state, not only the map that exposed the bug:
+
+- directory and title caches;
+- child-to-parent entries whose child is disposed;
+- child-to-parent entries whose parent is disposed, if their lifecycle contract does not outlive the parent;
+- per-session state dedup;
+- per-session FIFO tail once Workstream A exists, without interrupting an already serialized final body;
+- root/latest-session fallback pointers when they reference a disposed session.
+
+If the existing maps are insufficient to identify ownership safely, introduce one bounded `sessionId -> directory` ownership index rather than giving each map a separate disposal heuristic.
+
+### 4.3 Required tests
+
+Use the production shape: one factory product invoked as `plugin(ctxA)` and `plugin(ctxB)`. OpenCode and MiMo factory products are not a substitute for this test because they do not share closure state.
+
+1. Create sessions A and B in different directories, dispose A, and assert B keeps its directory, title, parent/headless classification, and dedup state.
+2. Assert B's next state body still contains B's directory and title.
+3. Assert every session owned by A is removed, including relevant child/parent entries.
+4. Assert a later title update for B is still detected and delivered normally.
+5. Cover Windows-equivalent directory spelling/case behavior and the applicable POSIX behavior.
+6. Cover the documented missing-directory fallback without silently treating a directory-scoped event as global in the normal case.
+
+## 5. Non-goals
+
+- Do not redesign the server's general last-writer-wins lifecycle model.
+- Do not put blocking permission approval behind the state queue.
+- Do not combine this work with title normalization, title-log privacy, or `metadataUpdatedAt`; those are PR #841 concerns.
+- Do not add metadata owner validation only for titles. If the localhost metadata trust boundary is hardened later, apply one consistent owner contract to context and title metadata.
+- Do not change OpenCode/MiMo session-ID namespaces.
+
+## 6. Completion gate
+
+This follow-up is complete only when delayed/failing transport tests prove per-session ordering, same-factory multi-directory tests prove selective disposal, and all fixtures remain hermetic: no real HOME, runtime file, localhost Clawd, or production plugin log may be touched.

--- a/docs/project/release-process.md
+++ b/docs/project/release-process.md
@@ -19,7 +19,8 @@ npm run audit:assets
 Manual workflow dispatch builds Windows, macOS, and Linux artifacts, checks
 each unpacked resources tree for retired Telegram sidecar binaries/source, and
 gates every package on its target-native Koffi payload, a packaged positive-call
-smoke, and updater metadata matching the generated artifacts. It then uploads
+smoke, and updater metadata matching both the generated artifacts and the exact
+`package.json` release version. It then uploads
 the installers plus JSON evidence manifests. It does not publish a GitHub
 Release.
 
@@ -48,7 +49,7 @@ Download and smoke-test the draft release assets before publishing the draft.
 If the draft is wrong, fix the issue before publishing; do not publish a known
 bad draft release.
 
-### v0.14.0 Draft Smoke Checklist
+### v0.15.0 Draft Smoke Checklist
 
 Use the draft release installer or package artifact, not `npm start`. Windows
 required items are the primary publish gate. If macOS or Linux hardware is not
@@ -58,7 +59,7 @@ notes.
 Before launching:
 
 - Download the draft release asset for the platform being tested.
-- Confirm the packaged app shows `0.14.0` metadata.
+- Confirm the packaged app shows `0.15.0` metadata.
 - Confirm packaged resources include `app.asar.unpacked/hooks`,
   `app.asar.unpacked/agents`, `app.asar.unpacked/extensions`,
   and `app.asar.unpacked/themes`.
@@ -68,8 +69,9 @@ Before launching:
   not a universal NSIS installer.
 - Download the native-package, Koffi prune/smoke, and updater metadata manifests.
   Confirm the target has one matching `koffi.node`, no foreign native payload,
-  and no unreviewed exception.
-- For migration smoke, install v0.13.0 first and save a copy of the old
+  and no unreviewed exception. Confirm each updater metadata `version` and every
+  listed artifact filename identify `0.15.0`.
+- For migration smoke, install v0.14.0 first and save a copy of the old
   `clawd-prefs.json` before upgrading.
 - For Reasonix smoke, prepare a machine with Reasonix initialized so
   `<Reasonix home>/` exists (`%APPDATA%\reasonix` on Windows,
@@ -81,9 +83,9 @@ Before launching:
 Required all-platform checks:
 
 - Fresh install, launch, pet appears, no error dialog.
-- Upgrade install over v0.13.0, launch, pet appears, no error dialog. Existing
+- Upgrade install over v0.14.0, launch, pet appears, no error dialog. Existing
   agent installation/enabled flags and user theme/animation choices remain intact.
-- Settings -> About shows `v0.14.0`, sourced from `app.getVersion()`.
+- Settings -> About shows `v0.15.0`, sourced from `app.getVersion()`.
 - First-run tutorial opens once for a fresh profile; Finish, Skip, and OS close
   each persist `tutorialSeen=true` and do not reopen on restart.
 - Upgrade profile with no `tutorialSeen` sees the tutorial once; an already-seen
@@ -92,13 +94,17 @@ Required all-platform checks:
   macOS installs default to pet + menu-bar accessory with no Dock tile.
 - Settings -> General / Agents / Animation & Sound render correctly in all supported
   languages, including sidebar SVG icons and the folded Animation Map subtab.
-- Settings -> About contributors include the six v0.14.0 first-time
-  contributors: `LinYsssss`, `He-wei-gui`, `liugou27`, `YOOGOMJA`,
-  `anupamme`, and `anthonyonazure`.
+- Settings -> About contributors include the two v0.15.0 first-time
+  contributors: `weed33834` and `arismarioneves`.
 - Reinstall one existing hook-based agent, such as Codex, and confirm the
   packaged hook script can `require()` its dependencies.
 - Run one real Claude Code or Codex session and confirm the pet reacts to state
   changes and still plays completion happy on Stop.
+- Confirm a completed turn uses the distinct default completion sound rather
+  than the ordinary confirmation cue.
+- Run one real OpenCode session through a title rename, tool activity, and
+  SessionEnd. HUD/Dashboard must show the bounded title, retain causal ordering,
+  and remove the session without replaying a stale state after a slow endpoint.
 - Restart Clawd during an active Claude session, then let the real hook resume
   and end it. Dashboard/HUD must keep one canonical session throughout and
   remove it cleanly on SessionEnd, with no duplicate or ghost recovery row.
@@ -137,6 +143,9 @@ Required all-platform checks:
   ZCode's native permission flow. From an Orca pane, jump back to the session
   and confirm the validated pane key focuses the correct pane locally and over
   managed Remote SSH.
+- Install QwenWork on Windows or macOS and confirm lifecycle state reaches Clawd,
+  `PermissionRequest` / `PermissionDenied` remain observation-only, and uninstall
+  removes only Clawd-managed hook entries.
 - Remote SSH profile with connect-on-launch connects after startup; repeat with
   local port 23333 occupied so the server binds a later port and the tunnel still
   targets the real bound port.
@@ -158,6 +167,10 @@ Recommended all-platform checks:
 
 - Free roam: enable it, wait idle, confirm the pet moves, keeps hitbox/HUD/bubble
   alignment, and cancels on mouse move, state change, drag, mini mode, and DND.
+- Free roam constraints: exercise axis off/horizontal/vertical both with and
+  without a valid fence, then use a small fence and invalid/missing fence input.
+  Targets must remain reachable and on-screen, with invalid input falling back
+  safely.
 - Dizzy spin: on the Clawd theme, circle the cursor rapidly and confirm dizzy
   triggers; repeat on Calico/Cloudling and confirm no unsupported-state glitch.
 - Low-power idle mode: verify sleeping/Cloudling static sleep behavior and that
@@ -165,7 +178,7 @@ Recommended all-platform checks:
 - Right-click Hide pet / Show pet still works; while hidden, a newly arriving
   permission request still shows a bubble, by design.
 - Settings -> About -> Check for updates completes without an error.
-- Update labels never show a duplicated prefix such as `vv0.14.0`.
+- Update labels never show a duplicated prefix such as `vv0.15.0`.
 - Telegram approval cards show the final outcome for decisions made on Telegram
   and for approvals resolved elsewhere.
 - Scan the mobile PWA pairing URL on a phone and confirm session cards appear.
@@ -194,6 +207,10 @@ Windows checks:
 
 macOS checks:
 
+- Required when macOS hardware is available: toggle menu-bar and Dock visibility,
+  restart, and confirm both preferences persist and Settings can still regain focus.
+- Required when macOS hardware is available: test Dock left/right/bottom plus
+  auto-hide and confirm physical-edge pinning stays on-screen across displays.
 - Required when macOS hardware is available: Ghostty cross-Space focus switches
   to the target Space without yanking the Ghostty window to the current desktop.
 - Required when macOS hardware is available: answer a permission with

--- a/docs/releases/release-v0.15.0.md
+++ b/docs/releases/release-v0.15.0.md
@@ -7,34 +7,41 @@ Free roam gains two independent ways to bound where the pet wanders. The OpenCod
 family, Codex, macOS, and Windows runtime paths each closed a set of real-world
 defects reported against v0.14.0.
 
-This release also takes over WinGet manifest publishing after discovering that x64
-users had been receiving the ARM64 installer since v0.6.2, and welcomes **three
-first-time contributors**.
+This release also prepares the project to take over WinGet manifest publishing, after
+discovering that x64 users had been receiving the ARM64 installer since v0.6.2, and
+welcomes **two first-time contributors**.
 
 ### Subscription Quota And Usage
 
 - **Identity-based ring colors and vendor glyphs** (#863) — healthy rings are colored
   by source identity rather than headroom, so the rolling and weekly windows stay
   distinguishable instead of collapsing into one thick green band. The Claude coin now
-  carries the vendor mark from the same MIT icon upstream as the other 21 runtime
-  icons; the remaining icons are byte-for-byte unchanged, with provenance and hashes
-  updated in `source-manifest.json` and the MIT attribution list in `NOTICE.md`.
+  carries the vendor mark, taken from the same MIT icon upstream that supplies the
+  other Lobe Icons agent glyphs; every other runtime icon is byte-for-byte unchanged,
+  with provenance and hashes updated in `source-manifest.json` and the MIT attribution
+  list in `NOTICE.md`.
 - **The readout follows the alert** (#864) — the coin used to always print the rolling
   window while the ring colored itself from the tightest window, so a coin could read
   "1% 5h" while the inner ring sat at 61% amber. The title now hands over to the
-  tightest window once it crosses the warning threshold, which keeps color from being
-  the only carrier of an alert. A flashback briefly replays the rolling number at the
-  moments it is most likely to be asked about, and each coin's glyph is scaled to its
-  own artwork rather than one shared zoom.
+  tightest window once it crosses the warning threshold, so in the common case the
+  digits report the alert instead of leaving color to carry it alone. A flashback
+  briefly replays the rolling number at the moments it is most likely to be asked
+  about; color remains the only alert channel during that ~1.6s window, in the 60-85%
+  band that does not pulse, and under `prefers-reduced-motion`. Each coin's glyph is
+  scaled to its own artwork rather than one shared zoom.
 - **Used / Remaining display modes** (#789) — a persisted preference selects whether
   the ring reports consumption or headroom, without changing quota ingestion or the
   warning thresholds. The same change consolidates reusable Settings buttons, warning
   dialogs, segmented choices, and dropdown behavior, and stabilizes Settings scrolling
   and dropdown lifecycles — including the theme-accessory case that previously lost its
   real scroll range after a selection. Thanks to @YOIMIYA66.
-- **Correct context windows for custom Claude models** (#809, issue #797) — context
-  usage is read from the Claude statusline rather than inferred, so a custom model no
-  longer displays a context length that does not match the model actually in use.
+- **Correct context windows for custom Claude models** (#809, issue #797) — when local
+  Claude quota collection is enabled, context usage is read from the Claude statusline
+  rather than inferred, so a custom model no longer displays a context length that does
+  not match the model actually in use. Collection stays opt-in (`Settings → General`)
+  because it installs Clawd's own statusline; an occupied third-party statusline is
+  preserved rather than taken over, and Clawd falls back to transcript-derived context
+  when registration does not succeed.
 
 ### Free Roam
 
@@ -54,8 +61,9 @@ first-time contributors**.
 
 - **Real session titles in the HUD** (#841, issue #829) — OpenCode sessions show their
   actual title instead of the project folder, and the title updates after OpenCode
-  renames a session. Titles are bounded, kept out of logs, and carry no telemetry
-  stamp. Thanks to first-time contributor @xiaoshidefeng.
+  renames a session. Titles are bounded, kept out of logs, stripped of Unicode
+  bidirectional formatting marks before display, and carry no telemetry stamp. Thanks
+  to @xiaoshidefeng.
 - **No premature idle during long active work** (#853, issue #850) — an active agent
   could fall back to idle mid-task and release the session; the stale floor is now
   scoped to interactive sessions and no longer fires while tools are still running.
@@ -64,8 +72,11 @@ first-time contributors**.
   requests for one session are serialized so an older lifecycle request can no longer
   arrive after a newer rename and restore the stale title, and
   `server.instance.disposed` clears only the disposing directory's sessions instead of
-  every cached session process-wide. Regression coverage locks the stale-floor
-  boundaries.
+  every cached session process-wide. Sustained state updates queued behind an
+  unresponsive local endpoint are coalesced to the latest snapshot and the retained
+  backlog is hard-capped. Lifecycle and metadata barriers retain their order within
+  that bound; `SessionEnd` replaces stale queued snapshots without overtaking the
+  active request. Regression coverage locks these ordering and stale-floor boundaries.
 - **Session cwd bound to its owning session** (#798, issue #796) — a session's working
   directory can no longer be attributed to a different session.
 
@@ -114,7 +125,7 @@ first-time contributors**.
   entirely in QwenWork's native flow: `PermissionRequest` / `PermissionDenied` are
   observation-only and the hook always returns `{}`. Detection, install, and uninstall
   go through `~/.QwenWorkCN/settings.json`. Windows and macOS only — QwenWork currently
-  ships no official Linux client. Thanks to first-time contributor @xiaoshidefeng.
+  ships no official Linux client. Thanks to @xiaoshidefeng.
 - **Hermes WSL Pair and Unpair** (#842, issue #540) — pairing and unpairing work against
   WSL targets.
 - **Unreviewed Codex hooks explained in Doctor** (#854) — Doctor distinguishes "hooks
@@ -132,6 +143,8 @@ first-time contributors**.
   connection recovers instead of failing permanently.
 - **Safe HTML in Telegram messages** (#802, issue #766) — message rendering escapes
   agent-controlled content instead of emitting it into Telegram's HTML parse mode.
+- **Distinct default completion sound** (#833) — built-in themes now use a dedicated,
+  softened completion cue instead of sharing the ordinary confirmation sound.
 
 ### Packaging, Security, And Localization
 
@@ -153,15 +166,15 @@ first-time contributors**.
 
 ### Contributors
 
-Three first-time contributors landed changes in this release:
+Two first-time contributors landed changes in this release:
 
 - @weed33834 — axis-constrained roam mode (#795)
 - @arismarioneves — Brazilian Portuguese locale (#822)
-- @xiaoshidefeng — OpenCode session titles (#841) and the QwenWork integration (#843)
 
-Returning contributors: @YOIMIYA66 (#789), @PeterShanxin (#853), @KaiC5504 (#807), and
-@anthonyonazure (#810), whose accessory and tint work shipped in v0.14.0 through
-co-author credit and who now lands a directly authored change.
+Returning contributors: @xiaoshidefeng (#841, #843), @YOIMIYA66 (#789),
+@PeterShanxin (#853), @KaiC5504 (#807), and @anthonyonazure (#810), whose accessory and
+tint work shipped in v0.14.0 through co-author credit and who now lands a directly
+authored change.
 
 ### Upgrade Notes
 
@@ -171,12 +184,25 @@ co-author credit and who now lands a directly authored change.
   the QwenWork desktop application on Windows or macOS.
 - Quota ring display mode (Used / Remaining) defaults to the existing behavior; no
   action is required to keep the previous readout.
+- Correct custom-model context windows require explicitly enabling local Claude quota
+  collection in Settings → General. Clawd preserves an occupied third-party statusline
+  and keeps transcript-derived context as the fallback when its own statusline cannot
+  be registered.
 - Free roam fence and axis constraint are both opt-in. With no fence file and the axis
   setting off, roaming behaves exactly as in v0.14.0.
 - Windows installs that used a WinGet-provided package before this release may be on the
   ARM64 build regardless of their architecture. Reinstalling from the GitHub release
   asset for the correct architecture is the reliable path until the corrected WinGet
   manifest is live.
+
+### Known Limitations
+
+- v0.15.0 Linux packaged artifacts have not been validated on real Linux hardware.
+  Wayland/XWayland transparency, positioning, cursor tracking and tray behavior, plus
+  MiMo JSONC permission and comment-preserving writes on POSIX, remain unverified for
+  this release.
+- Packaged macOS and Linux builds do not auto-update. Download future versions manually
+  from GitHub Releases.
 
 ### Validation Status
 

--- a/docs/releases/release-v0.15.0.md
+++ b/docs/releases/release-v0.15.0.md
@@ -1,0 +1,187 @@
+## v0.15.0
+
+v0.15.0 is a quota-legibility, free-roam, and platform-reliability release. The
+subscription quota ring becomes readable at a glance — identity-based colors, vendor
+glyphs, and a readout that follows whichever window is actually raising the alarm.
+Free roam gains two independent ways to bound where the pet wanders. The OpenCode
+family, Codex, macOS, and Windows runtime paths each closed a set of real-world
+defects reported against v0.14.0.
+
+This release also takes over WinGet manifest publishing after discovering that x64
+users had been receiving the ARM64 installer since v0.6.2, and welcomes **three
+first-time contributors**.
+
+### Subscription Quota And Usage
+
+- **Identity-based ring colors and vendor glyphs** (#863) — healthy rings are colored
+  by source identity rather than headroom, so the rolling and weekly windows stay
+  distinguishable instead of collapsing into one thick green band. The Claude coin now
+  carries the vendor mark from the same MIT icon upstream as the other 21 runtime
+  icons; the remaining icons are byte-for-byte unchanged, with provenance and hashes
+  updated in `source-manifest.json` and the MIT attribution list in `NOTICE.md`.
+- **The readout follows the alert** (#864) — the coin used to always print the rolling
+  window while the ring colored itself from the tightest window, so a coin could read
+  "1% 5h" while the inner ring sat at 61% amber. The title now hands over to the
+  tightest window once it crosses the warning threshold, which keeps color from being
+  the only carrier of an alert. A flashback briefly replays the rolling number at the
+  moments it is most likely to be asked about, and each coin's glyph is scaled to its
+  own artwork rather than one shared zoom.
+- **Used / Remaining display modes** (#789) — a persisted preference selects whether
+  the ring reports consumption or headroom, without changing quota ingestion or the
+  warning thresholds. The same change consolidates reusable Settings buttons, warning
+  dialogs, segmented choices, and dropdown behavior, and stabilizes Settings scrolling
+  and dropdown lifecycles — including the theme-accessory case that previously lost its
+  real scroll range after a selection. Thanks to @YOIMIYA66.
+- **Correct context windows for custom Claude models** (#809, issue #797) — context
+  usage is read from the Claude statusline rather than inferred, so a custom model no
+  longer displays a context length that does not match the model actually in use.
+
+### Free Roam
+
+- **Constrain to axis** (#795, issue #686) — an opt-in setting restricts idle wandering
+  to horizontal or vertical movement only, for users who prefer grid-aligned motion
+  over diagonal drift. Default off, so existing behavior is unchanged. Thanks to
+  first-time contributor @weed33834.
+- **Optional roam fence** (#810) — free roam can be bounded to a rectangle expressed as
+  fractions of the work area, so the pet can be kept to, say, the bottom-right quadrant.
+  The fence is re-read on every target pick, so edits apply live without a restart, and
+  the minimum hop distance scales down so small fences still produce reachable targets.
+  Thanks to @anthonyonazure.
+- **Hardened axis targets** (#819) — axis-constrained targets are clamped against the
+  same bounds as unconstrained ones, and the movement-style wording is clarified.
+
+### OpenCode Family
+
+- **Real session titles in the HUD** (#841, issue #829) — OpenCode sessions show their
+  actual title instead of the project folder, and the title updates after OpenCode
+  renames a session. Titles are bounded, kept out of logs, and carry no telemetry
+  stamp. Thanks to first-time contributor @xiaoshidefeng.
+- **No premature idle during long active work** (#853, issue #850) — an active agent
+  could fall back to idle mid-task and release the session; the stale floor is now
+  scoped to interactive sessions and no longer fires while tools are still running.
+  Thanks to @PeterShanxin.
+- **Ordered state delivery and directory-scoped disposal** (#855, #858) — `/state`
+  requests for one session are serialized so an older lifecycle request can no longer
+  arrive after a newer rename and restore the stale title, and
+  `server.instance.disposed` clears only the disposing directory's sessions instead of
+  every cached session process-wide. Regression coverage locks the stale-floor
+  boundaries.
+- **Session cwd bound to its owning session** (#798, issue #796) — a session's working
+  directory can no longer be attributed to a different session.
+
+### Codex Runtime
+
+- **Terminal turns fenced across event sources** (#831, issue #821) — after a Codex turn
+  ends, late `PreToolUse` / `PostToolUse` events can no longer pull the pet back into a
+  typing state, and `token_count` telemetry is separated from session liveness so a
+  metadata refresh cannot keep a stuck working session from timing out.
+- **Bounded rollout log reads** (#820, issue #817) — rollout log consumption is bounded
+  and recovery retries are hardened, closing a main-process error path.
+- **No flicker during Codex Pet drag transitions** (#804, issue #620) — drag direction,
+  release, and state changes switch animation rows inside the already-loaded SVG
+  document rather than rebuilding the spritesheet, removing the intermittent transparent
+  frame. (#803 reverts an earlier direct push of the same fix so it could land through
+  review.)
+
+### Platform: macOS
+
+- **Menu bar and Dock settings restored** (#851) — the menu-bar and Dock visibility
+  preferences apply and persist correctly again.
+- **Pinning against physical display bounds** (#826, issue #241) — edge pinning uses
+  physical display bounds, so the pet can reach the bottom of the screen when the Dock
+  is present and bottom pinning stays on-screen.
+
+### Platform: Windows
+
+- **Server-side process-chain resolution** (#837, issue #694) — native Windows process
+  ancestry queries (`NtQueryInformationProcess` primary, Toolhelp comparison) move
+  eligible `/state` and Codex `/permission` process-metadata resolution into the server,
+  with per-agent `legacy | shadow | b1a-authoritative` capability routing and bounded
+  shadow parity diagnostics. In authoritative mode the legacy hook-side PowerShell
+  snapshot is structurally skipped.
+- **Hardened FFI initialization and per-registry Koffi caching** (#839, #840, issue
+  #838) — process-query FFI initialization no longer fails open, and Koffi bindings are
+  cached per registry rather than re-resolved.
+- **Target-native Koffi packaging and foreign-native audit** (#824, issue #763) — each
+  release target keeps exactly one architecture-matching `koffi.node`, and a native
+  inventory audit rejects every foreign-architecture binary except the
+  electron-builder-managed Windows ia32 `elevate.exe` helper.
+
+### Agents And Diagnostics
+
+- **QwenWork (千问办公)** (#843) — a hook-only, state-only integration modeled on
+  QoderWork. The pet reflects QwenWork lifecycle state while permission decisions stay
+  entirely in QwenWork's native flow: `PermissionRequest` / `PermissionDenied` are
+  observation-only and the hook always returns `{}`. Detection, install, and uninstall
+  go through `~/.QwenWorkCN/settings.json`. Windows and macOS only — QwenWork currently
+  ships no official Linux client. Thanks to first-time contributor @xiaoshidefeng.
+- **Hermes WSL Pair and Unpair** (#842, issue #540) — pairing and unpairing work against
+  WSL targets.
+- **Unreviewed Codex hooks explained in Doctor** (#854) — Doctor distinguishes "hooks
+  are missing" from "hooks are installed but still need review in Codex `/hooks`", which
+  was the actual cause behind several "no permission prompt appears" reports.
+
+### Dashboard, Remote Access, And Notifications
+
+- **Persisted Sessions/Dashboard window bounds** (#807, #814, issue #801) — the window
+  remembers its position and size, with hardened persistence against invalid or
+  off-screen bounds. Thanks to @KaiC5504.
+- **Serialized Codespaces SSH transport** (#845, issue #546) — concurrent Codespaces
+  `gh cs ssh --stdio` activity no longer breaks Remote SSH deploy/probe on Windows.
+- **Safe Remote SSH reconnects** (#808, issue #800) — reconnect after a dropped
+  connection recovers instead of failing permanently.
+- **Safe HTML in Telegram messages** (#802, issue #766) — message rendering escapes
+  agent-controlled content instead of emitting it into Telegram's HTML parse mode.
+
+### Packaging, Security, And Localization
+
+- **WinGet manifest self-publishing groundwork** (#861, issue #860) — a prepare-only
+  workflow generates the manifest komac would submit and gates it on an architecture
+  contract. `rullerzhou-afk.clawd-on-desk` has been live in `microsoft/winget-pkgs`
+  since 2026-04-20 without ever being submitted by this project: a third-party release
+  tracker picked it up and, from v0.6.2 onward, produced manifests declaring two
+  `Architecture: x64` entries that both pointed at the **ARM64** installer. The NSIS
+  stub runs on x64, so the install reported success and the app then failed to launch.
+  Automatic submission stays deliberately disabled until the upstream manifest is
+  repaired by hand and komac's output is validated.
+- **npm dependency security hardening** (#846) — dependency and package validation are
+  tightened.
+- **Brazilian Portuguese (pt-BR)** (#822, #827) — a full pt-BR locale, with references
+  and language entry points synced. Thanks to first-time contributor @arismarioneves.
+- **Documentation accuracy** (#828, #849) — AGENTS references are corrected, contributor
+  credits updated, and runtime/safety boundaries synced with the code.
+
+### Contributors
+
+Three first-time contributors landed changes in this release:
+
+- @weed33834 — axis-constrained roam mode (#795)
+- @arismarioneves — Brazilian Portuguese locale (#822)
+- @xiaoshidefeng — OpenCode session titles (#841) and the QwenWork integration (#843)
+
+Returning contributors: @YOIMIYA66 (#789), @PeterShanxin (#853), @KaiC5504 (#807), and
+@anthonyonazure (#810), whose accessory and tint work shipped in v0.14.0 through
+co-author credit and who now lands a directly authored change.
+
+### Upgrade Notes
+
+- Launch Clawd once after upgrading so installed and enabled integrations can reconcile
+  their managed hooks/plugins against the packaged v0.15.0 files.
+- QwenWork is a new state-only integration and is not enabled by default. It requires
+  the QwenWork desktop application on Windows or macOS.
+- Quota ring display mode (Used / Remaining) defaults to the existing behavior; no
+  action is required to keep the previous readout.
+- Free roam fence and axis constraint are both opt-in. With no fence file and the axis
+  setting off, roaming behaves exactly as in v0.14.0.
+- Windows installs that used a WinGet-provided package before this release may be on the
+  ARM64 build regardless of their architecture. Reinstalling from the GitHub release
+  asset for the correct architecture is the reliable path until the corrected WinGet
+  manifest is live.
+
+### Validation Status
+
+> **Draft — not yet filled in.** This section is completed after the draft release is
+> built and smoke-tested, following `docs/project/release-process.md`. It must record:
+> the review passes that ran, the automated suite result, the asset audit, the final
+> multi-platform package build, which platforms received real-machine validation, and
+> any platform recorded as not real-machine validated.

--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -57,6 +57,11 @@ const STATE_PATH = "/state";
 // generous timeout is safe. 200ms was too tight when Clawd's IPC roundtrip
 // (main → renderer → main) ran under load and silently timed out.
 const POST_TIMEOUT_MS = 1000;
+// Keep one in-flight request plus a bounded pending suffix for each session.
+// A localhost process can accept fetches without answering, and OpenCode keeps
+// emitting events while that request waits. Without a hard cap, even an
+// explicitly serialized queue retains an unbounded chain of payloads/promises.
+const STATE_POST_MAX_PENDING = 32;
 
 // Orca hosts its terminals in a detached daemon that the process walk below can
 // never reach, so the pane key from the environment is the only handle on the tab
@@ -232,6 +237,10 @@ export function createOpencodeFamilyPlugin(config) {
   // Different sessions remain concurrent and /permission never enters this
   // queue.
   const _statePostTailBySession = new Map();
+  // Explicit queue state keeps retained work inspectable and bounded. Promise
+  // chaining alone looks bounded in the Map while every old closure/payload is
+  // still retained by the tail.
+  const _statePostQueueBySession = new Map();
   // Fallback session ID for legacy permission.asked events that omit sessionID.
   // Updated on every session.* / message.part.updated event so it stays fresh.
   // Not used for state dedup.
@@ -730,6 +739,7 @@ export function createOpencodeFamilyPlugin(config) {
     outbound.agent_pid = process.pid;
     const payload = JSON.stringify(outbound);
     return {
+      body: outbound,
       payload,
       logTag,
       cwdSource: cwd.source,
@@ -790,24 +800,109 @@ export function createOpencodeFamilyPlugin(config) {
     });
   }
 
+  function isReplaceableStateSnapshot(snapshot) {
+    const body = snapshot && snapshot.body;
+    return !!body
+      && body.metadata_only !== true
+      && ["UserPromptSubmit", "PreToolUse", "PostToolUse", "PreCompact"].includes(body.event);
+  }
+
+  function isMetadataStateSnapshot(snapshot) {
+    return !!(snapshot && snapshot.body && snapshot.body.metadata_only === true);
+  }
+
+  async function drainStatePostQueue(sessionId, queue) {
+    let allSucceeded = true;
+    while (queue.pending.length > 0) {
+      const snapshot = queue.pending.shift();
+      queue.active = snapshot;
+      try {
+        const delivered = await deliverPost(STATE_PATH, snapshot);
+        if (!delivered) allSucceeded = false;
+      } catch (err) {
+        allSucceeded = false;
+        debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} UNCAUGHT ${err && err.message}`);
+      } finally {
+        queue.active = null;
+      }
+    }
+
+    if (_statePostQueueBySession.get(sessionId) === queue) {
+      _statePostQueueBySession.delete(sessionId);
+    }
+    if (_statePostTailBySession.get(sessionId) === queue.settled) {
+      _statePostTailBySession.delete(sessionId);
+    }
+    queue.resolve(allSucceeded);
+  }
+
+  function createStatePostQueue(sessionId) {
+    let resolve;
+    const settled = new Promise((done) => { resolve = done; });
+    const queue = { active: null, pending: [], settled, resolve, draining: false };
+    _statePostQueueBySession.set(sessionId, queue);
+    _statePostTailBySession.set(sessionId, settled);
+    return queue;
+  }
+
+  function makeStatePostRoom(queue, incoming) {
+    if (queue.pending.length < STATE_POST_MAX_PENDING) return;
+    // A title-only update must never evict the latest lifecycle snapshot and
+    // leave the server stuck in an older error/idle state. Coalesce old metadata
+    // first; otherwise evict the oldest queued item. New lifecycle snapshots can
+    // preferentially replace old state/metadata because the incoming lifecycle
+    // itself preserves a fresh state at the tail.
+    const incomingMetadata = isMetadataStateSnapshot(incoming);
+    let index = incomingMetadata
+      ? queue.pending.findIndex((snapshot) => isMetadataStateSnapshot(snapshot))
+      : queue.pending.findIndex((snapshot) => (
+        isReplaceableStateSnapshot(snapshot) || isMetadataStateSnapshot(snapshot)
+      ));
+    if (index < 0) index = 0;
+    const [dropped] = queue.pending.splice(index, 1);
+    debugLog(`POST[${incoming.reqId}] ${incoming.logTag} overflow=dropped-old req=${dropped.reqId}`);
+  }
+
   function postStateToClawd(body) {
     const sessionId = normalizeSessionId(body && body.session_id) || DEFAULT_SESSION_ID;
     const snapshot = snapshotPost(body, `STATE state=${body && body.state}`);
-    const prior = _statePostTailBySession.get(sessionId) || Promise.resolve();
-    const delivery = prior
-      .catch(() => {})
-      .then(() => deliverPost(STATE_PATH, snapshot));
-    const settled = delivery.catch((err) => {
-      debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} UNCAUGHT ${err && err.message}`);
-      return false;
-    });
-    _statePostTailBySession.set(sessionId, settled);
-    void settled.then(() => {
-      if (_statePostTailBySession.get(sessionId) === settled) {
-        _statePostTailBySession.delete(sessionId);
+    const replaceable = isReplaceableStateSnapshot(snapshot);
+    const metadata = isMetadataStateSnapshot(snapshot);
+    const terminal = !!body && body.event === "SessionEnd";
+    let queue = _statePostQueueBySession.get(sessionId);
+
+    if (!queue) queue = createStatePostQueue(sessionId);
+
+    const activeTerminal = !!(queue.active && queue.active.body && queue.active.body.event === "SessionEnd");
+    const queuedTerminal = queue.pending.some((entry) => entry.body && entry.body.event === "SessionEnd");
+    if (!terminal && (activeTerminal || queuedTerminal)) {
+      debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} dropped=after-terminal`);
+      return queue.settled;
+    }
+
+    if (terminal) {
+      // SessionEnd is the final state. Keep the active request immutable, but
+      // replace every stale not-yet-started snapshot so recovery cannot replay
+      // obsolete work or leave a ghost session behind.
+      queue.pending.splice(0, queue.pending.length, snapshot);
+      debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} coalesced=terminal`);
+    } else {
+      const last = queue.pending.at(-1);
+      if ((replaceable && isReplaceableStateSnapshot(last)) ||
+          (metadata && isMetadataStateSnapshot(last))) {
+        queue.pending[queue.pending.length - 1] = snapshot;
+        debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} coalesced=${metadata ? "latest-metadata" : "latest-state"}`);
+      } else {
+        makeStatePostRoom(queue, snapshot);
+        queue.pending.push(snapshot);
       }
-    });
-    return settled;
+    }
+
+    if (!queue.draining) {
+      queue.draining = true;
+      void drainStatePostQueue(sessionId, queue);
+    }
+    return queue.settled;
   }
 
   // Fire-and-forget permission forward. Clawd decides allow/deny/always in its
@@ -964,6 +1059,8 @@ export function createOpencodeFamilyPlugin(config) {
     get _debugLogPath() { return DEBUG_LOG_PATH; },
     get _lastStatePerSession() { return _lastStatePerSession; },
     get _statePostTailBySession() { return _statePostTailBySession; },
+    get _statePostQueueBySession() { return _statePostQueueBySession; },
+    get _statePostMaxPending() { return STATE_POST_MAX_PENDING; },
     get _permissionTargetByRequestId() { return _permissionTargetByRequestId; },
     get _cachedPort() { return _cachedPort; },
     set _cachedPort(v) { _cachedPort = v; },

--- a/hooks/opencode-family-plugin/session-ids.mjs
+++ b/hooks/opencode-family-plugin/session-ids.mjs
@@ -27,17 +27,43 @@ function normalizeSessionText(value) {
 // ellipsis). A 17k-char title would otherwise blow the 16 KiB /state body
 // cap, trigger a headerless 413, and make the plugin distrust the response
 // and rescan all five ports on every event (#841 review).
-const SESSION_TITLE_CONTROL_RE = /[\u0000-\u001F\u007F-\u009F]+/g;
+// Unicode bidi formatting marks can visually reorder otherwise-safe text even
+// when the UI assigns it through textContent. Strip them at the plugin boundary
+// together with ordinary controls so the stored/wire title is never ambiguous.
+const SESSION_TITLE_CONTROL_RE = /[\u0000-\u001F\u007F-\u009F\u061C\u200E-\u200F\u202A-\u202E\u2066-\u2069]+/g;
 const SESSION_TITLE_MAX = 80;
+
+function replaceUnpairedSurrogates(value) {
+  let result = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xD800 && code <= 0xDBFF) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xDC00 && next <= 0xDFFF) {
+        result += value[index] + value[index + 1];
+        index += 1;
+      } else {
+        result += "\uFFFD";
+      }
+    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+      result += "\uFFFD";
+    } else {
+      result += value[index];
+    }
+  }
+  return result;
+}
+
 function normalizeTitle(value) {
   if (typeof value !== "string") return null;
-  const collapsed = value
+  const collapsed = replaceUnpairedSurrogates(value)
     .replace(SESSION_TITLE_CONTROL_RE, " ")
     .replace(/\s+/g, " ")
     .trim();
   if (!collapsed) return null;
-  return collapsed.length > SESSION_TITLE_MAX
-    ? `${collapsed.slice(0, SESSION_TITLE_MAX - 1)}…`
+  const characters = Array.from(collapsed);
+  return characters.length > SESSION_TITLE_MAX
+    ? `${characters.slice(0, SESSION_TITLE_MAX - 1).join("")}…`
     : collapsed;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clawd-on-desk",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clawd-on-desk",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clawd-on-desk",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A desktop pet that reacts to your Claude Code sessions in real-time.",
   "main": "src/main.js",
   "scripts": {

--- a/scripts/verify-updater-metadata.js
+++ b/scripts/verify-updater-metadata.js
@@ -58,9 +58,38 @@ function sha512Base64(filename) {
   return crypto.createHash("sha512").update(fs.readFileSync(filename)).digest("base64");
 }
 
-function validateContractShape(metadata, contract) {
+function validateContractShape(metadata, contract, expectedVersion) {
+  if (typeof expectedVersion !== "string" || !expectedVersion.trim()) {
+    throw new TypeError("expectedVersion is required");
+  }
   const urls = metadata.files.map((entry) => String(entry.url || ""));
   const errors = [];
+  if (String(metadata.version || "") !== expectedVersion) {
+    errors.push(`Updater metadata version must be ${expectedVersion}, got ${metadata.version || "<empty>"}`);
+  }
+  let expectedUrls;
+  if (contract === "windows") {
+    expectedUrls = new Set([
+      `Clawd-on-Desk-Setup-${expectedVersion}-x64.exe`,
+      `Clawd-on-Desk-Setup-${expectedVersion}-arm64.exe`,
+    ]);
+  } else if (contract === "mac") {
+    expectedUrls = new Set([
+      `Clawd-on-Desk-${expectedVersion}-x64.dmg`,
+      `Clawd-on-Desk-${expectedVersion}-arm64.dmg`,
+    ]);
+  } else if (contract === "linux") {
+    expectedUrls = new Set([
+      `Clawd-on-Desk-${expectedVersion}-x86_64.AppImage`,
+      `Clawd-on-Desk-${expectedVersion}-amd64.deb`,
+    ]);
+  }
+  if (!expectedUrls) throw new Error(`Unknown updater contract: ${contract || "<empty>"}`);
+  for (const url of urls) {
+    if (url && !expectedUrls.has(url)) {
+      errors.push(`Unexpected updater artifact URL for ${contract} ${expectedVersion}: ${url}`);
+    }
+  }
   if (contract === "windows") {
     if (urls.length !== 2 || !urls.some((url) => /-x64\.exe$/i.test(url)) ||
         !urls.some((url) => /-arm64\.exe$/i.test(url))) {
@@ -89,19 +118,20 @@ function validateContractShape(metadata, contract) {
     if (appImage && (!Number.isInteger(appImage.blockMapSize) || appImage.blockMapSize <= 0)) {
       errors.push("latest-linux.yml AppImage entry must contain a positive blockMapSize");
     }
-  } else {
-    throw new Error(`Unknown updater contract: ${contract || "<empty>"}`);
   }
   return errors;
 }
 
-function verifyUpdaterMetadata({ metadataPath, artifactRoot, contract } = {}) {
+function verifyUpdaterMetadata({ metadataPath, artifactRoot, contract, expectedVersion } = {}) {
   if (!metadataPath) throw new TypeError("metadataPath is required");
   if (!artifactRoot) throw new TypeError("artifactRoot is required");
+  if (typeof expectedVersion !== "string" || !expectedVersion.trim()) {
+    throw new TypeError("expectedVersion is required");
+  }
   const resolvedMetadata = path.resolve(metadataPath);
   const resolvedArtifacts = path.resolve(artifactRoot);
   const metadata = parseUpdaterYaml(fs.readFileSync(resolvedMetadata, "utf8"));
-  const errors = validateContractShape(metadata, contract);
+  const errors = validateContractShape(metadata, contract, expectedVersion);
   const files = [];
 
   for (const entry of metadata.files) {
@@ -131,6 +161,7 @@ function verifyUpdaterMetadata({ metadataPath, artifactRoot, contract } = {}) {
   return {
     schemaVersion: 1,
     contract,
+    expectedVersion,
     metadataPath: resolvedMetadata,
     artifactRoot: resolvedArtifacts,
     files,
@@ -140,24 +171,30 @@ function verifyUpdaterMetadata({ metadataPath, artifactRoot, contract } = {}) {
 }
 
 function parseArgs(argv) {
-  const options = { metadataPath: "", artifactRoot: "", contract: "", output: "" };
+  const options = { metadataPath: "", artifactRoot: "", contract: "", packageJson: "", output: "" };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === "--metadata") options.metadataPath = argv[++index] || "";
     else if (arg === "--artifact-root") options.artifactRoot = argv[++index] || "";
     else if (arg === "--contract") options.contract = argv[++index] || "";
+    else if (arg === "--package-json") options.packageJson = argv[++index] || "";
     else if (arg === "--output") options.output = argv[++index] || "";
     else throw new Error(`Unknown argument: ${arg}`);
   }
   if (!options.metadataPath) throw new Error("--metadata is required");
   if (!options.artifactRoot) throw new Error("--artifact-root is required");
   if (!options.contract) throw new Error("--contract is required");
+  if (!options.packageJson) throw new Error("--package-json is required");
   return options;
 }
 
 function runCli(argv = process.argv.slice(2)) {
   const options = parseArgs(argv);
-  const report = verifyUpdaterMetadata(options);
+  const packagePath = path.resolve(options.packageJson);
+  const packageData = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  const expectedVersion = typeof packageData.version === "string" ? packageData.version.trim() : "";
+  if (!expectedVersion) throw new Error(`Package version is missing: ${packagePath}`);
+  const report = verifyUpdaterMetadata({ ...options, expectedVersion });
   const json = `${JSON.stringify(report, null, 2)}\n`;
   if (options.output) {
     const outputPath = path.resolve(options.output);

--- a/src/settings-i18n.js
+++ b/src/settings-i18n.js
@@ -5379,7 +5379,7 @@
     "Yike-Ye", "xiaoshidefeng", "yanguibao1997", "JasonZH6600", "V1staz", "royhuang91", "Schlaflied", "KaiC5504",
     "jiaxuan1101", "kkirito16", "200780381", "Dxy2326", "lurui1997", "JesmonX", "chen86860",
     "LinYsssss", "He-wei-gui", "liugou27", "YOOGOMJA", "anupamme", "anthonyonazure", "weed33834",
-    "arismarioneves",
+    "arismarioneves", "aaronWool",
   ];
 
   root.ClawdSettingsI18n = {

--- a/src/settings-tab-about.js
+++ b/src/settings-tab-about.js
@@ -7,6 +7,13 @@
   let ops = null;
   let i18n = null;
 
+  // Contributors who are credited but whose GitHub account no longer resolves, so
+  // https://github.com/<name> would 404. tomaioo authored the Linux Electron sandbox
+  // gate (commit 2cab204e, shipped via the now-deleted PR #168) and the account was
+  // removed afterwards — lookup by login and by numeric id both 404, so it is gone
+  // rather than renamed. The contribution still ships in hooks/shared-process.js.
+  const NO_GITHUB_ACCOUNT = new Set(["tomaioo"]);
+
   function t(key) {
     return helpers.t(key);
   }
@@ -324,6 +331,15 @@
     const contribList = document.createElement("div");
     contribList.className = "about-contributors-list";
     for (const name of i18n.CONTRIBUTORS) {
+      // Contributors whose GitHub account no longer resolves keep their credit but
+      // get plain text: a link to a deleted account only leads to a 404.
+      if (NO_GITHUB_ACCOUNT.has(name)) {
+        const plain = document.createElement("span");
+        plain.className = "about-contributor-link";
+        plain.textContent = "@" + name;
+        contribList.appendChild(plain);
+        continue;
+      }
       const link = document.createElement("a");
       link.className = "about-contributor-link";
       link.textContent = "@" + name;

--- a/src/state-session-snapshot.js
+++ b/src/state-session-snapshot.js
@@ -67,18 +67,43 @@ function isDoneEvent(event) {
   return DONE_EVENTS.has(event);
 }
 
-const SESSION_TITLE_CONTROL_RE = /[\u0000-\u001F\u007F-\u009F]+/g;
+// Defense in depth for every agent title that reaches shared UI snapshots.
+// Bidi formatting marks are not HTML injection, but can visually reorder and
+// disguise filenames or commands even when renderers use textContent.
+const SESSION_TITLE_CONTROL_RE = /[\u0000-\u001F\u007F-\u009F\u061C\u200E-\u200F\u202A-\u202E\u2066-\u2069]+/g;
 const SESSION_TITLE_MAX = 80;
+
+function replaceUnpairedSurrogates(value) {
+  let result = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xD800 && code <= 0xDBFF) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xDC00 && next <= 0xDFFF) {
+        result += value[index] + value[index + 1];
+        index += 1;
+      } else {
+        result += "\uFFFD";
+      }
+    } else if (code >= 0xDC00 && code <= 0xDFFF) {
+      result += "\uFFFD";
+    } else {
+      result += value[index];
+    }
+  }
+  return result;
+}
 
 function normalizeTitle(value) {
   if (typeof value !== "string") return null;
-  const collapsed = value
+  const collapsed = replaceUnpairedSurrogates(value)
     .replace(SESSION_TITLE_CONTROL_RE, " ")
     .replace(/\s+/g, " ")
     .trim();
   if (!collapsed) return null;
-  return collapsed.length > SESSION_TITLE_MAX
-    ? `${collapsed.slice(0, SESSION_TITLE_MAX - 1)}\u2026`
+  const characters = Array.from(collapsed);
+  return characters.length > SESSION_TITLE_MAX
+    ? `${characters.slice(0, SESSION_TITLE_MAX - 1).join("")}\u2026`
     : collapsed;
 }
 

--- a/test/opencode-family-session-directory.test.js
+++ b/test/opencode-family-session-directory.test.js
@@ -543,6 +543,74 @@ describe("opencode-family session title (#829)", () => {
     assert.ok(metaPost.body.session_title.endsWith("…"));
   });
 
+  it("strips bidi formatting marks before storing or sending the title", async () => {
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
+    const hooks = await plugin(createContext("C:\\proj"));
+    const bidi = "safe\u061c\u200efile\u202etxt.exe\u2066done\u2069";
+
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_bidi",
+          info: { id: "ses_bidi", directory: "C:\\proj", title: bidi },
+        },
+      },
+    });
+    await settlePosts();
+
+    const stored = plugin.__test._sessionTitleById.get("opencode:ses_bidi");
+    assert.strictEqual(stored, "safe file txt.exe done");
+    assert.doesNotMatch(stored, /[\u061C\u200E-\u200F\u202A-\u202E\u2066-\u2069]/u);
+    assert.ok(fetchCalls.length > 0);
+    for (const call of fetchCalls) {
+      if (call.body && call.body.session_title) {
+        assert.doesNotMatch(call.body.session_title, /[\u061C\u200E-\u200F\u202A-\u202E\u2066-\u2069]/u);
+      }
+    }
+  });
+
+  it("keeps truncated titles well-formed at astral and surrogate boundaries", async () => {
+    const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
+    const hooks = await plugin(createContext("C:\\proj"));
+    const title = `${"A".repeat(78)}😀BC\uD83Dtail\uDC00`;
+
+    await hooks.event({
+      event: {
+        type: "session.created",
+        properties: {
+          sessionID: "ses_unicode_boundary",
+          info: { id: "ses_unicode_boundary", directory: "C:\\proj", title },
+        },
+      },
+    });
+    await settlePosts();
+
+    const stored = plugin.__test._sessionTitleById.get("opencode:ses_unicode_boundary");
+    assert.strictEqual(stored, `${"A".repeat(78)}😀…`);
+    assert.strictEqual(stored.isWellFormed(), true);
+    assert.strictEqual(Array.from(stored).length, 80);
+
+    await hooks.event({
+      event: {
+        type: "session.updated",
+        properties: {
+          sessionID: "ses_unicode_boundary",
+          info: {
+            id: "ses_unicode_boundary",
+            directory: "C:\\proj",
+            title: "before\uD83Dmiddle\uDC00after",
+          },
+        },
+      },
+    });
+    await settlePosts();
+    assert.strictEqual(
+      plugin.__test._sessionTitleById.get("opencode:ses_unicode_boundary"),
+      "before�middle�after",
+    );
+  });
+
   it("does not log the title text into the debug log", async () => {
     const plugin = createOpencodeFamilyPlugin(OPENCODE_CONFIG);
     const hooks = await plugin(createContext("C:\\proj"));

--- a/test/opencode-family-state-ordering-disposal.test.js
+++ b/test/opencode-family-state-ordering-disposal.test.js
@@ -270,6 +270,208 @@ describe("opencode-family per-session /state FIFO", () => {
     assert.strictEqual(plugin.__test._statePostTailBySession.size, 0);
   });
 
+  it("coalesces sustained states behind a slow in-flight delivery", async () => {
+    const plugin = createOpencodeFamilyPlugin(CONFIG);
+    await plugin(createContext(path.join(TMP_HOME, "coalesce")));
+    const calls = [];
+    const firstGate = deferred();
+
+    fetchImpl = async (url, opts) => {
+      const call = parseFetchCall(url, opts);
+      calls.push(call);
+      if (call.body.event === "UserPromptSubmit" && call.body.sequence === 0) {
+        await firstGate.promise;
+      }
+      return clawdResponse();
+    };
+
+    plugin.__test.postStateToClawd({
+      state: "thinking",
+      session_id: "opencode:ses_coalesce",
+      event: "UserPromptSubmit",
+      sequence: 0,
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+    });
+    await waitFor(() => calls.length === 1, "first state never began");
+
+    for (let sequence = 1; sequence <= 100; sequence += 1) {
+      plugin.__test.postStateToClawd({
+        state: sequence % 2 ? "working" : "thinking",
+        session_id: "opencode:ses_coalesce",
+        event: sequence % 2 ? "PreToolUse" : "UserPromptSubmit",
+        sequence,
+        agent_id: "opencode",
+        hook_source: "opencode-plugin",
+      });
+    }
+
+    const queued = plugin.__test._statePostQueueBySession.get("opencode:ses_coalesce");
+    assert.ok(queued);
+    assert.strictEqual(queued.pending.length, 1);
+    assert.strictEqual(calls.length, 1, "a queued state overtook the in-flight delivery");
+    firstGate.resolve();
+    await waitForQueueEmpty(plugin);
+
+    assert.deepStrictEqual(calls.map((call) => call.body.sequence), [0, 100]);
+    assert.strictEqual(plugin.__test._statePostQueueBySession.size, 0);
+  });
+
+  it("lets SessionEnd replace a stale sustained state pending behind a slow delivery", async () => {
+    const plugin = createOpencodeFamilyPlugin(CONFIG);
+    await plugin(createContext(path.join(TMP_HOME, "terminal-coalesce")));
+    const calls = [];
+    const firstGate = deferred();
+
+    fetchImpl = async (url, opts) => {
+      const call = parseFetchCall(url, opts);
+      calls.push(call);
+      if (call.body.sequence === 0) await firstGate.promise;
+      return clawdResponse();
+    };
+
+    plugin.__test.postStateToClawd({
+      state: "thinking",
+      session_id: "opencode:ses_terminal",
+      event: "UserPromptSubmit",
+      sequence: 0,
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+    });
+    await waitFor(() => calls.length === 1, "first state never began");
+    plugin.__test.postStateToClawd({
+      state: "working",
+      session_id: "opencode:ses_terminal",
+      event: "PreToolUse",
+      sequence: 1,
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+    });
+    plugin.__test.postStateToClawd({
+      state: "sleeping",
+      session_id: "opencode:ses_terminal",
+      event: "SessionEnd",
+      sequence: 2,
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+    });
+
+    firstGate.resolve();
+    await waitForQueueEmpty(plugin);
+    assert.deepStrictEqual(calls.map((call) => [call.body.sequence, call.body.event]), [
+      [0, "UserPromptSubmit"],
+      [2, "SessionEnd"],
+    ]);
+  });
+
+  it("hard-bounds a real event backlog across repeated error barriers", async () => {
+    const directory = path.join(TMP_HOME, "bounded-barriers");
+    const plugin = createOpencodeFamilyPlugin(CONFIG);
+    const hooks = await plugin(createContext(directory));
+    const calls = [];
+    const firstGate = deferred();
+
+    fetchImpl = async (url, opts) => {
+      const call = parseFetchCall(url, opts);
+      calls.push(call);
+      if (calls.length === 1) await firstGate.promise;
+      return clawdResponse();
+    };
+
+    await emit(hooks, lifecycle("session.created", "ses_bounded", directory, "Bounded"));
+    await waitFor(() => calls.length === 1, "first lifecycle request never began");
+
+    for (let index = 0; index < 100; index += 1) {
+      await emit(hooks, {
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses_bounded",
+          part: { type: "tool", state: { status: "running" } },
+        },
+      });
+      await emit(hooks, {
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses_bounded",
+          part: { type: "tool", state: { status: "error" } },
+        },
+      });
+      await emit(hooks, {
+        type: "session.status",
+        properties: { sessionID: "ses_bounded", status: { type: "busy" } },
+      });
+    }
+
+    const queue = plugin.__test._statePostQueueBySession.get("opencode:ses_bounded");
+    assert.ok(queue);
+    assert.ok(queue.pending.length <= plugin.__test._statePostMaxPending);
+    assert.strictEqual(calls.length, 1, "queued events overtook the in-flight delivery");
+
+    firstGate.resolve();
+    await waitForQueueEmpty(plugin);
+    assert.ok(calls.length <= plugin.__test._statePostMaxPending + 1);
+    assert.deepStrictEqual(
+      [calls.at(-1).body.state, calls.at(-1).body.event],
+      ["thinking", "UserPromptSubmit"],
+      "the bounded queue did not retain the freshest state",
+    );
+    assert.strictEqual(plugin.__test._statePostQueueBySession.size, 0);
+  });
+
+  it("does not let overflow title metadata evict the freshest lifecycle state", async () => {
+    const directory = path.join(TMP_HOME, "bounded-metadata");
+    const plugin = createOpencodeFamilyPlugin(CONFIG);
+    const hooks = await plugin(createContext(directory));
+    const calls = [];
+    const firstGate = deferred();
+
+    fetchImpl = async (url, opts) => {
+      const call = parseFetchCall(url, opts);
+      calls.push(call);
+      if (calls.length === 1) await firstGate.promise;
+      return clawdResponse();
+    };
+
+    await emit(hooks, lifecycle("session.created", "ses_metadata_bound", directory, "Old title"));
+    await waitFor(() => calls.length === 1, "first lifecycle request never began");
+
+    for (let index = 0; index < 40; index += 1) {
+      await emit(hooks, {
+        type: "message.part.updated",
+        properties: {
+          sessionID: "ses_metadata_bound",
+          part: { type: "tool", state: { status: "error" } },
+        },
+      });
+      await emit(hooks, {
+        type: "session.status",
+        properties: { sessionID: "ses_metadata_bound", status: { type: "busy" } },
+      });
+    }
+    await emit(hooks, lifecycle(
+      "session.updated",
+      "ses_metadata_bound",
+      directory,
+      "Fresh title",
+    ));
+
+    const queue = plugin.__test._statePostQueueBySession.get("opencode:ses_metadata_bound");
+    assert.ok(queue);
+    assert.ok(queue.pending.length <= plugin.__test._statePostMaxPending);
+
+    firstGate.resolve();
+    await waitForQueueEmpty(plugin);
+    const lifecycleCalls = calls.filter((call) => !call.body.metadata_only);
+    assert.deepStrictEqual(
+      [lifecycleCalls.at(-1).body.state, lifecycleCalls.at(-1).body.event],
+      ["thinking", "UserPromptSubmit"],
+    );
+    assert.strictEqual(
+      calls.some((call) => call.body.metadata_only && call.body.session_title === "Fresh title"),
+      true,
+    );
+  });
+
   it("keeps different sessions concurrent and /permission outside the state queue", async () => {
     const directory = path.join(TMP_HOME, "parallel");
     const plugin = createOpencodeFamilyPlugin(CONFIG);

--- a/test/readme-contributors.test.js
+++ b/test/readme-contributors.test.js
@@ -67,7 +67,13 @@ function loadSettingsContributors() {
 
 function extractContributorLogins(markdown, filename) {
   const section = extractContributorSection(markdown, filename);
-  return [...section.matchAll(/href="https:\/\/github\.com\/([^"/]+)"/g)].map((match) => match[1]);
+  const linked = [...section.matchAll(/href="https:\/\/github\.com\/([^"/]+)"/g)].map((match) => match[1]);
+  // A contributor whose GitHub account no longer resolves is credited as plain text
+  // rather than a link and avatar that both 404. Those entries still belong in the
+  // list, so collect them from the markup left over once every link is removed.
+  const unlinkedMarkup = section.replace(/<a\s[^>]*>[\s\S]*?<\/a>/g, "");
+  const unlinked = [...unlinkedMarkup.matchAll(/<sub>([^<]+)<\/sub>/g)].map((match) => match[1].trim());
+  return [...linked, ...unlinked];
 }
 
 function extractContributorTable(markdown, filename) {

--- a/test/release-version-contract.test.js
+++ b/test/release-version-contract.test.js
@@ -28,7 +28,17 @@ test("the current checkout satisfies the release version contract", () => {
   const result = verifyReleaseVersion({ root: path.join(__dirname, ".."), env: {} });
   assert.deepStrictEqual(result.errors, []);
   assert.strictEqual(result.ok, true);
-  assert.strictEqual(result.version, "0.14.0");
+  assert.strictEqual(result.version, "0.15.0");
+});
+
+test("the authoritative draft smoke checklist tracks the current package version", () => {
+  const root = path.join(__dirname, "..");
+  const version = require(path.join(root, "package.json")).version;
+  const escapedVersion = version.replace(/\./g, "\\.");
+  const processDoc = fs.readFileSync(path.join(root, "docs", "project", "release-process.md"), "utf8");
+  assert.match(processDoc, new RegExp(`### v${escapedVersion} Draft Smoke Checklist`));
+  assert.match(processDoc, new RegExp("packaged app shows `" + escapedVersion + "` metadata"));
+  assert.match(processDoc, new RegExp("About shows `v" + escapedVersion + "`"));
 });
 
 test("package, lock root, release note, and tag must agree exactly", (t) => {
@@ -65,5 +75,9 @@ test("build workflow validates the release contract before every platform build"
   assert.match(
     workflow,
     /release:\s*\n\s*if: github\.event_name == 'push' && startsWith\(github\.ref, 'refs\/tags\/v'\)/,
+  );
+  assert.strictEqual(
+    (workflow.match(/verify-updater-metadata\.js[^\n]+--package-json package\.json/g) || []).length,
+    3,
   );
 });

--- a/test/state-session-snapshot.test.js
+++ b/test/state-session-snapshot.test.js
@@ -12,6 +12,7 @@ const {
   getActiveSessionAliasKeys,
   sessionSnapshotSignature,
   sessionDisplayTitle,
+  normalizeTitle,
 } = require("../src/state-session-snapshot");
 const { makeSessionKey } = require("../src/session-key");
 const { sessionAliasKey } = require("../src/session-alias");
@@ -49,6 +50,23 @@ describe("deriveSourceInfo", () => {
         displayLabel: "",
       });
     }
+  });
+});
+
+describe("normalizeTitle", () => {
+  it("strips Unicode bidi formatting marks before UI snapshots", () => {
+    assert.strictEqual(
+      normalizeTitle("safe\u061c\u200efile\u202etxt.exe\u2066done\u2069"),
+      "safe file txt.exe done"
+    );
+  });
+
+  it("does not split astral characters or preserve unpaired surrogates", () => {
+    const truncated = normalizeTitle(`${"A".repeat(78)}😀BC`);
+    assert.strictEqual(truncated, `${"A".repeat(78)}😀…`);
+    assert.strictEqual(truncated.isWellFormed(), true);
+    assert.strictEqual(Array.from(truncated).length, 80);
+    assert.strictEqual(normalizeTitle("before\uD83Dmiddle\uDC00after"), "before�middle�after");
   });
 });
 

--- a/test/verify-updater-metadata.test.js
+++ b/test/verify-updater-metadata.test.js
@@ -8,9 +8,11 @@ const test = require("node:test");
 const {
   parseUpdaterYaml,
   sha512Base64,
+  validateContractShape,
   verifyUpdaterMetadata,
   parseArgs,
 } = require("../scripts/verify-updater-metadata");
+const CURRENT_VERSION = require("../package.json").version;
 
 function tempDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), "clawd-updater-metadata-"));
@@ -26,9 +28,9 @@ function writeArtifact(root, name, content) {
   };
 }
 
-function yamlFor(files, topPath, { appImageBlockMap = false } = {}) {
+function yamlFor(files, topPath, { appImageBlockMap = false, version = CURRENT_VERSION } = {}) {
   const top = files.find((entry) => entry.name === topPath);
-  const lines = ["version: 0.14.0", "files:"];
+  const lines = [`version: ${version}`, "files:"];
   for (const entry of files) {
     lines.push(`  - url: ${entry.name}`);
     lines.push(`    sha512: ${entry.sha512}`);
@@ -59,11 +61,16 @@ test("minimal updater YAML parser keeps files and top-level path separate", () =
 test("Windows dual-architecture updater metadata verifies bytes and hashes", (t) => {
   const root = tempDir();
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const x64 = writeArtifact(root, "Clawd-on-Desk-Setup-0.14.0-x64.exe", "x64");
-  const arm64 = writeArtifact(root, "Clawd-on-Desk-Setup-0.14.0-arm64.exe", "arm64");
+  const x64 = writeArtifact(root, `Clawd-on-Desk-Setup-${CURRENT_VERSION}-x64.exe`, "x64");
+  const arm64 = writeArtifact(root, `Clawd-on-Desk-Setup-${CURRENT_VERSION}-arm64.exe`, "arm64");
   const metadata = path.join(root, "latest.yml");
   fs.writeFileSync(metadata, yamlFor([x64, arm64], x64.name));
-  const report = verifyUpdaterMetadata({ metadataPath: metadata, artifactRoot: root, contract: "windows" });
+  const report = verifyUpdaterMetadata({
+    metadataPath: metadata,
+    artifactRoot: root,
+    contract: "windows",
+    expectedVersion: CURRENT_VERSION,
+  });
   assert.deepEqual(report.errors, []);
   assert.equal(report.files.length, 2);
 });
@@ -71,12 +78,17 @@ test("Windows dual-architecture updater metadata verifies bytes and hashes", (t)
 test("macOS contract requires two DMGs and no invented zip", (t) => {
   const root = tempDir();
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const x64 = writeArtifact(root, "Clawd-on-Desk-0.14.0-x64.dmg", "x64");
-  const arm64 = writeArtifact(root, "Clawd-on-Desk-0.14.0-arm64.dmg", "arm64");
+  const x64 = writeArtifact(root, `Clawd-on-Desk-${CURRENT_VERSION}-x64.dmg`, "x64");
+  const arm64 = writeArtifact(root, `Clawd-on-Desk-${CURRENT_VERSION}-arm64.dmg`, "arm64");
   const metadata = path.join(root, "latest-mac.yml");
   fs.writeFileSync(metadata, yamlFor([x64, arm64], x64.name));
   assert.deepEqual(
-    verifyUpdaterMetadata({ metadataPath: metadata, artifactRoot: root, contract: "mac" }).errors,
+    verifyUpdaterMetadata({
+      metadataPath: metadata,
+      artifactRoot: root,
+      contract: "mac",
+      expectedVersion: CURRENT_VERSION,
+    }).errors,
     [],
   );
 });
@@ -84,12 +96,17 @@ test("macOS contract requires two DMGs and no invented zip", (t) => {
 test("Linux contract requires AppImage, deb, path, and blockMapSize", (t) => {
   const root = tempDir();
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const appImage = writeArtifact(root, "Clawd-on-Desk-0.14.0-x86_64.AppImage", "appimage");
-  const deb = writeArtifact(root, "Clawd-on-Desk-0.14.0-amd64.deb", "deb");
+  const appImage = writeArtifact(root, `Clawd-on-Desk-${CURRENT_VERSION}-x86_64.AppImage`, "appimage");
+  const deb = writeArtifact(root, `Clawd-on-Desk-${CURRENT_VERSION}-amd64.deb`, "deb");
   const metadata = path.join(root, "latest-linux.yml");
   fs.writeFileSync(metadata, yamlFor([appImage, deb], appImage.name, { appImageBlockMap: true }));
   assert.deepEqual(
-    verifyUpdaterMetadata({ metadataPath: metadata, artifactRoot: root, contract: "linux" }).errors,
+    verifyUpdaterMetadata({
+      metadataPath: metadata,
+      artifactRoot: root,
+      contract: "linux",
+      expectedVersion: CURRENT_VERSION,
+    }).errors,
     [],
   );
 });
@@ -97,19 +114,93 @@ test("Linux contract requires AppImage, deb, path, and blockMapSize", (t) => {
 test("metadata verification reports missing artifacts and tampered hashes", (t) => {
   const root = tempDir();
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const x64 = writeArtifact(root, "Clawd-on-Desk-Setup-0.14.0-x64.exe", "x64");
-  const arm64 = { name: "Clawd-on-Desk-Setup-0.14.0-arm64.exe", size: 10, sha512: "wrong" };
+  const x64 = writeArtifact(root, `Clawd-on-Desk-Setup-${CURRENT_VERSION}-x64.exe`, "x64");
+  const arm64 = { name: `Clawd-on-Desk-Setup-${CURRENT_VERSION}-arm64.exe`, size: 10, sha512: "wrong" };
   const metadata = path.join(root, "latest.yml");
   fs.writeFileSync(metadata, yamlFor([x64, arm64], x64.name));
-  const report = verifyUpdaterMetadata({ metadataPath: metadata, artifactRoot: root, contract: "windows" });
+  const report = verifyUpdaterMetadata({
+    metadataPath: metadata,
+    artifactRoot: root,
+    contract: "windows",
+    expectedVersion: CURRENT_VERSION,
+  });
   assert.equal(report.errors.some((error) => /does not exist/.test(error)), true);
 });
 
-test("updater CLI parser requires metadata, artifact root, and contract", () => {
+test("metadata and every artifact URL must match the expected release version", (t) => {
+  const root = tempDir();
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const x64 = writeArtifact(root, `Clawd-on-Desk-Setup-${CURRENT_VERSION}-x64.exe`, "x64");
+  const arm64 = writeArtifact(root, `Clawd-on-Desk-Setup-${CURRENT_VERSION}-arm64.exe`, "arm64");
+  const metadata = path.join(root, "latest.yml");
+  fs.writeFileSync(metadata, yamlFor([x64, arm64], x64.name, { version: "0.14.0" }));
+  const staleMetadata = verifyUpdaterMetadata({
+    metadataPath: metadata,
+    artifactRoot: root,
+    contract: "windows",
+    expectedVersion: CURRENT_VERSION,
+  });
+  assert.equal(staleMetadata.errors.some((error) => /metadata version/.test(error)), true);
+
+  const staleX64 = writeArtifact(root, "Clawd-on-Desk-Setup-0.14.0-x64.exe", "old-x64");
+  const mixedMetadata = path.join(root, "latest-mixed.yml");
+  fs.writeFileSync(mixedMetadata, yamlFor([staleX64, arm64], staleX64.name));
+  const mixedAssets = verifyUpdaterMetadata({
+    metadataPath: mixedMetadata,
+    artifactRoot: root,
+    contract: "windows",
+    expectedVersion: CURRENT_VERSION,
+  });
+  assert.equal(mixedAssets.errors.some((error) => /Unexpected updater artifact URL/.test(error)), true);
+});
+
+test("stable updater contracts reject prerelease or extra version segments exactly", () => {
+  const cases = [
+    {
+      contract: "windows",
+      files: [
+        { url: `Clawd-on-Desk-Setup-${CURRENT_VERSION}-rc.1-x64.exe` },
+        { url: `Clawd-on-Desk-Setup-${CURRENT_VERSION}-arm64.exe` },
+      ],
+      path: `Clawd-on-Desk-Setup-${CURRENT_VERSION}-rc.1-x64.exe`,
+    },
+    {
+      contract: "mac",
+      files: [
+        { url: `Clawd-on-Desk-${CURRENT_VERSION}-rc.1-x64.dmg` },
+        { url: `Clawd-on-Desk-${CURRENT_VERSION}-arm64.dmg` },
+      ],
+      path: `Clawd-on-Desk-${CURRENT_VERSION}-rc.1-x64.dmg`,
+    },
+    {
+      contract: "linux",
+      files: [
+        { url: `Clawd-on-Desk-${CURRENT_VERSION}-rc.1-x86_64.AppImage`, blockMapSize: 1 },
+        { url: `Clawd-on-Desk-${CURRENT_VERSION}-amd64.deb` },
+      ],
+      path: `Clawd-on-Desk-${CURRENT_VERSION}-rc.1-x86_64.AppImage`,
+    },
+  ];
+
+  for (const fixture of cases) {
+    const errors = validateContractShape(
+      { version: CURRENT_VERSION, files: fixture.files, path: fixture.path },
+      fixture.contract,
+      CURRENT_VERSION,
+    );
+    assert.equal(errors.some((error) => /Unexpected updater artifact URL/.test(error)), true);
+  }
+});
+
+test("updater CLI parser requires metadata, artifact root, contract, and package version authority", () => {
   assert.throws(() => parseArgs([]), /--metadata is required/);
   assert.throws(() => parseArgs(["--metadata", "latest.yml"]), /--artifact-root is required/);
   assert.throws(
     () => parseArgs(["--metadata", "latest.yml", "--artifact-root", "dist"]),
     /--contract is required/,
+  );
+  assert.throws(
+    () => parseArgs(["--metadata", "latest.yml", "--artifact-root", "dist", "--contract", "windows"]),
+    /--package-json is required/,
   );
 });


### PR DESCRIPTION
> **Hold — do not merge on its own.** This is v0.15.0 release-prep housekeeping and
> should land together with the version PR.

Housekeeping found while checking that local and `origin/main` were in sync ahead of
v0.15.0. Three things, all documentation or ignore rules — no runtime code is touched.

## 1. Finish a half-done commit

The `.gitignore` whitelist entry for
`docs/plans/plan-opencode-family-state-ordering-and-instance-disposal-hardening.md`
had been added, but the document itself was never staged, so both halves sat
uncommitted in the working tree. They land together here.

The plan came out of the #841 review, which deliberately deferred two verified
hardening problems rather than expanding that PR into a transport refactor. Both were
fixed by #855 and covered by regressions in #858, so the status line is updated to say
so.

## 2. Refresh three stale plan statuses

`docs/` is private by default — 216 markdown files on disk, 57 in the repository — so
every published plan is a deliberate "this one is public" decision. Three of them still
carried pre-implementation status lines, which read as "not started" to anyone browsing
the repository:

| Plan | Said | Actually |
| --- | --- | --- |
| `plan-issue-763-koffi-target-native-packaging` | "no implementation is authorized by this document" | Shipped by #824 on 2026-08-07; issue closed the same day |
| `plan-issue-244-low-power-idle` | "Draft v1" | `lowPowerIdleMode` ships in `src/prefs.js`; the release smoke checklist covers it; issue closed 2026-07-12 |
| `plan-opencode-family-shared-integration` | Two PRs described in the future tense | #706 introduced the shared core on 2026-07-17; the rebased #607 followed on 2026-07-18 |

Each keeps its original wording as the design record and gains an implemented status
naming the shipping PR. `plan-codex-pet-compatibility` was left alone — its two
"Status on 2026-05-05" lines are per-phase experiment snapshots, correctly historical.

## 3. Close a gap in `.gitignore`

Seven directories were never ignored at all — not by `.gitignore`, not by a global
excludes file, not by `.git/info/exclude`:

- `.playwright-mcp/` — hundreds of MB of session artifacts, including a downloaded `.exe`
- `bin/` — the Telegram sidecar binaries for five platforms, retired in v0.14.0 and
  asserted absent by every release build
- `.worktrees/`, `Microsoft/` (a stray PowerShell module cache), `clawd-emoji-final/`,
  `.agents/`, `.vscode/`

A single `git add -A` would have pulled all of it in. None of the seven had tracked
files, so repository contents are unchanged — this only stops future accidents.

## Verification

- `git ls-files` returns 0 tracked files under each of the seven newly ignored paths.
- Untracked entries at the repository root drop from 16 to 2 (two hamster SVG sources
  and one Copilot capture tool, both still pending a keep-or-ignore decision).
- Every status claim above was checked against the merge commit and issue state, not
  from memory: #824 (`b8b47acc`), #855 (`c91ff7b4`), #706 (`eb5fc101`), #607 (merged
  2026-07-18).
