### PR TITLE
refactor: animate settings groups with CSS Grid

### DIFF
--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -717,7 +717,6 @@
       desc: t("rowQuotaRingGroupDesc"),
       defaultCollapsed: true,
       className: "quota-ring-collapsible",
-      animateExpansion: false,
       children: [optionList],
     });
     if (window.settingsAPI && typeof window.settingsAPI.getQuotaSourceCount === "function") {
@@ -726,12 +725,11 @@
           if (Number(count) <= 1) return;
           const revealMergeRow = () => {
             mergeRow.style.display = "";
-          };
-          if (typeof group.mutateCollapsibleBody === "function") {
-            group.mutateCollapsibleBody(revealMergeRow);
-          } else {
-            revealMergeRow();
+            if (!group.classList.contains("collapsed")) {
+              mergeRow.classList.add("collapsible-content-enter");
+            }
           }
+          revealMergeRow();
         })
         .catch(() => {});
     }
@@ -940,7 +938,6 @@
       desc: t("rowFlashDesc"),
       defaultCollapsed: true,
       className: "flash-collapsible",
-      animateExpansion: false,
       children: [buildOptionList("flash-option-list", [
         helpers.buildSwitchRow({
           key: "flashTaskbarOnComplete",

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -47,6 +47,10 @@
   const COLLAPSED_GROUPS_STORAGE_KEY = "clawd.settings.collapsedGroups.v1";
   const NAVIGATION_STORAGE_KEY = "clawd.settings.navigation.v1";
   const MAX_PERSISTED_SCROLL_TOP = 10_000_000;
+  // Keep the watchdog tied to the CSS transition rather than duplicating its
+  // duration here. The buffer only covers a transitionend event that is
+  // dropped by Chromium during a rapid state change.
+  const COLLAPSIBLE_TRANSITION_FALLBACK_BUFFER_MS = 80;
   // Runtime-only geometry belongs in the snapshot for consistency, but has no
   // mounted Settings control. Re-rendering for it would destroy focused inputs
   // and reset the active tab's scroll position after every window move/resize.
@@ -559,7 +563,6 @@
     children = [],
     defaultCollapsed = false,
     className = "",
-    animateExpansion = true,
   }) {
     const storedState = readCollapsedGroupState();
     let collapsed = Object.prototype.hasOwnProperty.call(storedState, id)
@@ -622,63 +625,105 @@
 
     const body = document.createElement("div");
     body.className = "collapsible-group-body";
-    for (const child of children) body.appendChild(child);
+    const bodyInner = document.createElement("div");
+    bodyInner.className = "collapsible-group-body-inner";
+    for (const child of children) bodyInner.appendChild(child);
+    body.appendChild(bodyInner);
 
-    function measureCollapsibleBodyHeight() {
-      return `${body.scrollHeight}px`;
+    let interactionLocked = false;
+    let interactionTransitionGeneration = 0;
+    let interactionUnlockTimer = null;
+    let interactionTransitionCleanup = null;
+
+    function prefersReducedMotion() {
+      return typeof root.matchMedia === "function"
+        && root.matchMedia("(prefers-reduced-motion: reduce)").matches;
     }
 
-    function setExpandedBodyHeight() {
-      body.style.setProperty("--collapsible-body-height", measureCollapsibleBodyHeight());
+    function parseCssTimeMs(value) {
+      const match = String(value || "").trim().match(/^([\d.]+)(ms|s)$/i);
+      if (!match) return null;
+      const amount = Number(match[1]);
+      if (!Number.isFinite(amount)) return null;
+      return match[2].toLowerCase() === "s" ? amount * 1000 : amount;
     }
 
-    function refreshCollapsibleHeight() {
-      if (collapsed || !group.classList.contains("expanding")) return;
-      requestAnimationFrame(() => {
-        if (!collapsed && group.classList.contains("expanding")) setExpandedBodyHeight();
-      });
-    }
-
-    function mutateCollapsibleBody(mutate) {
-      if (typeof mutate !== "function") return;
-      if (collapsed || group.classList.contains("collapsing")) {
-        mutate();
-        return;
+    function getInteractionFallbackMs() {
+      if (typeof root.getComputedStyle === "function") {
+        const computedStyle = root.getComputedStyle(body);
+        const duration = computedStyle && typeof computedStyle.getPropertyValue === "function"
+          ? parseCssTimeMs(computedStyle.getPropertyValue("--collapsible-grid-transition-duration"))
+          : null;
+        if (duration !== null) return duration + COLLAPSIBLE_TRANSITION_FALLBACK_BUFFER_MS;
       }
-      if (group.classList.contains("expanding")) {
-        mutate();
-        refreshCollapsibleHeight();
-        return;
-      }
-
-      const beforeHeight = body.scrollHeight;
-      mutate();
-      const afterHeight = body.scrollHeight;
-      const prefersReducedMotion = typeof window.matchMedia === "function"
-        && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      if (beforeHeight === afterHeight || prefersReducedMotion) return;
-
-      // The settled-open body normally uses max-height:none so reflow can grow
-      // freely. Pin its pre-mutation height for one frame, then animate to the
-      // new measured height instead of letting async rows cause a layout jump.
-      body.style.setProperty("--collapsible-body-height", `${beforeHeight}px`);
-      group.classList.add("resizing");
-      void body.offsetHeight;
-      requestAnimationFrame(() => {
-        if (collapsed || !group.classList.contains("resizing")) return;
-        body.style.setProperty("--collapsible-body-height", `${afterHeight}px`);
-      });
+      return COLLAPSIBLE_TRANSITION_FALLBACK_BUFFER_MS;
     }
 
-    function setBodyInteractivity(isCollapsed) {
+    function setBodyInteractivity(isCollapsed, { locked = false } = {}) {
+      const blocked = isCollapsed || locked;
       body.setAttribute("aria-hidden", isCollapsed ? "true" : "false");
       if ("inert" in body) {
-        body.inert = isCollapsed;
-      } else if (isCollapsed) {
+        body.inert = blocked;
+      } else if (blocked) {
         body.setAttribute("inert", "");
       } else {
         body.removeAttribute("inert");
       }
+      body.classList.toggle("collapsible-group-body-interaction-locked", locked);
+    }
+
+    function clearInteractionTransitionWatch() {
+      if (interactionUnlockTimer !== null && typeof root.clearTimeout === "function") {
+        root.clearTimeout(interactionUnlockTimer);
+      }
+      interactionUnlockTimer = null;
+      if (interactionTransitionCleanup) {
+        interactionTransitionCleanup();
+        interactionTransitionCleanup = null;
+      }
+    }
+
+    function invalidateInteractionTransition() {
+      interactionTransitionGeneration += 1;
+      clearInteractionTransitionWatch();
+    }
+
+    function finishBodyTransition(generation) {
+      if (generation !== interactionTransitionGeneration || !interactionLocked) return;
+      clearInteractionTransitionWatch();
+      interactionLocked = false;
+      setBodyInteractivity(collapsed);
+    }
+
+    function scheduleInteractionFallback(generation) {
+      if (typeof root.setTimeout !== "function") return;
+      if (interactionUnlockTimer !== null && typeof root.clearTimeout === "function") {
+        root.clearTimeout(interactionUnlockTimer);
+      }
+      interactionUnlockTimer = root.setTimeout(() => {
+        finishBodyTransition(generation);
+      }, getInteractionFallbackMs());
+    }
+
+    function watchBodyTransition() {
+      const generation = interactionTransitionGeneration;
+      const onTransitionEnd = (ev) => {
+        if (ev.target !== body || ev.propertyName !== "grid-template-rows") return;
+        finishBodyTransition(generation);
+      };
+      const onTransitionCancel = (ev) => {
+        if (ev.target !== body || ev.propertyName !== "grid-template-rows") return;
+        if (generation !== interactionTransitionGeneration || !interactionLocked) return;
+        if (prefersReducedMotion()) finishBodyTransition(generation);
+        else scheduleInteractionFallback(generation);
+      };
+      body.addEventListener("transitionend", onTransitionEnd);
+      body.addEventListener("transitioncancel", onTransitionCancel);
+      interactionTransitionCleanup = () => {
+        body.removeEventListener("transitionend", onTransitionEnd);
+        body.removeEventListener("transitioncancel", onTransitionCancel);
+      };
+      scheduleInteractionFallback(generation);
     }
 
     function preserveScrollAnchor(invoke) {
@@ -699,43 +744,14 @@
     }
 
     function applyCollapsedState({ animate = false } = {}) {
+      invalidateInteractionTransition();
       disclosure.setAttribute("aria-expanded", collapsed ? "false" : "true");
       const actionLabel = collapsed ? t("collapsibleExpand") : t("collapsibleCollapse");
       disclosure.setAttribute("aria-label", disclosureLabel ? `${actionLabel}: ${disclosureLabel}` : actionLabel);
-      group.classList.remove("expanding", "collapsing", "resizing");
-      if (!animate) {
-        group.classList.toggle("collapsed", collapsed);
-        setBodyInteractivity(collapsed);
-        if (collapsed) {
-          body.style.setProperty("--collapsible-body-height", "0px");
-        } else {
-          // Settled-open groups must NOT keep a pinned max-height: text zoom
-          // or window-width changes rewrap descriptions and grow the content,
-          // and a stale pinned height clips the bottom rows (overflow:
-          // hidden). A measured height is only needed while animating.
-          body.style.setProperty("--collapsible-body-height", "none");
-        }
-        return;
-      }
-
-      if (collapsed) {
-        group.classList.add("collapsing");
-        setBodyInteractivity(true);
-        setExpandedBodyHeight();
-        requestAnimationFrame(() => {
-          group.classList.add("collapsed");
-          body.style.setProperty("--collapsible-body-height", "0px");
-        });
-        return;
-      }
-
-      group.classList.add("expanding", "collapsed");
-      setBodyInteractivity(false);
-      body.style.setProperty("--collapsible-body-height", "0px");
-      requestAnimationFrame(() => {
-        group.classList.remove("collapsed");
-        setExpandedBodyHeight();
-      });
+      group.classList.toggle("collapsed", collapsed);
+      interactionLocked = animate && !prefersReducedMotion();
+      setBodyInteractivity(collapsed, { locked: interactionLocked });
+      if (interactionLocked) watchBodyTransition();
     }
 
     function toggleCollapsed() {
@@ -743,7 +759,7 @@
       const nextState = readCollapsedGroupState();
       nextState[id] = collapsed;
       writeCollapsedGroupState(nextState);
-      preserveScrollAnchor(() => applyCollapsedState({ animate: animateExpansion }));
+      preserveScrollAnchor(() => applyCollapsedState({ animate: true }));
     }
 
     disclosure.addEventListener("click", toggleCollapsed);
@@ -756,19 +772,7 @@
 
     group.appendChild(header);
     group.appendChild(body);
-    body.addEventListener("transitionend", (ev) => {
-      if (ev.target !== body || ev.propertyName !== "max-height") return;
-      group.classList.remove("expanding", "collapsing", "resizing");
-      // Release the pinned height once settled so later reflows (text zoom,
-      // window resize) can grow the body instead of clipping at the bottom.
-      if (!collapsed) body.style.setProperty("--collapsible-body-height", "none");
-    });
-    applyCollapsedState();
-    requestAnimationFrame(() => {
-      if (!collapsed) body.style.setProperty("--collapsible-body-height", "none");
-    });
-    group.refreshCollapsibleHeight = refreshCollapsibleHeight;
-    group.mutateCollapsibleBody = mutateCollapsibleBody;
+    applyCollapsedState({ animate: false });
     return group;
   }
 

--- a/src/settings.css
+++ b/src/settings.css
@@ -549,36 +549,53 @@ html, body {
   }
 }
 .collapsible-group-body {
-  max-height: var(--collapsible-body-height, 0px);
+  display: grid;
+  --collapsible-grid-transition-duration: 0.22s;
+  grid-template-rows: 1fr;
+  overflow: visible;
+  opacity: 1;
+  transform: translateY(0);
+  transition: grid-template-rows var(--collapsible-grid-transition-duration) cubic-bezier(0.22, 1, 0.36, 1), opacity 0.16s ease, transform 0.18s ease;
+}
+.collapsible-group-body-inner {
+  min-height: 0;
   overflow: hidden;
   border-top: 1px solid var(--row-border);
   padding: 10px 16px 12px 40px;
-  opacity: 1;
-  transform: translateY(0);
-  transition: max-height 0.22s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.16s ease, transform 0.18s ease, padding 0.18s ease, border-color 0.18s ease;
-  will-change: max-height, opacity, transform;
+  transition: padding 0.18s ease, border-color 0.18s ease;
 }
 .collapsible-group.collapsed > .collapsible-group-body {
-  max-height: 0;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transform: translateY(-4px);
+  pointer-events: none;
+}
+.collapsible-group-body.collapsible-group-body-interaction-locked {
+  pointer-events: none;
+}
+.collapsible-group.collapsed > .collapsible-group-body > .collapsible-group-body-inner {
   border-top-color: transparent;
   padding-top: 0;
   padding-bottom: 0;
-  opacity: 0;
-  transform: translateY(-4px);
 }
-.collapsible-group.expanding .collapsible-group-body,
-.collapsible-group.collapsing .collapsible-group-body,
-.collapsible-group.resizing .collapsible-group-body {
-  pointer-events: none;
-}
-.collapsible-group:not(.collapsed):has(.language-picker.open) > .collapsible-group-body {
+.collapsible-group:not(.collapsed):has(.language-picker.open) > .collapsible-group-body > .collapsible-group-body-inner {
   overflow: visible;
 }
-.agent-subgroup .collapsible-group-body {
+.collapsible-group:not(.collapsed):has(.language-picker.menu-mounted) > .collapsible-group-body > .collapsible-group-body-inner {
+  overflow: visible;
+}
+.agent-subgroup .collapsible-group-body-inner {
   padding: 0;
 }
-.agent-subgroup .collapsible-group-body .row:last-child {
+.agent-subgroup .collapsible-group-body-inner .row:last-child {
   border-bottom: none;
+}
+.collapsible-content-enter {
+  animation: collapsible-content-enter 0.18s ease both;
+}
+@keyframes collapsible-content-enter {
+  from { opacity: 0; transform: translateY(-3px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 .agent-instance-scan-btn {
   font-size: 10px;
@@ -669,8 +686,11 @@ html, body {
   .collapsible-group-chevron,
   .anim-override-chevron,
   .collapsible-group-summary,
-  .collapsible-group-body {
+  .collapsible-group-body,
+  .collapsible-group-body-inner,
+  .collapsible-content-enter {
     transition: none;
+    animation: none;
   }
 }
 

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -86,6 +86,10 @@ function loadSettingsCoreForTest(settingsAPI, {
     cb();
     return 1;
   },
+  matchMedia = () => ({ matches: false }),
+  setTimeout: setTimeoutOverride = globalThis.setTimeout,
+  clearTimeout: clearTimeoutOverride = globalThis.clearTimeout,
+  getComputedStyle: getComputedStyleOverride = null,
 } = {}) {
   const document = documentOverride || {
     body: { contains: () => false },
@@ -100,6 +104,10 @@ function loadSettingsCoreForTest(settingsAPI, {
     },
     document,
     requestAnimationFrame,
+    matchMedia,
+    setTimeout: setTimeoutOverride,
+    clearTimeout: clearTimeoutOverride,
+    getComputedStyle: getComputedStyleOverride,
     window: null,
     globalThis: null,
     settingsAPI,
@@ -5576,7 +5584,8 @@ describe("settings renderer browser environment", () => {
     assert.ok(/@media \(max-width:\s*720px\)\s*\{[\s\S]*\.session-hud-collapsible \.collapsible-group-summary\s*\{[\s\S]*flex:\s*0 0 calc\(100% - 22px\);[\s\S]*margin-left:\s*22px;/.test(css));
     assert.ok(/@media \(max-width:\s*720px\)\s*\{[\s\S]*\.session-hud-summary-control\s*\{[\s\S]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*width:\s*min\(238px,\s*100%\);/.test(css));
     assert.ok(/@media \(max-width:\s*720px\)\s*\{[\s\S]*\.session-hud-summary-control\s*\{[\s\S]*justify-self:\s*start;/.test(css));
-    assert.ok(/function buildFlashGroup\(\)[\s\S]*id:\s*"general:flash",[\s\S]*animateExpansion:\s*false,/.test(generalSource));
+    assert.ok(/function buildFlashGroup\(\)[\s\S]*id:\s*"general:flash",/.test(generalSource));
+    assert.ok(!generalSource.includes("animateExpansion"));
     assert.ok(/\.collapsible-group-text \.row-label\s*\{[\s\S]*text-overflow:\s*ellipsis;[\s\S]*white-space:\s*nowrap;/.test(css));
     assert.ok(/\.collapsible-group-text \.row-desc\s*\{[\s\S]*white-space:\s*normal;[\s\S]*-webkit-line-clamp:\s*2;/.test(css));
     assert.ok(/\.sound-summary-control\s*\{[\s\S]*display:\s*inline-flex;/.test(css));
@@ -6146,53 +6155,26 @@ describe("settings renderer browser environment", () => {
 
   it("reveals existing quota options immediately and absorbs async sources without a second expansion", async () => {
     const sourceCount = createDeferred();
-    const animationFrames = [];
-    const flushAnimationFrame = () => {
-      const callbacks = animationFrames.splice(0);
-      for (const callback of callbacks) callback();
-    };
     const harness = loadGeneralTabForTest({
       snapshot: makeGeneralSnapshot({ quotaMergeSources: false }),
       settingsAPI: { getQuotaSourceCount: () => sourceCount.promise },
-      requestAnimationFrame: (callback) => {
-        animationFrames.push(callback);
-        return animationFrames.length;
-      },
     });
     harness.renderContent();
-    flushAnimationFrame();
     const group = harness.content.querySelector(".quota-ring-collapsible");
     const header = group.querySelector(".collapsible-group-header");
     const body = group.querySelector(".collapsible-group-body");
+    const bodyInner = body.querySelector(".collapsible-group-body-inner");
     const mergeRow = harness.getSwitchMeta("quotaMergeSources").row;
-    Object.defineProperty(body, "scrollHeight", {
-      configurable: true,
-      get: () => (mergeRow.style.display === "none" ? 80 : 120),
-    });
+    assert.ok(bodyInner, "collapsible groups should wrap children in a Grid inner");
     header.dispatchEvent({ type: "click" });
-    assert.equal(group.classList.contains("expanding"), false);
     assert.equal(group.classList.contains("collapsed"), false);
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
     assert.equal(body.attributes["aria-hidden"], "false");
-    flushAnimationFrame();
 
     sourceCount.resolve(2);
     await new Promise((resolve) => setImmediate(resolve));
-    assert.equal(group.classList.contains("expanding"), false);
-    assert.equal(group.classList.contains("resizing"), true);
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "80px");
     assert.equal(mergeRow.style.display, "");
-
-    flushAnimationFrame();
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "120px");
-
-    body.dispatchEvent({
-      type: "transitionend",
-      propertyName: "max-height",
-      bubbles: false,
-    });
-    assert.equal(group.classList.contains("resizing"), false);
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
+    assert.equal(mergeRow.classList.contains("collapsible-content-enter"), true);
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "");
   });
 
   it("groups sound and volume into one collapsible control with in-place summary updates", () => {
@@ -7276,23 +7258,388 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(harness.content.querySelector(".theme-detail-hero"), null);
   });
 
-  it("animates collapsible Settings groups with measured height instead of instant hidden jumps", () => {
+  it("animates collapsible Settings groups with Grid intrinsic sizing", () => {
     const coreSource = fs.readFileSync(SETTINGS_UI_CORE, "utf8");
     const css = fs.readFileSync(SETTINGS_CSS, "utf8");
-    assert.ok(coreSource.includes("function measureCollapsibleBodyHeight("));
-    assert.ok(coreSource.includes("function preserveScrollAnchor("));
-    assert.ok(coreSource.includes('body.style.setProperty("--collapsible-body-height"'));
-    assert.ok(coreSource.includes("requestAnimationFrame(() => {"));
-    assert.ok(coreSource.includes("collapsing"));
-    assert.ok(coreSource.includes("expanding"));
-    assert.ok(coreSource.includes("function setBodyInteractivity(isCollapsed)"));
-    assert.ok(coreSource.includes('body.setAttribute("aria-hidden"'));
-    assert.ok(coreSource.includes("body.inert = isCollapsed"));
-    assert.ok(!coreSource.includes("body.hidden = collapsed;"));
-    assert.ok(/\.collapsible-group-body\s*\{[\s\S]*max-height:\s*var\(--collapsible-body-height,\s*0px\);/.test(css));
-    assert.ok(/\.collapsible-group-body\s*\{[\s\S]*transition:\s*max-height 0\.22s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\),\s*opacity 0\.16s ease,\s*transform 0\.18s ease,\s*padding 0\.18s ease,\s*border-color 0\.18s ease;/.test(css));
-    assert.ok(/\.collapsible-group\.collapsed\s*>\s*\.collapsible-group-body\s*\{[\s\S]*opacity:\s*0;[\s\S]*transform:\s*translateY\(-4px\);/.test(css));
-    assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.collapsible-group-body/.test(css));
+    const groupSource = coreSource.slice(
+      coreSource.indexOf("function buildCollapsibleGroup("),
+      coreSource.indexOf("function attachActivation(")
+    );
+    assert.ok(groupSource.includes("function preserveScrollAnchor("));
+    assert.ok(groupSource.includes("collapsible-group-body-inner"));
+    assert.ok(groupSource.includes("function setBodyInteractivity(isCollapsed,"));
+    assert.ok(groupSource.includes('body.setAttribute("aria-hidden"'));
+    assert.ok(groupSource.includes("body.inert = blocked"));
+    assert.ok(!groupSource.includes("scrollHeight"));
+    assert.ok(!groupSource.includes("animateExpansion"));
+    assert.ok(!groupSource.includes("collapsing"));
+    assert.ok(!groupSource.includes("expanding"));
+    assert.ok(!groupSource.includes("resizing"));
+    assert.ok(groupSource.includes("getComputedStyle(body)"));
+    assert.ok(groupSource.includes("parseCssTimeMs"));
+    assert.ok(/\.collapsible-group-body\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-rows:\s*1fr;/.test(css));
+    assert.ok(/--collapsible-grid-transition-duration:\s*0\.22s;/.test(css));
+    assert.ok(/transition:\s*grid-template-rows\s+var\(--collapsible-grid-transition-duration\)/.test(css));
+    assert.ok(/\.collapsible-group-body-inner\s*\{[\s\S]*min-height:\s*0;[\s\S]*overflow:\s*hidden;/.test(css));
+    assert.ok(/\.collapsible-group\.collapsed\s*>\s*\.collapsible-group-body\s*\{[\s\S]*grid-template-rows:\s*0fr;[\s\S]*opacity:\s*0;[\s\S]*transform:\s*translateY\(-4px\);/.test(css));
+    assert.ok(/\.collapsible-group\.collapsed\s*>\s*\.collapsible-group-body\s*>\s*\.collapsible-group-body-inner\s*\{[\s\S]*padding-top:\s*0;[\s\S]*padding-bottom:\s*0;/.test(css));
+    assert.ok(/\.collapsible-group-body\.collapsible-group-body-interaction-locked\s*\{[\s\S]*pointer-events:\s*none;/.test(css));
+    assert.ok(/\.collapsible-group:not\(\.collapsed\):has\(\.language-picker\.open\)\s*>\s*\.collapsible-group-body\s*>\s*\.collapsible-group-body-inner\s*\{[\s\S]*overflow:\s*visible;/.test(css));
+    assert.ok(/\.collapsible-group:not\(\.collapsed\):has\(\.language-picker\.menu-mounted\)\s*>\s*\.collapsible-group-body\s*>\s*\.collapsible-group-body-inner\s*\{[\s\S]*overflow:\s*visible;/.test(css));
+    assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.collapsible-group-body-inner[\s\S]*animation:\s*none;/.test(css));
+  });
+
+  it("keeps an opened language picker interactive inside an expanded collapsible group", () => {
+    const pickerHarness = loadSharedLanguagePickerForTest({
+      options: ["en", "zh", "ja"],
+    });
+    const boundary = pickerHarness.boundary;
+    const body = boundary.parentNode;
+    const localStorage = {
+      getItem: () => null,
+      setItem: () => {},
+    };
+    const document = {
+      body,
+      createElement: (tagName) => new FakeElement(tagName),
+      getElementById: () => null,
+    };
+    const core = loadSettingsCoreForTest({}, { document, localStorage });
+
+    // Move the real picker created by language-picker.js into the shared
+    // collapsible body so both components exercise their actual DOM contract.
+    pickerHarness.picker.remove();
+    const group = core.helpers.buildCollapsibleGroup({
+      id: "test:language-picker-group",
+      title: "Language",
+      defaultCollapsed: true,
+      children: [pickerHarness.picker],
+    });
+    boundary.appendChild(group);
+
+    const groupBody = group.querySelector(".collapsible-group-body");
+    const disclosure = group.querySelector(".collapsible-group-header");
+    assert.strictEqual(groupBody.getAttribute("aria-hidden"), "true");
+    assert.strictEqual(groupBody.getAttribute("inert"), "");
+    assert.strictEqual(pickerHarness.trigger.getAttribute("aria-expanded"), "false");
+
+    disclosure.dispatchEvent(createKeyboardEventForTest("Enter"));
+    assert.strictEqual(groupBody.getAttribute("aria-hidden"), "false");
+    assert.strictEqual(groupBody.getAttribute("inert"), "");
+    assert.strictEqual(groupBody.classList.contains("collapsible-group-body-interaction-locked"), true);
+
+    groupBody.dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.strictEqual(groupBody.getAttribute("inert"), undefined);
+    assert.strictEqual(groupBody.classList.contains("collapsible-group-body-interaction-locked"), false);
+
+    pickerHarness.trigger.dispatchEvent({ type: "click", bubbles: false });
+    assert.strictEqual(pickerHarness.picker.classList.contains("open"), true);
+    assert.strictEqual(pickerHarness.trigger.getAttribute("aria-expanded"), "true");
+    assert.strictEqual(pickerHarness.menu.getAttribute("aria-hidden"), "false");
+    assert.strictEqual(groupBody.getAttribute("aria-hidden"), "false");
+    assert.strictEqual(groupBody.getAttribute("inert"), undefined);
+    assert.strictEqual(groupBody.contains(pickerHarness.menu), true);
+  });
+
+  it("drives collapsible groups through keyboard, persistence, inert, nesting, and scroll-anchor behavior", () => {
+    const storageData = {};
+    const localStorage = {
+      getItem: (key) => Object.prototype.hasOwnProperty.call(storageData, key)
+        ? storageData[key]
+        : null,
+      setItem: (key, value) => {
+        storageData[key] = String(value);
+      },
+    };
+    const raf = createQueuedRaf();
+    const body = new FakeElement("body");
+    const content = new FakeElement("main");
+    content.id = "content";
+    content.scrollTop = 200;
+    body.appendChild(content);
+    const document = {
+      body,
+      createElement: (tagName) => new FakeElement(tagName),
+      getElementById: (id) => (id === "content" ? content : null),
+    };
+    const core = loadSettingsCoreForTest({}, {
+      document,
+      localStorage,
+      requestAnimationFrame: raf.requestAnimationFrame,
+    });
+    const child = new FakeElement("div");
+    child.textContent = "Initial detail";
+    const group = core.helpers.buildCollapsibleGroup({
+      id: "test:behavior",
+      title: "Behavior",
+      disclosureLabel: "Behavior",
+      defaultCollapsed: true,
+      children: [child],
+    });
+    content.appendChild(group);
+    const disclosure = group.querySelector(".collapsible-group-disclosure")
+      || group.querySelector(".collapsible-group-header");
+    const bodyNode = group.querySelector(".collapsible-group-body");
+    const bodyInner = group.querySelector(".collapsible-group-body-inner");
+    disclosure.getBoundingClientRect = () => ({
+      top: group.classList.contains("collapsed") ? 100 : 140,
+    });
+
+    assert.strictEqual(group.classList.contains("collapsed"), true);
+    assert.strictEqual(disclosure.getAttribute("aria-expanded"), "false");
+    assert.strictEqual(bodyNode.getAttribute("aria-hidden"), "true");
+    assert.strictEqual(bodyNode.getAttribute("inert"), "");
+
+    const expandEvent = createKeyboardEventForTest("Enter");
+    disclosure.dispatchEvent(expandEvent);
+    assert.strictEqual(expandEvent.defaultPrevented, true);
+    assert.strictEqual(group.classList.contains("collapsed"), false);
+    assert.strictEqual(disclosure.getAttribute("aria-expanded"), "true");
+    assert.strictEqual(bodyNode.getAttribute("aria-hidden"), "false");
+    assert.strictEqual(bodyNode.getAttribute("inert"), "");
+    assert.strictEqual(bodyNode.classList.contains("collapsible-group-body-interaction-locked"), true);
+    assert.strictEqual(content.scrollTop, 200, "anchor correction waits for the layout frame");
+    raf.flush();
+    assert.strictEqual(content.scrollTop, 240, "expansion preserves the header's scroll anchor");
+    bodyNode.dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.strictEqual(bodyNode.getAttribute("inert"), undefined);
+    assert.strictEqual(bodyNode.classList.contains("collapsible-group-body-interaction-locked"), false);
+    assert.deepStrictEqual(JSON.parse(storageData["clawd.settings.collapsedGroups.v1"]), {
+      "test:behavior": false,
+    });
+
+    let asyncClicks = 0;
+    const asyncChild = new FakeElement("button");
+    asyncChild.type = "button";
+    asyncChild.tabIndex = 0;
+    asyncChild.textContent = "Async detail";
+    asyncChild.addEventListener("click", () => {
+      asyncClicks++;
+    });
+    bodyInner.appendChild(asyncChild);
+    assert.strictEqual(bodyInner.contains(asyncChild), true);
+    assert.strictEqual(asyncChild.disabled, false);
+    assert.strictEqual(asyncChild.tabIndex, 0);
+    asyncChild.dispatchEvent({ type: "click", bubbles: false });
+    assert.strictEqual(asyncClicks, 1, "async content remains interactive while expanded");
+
+    const collapseEvent = createKeyboardEventForTest(" ");
+    disclosure.dispatchEvent(collapseEvent);
+    assert.strictEqual(collapseEvent.defaultPrevented, true);
+    assert.strictEqual(group.classList.contains("collapsed"), true);
+    assert.strictEqual(bodyNode.getAttribute("inert"), "");
+    assert.strictEqual(bodyNode.classList.contains("collapsible-group-body-interaction-locked"), true);
+    bodyNode.dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.strictEqual(bodyNode.classList.contains("collapsible-group-body-interaction-locked"), false);
+    raf.flush();
+
+    const inner = core.helpers.buildCollapsibleGroup({
+      id: "test:inner",
+      title: "Inner",
+      defaultCollapsed: true,
+      children: [new FakeElement("div")],
+    });
+    const outer = core.helpers.buildCollapsibleGroup({
+      id: "test:outer",
+      title: "Outer",
+      children: [inner],
+    });
+    content.appendChild(outer);
+    const outerDisclosure = outer.querySelector(".collapsible-group-header");
+    const innerDisclosure = inner.querySelector(".collapsible-group-header");
+    assert.strictEqual(outer.classList.contains("collapsed"), false);
+    assert.strictEqual(inner.classList.contains("collapsed"), true);
+
+    innerDisclosure.dispatchEvent({ type: "click" });
+    assert.strictEqual(inner.classList.contains("collapsed"), false);
+    assert.strictEqual(outer.classList.contains("collapsed"), false,
+      "opening the inner group must not toggle its expanded parent");
+    inner.querySelector(".collapsible-group-body").dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+
+    outerDisclosure.dispatchEvent({ type: "click" });
+    assert.strictEqual(outer.classList.contains("collapsed"), true);
+    assert.strictEqual(inner.classList.contains("collapsed"), false);
+    assert.strictEqual(innerDisclosure.getAttribute("aria-expanded"), "true");
+    outer.querySelector(".collapsible-group-body").dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+
+    innerDisclosure.dispatchEvent({ type: "click" });
+    assert.strictEqual(inner.classList.contains("collapsed"), true);
+    assert.strictEqual(outer.classList.contains("collapsed"), true,
+      "toggling the inner group must not toggle its collapsed parent");
+    inner.querySelector(".collapsible-group-body").dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+
+    const reducedMotionBody = new FakeElement("body");
+    const reducedMotionContent = new FakeElement("main");
+    reducedMotionContent.id = "content";
+    reducedMotionBody.appendChild(reducedMotionContent);
+    const reducedMotionCore = loadSettingsCoreForTest({}, {
+      document: {
+        body: reducedMotionBody,
+        createElement: (tagName) => new FakeElement(tagName),
+        getElementById: (id) => (id === "content" ? reducedMotionContent : null),
+      },
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {},
+      },
+      matchMedia: () => ({ matches: true }),
+    });
+    const reducedMotionGroup = reducedMotionCore.helpers.buildCollapsibleGroup({
+      id: "test:reduced-motion",
+      title: "Reduced motion",
+      defaultCollapsed: true,
+      children: [new FakeElement("button")],
+    });
+    reducedMotionContent.appendChild(reducedMotionGroup);
+    const reducedMotionDisclosure = reducedMotionGroup.querySelector(".collapsible-group-header");
+    const reducedMotionBodyNode = reducedMotionGroup.querySelector(".collapsible-group-body");
+    reducedMotionDisclosure.dispatchEvent({ type: "click" });
+    assert.strictEqual(reducedMotionBodyNode.getAttribute("inert"), undefined);
+    assert.strictEqual(reducedMotionBodyNode.classList.contains("collapsible-group-body-interaction-locked"), false);
+
+    const restoredBody = new FakeElement("body");
+    const restoredContent = new FakeElement("main");
+    restoredContent.id = "content";
+    restoredBody.appendChild(restoredContent);
+    const restoredCore = loadSettingsCoreForTest({}, {
+      document: {
+        body: restoredBody,
+        createElement: (tagName) => new FakeElement(tagName),
+        getElementById: (id) => (id === "content" ? restoredContent : null),
+      },
+      localStorage,
+    });
+    const restored = restoredCore.helpers.buildCollapsibleGroup({
+      id: "test:behavior",
+      title: "Behavior",
+      defaultCollapsed: true,
+      children: [new FakeElement("div")],
+    });
+    restoredContent.appendChild(restored);
+    assert.strictEqual(restored.classList.contains("collapsed"), true,
+      "the later collapse should be persisted for a new renderer instance");
+    assert.strictEqual(restored.querySelector(".collapsible-group-body").getAttribute("inert"), "");
+  });
+
+  it("does not leave collapsible content locked across cancelled or missing transitions", () => {
+    const timers = [];
+    const cssTransitionDuration = fs.readFileSync(SETTINGS_CSS, "utf8")
+      .match(/--collapsible-grid-transition-duration:\s*([^;]+);/)[1]
+      .trim();
+    const cssTransitionDurationMs = cssTransitionDuration.endsWith("ms")
+      ? Number.parseFloat(cssTransitionDuration)
+      : Number.parseFloat(cssTransitionDuration) * 1000;
+    const timerApi = {
+      setTimeout(callback, ms) {
+        timers.push({ callback, ms, cleared: false });
+        return timers.length;
+      },
+      clearTimeout(id) {
+        if (timers[id - 1]) timers[id - 1].cleared = true;
+      },
+    };
+    const body = new FakeElement("body");
+    const content = new FakeElement("main");
+    content.id = "content";
+    body.appendChild(content);
+    const document = {
+      body,
+      createElement: (tagName) => new FakeElement(tagName),
+      getElementById: (id) => (id === "content" ? content : null),
+    };
+    let reducedMotion = false;
+    const core = loadSettingsCoreForTest({}, {
+      document,
+      localStorage: { getItem: () => null, setItem: () => {} },
+      matchMedia: () => ({ matches: reducedMotion }),
+      setTimeout: timerApi.setTimeout,
+      clearTimeout: timerApi.clearTimeout,
+      getComputedStyle: () => ({
+        getPropertyValue: (name) => name === "--collapsible-grid-transition-duration"
+          ? cssTransitionDuration
+          : "",
+      }),
+    });
+    const group = core.helpers.buildCollapsibleGroup({
+      id: "test:transition-watch",
+      title: "Transition watch",
+      defaultCollapsed: true,
+      children: [new FakeElement("button")],
+    });
+    content.appendChild(group);
+    const disclosure = group.querySelector(".collapsible-group-header");
+    const bodyNode = group.querySelector(".collapsible-group-body");
+
+    disclosure.dispatchEvent({ type: "click" });
+    assert.strictEqual(bodyNode.getAttribute("inert"), "");
+    assert.strictEqual(timers.length, 1);
+    assert.ok(timers[0].ms > cssTransitionDurationMs,
+      "the fallback must outlast the CSS grid transition");
+    const firstTransitionEnd = bodyNode.eventListeners.transitionend[0];
+
+    // A rapid reverse invalidates the old callback and keeps the new target locked.
+    disclosure.dispatchEvent({ type: "click" });
+    assert.strictEqual(group.classList.contains("collapsed"), true);
+    assert.strictEqual(bodyNode.getAttribute("inert"), "");
+    firstTransitionEnd({ target: bodyNode, propertyName: "grid-template-rows" });
+    assert.strictEqual(bodyNode.getAttribute("inert"), "");
+    assert.strictEqual(timers.length, 2);
+    assert.strictEqual(timers[0].cleared, true, "reversing the transition clears the stale fallback");
+
+    // transitioncancel does not unlock a normal-motion transition immediately;
+    // the generation's fallback still owns the final unlock.
+    bodyNode.dispatchEvent({
+      type: "transitioncancel",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.strictEqual(bodyNode.getAttribute("inert"), "");
+    assert.strictEqual(timers[1].cleared, true, "cancelling the transition replaces its fallback");
+    const cancelFallback = timers.find((timer) => !timer.cleared);
+    assert.ok(cancelFallback, "a cancelled normal-motion transition keeps a live fallback");
+    cancelFallback.callback();
+    assert.strictEqual(bodyNode.getAttribute("inert"), "", "collapsed content remains inert after its fallback settles");
+    assert.strictEqual(bodyNode.classList.contains("collapsible-group-body-interaction-locked"), false);
+
+    // If reduced motion changes while a transition is active, cancel settles
+    // immediately even when no transitionend event can be emitted.
+    reducedMotion = false;
+    disclosure.dispatchEvent({ type: "click" });
+    assert.strictEqual(bodyNode.getAttribute("inert"), "");
+    reducedMotion = true;
+    bodyNode.dispatchEvent({
+      type: "transitioncancel",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.strictEqual(bodyNode.getAttribute("inert"), undefined);
+    assert.strictEqual(bodyNode.classList.contains("collapsible-group-body-interaction-locked"), false);
+    assert.strictEqual(timers.every((timer) => timer.cleared), true,
+      "reduced-motion cancellation clears the active fallback");
   });
 
   it("collapses only the detailed bubble policy controls while keeping primary bubble rows visible", () => {
@@ -8841,10 +9188,14 @@ describe("settings renderer browser environment", () => {
     harness.core.ops.requestRender({ content: true });
     const expandedBody = harness.content.querySelector(".collapsible-group-body");
     assert.ok(expandedBody, "agent group body should render");
-    assert.notStrictEqual(
+    assert.ok(
+      expandedBody.querySelector(".collapsible-group-body-inner"),
+      "expanded groups should render children inside the intrinsic Grid track"
+    );
+    assert.equal(
       expandedBody.style.getPropertyValue("--collapsible-body-height"),
-      "0px",
-      "expanded groups should not paint one frame at 0px height before the next animation frame runs"
+      "",
+      "expanded groups should not pin a measured body height"
     );
   });
 


### PR DESCRIPTION
## Summary

- Replace the shared Settings collapsible group's measured `max-height` animation with a CSS Grid `0fr` to `1fr` transition.
- Keep persistence, keyboard controls, ARIA state, `inert`, nested groups, dropdown overflow, scroll anchoring, and reduced-motion behavior intact.
- Remove the remaining `animateExpansion: false` call-site exceptions and use a local fade-in only for asynchronously inserted content.

## Problem context

The previous implementation read `scrollHeight`, wrote a measured CSS height, and waited for animation frames while tracking `expanding`, `collapsing`, and `resizing` states. That created a visible click delay and made dynamic Settings rows vulnerable to clipping or a second layout jump. Some groups disabled animation to avoid those symptoms, which made the shared interaction inconsistent.

## What changed

- Added a stable body-inner wrapper so the outer body owns the Grid track while the inner element owns content overflow, padding, and borders.
- Replaced height measurement and RAF-driven expansion with intrinsic Grid sizing and direct state updates.
- Centralized transition interaction locking. Rapid reversals invalidate stale generations; `transitionend`, `transitioncancel`, and a watchdog release `inert` safely.
- Derive the watchdog duration from the CSS transition custom property and add only a small event-loss buffer, so CSS and JavaScript do not carry duplicate animation durations.
- Preserve the language-picker overflow escape for both open and mounted menu lifecycles, and keep reduced-motion transitions and animations disabled.
- Mark newly revealed quota content for a short local fade-in without reintroducing group-level height measurement.

## Behavior after this PR

Settings groups begin opening or closing immediately using intrinsic layout. Hidden content remains non-interactive during the transition and becomes interactive after the current transition settles; stale callbacks cannot unlock a newer state. Async rows naturally expand the open group, nested groups remain independent, and persisted state / ARIA / keyboard behavior remain unchanged. Reduced-motion users receive an immediate state change without motion.

No Settings store/controller, IPC, preference schema, or business behavior was changed.

## Validation

- `node --test test/settings-renderer-browser-env.test.js` — 222 passed, 0 failed.
- `npm test` — passed on Windows.
- `node --check src/settings-ui-core.js` — passed.
- `node --check test/settings-renderer-browser-env.test.js` — passed.
- `git diff --check` — passed (only the repository's existing LF/CRLF warnings were reported).

## Platform note

Automated validation ran on Windows. This draft intentionally remains open for Electron GUI smoke testing of sound, quota, taskbar flash, Agent lists, nested remote approval menus, narrow windows, text scaling, light/dark themes, and reduced motion before it is marked ready.

## Scope control

This PR covers the shared Settings collapsible component only. Electron's native tray menu and buttons in independent windows are unchanged. The standard-button migration is delivered separately in the companion draft PR.

Part of #857
