### PR TITLE
fix(sessions): parse remote cwd basenames cross-platform

### DIFF
--- a/src/state-session-snapshot.js
+++ b/src/state-session-snapshot.js
@@ -197,7 +197,7 @@ function getEffectiveSessionTitle(id, sessionLike, options = {}) {
 
 // Agents whose sessions can run inside an app-managed workspace directory whose
 // leaf is an opaque internal ID (e.g. "mqgw60jiigjsjcid"). For those, the
-// `path.basename(cwd)` fallback below would put that ID in the HUD, Dashboard
+// cwd basename fallback below would put that ID in the HUD, Dashboard
 // and session menu, so it is skipped and the shortened session id wins instead.
 //
 // Deliberately an agent↔path PAIRING, not two independent checks: the pattern
@@ -266,7 +266,15 @@ function sessionDisplayTitle(id, sessionLike, sessionAliases = {}, options = {})
   if (title) return title;
   const cwd = sessionLike && sessionLike.cwd;
   if (cwd && typeof cwd === "string" && !isInternalWorkspaceCwd(id, sessionLike, cwd)) {
-    return path.basename(cwd);
+    // Session metadata can cross operating-system boundaries (for example a
+    // Windows agent reported to a macOS/Linux Clawd). Select the path dialect
+    // from the value instead of the host, while preserving backslashes that
+    // are legal characters in a POSIX path component.
+    const windowsPath = /^[A-Za-z]:[\\/]/.test(cwd) || /^([\\/])\1/.test(cwd);
+    const cwdBasename = windowsPath
+      ? path.win32.basename(cwd)
+      : path.posix.basename(cwd);
+    if (cwdBasename) return cwdBasename;
   }
   const rawSessionId = (sessionLike && sessionLike.rawSessionId) || id;
   return shortenSessionIdForDisplay(rawSessionId, sessionLike);

--- a/test/state-session-snapshot.test.js
+++ b/test/state-session-snapshot.test.js
@@ -183,11 +183,51 @@ describe("isSessionInProgress state mapping", () => {
 });
 
 describe("sessionDisplayTitle cwd fallback", () => {
-  it("falls back to path.basename(cwd) for normal project paths", () => {
+  it("derives normal project basenames independent of the host platform", () => {
     assert.strictEqual(
       sessionDisplayTitle("qoderwork:abc123", session("working", { cwd: "/home/me/projects/myapp" })),
       "myapp"
     );
+    assert.strictEqual(
+      sessionDisplayTitle("claude:abc123", session("working", { cwd: "C:\\Users\\me\\projects\\myapp" })),
+      "myapp"
+    );
+    assert.strictEqual(
+      sessionDisplayTitle("claude:abc123", session("working", { cwd: "\\\\server\\share\\projects\\myapp" })),
+      "myapp"
+    );
+    assert.strictEqual(
+      sessionDisplayTitle("claude:abc123", session("working", { cwd: "C:/Users/me/projects\\myapp" })),
+      "myapp"
+    );
+    assert.strictEqual(
+      sessionDisplayTitle("claude:abc123", session("working", { cwd: "//server/share/projects\\myapp" })),
+      "myapp"
+    );
+    assert.strictEqual(
+      sessionDisplayTitle("claude:abc123", session("working", { cwd: "//?/C:/Users/me/projects\\myapp" })),
+      "myapp"
+    );
+  });
+
+  it("preserves backslashes that are part of a POSIX path component", () => {
+    assert.strictEqual(
+      sessionDisplayTitle("claude:abc123", session("working", { cwd: "/tmp/project\\name" })),
+      "project\\name"
+    );
+    assert.strictEqual(
+      sessionDisplayTitle("claude:abc123", session("working", { cwd: "/\\mount/project\\name" })),
+      "project\\name"
+    );
+  });
+
+  it("falls back to the session id for filesystem roots", () => {
+    for (const cwd of ["/", "C:\\"]) {
+      assert.strictEqual(
+        sessionDisplayTitle("claude:canonical", session("working", { cwd, rawSessionId: "root42" })),
+        "root42"
+      );
+    }
   });
 
   it("skips QoderWork internal workspace cwds so the HUD never shows a raw workspace id", () => {


### PR DESCRIPTION
## Summary
- parse fallback session titles with Windows-aware basename handling on every host
- cover Windows-style remote cwd metadata in the shared session snapshot tests

## Why
Full release run 31620581707 exposed this on macOS and Linux: a Windows QwenWork cwd was rendered as the complete path instead of its basename.

## Validation
- node --test test/state-session-snapshot.test.js
- npm test (7714 pass, 0 fail, 35 skip)
- git diff --check