### PR TITLE
fix(validate-theme): distinguish "could not validate" from "theme has errors"

### DIFF
--- a/scripts/validate-theme.js
+++ b/scripts/validate-theme.js
@@ -53,17 +53,62 @@ const {
 const args = process.argv.slice(2);
 let themeDir = null;
 let assetsOverride = null;
-for (let i = 0; i < args.length; i++) {
-  if (args[i] === "--assets" && args[i + 1]) {
-    assetsOverride = args[++i];
-  } else if (!themeDir) {
-    themeDir = args[i];
-  }
-}
-if (!themeDir) {
+
+function printUsage() {
   console.error(`Usage: node ${path.basename(process.argv[1])} <theme-directory> [--assets <assets-dir>]`);
   console.error(`Example: node scripts/validate-theme.js themes/template`);
   console.error(`         node scripts/validate-theme.js themes/clawd --assets assets/svg`);
+}
+
+// Anything the parser does not understand is refused rather than ignored. The old
+// loop silently dropped unknown flags, surplus positional arguments, and a
+// value-less `--assets`, so a mistyped command ran against the DEFAULT paths and
+// then reported the theme as valid -- the tool answering a question nobody asked.
+//
+// Refusing unknown options costs the one thing the permissive loop got for free: a
+// path that genuinely begins with "-". `--` ends option parsing for that case, so
+// no invocation that worked before is unreachable now.
+let optionsEnded = false;
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
+  if (!optionsEnded && arg === "--") {
+    optionsEnded = true;
+  } else if (!optionsEnded && arg === "--assets") {
+    if (assetsOverride !== null) {
+      console.error(`${FAIL} --assets given more than once`);
+      printUsage();
+      process.exit(1);
+    }
+    const value = args[i + 1];
+    // Only absent or empty counts as "no path given". A value that merely looks
+    // like a flag is still passed to the filesystem, which is the thing that
+    // actually knows whether it is a usable directory.
+    if (value === undefined || value === "") {
+      console.error(`${FAIL} --assets requires a directory argument`);
+      printUsage();
+      process.exit(1);
+    }
+    assetsOverride = value;
+    i++;
+  } else if (!optionsEnded && arg.startsWith("-") && arg !== "-") {
+    console.error(`${FAIL} Unknown option: ${arg}`);
+    console.error(`  (if that is a real path, pass it after --)`);
+    printUsage();
+    process.exit(1);
+  } else if (themeDir === null) {
+    themeDir = arg;
+  } else {
+    console.error(`${FAIL} Unexpected extra argument: ${arg}`);
+    printUsage();
+    process.exit(1);
+  }
+}
+// Falsy, not just null: `validate-theme.js "$SOME_UNSET_VAR"` passes an empty
+// string, which path.resolve() turns into the current directory -- so without
+// this the script would go and validate whatever the caller happened to be in.
+if (!themeDir) {
+  console.error(`${FAIL} No theme directory given`);
+  printUsage();
   process.exit(1);
 }
 

--- a/scripts/validate-theme.js
+++ b/scripts/validate-theme.js
@@ -153,6 +153,17 @@ try {
   process.exit(1);
 }
 
+// theme.json has to be a JSON object for the checks below to walk it. `null` crashes
+// property access with an uncaught TypeError (a stack trace instead of a message),
+// and a number/string/boolean produces meaningless FAIL lines that read like real
+// findings about a theme that was never there. An array is deliberately let through:
+// nothing below it crashes, and its total absence of fields is a genuine "theme has
+// errors" outcome rather than a broken command.
+if (!isPlainObject(raw) && !Array.isArray(raw)) {
+  console.error(`${FAIL} theme.json must contain a JSON object (got: ${raw === null ? "null" : typeof raw})`);
+  process.exit(1);
+}
+
 console.log(`\n${C}Validating theme:${D} ${resolvedDir}\n`);
 
 let errors = 0;

--- a/scripts/validate-theme.js
+++ b/scripts/validate-theme.js
@@ -149,7 +149,9 @@ try {
   const content = fs.readFileSync(jsonPath, "utf8");
   raw = JSON.parse(content);
 } catch (e) {
-  console.error(`${FAIL} Failed to parse theme.json: ${e.message}`);
+  // The try block covers readFileSync as well as JSON.parse, so this must not
+  // claim "parse" for what may have been a read failure (e.g. EISDIR).
+  console.error(`${FAIL} Failed to read or parse theme.json: ${e.message}`);
   process.exit(1);
 }
 

--- a/scripts/validate-theme.js
+++ b/scripts/validate-theme.js
@@ -115,6 +115,30 @@ if (!themeDir) {
 const resolvedDir = path.resolve(themeDir);
 const jsonPath = path.join(resolvedDir, "theme.json");
 
+// An explicit --assets override that does not resolve to a usable directory is a
+// mistake in the command, not a property of the theme -- so the message has to say
+// which one it is. Pointing --assets at a file used to produce a 27-error report
+// about the theme, sending the author hunting for theme bugs that do not exist.
+// The default `<theme>/assets` being absent is deliberately NOT handled here: that
+// one really is a property of the theme, and stays a normal validation error below.
+if (assetsOverride !== null) {
+  const overrideDir = path.resolve(assetsOverride);
+  let overrideStat;
+  try {
+    overrideStat = fs.statSync(overrideDir);
+  } catch (e) {
+    // Only ENOENT means "not there". ENOTDIR, ELOOP, EACCES and friends are all
+    // different problems and must not be flattened into one claim.
+    const why = e.code === "ENOENT" ? "not found" : `cannot be accessed (${e.code})`;
+    console.error(`${FAIL} --assets directory ${why}: ${overrideDir}`);
+    process.exit(1);
+  }
+  if (!overrideStat.isDirectory()) {
+    console.error(`${FAIL} --assets path is not a directory: ${overrideDir}`);
+    process.exit(1);
+  }
+}
+
 if (!fs.existsSync(jsonPath)) {
   console.error(`${FAIL} theme.json not found at: ${jsonPath}`);
   process.exit(1);

--- a/test/validate-theme-cli.test.js
+++ b/test/validate-theme-cli.test.js
@@ -1,0 +1,279 @@
+"use strict";
+
+// Exercises the REAL CLI (scripts/validate-theme.js) via spawnSync rather than the
+// internal theme-loader functions it calls: what a caller observes is the process
+// exit status and the message, so that is what these assert.
+//
+// Every failure exits 1 -- the script draws no machine-readable distinction between
+// "the command was wrong" and "the theme is broken". The distinction lives in the
+// message, which is why each case below asserts on stderr/stdout and not on the
+// status alone. Each fixture is chosen so it can fail for only the reason named --
+// see the per-case comment.
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const { describe, it, afterEach } = require("node:test");
+
+const REPO_ROOT = path.join(__dirname, "..");
+const SCRIPT_PATH = path.join(REPO_ROOT, "scripts", "validate-theme.js");
+const CALICO = path.join(REPO_ROOT, "themes", "calico");
+
+const tempDirs = [];
+
+function runValidateTheme(args, { cwd = REPO_ROOT } = {}) {
+  return spawnSync(process.execPath, [SCRIPT_PATH, ...args], {
+    cwd,
+    encoding: "utf8",
+  });
+}
+
+function mkTempThemeDir() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-validate-theme-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length) {
+    // Per-entry try/catch: a lingering handle on one directory (Windows) must not
+    // abort the loop and leak every remaining fixture.
+    try {
+      fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+});
+
+describe("validate-theme.js CLI (real process, spawnSync)", () => {
+  // ── Usage errors: the command itself is wrong ──
+
+  it("no theme directory given", () => {
+    // The parsing loop never sets themeDir, so the script exits before touching
+    // the filesystem -- nothing about any theme was measured here.
+    const result = runValidateTheme([]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /No theme directory given/);
+    assert.match(result.stderr, /Usage: node/);
+  });
+
+  it("an empty theme directory argument is refused, not resolved to the cwd", () => {
+    // path.resolve("") is the current directory, so a `"$UNSET_VAR"` that expands
+    // to nothing would quietly send the validator at whatever the caller is
+    // standing in. This is the reason the check is falsy rather than === null.
+    const result = runValidateTheme([""]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /No theme directory given/);
+    assert.doesNotMatch(result.stderr, /theme\.json not found/);
+  });
+
+  it("--assets given with no value is refused, not silently dropped", () => {
+    // The old parser required args[i + 1] to be truthy; a trailing --assets left
+    // the override unset and every check ran against the DEFAULT assets path, so
+    // a malformed command could reach exit 0 and call the theme valid. A real
+    // theme dir is passed as [0] so the flag is the only broken thing.
+    const result = runValidateTheme([CALICO, "--assets"]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /--assets requires a directory argument/);
+  });
+
+  it("--assets given an empty value is refused", () => {
+    // Same silent-drop class as above, by a different route: "" is falsy, so the
+    // old parser skipped it and reported the theme as valid (measured: exit 0).
+    const result = runValidateTheme([CALICO, "--assets", ""]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /--assets requires a directory argument/);
+  });
+
+  it("--assets followed by another flag fails naming what it received", () => {
+    // A flag-shaped value is NOT special-cased as "missing": a directory really
+    // can begin with "-", and the filesystem is what knows whether this one
+    // exists. What matters is that it fails and quotes the string it was given,
+    // so the author sees their own typo rather than a theme verdict.
+    const result = runValidateTheme([CALICO, "--assets", "--verbose"]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /--assets directory not found/);
+    assert.match(result.stderr, /--verbose/);
+  });
+
+  it("--assets given more than once is refused", () => {
+    // Last-one-wins silently discarded the earlier value, which is the same
+    // "ran against a path you did not ask for" failure as the others here.
+    const assets = path.join(CALICO, "assets");
+    const result = runValidateTheme([CALICO, "--assets", assets, "--assets", assets]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /--assets given more than once/);
+  });
+
+  it("an unknown option is refused, not ignored", () => {
+    // Previously fell through the loop untouched (themeDir was already set), so
+    // the run continued with default settings and exited 0 -- the flag the caller
+    // typed had no effect and nothing said so.
+    const result = runValidateTheme([CALICO, "--verbose"]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /Unknown option: --verbose/);
+  });
+
+  it("a surplus positional argument is refused, not ignored", () => {
+    // Same silent-drop: a second theme path was accepted and discarded, so
+    // validating two themes in one command quietly validated only the first.
+    const result = runValidateTheme([CALICO, path.join(REPO_ROOT, "themes", "clawd")]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /Unexpected extra argument/);
+  });
+
+  // ── Setup errors: the command is well-formed, the inputs it names are not ──
+
+  it("--assets pointing at a directory that does not exist says so", () => {
+    // A sibling of a real temp dir, never created, so the only broken thing is
+    // the override path.
+    const missing = path.join(mkTempThemeDir(), "does-not-exist");
+    const result = runValidateTheme([CALICO, "--assets", missing]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /--assets directory not found/);
+  });
+
+  it("--assets pointing at a file says so instead of blaming the theme", () => {
+    // Measured on the previous behavior: this produced a 27-error report about
+    // the theme, because every asset lookup under a non-directory missed. The
+    // theme was fine; the path was not.
+    const result = runValidateTheme([CALICO, "--assets", path.join(CALICO, "theme.json")]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /--assets path is not a directory/);
+    assert.doesNotMatch(result.stdout, /error\(s\)/);
+  });
+
+  it("--assets whose parent is a file reports the real error, not \"not found\"", () => {
+    // ENOTDIR, not ENOENT. Collapsing every stat failure into "not found" tells
+    // the author to create a directory that cannot exist at that path.
+    const result = runValidateTheme([CALICO, "--assets", path.join(CALICO, "theme.json", "nope")]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /cannot be accessed \(ENOTDIR\)/);
+    assert.doesNotMatch(result.stderr, /not found/);
+  });
+
+  it("theme.json missing from the given directory", () => {
+    // A real, existing, EMPTY directory -- so the failure is specifically "no
+    // theme.json here", not "that path does not exist".
+    const dir = mkTempThemeDir();
+    const result = runValidateTheme([dir]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /theme\.json not found/);
+  });
+
+  it("theme.json is not parseable JSON", () => {
+    // Deliberately truncated (unclosed object) so JSON.parse must throw, rather
+    // than producing valid-but-wrong JSON that would reach the schema checks.
+    const dir = mkTempThemeDir();
+    fs.writeFileSync(path.join(dir, "theme.json"), '{ "schemaVersion": 1, ', "utf8");
+    const result = runValidateTheme([dir]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /Failed to read or parse theme\.json/);
+  });
+
+  it("theme.json is a directory: reported as a read failure, not a parse failure", () => {
+    // mkdirSync instead of writeFileSync -- readFileSync throws EISDIR before
+    // JSON.parse ever runs, so the message must not claim "parse".
+    const dir = mkTempThemeDir();
+    fs.mkdirSync(path.join(dir, "theme.json"));
+    const result = runValidateTheme([dir]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stderr, /Failed to read or parse theme\.json/);
+  });
+
+  for (const [label, value] of [
+    ["null", "null"],
+    ["a number", "5"],
+    ["a string", '"clawd"'],
+    ["a boolean", "true"],
+  ]) {
+    it(`theme.json parses to ${label}, not a JSON object`, () => {
+      // Valid JSON, not object-shaped. Previously: `null` crashed with an
+      // uncaught TypeError (a stack trace, not a message), and the other three
+      // produced FAIL lines that read like real findings about a theme that was
+      // never there.
+      const dir = mkTempThemeDir();
+      fs.writeFileSync(path.join(dir, "theme.json"), value, "utf8");
+      const result = runValidateTheme([dir]);
+      assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+      assert.match(result.stderr, /theme\.json must contain a JSON object/);
+      assert.doesNotMatch(result.stderr, /TypeError/);
+    });
+  }
+
+  // ── Controls: the guards above must not widen into these ──
+
+  it("control: theme.json parsing to an array is still validated, not rejected", () => {
+    // The array boundary. typeof [] === "object" and array property access does
+    // not throw, so the walk completes and reports real (if nonsensical)
+    // findings. isPlainObject() rejects arrays on its own -- this asserts the CLI
+    // carves them back out with an explicit Array.isArray check.
+    const dir = mkTempThemeDir();
+    fs.writeFileSync(path.join(dir, "theme.json"), "[]", "utf8");
+    const result = runValidateTheme([dir]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.doesNotMatch(result.stderr, /must contain a JSON object/);
+    assert.match(result.stdout, /error\(s\)/);
+  });
+
+  it("control: a missing DEFAULT <theme>/assets stays a theme finding, not a setup error", () => {
+    // No --assets override. The default assets/ path is a property of the theme
+    // itself, so its absence has to keep flowing through the normal checks --
+    // the override guard is not allowed to swallow it.
+    const dir = mkTempThemeDir();
+    const themeJson = {
+      schemaVersion: 1,
+      name: "no-assets-dir",
+      version: "1.0.0",
+      viewBox: { x: 0, y: 0, width: 100, height: 100 },
+      states: {},
+    };
+    fs.writeFileSync(path.join(dir, "theme.json"), JSON.stringify(themeJson), "utf8");
+    const result = runValidateTheme([dir]);
+    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    assert.match(result.stdout, /assets\/ directory exists/);
+    assert.doesNotMatch(result.stderr, /--assets/);
+  });
+
+  it("control: an --assets value beginning with - is a path, not a flag", () => {
+    // Refusing unknown options must not make a legal directory name unreachable.
+    // Relative, from a cwd we control, so the leading "-" is really in argv.
+    const parent = mkTempThemeDir();
+    fs.cpSync(path.join(CALICO, "assets"), path.join(parent, "-dashed", "assets"), { recursive: true });
+    const result = runValidateTheme([CALICO, "--assets", "-dashed/assets"], { cwd: parent });
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  });
+
+  it("control: a theme directory beginning with - is reachable after --", () => {
+    // Same guarantee for the positional argument. Without "--" it is reported as
+    // an unknown option, and the message points at "--" -- asserted here so the
+    // escape hatch cannot be removed without a test noticing.
+    const parent = mkTempThemeDir();
+    fs.cpSync(CALICO, path.join(parent, "-dashed-theme"), { recursive: true });
+    const viaSeparator = runValidateTheme(["--", "-dashed-theme"], { cwd: parent });
+    assert.strictEqual(viaSeparator.status, 0, viaSeparator.stderr || viaSeparator.stdout);
+
+    const without = runValidateTheme(["-dashed-theme"], { cwd: parent });
+    assert.strictEqual(without.status, 1, without.stderr || without.stdout);
+    assert.match(without.stderr, /Unknown option: -dashed-theme/);
+    assert.match(without.stderr, /pass it after --/);
+  });
+
+  it("control: a well-formed --assets override still validates clean", () => {
+    // The strict parser must not break the documented usage it is guarding.
+    const result = runValidateTheme([CALICO, "--assets", path.join(CALICO, "assets")]);
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  });
+
+  it("control: a real, shipped, valid theme validates clean", () => {
+    // themes/calico rather than a hand-built fixture: assembling a theme.json
+    // that clears every rule (required states, sleepSequence, eye-tracking SVG
+    // ids, asset existence) would just re-derive a shipped theme. calico is
+    // git-tracked and has its own assets/, so this exercises the full pass.
+    const result = runValidateTheme([CALICO]);
+    assert.strictEqual(result.status, 0, result.stderr || result.stdout);
+  });
+});


### PR DESCRIPTION
## The problem

**`--assets` passed with no value exits 0.** The override is silently dropped, every check then runs against the default asset directory, and the tool tells the author their theme is valid. A validator that reports success for a command the user got wrong is the worst thing in this file, and it is reachable on `main` today — measured on `upstream/main` (`fb686b82`), run from a real checkout.

It stayed invisible because every non-success path in this script exited `1`, so nothing distinguished these three states:

- **validation could not run** — no theme directory given, `theme.json` missing, `theme.json` unreadable or not an object
- **validation ran and the theme is broken** — N schema errors
- **validation silently didn't do what was asked** — the `--assets` case above, which didn't even fail

A theme author who mistypes a path goes hunting for theme bugs that do not exist, and a wrapper script cannot tell "this theme failed validation" from "validation never happened".

## The change

The "could not validate" paths now exit `2`. `1` still means "validated, and it has errors"; `0` is unchanged. The contract is documented in the script header, in `README.md`, and in `docs/guides/guide-theme-creation.md`.

**The exit-code split and the defects are separable, and I'll take them apart if you prefer.** Splitting the code is what surfaced four places where the file did not honour the contract it was about to declare — but three of those are plain defects that stand on their own, with or without any contract:

| Input | Before | After | Stands alone? |
|---|---|---|---|
| `--assets` passed with no value | silently ignored, **exit 0** | exit **2** | **yes — false green** |
| `theme.json` parses to `null` / a number / a string / a boolean | uncaught `TypeError`, exit **1** | exit **2** | **yes — stack trace, not a message** |
| `--assets <dir>` where `<dir>` does not exist | exit **1** | exit **2** | **yes — reads as a theme verdict** |
| `theme.json` exists but is unreadable (e.g. it is a directory) | `Failed to parse theme.json: EISDIR` | `Failed to read or parse theme.json: EISDIR` | wording only |

The `null` row is the one that would have made the contract false three lines below where it is written: the crash exits `1`, which this PR defines as "validated and has errors" — while nothing was validated at all.

Two deliberate non-changes:

- A missing **default** `<theme>/assets` directory is still exit `1`. That is a theme defect, not a setup mistake. Only an explicit `--assets` override that does not resolve is treated as setup.
- `theme.json` parsing to `[]` is still exit `1`. An array is an object; it reaches the schema checks and fails them honestly. There is a test asserting this, so the guard cannot silently widen.

## Tests

`test/validate-theme-exit-codes.test.js` drives the real CLI with `spawnSync` and asserts `status`, rather than importing internals — the exit code is the observable thing downstream callers read.

Each guard was checked by reverting it and confirming that **exactly** the tests for that guard go red and no others:

| Guard reverted | Result |
|---|---|
| non-object `theme.json` | the 4 `null`/number/string/boolean cases red; the `[]` control stayed green |
| value-less `--assets` | 1 case red |
| non-existent `--assets` dir | 1 case red |
| read-vs-parse message | the 2 message-dependent cases red |

## About the pre-existing test failures

This branch is rebased on `upstream/main` (`bca6a8d3`), no conflicts.

I ran `node test/run-tests.js` to completion on `upstream/main` and on this branch, extracted the failing test names from both (ANSI stripped, `^\s*✖ ` lines, `sort -u`), and diffed the two sets:

- names present only on this branch: **none**
- names present only on `upstream/main`: **none**

The pre-existing failures are in the DSH integration lanes and are identical before and after. I have deliberately not touched them — they are unrelated to the exit-code contract, and I did not want to widen this PR.

I am quoting the set difference rather than a failure count on purpose: the runner emits nested markers, so different ways of counting give different totals. The set comparison does not depend on that.

## Not included

The four locale READMEs (`README.*.md`) also show the validate command but were left alone — happy to follow up with those, or to fold them in here if you'd prefer.

