### PR TITLE
fix(prefs): fail closed when settings are unreadable

### DIFF
--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -267,7 +267,7 @@ CodeBuddy direct HTTP `PermissionRequest` 不经过 Clawd command hook，因此�
 
 ## Hook And Plugin Sync
 
-启动链路只会自动补齐 `integrationInstalled=true` 且 `enabled=true` 的缺失集成：
+启动链路只会自动补齐 `integrationInstalled=true` 且 `enabled=true` 的缺失集成；若 prefs 文件不可读（`locked && recovered`），内存 snapshot 只是非权威 defaults fallback，整条 prefs-backed agent runtime gate 会 fail closed，本次进程不自动同步集成、不启动 monitor、不接受 state/permission ingress，也不恢复旧 session：
 
 - `server.js` 启动后异步同步已安装且已启用的 Claude / Codex / Copilot / Gemini / Antigravity / Cursor / CodeBuddy / WorkBuddy / Kiro / Kimi / Qwen / ZCode / CodeWhale / Qoder / QoderWork / QwenWork / Reasonix hooks、opencode / MiMo Code / OpenClaw / Hermes / DeepSeek Harness plugins 和 Pi extension；Hermes 同步会先做无副作用安装探测，未安装时不创建 `~/.hermes`；DSH startup sync 不初始化缺失的 web profile，只 repair 已 opt-in 的 marker-owned entry
 - Claude hook 同步时还会扫 `DEPRECATED_CORE_HOOKS`（当前含 `WorktreeCreate`）清掉旧版本留下的过时 Clawd hook。常规所有权仍认 command 中的字面 `clawd-hook.js` marker；兼容 #852 的外部 env 间接形式时，只有“单条简单 Node 调用 + 精确 `CLAWD_HOOK_PATH` token + 唯一事件参数”，且 `settings.env.CLAWD_HOOK_PATH` 的跨平台 basename 恰为 `clawd-hook.js` 才视为 owned。复合命令、间接 env 值和第三方同事件 hook 均 fail closed。deprecated / versioned / HTTP-only / uninstall 路径删除全部 owned 命中；active state hook 则按子项位置折叠成一条，优先保留已 canonical 的命令并保留 mixed wrapper 的 matcher / 第三方 sibling。迁移不会改写 `settings.env`；严格的反注入规则只校验外部 env Node 候选，不会拒绝安装器已解析/保留的绝对路径（如含括号的 Windows 路径）。若 env-only 事件无法验证可用的绝对 Node 路径，会保留一条 env hook 而不是降级成裸 `node`；若已有 literal hook，则保留 literal 而不让不可迁移的 env duplicate 取代它

--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -55,7 +55,7 @@ Settings 是独立 `BrowserWindow`，采用 5 层结构：
 
 | 层 | 文件 | 职责 |
 |---|---|---|
-| Schema / 持久化 | `src/prefs.js` | `SCHEMA` 定义；`load/save/migrate/validate`；坏文件自动 `.bak` + fallback |
+| Schema / 持久化 | `src/prefs.js` | `SCHEMA` 定义；`load/save/migrate/validate`；JSON 损坏自动 `.bak` + fallback；文件本身不可读时进入不覆盖原文件的 read-failure safe mode |
 | 内存 store | `src/settings-store.js` | `createStore()` 返回 `{ getSnapshot, subscribe, _commit }`；`_commit` closure-private |
 | 控制器 / actions | `src/settings-controller.js` + `src/settings-actions*.js` | controller 是唯一写入者；actions 提供校验、command 与失败可阻止提交的 pre-commit gates |
 | 提交后 effects | `src/settings-effect-router.js` | 订阅 committed changes，更新 tray/dock/window/HUD/renderer 等 runtime 状态与广播；失败不得回滚已提交 prefs |
@@ -66,6 +66,7 @@ Settings 是独立 `BrowserWindow`，采用 5 层结构：
 - `applyUpdate` 和 `applyBulk` 对同步/异步 pre-commit gate 同构
 - `hydrate()` 是唯一跳过 pre-commit gate 的入口；post-commit effects 由 router 订阅 store changes
 - 设置写入路径只有 `controller → store → subscribers`
+- `prefs.load()` 返回 `locked && recovered` 表示文件字节从未成功读取：controller 会在 validator / command / 外部 effect 之前拒绝用户 mutation，agent runtime 的启动同步、monitor、state/permission ingress 与 session recovery 全部 fail closed；修复文件访问并重启后才恢复。可读的 future-version `locked && !recovered` 继续保持既有的当前进程内存可改、磁盘不覆盖语义
 - `idleVisual` 是 per-theme 文件映射；缺失键表示使用主题默认，主题升级删除已选文件或删除主题时会安静回退，不改变逻辑状态
 - About tab 使用 inline SVG，而不是 `<object>`，因为 `settings.html` CSP 是 `default-src 'none'`
 

--- a/src/agent-gate.js
+++ b/src/agent-gate.js
@@ -40,7 +40,73 @@ function getCodexPermissionMode(snapshot) {
 }
 const isCodexPermissionInterceptEnabled = (snapshot) => getCodexPermissionMode(snapshot) === "intercept";
 
+// Runtime reader over the live Settings controller snapshot. The pure helpers
+// above deliberately fail open for missing legacy fields; that is correct only
+// when the snapshot came from readable prefs. An unreadable prefs file instead
+// supplies an in-memory defaults fallback, so every prefs-backed runtime gate
+// must fail closed until restart rather than treating those defaults as user
+// intent.
+function createRuntimeAgentGate({ getSnapshot, isAuthoritative = () => true } = {}) {
+  if (typeof getSnapshot !== "function") {
+    throw new TypeError("createRuntimeAgentGate requires getSnapshot");
+  }
+
+  function canUseSnapshot() {
+    try {
+      return isAuthoritative() !== false;
+    } catch {
+      return false;
+    }
+  }
+
+  function withSnapshot(read) {
+    if (!canUseSnapshot()) return false;
+    try {
+      return read(getSnapshot());
+    } catch {
+      return false;
+    }
+  }
+
+  return Object.freeze({
+    isAuthoritative: canUseSnapshot,
+    isAgentEnabled(agentId) {
+      return withSnapshot((current) => isAgentEnabled(current, agentId));
+    },
+    isAgentIntegrationInstalled(agentId) {
+      return withSnapshot((current) => isAgentIntegrationInstalled(current, agentId));
+    },
+    shouldSyncAgentIntegration(agentId) {
+      return withSnapshot((current) => shouldSyncAgentIntegration(current, agentId));
+    },
+    isAgentPermissionsEnabled(agentId) {
+      return withSnapshot((current) => isAgentPermissionsEnabled(current, agentId));
+    },
+    isAgentSubagentPermissionsEnabled(agentId) {
+      return withSnapshot((current) => isAgentSubagentPermissionsEnabled(current, agentId));
+    },
+    isAgentNotificationHookEnabled(agentId) {
+      return withSnapshot((current) => isAgentNotificationHookEnabled(current, agentId));
+    },
+    isCodexNativeNotificationSoundEnabled() {
+      return withSnapshot((current) => isCodexNativeNotificationSoundEnabled(current));
+    },
+    isCodexPermissionInterceptEnabled() {
+      return withSnapshot((current) => isCodexPermissionInterceptEnabled(current));
+    },
+    hasAnyEnabledAgent() {
+      return withSnapshot((current) => {
+        const agents = current && current.agents;
+        if (!agents || typeof agents !== "object") return true;
+        const probe = { agents };
+        return Object.keys(agents).some((agentId) => isAgentEnabled(probe, agentId));
+      });
+    },
+  });
+}
+
 module.exports = {
+  createRuntimeAgentGate,
   getCodexPermissionMode,
   isAgentIntegrationInstalled,
   isAgentEnabled,

--- a/src/main.js
+++ b/src/main.js
@@ -531,10 +531,10 @@ const _settingsController = createSettingsController({
   },
 });
 _settingsController.subscribeKey("agents", (_agents, snapshot) => {
-  // A future-version prefs file is intentionally read-only. Settings may still
-  // change in memory for the current process, but publishing those ephemeral
-  // values would let a retained hook cold-launch Clawd against the durable
-  // prefs truth.
+  // A readable future-version prefs file may still change in memory for the
+  // current process. An unreadable prefs file rejects mutations earlier in the
+  // controller. In both locked cases, publishing ephemeral values would let a
+  // retained hook cold-launch Clawd against a different durable prefs truth.
   if (_settingsController.isLocked()) return;
   _syncCodexAutoStartGate(snapshot, "settings");
 });
@@ -1589,15 +1589,15 @@ const {
 
 // ── Permission bubble — delegated to src/permission.js ──
 const {
-  isAgentIntegrationInstalled: _isAgentIntegrationInstalled,
-  isAgentEnabled: _isAgentEnabled,
-  isAgentPermissionsEnabled: _isAgentPermissionsEnabled,
-  isAgentSubagentPermissionsEnabled: _isAgentSubagentPermissionsEnabled,
-  isAgentNotificationHookEnabled: _isAgentNotificationHookEnabled,
-  isCodexNativeNotificationSoundEnabled: _isCodexNativeNotificationSoundEnabled,
-  isCodexPermissionInterceptEnabled: _isCodexPermissionInterceptEnabled,
-  shouldSyncAgentIntegration: _shouldSyncAgentIntegration,
+  createRuntimeAgentGate,
 } = require("./agent-gate");
+const _runtimeAgentGate = createRuntimeAgentGate({
+  getSnapshot: () => _settingsController.getSnapshot(),
+  // locked && recovered means prefs bytes were never read and the snapshot is
+  // only defaults. Keep every prefs-backed agent path closed for this process;
+  // fixing file access and restarting is the only authority transition.
+  isAuthoritative: () => !_settingsController.hasReadFailure(),
+});
 const _permCtx = {
   get win() { return win; },
   get lang() { return lang; },
@@ -1619,14 +1619,13 @@ const _permCtx = {
   // pendingPermissions list changes (notifyPermissionsChanged), so a bubble
   // that leaves the list mid-edit can't strand the pet faded + click-through.
   syncImeEditingPetDodge: () => topmostRuntime.syncImeEditingPetDodge(),
-  isAgentEnabled: (agentId) =>
-    _isAgentEnabled({ agents: _settingsController.get("agents") }, agentId),
+  isAgentEnabled: (agentId) => _runtimeAgentGate.isAgentEnabled(agentId),
   isAgentPermissionsEnabled: (agentId) =>
-    _isAgentPermissionsEnabled({ agents: _settingsController.get("agents") }, agentId),
+    _runtimeAgentGate.isAgentPermissionsEnabled(agentId),
   isAgentSubagentPermissionsEnabled: (agentId) =>
-    _isAgentSubagentPermissionsEnabled({ agents: _settingsController.get("agents") }, agentId),
+    _runtimeAgentGate.isAgentSubagentPermissionsEnabled(agentId),
   isCodexPermissionInterceptEnabled: () =>
-    _isCodexPermissionInterceptEnabled({ agents: _settingsController.get("agents") }),
+    _runtimeAgentGate.isCodexPermissionInterceptEnabled(),
   // The permission layer consumes one normalized runtime mode. DND,
   // headless, per-agent and bubble gates run before this chokepoint.
   getPermissionAutomationMode: () =>
@@ -1859,12 +1858,12 @@ const _stateCtx = {
   // permissionsEnabled=false toggle would silently rebuild holds on every
   // incoming Kimi PermissionRequest.
   isAgentPermissionsEnabled: (agentId) =>
-    _isAgentPermissionsEnabled({ agents: _settingsController.get("agents") }, agentId),
+    _runtimeAgentGate.isAgentPermissionsEnabled(agentId),
   // state.js gates self-issued Notification events (idle / wait-for-input
   // pings) via this reader. Living in updateSession (not at the HTTP
   // boundary) keeps the gate consistent for hook / log-poll / plugin paths.
   isAgentNotificationHookEnabled: (agentId) =>
-    _isAgentNotificationHookEnabled({ agents: _settingsController.get("agents") }, agentId),
+    _runtimeAgentGate.isAgentNotificationHookEnabled(agentId),
   resolveAgentDisplayName: _resolveAgentDisplayName,
   miniPeekIn: () => miniPeekIn(),
   miniPeekOut: () => miniPeekOut(),
@@ -1914,22 +1913,8 @@ const _stateCtx = {
     if (sessionAutomationCoordinator) sessionAutomationCoordinator.onSessionLifecycleEnd(payload);
   },
   getIdleVisualChoice,
-  isAgentEnabled: (agentId) => _isAgentEnabled({ agents: _settingsController.get("agents") }, agentId),
-  hasAnyEnabledAgent: () => {
-    // `get("agents")` returns the live reference (no clone) — we're only
-    // reading. Missing agents field falls back to "assume enabled" (the
-    // legacy default-true contract for unconfigured installs); but an
-    // explicit empty object means every agent was cleared, so return
-    // false. Without that distinction, a user who wiped the field would
-    // still trigger startup-recovery process scans.
-    const agents = _settingsController.get("agents");
-    if (!agents || typeof agents !== "object") return true;
-    const probe = { agents };
-    for (const id of Object.keys(agents)) {
-      if (_isAgentEnabled(probe, id)) return true;
-    }
-    return false;
-  },
+  isAgentEnabled: (agentId) => _runtimeAgentGate.isAgentEnabled(agentId),
+  hasAnyEnabledAgent: () => _runtimeAgentGate.hasAnyEnabledAgent(),
 };
 const _state = require("./state")(_stateCtx);
 const _kimiQuotaCredentialStore = createKimiQuotaCredentialStore({ safeStorage });
@@ -1950,7 +1935,7 @@ _settingsController.subscribeKey("kimiQuotaCollectionEnabled", (enabled) => {
   });
 });
 _settingsController.subscribeKey("agents", (_agents, snapshot) => {
-  if (!_isAgentEnabled(snapshot, "kimi-cli")) {
+  if (!_runtimeAgentGate.isAgentEnabled("kimi-cli")) {
     _kimiQuotaRuntime.invalidateRequests();
   }
 });
@@ -2348,7 +2333,7 @@ agentRuntime = createAgentRuntimeMain({
   getServer: () => _server,
   getStateRuntime: () => _state,
   getPermissionRuntime: () => _perm,
-  isAgentEnabled: (agentId) => _isAgentEnabled(_settingsController.getSnapshot(), agentId),
+  isAgentEnabled: (agentId) => _runtimeAgentGate.isAgentEnabled(agentId),
   updateSession: (sessionId, state, event, opts) => updateSession(sessionId, state, event, opts),
   debugLog: (msg) => sessionLog(msg),
   captureGhosttyTerminalId,
@@ -2390,14 +2375,14 @@ const _serverCtx = {
   captureForegroundWindowsTerminal: _captureForegroundWindowsTerminal,
   debugLog: (msg) => sessionLog(msg),
   recordWindowsProcessChainShadow: (record) => recordWindowsProcessChainShadow(record),
-  isAgentEnabled: (agentId) => _isAgentEnabled({ agents: _settingsController.get("agents") }, agentId),
+  isAgentEnabled: (agentId) => _runtimeAgentGate.isAgentEnabled(agentId),
   shouldSyncAgentIntegration: (agentId) =>
-    _shouldSyncAgentIntegration({ agents: _settingsController.get("agents") }, agentId),
+    _runtimeAgentGate.shouldSyncAgentIntegration(agentId),
   getAgentIntegrationOptions: _getAgentIntegrationOptions,
-  isAgentPermissionsEnabled: (agentId) => _isAgentPermissionsEnabled({ agents: _settingsController.get("agents") }, agentId),
-  isAgentSubagentPermissionsEnabled: (agentId) => _isAgentSubagentPermissionsEnabled({ agents: _settingsController.get("agents") }, agentId),
-  isCodexNativeNotificationSoundEnabled: () => _isCodexNativeNotificationSoundEnabled({ agents: _settingsController.get("agents") }),
-  isCodexPermissionInterceptEnabled: () => _isCodexPermissionInterceptEnabled({ agents: _settingsController.get("agents") }),
+  isAgentPermissionsEnabled: (agentId) => _runtimeAgentGate.isAgentPermissionsEnabled(agentId),
+  isAgentSubagentPermissionsEnabled: (agentId) => _runtimeAgentGate.isAgentSubagentPermissionsEnabled(agentId),
+  isCodexNativeNotificationSoundEnabled: () => _runtimeAgentGate.isCodexNativeNotificationSoundEnabled(),
+  isCodexPermissionInterceptEnabled: () => _runtimeAgentGate.isCodexPermissionInterceptEnabled(),
   codexSubagentClassifier: agentRuntime.getCodexSubagentClassifier(),
   setState,
   updateSession: agentRuntime.updateSessionFromServer,
@@ -4341,11 +4326,10 @@ function createWindow() {
   startHttpServer().then((port) => {
     if (port == null) return;
     const restoredSessionIds = restoreSessionsFromRecoveryLeases(_state, {
-      isAgentEnabled: (agentId) => {
-        const snapshot = { agents: _settingsController.get("agents") };
-        return _isAgentEnabled(snapshot, agentId)
-          && _isAgentIntegrationInstalled(snapshot, agentId);
-      },
+      isAgentEnabled: (agentId) => (
+        _runtimeAgentGate.isAgentEnabled(agentId)
+        && _runtimeAgentGate.isAgentIntegrationInstalled(agentId)
+      ),
     });
     if (restoredSessionIds.length > 0) {
       const recoveredSnapshot = _state.buildSessionSnapshot();
@@ -4735,7 +4719,7 @@ if (!gotTheLock) {
       const verdict = getCodexHookHealth({ prefs: snapshot });
       const prevSignature = _settingsController.get("codexHookHealthLastNotified") || "";
       const decision = decideCodexHookNotification(verdict, prevSignature, {
-        codexEnabled: _isAgentEnabled(snapshot, "codex"),
+        codexEnabled: _runtimeAgentGate.isAgentEnabled("codex"),
         notifyEnabled: _settingsController.get("codexHookHealthNotifyEnabled") !== false,
       });
       if (decision.nextSignature !== prevSignature) {

--- a/src/settings-controller.js
+++ b/src/settings-controller.js
@@ -19,6 +19,7 @@
 //   getSnapshot() / get(key)       read access
 //   subscribe(fn) / subscribeKey(key, fn)   reactive side effects
 //   persist()                      manual flush (idempotent — no-op if locked)
+//   isLocked() / hasReadFailure()  persistence / startup-authority state
 //
 // **updateRegistry entry shapes**: each entry in `updates` may be either
 //
@@ -52,6 +53,14 @@
 // (noop). `status: 'error'` means validation failed and the store wasn't
 // touched.
 //
+// An unreadable prefs file is a stronger condition than a readable
+// future-version file. Both are `locked`, but only the unreadable path is also
+// `recovered`. In that `locked && recovered` safe mode, user mutations and
+// commands are rejected before validators/effects run: the in-memory snapshot
+// is only defaults, so neither it nor any external side effect is authoritative.
+// `hydrate()` remains available for startup imports of external truth; it skips
+// pre-commit effects and still cannot write through the locked persistence gate.
+//
 // The store's `_commit` is captured here as a closure — callers of
 // createSettingsController never see it, so the only way to mutate state is
 // through this controller.
@@ -77,6 +86,7 @@ function createSettingsController({
   const loaded = loadResult || prefs.load(prefsPath);
   const initialSnapshot = loaded.snapshot;
   let locked = !!loaded.locked;
+  const readFailure = loaded.locked === true && loaded.recovered === true;
 
   const store = createStore(initialSnapshot);
 
@@ -108,7 +118,14 @@ function createSettingsController({
   }
 
   function persistInternal(snapshot = store.getSnapshot()) {
-    if (locked) return { status: "ok", noop: true, locked: true };
+    if (locked) {
+      return {
+        status: "ok",
+        noop: true,
+        locked: true,
+        ...(readFailure ? { readFailure: true } : {}),
+      };
+    }
     if (!prefsPath) return { status: "ok", noop: true };
     try {
       prefs.save(prefsPath, snapshot);
@@ -121,6 +138,18 @@ function createSettingsController({
 
   function isThenable(v) {
     return v && typeof v.then === "function";
+  }
+
+  function readFailureResult(operation) {
+    return {
+      status: "error",
+      code: "prefs-read-failure",
+      locked: true,
+      readFailure: true,
+      message:
+        `Cannot ${operation}: the preferences file could not be read. ` +
+        "Fix access to the file and restart Clawd before changing settings.",
+    };
   }
 
   // Resolve an entry's validator function. Function-form entries ARE the
@@ -204,6 +233,9 @@ function createSettingsController({
     }
     if (store.get(key) === value) {
       return { status: "ok", noop: true };
+    }
+    if (readFailure && options.allowDuringReadFailure !== true) {
+      return readFailureResult(`change ${key}`);
     }
     const validator = resolveValidator(entry);
     if (!validator) {
@@ -399,7 +431,10 @@ function createSettingsController({
     const entries = Object.keys(partial).map((key) => ({
       key,
       value: partial[key],
-      actionResult: invokeAction(key, partial[key], { skipEffect: true }),
+      actionResult: invokeAction(key, partial[key], {
+        skipEffect: true,
+        allowDuringReadFailure: true,
+      }),
     }));
     const anyAsync = entries.some((e) => isThenable(e.actionResult));
 
@@ -432,6 +467,7 @@ function createSettingsController({
         message: `unknown command: ${name}`,
       };
     }
+    if (readFailure) return readFailureResult(`run ${name}`);
     let result;
     try {
       result = await command(payload, buildDeps());
@@ -531,6 +567,10 @@ function createSettingsController({
     return locked;
   }
 
+  function hasReadFailure() {
+    return readFailure;
+  }
+
   function dispose() {
     store.dispose();
   }
@@ -546,6 +586,7 @@ function createSettingsController({
     subscribeKey,
     persist,
     isLocked,
+    hasReadFailure,
     dispose,
   };
 }

--- a/test/agent-gate.test.js
+++ b/test/agent-gate.test.js
@@ -4,6 +4,7 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert");
 
 const {
+  createRuntimeAgentGate,
   getCodexPermissionMode,
   isAgentEnabled,
   isAgentIntegrationInstalled,
@@ -226,6 +227,73 @@ describe("Codex permission mode gate", () => {
       isCodexPermissionInterceptEnabled({ agents: { codex: { permissionMode: "native" } } }),
       false
     );
+  });
+});
+
+describe("createRuntimeAgentGate", () => {
+  it("preserves the normalized prefs gates while the snapshot is authoritative", () => {
+    const snapshot = prefs.getDefaults();
+    const gate = createRuntimeAgentGate({
+      getSnapshot: () => snapshot,
+      isAuthoritative: () => true,
+    });
+
+    assert.strictEqual(gate.isAuthoritative(), true);
+    assert.strictEqual(gate.isAgentEnabled("claude-code"), true);
+    assert.strictEqual(gate.isAgentIntegrationInstalled("codex"), true);
+    assert.strictEqual(gate.shouldSyncAgentIntegration("codex"), true);
+    assert.strictEqual(gate.isAgentPermissionsEnabled("codex"), true);
+    assert.strictEqual(gate.isAgentSubagentPermissionsEnabled("claude-code"), true);
+    assert.strictEqual(gate.isAgentNotificationHookEnabled("codex"), true);
+    assert.strictEqual(gate.isCodexPermissionInterceptEnabled(), true);
+    assert.strictEqual(gate.hasAnyEnabledAgent(), true);
+  });
+
+  it("fails every prefs-backed runtime gate closed for a non-authoritative snapshot", () => {
+    const snapshot = prefs.getDefaults();
+    const gate = createRuntimeAgentGate({
+      getSnapshot: () => snapshot,
+      isAuthoritative: () => false,
+    });
+
+    assert.strictEqual(gate.isAuthoritative(), false);
+    assert.strictEqual(gate.isAgentEnabled("claude-code"), false);
+    assert.strictEqual(gate.isAgentIntegrationInstalled("codex"), false);
+    assert.strictEqual(gate.shouldSyncAgentIntegration("codex"), false);
+    assert.strictEqual(gate.isAgentPermissionsEnabled("codex"), false);
+    assert.strictEqual(gate.isAgentSubagentPermissionsEnabled("claude-code"), false);
+    assert.strictEqual(gate.isAgentNotificationHookEnabled("codex"), false);
+    assert.strictEqual(gate.isCodexNativeNotificationSoundEnabled(), false);
+    assert.strictEqual(gate.isCodexPermissionInterceptEnabled(), false);
+    assert.strictEqual(gate.hasAnyEnabledAgent(), false);
+  });
+
+  it("fails closed if the authority probe throws", () => {
+    const gate = createRuntimeAgentGate({
+      getSnapshot: () => prefs.getDefaults(),
+      isAuthoritative: () => {
+        throw new Error("authority unavailable");
+      },
+    });
+
+    assert.strictEqual(gate.isAuthoritative(), false);
+    assert.strictEqual(gate.isAgentEnabled("codex"), false);
+    assert.strictEqual(gate.shouldSyncAgentIntegration("codex"), false);
+    assert.strictEqual(gate.isCodexPermissionInterceptEnabled(), false);
+  });
+
+  it("fails closed if the authoritative snapshot reader throws", () => {
+    const gate = createRuntimeAgentGate({
+      getSnapshot: () => {
+        throw new Error("snapshot unavailable");
+      },
+    });
+
+    assert.strictEqual(gate.isAuthoritative(), true);
+    assert.strictEqual(gate.isAgentEnabled("codex"), false);
+    assert.strictEqual(gate.shouldSyncAgentIntegration("codex"), false);
+    assert.strictEqual(gate.isCodexPermissionInterceptEnabled(), false);
+    assert.strictEqual(gate.hasAnyEnabledAgent(), false);
   });
 });
 

--- a/test/main-codex-auto-start-gate.test.js
+++ b/test/main-codex-auto-start-gate.test.js
@@ -83,3 +83,28 @@ test("future-version locked settings cannot publish an ephemeral Codex gate", ()
     "locked settings must return before publishing the settings gate"
   );
 });
+
+test("unreadable prefs fail every prefs-backed agent runtime gate closed", () => {
+  const source = fs.readFileSync(MAIN_PATH, "utf8").replace(/\r\n/g, "\n");
+  const gateIndex = source.indexOf("const _runtimeAgentGate = createRuntimeAgentGate({");
+  const authorityIndex = source.indexOf(
+    "isAuthoritative: () => !_settingsController.hasReadFailure()",
+    gateIndex
+  );
+
+  assert.ok(gateIndex >= 0, "main.js should create one centralized runtime agent gate");
+  assert.ok(
+    authorityIndex > gateIndex,
+    "the runtime agent gate must reject the defaults fallback from unreadable prefs"
+  );
+
+  for (const expected of [
+    "_runtimeAgentGate.isAgentEnabled(agentId)",
+    "_runtimeAgentGate.shouldSyncAgentIntegration(agentId)",
+    "_runtimeAgentGate.isAgentPermissionsEnabled(agentId)",
+    "_runtimeAgentGate.isAgentSubagentPermissionsEnabled(agentId)",
+    "_runtimeAgentGate.isCodexPermissionInterceptEnabled()",
+  ]) {
+    assert.ok(source.includes(expected), `main.js should route ${expected} through the safe gate`);
+  }
+});

--- a/test/settings-controller.test.js
+++ b/test/settings-controller.test.js
@@ -42,6 +42,7 @@ describe("createSettingsController construction", () => {
     assert.strictEqual(ctrl.get("lang"), "en");
     assert.strictEqual(ctrl.get("soundMuted"), false);
     assert.strictEqual(ctrl.isLocked(), false);
+    assert.strictEqual(ctrl.hasReadFailure(), false);
   });
 
   it("respects locked state from future-version files", () => {
@@ -52,6 +53,7 @@ describe("createSettingsController construction", () => {
     try {
       const ctrl = createSettingsController({ prefsPath: p });
       assert.strictEqual(ctrl.isLocked(), true);
+      assert.strictEqual(ctrl.hasReadFailure(), false);
     } finally {
       console.warn = originalWarn;
     }
@@ -1346,6 +1348,103 @@ describe("locked controller (future-version files)", () => {
     const onDisk = JSON.parse(fs.readFileSync(p, "utf8"));
     assert.strictEqual(onDisk.version, 999);
     assert.strictEqual(onDisk.lang, "en");
+  });
+});
+
+describe("unreadable prefs safe mode", () => {
+  function createControllerWithReadFailure(p, injectedDeps = {}) {
+    const originalReadFileSync = fs.readFileSync;
+    const originalWarn = console.warn;
+    fs.readFileSync = (target, ...args) => {
+      if (target === p) {
+        const err = new Error("injected prefs read failure");
+        err.code = "EACCES";
+        throw err;
+      }
+      return originalReadFileSync(target, ...args);
+    };
+    console.warn = () => {};
+    try {
+      return createSettingsController({ prefsPath: p, injectedDeps });
+    } finally {
+      fs.readFileSync = originalReadFileSync;
+      console.warn = originalWarn;
+    }
+  }
+
+  it("blocks updates and commands before any external effect on every platform", async () => {
+    const p = makeTempPath();
+    const original = JSON.stringify({
+      version: prefs.CURRENT_VERSION,
+      lang: "en",
+      agents: {
+        "qwen-code": {
+          integrationInstalled: false,
+          enabled: false,
+        },
+      },
+    });
+    fs.writeFileSync(p, original, "utf8");
+
+    const calls = [];
+    const ctrl = createControllerWithReadFailure(p, {
+      setOpenAtLogin: (enabled) => calls.push(["openAtLogin", enabled]),
+      syncIntegrationForAgent: async (agentId) => {
+        calls.push(["sync", agentId]);
+        return { status: "ok" };
+      },
+      startMonitorForAgent: (agentId) => calls.push(["monitor", agentId]),
+    });
+
+    assert.strictEqual(ctrl.isLocked(), true);
+    assert.strictEqual(ctrl.hasReadFailure(), true);
+
+    const pureUpdate = ctrl.applyUpdate("lang", "zh");
+    assert.strictEqual(pureUpdate.status, "error");
+    assert.strictEqual(pureUpdate.code, "prefs-read-failure");
+
+    const effectUpdate = ctrl.applyUpdate("openAtLogin", true);
+    assert.strictEqual(effectUpdate.status, "error");
+    assert.strictEqual(effectUpdate.code, "prefs-read-failure");
+
+    const bulk = ctrl.applyBulk({ soundMuted: true, showTray: false });
+    assert.strictEqual(bulk.status, "error");
+    assert.strictEqual(bulk.code, "prefs-read-failure");
+
+    const command = await ctrl.applyCommand("installAgentIntegration", {
+      agentId: "qwen-code",
+    });
+    assert.strictEqual(command.status, "error");
+    assert.strictEqual(command.code, "prefs-read-failure");
+
+    assert.deepStrictEqual(calls, [], "safe mode must stop external effects before they start");
+    assert.strictEqual(ctrl.get("lang"), "en");
+    assert.strictEqual(ctrl.get("openAtLogin"), false);
+    assert.strictEqual(ctrl.get("agents")["qwen-code"].integrationInstalled, false);
+    assert.strictEqual(fs.readFileSync(p, "utf8"), original);
+  });
+
+  it("allows side-effect-free startup hydration without making prefs writable", () => {
+    const p = makeTempPath();
+    const original = JSON.stringify({ version: prefs.CURRENT_VERSION, lang: "en" });
+    fs.writeFileSync(p, original, "utf8");
+    const ctrl = createControllerWithReadFailure(p);
+
+    const result = ctrl.hydrate({
+      openAtLogin: true,
+      openAtLoginHydrated: true,
+    });
+
+    assert.strictEqual(result.status, "ok");
+    assert.strictEqual(ctrl.get("openAtLogin"), true);
+    assert.strictEqual(ctrl.get("openAtLoginHydrated"), true);
+    assert.deepStrictEqual(ctrl.persist(), {
+      status: "ok",
+      noop: true,
+      locked: true,
+      readFailure: true,
+    });
+    assert.strictEqual(fs.readFileSync(p, "utf8"), original);
   });
 });
 

--- a/test/startup-session-recovery-regressions.test.js
+++ b/test/startup-session-recovery-regressions.test.js
@@ -177,8 +177,8 @@ describe("startup session recovery regressions", () => {
     const recoveryBlock = mainSource.slice(restoreIndex, completionIndex);
     assert.match(
       recoveryBlock,
-      /_isAgentEnabled\(snapshot, agentId\)\s*&&\s*_isAgentIntegrationInstalled\(snapshot, agentId\)/,
-      "main must require both enabled and installed integration state",
+      /_runtimeAgentGate\.isAgentEnabled\(agentId\)\s*&&\s*_runtimeAgentGate\.isAgentIntegrationInstalled\(agentId\)/,
+      "main must require authoritative enabled and installed integration state",
     );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #888.

- distinguish unreadable prefs (locked + recovered) from readable future-version prefs
- reject Settings mutations and commands before validators or external effects when the prefs snapshot is non-authoritative
- centralize prefs-backed runtime gates so startup integration sync, monitors, state/permission ingress, Codex interception, and session recovery all fail closed
- preserve the existing future-version locked behavior and allow side-effect-free startup hydration
- document the safe-mode contract

## Tests

- 387 relevant controller/runtime/integration/route tests passed
- 143 focused controller/gate/startup tests passed after the final hardening change
- npm test: 8,249 passed, 37 skipped, 2 failed in unchanged test/codex-install.test.js
- origin/main A/B reproduces the same two Windows failures with the same null !== 0 assertions, so they are baseline/environment failures
- git diff --check passed