### PR TITLE
fix(opencode): support Desktop permission bridge

### DIFF
--- a/agents/opencode-family.js
+++ b/agents/opencode-family.js
@@ -7,11 +7,12 @@
 // eventSource but use entirely different plugin shapes and must stay
 // independent. Joining the family requires satisfying the full opencode wire
 // contract (session.* / message.part.updated event shapes, permission.asked
-// payload, once/always/reject reply vocabulary, Bun runtime with Bun.serve,
+// payload, once/always/reject reply vocabulary, Bun CLI/TUI or Node Desktop
+// runtime with a loopback reverse bridge,
 // ctx.{client,serverUrl,directory} init, in-process plugin execution).
 //
 // NOTE for the plugin side: hooks/opencode-family-plugin/core.mjs runs inside
-// the host's Bun process and cannot require this CJS module. Plugin entries
+// the host process and cannot require this CJS module. Plugin entries
 // pass their four identity params as literals; test/registry cross-checks
 // assert the literals match this registry so they cannot drift.
 

--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -118,11 +118,13 @@ ZCode 状态同步（hook-only，config.json）：
 
 opencode 状态同步（in-process plugin，~0ms 延迟）：
   opencode 触发事件（session.created / session.status / message.part.updated 等）
-    → hooks/opencode-plugin/index.mjs（Bun 运行时，插件跑在 opencode.exe 进程内）
+    → hooks/opencode-plugin/index.mjs（CLI/TUI 运行于 Bun；Desktop sidecar 运行于 Electron utilityProcess / Node）
     → translateEvent 映射（opencode v2 事件名 → PascalCase Clawd event 名）
     → session.created 的 event.properties.info.parentID 会被记录为 child → parent 映射，child 状态上报带 headless: true
     → fire-and-forget HTTP POST 127.0.0.1:23333/state
     → 同上状态机（agent_id: opencode）
+  permission.asked 通过 plugin POST /permission 进入 Clawd；决定经随机 localhost 端口上的反向 bridge 返回，
+  CLI/TUI bridge 使用 Bun.serve，Desktop bridge 使用 node:http，再由 plugin 调用宿主 SDK 的 permission reply route。
 
 MiMo Code 状态同步（in-process plugin，~0ms 延迟）：
   MiMo Code 触发事件（session.created / session.status / message.part.updated 等）

--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -1303,6 +1303,16 @@ export function createOpencodeFamilyPlugin(config) {
     get _bridgeUrl() { return _bridgeUrl; },
     get _bridgeTokenHex() { return _bridgeTokenHex; },
     get _bridgeRuntime() { return _bridgeRuntime; },
+    get _bridgeAddress() {
+      return _bridgeRuntime === "node" && _bridgeServer && typeof _bridgeServer.address === "function"
+        ? _bridgeServer.address()
+        : null;
+    },
+    get _bridgeErrorListenerCount() {
+      return _bridgeRuntime === "node" && _bridgeServer && typeof _bridgeServer.listenerCount === "function"
+        ? _bridgeServer.listenerCount("error")
+        : 0;
+    },
     closeBridgeForTest,
     get _pidChain() { return _pidChain; },
   };
@@ -1764,6 +1774,9 @@ export function createOpencodeFamilyPlugin(config) {
       };
       const onListening = () => {
         server.removeListener("error", onError);
+        server.on("error", (err) => {
+          debugLog(`BRIDGE node server ERROR: ${err && err.message}`);
+        });
         resolve(server);
       };
       server.once("error", onError);

--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -1,7 +1,7 @@
 // Clawd on Desk — opencode-family plugin core
 //
 // Shared runtime for opencode-derived hosts (opencode, mimocode, …). Runs
-// inside the host process (Bun runtime) and forwards session/tool events to
+// inside the host process (Bun CLI/TUI or Node-based Desktop sidecar) and forwards session/tool events to
 // the Clawd HTTP server (127.0.0.1:23333-23337).
 //
 // This module is IMPORTED by the thin per-agent entries
@@ -13,12 +13,12 @@
 // Each entry calls createOpencodeFamilyPlugin() exactly ONCE at module
 // evaluation ("one state instance per entry-module evaluation"). Re-creating
 // per plugin invocation would wipe the dedup/parent maps, leak the previous
-// Bun.serve bridge (it has no shutdown path by design — the server dies with
+// reverse bridge (it has no production shutdown path — the server dies with
 // the host process), and strand in-flight permission requests that hold the
 // old bridge URL/token.
 //
 // Design invariants (unchanged from the original opencode plugin):
-//   - Zero dependencies (Bun's built-in fetch + fs/os/path + Bun.serve + node:crypto)
+//   - Zero dependencies (runtime fetch + Node built-ins + Bun.serve when present)
 //   - fire-and-forget: event hook never awaits the fetch, so slow/broken Clawd
 //     cannot stall the host
 //   - same-state dedup — consecutive identical states skip POST
@@ -30,9 +30,11 @@
 //   Phase 2 Spike — ctx.serverUrl is a phantom URL, ctx.client.fetch is
 //   bound to Server.Default().fetch() in-process). So Clawd cannot call
 //   the host's REST API directly from outside the Bun process. Instead we
-//   start a tiny Bun.serve() bridge here: Clawd POSTs decisions to the
+//   start a tiny loopback bridge here: Clawd POSTs decisions to the
 //   bridge, and the bridge calls ctx.client._client.post() — the same
 //   in-process Hono router that `opencode serve` would expose externally.
+//   CLI/TUI uses Bun.serve(); Desktop's Electron utilityProcess runs the
+//   sidecar under Node, so it uses node:http with the same Web Request handler.
 //   A random 32-byte hex token gates the bridge endpoint since localhost
 //   TCP is visible to any process on the machine.
 
@@ -41,6 +43,7 @@ import { homedir, platform } from "os";
 import { join, posix, win32 } from "path";
 import { randomBytes, timingSafeEqual } from "crypto";
 import { execFileSync, execSync } from "child_process";
+import { createServer as createHttpServer } from "http";
 import {
   getEventSessionInfo,
   getEventSessionId,
@@ -73,6 +76,7 @@ const POST_TIMEOUT_MS = 1000;
 // emitting events while that request waits. Without a hard cap, even an
 // explicitly serialized queue retains an unbounded chain of payloads/promises.
 const STATE_POST_MAX_PENDING = 32;
+const BRIDGE_MAX_BODY_BYTES = 64 * 1024;
 
 // Orca hosts its terminals in a detached daemon that the process walk below can
 // never reach, so the pane key from the environment is the only handle on the tab
@@ -344,6 +348,8 @@ export function createOpencodeFamilyPlugin(config) {
   let _bridgeTokenHex = "";
   let _bridgeTokenBuf = null;
   let _bridgeServer = null;
+  let _bridgeRuntime = "";
+  let _bridgeStartPromise = null;
 
   // Debug log is reset on plugin init so each host startup gets a clean
   // file. message.part.updated ignores are filtered out at the event-handler
@@ -1296,6 +1302,8 @@ export function createOpencodeFamilyPlugin(config) {
     set _cachedPort(v) { _cachedPort = v; },
     get _bridgeUrl() { return _bridgeUrl; },
     get _bridgeTokenHex() { return _bridgeTokenHex; },
+    get _bridgeRuntime() { return _bridgeRuntime; },
+    closeBridgeForTest,
     get _pidChain() { return _pidChain; },
   };
 
@@ -1661,33 +1669,164 @@ export function createOpencodeFamilyPlugin(config) {
     }
   }
 
-  // Start the Bun.serve reverse bridge on a random localhost port. Called once
-  // at plugin init. Survives the plugin's lifetime; the host owns the process
-  // so there's no explicit shutdown path — the server dies with the process.
-  function startBridge() {
+  function resetBridgeState() {
+    _bridgeServer = null;
+    _bridgeRuntime = "";
+    _bridgeUrl = "";
+    _bridgeTokenHex = "";
+    _bridgeTokenBuf = null;
+  }
+
+  async function writeNodeBridgeResponse(res, response) {
+    if (res.headersSent || res.destroyed) return;
+    res.statusCode = response.status;
+    for (const [name, value] of response.headers.entries()) {
+      res.setHeader(name, value);
+    }
+    const bytes = Buffer.from(await response.arrayBuffer());
+    res.end(bytes);
+  }
+
+  async function handleNodeBridgeRequest(req, res) {
+    try {
+      const requestUrl = new URL(req.url || "/", "http://127.0.0.1");
+      const authorization = Array.isArray(req.headers.authorization)
+        ? req.headers.authorization[0]
+        : req.headers.authorization;
+
+      // Reject unauthenticated POSTs before consuming a body. The shared Web
+      // handler repeats this check so the Bun and Node paths have one security
+      // boundary even if this fast path changes later.
+      if (req.method === "POST" && requestUrl.pathname === "/reply"
+          && !verifyBridgeToken(authorization)) {
+        await writeNodeBridgeResponse(res, new Response("unauthorized", { status: 401 }));
+        req.resume();
+        return;
+      }
+
+      const contentLength = Number(req.headers["content-length"] || 0);
+      if (Number.isFinite(contentLength) && contentLength > BRIDGE_MAX_BODY_BYTES) {
+        await writeNodeBridgeResponse(res, new Response("payload too large", { status: 413 }));
+        req.resume();
+        return;
+      }
+
+      const chunks = [];
+      let size = 0;
+      let tooLarge = false;
+      for await (const chunk of req) {
+        if (tooLarge) continue;
+        size += chunk.length;
+        if (size > BRIDGE_MAX_BODY_BYTES) {
+          tooLarge = true;
+          chunks.length = 0;
+          continue;
+        }
+        chunks.push(chunk);
+      }
+      if (tooLarge) {
+        await writeNodeBridgeResponse(res, new Response("payload too large", { status: 413 }));
+        return;
+      }
+
+      const headers = new Headers();
+      for (const [name, value] of Object.entries(req.headers)) {
+        if (Array.isArray(value)) {
+          for (const item of value) headers.append(name, item);
+        } else if (value !== undefined) {
+          headers.set(name, value);
+        }
+      }
+      const method = req.method || "GET";
+      const init = { method, headers };
+      if (method !== "GET" && method !== "HEAD" && size > 0) {
+        init.body = Buffer.concat(chunks, size);
+      }
+      const response = await handleBridgeRequest(new Request(requestUrl, init));
+      await writeNodeBridgeResponse(res, response);
+    } catch (err) {
+      debugLog(`BRIDGE node request THROW: ${err && err.message}`);
+      if (!res.headersSent && !res.destroyed) {
+        res.statusCode = 500;
+        res.end("internal error");
+      }
+    }
+  }
+
+  function listenNodeBridge() {
+    return new Promise((resolve, reject) => {
+      const server = createHttpServer((req, res) => {
+        void handleNodeBridgeRequest(req, res);
+      });
+      const onError = (err) => {
+        server.removeListener("listening", onListening);
+        reject(err);
+      };
+      const onListening = () => {
+        server.removeListener("error", onError);
+        resolve(server);
+      };
+      server.once("error", onError);
+      server.once("listening", onListening);
+      server.listen({ host: "127.0.0.1", port: 0 });
+    });
+  }
+
+  // Start one reverse bridge on a random loopback port. OpenCode may initialize
+  // the same factory concurrently for several directories, so every caller
+  // awaits the same in-flight start before it publishes bridge coordinates.
+  async function startBridge() {
     if (_bridgeServer && _bridgeUrl && _bridgeTokenBuf) return;
-    if (typeof Bun === "undefined" || !Bun.serve) {
-      debugLog(`BRIDGE start FAILED: Bun.serve not available (not running under Bun?)`);
+    if (_bridgeStartPromise) return _bridgeStartPromise;
+
+    _bridgeStartPromise = (async () => {
+      try {
+        _bridgeTokenBuf = randomBytes(32);
+        _bridgeTokenHex = _bridgeTokenBuf.toString("hex");
+        if (typeof Bun !== "undefined" && Bun.serve) {
+          _bridgeRuntime = "bun";
+          _bridgeServer = Bun.serve({
+            port: 0,
+            hostname: "127.0.0.1",
+            fetch: handleBridgeRequest,
+          });
+        } else {
+          _bridgeRuntime = "node";
+          _bridgeServer = await listenNodeBridge();
+        }
+        const address = _bridgeRuntime === "bun" ? { port: _bridgeServer.port } : _bridgeServer.address();
+        const port = address && typeof address === "object" ? address.port : null;
+        if (!Number.isInteger(port) || port <= 0) throw new Error("bridge did not receive a port");
+        _bridgeUrl = `http://127.0.0.1:${port}`;
+        debugLog(`BRIDGE listening runtime=${_bridgeRuntime} on ${_bridgeUrl} (token ${_bridgeTokenHex.slice(0, 8)}…)`);
+      } catch (err) {
+        debugLog(`BRIDGE start THROW: ${err && err.message}`);
+        if (_bridgeRuntime === "node" && _bridgeServer && typeof _bridgeServer.close === "function") {
+          try { _bridgeServer.close(); } catch {}
+        }
+        resetBridgeState();
+      }
+    })();
+
+    try {
+      await _bridgeStartPromise;
+    } finally {
+      _bridgeStartPromise = null;
+    }
+  }
+
+  async function closeBridgeForTest() {
+    if (_bridgeStartPromise) await _bridgeStartPromise;
+    const server = _bridgeServer;
+    const runtime = _bridgeRuntime;
+    resetBridgeState();
+    if (!server) return;
+    if (runtime === "bun") {
+      if (typeof server.stop === "function") server.stop(true);
       return;
     }
-    try {
-      _bridgeTokenBuf = randomBytes(32);
-      _bridgeTokenHex = _bridgeTokenBuf.toString("hex");
-      _bridgeServer = Bun.serve({
-        port: 0,              // ask the OS for an unused port
-        hostname: "127.0.0.1",
-        fetch: handleBridgeRequest,
-      });
-      const port = _bridgeServer.port;
-      _bridgeUrl = `http://127.0.0.1:${port}`;
-      debugLog(`BRIDGE listening on ${_bridgeUrl} (token ${_bridgeTokenHex.slice(0, 8)}…)`);
-    } catch (err) {
-      debugLog(`BRIDGE start THROW: ${err && err.message}`);
-      _bridgeServer = null;
-      _bridgeUrl = "";
-      _bridgeTokenHex = "";
-      _bridgeTokenBuf = null;
-    }
+    if (typeof server.close !== "function") return;
+    await new Promise((resolve) => server.close(() => resolve()));
   }
 
   // Plugin entrypoint (the host loads this via the entry's default export).
@@ -1703,7 +1842,7 @@ export function createOpencodeFamilyPlugin(config) {
     debugLog(`INIT directory=${instanceDirectory} serverUrl=${instanceServerUrl} pid=${process.pid} hasClient=${!!instanceClient}`);
     // Sync init blocks the TUI boot path; later POSTs hit the cached result.
     getStablePid();
-    startBridge();
+    await startBridge();
 
     return {
       event: async ({ event }) => {

--- a/src/permission.js
+++ b/src/permission.js
@@ -2108,12 +2108,12 @@ function applyPermissionSuggestion(perm, index, options = {}) {
   syncPermissionShortcuts();
 
   // opencode-family: decisions go back via the plugin's reverse bridge
-  // (Bun.serve on a random localhost port). The plugin then calls the host's
-  // in-process Hono route. Plugin sent us a fire-and-forget POST — no HTTP
+  // (Bun.serve or node:http on a random localhost port). The plugin then calls
+  // the host's in-process Hono route. Plugin sent us a fire-and-forget POST — no HTTP
   // response to complete on this connection.
   if (isOpencodeFamilyEntry(permEntry)) {
-    // Autoclose: silent drop — same DND semantics. The host TUI falls back
-    // to its built-in prompt so the user can answer in the terminal.
+    // Autoclose: silent drop — same DND semantics. The host falls back to its
+    // built-in terminal or Desktop prompt so the user can answer natively.
     if (behavior === "no-decision") return;
     let reply;
     if (behavior === "deny") reply = "reject";
@@ -2256,12 +2256,12 @@ function permLog(msg) {
   rotatedAppend(ctx.permDebugLog, `[${new Date().toISOString()}] ${msg}\n`);
 }
 
-// Fire-and-forget POST to the family plugin's reverse bridge. The plugin
-// runs inside the host's Bun process and does NOT expose the host's own
-// permission route externally — TUI mode has no TCP listener at all (see
-// Phase 2 Spike in docs/plans/plan-opencode-integration.md). Instead the plugin
-// starts its own Bun.serve on a random localhost port and forwards our
-// decision to the host's in-process Hono router via ctx.client._client.post().
+// Fire-and-forget POST to the family plugin's reverse bridge. The plugin runs
+// inside the host and does NOT expose the host's own permission route
+// externally — TUI mode has no TCP listener at all (see Phase 2 Spike in
+// docs/plans/plan-opencode-integration.md). Instead the plugin starts a tiny
+// Bun.serve (CLI/TUI) or node:http (Desktop) listener on a random port and
+// forwards our decision to the host's in-process Hono router via ctx.client._client.post().
 //
 // Shape: POST http://127.0.0.1:<plugin-port>/reply
 //   Authorization: Bearer <hex token>
@@ -2269,8 +2269,8 @@ function permLog(msg) {
 //
 // Uses raw http.request (not fetch) to avoid Electron main-process fetch
 // polyfill concerns. Bridge is always 127.0.0.1 bound by the plugin so no
-// IPv4/IPv6 gotcha. 5s timeout — on failure the host TUI still falls
-// back to terminal-based approval.
+// IPv4/IPv6 gotcha. 5s timeout — on failure the host still falls back to its
+// native terminal or Desktop approval.
 function replyOpencodeFamilyPermission({ agentId, bridgeUrl, bridgeToken, requestId, reply, toolName }) {
   const tag = agentId || "opencode-family";
   if (!bridgeUrl || !bridgeToken || !requestId) {

--- a/test/opencode-family-bridge.test.js
+++ b/test/opencode-family-bridge.test.js
@@ -5,7 +5,7 @@
 // carrying the live bridge coordinates).
 //
 // permission-family-roundtrip.test.js covers the Electron→bridge half; this
-// file covers the Bun half by initializing the REAL factory plugin with a
+// file covers the Bun runtime half by initializing the REAL factory plugin with a
 // fake `globalThis.Bun.serve` that captures the fetch handler, a fake global
 // fetch (so nothing touches a live Clawd on the real ports), and a mock SDK
 // client — then drives handleBridgeRequest/verifyBridgeToken/startBridge/

--- a/test/opencode-family-node-bridge.test.js
+++ b/test/opencode-family-node-bridge.test.js
@@ -79,14 +79,15 @@ async function emitPermission(instance, requestId, sessionID = "ses_node") {
   });
 }
 
-function requestBridge(url, { token, body, rawBody } = {}) {
+function requestBridge(url, { token, body, rawBody, chunked = false } = {}) {
   return new Promise((resolve, reject) => {
     const payload = rawBody === undefined ? JSON.stringify(body) : rawBody;
     const target = new URL("/reply", url);
     const headers = {
       "Content-Type": "application/json",
-      "Content-Length": Buffer.byteLength(payload),
     };
+    if (chunked) headers["Transfer-Encoding"] = "chunked";
+    else headers["Content-Length"] = Buffer.byteLength(payload);
     if (token !== undefined) headers.Authorization = `Bearer ${token}`;
     const req = http.request(target, { method: "POST", headers }, (res) => {
       const chunks = [];
@@ -97,7 +98,13 @@ function requestBridge(url, { token, body, rawBody } = {}) {
       }));
     });
     req.on("error", reject);
-    req.end(payload);
+    if (!chunked) {
+      req.end(payload);
+      return;
+    }
+    const midpoint = Math.floor(payload.length / 2);
+    req.write(payload.slice(0, midpoint));
+    req.end(payload.slice(midpoint));
   });
 }
 
@@ -109,6 +116,12 @@ describe("opencode-family Node reverse bridge", () => {
     assert.strictEqual(instance.plugin.__test._bridgeRuntime, "node");
     assert.match(instance.plugin.__test._bridgeUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
     assert.match(instance.plugin.__test._bridgeTokenHex, /^[a-f0-9]{64}$/);
+    const address = instance.plugin.__test._bridgeAddress;
+    assert.ok(address && typeof address === "object", "node bridge must expose its bound address");
+    assert.strictEqual(address.address, "127.0.0.1");
+    assert.strictEqual(address.port, Number(new URL(instance.plugin.__test._bridgeUrl).port));
+    assert.ok(instance.plugin.__test._bridgeErrorListenerCount > 0,
+      "node bridge must retain an error listener after binding");
 
     fetchCalls.length = 0;
     await emitPermission(instance, "per_node_once");
@@ -155,6 +168,13 @@ describe("opencode-family Node reverse bridge", () => {
       rawBody: "x".repeat(64 * 1024 + 1),
     });
     assert.strictEqual(oversized.status, 413);
+
+    const streamedOversized = await requestBridge(instance.plugin.__test._bridgeUrl, {
+      token,
+      rawBody: "x".repeat(64 * 1024 + 1),
+      chunked: true,
+    });
+    assert.strictEqual(streamedOversized.status, 413);
 
     await emitPermission(instance, "per_after_bad_body");
     const accepted = await requestBridge(instance.plugin.__test._bridgeUrl, {

--- a/test/opencode-family-node-bridge.test.js
+++ b/test/opencode-family-node-bridge.test.js
@@ -1,0 +1,191 @@
+"use strict";
+
+// OpenCode Desktop runs its sidecar in an Electron utilityProcess under Node,
+// so Bun.serve is absent. These tests exercise the real node:http listener on
+// loopback instead of a fake Bun server.
+
+const assert = require("node:assert");
+const fs = require("node:fs");
+const http = require("node:http");
+const os = require("node:os");
+const path = require("node:path");
+const { after, before, describe, it } = require("node:test");
+const { pathToFileURL } = require("node:url");
+
+const TMP_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-family-node-bridge-"));
+process.env.HOME = TMP_HOME;
+process.env.USERPROFILE = TMP_HOME;
+
+let createOpencodeFamilyPlugin;
+const fetchCalls = [];
+
+before(async () => {
+  delete globalThis.Bun;
+  globalThis.fetch = async (url, opts) => {
+    fetchCalls.push({
+      url: String(url),
+      body: opts && opts.body ? JSON.parse(opts.body) : null,
+    });
+    return { status: 200, headers: { get: () => null }, text: async () => "" };
+  };
+  const modulePath = path.join(__dirname, "..", "hooks", "opencode-family-plugin", "core.mjs");
+  ({ createOpencodeFamilyPlugin } = await import(pathToFileURL(modulePath).href));
+});
+
+after(() => {
+  delete globalThis.Bun;
+  fs.rmSync(TMP_HOME, { recursive: true, force: true });
+});
+
+const OC = Object.freeze({
+  agentId: "opencode",
+  hookSource: "opencode-plugin",
+  logFileName: "opencode-plugin.log",
+  sessionIdPrefix: "opencode:",
+});
+
+function createContext(directory, sdkCalls) {
+  return {
+    serverUrl: "http://127.0.0.1:1/",
+    directory,
+    client: {
+      _client: {
+        post: async (args) => {
+          sdkCalls.push(args);
+          return { data: {} };
+        },
+      },
+    },
+  };
+}
+
+async function initNodeInstance({ plugin = createOpencodeFamilyPlugin(OC), directory = "/tmp/node-project" } = {}) {
+  const sdkCalls = [];
+  const hooks = await plugin(createContext(directory, sdkCalls));
+  return { plugin, hooks, sdkCalls, directory };
+}
+
+async function emitPermission(instance, requestId, sessionID = "ses_node") {
+  await instance.hooks.event({
+    event: {
+      type: "permission.asked",
+      properties: {
+        id: requestId,
+        sessionID,
+        permission: "bash",
+        metadata: { command: "pwd" },
+      },
+    },
+  });
+}
+
+function requestBridge(url, { token, body, rawBody } = {}) {
+  return new Promise((resolve, reject) => {
+    const payload = rawBody === undefined ? JSON.stringify(body) : rawBody;
+    const target = new URL("/reply", url);
+    const headers = {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(payload),
+    };
+    if (token !== undefined) headers.Authorization = `Bearer ${token}`;
+    const req = http.request(target, { method: "POST", headers }, (res) => {
+      const chunks = [];
+      res.on("data", (chunk) => chunks.push(chunk));
+      res.on("end", () => resolve({
+        status: res.statusCode,
+        body: Buffer.concat(chunks).toString("utf8"),
+      }));
+    });
+    req.on("error", reject);
+    req.end(payload);
+  });
+}
+
+describe("opencode-family Node reverse bridge", () => {
+  it("listens on loopback and forwards an authenticated permission reply", async (t) => {
+    const instance = await initNodeInstance();
+    t.after(() => instance.plugin.__test.closeBridgeForTest());
+
+    assert.strictEqual(instance.plugin.__test._bridgeRuntime, "node");
+    assert.match(instance.plugin.__test._bridgeUrl, /^http:\/\/127\.0\.0\.1:\d+$/);
+    assert.match(instance.plugin.__test._bridgeTokenHex, /^[a-f0-9]{64}$/);
+
+    fetchCalls.length = 0;
+    await emitPermission(instance, "per_node_once");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    const forwarded = fetchCalls.find((call) => call.url.endsWith("/permission"));
+    assert.ok(forwarded, "permission was not forwarded to Clawd");
+    assert.strictEqual(forwarded.body.bridge_url, instance.plugin.__test._bridgeUrl);
+    assert.strictEqual(forwarded.body.bridge_token, instance.plugin.__test._bridgeTokenHex);
+
+    const unauthorized = await requestBridge(instance.plugin.__test._bridgeUrl, {
+      token: "ff".repeat(32),
+      body: { request_id: "per_node_once", reply: "once" },
+    });
+    assert.strictEqual(unauthorized.status, 401);
+    assert.strictEqual(instance.sdkCalls.length, 0);
+
+    const accepted = await requestBridge(instance.plugin.__test._bridgeUrl, {
+      token: instance.plugin.__test._bridgeTokenHex,
+      body: { request_id: "per_node_once", reply: "once" },
+    });
+    assert.strictEqual(accepted.status, 200);
+    assert.deepStrictEqual(JSON.parse(accepted.body), { ok: true });
+    assert.deepStrictEqual(instance.sdkCalls, [{
+      url: "/permission/per_node_once/reply",
+      query: { directory: "/tmp/node-project" },
+      body: { reply: "once" },
+      headers: { "Content-Type": "application/json" },
+    }]);
+  });
+
+  it("rejects malformed and oversized bodies without poisoning the listener", async (t) => {
+    const instance = await initNodeInstance();
+    t.after(() => instance.plugin.__test.closeBridgeForTest());
+    const token = instance.plugin.__test._bridgeTokenHex;
+
+    const malformed = await requestBridge(instance.plugin.__test._bridgeUrl, {
+      token,
+      rawBody: "{not json",
+    });
+    assert.strictEqual(malformed.status, 400);
+
+    const oversized = await requestBridge(instance.plugin.__test._bridgeUrl, {
+      token,
+      rawBody: "x".repeat(64 * 1024 + 1),
+    });
+    assert.strictEqual(oversized.status, 413);
+
+    await emitPermission(instance, "per_after_bad_body");
+    const accepted = await requestBridge(instance.plugin.__test._bridgeUrl, {
+      token,
+      body: { request_id: "per_after_bad_body", reply: "reject" },
+    });
+    assert.strictEqual(accepted.status, 200);
+    assert.strictEqual(instance.sdkCalls.length, 1);
+  });
+
+  it("serializes concurrent directory initialization and preserves request ownership", async (t) => {
+    const plugin = createOpencodeFamilyPlugin(OC);
+    const callsA = [];
+    const callsB = [];
+    const [hooksA, hooksB] = await Promise.all([
+      plugin(createContext("/tmp/project-a", callsA)),
+      plugin(createContext("/tmp/project-b", callsB)),
+    ]);
+    t.after(() => plugin.__test.closeBridgeForTest());
+
+    assert.strictEqual(plugin.__test._bridgeRuntime, "node");
+    const instanceA = { plugin, hooks: hooksA, sdkCalls: callsA };
+    await emitPermission(instanceA, "per_project_a", "ses_a");
+    const response = await requestBridge(plugin.__test._bridgeUrl, {
+      token: plugin.__test._bridgeTokenHex,
+      body: { request_id: "per_project_a", reply: "always" },
+    });
+
+    assert.strictEqual(response.status, 200);
+    assert.strictEqual(callsA.length, 1);
+    assert.strictEqual(callsB.length, 0);
+    assert.deepStrictEqual(callsA[0].query, { directory: "/tmp/project-a" });
+  });
+});

--- a/test/permission-family-roundtrip.test.js
+++ b/test/permission-family-roundtrip.test.js
@@ -5,7 +5,7 @@
 //
 // These execute the full chain — handleDecide (IPC entry) → familyAlwaysPicked
 // → resolvePermissionEntry → replyOpencodeFamilyPermission → an actual HTTP
-// listener standing in for the plugin's Bun.serve bridge — so a regression in
+// listener standing in for the plugin's Bun/Node reverse bridge — so a regression in
 // any hop (e.g. Always silently degrading to "once", or no-decision leaking a
 // bridge POST) turns a real request red instead of surviving source-string
 // checks.


### PR DESCRIPTION
## Summary

Follow-up to #899: make OpenCode permission bubbles work in Desktop as well as CLI/TUI.

- keep the existing `Bun.serve` reverse bridge for Bun-based CLI/TUI hosts
- add a `node:http` loopback bridge for OpenCode Desktop's Electron `utilityProcess`
- reuse the same authenticated Web `Request` handler and SDK reply path in both runtimes
- serialize concurrent directory initialization so a factory publishes one fully initialized bridge
- cap Desktop bridge request bodies at 64 KiB and reject unauthenticated requests before reading them

## Root cause

OpenCode Desktop 1.18.18 runs its sidecar in an Electron `utilityProcess` under Node. The plugin previously required `Bun.serve`, so Desktop forwarded permission events with empty bridge coordinates. Clawd could observe state, but it could not send Allow/Always/Deny decisions back to the host.

The new fallback binds only to `127.0.0.1` on an OS-assigned port and retains the existing random 32-byte bearer token. A bridge startup failure still leaves the request undecided so OpenCode's native prompt remains authoritative.

## Verification

Automated:

- `node --test test/opencode-family-node-bridge.test.js test/opencode-family-bridge.test.js test/permission-family-roundtrip.test.js` — 15/15 pass
- OpenCode/permission related suite — 291/291 pass
- full suite — 8,223 pass, 30 fail, 26 skip out of 8,279; the 30 failures are the existing DeepSeek Harness environment/baseline failures, with no OpenCode or permission regression
- `node --check hooks/opencode-family-plugin/core.mjs`
- `git diff --check`

Real device (macOS 26.5.2, OpenCode Desktop 1.18.18, exact branch commit):

1. With `bash: "ask"`, a real `pwd` tool request reached Clawd with a non-empty Node bridge URL; `once` returned HTTP 200 and OpenCode executed it in the expected repository.
2. With Clawd automation temporarily off, a real `whoami` request displayed the Clawd permission bubble; Deny returned `reject`, HTTP 200, and OpenCode recorded the tool failure without executing the command.
3. With the test Clawd instance stopped, a real `uname -s` request stayed pending in OpenCode's native permission UI; Allow Once executed it and returned `Darwin`.

The temporary JSONC permission fixture, Clawd automation setting, model selection, and model visibility toggles were restored after the test. Windows Desktop remains unverified on real hardware in this PR.
