### PR TITLE
fix(state): keep the assistant output through a held completion

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -182,6 +182,11 @@ let pendingState = null;
 // #406 Stop completion debounce: sessionId -> timer holding a Stop as "working"
 // until a quiet window confirms the turn really ended.
 const pendingCompletionTimers = new Map();
+// Sessions whose completion the #406 gate is currently withholding, by either
+// shape: a debounce timer, or a hard hold that only a later Stop can release.
+// This is the exact window in which a replayed Stop must still know the answer
+// the withheld Stop carried, and it is entered only from the claude-code gate.
+const withheldCompletions = new Set();
 let eyeResendTimer = null;
 let updateVisualState = null;
 let updateVisualKind = null;
@@ -1436,6 +1441,9 @@ function scheduleCompletionDebounce(sessionId, debounceMs) {
 }
 
 function cancelCompletionDebounce(sessionId, reason) {
+  // Runs before the early return: a hard hold has no timer, and it still has to
+  // release the withheld marker.
+  withheldCompletions.delete(sessionId);
   const timer = pendingCompletionTimers.get(sessionId);
   if (!timer) return;
   clearTimeout(timer);
@@ -1446,6 +1454,7 @@ function cancelCompletionDebounce(sessionId, reason) {
 function clearAllCompletionDebounces() {
   for (const timer of pendingCompletionTimers.values()) clearTimeout(timer);
   pendingCompletionTimers.clear();
+  withheldCompletions.clear();
 }
 
 function cancelClaudeTranscriptCompletionProbe(sessionId, reason) {
@@ -1515,6 +1524,7 @@ function scheduleClaudeTranscriptCompletionProbe(sessionId, transcriptPath) {
 // and only now flip awaitingInputSinceStop. Then celebrate, unless a Kimi
 // permission lock is holding the pet.
 function promoteCompletion(sessionId) {
+  withheldCompletions.delete(sessionId);
   const session = sessions.get(sessionId);
   if (!session) return;
   session.subagentTracker = clearSubagentTracker(cloneSubagentTracker(session));
@@ -1889,8 +1899,30 @@ function updateSession(sessionId, state, event, opts = {}) {
   );
   const srcContextUsage = resolvedContextUsage.contextUsage;
   const srcContextUsageOrigin = resolvedContextUsage.contextUsageOrigin;
-  const srcAssistantLastOutput = normalizeAssistantOutput(assistantLastOutput);
-  const srcAssistantLastOutputTruncated = !!(srcAssistantLastOutput && assistantLastOutputTruncated === true);
+  // Sticky ONLY while the #406 gate is withholding this session's completion.
+  // The Stop that carries the answer can be withheld and replayed later by
+  // promoteCompletion; any event arriving inside that window (Notification,
+  // PermissionResult, SessionStart(resume), ...) carries no assistant output and
+  // would otherwise rewrite the recorded answer to null, so the replayed
+  // completion ships title-only -- or, with plain Telegram pings disabled, is
+  // dropped entirely.
+  //
+  // The window is the bound. An earlier attempt made the field sticky for every
+  // event and cleared it at a guessed turn boundary (UserPromptSubmit /
+  // SessionStart), which leaked one turn's answer into the next on any agent
+  // that emits neither -- the Codex JSONL monitor emits task_started /
+  // task_complete and nothing else, so the clear was structurally unreachable
+  // there. Only the claude-code gate ever populates withheldCompletions, so
+  // agents that cannot be withheld cannot carry anything forward.
+  const incomingAssistantLastOutput = normalizeAssistantOutput(assistantLastOutput);
+  const srcAssistantLastOutput = incomingAssistantLastOutput
+    || (withheldCompletions.has(sessionId) ? (existing && existing.assistantLastOutput) || null : null);
+  const srcAssistantLastOutputTruncated = !!(
+    srcAssistantLastOutput
+    && (incomingAssistantLastOutput
+      ? assistantLastOutputTruncated === true
+      : !!(existing && existing.assistantLastOutputTruncated === true))
+  );
   const incomingToolName = normalizeToolName(toolName);
   const srcToolName = incomingToolName || (existing && existing.lastToolName) || null;
   const srcTranscriptPath = normalizeTranscriptPath(transcriptPath) || (existing && existing.transcriptPath) || null;
@@ -1929,12 +1961,17 @@ function updateSession(sessionId, state, event, opts = {}) {
       backgroundTasksCount,
       sessionCronsCount,
       stopHookActive,
-      hasFinalAssistantText: !!srcAssistantLastOutput,
+      // Incoming, never the carried-forward value: this asks whether THIS Stop
+      // ended the turn with text. Feeding it a carried value flips a genuinely
+      // text-less Stop from "hold" to "promote", celebrating and pushing while
+      // background work is still live -- the exact case #406 exists to prevent.
+      hasFinalAssistantText: !!incomingAssistantLastOutput,
       headless: srcHeadless,
     });
     const hardLiveWork = disposition.kind === "hold";
     const debounceMs = disposition.debounceMs;
     if (hardLiveWork || debounceMs > 0) {
+      withheldCompletions.add(sessionId);
       // Hold the Stop as "working" and DROP the event to null so recentEvents
       // keeps NO "Stop" tail while held. Why null and not "Stop": deriveSessionBadge
       // only inspects the latest event, so a withheld Stop tail would (a) be

--- a/src/state.js
+++ b/src/state.js
@@ -179,14 +179,9 @@ let stateChangedAt = Date.now();
 let pendingTimer = null;
 let autoReturnTimer = null;
 let pendingState = null;
-// #406 Stop completion debounce: sessionId -> timer holding a Stop as "working"
-// until a quiet window confirms the turn really ended.
-const pendingCompletionTimers = new Map();
-// Sessions whose completion the #406 gate is currently withholding, by either
-// shape: a debounce timer, or a hard hold that only a later Stop can release.
-// This is the exact window in which a replayed Stop must still know the answer
-// the withheld Stop carried, and it is entered only from the claude-code gate.
-const withheldCompletions = new Set();
+// #406 Stop completion debounce: sessionId -> record holding one exact Stop
+// as "working" until a quiet window confirms the turn really ended.
+const pendingCompletionDebounces = new Map();
 let eyeResendTimer = null;
 let updateVisualState = null;
 let updateVisualKind = null;
@@ -1160,7 +1155,7 @@ function evictOldestSessionIfNeeded(sessionId) {
     }
   }
 
-  if (oldestId) sessions.delete(oldestId);
+  if (oldestId) deleteSessionWithCompletionCleanup(oldestId, "max-sessions-evict");
 }
 
 // Sets / clears `requiresCompletionAck` based on the current event.
@@ -1430,31 +1425,39 @@ function getQuotaSourceCount() {
 // and bg-only Stops with final assistant text can be debounced: hold "working"
 // and only celebrate if no forward-progress event for the session arrives
 // within the window.
-function scheduleCompletionDebounce(sessionId, debounceMs) {
-  const existing = pendingCompletionTimers.get(sessionId);
-  if (existing) clearTimeout(existing);
-  const timer = setTimeout(() => {
-    pendingCompletionTimers.delete(sessionId);
-    promoteCompletion(sessionId);
+function scheduleCompletionDebounce(sessionId, debounceMs, payload = {}) {
+  const existing = pendingCompletionDebounces.get(sessionId);
+  if (existing && existing.timer) clearTimeout(existing.timer);
+  const text = normalizeAssistantOutput(payload && payload.text);
+  const record = {
+    timer: null,
+    assistantLastOutput: text,
+    assistantLastOutputTruncated: !!(text && payload && payload.truncated === true),
+  };
+  record.timer = setTimeout(() => {
+    if (pendingCompletionDebounces.get(sessionId) !== record) return;
+    pendingCompletionDebounces.delete(sessionId);
+    promoteCompletion(sessionId, {
+      text: record.assistantLastOutput,
+      truncated: record.assistantLastOutputTruncated,
+    });
   }, debounceMs);
-  pendingCompletionTimers.set(sessionId, timer);
+  pendingCompletionDebounces.set(sessionId, record);
 }
 
 function cancelCompletionDebounce(sessionId, reason) {
-  // Runs before the early return: a hard hold has no timer, and it still has to
-  // release the withheld marker.
-  withheldCompletions.delete(sessionId);
-  const timer = pendingCompletionTimers.get(sessionId);
-  if (!timer) return;
-  clearTimeout(timer);
-  pendingCompletionTimers.delete(sessionId);
+  const record = pendingCompletionDebounces.get(sessionId);
+  if (!record) return;
+  if (record.timer) clearTimeout(record.timer);
+  pendingCompletionDebounces.delete(sessionId);
   debugSession(`stop-debounce cancel sid=${sessionId} by=${reason || "-"}`);
 }
 
 function clearAllCompletionDebounces() {
-  for (const timer of pendingCompletionTimers.values()) clearTimeout(timer);
-  pendingCompletionTimers.clear();
-  withheldCompletions.clear();
+  for (const record of pendingCompletionDebounces.values()) {
+    if (record && record.timer) clearTimeout(record.timer);
+  }
+  pendingCompletionDebounces.clear();
 }
 
 function cancelClaudeTranscriptCompletionProbe(sessionId, reason) {
@@ -1468,6 +1471,12 @@ function cancelClaudeTranscriptCompletionProbe(sessionId, reason) {
 function clearAllClaudeTranscriptCompletionProbes() {
   for (const { timer } of claudeTranscriptCompletionProbes.values()) clearTimeout(timer);
   claudeTranscriptCompletionProbes.clear();
+}
+
+function deleteSessionWithCompletionCleanup(sessionId, reason) {
+  cancelCompletionDebounce(sessionId, reason);
+  cancelClaudeTranscriptCompletionProbe(sessionId, reason);
+  return sessions.delete(sessionId);
 }
 
 function isClaudeElicitationCompletionTool(toolName) {
@@ -1523,10 +1532,18 @@ function scheduleClaudeTranscriptCompletionProbe(sessionId, transcriptPath) {
 // tail over any Notification that landed during the window), settle to idle,
 // and only now flip awaitingInputSinceStop. Then celebrate, unless a Kimi
 // permission lock is holding the pet.
-function promoteCompletion(sessionId) {
-  withheldCompletions.delete(sessionId);
+function promoteCompletion(sessionId, completionPayload = undefined) {
   const session = sessions.get(sessionId);
   if (!session) return;
+  if (completionPayload !== undefined) {
+    const text = normalizeAssistantOutput(completionPayload && completionPayload.text);
+    session.assistantLastOutput = text;
+    session.assistantLastOutputTruncated = !!(
+      text
+      && completionPayload
+      && completionPayload.truncated === true
+    );
+  }
   session.subagentTracker = clearSubagentTracker(cloneSubagentTracker(session));
   // The stored session settles idle, but this Stop consumed the completion
   // attention cue. Record that distinction so a later duplicate Stop is
@@ -1899,29 +1916,11 @@ function updateSession(sessionId, state, event, opts = {}) {
   );
   const srcContextUsage = resolvedContextUsage.contextUsage;
   const srcContextUsageOrigin = resolvedContextUsage.contextUsageOrigin;
-  // Sticky ONLY while the #406 gate is withholding this session's completion.
-  // The Stop that carries the answer can be withheld and replayed later by
-  // promoteCompletion; any event arriving inside that window (Notification,
-  // PermissionResult, SessionStart(resume), ...) carries no assistant output and
-  // would otherwise rewrite the recorded answer to null, so the replayed
-  // completion ships title-only -- or, with plain Telegram pings disabled, is
-  // dropped entirely.
-  //
-  // The window is the bound. An earlier attempt made the field sticky for every
-  // event and cleared it at a guessed turn boundary (UserPromptSubmit /
-  // SessionStart), which leaked one turn's answer into the next on any agent
-  // that emits neither -- the Codex JSONL monitor emits task_started /
-  // task_complete and nothing else, so the clear was structurally unreachable
-  // there. Only the claude-code gate ever populates withheldCompletions, so
-  // agents that cannot be withheld cannot carry anything forward.
   const incomingAssistantLastOutput = normalizeAssistantOutput(assistantLastOutput);
-  const srcAssistantLastOutput = incomingAssistantLastOutput
-    || (withheldCompletions.has(sessionId) ? (existing && existing.assistantLastOutput) || null : null);
+  const srcAssistantLastOutput = incomingAssistantLastOutput;
   const srcAssistantLastOutputTruncated = !!(
     srcAssistantLastOutput
-    && (incomingAssistantLastOutput
-      ? assistantLastOutputTruncated === true
-      : !!(existing && existing.assistantLastOutputTruncated === true))
+    && assistantLastOutputTruncated === true
   );
   const incomingToolName = normalizeToolName(toolName);
   const srcToolName = incomingToolName || (existing && existing.lastToolName) || null;
@@ -1971,7 +1970,6 @@ function updateSession(sessionId, state, event, opts = {}) {
     const hardLiveWork = disposition.kind === "hold";
     const debounceMs = disposition.debounceMs;
     if (hardLiveWork || debounceMs > 0) {
-      withheldCompletions.add(sessionId);
       // Hold the Stop as "working" and DROP the event to null so recentEvents
       // keeps NO "Stop" tail while held. Why null and not "Stop": deriveSessionBadge
       // only inspects the latest event, so a withheld Stop tail would (a) be
@@ -1994,7 +1992,10 @@ function updateSession(sessionId, state, event, opts = {}) {
             `stop-gate sid=${sessionId} bg=${backgroundTasksCount} crons=${sessionCronsCount} active=${stopHookActive} action=debounce-working`
           );
         }
-        scheduleCompletionDebounce(sessionId, debounceMs);
+        scheduleCompletionDebounce(sessionId, debounceMs, {
+          text: incomingAssistantLastOutput,
+          truncated: assistantLastOutputTruncated === true,
+        });
       }
     }
     // debounceMs <= 0 && !hardLiveWork → keep "attention" (immediate celebration).
@@ -2171,7 +2172,7 @@ function updateSession(sessionId, state, event, opts = {}) {
         sessions.set(sessionId, { state: resumeState, updatedAt: Date.now(), displayHint: dh, ...base, resumeState: null });
         debugSession(`subagent-stop restore ${describeSession(sessionId, sessions.get(sessionId))}`);
       } else {
-        sessions.delete(sessionId);
+        deleteSessionWithCompletionCleanup(sessionId, "subagent-stop-no-resume");
         debugSession(`subagent-stop delete sid=${sessionId} reason=no-resume`);
       }
     } else {
@@ -2200,7 +2201,7 @@ function updateSession(sessionId, state, event, opts = {}) {
         reason: "session-end",
       });
     }
-    sessions.delete(sessionId);
+    deleteSessionWithCompletionCleanup(sessionId, "session-end");
     debugSession(`session-end delete ${describeSession(sessionId, endingSession)}`);
     cleanStaleSessions();
     if (srcAgentId === "kimi-cli") disposeKimiPermissionSession(sessionId);
@@ -2556,7 +2557,7 @@ function cleanStaleSessions() {
           reason: `stale-delete-${decision.reason}`,
         });
       }
-      sessions.delete(id); changed = true;
+      deleteSessionWithCompletionCleanup(id, `stale-delete-${decision.reason}`); changed = true;
       continue;
     }
 
@@ -2608,7 +2609,7 @@ function dismissSession(sessionId) {
   const session = sessions.get(id);
   if (!session) return false;
   if (session.agentId === "codex") cancelCodexExitProbe(id, "session-hidden");
-  sessions.delete(id);
+  deleteSessionWithCompletionCleanup(id, "session-hidden");
   if (session.agentId === "kimi-cli") disposeKimiSessionState(id, "kimi-session-hidden");
   const resolved = resolveDisplayState();
   setState(resolved, getSvgOverride(resolved));
@@ -2673,7 +2674,7 @@ function clearSessionsByAgent(agentId) {
   for (const [id, s] of sessions) {
     if (s && s.agentId === agentId) {
       if (agentId === "codex") cancelCodexExitProbe(id, "clear-sessions");
-      sessions.delete(id);
+      deleteSessionWithCompletionCleanup(id, "clear-sessions");
       if (agentId === "kimi-cli") disposeKimiSessionState(id, "kimi-clear-sessions");
       removed++;
     }

--- a/test/completion-notify-integration.test.js
+++ b/test/completion-notify-integration.test.js
@@ -120,3 +120,240 @@ describe("#406 state -> Telegram completion integration", () => {
     assert.strictEqual(sent.length, 1, "the Notification does not bury the completion; exactly one push");
   });
 });
+
+// The gate above can withhold a Stop and replay it later via promoteCompletion.
+// Any event arriving inside that window carries no assistant output, so before
+// the state.js carry-forward the recorded answer was rewritten to null and the
+// promoted completion shipped title-only — or, with plain pings disabled, was
+// dropped entirely. The cases above drive this exact sequence but assert only
+// sent.length, which is why the regression was invisible.
+describe("#406 completion hold preserves the assistant output", () => {
+  let api;
+  let sent;
+  let savedDebounceEnv;
+
+  // Assert on the VISIBLE text, never on JSON.stringify of the message: the
+  // message object carries a `truncated` field, so a serialized form contains
+  // the word "truncated" whatever its value.
+  function sentText(i) {
+    const value = sent[i];
+    return value && typeof value === "object" && typeof value.plainText === "string"
+      ? value.plainText
+      : String(value == null ? "" : value);
+  }
+
+  function setup({ notifyOnComplete = true } = {}) {
+    sent = [];
+    const companion = createTelegramCompanion({
+      getClient: () => ({
+        sendNotification: async (text) => { sent.push(text); return { ok: true }; },
+      }),
+      isEnabled: () => true,
+      getNotifyOnComplete: () => notifyOnComplete,
+      getCompletionOutputMode: () => "full",
+    });
+    companion.onSnapshot({ sessions: [] }); // prime dedupe (no backlog re-ping)
+    api = require("../src/state")(makeCtx({
+      broadcastSessionSnapshot: (snapshot) => companion.onSnapshot(snapshot),
+    }));
+  }
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    savedDebounceEnv = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    process.env.CLAWD_COMPLETION_DEBOUNCE_MS = "1000";
+  });
+  afterEach(() => {
+    if (api) api.cleanup();
+    api = null;
+    mock.timers.reset();
+    if (savedDebounceEnv === undefined) delete process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    else process.env.CLAWD_COMPLETION_DEBOUNCE_MS = savedDebounceEnv;
+  });
+
+  it("keeps the answer when a Notification lands inside the hold", async () => {
+    setup();
+    stop(api, "s1", { assistantLastOutput: "HELD-TURN-ANSWER" });
+    mock.timers.tick(400);
+    api.updateSession("s1", "notification", "Notification", { agentId: "claude-code" });
+    await flush();
+    mock.timers.tick(1000);
+    await flush();
+    assert.strictEqual(sent.length, 1, "exactly one completion push");
+    assert.ok(
+      sentText(0).includes("HELD-TURN-ANSWER"),
+      `promoted completion must still carry the assistant output, got: ${sentText(0)}`,
+    );
+  });
+
+  it("still delivers the completion when plain pings are off and an event lands inside the hold", async () => {
+    // With getNotifyOnComplete() false the push exists only to carry the
+    // output, so losing the field drops the notification outright.
+    setup({ notifyOnComplete: false });
+    stop(api, "s1", { assistantLastOutput: "OUTPUT-ONLY-ANSWER" });
+    mock.timers.tick(400);
+    api.updateSession("s1", "notification", "Notification", { agentId: "claude-code" });
+    await flush();
+    mock.timers.tick(1000);
+    await flush();
+    assert.strictEqual(sent.length, 1, "output-only completion must not be dropped");
+    assert.ok(
+      sentText(0).includes("OUTPUT-ONLY-ANSWER"),
+      `output-only completion must carry the assistant output, got: ${sentText(0)}`,
+    );
+  });
+
+  // The truncated flag is inherited only when the text is inherited. If it were
+  // taken from the incoming event instead, a carried-forward truncated answer
+  // would ship without its "(truncated)" marker and read as complete.
+  it("carries the truncation marker along with the answer", async () => {
+    setup();
+    stop(api, "s1", { assistantLastOutput: "CLIPPED-ANSWER", assistantLastOutputTruncated: true });
+    mock.timers.tick(400);
+    api.updateSession("s1", "notification", "Notification", { agentId: "claude-code" });
+    await flush();
+    mock.timers.tick(1000);
+    await flush();
+
+    assert.strictEqual(sent.length, 1, "exactly one completion push");
+    assert.ok(sentText(0).includes("CLIPPED-ANSWER"), "the answer survives");
+    assert.ok(
+      sentText(0).includes("Assistant output (truncated):"),
+      `a carried-forward truncated answer must still be marked truncated, got: ${sentText(0)}`,
+    );
+  });
+
+  it("does not leak the previous turn's answer into the next completion", async () => {
+    setup();
+    stop(api, "s1", { assistantLastOutput: "TURN-ONE-ANSWER" });
+    mock.timers.tick(1000);
+    await flush();
+    assert.strictEqual(sent.length, 1, "turn one pushes once");
+
+    api.updateSession("s1", "working", "UserPromptSubmit", { agentId: "claude-code" });
+    await flush();
+    stop(api, "s1", { agentId: "claude-code" }); // turn two ends with no text
+    mock.timers.tick(1000);
+    await flush();
+    assert.strictEqual(sent.length, 2, "turn two pushes once");
+    assert.ok(
+      !sentText(1).includes("TURN-ONE-ANSWER"),
+      `turn two must not carry turn one's answer, got: ${sentText(1)}`,
+    );
+  });
+});
+
+// The carry-forward is bounded by the hold window, not by a guessed turn
+// boundary. These pin the two ways a boundary-based version went wrong.
+describe("#406 completion hold does not overreach", () => {
+  let api;
+  let sent;
+  let savedDebounceEnv;
+
+  function sentText(i) {
+    const value = sent[i];
+    return value && typeof value === "object" && typeof value.plainText === "string"
+      ? value.plainText
+      : String(value == null ? "" : value);
+  }
+
+  function setup() {
+    sent = [];
+    const companion = createTelegramCompanion({
+      getClient: () => ({
+        sendNotification: async (text) => { sent.push(text); return { ok: true }; },
+      }),
+      isEnabled: () => true,
+      getNotifyOnComplete: () => true,
+      getCompletionOutputMode: () => "full",
+    });
+    companion.onSnapshot({ sessions: [] });
+    api = require("../src/state")(makeCtx({
+      broadcastSessionSnapshot: (snapshot) => companion.onSnapshot(snapshot),
+    }));
+  }
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    savedDebounceEnv = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    process.env.CLAWD_COMPLETION_DEBOUNCE_MS = "1000";
+  });
+  afterEach(() => {
+    if (api) api.cleanup();
+    api = null;
+    mock.timers.reset();
+    if (savedDebounceEnv === undefined) delete process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    else process.env.CLAWD_COMPLETION_DEBOUNCE_MS = savedDebounceEnv;
+  });
+
+  // The Codex JSONL monitor emits task_started / task_complete and never
+  // UserPromptSubmit or SessionStart, so a boundary-based carry-forward could
+  // never clear and shipped turn N's answer as turn N+1's completion. Only the
+  // claude-code gate can withhold, so codex must never carry anything forward.
+  it("never carries an answer between turns on an agent that cannot be withheld", async () => {
+    setup();
+    api.updateSession("cx1", "attention", "event_msg:task_complete", {
+      agentId: "codex",
+      assistantLastOutput: "TURN-ONE-SECRET-ANSWER",
+    });
+    await flush();
+    assert.strictEqual(sent.length, 1, "turn one pushes once");
+    assert.ok(sentText(0).includes("TURN-ONE-SECRET-ANSWER"), "turn one carries its own answer");
+
+    mock.timers.tick(5000);
+    api.updateSession("cx1", "working", "event_msg:task_started", { agentId: "codex" });
+    await flush();
+    api.updateSession("cx1", "attention", "event_msg:task_complete", { agentId: "codex" });
+    await flush();
+
+    assert.strictEqual(sent.length, 2, "turn two pushes once");
+    assert.ok(
+      !sentText(1).includes("TURN-ONE-SECRET-ANSWER"),
+      `turn two must not carry turn one's answer, got: ${sentText(1)}`,
+    );
+  });
+
+  // A held completion can end by being CANCELLED rather than promoted -- a new
+  // prompt inside the quiet window means the turn never ended. The marker has to
+  // be released there too, or the answer stays sticky into the next turn.
+  it("releases the carry-forward when the hold is cancelled instead of promoted", async () => {
+    setup();
+    stop(api, "s2", { assistantLastOutput: "CANCELLED-TURN-ANSWER" });
+    mock.timers.tick(400);
+    api.updateSession("s2", "working", "UserPromptSubmit", { agentId: "claude-code" });
+    await flush();
+    assert.strictEqual(sent.length, 0, "a cancelled hold never pushes");
+
+    mock.timers.tick(5000);
+    stop(api, "s2", { agentId: "claude-code" }); // next turn ends with no text
+    mock.timers.tick(1000);
+    await flush();
+
+    assert.strictEqual(sent.length, 1, "the next turn pushes once");
+    assert.ok(
+      !sentText(0).includes("CANCELLED-TURN-ANSWER"),
+      `a cancelled hold must not leak its answer forward, got: ${sentText(0)}`,
+    );
+  });
+
+  // The gate asks whether THIS Stop ended the turn with text. A carried-forward
+  // value made a text-less Stop look complete, releasing a hard hold while
+  // background work was still live.
+  it("does not let a carried answer release a hard hold", async () => {
+    setup();
+    stop(api, "s9", { stopHookActive: true, assistantLastOutput: "TURN-TEXT" });
+    await flush();
+    assert.strictEqual(sent.length, 0, "a stop-hook veto holds");
+
+    mock.timers.tick(5000);
+    stop(api, "s9", { backgroundTasksCount: 1 });
+    await flush();
+    mock.timers.tick(5000);
+    await flush();
+
+    assert.strictEqual(
+      sent.length, 0,
+      `live background work must still hold; pushed: ${sent.map((_, i) => sentText(i)).join(" | ")}`,
+    );
+  });
+});

--- a/test/completion-notify-integration.test.js
+++ b/test/completion-notify-integration.test.js
@@ -336,6 +336,101 @@ describe("#406 completion hold does not overreach", () => {
     );
   });
 
+  it("does not leak hard-held intermediate output into a later textless Stop", async () => {
+    setup();
+    stop(api, "s-hard", {
+      stopHookActive: true,
+      assistantLastOutput: "INTERMEDIATE-NOT-FINAL",
+    });
+    mock.timers.tick(5000);
+    await flush();
+    assert.strictEqual(sent.length, 0, "hard-held intermediate output must not push");
+
+    stop(api, "s-hard");
+    mock.timers.tick(1000);
+    await flush();
+
+    assert.strictEqual(sent.length, 1, "the later plain Stop still completes once");
+    assert.ok(
+      !sentText(0).includes("INTERMEDIATE-NOT-FINAL"),
+      `later textless Stop must not reuse hard-held intermediate output, got: ${sentText(0)}`,
+    );
+  });
+
+  it("uses only the later Stop output after a hard-held intermediate Stop", async () => {
+    setup();
+    stop(api, "s-hard-final", {
+      stopHookActive: true,
+      assistantLastOutput: "INTERMEDIATE-NOT-FINAL",
+    });
+    mock.timers.tick(5000);
+    await flush();
+
+    stop(api, "s-hard-final", { assistantLastOutput: "ACTUAL-FINAL-ANSWER" });
+    mock.timers.tick(1000);
+    await flush();
+
+    assert.strictEqual(sent.length, 1, "the later final Stop completes once");
+    assert.ok(sentText(0).includes("ACTUAL-FINAL-ANSWER"), "later Stop output survives");
+    assert.ok(
+      !sentText(0).includes("INTERMEDIATE-NOT-FINAL"),
+      `later final Stop must not include hard-held intermediate output, got: ${sentText(0)}`,
+    );
+  });
+
+  it("does not leak hard-held output through a Notification into a later textless Stop", async () => {
+    setup();
+    stop(api, "s-hard-notification", {
+      stopHookActive: true,
+      assistantLastOutput: "INTERMEDIATE-NOT-FINAL",
+    });
+    api.updateSession("s-hard-notification", "notification", "Notification", { agentId: "claude-code" });
+    mock.timers.tick(5000);
+    await flush();
+    assert.strictEqual(sent.length, 0, "hard-held intermediate output must not push through notification");
+
+    stop(api, "s-hard-notification");
+    mock.timers.tick(1000);
+    await flush();
+
+    assert.strictEqual(sent.length, 1, "the later textless Stop completes once");
+    assert.ok(
+      !sentText(0).includes("INTERMEDIATE-NOT-FINAL"),
+      `later textless Stop must not inherit hard-held output after Notification, got: ${sentText(0)}`,
+    );
+  });
+
+  it("uses the superseding debounced Stop payload exactly once", async () => {
+    setup();
+    stop(api, "s-supersede", { assistantLastOutput: "FIRST-DEBOUNCED-ANSWER" });
+    mock.timers.tick(500);
+    stop(api, "s-supersede", { assistantLastOutput: "SECOND-DEBOUNCED-ANSWER" });
+    mock.timers.tick(1000);
+    await flush();
+
+    assert.strictEqual(sent.length, 1, "the superseding Stop completes once");
+    assert.ok(sentText(0).includes("SECOND-DEBOUNCED-ANSWER"), "latest debounced Stop output wins");
+    assert.ok(
+      !sentText(0).includes("FIRST-DEBOUNCED-ANSWER"),
+      `superseded Stop output must not leak, got: ${sentText(0)}`,
+    );
+  });
+
+  it("does not send a duplicate completion notification for the same Stop payload", async () => {
+    setup();
+    stop(api, "s-dup-payload", { assistantLastOutput: "FINAL-ONCE" });
+    mock.timers.tick(1000);
+    await flush();
+    assert.strictEqual(sent.length, 1, "first completion pushes once");
+    assert.ok(sentText(0).includes("FINAL-ONCE"), "first completion carries its output");
+
+    stop(api, "s-dup-payload", { assistantLastOutput: "FINAL-ONCE" });
+    mock.timers.tick(1000);
+    await flush();
+
+    assert.strictEqual(sent.length, 1, "duplicate Stop with the same payload must not push again");
+  });
+
   // The gate asks whether THIS Stop ended the turn with text. A carried-forward
   // value made a text-less Stop look complete, releasing a hard hold while
   // background work was still live.

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -11,7 +11,7 @@ themeLoader.init(path.join(__dirname, "..", "src"));
 const _defaultTheme = themeLoader.loadTheme("clawd");
 const _calicoTheme = themeLoader.loadTheme("calico");
 const { createTranslator } = require("../src/i18n");
-const { makeSessionKey } = require("../src/session-key");
+const { makeSessionKey, resolveSessionIdentity } = require("../src/session-key");
 const { isSessionInProgress } = require("../src/state-session-snapshot");
 const { countLiveSubagents } = require("../src/state-visual-resolver");
 
@@ -4407,6 +4407,197 @@ describe("Stop completion gate (#406)", () => {
     assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
   });
 
+  it("debounce: dismissSession cancels a pending completion before same-id lease restore", () => {
+    const rawSessionId = "debounce-dismiss-restore";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
+    update(api, {
+      id: sessionId,
+      rawSessionId,
+      state: "attention",
+      event: "Stop",
+      assistantLastOutput: "OLD DEBOUNCED OUTPUT",
+    });
+    mock.timers.tick(500);
+    assert.strictEqual(api.dismissSession(sessionId), true);
+    assert.strictEqual(api.restoreSessionFromLease({
+      sessionId: rawSessionId,
+      agentId: "claude-code",
+      active: true,
+      eventAt: 1,
+      validUntil: null,
+      state: "working",
+      pid: 12345,
+      cwd: "/tmp",
+    }), true);
+
+    mock.timers.tick(1000);
+
+    const session = api.sessions.get(sessionId);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.assistantLastOutput, null);
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+  });
+
+  it("debounce: background-task final-text quiet window is cancelled before same-id lease restore", () => {
+    const rawSessionId = "debounce-bg-final-dismiss-restore";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
+    update(api, {
+      id: sessionId,
+      rawSessionId,
+      state: "attention",
+      event: "Stop",
+      backgroundTasksCount: 1,
+      assistantLastOutput: "OLD BG-FINAL OUTPUT",
+    });
+    mock.timers.tick(500);
+    assert.strictEqual(api.dismissSession(sessionId), true);
+    assert.strictEqual(api.restoreSessionFromLease({
+      sessionId: rawSessionId,
+      agentId: "claude-code",
+      active: true,
+      eventAt: 1,
+      validUntil: null,
+      state: "working",
+      pid: 12345,
+      cwd: "/tmp",
+    }), true);
+
+    mock.timers.tick(1000);
+
+    const session = api.sessions.get(sessionId);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.assistantLastOutput, null);
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+  });
+
+  it("debounce: clearSessionsByAgent cancels a pending completion before same-id lease restore", () => {
+    const rawSessionId = "debounce-clear-restore";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
+    update(api, {
+      id: sessionId,
+      rawSessionId,
+      state: "attention",
+      event: "Stop",
+      assistantLastOutput: "OLD DEBOUNCED OUTPUT",
+    });
+    mock.timers.tick(500);
+    assert.strictEqual(api.clearSessionsByAgent("claude-code"), 1);
+    assert.strictEqual(api.restoreSessionFromLease({
+      sessionId: rawSessionId,
+      agentId: "claude-code",
+      active: true,
+      eventAt: 1,
+      validUntil: null,
+      state: "working",
+      pid: 12345,
+      cwd: "/tmp",
+    }), true);
+
+    mock.timers.tick(1000);
+
+    const session = api.sessions.get(sessionId);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.assistantLastOutput, null);
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+  });
+
+  it("debounce: stale-delete cancels a pending completion before same-id lease restore", () => {
+    api.cleanup();
+    ctx = makeCtx({
+      processKill: makePidKill(new Set()),
+      playSound: (name) => soundsPlayed.push(name),
+      sendToRenderer: (channel, ...args) => {
+        if (channel === "state-change") stateChanges.push(args[0]);
+      },
+    });
+    api = require("../src/state")(ctx);
+    const rawSessionId = "debounce-stale-delete-restore";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
+    update(api, {
+      id: sessionId,
+      rawSessionId,
+      state: "attention",
+      event: "Stop",
+      assistantLastOutput: "OLD STALE-DELETED OUTPUT",
+      agentPid: 12345,
+    });
+    const pending = api.sessions.get(sessionId);
+    pending.pidReachable = true;
+    pending.agentPid = 12345;
+    mock.timers.tick(500);
+    api.cleanStaleSessions();
+    assert.strictEqual(api.sessions.has(sessionId), false);
+    assert.strictEqual(api.restoreSessionFromLease({
+      sessionId: rawSessionId,
+      agentId: "claude-code",
+      active: true,
+      eventAt: 1,
+      validUntil: null,
+      state: "working",
+      pid: 12345,
+      cwd: "/tmp",
+    }), true);
+
+    mock.timers.tick(1000);
+
+    const session = api.sessions.get(sessionId);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.assistantLastOutput, null);
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+  });
+
+  it("debounce: MAX_SESSIONS eviction cancels a pending completion before same-id lease restore", () => {
+    const rawSessionId = "debounce-evict-restore";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
+    update(api, {
+      id: sessionId,
+      rawSessionId,
+      state: "attention",
+      event: "Stop",
+      assistantLastOutput: "OLD EVICTED OUTPUT",
+    });
+    api.sessions.get(sessionId).updatedAt = Date.now();
+    mock.timers.tick(500);
+    for (let i = 0; i < 19; i++) {
+      api.sessions.set(`evict-filler-${i}`, rawSession("idle", {
+        agentId: "codex",
+        host: "ssh:example.com",
+        updatedAt: Date.now() + i + 1,
+      }));
+    }
+
+    update(api, {
+      id: "eviction-trigger",
+      state: "working",
+      event: "PreToolUse",
+      agentId: "claude-code",
+    });
+    assert.strictEqual(api.sessions.has(sessionId), false, "pending completion owner should be evicted");
+    assert.strictEqual(api.dismissSession("eviction-trigger"), true, "make room for the restored lease");
+    assert.strictEqual(api.restoreSessionFromLease({
+      sessionId: rawSessionId,
+      agentId: "claude-code",
+      active: true,
+      eventAt: 1,
+      validUntil: null,
+      state: "working",
+      pid: 12345,
+      cwd: "/tmp",
+    }), true);
+
+    mock.timers.tick(1000);
+
+    const session = api.sessions.get(sessionId);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.assistantLastOutput, null);
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+  });
+
   it("debounce: a duplicate Stop after auto-return does not replay completion", () => {
     update(api, { id: "s1", state: "attention", event: "Stop" });
     mock.timers.tick(1000);
@@ -4530,36 +4721,106 @@ describe("Stop completion gate (#406)", () => {
   it("Claude AskUserQuestion PostToolUse falls back to transcript completion when Stop is missed", () => {
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-claude-stop-fallback-"));
     const transcript = path.join(dir, "transcript.jsonl");
+    const rawSessionId = "claude-probe-hit";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
     fs.writeFileSync(transcript, [
-      JSON.stringify({ type: "assistant", sessionId: "s1", message: { content: [{ type: "tool_use", name: "AskUserQuestion" }] } }),
-      JSON.stringify({ type: "user", sessionId: "s1", message: { content: [{ type: "tool_result", content: "Allow" }] } }),
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "AskUserQuestion" }] } }),
+      JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", content: "Allow" }] } }),
     ].join("\n") + "\n");
 
     update(api, {
-      id: "s1",
+      id: sessionId,
       state: "working",
       event: "PostToolUse",
+      rawSessionId,
       toolName: "AskUserQuestion",
       transcriptPath: transcript,
     });
 
     mock.timers.tick(1999);
-    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.strictEqual(api.sessions.get(sessionId).state, "working");
     assert.deepStrictEqual(soundsPlayed, []);
 
     fs.appendFileSync(transcript, JSON.stringify({
       type: "assistant",
-      sessionId: "s1",
       message: { content: "Final answer from Claude Desktop." },
     }) + "\n");
     mock.timers.tick(1);
 
-    const session = api.sessions.get("s1");
+    const session = api.sessions.get(sessionId);
     assert.strictEqual(session.state, "idle");
     assert.strictEqual(session.assistantLastOutput, "Final answer from Claude Desktop.");
     assert.strictEqual(api.getCurrentState(), "attention");
     assert.ok(soundsPlayed.includes("complete"));
     assert.strictEqual(api.deriveSessionBadge(session), "done");
+  });
+
+  it("Claude transcript fallback documents raw transcript sessionId mismatch", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-claude-stop-fallback-"));
+    const transcript = path.join(dir, "transcript.jsonl");
+    const rawSessionId = "claude-probe-raw-mismatch";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: "assistant", sessionId: rawSessionId, message: { content: [{ type: "tool_use", name: "AskUserQuestion" }] } }),
+      JSON.stringify({ type: "user", sessionId: rawSessionId, message: { content: [{ type: "tool_result", content: "Allow" }] } }),
+      JSON.stringify({ type: "assistant", sessionId: rawSessionId, message: { content: "Final answer from raw transcript." } }),
+    ].join("\n") + "\n");
+
+    update(api, {
+      id: sessionId,
+      state: "working",
+      event: "PostToolUse",
+      rawSessionId,
+      toolName: "AskUserQuestion",
+      transcriptPath: transcript,
+    });
+    mock.timers.tick(10000);
+
+    const session = api.sessions.get(sessionId);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.assistantLastOutput, null);
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+  });
+
+  it("Claude transcript completion fallback is cancelled before restoring the same raw session id", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-claude-stop-fallback-"));
+    const transcript = path.join(dir, "transcript.jsonl");
+    const rawSessionId = "claude-probe-restore-race";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "AskUserQuestion" }] } }),
+      JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", content: "Allow" }] } }),
+      JSON.stringify({ type: "assistant", message: { content: "OLD TRANSCRIPT FINAL" } }),
+    ].join("\n") + "\n");
+
+    update(api, {
+      id: sessionId,
+      state: "working",
+      event: "PostToolUse",
+      rawSessionId,
+      toolName: "AskUserQuestion",
+      transcriptPath: transcript,
+    });
+    assert.strictEqual(api.dismissSession(sessionId), true);
+    assert.strictEqual(api.restoreSessionFromLease({
+      sessionId: rawSessionId,
+      agentId: "claude-code",
+      active: true,
+      eventAt: 1,
+      validUntil: null,
+      state: "working",
+      pid: 12345,
+      cwd: dir,
+    }), true);
+
+    mock.timers.tick(2000);
+
+    const session = api.sessions.get(sessionId);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.assistantLastOutput, null);
+    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
   });
 
   it("Claude transcript completion fallback is limited to AskUserQuestion tool results", () => {


### PR DESCRIPTION
## What breaks

Claude completion can be delayed by the #406 completion gate. In that window, the original `Stop` may carry the assistant's final output, while later housekeeping events such as `Notification` do not.

If the delayed completion is replayed after those later events rewrite the session fields, completion consumers can lose the assistant output and send a title-only completion. With output-only notification settings, that can drop the completion notification entirely.

There is a second lifecycle hazard in the same area: delayed completion callbacks must not survive session deletion and later promote a newly restored lifecycle that happens to reuse the same canonical session id.

## The fix

This PR now uses an exact per-debounce record instead of a session-level sticky carry flag:

- `pendingCompletionDebounces` stores the payload for the specific `Stop` that actually entered the debounce window.
- Hard holds such as `stop_hook_active`, live background tasks without final text, or session crons do not create a replay record, so they cannot leak intermediate output into a later `Stop`.
- `promoteCompletion(sessionId, completionPayload = undefined)` treats an explicit payload object as the debounce path. `undefined` remains the transcript/current-session path. Empty payloads clear output instead of preserving stale text.

Session deletion now goes through `deleteSessionWithCompletionCleanup()`, which cancels both completion debounce records and Claude transcript completion probes before deleting the session. The six deletion paths covered are:

- max-session eviction;
- subagent no-resume cleanup;
- `SessionEnd`;
- stale-delete cleanup;
- `dismissSession()`;
- `clearSessionsByAgent()`.

The canonical/raw transcript `sessionId` mismatch found during review is deliberately left out of this PR and is tracked separately in #908.

## Tests

Added and updated coverage in:

- `test/completion-notify-integration.test.js`
- `test/state.test.js`

The regression matrix covers:

- held/debounced completion output surviving housekeeping events;
- output-only completion notifications not being dropped;
- truncation metadata replaying with the exact payload;
- hard-held intermediate output not leaking into later textless or final `Stop` events;
- hard hold plus `Notification` plus later textless `Stop`;
- superseding debounced `Stop` using the latest payload exactly once;
- duplicate same-payload `Stop` not sending a duplicate completion notification;
- dismiss / clear-agent / stale-delete / max-session eviction deleting a session before same-id lease restore without an old timer promoting the new lifecycle;
- Claude transcript probe deletion before same-id restore;
- a raw transcript `sessionId` mismatch guard documenting the current follow-up boundary.

Local targeted validation on this exact head:

```text
test/state.test.js                         338/338
test/completion-notify-integration.test.js  19/19
test/state-session-snapshot.test.js         64/64
test/telegram-companion.test.js             25/25
total                                      446/446
```

The PR check currently run by GitHub is repository asset audit, and it passes on the exact head. This PR does not claim full-suite CI coverage or real-device verification.

## Scope notes

Slack (#836) reads the same session snapshot output and benefits from the corrected lifecycle behavior, but this PR is intentionally independent of #836.

Found by @shengmai-justin while validating #836.

## Not verified

This is harness/fake-timer evidence, plus the repository asset audit check. It is not real Claude Code validation. Real Claude Code coverage for controlled `Stop` hook behavior and transcript timing remains part of the later integration/acceptance plan.
