### PR TITLE
refactor: migrate settings actions to shared buttons

### DIFF
--- a/src/settings-tab-about.js
+++ b/src/settings-tab-about.js
@@ -78,22 +78,29 @@
 
     const actions = document.createElement("div");
     actions.className = "about-update-error-actions";
-    const copyButton = document.createElement("button");
-    copyButton.type = "button";
-    copyButton.className = "soft-btn about-update-error-copy";
-    copyButton.textContent = t("aboutUpdateErrorCopy");
+    const copyButton = helpers.buildButton({
+      label: t("aboutUpdateErrorCopy"),
+      size: "compact",
+      className: "about-update-error-copy",
+    });
     copyButton.addEventListener("click", async () => {
-      copyButton.disabled = true;
+      helpers.setButtonState(copyButton, { pending: true });
       try {
         const copy = window.settingsAPI && window.settingsAPI.copyUpdateError;
         if (typeof copy !== "function") throw new Error("clipboard unavailable");
         const result = await copy(String(report.copyText || report.detail || report.message || ""));
         if (!result || result.status !== "ok") throw new Error(result && result.message || "copy failed");
-        copyButton.textContent = t("aboutUpdateErrorCopied");
+        helpers.setButtonState(copyButton, {
+          pending: false,
+          labelKey: "aboutUpdateErrorCopied",
+        });
       } catch (_) {
-        copyButton.textContent = t("aboutUpdateErrorCopyFailed");
+        helpers.setButtonState(copyButton, {
+          pending: false,
+          labelKey: "aboutUpdateErrorCopyFailed",
+        });
       } finally {
-        copyButton.disabled = false;
+        helpers.setButtonState(copyButton, { pending: false });
       }
     });
     actions.appendChild(copyButton);

--- a/src/settings-tab-agents.js
+++ b/src/settings-tab-agents.js
@@ -365,19 +365,22 @@
 
     const control = document.createElement("div");
     control.className = "custom-tool-discovery-control custom-tool-discovery-actions";
-    const addButton = document.createElement("button");
-    addButton.type = "button";
-    addButton.className = "soft-btn accent custom-tool-path-picker";
-    addButton.textContent = t("customToolManualAdd");
+    const addButton = helpers.buildButton({
+      label: t("customToolManualAdd"),
+      tone: "accent",
+      size: "compact",
+      className: "custom-tool-path-picker",
+    });
     addButton.addEventListener("click", () => addPickedCustomDiscoveryPath(addButton));
     control.appendChild(addButton);
-    const scanButton = document.createElement("button");
-    scanButton.type = "button";
-    scanButton.className = "soft-btn custom-tool-scan";
-    scanButton.textContent = t("customToolRescan");
+    const scanButton = helpers.buildButton({
+      label: t("customToolRescan"),
+      size: "compact",
+      className: "custom-tool-scan",
+    });
     scanButton.addEventListener("click", async () => {
       const scanStartedAt = Date.now();
-      scanButton.disabled = true;
+      helpers.setButtonState(scanButton, { pending: true });
       scanStatus.classList.remove("failed");
       scanStatus.classList.add("pending");
       scanStatus.textContent = t("customToolScanStatusScanning");
@@ -395,7 +398,7 @@
         scanStatus.textContent = t("customToolScanStatusFailed");
       } finally {
         scanStatus.classList.remove("pending");
-        scanButton.disabled = false;
+        helpers.setButtonState(scanButton, { pending: false });
       }
     });
     control.appendChild(scanButton);
@@ -416,14 +419,17 @@
 
     const control = document.createElement("div");
     control.className = "custom-tool-wsl-scan";
-    const scanButton = document.createElement("button");
-    scanButton.type = "button";
-    scanButton.className = "soft-btn agent-instance-scan-btn";
-    scanButton.textContent = t("agentInstanceScanWsl");
-    scanButton.title = t("agentInstanceScanWslDesc");
+    const scanButton = helpers.buildButton({
+      label: t("agentInstanceScanWsl"),
+      size: "compact",
+      className: "agent-instance-scan-btn",
+      title: t("agentInstanceScanWslDesc"),
+    });
     scanButton.addEventListener("click", async () => {
-      scanButton.disabled = true;
-      scanButton.textContent = t("agentInstanceScanning");
+      helpers.setButtonState(scanButton, {
+        pending: true,
+        labelKey: "agentInstanceScanning",
+      });
       try {
         if (ops && typeof ops.fetchAgentInstallationHints === "function") {
           await ops.fetchAgentInstallationHints({ refreshWsl: true });
@@ -432,8 +438,10 @@
       } catch (err) {
         console.warn("WSL scan failed:", err && err.message);
       } finally {
-        scanButton.disabled = false;
-        scanButton.textContent = t("agentInstanceScanWsl");
+        helpers.setButtonState(scanButton, {
+          pending: false,
+          labelKey: "agentInstanceScanWsl",
+        });
       }
     });
     control.appendChild(scanButton);
@@ -471,8 +479,10 @@
       return;
     }
     const originalLabel = button.textContent;
-    button.disabled = true;
-    button.textContent = t("customToolScanStatusScanning");
+    helpers.setButtonState(button, {
+      pending: true,
+      labelKey: "customToolScanStatusScanning",
+    });
     try {
       const result = await window.settingsAPI.pickAgentDiscoveryPath("directory");
       if (!result || result.status === "cancel") return;
@@ -496,8 +506,10 @@
     } catch (err) {
       ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
     } finally {
-      button.disabled = false;
-      button.textContent = originalLabel;
+      helpers.setButtonState(button, {
+        pending: false,
+        label: originalLabel,
+      });
     }
   }
 
@@ -554,22 +566,29 @@
     row.appendChild(text);
 
     if (result.application) {
-      const status = document.createElement(result.application.added ? "span" : "button");
-      status.className = result.application.added
-        ? "custom-tool-result-status"
-        : "soft-btn accent custom-tool-add";
-      status.textContent = result.application.added ? t("customToolAdded") : t("customToolAdd");
-      if (!result.application.added) {
-        status.type = "button";
+      const status = result.application.added
+        ? document.createElement("span")
+        : helpers.buildButton({
+          label: t("customToolAdd"),
+          tone: "accent",
+          size: "compact",
+          className: "custom-tool-add",
+        });
+      if (result.application.added) {
+        status.className = "custom-tool-result-status";
+        status.textContent = t("customToolAdded");
+      } else {
         status.addEventListener("click", () => addCustomApplication(result, status));
       }
       row.appendChild(status);
     }
     if (result.path) {
-      const removePathButton = document.createElement("button");
-      removePathButton.type = "button";
-      removePathButton.className = "soft-btn danger custom-tool-remove-path";
-      removePathButton.textContent = t("customToolRemovePath");
+      const removePathButton = helpers.buildButton({
+        label: t("customToolRemovePath"),
+        tone: "danger",
+        size: "compact",
+        className: "custom-tool-remove-path",
+      });
       removePathButton.addEventListener("click", () => removeCustomDiscoveryPath(result.path, removePathButton));
       row.appendChild(removePathButton);
     }
@@ -578,7 +597,7 @@
 
   async function removeCustomDiscoveryPath(pathToRemove, button) {
     if (!window.settingsAPI || typeof window.settingsAPI.command !== "function") return;
-    button.disabled = true;
+    helpers.setButtonState(button, { pending: true });
     try {
       const paths = readers.readAgentCustomDiscoveryPaths("custom")
         .filter((entry) => entry !== pathToRemove);
@@ -594,7 +613,7 @@
       }
       ops.requestRender({ content: true });
     } catch (err) {
-      button.disabled = false;
+      helpers.setButtonState(button, { pending: false });
       ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
     }
   }
@@ -612,7 +631,7 @@
   }
 
   async function addCustomApplication(result, button) {
-    button.disabled = true;
+    helpers.setButtonState(button, { pending: true });
     try {
       const response = await window.settingsAPI.command("addCustomApplication", { path: result.path });
       if (!response || response.status !== "ok") throw new Error((response && response.message) || "add failed");
@@ -623,7 +642,7 @@
       await refreshCustomAgentUi();
     } catch (err) {
       ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
-      button.disabled = false;
+      helpers.setButtonState(button, { pending: false });
     }
   }
 
@@ -702,20 +721,24 @@
 
     const actions = document.createElement("div");
     actions.className = "agent-hint-actions agent-install-hint-actions";
-    const installBtn = document.createElement("button");
-    installBtn.type = "button";
-    installBtn.className = "soft-btn accent agent-install-hint-install";
-    installBtn.textContent = agentHintActionPending
-      ? t("agentIntegrationWorking")
-      : t("agentInstallHintInstallRecommended");
-    installBtn.disabled = !!agentHintActionPending;
+    const installBtn = helpers.buildButton({
+      label: agentHintActionPending
+        ? t("agentIntegrationWorking")
+        : t("agentInstallHintInstallRecommended"),
+      tone: "accent",
+      size: "compact",
+      className: "agent-install-hint-install",
+      disabled: !!agentHintActionPending,
+      pending: !!agentHintActionPending,
+    });
     installBtn.addEventListener("click", () => installRecommendedHints(agentIds));
 
-    const dismissBtn = document.createElement("button");
-    dismissBtn.type = "button";
-    dismissBtn.className = "soft-btn agent-install-hint-dismiss";
-    dismissBtn.textContent = t("agentInstallHintDismiss");
-    dismissBtn.disabled = !!agentHintActionPending;
+    const dismissBtn = helpers.buildButton({
+      label: t("agentInstallHintDismiss"),
+      size: "compact",
+      className: "agent-install-hint-dismiss",
+      disabled: !!agentHintActionPending,
+    });
     dismissBtn.addEventListener("click", () => dismissInstallHints(agentIds));
 
     actions.appendChild(installBtn);
@@ -743,20 +766,24 @@
 
     const actions = document.createElement("div");
     actions.className = "agent-hint-actions agent-cleanup-hint-actions";
-    const removeBtn = document.createElement("button");
-    removeBtn.type = "button";
-    removeBtn.className = "soft-btn accent agent-cleanup-hint-remove";
-    removeBtn.textContent = agentHintActionPending
-      ? t("agentIntegrationWorking")
-      : t("agentCleanupHintRemove");
-    removeBtn.disabled = !!agentHintActionPending;
+    const removeBtn = helpers.buildButton({
+      label: agentHintActionPending
+        ? t("agentIntegrationWorking")
+        : t("agentCleanupHintRemove"),
+      tone: "accent",
+      size: "compact",
+      className: "agent-cleanup-hint-remove",
+      disabled: !!agentHintActionPending,
+      pending: !!agentHintActionPending,
+    });
     removeBtn.addEventListener("click", () => removeCleanupHints(agentIds));
 
-    const dismissBtn = document.createElement("button");
-    dismissBtn.type = "button";
-    dismissBtn.className = "soft-btn agent-cleanup-hint-dismiss";
-    dismissBtn.textContent = t("agentCleanupHintDismiss");
-    dismissBtn.disabled = !!agentHintActionPending;
+    const dismissBtn = helpers.buildButton({
+      label: t("agentCleanupHintDismiss"),
+      size: "compact",
+      className: "agent-cleanup-hint-dismiss",
+      disabled: !!agentHintActionPending,
+    });
     dismissBtn.addEventListener("click", () => dismissCleanupHints(agentIds));
 
     actions.appendChild(removeBtn);
@@ -1055,19 +1082,21 @@
       },
       buildExtraControls: (ctrl) => {
         if (agent.custom) {
-          const button = document.createElement("button");
-          button.type = "button";
-          button.className = "soft-btn danger custom-agent-remove";
-          button.textContent = t("customToolRemove");
+          const button = helpers.buildButton({
+            label: t("customToolRemove"),
+            tone: "danger",
+            size: "compact",
+            className: "custom-agent-remove",
+          });
           button.addEventListener("click", async () => {
-            button.disabled = true;
+            helpers.setButtonState(button, { pending: true });
             try {
               const result = await window.settingsAPI.command("removeCustomApplication", { id: agent.id });
               if (!result || result.status !== "ok") throw new Error((result && result.message) || "remove failed");
               await refreshCustomAgentUi();
             } catch (err) {
               ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
-              button.disabled = false;
+              helpers.setButtonState(button, { pending: false });
             }
           });
           ctrl.appendChild(button);
@@ -1126,10 +1155,11 @@
         text.appendChild(desc);
         row.appendChild(text);
         if (["customToolAgentId", "customAgentStateEndpoint", "customAgentPayloadExample"].includes(labelKey)) {
-          const copyButton = document.createElement("button");
-          copyButton.type = "button";
-          copyButton.className = "soft-btn custom-agent-copy";
-          copyButton.textContent = t("customAgentCopy");
+          const copyButton = helpers.buildButton({
+            label: t("customAgentCopy"),
+            size: "compact",
+            className: "custom-agent-copy",
+          });
           copyButton.addEventListener("click", async () => {
             try {
               if (!navigator.clipboard || typeof navigator.clipboard.writeText !== "function") {
@@ -1362,13 +1392,17 @@
     const ctrl = document.createElement("div");
     ctrl.className = "row-control";
 
-    const button = document.createElement("button");
-    button.className = "soft-btn agent-instance-action";
-    button.textContent = t("agentInstancePair");
-    button.title = `WSL: ${wslEntry.distro}`;
+    const button = helpers.buildButton({
+      label: t("agentInstancePair"),
+      size: "compact",
+      className: "agent-instance-action",
+      title: `WSL: ${wslEntry.distro}`,
+    });
     button.addEventListener("click", async () => {
-      button.disabled = true;
-      button.textContent = t("agentInstancePairing");
+      helpers.setButtonState(button, {
+        pending: true,
+        labelKey: "agentInstancePairing",
+      });
       try {
         if (window.settingsAPI && typeof window.settingsAPI.command === "function") {
           const result = await window.settingsAPI.command("deployToWsl", {
@@ -1402,8 +1436,10 @@
         // Refresh after both success and failure: an installer can leave
         // managed files that the user must be able to Unpair/repair.
         refreshWslHints();
-        button.disabled = false;
-        button.textContent = t("agentInstancePair");
+        helpers.setButtonState(button, {
+          pending: false,
+          labelKey: "agentInstancePair",
+        });
       }
     });
     ctrl.appendChild(button);
@@ -1416,13 +1452,17 @@
       ? wslEntry.integrationFilesPresent === true
       : wslEntry.hooksFilesPresent === true;
     if (canUnpair) {
-      const unpairBtn = document.createElement("button");
-      unpairBtn.className = "soft-btn agent-instance-action";
-      unpairBtn.textContent = t("agentInstanceUnpair");
-      unpairBtn.title = `WSL: ${wslEntry.distro}`;
+      const unpairBtn = helpers.buildButton({
+        label: t("agentInstanceUnpair"),
+        size: "compact",
+        className: "agent-instance-action",
+        title: `WSL: ${wslEntry.distro}`,
+      });
       unpairBtn.addEventListener("click", async () => {
-        unpairBtn.disabled = true;
-        unpairBtn.textContent = t("agentInstanceUnpairing");
+        helpers.setButtonState(unpairBtn, {
+          pending: true,
+          labelKey: "agentInstanceUnpairing",
+        });
         try {
           if (window.settingsAPI && typeof window.settingsAPI.command === "function") {
             const result = await window.settingsAPI.command("removeFromWsl", {
@@ -1442,8 +1482,10 @@
           ops.showToast(String(err && err.message ? err.message : err), { error: true });
         } finally {
           refreshWslHints();
-          unpairBtn.disabled = false;
-          unpairBtn.textContent = t("agentInstanceUnpair");
+          helpers.setButtonState(unpairBtn, {
+            pending: false,
+            labelKey: "agentInstanceUnpair",
+          });
         }
       });
       ctrl.appendChild(unpairBtn);
@@ -1604,9 +1646,11 @@
   function syncAgentIntegrationAction(meta) {
     if (!meta || !meta.button) return;
     const installed = readers.readAgentIntegrationInstalled(meta.agentId);
-    meta.button.disabled = false;
-    meta.button.classList.remove("pending");
-    meta.button.textContent = t(installed ? "agentIntegrationUninstall" : "agentIntegrationInstall");
+    helpers.setButtonState(meta.button, {
+      disabled: false,
+      pending: false,
+      labelKey: installed ? "agentIntegrationUninstall" : "agentIntegrationInstall",
+    });
     meta.button.setAttribute(
       "aria-label",
       t(installed ? "agentIntegrationUninstall" : "agentIntegrationInstall")
@@ -1615,9 +1659,10 @@
   }
 
   function buildAgentIntegrationActionButton(agent) {
-    const button = document.createElement("button");
-    button.type = "button";
-    button.className = "soft-btn agent-integration-action";
+    const button = helpers.buildButton({
+      size: "compact",
+      className: "agent-integration-action",
+    });
     const meta = {
       button,
       agentId: agent.id,
@@ -1633,9 +1678,10 @@
       if (installed && typeof window.confirm === "function" && !window.confirm(t("agentIntegrationUninstallConfirm"))) {
         return;
       }
-      button.disabled = true;
-      button.classList.add("pending");
-      button.textContent = t("agentIntegrationWorking");
+      helpers.setButtonState(button, {
+        pending: true,
+        labelKey: "agentIntegrationWorking",
+      });
       window.settingsAPI.command(command, { agentId: agent.id }).then((result) => {
         if (result && result.status === "skipped") {
           ops.showToast(formatHintResult(t("agentIntegrationInstallSkipped"), {

--- a/src/settings-tab-discord-presence.js
+++ b/src/settings-tab-discord-presence.js
@@ -129,11 +129,12 @@
       view.appIdDirty = true;
     });
 
-    const saveBtn = document.createElement("button");
-    saveBtn.type = "button";
-    saveBtn.className = "soft-btn accent";
-    saveBtn.textContent = view.configPending ? t("discordPresenceSaving") : t("discordPresenceSaveAppId");
-    saveBtn.disabled = view.configPending;
+    const saveBtn = helpers.buildButton({
+      label: view.configPending ? t("discordPresenceSaving") : t("discordPresenceSaveAppId"),
+      tone: "accent",
+      disabled: view.configPending,
+      pending: view.configPending,
+    });
     saveBtn.addEventListener("click", () => {
       const raw = String(view.appIdDraft == null ? draft : view.appIdDraft).trim();
       if (raw && !APP_ID_RE.test(raw)) {

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -193,15 +193,18 @@
 
     const controls = document.createElement("div");
     controls.className = "row-control roam-area-controls";
-    const resetButton = document.createElement("button");
-    resetButton.type = "button";
-    resetButton.className = "soft-btn roam-area-reset";
-    resetButton.textContent = t("roamAreaReset");
+    const resetButton = helpers.buildButton({
+      label: t("roamAreaReset"),
+      size: "compact",
+      className: "roam-area-reset",
+    });
     resetButton.style.display = "none";
-    const chooseButton = document.createElement("button");
-    chooseButton.type = "button";
-    chooseButton.className = "soft-btn accent roam-area-choose";
-    chooseButton.textContent = t("roamAreaChoose");
+    const chooseButton = helpers.buildButton({
+      label: t("roamAreaChoose"),
+      tone: "accent",
+      size: "compact",
+      className: "roam-area-choose",
+    });
     controls.appendChild(resetButton);
     controls.appendChild(chooseButton);
     row.appendChild(text);
@@ -213,9 +216,8 @@
     }
     function setBusy(next) {
       busy = !!next;
-      chooseButton.disabled = busy;
-      resetButton.disabled = busy;
-      chooseButton.classList.toggle("pending", busy);
+      helpers.setButtonState(chooseButton, { pending: busy });
+      helpers.setButtonState(resetButton, { pending: busy });
     }
     function applyStatus(result) {
       if (!isMounted()) return;
@@ -588,23 +590,28 @@
   function buildDashboardRow() {
     const row = document.createElement("div");
     row.className = "row";
-    row.innerHTML =
-      `<div class="row-text">` +
-        `<span class="row-label"></span>` +
-        `<span class="row-desc"></span>` +
-      `</div>` +
-      `<div class="row-control">` +
-        `<button type="button" class="soft-btn accent"></button>` +
-      `</div>`;
-    row.querySelector(".row-label").textContent = t("rowSessionDashboard");
-    row.querySelector(".row-desc").textContent = t("rowSessionDashboardDesc");
-    const btn = row.querySelector("button");
-    btn.textContent = t("actionOpenDashboard");
+    const text = document.createElement("div");
+    text.className = "row-text";
+    const label = document.createElement("span");
+    label.className = "row-label";
+    label.textContent = t("rowSessionDashboard");
+    const desc = document.createElement("span");
+    desc.className = "row-desc";
+    desc.textContent = t("rowSessionDashboardDesc");
+    text.append(label, desc);
+    const control = document.createElement("div");
+    control.className = "row-control";
+    const btn = helpers.buildButton({
+      label: t("actionOpenDashboard"),
+      tone: "accent",
+    });
     btn.addEventListener("click", () => {
       if (window.settingsAPI && typeof window.settingsAPI.openDashboard === "function") {
         window.settingsAPI.openDashboard();
       }
     });
+    control.appendChild(btn);
+    row.append(text, control);
     return row;
   }
 
@@ -934,12 +941,12 @@
     // as a card; mirrors how Sound group puts the volume slider on its own row.
     const resetRow = document.createElement("div");
     resetRow.className = "row session-cleanup-reset-row";
-    const resetButton = document.createElement("button");
-    resetButton.type = "button";
-    resetButton.className = "soft-btn";
-    resetButton.textContent = t("actionResetSessionCleanup");
+    const resetButton = helpers.buildButton({
+      label: t("actionResetSessionCleanup"),
+      size: "compact",
+    });
     resetButton.addEventListener("click", async () => {
-      resetButton.disabled = true;
+      helpers.setButtonState(resetButton, { pending: true });
       try {
         const result = await window.settingsAPI.command(
           "sessionCleanup.setTriple",
@@ -952,7 +959,7 @@
       } catch (err) {
         ops.showToast(t("toastSaveFailed") + (err && err.message), { error: true });
       } finally {
-        resetButton.disabled = false;
+        helpers.setButtonState(resetButton, { pending: false });
       }
     });
     resetRow.appendChild(resetButton);

--- a/src/settings-tab-remote-ssh.js
+++ b/src/settings-tab-remote-ssh.js
@@ -263,9 +263,11 @@
     headTitle.textContent = t("remoteSshSectionProfiles");
     header.appendChild(headTitle);
 
-    const addBtn = document.createElement("button");
-    addBtn.className = "soft-btn accent";
-    addBtn.textContent = t("remoteSshAddProfile");
+    const addBtn = helpers.buildButton({
+      label: t("remoteSshAddProfile"),
+      tone: "accent",
+      size: "compact",
+    });
     addBtn.addEventListener("click", () => {
       view.editing = {
         id: uuid(),
@@ -337,8 +339,6 @@
       actions.appendChild(warn);
     }
 
-    const connectBtn = document.createElement("button");
-    connectBtn.className = "soft-btn";
     const transportOperationActive = !!(
       status.transportPhase && status.transportPhase !== "idle"
     );
@@ -346,16 +346,18 @@
       || status.status === "connecting"
       || status.status === "reconnecting"
       || (transportOperationActive && status.transportDesiredConnected === true);
+    const deploymentReady = hasDeploymentStamp(profile);
+    const connectBtn = helpers.buildButton({
+      label: disconnectAvailable ? t("remoteSshDisconnect") : t("remoteSshConnect"),
+      size: "compact",
+      disabled: !disconnectAvailable && (!deploymentReady || transportOperationActive),
+    });
     if (disconnectAvailable) {
-      connectBtn.textContent = t("remoteSshDisconnect");
       connectBtn.addEventListener("click", (e) => {
         e.stopPropagation();
         requestProfileDisconnect(profile.id);
       });
     } else {
-      connectBtn.textContent = t("remoteSshConnect");
-      const deploymentReady = hasDeploymentStamp(profile);
-      connectBtn.disabled = !deploymentReady || transportOperationActive;
       if (!deploymentReady) {
         connectBtn.title = t("remoteSshErrDeploymentRequired");
       } else if (transportOperationActive) {
@@ -395,11 +397,12 @@
     headTitle.textContent = profile.label;
     header.appendChild(headTitle);
 
-    const editBtn = document.createElement("button");
-    editBtn.className = "soft-btn";
-    editBtn.textContent = t("remoteSshEdit");
-    editBtn.disabled = transportOwnedByAnother;
-    if (transportConflictTitle) editBtn.title = transportConflictTitle;
+    const editBtn = helpers.buildButton({
+      label: t("remoteSshEdit"),
+      size: "compact",
+      disabled: transportOwnedByAnother,
+      title: transportConflictTitle,
+    });
     editBtn.addEventListener("click", () => {
       if (transportOwnedByAnother) return;
       view.editing = { ...profile };
@@ -407,11 +410,15 @@
     });
     header.appendChild(editBtn);
 
-    const deleteBtn = document.createElement("button");
-    deleteBtn.className = "soft-btn remote-ssh-btn-danger";
-    deleteBtn.textContent = t("remoteSshDelete");
-    deleteBtn.disabled = view.deletingProfileIds.has(profile.id) || transportOwnedByAnother;
-    if (transportConflictTitle) deleteBtn.title = transportConflictTitle;
+    const deleteBtn = helpers.buildButton({
+      label: t("remoteSshDelete"),
+      tone: "danger",
+      size: "compact",
+      className: "remote-ssh-btn-danger",
+      disabled: transportOwnedByAnother,
+      pending: view.deletingProfileIds.has(profile.id),
+      title: transportConflictTitle,
+    });
     deleteBtn.addEventListener("click", async () => {
       if (view.deletingProfileIds.has(profile.id) || transportOwnedByAnother) return;
       if (!confirm(t("remoteSshDeleteConfirm").replace("{label}", profile.label))) return;
@@ -507,17 +514,18 @@
       : t("remoteSshAccountDefault");
     runtimeRow.appendChild(runtimeValue);
     if (isolated || view.profileIsolationAvailable) {
-      const modeButton = document.createElement("button");
-      modeButton.className = "soft-btn";
-      modeButton.textContent = t(isolated ? "remoteSshDisableIsolation" : "remoteSshEnableIsolation");
-      modeButton.disabled = transportOwnedByAnother;
-      if (transportConflictTitle) modeButton.title = transportConflictTitle;
+      const modeButton = helpers.buildButton({
+        label: t(isolated ? "remoteSshDisableIsolation" : "remoteSshEnableIsolation"),
+        size: "compact",
+        disabled: transportOwnedByAnother,
+        title: transportConflictTitle,
+      });
       modeButton.addEventListener("click", async () => {
         if (transportOwnedByAnother) return;
         if (!window.remoteSsh || typeof window.remoteSsh.setRuntimeMode !== "function") return;
         const prompt = t(isolated ? "remoteSshDisableIsolationConfirm" : "remoteSshEnableIsolationConfirm");
         if (!confirm(prompt)) return;
-        modeButton.disabled = true;
+        helpers.setButtonState(modeButton, { pending: true });
         const target = isolated ? "account-default" : "profile-isolated";
         try {
           const result = await window.remoteSsh.setRuntimeMode(profile.id, target, true);
@@ -552,9 +560,10 @@
         for (const name of ["claude", "codex", "copilot"]) {
           const capability = isolatedRuntime.capabilities && isolatedRuntime.capabilities[name];
           if (!capability || !capability.present || !capability.wrapperPath) continue;
-          const copy = document.createElement("button");
-          copy.className = "soft-btn";
-          copy.textContent = t("remoteSshCopyWrapper").replace("{name}", name);
+          const copy = helpers.buildButton({
+            label: t("remoteSshCopyWrapper").replace("{name}", name),
+            size: "compact",
+          });
           copy.addEventListener("click", async () => {
             try {
               await navigator.clipboard.writeText(capability.wrapperPath);
@@ -574,17 +583,20 @@
       const revokeActions = document.createElement("div");
       revokeActions.className = "remote-ssh-actions";
       const addRevokeButton = (mode, labelKey, firstConfirmKey) => {
-        const button = document.createElement("button");
-        button.className = "soft-btn remote-ssh-btn-danger";
-        button.textContent = t(labelKey);
-        button.disabled = transportOwnedByAnother;
-        if (transportConflictTitle) button.title = transportConflictTitle;
+        const button = helpers.buildButton({
+          label: t(labelKey),
+          tone: "danger",
+          size: "compact",
+          className: "remote-ssh-btn-danger",
+          disabled: transportOwnedByAnother,
+          title: transportConflictTitle,
+        });
         button.addEventListener("click", async () => {
           if (transportOwnedByAnother) return;
           if (!window.remoteSsh || typeof window.remoteSsh.forceRevoke !== "function") return;
           if (!confirm(t(firstConfirmKey))) return;
           if (!confirm(t("remoteSshForceRevokeSecondConfirm"))) return;
-          button.disabled = true;
+          helpers.setButtonState(button, { pending: true });
           try {
             const result = await window.remoteSsh.forceRevoke(profile.id, mode, true);
             if (!result || result.status !== "ok") {
@@ -608,11 +620,11 @@
     // Action buttons
     const actions = document.createElement("div");
     actions.className = "remote-ssh-actions";
-    const authBtn = document.createElement("button");
-    authBtn.className = "soft-btn";
-    authBtn.textContent = t("remoteSshAuthenticate");
-    authBtn.disabled = transportOwnedByAnother;
-    authBtn.title = transportConflictTitle || t("remoteSshAuthenticateHint");
+    const authBtn = helpers.buildButton({
+      label: t("remoteSshAuthenticate"),
+      disabled: transportOwnedByAnother,
+      title: transportConflictTitle || t("remoteSshAuthenticateHint"),
+    });
     authBtn.addEventListener("click", () => {
       if (transportOwnedByAnother) return;
       if (!window.remoteSsh) return;
@@ -622,11 +634,11 @@
     });
     actions.appendChild(authBtn);
 
-    const termBtn = document.createElement("button");
-    termBtn.className = "soft-btn";
-    termBtn.textContent = t("remoteSshOpenTerminal");
-    termBtn.disabled = transportOwnedByAnother;
-    if (transportConflictTitle) termBtn.title = transportConflictTitle;
+    const termBtn = helpers.buildButton({
+      label: t("remoteSshOpenTerminal"),
+      disabled: transportOwnedByAnother,
+      title: transportConflictTitle,
+    });
     termBtn.addEventListener("click", () => {
       if (transportOwnedByAnother) return;
       if (!window.remoteSsh) return;
@@ -636,12 +648,14 @@
     });
     actions.appendChild(termBtn);
 
-    const deployBtn = document.createElement("button");
-    deployBtn.className = "soft-btn accent";
     const isDeploying = view.deployingProfileIds.has(profile.id);
-    deployBtn.textContent = isDeploying ? t("remoteSshDeploying") : t("remoteSshDeploy");
-    deployBtn.disabled = isDeploying || transportOwnedByAnother;
-    if (transportConflictTitle) deployBtn.title = transportConflictTitle;
+    const deployBtn = helpers.buildButton({
+      label: isDeploying ? t("remoteSshDeploying") : t("remoteSshDeploy"),
+      tone: "accent",
+      disabled: transportOwnedByAnother,
+      pending: isDeploying,
+      title: transportConflictTitle,
+    });
     deployBtn.addEventListener("click", () => {
       if (!window.remoteSsh || transportOwnedByAnother) return;
       view.deployingProfileIds.add(profile.id);
@@ -904,18 +918,19 @@
     const formActions = document.createElement("div");
     formActions.className = "remote-ssh-form-actions";
 
-    const cancelBtn = document.createElement("button");
-    cancelBtn.className = "soft-btn";
-    cancelBtn.textContent = t("remoteSshCancel");
+    const cancelBtn = helpers.buildButton({
+      label: t("remoteSshCancel"),
+    });
     cancelBtn.addEventListener("click", () => {
       view.editing = null;
       ops.requestRender({ content: true });
     });
     formActions.appendChild(cancelBtn);
 
-    const saveBtn = document.createElement("button");
-    saveBtn.className = "soft-btn accent";
-    saveBtn.textContent = t("remoteSshSave");
+    const saveBtn = helpers.buildButton({
+      label: t("remoteSshSave"),
+      tone: "accent",
+    });
     saveBtn.addEventListener("click", () => {
       // Strip empty optional strings before submitting.
       const payload = {

--- a/src/settings-tab-telegram-approval.js
+++ b/src/settings-tab-telegram-approval.js
@@ -634,27 +634,29 @@
 
     const actions = document.createElement("div");
     actions.className = "tg-native-migration-gate-actions";
-    const verify = document.createElement("button");
-    verify.type = "button";
-    verify.className = "soft-btn accent";
-    verify.textContent = testingFromRequired
-      ? t("telegramNativeMigrationWaiting")
-      : t("telegramNativeMigrationVerify");
-    verify.disabled = migrationPending || testingFromRequired;
+    const verify = helpers.buildButton({
+      label: testingFromRequired
+        ? t("telegramNativeMigrationWaiting")
+        : t("telegramNativeMigrationVerify"),
+      tone: "accent",
+      size: "compact",
+      disabled: migrationPending || testingFromRequired,
+      pending: testingFromRequired,
+    });
     verify.addEventListener("click", () => {
       if (verify.disabled) return;
       migrationDispatch("USER_TEST_NATIVE");
     });
-    const disable = document.createElement("button");
-    disable.type = "button";
-    disable.className = "soft-btn";
-    disable.textContent = t("telegramNativeMigrationDisable");
-    disable.disabled = migrationPending;
+    const disable = helpers.buildButton({
+      label: t("telegramNativeMigrationDisable"),
+      size: "compact",
+      disabled: migrationPending,
+    });
     disable.addEventListener("click", () => migrationDispatch("USER_DISABLE"));
-    const guide = document.createElement("button");
-    guide.type = "button";
-    guide.className = "soft-btn";
-    guide.textContent = t("telegramNativeMigrationGuide");
+    const guide = helpers.buildButton({
+      label: t("telegramNativeMigrationGuide"),
+      size: "compact",
+    });
     guide.addEventListener("click", () => {
       helpers.openExternalSafe(
         "https://github.com/rullerzhou-afk/clawd-on-desk/blob/main/docs/guides/telegram-approval.md"
@@ -858,10 +860,10 @@
 
     const ctrl = document.createElement("div");
     ctrl.className = "row-control";
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className = "soft-btn";
-    btn.textContent = t("telegramApprovalReplaceToken");
+    const btn = helpers.buildButton({
+      label: t("telegramApprovalReplaceToken"),
+      size: "compact",
+    });
     btn.addEventListener("click", () => {
       view.tokenEditing = true;
       ops.requestRender({ content: true });
@@ -905,11 +907,12 @@
     input.placeholder = t("telegramApprovalBotTokenPlaceholder");
     input.className = "tg-approval-input";
 
-    const saveBtn = document.createElement("button");
-    saveBtn.type = "button";
-    saveBtn.className = "soft-btn accent";
-    saveBtn.textContent = view.tokenPending ? t("telegramApprovalSaving") : t("telegramApprovalSaveToken");
-    saveBtn.disabled = view.tokenPending;
+    const saveBtn = helpers.buildButton({
+      label: view.tokenPending ? t("telegramApprovalSaving") : t("telegramApprovalSaveToken"),
+      tone: "accent",
+      disabled: view.tokenPending,
+      pending: view.tokenPending,
+    });
     saveBtn.addEventListener("click", () => {
       const token = input.value.trim();
       if (!token) {
@@ -939,11 +942,11 @@
     ctrl.appendChild(saveBtn);
 
     if (configured) {
-      const cancelBtn = document.createElement("button");
-      cancelBtn.type = "button";
-      cancelBtn.className = "soft-btn";
-      cancelBtn.textContent = t("telegramApprovalCancel");
-      cancelBtn.disabled = view.tokenPending;
+      const cancelBtn = helpers.buildButton({
+        label: t("telegramApprovalCancel"),
+        size: "compact",
+        disabled: view.tokenPending,
+      });
       cancelBtn.addEventListener("click", () => {
         view.tokenEditing = false;
         ops.requestRender({ content: true });
@@ -986,11 +989,12 @@
     input.value = draft.allowedTgUserId || "";
     input.addEventListener("input", () => setFormDraftValue("allowedTgUserId", input.value));
 
-    const saveBtn = document.createElement("button");
-    saveBtn.type = "button";
-    saveBtn.className = "soft-btn accent";
-    saveBtn.textContent = view.configPending ? t("telegramApprovalSaving") : t("telegramApprovalSaveRecipient");
-    saveBtn.disabled = view.configPending;
+    const saveBtn = helpers.buildButton({
+      label: view.configPending ? t("telegramApprovalSaving") : t("telegramApprovalSaveRecipient"),
+      tone: "accent",
+      disabled: view.configPending,
+      pending: view.configPending,
+    });
     saveBtn.addEventListener("click", () => {
       const raw = String(getFormDraft().allowedTgUserId || "").trim();
       if (!raw) {
@@ -1267,11 +1271,13 @@
 
     const ctrl = document.createElement("div");
     ctrl.className = "row-control";
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className = "soft-btn accent";
-    btn.textContent = view.testPending ? t("telegramApprovalTesting") : t("telegramApprovalSendTest");
-    btn.disabled = testDisabled;
+    const btn = helpers.buildButton({
+      label: view.testPending ? t("telegramApprovalTesting") : t("telegramApprovalSendTest"),
+      tone: "accent",
+      size: "compact",
+      disabled: testDisabled,
+      pending: view.testPending,
+    });
     if (testDisabled && !view.testPending) {
       btn.title = (s.message && String(s.message)) || t("telegramApprovalCardMissingBoth");
     }
@@ -1378,10 +1384,10 @@
 
     const ctrl = document.createElement("div");
     ctrl.className = "row-control";
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className = "soft-btn";
-    btn.textContent = t("feishuApprovalReplaceSecrets");
+    const btn = helpers.buildButton({
+      label: t("feishuApprovalReplaceSecrets"),
+      size: "compact",
+    });
     btn.addEventListener("click", () => {
       feishuView.secretEditing = true;
       ops.requestRender({ content: true });
@@ -1423,11 +1429,12 @@
     const verificationInput = buildFeishuSecretInput("feishuApprovalVerificationTokenPlaceholder", true);
     const encryptInput = buildFeishuSecretInput("feishuApprovalEncryptKeyPlaceholder", true);
 
-    const saveBtn = document.createElement("button");
-    saveBtn.type = "button";
-    saveBtn.className = "soft-btn accent";
-    saveBtn.textContent = feishuView.secretPending ? t("feishuApprovalSaving") : t("feishuApprovalSaveSecrets");
-    saveBtn.disabled = feishuView.secretPending;
+    const saveBtn = helpers.buildButton({
+      label: feishuView.secretPending ? t("feishuApprovalSaving") : t("feishuApprovalSaveSecrets"),
+      tone: "accent",
+      disabled: feishuView.secretPending,
+      pending: feishuView.secretPending,
+    });
     saveBtn.addEventListener("click", () => {
       const payload = {
         appId: appIdInput.value.trim(),
@@ -1473,11 +1480,11 @@
     ctrl.appendChild(encryptInput);
     ctrl.appendChild(saveBtn);
     if (configured) {
-      const cancelBtn = document.createElement("button");
-      cancelBtn.type = "button";
-      cancelBtn.className = "soft-btn";
-      cancelBtn.textContent = t("telegramApprovalCancel");
-      cancelBtn.disabled = feishuView.secretPending;
+      const cancelBtn = helpers.buildButton({
+        label: t("telegramApprovalCancel"),
+        size: "compact",
+        disabled: feishuView.secretPending,
+      });
       cancelBtn.addEventListener("click", () => {
         feishuView.secretEditing = false;
         ops.requestRender({ content: true });
@@ -1591,11 +1598,12 @@
     input.value = draft.approverId || "";
     input.addEventListener("input", () => setFeishuFormDraftValue("approverId", input.value));
 
-    const saveBtn = document.createElement("button");
-    saveBtn.type = "button";
-    saveBtn.className = "soft-btn accent";
-    saveBtn.textContent = feishuView.configPending ? t("feishuApprovalSaving") : t("feishuApprovalSaveApprover");
-    saveBtn.disabled = feishuView.configPending;
+    const saveBtn = helpers.buildButton({
+      label: feishuView.configPending ? t("feishuApprovalSaving") : t("feishuApprovalSaveApprover"),
+      tone: "accent",
+      disabled: feishuView.configPending,
+      pending: feishuView.configPending,
+    });
     saveBtn.addEventListener("click", () => {
       const nextDraft = getFeishuFormDraft();
       const approverId = String(nextDraft.approverId || "").trim();
@@ -1781,11 +1789,13 @@
 
     const ctrl = document.createElement("div");
     ctrl.className = "row-control";
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className = "soft-btn accent";
-    btn.textContent = feishuView.testPending ? t("feishuApprovalTesting") : t("feishuApprovalSendTest");
-    btn.disabled = testDisabled;
+    const btn = helpers.buildButton({
+      label: feishuView.testPending ? t("feishuApprovalTesting") : t("feishuApprovalSendTest"),
+      tone: "accent",
+      size: "compact",
+      disabled: testDisabled,
+      pending: feishuView.testPending,
+    });
     if (testDisabled && !feishuView.testPending) {
       // Prefer the translated reason the button is dead; the raw English
       // s.message is the last resort, not the first choice.

--- a/src/settings-tab-theme.js
+++ b/src/settings-tab-theme.js
@@ -607,57 +607,57 @@
     row.className = "theme-actions";
 
     const codexGroup = buildThemeActionGroup(t("themeActionGroupCodexPets"));
-    const importBtn = document.createElement("button");
-    importBtn.type = "button";
-    importBtn.className = "soft-btn";
-    importBtn.textContent = t("themeImportPetZip");
-    importBtn.disabled = !!runtime.codexPetZipImportPending
-      || !window.settingsAPI
-      || typeof window.settingsAPI.importCodexPetZip !== "function";
-    if (runtime.codexPetZipImportPending) importBtn.classList.add("pending");
+    const importBtn = helpers.buildButton({
+      label: t("themeImportPetZip"),
+      size: "compact",
+      disabled: !!runtime.codexPetZipImportPending
+        || !window.settingsAPI
+        || typeof window.settingsAPI.importCodexPetZip !== "function",
+      pending: !!runtime.codexPetZipImportPending,
+    });
     importBtn.addEventListener("click", handleImportCodexPetZip);
     codexGroup.buttons.appendChild(importBtn);
 
-    const refreshBtn = document.createElement("button");
-    refreshBtn.type = "button";
-    refreshBtn.className = "soft-btn";
-    refreshBtn.textContent = t("themeRefreshImportedPets");
-    refreshBtn.disabled = !!runtime.codexPetsRefreshPending
-      || !window.settingsAPI
-      || typeof window.settingsAPI.refreshCodexPets !== "function";
-    if (runtime.codexPetsRefreshPending) refreshBtn.classList.add("pending");
+    const refreshBtn = helpers.buildButton({
+      label: t("themeRefreshImportedPets"),
+      size: "compact",
+      disabled: !!runtime.codexPetsRefreshPending
+        || !window.settingsAPI
+        || typeof window.settingsAPI.refreshCodexPets !== "function",
+      pending: !!runtime.codexPetsRefreshPending,
+    });
     refreshBtn.addEventListener("click", handleRefreshCodexPets);
     codexGroup.buttons.appendChild(refreshBtn);
     row.appendChild(codexGroup.group);
 
     const userThemeGroup = buildThemeActionGroup(t("themeActionGroupUserThemes"));
-    const importThemeBtn = document.createElement("button");
-    importThemeBtn.type = "button";
-    importThemeBtn.className = "soft-btn";
-    importThemeBtn.textContent = t("themeImportUserThemeZip");
-    importThemeBtn.title = t("themeImportUserThemeZipHint");
-    importThemeBtn.disabled = !!runtime.userThemeZipImportPending
-      || !window.settingsAPI
-      || typeof window.settingsAPI.importUserThemeZip !== "function";
-    if (runtime.userThemeZipImportPending) importThemeBtn.classList.add("pending");
+    const importThemeBtn = helpers.buildButton({
+      label: t("themeImportUserThemeZip"),
+      size: "compact",
+      title: t("themeImportUserThemeZipHint"),
+      disabled: !!runtime.userThemeZipImportPending
+        || !window.settingsAPI
+        || typeof window.settingsAPI.importUserThemeZip !== "function",
+      pending: !!runtime.userThemeZipImportPending,
+    });
     importThemeBtn.addEventListener("click", handleImportUserThemeZip);
     userThemeGroup.buttons.appendChild(importThemeBtn);
 
-    const userThemeFolderBtn = document.createElement("button");
-    userThemeFolderBtn.type = "button";
-    userThemeFolderBtn.className = "soft-btn";
-    userThemeFolderBtn.textContent = t("themeOpenUserThemesFolder");
-    userThemeFolderBtn.disabled = !window.settingsAPI
-      || typeof window.settingsAPI.openUserThemesDir !== "function";
+    const userThemeFolderBtn = helpers.buildButton({
+      label: t("themeOpenUserThemesFolder"),
+      size: "compact",
+      disabled: !window.settingsAPI
+        || typeof window.settingsAPI.openUserThemesDir !== "function",
+    });
     userThemeFolderBtn.addEventListener("click", handleOpenUserThemesFolder);
     userThemeGroup.buttons.appendChild(userThemeFolderBtn);
 
-    const refreshThemesBtn = document.createElement("button");
-    refreshThemesBtn.type = "button";
-    refreshThemesBtn.className = "soft-btn";
-    refreshThemesBtn.textContent = t("themeRefreshThemes");
-    refreshThemesBtn.disabled = !window.settingsAPI
-      || typeof window.settingsAPI.listThemes !== "function";
+    const refreshThemesBtn = helpers.buildButton({
+      label: t("themeRefreshThemes"),
+      size: "compact",
+      disabled: !window.settingsAPI
+        || typeof window.settingsAPI.listThemes !== "function",
+    });
     refreshThemesBtn.addEventListener("click", handleRefreshThemes);
     userThemeGroup.buttons.appendChild(refreshThemesBtn);
     row.appendChild(userThemeGroup.group);

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -98,6 +98,11 @@
     nextTransientUiSeq: 1,
   };
 
+  // Button state is kept separate from the native `disabled` property so a
+  // pending operation can be cleared without losing a business-level disable
+  // decision supplied by the feature tab.
+  const settingsButtonStates = new WeakMap();
+
   const runtime = {
     agentMetadata: null,
     agentInstallationHints: null,
@@ -366,9 +371,43 @@
     return section;
   }
 
+  function applyButtonState(button, buttonState) {
+    button.textContent = buttonState.label;
+    button.disabled = buttonState.disabled || buttonState.pending;
+    button.classList.toggle("pending", buttonState.pending);
+    button.setAttribute("aria-busy", buttonState.pending ? "true" : "false");
+  }
+
   // Shared Settings button primitive. Feature tabs keep ownership of business
   // behavior while tone, sizing and pending/accessibility semantics stay
-  // consistent across the Settings window.
+  // consistent across the Settings window. `setButtonState` is intentionally
+  // small: it updates presentation state without moving business logic into
+  // this shared layer.
+  function setButtonState(button, patch = {}) {
+    if (!button || typeof button !== "object") return button;
+    const current = settingsButtonStates.get(button);
+    if (!current) {
+      throw new TypeError("setButtonState requires a button built by buildButton");
+    }
+    const next = { ...current };
+    if (Object.prototype.hasOwnProperty.call(patch, "label")) {
+      next.label = patch.label == null ? "" : String(patch.label);
+      next.labelKey = null;
+    } else if (Object.prototype.hasOwnProperty.call(patch, "labelKey")) {
+      next.labelKey = patch.labelKey == null ? null : String(patch.labelKey);
+      next.label = next.labelKey ? t(next.labelKey) : "";
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, "disabled")) {
+      next.disabled = patch.disabled === true;
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, "pending")) {
+      next.pending = patch.pending === true;
+    }
+    settingsButtonStates.set(button, next);
+    applyButtonState(button, next);
+    return button;
+  }
+
   function buildButton(config = {}) {
     const button = document.createElement("button");
     const tone = ["neutral", "accent", "danger", "quiet"].includes(config.tone)
@@ -385,15 +424,19 @@
       tone === "neutral" ? "" : tone,
       config.className || "",
     ].filter(Boolean).join(" ");
-    button.textContent = config.label != null
-      ? String(config.label)
-      : (config.labelKey ? t(config.labelKey) : "");
+    const buttonState = {
+      disabled: config.disabled === true,
+      pending: config.pending === true,
+      label: config.label != null
+        ? String(config.label)
+        : (config.labelKey ? t(config.labelKey) : ""),
+      labelKey: config.labelKey ? String(config.labelKey) : null,
+    };
+    settingsButtonStates.set(button, buttonState);
     if (config.ariaLabel) button.setAttribute("aria-label", String(config.ariaLabel));
     if (config.title) button.title = String(config.title);
-    if (config.disabled === true || config.pending === true) button.disabled = true;
-    button.classList.toggle("pending", config.pending === true);
-    button.setAttribute("aria-busy", config.pending === true ? "true" : "false");
     if (typeof config.onClick === "function") button.addEventListener("click", config.onClick);
+    applyButtonState(button, buttonState);
     return button;
   }
 
@@ -1856,6 +1899,7 @@
   core.helpers = {
     t,
     buildButton,
+    setButtonState,
     showSettingsDialog,
     showSettingsConfirmModal,
     escapeHtml,

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -402,6 +402,10 @@ class FakeElement {
   }
 }
 
+function loadSharedButtonHelpersForTest(document, settingsAPI = {}) {
+  return loadSettingsCoreForTest(settingsAPI, { document }).helpers;
+}
+
 function loadSharedLanguagePickerForTest({
   value = "en",
   options = ["en", "zh", "ja"],
@@ -831,6 +835,7 @@ function createKeyboardEventForTest(key) {
 function loadRemoteSshTabForTest({
   snapshot,
   cleanup = () => Promise.resolve({ status: "ok", uninstalled: true }),
+  deploy = () => Promise.resolve({ status: "ok" }),
   command = () => Promise.resolve({ status: "ok" }),
   confirm = () => true,
   listStatuses = null,
@@ -869,7 +874,7 @@ function loadRemoteSshTabForTest({
     disconnect: () => Promise.resolve({ status: "ok" }),
     authenticate: () => Promise.resolve({ status: "ok" }),
     openTerminal: () => Promise.resolve({ status: "ok" }),
-    deploy: () => Promise.resolve({ status: "ok" }),
+    deploy: (profileId, options) => deploy(profileId, options),
   };
   if (typeof listStatuses === "function") remoteSsh.listStatuses = listStatuses;
   const context = {
@@ -1112,6 +1117,7 @@ function loadAgentsTabForTest({
   collapsedGroups = {},
   settingsAPI = {},
   doctor = null,
+  confirm = () => true,
 } = {}) {
   const raf = createQueuedRaf();
   const body = new FakeElement("body");
@@ -1144,6 +1150,7 @@ function loadAgentsTabForTest({
     document,
     requestAnimationFrame: (cb) => raf.requestAnimationFrame(cb),
     setTimeout,
+    confirm,
     window: null,
     globalThis: null,
     settingsAPI: {
@@ -1430,6 +1437,7 @@ function loadTelegramApprovalTabForTest({
   vm.createContext(context);
   vm.runInContext(fs.readFileSync(LANGUAGE_PICKER_JS, "utf8"), context);
   vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-telegram-approval.js"), "utf8"), context);
+  const buttonHelpers = loadSharedButtonHelpersForTest(document, api);
 
   const core = {
     state: {
@@ -1454,6 +1462,8 @@ function loadTelegramApprovalTabForTest({
     runtime: {},
     helpers: {
       t: (key) => key,
+      buildButton: buttonHelpers.buildButton,
+      setButtonState: buttonHelpers.setButtonState,
       showSettingsConfirmModal: showConfirmModal,
       buildSection: (_title, rows) => {
         const section = document.createElement("section");
@@ -1619,6 +1629,7 @@ function loadDiscordPresenceTabForTest({ snapshot, update } = {}) {
   context.globalThis = context;
   vm.createContext(context);
   vm.runInContext(fs.readFileSync(SETTINGS_TAB_DISCORD_PRESENCE, "utf8"), context);
+  const buttonHelpers = loadSharedButtonHelpersForTest(document, settingsAPI);
 
   const core = {
     state: {
@@ -1634,6 +1645,8 @@ function loadDiscordPresenceTabForTest({ snapshot, update } = {}) {
     },
     helpers: {
       t: (key) => key,
+      buildButton: buttonHelpers.buildButton,
+      setButtonState: buttonHelpers.setButtonState,
       buildSection: (_title, rows) => {
         const section = document.createElement("section");
         for (const row of rows) section.appendChild(row);
@@ -1715,6 +1728,7 @@ function loadAboutTabForTest({
   context.globalThis = context;
   vm.createContext(context);
   vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-about.js"), "utf8"), context);
+  const buttonHelpers = loadSharedButtonHelpersForTest(document, context.settingsAPI);
 
   const core = {
     state: {
@@ -1725,6 +1739,8 @@ function loadAboutTabForTest({
     runtime: { about: { infoCache: null, clickCount: 0, updateCheckSnapshot: { state: "idle" } } },
     helpers: {
       t: (key) => key,
+      buildButton: buttonHelpers.buildButton,
+      setButtonState: buttonHelpers.setButtonState,
       setSwitchVisual: (element, checked, options = {}) => {
         element.classList.toggle("on", !!checked);
         element.classList.toggle("pending", !!options.pending);
@@ -2189,11 +2205,15 @@ describe("settings renderer browser environment", () => {
     const pendingDelete = harness.content.querySelector(".remote-ssh-btn-danger");
     assert.notStrictEqual(pendingDelete, originalDelete, "starting cleanup rebuilds the detail view");
     assert.strictEqual(pendingDelete.disabled, true);
+    assert.strictEqual(pendingDelete.classList.contains("pending"), true);
+    assert.strictEqual(pendingDelete.getAttribute("aria-busy"), "true");
 
     harness.emitStatus({ profileId: profile.id, status: "idle" });
     const afterStatusRerender = harness.content.querySelector(".remote-ssh-btn-danger");
     assert.notStrictEqual(afterStatusRerender, pendingDelete);
     assert.strictEqual(afterStatusRerender.disabled, true, "runtime status repaint preserves pending state");
+    assert.strictEqual(afterStatusRerender.classList.contains("pending"), true);
+    assert.strictEqual(afterStatusRerender.getAttribute("aria-busy"), "true");
 
     // FakeElement permits dispatching a disabled button, unlike the browser.
     // The handler guard must still prevent duplicate destructive IPC work.
@@ -2205,6 +2225,43 @@ describe("settings renderer browser environment", () => {
     await new Promise((resolve) => setImmediate(resolve));
     assert.deepStrictEqual(harness.commandCalls, [{ action: "remoteSsh.delete", payload: profile.id }]);
     assert.strictEqual(harness.content.querySelector(".remote-ssh-detail"), null);
+  });
+
+  it("exposes Remote SSH deployment as a pending shared action and clears it after failure", async () => {
+    const deployDeferred = createDeferred();
+    const profile = {
+      id: "remote-deploy",
+      label: "Deploy host",
+      host: "deploy.example.com",
+      remoteForwardPort: 23335,
+      lastDeployedAt: Date.now(),
+    };
+    const harness = loadRemoteSshTabForTest({
+      snapshot: { lang: "en", remoteSsh: { profiles: [profile] } },
+      deploy: () => deployDeferred.promise,
+    });
+
+    harness.content.querySelector(".remote-ssh-card").dispatchEvent({ type: "click" });
+    const deployButton = harness.content.querySelectorAll("button")
+      .find((button) => button.textContent === "Deploy / Repair Hooks");
+    assert.ok(deployButton);
+
+    deployButton.dispatchEvent({ type: "click" });
+    const pendingButton = harness.content.querySelectorAll("button")
+      .find((button) => button.textContent === "Deploying…");
+    assert.ok(pendingButton, "deployment rerender should keep the action mounted");
+    assert.strictEqual(pendingButton.disabled, true);
+    assert.strictEqual(pendingButton.classList.contains("pending"), true);
+    assert.strictEqual(pendingButton.getAttribute("aria-busy"), "true");
+
+    deployDeferred.resolve({ status: "error", message: "deploy failed" });
+    await new Promise((resolve) => setImmediate(resolve));
+    const recoveredButton = harness.content.querySelectorAll("button")
+      .find((button) => button.textContent === "Deploy / Repair Hooks");
+    assert.ok(recoveredButton);
+    assert.strictEqual(recoveredButton.disabled, false);
+    assert.strictEqual(recoveredButton.classList.contains("pending"), false);
+    assert.strictEqual(recoveredButton.getAttribute("aria-busy"), "false");
   });
 
   it("re-enables remote profile deletion when incomplete cleanup is kept for retry", async () => {
@@ -5049,6 +5106,53 @@ describe("settings renderer browser environment", () => {
     assert.equal(button.getAttribute("aria-label"), "Delete profile");
   });
 
+  it("updates shared button state without losing business disabled state", () => {
+    const document = {
+      body: new FakeElement("body"),
+      createElement: (tagName) => new FakeElement(tagName),
+      getElementById: () => null,
+    };
+    const core = loadSettingsCoreForTest({}, { document });
+    const button = core.helpers.buildButton({
+      label: "Install",
+      disabled: true,
+    });
+
+    assert.equal(button.textContent, "Install");
+    assert.equal(button.disabled, true);
+
+    core.helpers.setButtonState(button, { pending: true, label: "Installing" });
+    assert.equal(button.disabled, true);
+    assert.equal(button.classList.contains("pending"), true);
+    assert.equal(button.getAttribute("aria-busy"), "true");
+    assert.equal(button.textContent, "Installing");
+
+    core.helpers.setButtonState(button, { pending: false, disabled: false });
+    assert.equal(button.disabled, false);
+    assert.equal(button.classList.contains("pending"), false);
+    assert.equal(button.getAttribute("aria-busy"), "false");
+  });
+
+  it("rejects state updates for buttons outside the shared primitive", () => {
+    const document = {
+      body: new FakeElement("body"),
+      createElement: (tagName) => new FakeElement(tagName),
+      getElementById: () => null,
+    };
+    const core = loadSettingsCoreForTest({}, { document });
+    const rawButton = document.createElement("button");
+    rawButton.textContent = "Specialized";
+
+    assert.throws(
+      () => core.helpers.setButtonState(rawButton, { pending: true, label: "Changed" }),
+      /requires a button built by buildButton/
+    );
+    assert.equal(rawButton.textContent, "Specialized");
+    assert.equal(rawButton.disabled, false);
+    assert.equal(rawButton.classList.contains("pending"), false);
+    assert.equal(rawButton.getAttribute("aria-busy"), undefined);
+  });
+
   it("uses the shared Settings dialog shell with ARIA links and focus restoration", async () => {
     const body = new FakeElement("body");
     const modalRoot = new FakeElement("div");
@@ -5086,8 +5190,13 @@ describe("settings renderer browser environment", () => {
     assert.equal(icon.children[0].tagName, "SVG");
     assert.equal(icon.children[0].getAttribute("viewBox"), "0 0 20 20");
     assert.equal(icon.children[0].children[0].getAttribute("d"), "M10 4.2v7.4m0 3.1v.1");
+    const dialogButtons = dialog.querySelectorAll("button");
+    assert.equal(dialogButtons.length, 2);
+    assert.ok(dialogButtons.every((button) => button.classList.contains("settings-button")));
+    assert.ok(dialogButtons.every((button) => button.classList.contains("settings-button-large")));
+    assert.equal(dialogButtons[1].classList.contains("danger"), true);
     assert.equal(listeners.has("keydown"), true);
-    dialog.querySelectorAll("button")[1].dispatchEvent({ type: "click" });
+    dialogButtons[1].dispatchEvent({ type: "click" });
 
     assert.equal(await resultPromise, "remove");
     assert.equal(modalRoot.children.length, 0);
@@ -5912,6 +6021,33 @@ describe("settings renderer browser environment", () => {
       assert.strictEqual(matchCount, SUPPORTED_LANGS.length,
         `${key} should appear in all ${SUPPORTED_LANGS.length} supported language tables (saw ${matchCount})`);
     }
+  });
+
+  it("integrates the General reset action with shared pending state and failure recovery", async () => {
+    const commandDeferred = createDeferred();
+    const harness = loadGeneralTabForTest({
+      snapshot: makeGeneralSnapshot(),
+      settingsAPI: {
+        command: () => commandDeferred.promise,
+      },
+    });
+    harness.renderContent();
+
+    const button = harness.content.querySelector(".session-cleanup-reset-row button");
+    assert.ok(button);
+    assert.ok(button.classList.contains("settings-button"));
+    assert.strictEqual(button.disabled, false);
+
+    button.dispatchEvent({ type: "click", bubbles: false });
+    assert.strictEqual(button.disabled, true);
+    assert.strictEqual(button.classList.contains("pending"), true);
+    assert.strictEqual(button.getAttribute("aria-busy"), "true");
+
+    commandDeferred.resolve({ status: "error", message: "reset failed" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.strictEqual(button.disabled, false);
+    assert.strictEqual(button.classList.contains("pending"), false);
+    assert.strictEqual(button.getAttribute("aria-busy"), "false");
   });
 
   it("uses collapsible option lists for Session HUD and sound controls", () => {
@@ -8397,6 +8533,61 @@ describe("settings renderer browser environment", () => {
     assert.ok(!agentsSource.includes("if (disabled || btn.classList.contains(\"active\")) return;"));
     assert.ok(agentsSource.includes("if (btn.disabled || btn.classList.contains(\"active\")) return;"));
     assert.ok(!agentsSource.includes("codex-permission-mode-transitioning"));
+  });
+
+  it("integrates Agent install and uninstall actions with pending and confirmation", async () => {
+    const installDeferred = createDeferred();
+    const installHarness = loadAgentsTabForTest({
+      snapshot: {
+        agents: {
+          "qwen-code": { integrationInstalled: false, enabled: false },
+        },
+      },
+      agentMetadata: [{ id: "qwen-code", name: "Qwen Code", eventSource: "hook", capabilities: {} }],
+      settingsAPI: {
+        command: () => installDeferred.promise,
+      },
+    });
+    installHarness.core.ops.requestRender({ content: true });
+
+    const installButton = installHarness.content.querySelector(".agent-integration-action");
+    assert.ok(installButton);
+    assert.ok(installButton.classList.contains("settings-button"));
+    assert.strictEqual(installButton.textContent, "Install");
+    installButton.dispatchEvent({ type: "click", bubbles: false });
+    assert.strictEqual(installButton.disabled, true);
+    assert.strictEqual(installButton.classList.contains("pending"), true);
+    assert.strictEqual(installButton.getAttribute("aria-busy"), "true");
+
+    installDeferred.resolve({ status: "error", message: "install failed" });
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.strictEqual(installButton.disabled, false);
+    assert.strictEqual(installButton.classList.contains("pending"), false);
+    assert.strictEqual(installButton.getAttribute("aria-busy"), "false");
+    assert.strictEqual(installButton.textContent, "Install");
+
+    const uninstallCalls = [];
+    const uninstallHarness = loadAgentsTabForTest({
+      snapshot: {
+        agents: {
+          "qwen-code": { integrationInstalled: true, enabled: true },
+        },
+      },
+      agentMetadata: [{ id: "qwen-code", name: "Qwen Code", eventSource: "hook", capabilities: {} }],
+      confirm: () => false,
+      settingsAPI: {
+        command: (...args) => {
+          uninstallCalls.push(args);
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+    });
+    uninstallHarness.core.ops.requestRender({ content: true });
+    const uninstallButton = uninstallHarness.content.querySelector(".agent-integration-action");
+    assert.ok(uninstallButton);
+    uninstallButton.dispatchEvent({ type: "click", bubbles: false });
+    assert.deepStrictEqual(uninstallCalls, []);
+    assert.strictEqual(uninstallButton.classList.contains("pending"), false);
   });
 
   it("confirms before uninstalling an agent integration", () => {

--- a/test/settings-tab-remote-ssh.test.js
+++ b/test/settings-tab-remote-ssh.test.js
@@ -189,7 +189,7 @@ test("settings-tab-remote-ssh.js blocks unstamped Connect and handles the IPC de
   assert.match(code, /function\s+hasDeploymentStamp\s*\(\s*profile\s*\)/);
   assert.match(code, /profile\.lastDeployedAt/);
   assert.match(code, /const\s+deploymentReady\s*=\s*hasDeploymentStamp\(profile\)/);
-  assert.match(code, /connectBtn\.disabled\s*=\s*!deploymentReady\s*\|\|\s*transportOperationActive/);
+  assert.match(code, /disabled:\s*!disconnectAvailable\s*&&\s*\(!deploymentReady\s*\|\|\s*transportOperationActive\)/);
   assert.match(code, /result\.reason\s*===\s*"deployment_required"/);
   assert.match(code, /result\.hint\s*\|\|\s*"remoteSshErrDeploymentRequired"/);
   const readinessBody = code.match(/function\s+hasDeploymentStamp\s*\([^)]*\)\s*\{([\s\S]*?)\n\s*\}/);
@@ -204,7 +204,7 @@ test("settings-tab-remote-ssh.js keeps Disconnect available while a managed oper
   assert.match(code, /status\.transportDesiredConnected\s*===\s*true/);
   assert.match(code, /transportOperationActive\s*&&\s*status\.transportDesiredConnected/);
   assert.match(code, /requestProfileDisconnect\(profile\.id\)/);
-  assert.match(code, /connectBtn\.disabled\s*=\s*!deploymentReady\s*\|\|\s*transportOperationActive/);
+  assert.match(code, /disabled:\s*!disconnectAvailable\s*&&\s*\(!deploymentReady\s*\|\|\s*transportOperationActive\)/);
   assert.match(code, /else if \(transportOperationActive\)[\s\S]*connectBtn\.title\s*=\s*statusMessageText\(status\)/);
 });
 


### PR DESCRIPTION
## Summary

- Migrate the first wave of ordinary Settings actions to the shared `buildButton` primitive.
- Keep feature tabs responsible for commands, confirmations, persistence, and error handling while the shared layer owns button presentation and pending semantics.
- Preserve specialized controls such as switches, segmented radios, dropdown options, icon-only actions, and collapsible headers.

## Problem context

After the shared Settings button primitive landed, ordinary text actions still constructed buttons independently across General, Agents, Remote SSH, approval, Theme, About, and Discord Presence pages. That left tone, sizing, disabled/pending behavior, and accessibility state inconsistent and made common fixes expensive.

## What changed

- Route the first-wave save, cancel, refresh, install, uninstall, copy, open-directory, deploy, and dialog-footer actions through `buildButton`.
- Use the shared tone and size variants while retaining page-specific classes only for layout and feature styling.
- Keep business callbacks, confirmation gates, persistence, rollback, and IPC ownership in the feature tabs.
- Use the explicit registered-button state contract for dynamic pending/disabled updates; raw or specialized buttons are rejected instead of silently receiving shared state.
- Extend the shared primitive only where migrated call sites need its existing accessibility and state semantics; no universal clickable abstraction is introduced.

## Behavior after this PR

Standard text actions share consistent visual hierarchy, focus treatment, disabled behavior, and pending feedback across the migrated Settings pages. Existing commands, confirmation order, failure rollback, and IPC payloads remain unchanged. Specialized controls retain their own semantics and layout. A button cannot be updated through the shared state API unless it was created by `buildButton`.

## Validation

- `node --test test/settings-renderer-browser-env.test.js test/settings-tab-remote-ssh.test.js` — 254 passed, 0 failed.
- `node --test test/reasonix-hook-delivery.test.js` — 11 passed, 0 failed.
- `npm test` — an initial parallel run reported one transient failure; the immediate full-suite rerun passed with 7,629 tests, 7,595 passed, 0 failed, and 33 skipped.
- `git diff --check` — passed (only the repository's existing LF/CRLF warnings were reported).

## Platform note

Automated validation ran on Windows. This draft intentionally remains open for Electron GUI smoke testing of migrated actions, pending/error states, destructive confirmations, keyboard focus order, narrow layouts, and light/dark themes before it is marked ready.

## Scope control

This PR covers the first wave of standard text buttons in Settings. Switches, segmented radios, dropdown options, collapsible headers, animation/resource selectors, icon-only controls, system tray menus, and independent windows remain out of scope. The collapsible-animation migration is delivered in the companion draft PR.

Part of #857
