### PR TITLE
fix(prefs): an unreadable prefs file must not be overwritten with defaults

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -12,7 +12,9 @@
 // `validate(snapshot)` — coerces an arbitrary object into a valid snapshot, dropping bad fields
 // `migrate(raw)` — applies version-to-version migrations, returns the upgraded raw snapshot
 //
-// Bad-file handling: read failure → backup as `clawd-prefs.json.bak` → return defaults.
+// Bad-file handling: unparseable file → backup as `clawd-prefs.json.bak` → return defaults.
+//   Unreadable file (EACCES/EIO/...) → defaults in memory, but `locked` so save() will not
+//   overwrite a file we were never able to read.
 // Future-version handling: read succeeds but version > current → warn + refuse to overwrite
 //   (caller still gets a valid snapshot, but `save()` becomes a no-op via the locked flag).
 
@@ -1275,8 +1277,13 @@ function normalizeIdleVisual(value, defaultsValue) {
 // Read prefs from disk. Returns
 // `{ snapshot, locked, fresh?, recovered?, codexAutoStartAuthoritative? }`:
 //   - snapshot: a valid prefs object (always — falls back to defaults on any error)
-//   - locked: true if the file came from a future version; save() should be a no-op
-//             to avoid clobbering it.
+//   - locked: true when the on-disk file must not be overwritten, and save() should
+//             be a no-op. Two triggers: the file came from a future version, or the
+//             file exists and could not be read at all. Both mean "we do not know
+//             what is in there", which is the same reason not to write over it.
+//             The unreadable case also sets `recovered`, so `locked && recovered`
+//             together is a valid combination (the future-version case sets only
+//             `locked`, the unparseable case only `recovered`).
 //   - fresh: true ONLY when there was no prefs file at all (brand-new install).
 //            Callers use this to seed first-run-only state (e.g. UI language from
 //            the device locale) without ever overriding an existing user's choices.
@@ -1290,17 +1297,39 @@ function normalizeIdleVisual(value, defaultsValue) {
 //                invalid type. Missing legacy fields retain their historical
 //                default/migration behavior.
 function load(prefsPath) {
-  let raw;
+  // Read and parse are separated on purpose. "We could not read the bytes" and
+  // "we read the bytes and they are not valid prefs" are different states, and
+  // only the second one justifies replacing the file with defaults.
+  let text;
   try {
-    const text = fs.readFileSync(prefsPath, "utf8");
-    raw = JSON.parse(text);
+    text = fs.readFileSync(prefsPath, "utf8");
   } catch (err) {
     // Missing file is normal on first run — return defaults silently, flagged
     // fresh so the caller can seed device-locale language exactly once.
     if (err && err.code === "ENOENT") {
       return { snapshot: getDefaults(), locked: false, fresh: true };
     }
-    // Any other error (parse fail, permission, etc.) → backup + defaults
+    // The file exists but could not be read (EACCES, EIO, a directory, ...).
+    // We do not know what it says, so a later save() must not overwrite it with
+    // defaults — that is exactly what `locked` already means for the
+    // future-version branch below ("save() should be a no-op to avoid
+    // clobbering it"). Reusing it here keeps the user's real prefs on disk.
+    //
+    // No backup is attempted on this path: copyFileSync would read the same
+    // unreadable file, so it could only fail and emit a second warning.
+    console.warn(
+      "Clawd: prefs file could not be read — keeping defaults in memory and refusing to overwrite it:",
+      err.message,
+    );
+    return { snapshot: getDefaults(), locked: true, recovered: true };
+  }
+
+  let raw;
+  try {
+    raw = JSON.parse(text);
+  } catch (err) {
+    // The file WAS readable and its contents are not valid JSON. Backing it up
+    // and continuing from defaults is the intended recovery, unchanged.
     try {
       const bak = prefsPath + ".bak";
       fs.copyFileSync(prefsPath, bak);

--- a/test/prefs.test.js
+++ b/test/prefs.test.js
@@ -1511,6 +1511,64 @@ describe("prefs.load", () => {
     );
   });
 
+  // POSIX-only: on Windows `chmod` only toggles the read-only bit and does not deny
+  // reads, so the EACCES branch is unreachable there and these assertions would fail
+  // for a reason that has nothing to do with prefs. `npm test` does run on
+  // windows-latest (.github/workflows/build.yml), so the skip is load-bearing.
+  // Same shape as `posixOnly` in test/antigravity-install.test.js.
+  const unreadableOnly = {
+    skip: process.platform === "win32" ? "chmod cannot deny reads on Windows" : false,
+  };
+
+  it("locks an unreadable prefs file so save() cannot clobber it", unreadableOnly, function () {
+    // Root can read anything, so the EACCES path is unreachable there too.
+    if (typeof process.getuid === "function" && process.getuid() === 0) return this.skip?.();
+    // 0o200 (write-only), NOT 0o000. With 0o000 the file is also unwritable, so the
+    // clobber this test exists to prevent could never happen there — the lane would
+    // assert a flag while the invariant was safe for an unrelated reason. Write-only
+    // is the state that actually loses data: unreadable, yet perfectly writable.
+    const p = makeTempPath();
+    const original = JSON.stringify({ agents: { "claude-code": { enabled: false } } });
+    fs.writeFileSync(p, original, "utf8");
+    fs.chmodSync(p, 0o200);
+    try {
+      const loaded = prefs.load(p);
+      assert.strictEqual(loaded.locked, true);
+      assert.strictEqual(loaded.recovered, true);
+      assert.deepStrictEqual(loaded.snapshot, prefs.getDefaults());
+      // No backup: copyFileSync would read the same unreadable file.
+      assert.strictEqual(fs.existsSync(p + ".bak"), false);
+
+    } finally {
+      fs.chmodSync(p, 0o600);
+    }
+  });
+
+  // Separate from the lane above **on purpose**: that one asserts the flag, and an
+  // assertion on the flag short-circuits before the outcome is ever exercised. This
+  // one never looks at `locked` directly — it only does what the single real caller
+  // does (settings-controller.js:111, `if (locked) return { noop: true }`) and then
+  // asks the question that actually matters: is the user's file still there?
+  it("does not clobber prefs it could not read", unreadableOnly, function () {
+    if (typeof process.getuid === "function" && process.getuid() === 0) return this.skip?.();
+    const p = makeTempPath();
+    const original = JSON.stringify({ agents: { "claude-code": { enabled: false } } });
+    fs.writeFileSync(p, original, "utf8");
+    fs.chmodSync(p, 0o200); // write-only: unreadable, yet perfectly writable
+    try {
+      const loaded = prefs.load(p);
+      if (!loaded.locked) prefs.save(p, loaded.snapshot);
+      fs.chmodSync(p, 0o600);
+      assert.strictEqual(
+        fs.readFileSync(p, "utf8"),
+        original,
+        "prefs we could not read must survive a persist attempt byte for byte"
+      );
+    } finally {
+      fs.chmodSync(p, 0o600);
+    }
+  });
+
   it("marks a non-object prefs root as a recovered defaults snapshot", () => {
     const p = makeTempPath();
     fs.writeFileSync(p, "null", "utf8");


### PR DESCRIPTION
`prefs.load()` treats every non-`ENOENT` error the same way — the comment says so directly:

```js
// Any other error (parse fail, permission, etc.) → backup + defaults
```

But those are two different states, and only one of them justifies replacing the user's file.

## What goes wrong when the file exists and cannot be **read** (EACCES, EIO, …)

- Defaults are returned with `locked: false`, so `settings-controller.js:111`
  (`if (locked) return { noop: true }`) does **not** protect it — a later persist writes
  defaults over prefs we were never able to read.
- The defaults say `"claude-code": { integrationInstalled: true, enabled: true }`
  (`src/prefs.js:353`), so a user who had **disabled** the integration silently gets it back on.
- `main.js:538` also stops suppressing the runtime gate. Before this change,
  *unreadable prefs + one settings toggle* was enough to re-publish the Codex auto-start gate
  as enabled — from the very snapshot `main.js:4663` calls not authoritative
  (`getDefaults().agents.codex.enabled === true`).
- The backup cannot work: `fs.copyFileSync` reads the same unreadable file, so that branch
  only ever emits a second warning
  (`prefs file unreadable and backup failed: EACCES … EACCES …`).

## Why reuse `locked` instead of adding a flag

`load()` already has the mechanism for *"we cannot trust this file, do not write over it"* —
the future-version branch returns `locked: true`. Its only two consumers are
`settings-controller.js:111` (persist becomes a no-op) and `main.js:538` (gate publication
suppressed), and **both are the right behaviour for a file we could not read**. A separate flag
would have to be wired into both, and the easy one to miss is `main.js:538`.

The return-value docblock is updated to describe both triggers and the new
`locked && recovered` combination (previously future-version set only `locked`, unparseable
set only `recovered`).

## Change

Read and parse are separated.

| | before | after |
|---|---|---|
| read failure | backup attempt (always fails) + defaults, `locked: false` | defaults, **`locked: true`**, one clear warning, no backup attempt |
| parse failure | backup to `.bak` + defaults, `locked: false` | **unchanged** |

`recovered: true` is kept on both paths so the startup gate at `main.js:4667` keeps failing
closed exactly as it does today.

## Measured (temp fixtures, before vs after)

```
lane                    before                          after
file missing            locked=f fresh=t                unchanged
valid (enabled:false)   locked=f enabled=false          unchanged
unparseable JSON        locked=f recovered=t .bak=yes   unchanged
unreadable (0o200)      locked=FALSE, save SUCCEEDS,    locked=TRUE, save is a
                        disk enabled becomes TRUE       no-op, disk unchanged
```

Only the last row moves.

## Tests

Two lanes, deliberately separate:

- one asserts the **flags** (`locked`/`recovered`, no `.bak`)
- one never looks at `locked` and asserts the **outcome**: it does only what the single real
  caller does (`if (locked) noop`) and then checks the file is still byte-identical.
  Reverting `src/prefs.js` makes that one fail on the content assertion, not on a flag.

Fixtures use **`0o200` (write-only)**, not `0o000` — a `0o000` file is also *unwritable*, so the
clobber could never happen there and the lane would look green for an unrelated reason.
Write-only is the state that actually loses data: unreadable, yet perfectly writable.

POSIX-only, following `posixOnly` in `test/antigravity-install.test.js` — on Windows `chmod`
cannot deny reads, and `npm test` does run on `windows-latest`. Also skipped under root.

```
node --test test/prefs.test.js   →  178 pass / 0 fail
node --test test/settings-controller.test.js test/main-codex-auto-start-gate.test.js
                                 →  79 pass / 0 fail
```

## One thing I am not sure about

`locked: true` makes persist a no-op, so while the file is unreadable a user changing something
in Settings will not have it written to disk, and there is no UI surface for `locked` today.

That is not new — the future-version path already behaves this way — and the alternative is
worse and irreversible: a silent non-save is self-healing once the permissions are fixed, while
a clobber loses data permanently. But it is a behaviour change, and if you would rather have a
separate flag, or surface `locked` in the UI as a follow-up, I am happy to reshape this.

I deliberately did **not** add a settings surface for it here.