### PR TITLE
test(validate-theme): make the CLI cases assert what they claim

### DIFF
--- a/test/validate-theme-cli.test.js
+++ b/test/validate-theme-cli.test.js
@@ -146,7 +146,15 @@ describe("validate-theme.js CLI (real process, spawnSync)", () => {
     assert.doesNotMatch(result.stdout, /error\(s\)/);
   });
 
-  it("--assets whose parent is a file reports the real error, not \"not found\"", () => {
+  it("--assets whose parent is a file reports the real error, not \"not found\"", {
+    // POSIX-specific. stat() on a path whose parent component is a file gives
+    // ENOTDIR here; Windows reports this shape through a different errno, and we
+    // have no Windows host to measure it on. Skipped rather than pinned to a
+    // behavior nobody has observed -- a guess that happens to be wrong would go
+    // red in the release-tag lane, which is the one place a red test costs a
+    // build. The macOS and Linux lanes keep the guarantee.
+    skip: process.platform === "win32" ? "stat() errno for a file-as-parent component is unmeasured on Windows" : false,
+  }, () => {
     // ENOTDIR, not ENOENT. Collapsing every stat failure into "not found" tells
     // the author to create a directory that cannot exist at that path.
     const result = runValidateTheme([CALICO, "--assets", path.join(CALICO, "theme.json", "nope")]);
@@ -234,7 +242,12 @@ describe("validate-theme.js CLI (real process, spawnSync)", () => {
     fs.writeFileSync(path.join(dir, "theme.json"), JSON.stringify(themeJson), "utf8");
     const result = runValidateTheme([dir]);
     assert.strictEqual(result.status, 1, result.stderr || result.stdout);
-    assert.match(result.stdout, /assets\/ directory exists/);
+    // check() prints the SAME message whether it passed or failed -- only the
+    // glyph differs -- and this fixture's states:{} guarantees exit 1 on its own,
+    // so matching the bare text would hold even if the assets check stopped being
+    // reported at all. Pin the FAIL glyph so the assertion can actually tell the
+    // two apart.
+    assert.match(result.stdout, /\u2717\u001b\[0m assets\/ directory exists/);
     assert.doesNotMatch(result.stderr, /--assets/);
   });
 

--- a/test/validate-theme-cli.test.js
+++ b/test/validate-theme-cli.test.js
@@ -156,10 +156,11 @@ describe("validate-theme.js CLI (real process, spawnSync)", () => {
   });
 
   it("--assets whose parent is a file reports the real error, not \"not found\"", {
-    // POSIX-specific. stat() on a path whose parent component is a file gives
-    // ENOTDIR here; Windows reports this shape through a different errno, and we
-    // have no Windows host to measure it on. Skipped rather than pinned to a
-    // behavior nobody has observed -- a guess that happens to be wrong would go
+    // stat() on a path whose parent component is a file gives ENOTDIR here.
+    // Whether Windows spells it the same way is UNMEASURED -- ENOENT is the
+    // plausible candidate, but nobody here has a Windows host to check, so this
+    // is skipped rather than pinned to a behavior nobody has observed. A guess
+    // that happens to be wrong would go
     // red in the release-tag lane, which is the one place a red test costs a
     // build. The macOS and Linux lanes keep the guarantee.
     skip: process.platform === "win32" ? "stat() errno for a file-as-parent component is unmeasured on Windows" : false,
@@ -266,10 +267,14 @@ describe("validate-theme.js CLI (real process, spawnSync)", () => {
     assert.strictEqual(missing.status, 1, missing.stderr || missing.stdout);
     assert.doesNotMatch(missing.stderr, /--assets/);
 
-    // check() prints the SAME message whether it passed or failed -- only the
-    // glyph differs -- and this fixture's states:{} guarantees exit 1 on its own,
-    // so neither the message nor the status can show that the assets check still
-    // runs. Re-run the identical theme with an (empty) assets/ present and require
+    // The blind spot this closes is narrow, so be precise about it: if the guard
+    // widened outright the case above already fails, because an early exit leaves
+    // stdout empty. What slips through is the quieter form -- the assets check
+    // reporting a false PASS while the run otherwise proceeds. check() prints the
+    // SAME message whether it passed or failed (only the glyph differs) and this
+    // fixture's states:{} guarantees exit 1 on its own, so neither the message nor
+    // the status can tell a false pass from a real finding.
+    // Re-run the identical theme with an (empty) assets/ present and require
     // exactly one finding to disappear. A delta pins behavior instead of
     // presentation: it survives recolors, glyph changes and future rule additions,
     // none of which say anything about whether this check happened.

--- a/test/validate-theme-cli.test.js
+++ b/test/validate-theme-cli.test.js
@@ -30,6 +30,15 @@ function runValidateTheme(args, { cwd = REPO_ROOT } = {}) {
   });
 }
 
+// The summary line is `<n> error(s)[, <m> warning(s)]. Fix errors ...`, wrapped in
+// ANSI. Read the count rather than a glyph: it tracks what the validator DID, not
+// how it painted it.
+function errorCount(stdout) {
+  const m = stdout.match(/(\d+) error\(s\)/);
+  assert.ok(m, `no error summary in:\n${stdout}`);
+  return Number(m[1]);
+}
+
 function mkTempThemeDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-validate-theme-"));
   tempDirs.push(dir);
@@ -189,7 +198,20 @@ describe("validate-theme.js CLI (real process, spawnSync)", () => {
     fs.mkdirSync(path.join(dir, "theme.json"));
     const result = runValidateTheme([dir]);
     assert.strictEqual(result.status, 1, result.stderr || result.stdout);
-    assert.match(result.stderr, /Failed to read or parse theme\.json/);
+    // Colon-space immediately after the prefix: the errno detail is the whole
+    // point, and nothing may be spliced in front of it re-asserting "parse".
+    assert.match(result.stderr, /Failed to read or parse theme\.json: /);
+
+    // That prefix is byte-identical to the one the unparseable-JSON case asserts,
+    // so alone it cannot tell a read failure from a parse failure -- the very
+    // distinction this test is named for. Run that case here too and require the
+    // detail to differ. Comparing beats pinning an errno: EISDIR is not spelled
+    // the same everywhere, and this stays true wherever it runs.
+    const parseDir = mkTempThemeDir();
+    fs.writeFileSync(path.join(parseDir, "theme.json"), '{ "schemaVersion": 1, ', "utf8");
+    const parseResult = runValidateTheme([parseDir]);
+    assert.match(parseResult.stderr, /Failed to read or parse theme\.json: /);
+    assert.notStrictEqual(result.stderr, parseResult.stderr, result.stderr);
   });
 
   for (const [label, value] of [
@@ -240,15 +262,24 @@ describe("validate-theme.js CLI (real process, spawnSync)", () => {
       states: {},
     };
     fs.writeFileSync(path.join(dir, "theme.json"), JSON.stringify(themeJson), "utf8");
-    const result = runValidateTheme([dir]);
-    assert.strictEqual(result.status, 1, result.stderr || result.stdout);
+    const missing = runValidateTheme([dir]);
+    assert.strictEqual(missing.status, 1, missing.stderr || missing.stdout);
+    assert.doesNotMatch(missing.stderr, /--assets/);
+
     // check() prints the SAME message whether it passed or failed -- only the
     // glyph differs -- and this fixture's states:{} guarantees exit 1 on its own,
-    // so matching the bare text would hold even if the assets check stopped being
-    // reported at all. Pin the FAIL glyph so the assertion can actually tell the
-    // two apart.
-    assert.match(result.stdout, /\u2717\u001b\[0m assets\/ directory exists/);
-    assert.doesNotMatch(result.stderr, /--assets/);
+    // so neither the message nor the status can show that the assets check still
+    // runs. Re-run the identical theme with an (empty) assets/ present and require
+    // exactly one finding to disappear. A delta pins behavior instead of
+    // presentation: it survives recolors, glyph changes and future rule additions,
+    // none of which say anything about whether this check happened.
+    fs.mkdirSync(path.join(dir, "assets"));
+    const present = runValidateTheme([dir]);
+    assert.strictEqual(
+      errorCount(missing.stdout) - errorCount(present.stdout),
+      1,
+      `${missing.stdout}\n--- with assets/ ---\n${present.stdout}`
+    );
   });
 
   it("control: an --assets value beginning with - is a path, not a flag", () => {
@@ -273,6 +304,25 @@ describe("validate-theme.js CLI (real process, spawnSync)", () => {
     assert.strictEqual(without.status, 1, without.stderr || without.stdout);
     assert.match(without.stderr, /Unknown option: -dashed-theme/);
     assert.match(without.stderr, /pass it after --/);
+  });
+
+  it("--assets actually redirects the lookups, it is not just validated and dropped", () => {
+    // Every other --assets case in this file passes an override that resolves to
+    // the same files as the default, so exit 0 proves the guard let it through --
+    // never that the value reached the lookups. Measured: dropping the override at
+    // the point of use (`assetsDir = path.join(resolvedDir, "assets")`) left all
+    // 24 cases green. Point a VALID, existing, EMPTY directory at a theme whose
+    // own assets/ is complete: only an honoured override can make it miss.
+    const empty = mkTempThemeDir();
+    const redirected = runValidateTheme([CALICO, "--assets", empty]);
+    assert.strictEqual(redirected.status, 1, redirected.stderr || redirected.stdout);
+    // Ordinary missing-asset findings, not a setup error: the path is a perfectly
+    // good directory, it simply has nothing in it.
+    assert.doesNotMatch(redirected.stderr, /--assets/);
+    assert.ok(errorCount(redirected.stdout) > 0, redirected.stdout);
+    // ...and the same theme without the override is clean, so the override is the
+    // only thing that changed.
+    assert.strictEqual(runValidateTheme([CALICO]).status, 0);
   });
 
   it("control: a well-formed --assets override still validates clean", () => {


### PR DESCRIPTION
Follow-up to #892. **Test-only** — `test/validate-theme-cli.test.js` is the single file touched (+69/−6), `scripts/validate-theme.js` is not modified, so no behavior changes.

Four cases in the new CLI lane did not assert what their names claim. I found the first two while reviewing #892 and said there I would clean them up myself; a subagent review of that first commit found the other two, including one hole larger than any of them.

---

## 1. `--assets` could be validated and then thrown away, with every case green

The strongest of the four. Measured on the tip of `main`:

```
scripts/validate-theme.js:300
- const assetsDir = assetsOverride ? path.resolve(assetsOverride) : path.join(resolvedDir, "assets");
+ const assetsDir = path.join(resolvedDir, "assets");        // override honoured nowhere

  node --test test/validate-theme-cli.test.js   ->   24 pass / 0 fail
```

The flag can be parsed, rejected when malformed, stat'd, type-checked — and then discarded before a single lookup, and nothing notices. Every existing `--assets` case passes an override that resolves to the *same files as the default*; one of them literally passes `themes/calico/assets`, which **is** the default. So exit 0 proved the guard let the value through, never that the value arrived anywhere.

New case points a valid, existing, **empty** directory at a theme whose own `assets/` is complete — only an honoured override can make those lookups miss — and pairs it with an un-overridden run of the same theme that exits 0, so the override is the only variable. That mutation now dies.

## 2. A control with one blind spot

`control: a missing DEFAULT <theme>/assets stays a theme finding, not a setup error` guards the `--assets` guard against widening and swallowing the default-assets check.

**It does catch that.** Widening the guard on `main` so it also resolves the default path takes the pre-fix file to **15 pass / 9 fail**, the control among the dead — an early exit leaves stdout empty, so the old `assert.match` had nothing to match. I originally wrote this section up as "a control that could not fail"; that was wrong, and a fact-check pass caught it.

The blind spot is narrower: the assets check reporting a **false pass** while the run otherwise proceeds normally. Neither assertion can see that, for two independent reasons:

- `check()` (`scripts/validate-theme.js:178`) prints the **same message text** for pass and fail — only the glyph differs — so `assert.match(result.stdout, /assets\/ directory exists/)` matched the ✓ line and the ✗ line equally.
- The fixture's `states: {}` guarantees `status === 1` from unrelated schema errors, so the status assertion carried no weight either.

```
check(assetsDirExists, `assets/ directory exists`)  ->  24 pass / 0 fail
check(true,            `assets/ directory exists`)  ->  24 pass / 0 fail   # reports nothing, still green
```

**My first attempt at this pinned the wrong thing** and the review caught it: it asserted the FAIL glyph together with its ANSI reset, which detected the mutation but went red under two changes that alter nothing about behavior — recolouring the reset from `\x1b[0m` to `\x1b[39m`, and refreshing the glyph `U+2717` → `U+2718`. It would also have become dependent on the developer's ambient environment the day anything here honours `NO_COLOR`, since `runValidateTheme` does not pin `env`. And it was the only ANSI-escape assertion in `test/`.

Replaced with an **error-count delta**: the same theme run twice, with and without an empty `assets/`, requiring exactly one finding to disappear. That pins behavior rather than presentation, and future rule additions cancel out of a delta.

## 3. Read-vs-parse asserted a string identical to its neighbour

`theme.json is a directory: reported as a read failure, not a parse failure` asserted `/Failed to read or parse theme\.json/` — byte-identical to what the unparseable-JSON case above it asserts. It therefore had no power to draw the one distinction it is named for. Rewording the message to falsely re-assert "parse", and dropping the `: ${e.message}` detail entirely, both survived all 24 cases.

Now requires the colon-space immediately after the prefix (nothing may be spliced in front of the errno detail) and compares the two stderrs directly. Comparing beats pinning `EISDIR`, which is not spelled the same everywhere — see 4.

## 4. An errno pinned on a platform we cannot measure

`--assets whose parent is a file reports the real error, not "not found"` asserts the literal string `cannot be accessed (ENOTDIR)` plus `doesNotMatch(/not found/)`.

`ENOTDIR` is what a POSIX `stat()` gives for a path whose parent component is a file. **Whether Windows spells it the same way is unmeasured — I have no Windows host to check.** `ENOENT` is the plausible candidate, and if that is what it gives, `validate-theme.js:133-134` writes `--assets directory not found: …` to stderr and *both* assertions fail. I am not asserting that it does. The case is skipped on win32 with the reason recorded, using an idiom already in the repo — this exact shape (`{ skip: process.platform === "win32" ? "reason" : false }`) in 6 test files including `test/prefs.test.js:1520`, and some platform-gated `skip:` in 24. It stays live on macOS and Linux, where the ENOTDIR-vs-ENOENT distinction it guards is real.

Worth the care specifically because [`build.yml`](.github/workflows/build.yml) has **no `pull_request` trigger** — its `windows-latest` `npm test` first runs on a release tag, or on a manual `workflow_dispatch`. A wrong assertion here does not show up as a red PR; it shows up as a blocked release.

---

## Verification

`node --test test/validate-theme-cli.test.js` → **25 pass / 0 fail / 0 skipped**. Each mutation killed by exactly its own case:

| mutation to `scripts/validate-theme.js` | before | after |
|---|---|---|
| `assetsDir` ignores the override | 24 pass / 0 fail | ✗ `--assets actually redirects the lookups…` |
| `check(true, \`assets/ directory exists\`)` | 24 pass / 0 fail | ✗ `control: a missing DEFAULT <theme>/assets…` |
| splice `(JSON parse error)` into the message | 24 pass / 0 fail | ✗ `theme.json is a directory…` |
| drop `: ${e.message}` | 24 pass / 0 fail | ✗ `theme.json is a directory…` |
| reset `\x1b[0m` → `\x1b[39m` (cosmetic) | red under my first attempt | **stays green** |
| glyph `U+2717` → `U+2718` (cosmetic) | red under my first attempt | **stays green** |

Forcing the win32 skip predicate to `true` gives 24 pass / 1 skipped / 0 fail, so that path is live rather than silently passing.

Full suite on this branch: **8334 tests, 8278 pass, 30 fail** — failing-test-name set compared against `main` in both directions, **zero difference** (the 30 are the pre-existing DSH/agent-detector lanes). The third commit is comment-only.

## Deliberately not in this PR

Two P3s from the #892 review, kept separate so this stays reviewable:

- `--assets <dir with mode 000>` still produces the misleading "27 error(s)" theme report — `fs.statSync` only needs search permission on the *parent*, so the guard passes an unreadable target. **`main` behaves identically**, so this is an unclosed corner of the same class, not a regression. `fs.accessSync(overrideDir, fs.constants.R_OK)` would close it.
- A bare `-` as the theme directory is untested; the `arg !== "-"` carve-out survives mutation.
