### PR TITLE
fix(win): stop treating a maximized window as a fullscreen app

### DIFF
--- a/src/win-fullscreen-detect.js
+++ b/src/win-fullscreen-detect.js
@@ -16,10 +16,11 @@
 // returns a probe that always answers false, so the watchdog keeps its current
 // behavior rather than ever hiding the pet because the FFI broke.
 
-// A maximized normal window covers the work area but leaves the taskbar strip,
-// so its rect stops short of the full monitor. A fullscreen app covers the
-// whole monitor (rcMonitor). A couple of px of slack absorbs DPI rounding
-// without mistaking a maximized window for fullscreen.
+// A maximized normal window covers the work area, so on a monitor that reserves
+// a taskbar strip its rect stops short of the full monitor while a fullscreen
+// app covers the whole monitor (rcMonitor). A couple of px of slack absorbs DPI
+// rounding. Geometry alone is NOT sufficient though — see isMaximizedNormalWindow
+// for the monitors where rcWork == rcMonitor and this test stops separating them.
 const FULLSCREEN_TOLERANCE_PX = 2;
 
 const MONITOR_DEFAULTTONEAREST = 2;
@@ -37,10 +38,34 @@ const DESKTOP_SHELL_WINDOW_CLASSES = new Set(["progman", "workerw"]);
 // Ample for real class names; matches win-foreground-terminal.js.
 const CLASS_NAME_BUF_LEN = 256;
 
+// #871: the geometry test above silently assumes the monitor reserves a taskbar
+// strip. A secondary display usually shows no taskbar, and an auto-hidden
+// taskbar reserves a 1px sliver that fits inside FULLSCREEN_TOLERANCE_PX — in
+// both cases rcWork == rcMonitor, so an ordinary MAXIMIZED window covers
+// rcMonitor and geometry calls it a fullscreen app. The pet then flipped its hit
+// window non-activating, and setFocusable(false) deactivates whatever had focus
+// (same mechanism as #719), so clicking an input box in a maximized browser on
+// that monitor lost focus.
+//
+// A window that is maximized AND still owns its caption is a normal window, not
+// a fullscreen presentation. Deliberately narrower than "has a caption": it only
+// overrides the verdict for maximized windows, so exclusive fullscreen, a
+// borderless WS_POPUP, and F11 (which drops the caption) all keep the answer
+// they got before — #538 / #562 stand-down behavior is untouched.
+const GWL_STYLE = -16;
+const WS_CAPTION = 0x00c00000; // WS_BORDER | WS_DLGFRAME — check the whole mask
+const WS_MAXIMIZE = 0x01000000;
+
 // Win32 class-name comparison is case-insensitive.
 function isDesktopShellWindowClass(className) {
   return typeof className === "string"
     && DESKTOP_SHELL_WINDOW_CLASSES.has(className.toLowerCase());
+}
+
+// Pure style decision, exported for the same reason as rectCoversMonitor.
+function isMaximizedNormalWindow(style) {
+  if (!Number.isFinite(style)) return false;
+  return (style & WS_MAXIMIZE) !== 0 && (style & WS_CAPTION) === WS_CAPTION;
 }
 
 // Pure geometry: does the window rect cover the entire monitor rect (not just
@@ -69,9 +94,10 @@ function createForegroundFullscreenProbe(options = {}) {
   let GetMonitorInfoW;
   let GetClassNameW;
   let monitorInfoSize;
+  let user32;
   try {
     const koffi = options.koffi || require("koffi");
-    const user32 = koffi.load("user32.dll");
+    user32 = koffi.load("user32.dll");
     // LONG is 32-bit even on Win64 (LLP64); use int32 to be unambiguous.
     koffi.struct("ClawdRECT", { left: "int32", top: "int32", right: "int32", bottom: "int32" });
     koffi.struct("ClawdMONITORINFO", {
@@ -89,6 +115,19 @@ function createForegroundFullscreenProbe(options = {}) {
   } catch (err) {
     if (typeof options.onError === "function") options.onError(err);
     return noop;
+  }
+
+  // Bound separately (#871): GetWindowLongPtrW is a macro over GetWindowLongW on
+  // 32-bit Windows, so the export can be missing. Losing it must only cost the
+  // style refinement — folding it into the block above would turn a missing
+  // symbol into a constant-false probe and silently undo the #538 stand-down.
+  // Return type int32 for the same reason the RECT fields are: only the low 32
+  // bits carry style flags, LONG_PTR's high half is padding here.
+  let GetWindowLongPtrW = null;
+  try {
+    GetWindowLongPtrW = user32.func("int32 __stdcall GetWindowLongPtrW(void* hWnd, int nIndex)");
+  } catch (err) {
+    if (typeof options.onError === "function") options.onError(err);
   }
 
   return function isForegroundFullscreen() {
@@ -118,6 +157,15 @@ function createForegroundFullscreenProbe(options = {}) {
         for (let i = 0; i < classLen; i++) className += String.fromCharCode(classBuf[i]);
         if (isDesktopShellWindowClass(className)) return false;
       }
+
+      // #871: last, separate a merely maximized window from a real fullscreen
+      // presentation. Unavailable binding or a 0 read (GetWindowLongPtrW's
+      // failure return) keeps the geometric answer, matching the class-read
+      // fallback above.
+      if (GetWindowLongPtrW) {
+        const style = GetWindowLongPtrW(hwnd, GWL_STYLE);
+        if (isMaximizedNormalWindow(style)) return false;
+      }
       return true;
     } catch (err) {
       // Any FFI hiccup at call time: behave as "not fullscreen" so the
@@ -132,5 +180,6 @@ module.exports = {
   createForegroundFullscreenProbe,
   rectCoversMonitor,
   isDesktopShellWindowClass,
+  isMaximizedNormalWindow,
   FULLSCREEN_TOLERANCE_PX,
 };

--- a/test/win-fullscreen-detect.test.js
+++ b/test/win-fullscreen-detect.test.js
@@ -7,6 +7,7 @@ const {
   createForegroundFullscreenProbe,
   rectCoversMonitor,
   isDesktopShellWindowClass,
+  isMaximizedNormalWindow,
   FULLSCREEN_TOLERANCE_PX,
 } = require("../src/win-fullscreen-detect");
 
@@ -45,6 +46,15 @@ function fakeKoffi(behavior) {
               return name.length;
             };
           }
+          if (signature.includes("GetWindowLongPtrW")) {
+            // The style binding is resolved in its own try/catch so a missing
+            // export degrades to the geometric answer; this simulates that.
+            if (behavior.styleFuncUnavailable) throw new Error("GetWindowLongPtrW unavailable");
+            return () => {
+              if (behavior.styleThrows) throw new Error("GetWindowLongPtrW exploded");
+              return behavior.style === undefined ? 0 : behavior.style;
+            };
+          }
           throw new Error(`unexpected func: ${signature}`);
         },
       };
@@ -60,6 +70,14 @@ const MONITOR = { left: 0, top: 0, right: 1920, bottom: 1080 };
 const FULLSCREEN_RECT = { left: 0, top: 0, right: 1920, bottom: 1080 };
 // Maximized normal window: covers work area but leaves the 40px taskbar strip.
 const MAXIMIZED_RECT = { left: 0, top: 0, right: 1920, bottom: 1040 };
+
+const WS_CAPTION = 0x00c00000;
+const WS_THICKFRAME = 0x00040000;
+const WS_MAXIMIZE = 0x01000000;
+// A maximized ordinary window (title bar + sizing border), e.g. a maximized browser.
+const MAXIMIZED_NORMAL_STYLE = WS_MAXIMIZE | WS_CAPTION | WS_THICKFRAME;
+// Borderless fullscreen: the caption is dropped, which is what distinguishes it.
+const BORDERLESS_STYLE = 0;
 
 describe("rectCoversMonitor", () => {
   it("treats an exact monitor-covering window as fullscreen", () => {
@@ -101,6 +119,31 @@ describe("isDesktopShellWindowClass", () => {
     assert.strictEqual(isDesktopShellWindowClass("Chrome_WidgetWin_1"), false);
     assert.strictEqual(isDesktopShellWindowClass(""), false);
     assert.strictEqual(isDesktopShellWindowClass(null), false);
+  });
+});
+
+describe("isMaximizedNormalWindow", () => {
+  it("matches a maximized window that still has its caption", () => {
+    assert.strictEqual(isMaximizedNormalWindow(MAXIMIZED_NORMAL_STYLE), true);
+  });
+
+  it("rejects a maximized window with no caption (borderless fullscreen)", () => {
+    assert.strictEqual(isMaximizedNormalWindow(WS_MAXIMIZE), false);
+  });
+
+  it("rejects a captioned window that is not maximized", () => {
+    assert.strictEqual(isMaximizedNormalWindow(WS_CAPTION | WS_THICKFRAME), false);
+  });
+
+  it("requires the full WS_CAPTION mask, not either half", () => {
+    assert.strictEqual(isMaximizedNormalWindow(WS_MAXIMIZE | 0x00800000), false);
+    assert.strictEqual(isMaximizedNormalWindow(WS_MAXIMIZE | 0x00400000), false);
+  });
+
+  it("rejects unusable style values", () => {
+    assert.strictEqual(isMaximizedNormalWindow(0), false);
+    assert.strictEqual(isMaximizedNormalWindow(NaN), false);
+    assert.strictEqual(isMaximizedNormalWindow(null), false);
   });
 });
 
@@ -213,5 +256,85 @@ describe("createForegroundFullscreenProbe", () => {
       }),
     });
     assert.strictEqual(probe(), true);
+  });
+
+  // #871: a monitor with no reserved taskbar strip (a secondary display, or an
+  // auto-hidden taskbar whose 1px sliver fits inside FULLSCREEN_TOLERANCE_PX)
+  // has rcWork == rcMonitor, so an ordinary MAXIMIZED window covers the monitor
+  // and geometry alone calls it fullscreen. That flipped the hit window
+  // non-activating, and setFocusable(false) deactivates whatever had focus.
+  it("does not treat a maximized window on a taskbar-less monitor as fullscreen", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "Chrome_WidgetWin_1", style: MAXIMIZED_NORMAL_STYLE,
+      }),
+    });
+    assert.strictEqual(probe(), false);
+  });
+
+  it("still reports fullscreen for a monitor-covering window with no caption", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "UnrealWindow", style: BORDERLESS_STYLE,
+      }),
+    });
+    assert.strictEqual(probe(), true);
+  });
+
+  // Borderless-fullscreen games often maximize a caption-less window; only the
+  // caption separates them from a maximized browser (#538 must not regress).
+  it("still reports fullscreen for a maximized borderless window", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "UnrealWindow", style: WS_MAXIMIZE,
+      }),
+    });
+    assert.strictEqual(probe(), true);
+  });
+
+  it("keeps the geometric answer when the style binding is unavailable", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "Chrome_WidgetWin_1", styleFuncUnavailable: true,
+      }),
+    });
+    assert.strictEqual(probe(), true);
+  });
+
+  // 0 is GetWindowLongPtrW's documented failure return, not an exception, so it
+  // degrades like a 0-length class read: keep the geometric answer.
+  it("keeps the geometric answer when the style read returns its failure value", () => {
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "Chrome_WidgetWin_1", style: 0,
+      }),
+    });
+    assert.strictEqual(probe(), true);
+  });
+
+  // A THROWN style read is different: it takes the probe's existing call-time
+  // catch, which answers "not fullscreen" for every FFI call in this function.
+  it("reports a thrown style read through the call-time diagnostic", () => {
+    let callErrors = 0;
+    const probe = createForegroundFullscreenProbe({
+      isWin: true,
+      koffi: fakeKoffi({
+        hwnd: {}, hMonitor: {}, winRect: FULLSCREEN_RECT, monitorRect: MONITOR,
+        className: "Chrome_WidgetWin_1", styleThrows: true,
+      }),
+      onCallError: () => { callErrors++; },
+    });
+    assert.strictEqual(probe(), false);
+    assert.strictEqual(callErrors, 1);
   });
 });


### PR DESCRIPTION
## The bug

`isForegroundFullscreen()` decided from geometry alone: does the foreground window's rect cover `rcMonitor`? That test carries an assumption stated in its own comment — *"a maximized normal window covers the work area but leaves the taskbar strip, so its rect stops short of the full monitor."*

That only holds on a monitor that **reserves** a taskbar strip. A secondary display usually shows no taskbar, and an auto-hidden taskbar reserves a sliver that fits inside `FULLSCREEN_TOLERANCE_PX`. In both cases `rcWork == rcMonitor`, so an ordinary **maximized** window covers the monitor and gets classified as a fullscreen app.

From there the existing machinery does the damage: the ~1s focusable poll from #562 flips the hit window non-activating, and Electron's `setFocusable(false)` ends in `Focus(false)` on Windows, which deactivates the foreground app. Clicking an input box in a maximized browser on such a monitor loses focus — repeatedly, until the state settles, because `setHitWinFocusable` is gated on `isFocusable()` and so only fires on transitions.

Same failure family as #719 — a second blind spot in the same probe.

Each detail in the report maps to the mechanism:

| reported | mechanism |
|---|---|
| started at v0.11.0 | #562's focusable poll first shipped in v0.11.0 |
| screen 2 only, never screen 1 | screen 1 reserves the taskbar, so the rect stops short there |
| maximized breaks it, a small window doesn't | a windowed browser doesn't cover the monitor |
| loses focus several times, then settles | the call is change-gated, so it fires only on transitions |
| hiding the pet fixes it | a hidden hit window can't deactivate anything |

## The fix

Read the window style and treat a window that is **maximized AND still owns its caption** as a normal window.

This is deliberately narrower than "has a caption": it only overrides the verdict for maximized windows, so exclusive fullscreen, a borderless `WS_POPUP`, and F11 (which drops the caption) all keep the answer they had — the #538 / #562 stand-down behavior is unchanged.

The style binding is resolved in its own `try`/`catch`. `GetWindowLongPtrW` is a macro over `GetWindowLongW` on 32-bit Windows, so the export can be missing; folding it into the main block would turn a missing symbol into a constant-false probe and silently undo the #538 stand-down. A `0` read — its documented failure return — keeps the geometric answer, matching the existing class-read fallback directly above it.

## Verification

- `test/win-fullscreen-detect.test.js`: 18 → 29 tests. Full suite 8194 → 8205 tests, 8159 → 8170 pass, skipped unchanged. The regression test would fail if the exact bug came back.
- Checked against the real `user32.dll`, not only the fake koffi the unit tests use: the export binds with the signature used here, and a live window sweep confirmed maximized Chromium/Electron windows carry `WS_MAXIMIZE|WS_CAPTION` while every monitor-covering window on the machine was caption-less. The discriminator separates the two populations it claims to.
- Live A/B of the actual probe, before vs after, with the taskbar auto-hidden to produce `rcWork == rcMonitor` (the same geometry a taskbar-less second display gives). The maximized windows re-maximized from bottom `823` to `871` on an `864px` monitor and began covering it; the old code answered `fullscreen=true` for all three, the new code `false`. The lock screen, Windows Input Experience and the NVIDIA overlay stayed `true` in both.

## Residual risk

Verified on a single monitor, using auto-hide to synthesize `rcWork == rcMonitor`. The geometry is identical to the reporter's setup, but I have not tested a physical dual-monitor machine — that is the one check worth repeating on your side.

A fullscreen presentation that kept *both* a caption and the maximized state would now be treated as a normal window. None of the monitor-covering windows observed had that shape, and such a window is visually indistinguishable from a maximized one, but it is the behavior change this makes.

Fixes #871
