### PR TITLE
fix(#862): escalate juggling tier by live subagent count

### DIFF
--- a/src/state-visual-resolver.js
+++ b/src/state-visual-resolver.js
@@ -100,6 +100,17 @@ function countActiveSessionsByStates(sessions, states) {
   return count;
 }
 
+function countLiveSubagents(sessions) {
+  let count = 0;
+  for (const [, session] of normalizeSessionsIterable(sessions)) {
+    if (!session.headless && session.state === "juggling") {
+      const live = session.subagentLive;
+      count += Number.isFinite(live) && live >= 1 ? live : 1;
+    }
+  }
+  return count;
+}
+
 function selectTieredStateFile(tiers, count, fallbackFile) {
   if (tiers) {
     for (const tier of tiers) {
@@ -123,10 +134,7 @@ function getWorkingSvg(options = {}) {
 }
 
 function getJugglingSvg(options = {}) {
-  const count = countActiveSessionsByStates(
-    options.sessions,
-    new Set(["juggling"])
-  );
+  const count = countLiveSubagents(options.sessions);
   const stateSvgs = options.stateSvgs;
   return selectTieredStateFile(
     options.theme && options.theme.jugglingTiers,
@@ -181,6 +189,7 @@ module.exports = {
   hasOwnVisualFiles,
   resolveVisualBinding,
   countActiveSessionsByStates,
+  countLiveSubagents,
   selectTieredStateFile,
   getWorkingSvg,
   getJugglingSvg,

--- a/src/state.js
+++ b/src/state.js
@@ -1072,7 +1072,7 @@ function getLastSessionSnapshot() {
 
 function describeSession(sessionId, session) {
   if (!session) return `sid=${sessionId} <deleted>`;
-  return [
+  const fields = [
     `sid=${sessionId}`,
     `state=${session.state || "-"}`,
     `resume=${session.resumeState || "-"}`,
@@ -1081,7 +1081,11 @@ function describeSession(sessionId, session) {
     `sourcePid=${session.sourcePid || "-"}`,
     `pidReachable=${session.pidReachable ? 1 : 0}`,
     `headless=${session.headless ? 1 : 0}`,
-  ].join(" ");
+  ];
+  if (session.state === "juggling" && Object.prototype.hasOwnProperty.call(session, "subagentLive")) {
+    fields.push(`live=${session.subagentLive}`);
+  }
+  return fields.join(" ");
 }
 
 // #583: renders hook-reported stdin diagnostics (present only when the hook's
@@ -1997,15 +2001,23 @@ function updateSession(sessionId, state, event, opts = {}) {
     }
 
     if (existing.state === "juggling") {
-      const resumeState = existing.resumeState || null;
-      if (resumeState) {
-        const dh = pickDisplayHint(resumeState, existing, displayHint);
-        sessions.set(sessionId, { state: resumeState, updatedAt: Date.now(), displayHint: dh, ...base, resumeState: null });
-        debugSession(`subagent-stop restore ${describeSession(sessionId, sessions.get(sessionId))}`);
+      const remaining = (existing.subagentLive || 1) - 1;
+      if (remaining > 0) {
+        const dh = pickDisplayHint("juggling", existing, displayHint);
+        sessions.set(sessionId, { state: "juggling", updatedAt: Date.now(), displayHint: dh, ...base, subagentLive: remaining, resumeState: existing.resumeState });
+        debugSession(`subagent-stop hold ${describeSession(sessionId, sessions.get(sessionId))}`);
       } else {
-        sessions.delete(sessionId);
-        debugSession(`subagent-stop delete sid=${sessionId} reason=no-resume`);
+        const resumeState = existing.resumeState || null;
+        if (resumeState) {
+          const dh = pickDisplayHint(resumeState, existing, displayHint);
+          sessions.set(sessionId, { state: resumeState, updatedAt: Date.now(), displayHint: dh, ...base, resumeState: null });
+          debugSession(`subagent-stop restore ${describeSession(sessionId, sessions.get(sessionId))}`);
+        } else {
+          sessions.delete(sessionId);
+          debugSession(`subagent-stop delete sid=${sessionId} reason=no-resume`);
+        }
       }
+      debugSession(`subagent-visual sid=${sessionId} live=${Math.max(0, remaining)} asset=${getSvgOverride("juggling") || "-"}`);
     } else {
       const dh = pickDisplayHint(existing.state, existing, displayHint);
       sessions.set(sessionId, { state: existing.state, updatedAt: Date.now(), displayHint: dh, ...base, resumeState: null });
@@ -2049,13 +2061,19 @@ function updateSession(sessionId, state, event, opts = {}) {
     return;
   } else if (preservedState) {
     const dh = pickDisplayHint(preservedState, existing, displayHint);
-    sessions.set(sessionId, {
+    const preserved = {
       state: preservedState,
       updatedAt: Date.now(),
       displayHint: dh,
       ...base,
       resumeState: srcResumeState,
-    });
+    };
+    // #862: preserve_state rebuilds the record; a juggling session must keep
+    // its live-subagent count or the 2+ tier drops while subagents still run.
+    if (preservedState === "juggling" && Number.isFinite(existing.subagentLive)) {
+      preserved.subagentLive = existing.subagentLive;
+    }
+    sessions.set(sessionId, preserved);
   } else if (state === "attention" || state === "notification" || SLEEP_SEQUENCE.has(state)) {
     sessions.set(sessionId, { state: "idle", updatedAt: Date.now(), displayHint: null, ...base, resumeState: null });
   } else if (ONESHOT_STATES.has(state)) {
@@ -2071,9 +2089,11 @@ function updateSession(sessionId, state, event, opts = {}) {
   } else {
     if (isSubagentStart) {
       const dh = pickDisplayHint(state, existing, displayHint);
+      const subagentLive = existing && existing.state === "juggling" ? (existing.subagentLive || 1) + 1 : 1;
       const resumeState = existing && existing.state !== "juggling" ? existing.state : srcResumeState;
-      sessions.set(sessionId, { state, updatedAt: Date.now(), displayHint: dh, ...base, resumeState });
+      sessions.set(sessionId, { state, updatedAt: Date.now(), displayHint: dh, ...base, subagentLive, resumeState });
       debugSession(`subagent-start store ${describeSession(sessionId, sessions.get(sessionId))}`);
+      debugSession(`subagent-visual sid=${sessionId} live=${subagentLive} asset=${getSvgOverride("juggling") || "-"}`);
     } else if (existing && existing.state === "juggling" && state === "working") {
       existing.updatedAt = Date.now();
       existing.displayHint = pickDisplayHint("juggling", existing, displayHint);
@@ -2272,6 +2292,9 @@ function restoreSessionFromLease(lease) {
   const sourcePid = Number.isInteger(lease.sourcePid) && lease.sourcePid > 0 ? lease.sourcePid : null;
   if (!pid && !sourcePid) return false;
   sessions.set(sessionId, {
+    // #862 known limitation: leases do not record the live-subagent count, so
+    // a juggling session restored after a daemon restart re-enters at the
+    // 1-subagent tier until the next SubagentStart/Stop event corrects it.
     state: lease.state,
     updatedAt: Date.now(),
     displayHint: null,

--- a/test/state-visual-resolver.test.js
+++ b/test/state-visual-resolver.test.js
@@ -9,13 +9,25 @@ const {
   hasOwnVisualFiles,
   resolveVisualBinding,
   countActiveSessionsByStates,
+  countLiveSubagents,
   selectTieredStateFile,
+  getJugglingSvg,
   getWinningSessionDisplayHint,
   getSvgOverride,
 } = require("../src/state-visual-resolver");
 
 function session(state, overrides = {}) {
   return { state, updatedAt: 1000, headless: false, ...overrides };
+}
+
+function resolveJugglingSvg(sessions) {
+  return getJugglingSvg({
+    sessions,
+    theme: {
+      jugglingTiers: [{ minSessions: 2, file: "juggling-two.svg" }],
+    },
+    stateSvgs: { juggling: ["juggling-one.svg"] },
+  });
 }
 
 describe("state-visual-resolver bindings", () => {
@@ -82,6 +94,55 @@ describe("state-visual-resolver SVG overrides", () => {
       { minSessions: 3, file: "three.svg" },
       { minSessions: 2, file: "two.svg" },
     ], 3, "one.svg"), "three.svg");
+  });
+
+  it("selects the 2+ juggling tier for one session with two live subagents", () => {
+    const sessions = new Map([
+      ["j1", session("juggling", { subagentLive: 2 })],
+    ]);
+
+    assert.strictEqual(resolveJugglingSvg(sessions), "juggling-two.svg");
+  });
+
+  it("selects the tier-1 juggling file for explicit and legacy single-subagent records", () => {
+    const explicit = new Map([
+      ["j1", session("juggling", { subagentLive: 1 })],
+    ]);
+    const legacy = new Map([
+      ["j1", session("juggling")],
+    ]);
+
+    assert.strictEqual(resolveJugglingSvg(explicit), "juggling-one.svg");
+    assert.strictEqual(resolveJugglingSvg(legacy), "juggling-one.svg");
+  });
+
+  it("preserves 2+ juggling escalation across legacy session records", () => {
+    const sessions = new Map([
+      ["j1", session("juggling")],
+      ["j2", session("juggling")],
+    ]);
+
+    assert.strictEqual(resolveJugglingSvg(sessions), "juggling-two.svg");
+  });
+
+  it("excludes headless juggling sessions from the live-subagent sum", () => {
+    const sessions = new Map([
+      ["visible", session("juggling", { subagentLive: 1 })],
+      ["headless", session("juggling", { subagentLive: 4, headless: true })],
+    ]);
+
+    assert.strictEqual(countLiveSubagents(sessions), 1);
+    assert.strictEqual(resolveJugglingSvg(sessions), "juggling-one.svg");
+  });
+
+  it("treats zero, negative, and NaN counters as a single live subagent", () => {
+    const sessions = new Map([
+      ["zero", session("juggling", { subagentLive: 0 })],
+      ["negative", session("juggling", { subagentLive: -1 })],
+      ["nan", session("juggling", { subagentLive: NaN })],
+    ]);
+
+    assert.strictEqual(countLiveSubagents(sessions), 3);
   });
 
   it("uses the most recently updated display hint and ignores headless sessions", () => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1407,6 +1407,65 @@ describe("updateSession()", () => {
     assert.strictEqual(api.sessions.get("s1").state, "working");
   });
 
+  it("tracks concurrent subagents and restores only after the final stop", () => {
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    update(api, { id: "s1", state: "juggling", event: "SubagentStart" });
+    update(api, { id: "s1", state: "juggling", event: "SubagentStart" });
+
+    let stored = api.sessions.get("s1");
+    assert.strictEqual(stored.subagentLive, 2);
+    assert.strictEqual(stored.resumeState, "working");
+    assert.strictEqual(api.getSvgOverride("juggling"), "clawd-working-juggling.svg");
+
+    update(api, { id: "s1", state: "working", event: "SubagentStop" });
+
+    stored = api.sessions.get("s1");
+    assert.strictEqual(stored.state, "juggling");
+    assert.strictEqual(stored.subagentLive, 1);
+    assert.strictEqual(stored.resumeState, "working");
+    assert.strictEqual(api.getSvgOverride("juggling"), "clawd-headphones-groove.svg");
+
+    update(api, { id: "s1", state: "working", event: "SubagentStop" });
+
+    stored = api.sessions.get("s1");
+    assert.strictEqual(stored.state, "working");
+    assert.strictEqual(stored.resumeState, null);
+    assert.strictEqual(Object.hasOwn(stored, "subagentLive"), false);
+  });
+
+  it("preserve_state refresh keeps the live-subagent counter while juggling", () => {
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    update(api, { id: "s1", state: "juggling", event: "SubagentStart" });
+    update(api, { id: "s1", state: "juggling", event: "SubagentStart" });
+
+    api.updateSession("s1", "working", "event_msg:token_count", {
+      agentId: "claude-code",
+      cwd: "/tmp",
+      preserveState: true,
+    });
+
+    const stored = api.sessions.get("s1");
+    assert.strictEqual(stored.state, "juggling");
+    assert.strictEqual(stored.subagentLive, 2);
+    assert.strictEqual(stored.resumeState, "working");
+    assert.strictEqual(api.getSvgOverride("juggling"), "clawd-working-juggling.svg");
+
+    update(api, { id: "s1", state: "working", event: "SubagentStop" });
+    update(api, { id: "s1", state: "working", event: "SubagentStop" });
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+  });
+
+  it("restores a legacy juggling record without a live-subagent counter on its first stop", () => {
+    api.sessions.set("legacy", rawSession("juggling", { resumeState: "thinking" }));
+    assert.strictEqual(Object.hasOwn(api.sessions.get("legacy"), "subagentLive"), false);
+
+    update(api, { id: "legacy", state: "working", event: "SubagentStop" });
+
+    const stored = api.sessions.get("legacy");
+    assert.strictEqual(stored.state, "thinking");
+    assert.strictEqual(stored.resumeState, null);
+  });
+
   it("subagent-only session is removed on SubagentStop", () => {
     update(api, { id: "s1", state: "juggling", event: "SubagentStart" });
     assert.ok(api.sessions.has("s1"));


### PR DESCRIPTION
## What

Fixes #862 — with 2+ concurrent subagents in one session, the pet now escalates to the documented 2+ juggling tier (`clawd-working-juggling.svg`) instead of staying on `clawd-headphones-groove.svg`.

## Why

`getJugglingSvg()` fed the tier selector with the number of **sessions** in the juggling state, while the documented behavior (docs/guides/state-mapping.md) tiers by **live subagent count** — a single session could never reach the 2+ tier. The root cause is that the session record never tracked how many subagents were alive: a second `SubagentStart` simply overwrote the record.

The missing counter also caused a second, unreported defect (reproduced on macOS 15 / v0.15.0, log below): with 2 live subagents, the **first** `SubagentStop` immediately restored `resumeState`, ending juggling while a subagent was still running.

```
23:09:54.056 subagent-start store sid=X state=juggling resume=working
23:09:55.069 subagent-start store sid=X state=juggling resume=working   ← live=2, no stop between
23:10:05.227 subagent-stop restore sid=X state=working                  ← first stop, premature exit
```

## How

- `src/state.js` — track `subagentLive` on the session record: `SubagentStart` increments it (initializes to 1 from any non-juggling state, capturing `resumeState` exactly as before); `SubagentStop` decrements and only restores `resumeState` when the count reaches zero (new `subagent-stop hold` outcome in between, preserving `resumeState`); `preserve_state` record rebuilds keep the counter while juggling.
- `src/state-visual-resolver.js` — new `countLiveSubagents()` sums `subagentLive` (non-finite/sub-1 values count as 1) across non-headless juggling sessions; `getJugglingSvg()` uses it. Cross-session escalation (2 sessions × 1 subagent each → 2+ tier) behaves exactly as before; the same-session case is what changes.
- Logging (the self-diagnosing log the issue asked for): `describeSession` emits `live=N` on juggling session lines, and SubagentStart/Stop now also log the resolved tier asset, e.g.
  `subagent-visual sid=… live=2 asset=clawd-working-juggling.svg`
  so tier selection is visible in `session-debug.log` without a screenshot.
- Untouched on purpose: `workingTiers` / `getWorkingSvg` (session-count semantics are correct there), `displayHint` precedence, theme schema and theme JSONs (`minSessions` key name kept for third-party themes), hook payloads, session snapshot whitelist (the counter stays out of the HUD/Dashboard IPC contract).

## Known limitation

Session-recovery leases don't record the live-subagent count, so a juggling session restored after a daemon restart re-enters at the 1-subagent tier until the next SubagentStart/Stop corrects it (commented at the restore site). Faithful restore would need a lease-format change — deliberately out of scope here; happy to follow up if wanted.

## Tests

8 new tests (5 resolver, 3 state-flow), following the existing `node:test` patterns:

- one session with `subagentLive: 2` → 2+ tier file (core regression)
- legacy records without the counter → tier-1 / unchanged restore semantics
- cross-session sum preserved; headless sessions excluded; zero/negative/NaN counters normalize to 1
- start ×2 → 2+ asset; stop ×1 → still juggling, tier-1 asset, `resumeState` intact; stop ×2 → restore (the premature-exit regression)
- `preserve_state` refresh keeps the counter (verified red without the fix: `undefined !== 2`)

Full suite: 7702 pass / 0 fail / 26 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
