### PR TITLE
fix(telegram): stop rendering the session key envelope as the session id

### DIFF
--- a/src/session-key.js
+++ b/src/session-key.js
@@ -39,29 +39,7 @@ function resolveSessionIdentity(rawSessionId, profileId = LOCAL_SESSION_PROFILE_
   });
 }
 
-// Display helpers can be handed the envelope instead of the raw id: a session
-// created without an explicit rawSessionId falls back to its own key
-// (state.js `(existing && existing.rawSessionId) || rawSessionId || sessionId`).
-// Shortening the envelope renders the same few characters for every session on
-// a profile, so recover the raw id first. The round-trip check keeps this from
-// mangling a raw id that merely looks like a key.
-function decodeSessionKey(value) {
-  if (typeof value !== "string") return null;
-  const parts = value.split(".");
-  if (parts.length !== 3 || parts[0] !== SESSION_KEY_VERSION) return null;
-  try {
-    const profileId = Buffer.from(parts[1], "base64url").toString("utf8");
-    const rawSessionId = Buffer.from(parts[2], "base64url").toString("utf8");
-    if (!profileId || !rawSessionId) return null;
-    if (makeSessionKey({ profileId, rawSessionId }) !== value) return null;
-    return { profileId, rawSessionId };
-  } catch {
-    return null;
-  }
-}
-
 module.exports = {
-  decodeSessionKey,
   LOCAL_SESSION_PROFILE_ID,
   SESSION_KEY_VERSION,
   normalizeRawSessionId,

--- a/src/session-key.js
+++ b/src/session-key.js
@@ -39,7 +39,29 @@ function resolveSessionIdentity(rawSessionId, profileId = LOCAL_SESSION_PROFILE_
   });
 }
 
+// Display helpers can be handed the envelope instead of the raw id: a session
+// created without an explicit rawSessionId falls back to its own key
+// (state.js `(existing && existing.rawSessionId) || rawSessionId || sessionId`).
+// Shortening the envelope renders the same few characters for every session on
+// a profile, so recover the raw id first. The round-trip check keeps this from
+// mangling a raw id that merely looks like a key.
+function decodeSessionKey(value) {
+  if (typeof value !== "string") return null;
+  const parts = value.split(".");
+  if (parts.length !== 3 || parts[0] !== SESSION_KEY_VERSION) return null;
+  try {
+    const profileId = Buffer.from(parts[1], "base64url").toString("utf8");
+    const rawSessionId = Buffer.from(parts[2], "base64url").toString("utf8");
+    if (!profileId || !rawSessionId) return null;
+    if (makeSessionKey({ profileId, rawSessionId }) !== value) return null;
+    return { profileId, rawSessionId };
+  } catch {
+    return null;
+  }
+}
+
 module.exports = {
+  decodeSessionKey,
   LOCAL_SESSION_PROFILE_ID,
   SESSION_KEY_VERSION,
   normalizeRawSessionId,

--- a/src/state-session-snapshot.js
+++ b/src/state-session-snapshot.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { decodeSessionKey } = require("./session-key");
+
 const path = require("path");
 const { sessionAliasKey } = require("./session-alias");
 const { getSessionFocusTarget } = require("./session-focus");
@@ -241,9 +243,17 @@ function isInternalWorkspaceCwd(id, sessionLike, cwd) {
   return false;
 }
 
-function shortenSessionIdForDisplay(value, sessionLike) {
+// `options.ellipsis: false` drops the trailing ".." for callers that render the
+// value as a compact tag (for example "#abc123"), where the dots read as part of
+// the id rather than as truncation.
+// `options.sanitize` runs on the full recovered id, before shortening. Scrubbers
+// that match whole tokens (a run of digits, a telegram-shaped id) cannot fire
+// against a six-character window, so a caller that redacts must redact first.
+function shortenSessionIdForDisplay(value, sessionLike, options = {}) {
   if (value === null || value === undefined) return value;
   let displayId = String(value);
+  const decoded = decodeSessionKey(displayId);
+  if (decoded) displayId = decoded.rawSessionId;
   const agentId = sessionLike && sessionLike.agentId;
   for (const entry of INTERNAL_WORKSPACE_AGENTS) {
     if (!displayId.startsWith(entry.sessionPrefix)) continue;
@@ -256,7 +266,9 @@ function shortenSessionIdForDisplay(value, sessionLike) {
     if (stripped.trim()) displayId = stripped;
     break;
   }
-  return displayId.length > 6 ? `${displayId.slice(0, 6)}..` : displayId;
+  if (typeof options.sanitize === "function") displayId = String(options.sanitize(displayId) || "");
+  const suffix = options.ellipsis === false ? "" : "..";
+  return displayId.length > 6 ? `${displayId.slice(0, 6)}${suffix}` : displayId;
 }
 
 function sessionDisplayTitle(id, sessionLike, sessionAliases = {}, options = {}) {
@@ -624,6 +636,7 @@ module.exports = {
   getSessionAliasEntry,
   getEffectiveSessionTitle,
   sessionDisplayTitle,
+  shortenSessionIdForDisplay,
   sessionMenuComparator,
   sessionUpdatedAtComparator,
   buildSessionSnapshotEntry,

--- a/src/state-session-snapshot.js
+++ b/src/state-session-snapshot.js
@@ -1,7 +1,6 @@
 "use strict";
 
-const { decodeSessionKey } = require("./session-key");
-
+const crypto = require("crypto");
 const path = require("path");
 const { sessionAliasKey } = require("./session-alias");
 const { getSessionFocusTarget } = require("./session-focus");
@@ -243,17 +242,9 @@ function isInternalWorkspaceCwd(id, sessionLike, cwd) {
   return false;
 }
 
-// `options.ellipsis: false` drops the trailing ".." for callers that render the
-// value as a compact tag (for example "#abc123"), where the dots read as part of
-// the id rather than as truncation.
-// `options.sanitize` runs on the full recovered id, before shortening. Scrubbers
-// that match whole tokens (a run of digits, a telegram-shaped id) cannot fire
-// against a six-character window, so a caller that redacts must redact first.
-function shortenSessionIdForDisplay(value, sessionLike, options = {}) {
+function shortenSessionIdForDisplay(value, sessionLike) {
   if (value === null || value === undefined) return value;
   let displayId = String(value);
-  const decoded = decodeSessionKey(displayId);
-  if (decoded) displayId = decoded.rawSessionId;
   const agentId = sessionLike && sessionLike.agentId;
   for (const entry of INTERNAL_WORKSPACE_AGENTS) {
     if (!displayId.startsWith(entry.sessionPrefix)) continue;
@@ -266,9 +257,21 @@ function shortenSessionIdForDisplay(value, sessionLike, options = {}) {
     if (stripped.trim()) displayId = stripped;
     break;
   }
-  if (typeof options.sanitize === "function") displayId = String(options.sanitize(displayId) || "");
-  const suffix = options.ellipsis === false ? "" : "..";
-  return displayId.length > 6 ? `${displayId.slice(0, 6)}${suffix}` : displayId;
+  return displayId.length > 6 ? `${displayId.slice(0, 6)}..` : displayId;
+}
+
+function buildDisplaySessionTag(canonicalSessionId) {
+  if (typeof canonicalSessionId !== "string") return "";
+  const trimmed = canonicalSessionId.trim();
+  if (!trimmed) return "";
+  return crypto.createHash("sha256").update(trimmed).digest("hex").slice(0, 10);
+}
+
+function getEntryDisplaySessionTag(entry) {
+  if (entry && typeof entry.displaySessionTag === "string" && entry.displaySessionTag) {
+    return entry.displaySessionTag;
+  }
+  return buildDisplaySessionTag(entry && entry.id);
 }
 
 function sessionDisplayTitle(id, sessionLike, sessionAliases = {}, options = {}) {
@@ -346,6 +349,7 @@ function buildSessionSnapshotEntry(id, session, sessionAliases = {}, options = {
     id,
     profileId: (session && session.profileId) || "local",
     rawSessionId: (session && session.rawSessionId) || id,
+    displaySessionTag: buildDisplaySessionTag(id),
     agentId,
     agentName: resolveAgentDisplayName(agentId),
     iconUrl: getAgentIconUrl(agentId),
@@ -584,6 +588,7 @@ function sessionSnapshotSignature(snapshot) {
       id: entry.id,
       profileId: entry.profileId,
       rawSessionId: entry.rawSessionId,
+      displaySessionTag: entry.displaySessionTag,
       state: entry.state,
       startupRecovered: !!entry.startupRecovered,
       badge: entry.badge,
@@ -636,7 +641,8 @@ module.exports = {
   getSessionAliasEntry,
   getEffectiveSessionTitle,
   sessionDisplayTitle,
-  shortenSessionIdForDisplay,
+  buildDisplaySessionTag,
+  getEntryDisplaySessionTag,
   sessionMenuComparator,
   sessionUpdatedAtComparator,
   buildSessionSnapshotEntry,

--- a/src/telegram-approval-runtime-status.js
+++ b/src/telegram-approval-runtime-status.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { shortenSessionIdForDisplay } = require("./state-session-snapshot");
+const { getEntryDisplaySessionTag } = require("./state-session-snapshot");
 
 const telegramApprovalSettings = require("./telegram-approval-settings");
 const {
@@ -653,20 +653,8 @@ function formatAge(seconds, locale = STATUS_LOCALES.en) {
   return formatTemplate(age.day || STATUS_LOCALES.en.age.day, { n: Math.floor(hours / 24) });
 }
 
-// See telegram-companion: entry.id is the namespaced key, so it must not be
-// sliced directly. Shorten the raw id through the shared helper, then sanitize.
 function shortId(entry) {
-  const raw = (entry && entry.rawSessionId) || (entry && entry.id);
-  // Shorten first, then sanitize. The scrubber's whole-token rules cannot match
-  // inside a six-character window, but that is the point: cutting to six
-  // characters IS the redaction here -- a six-character prefix of a token is not
-  // a token. Sanitizing first was tried and is worse: the numeric-id rule fires
-  // on the leading group of an ordinary session UUID, so every session collapses
-  // to "<redac" and the field stops disambiguating, which is the defect this
-  // whole change exists to fix. sanitizeStatusText still runs to strip control
-  // characters and collapse whitespace.
-  const display = shortenSessionIdForDisplay(raw, entry, { ellipsis: false });
-  return sanitizeStatusText(display, 32) || "";
+  return sanitizeStatusText(getEntryDisplaySessionTag(entry), 32) || "";
 }
 
 function summarizeSession(entry, now) {

--- a/src/telegram-approval-runtime-status.js
+++ b/src/telegram-approval-runtime-status.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { shortenSessionIdForDisplay } = require("./state-session-snapshot");
+
 const telegramApprovalSettings = require("./telegram-approval-settings");
 const {
   normalizeTelegramVerificationFailure,
@@ -651,10 +653,20 @@ function formatAge(seconds, locale = STATUS_LOCALES.en) {
   return formatTemplate(age.day || STATUS_LOCALES.en.age.day, { n: Math.floor(hours / 24) });
 }
 
-function shortId(id) {
-  const s = sanitizeStatusText(id, 32);
-  if (!s) return "";
-  return s.length > 8 ? s.slice(0, 8) : s;
+// See telegram-companion: entry.id is the namespaced key, so it must not be
+// sliced directly. Shorten the raw id through the shared helper, then sanitize.
+function shortId(entry) {
+  const raw = (entry && entry.rawSessionId) || (entry && entry.id);
+  // Shorten first, then sanitize. The scrubber's whole-token rules cannot match
+  // inside a six-character window, but that is the point: cutting to six
+  // characters IS the redaction here -- a six-character prefix of a token is not
+  // a token. Sanitizing first was tried and is worse: the numeric-id rule fires
+  // on the leading group of an ordinary session UUID, so every session collapses
+  // to "<redac" and the field stops disambiguating, which is the defect this
+  // whole change exists to fix. sanitizeStatusText still runs to strip control
+  // characters and collapse whitespace.
+  const display = shortenSessionIdForDisplay(raw, entry, { ellipsis: false });
+  return sanitizeStatusText(display, 32) || "";
 }
 
 function summarizeSession(entry, now) {
@@ -663,7 +675,7 @@ function summarizeSession(entry, now) {
     ? entry.lastEvent
     : null;
   return {
-    id: shortId(entry.id),
+    id: shortId(entry),
     agentId: sanitizeStatusText(entry.agentId || "unknown", 48) || "unknown",
     state: sanitizeStatusText(entry.state || "idle", 32) || "idle",
     badge: sanitizeStatusText(entry.badge || "idle", 32) || "idle",

--- a/src/telegram-companion.js
+++ b/src/telegram-companion.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { shortenSessionIdForDisplay } = require("./state-session-snapshot");
+
 const {
   clipUtf16Safe,
   concatTelegramParts,
@@ -116,9 +118,13 @@ function folderName(cwd) {
   return parts[parts.length - 1] || "";
 }
 
-function shortId(id) {
-  const s = String(id || "");
-  return s.length > 6 ? s.slice(0, 6) : s;
+// `entry.id` is the namespaced session key ("s1.<profile>.<raw>"), so slicing it
+// yields the envelope rather than the session: every local session collapses to
+// the same six characters. Shorten the raw id through the shared helper the
+// HUD/Dashboard already use, so the notification agrees with the app.
+function entryShortId(entry, options) {
+  const raw = (entry && entry.rawSessionId) || (entry && entry.id);
+  return shortenSessionIdForDisplay(raw, entry, options);
 }
 
 function getNotificationLocale(lang) {
@@ -221,13 +227,13 @@ function formatNotification(entry, options = {}) {
   const interrupted = entry.badge === "interrupted";
   const icon = interrupted ? "⚠️" : "✅"; // ⚠️ / ✅
   const status = interrupted ? locale.interrupted : locale.done;
-  const title = entry.displayTitle || (entry.id ? `${shortId(entry.id)}..` : locale.session);
+  const title = entry.displayTitle || (entry.id ? entryShortId(entry) : locale.session);
   const meta = [];
   if (entry.agentId) meta.push(entry.agentId);
   const folder = folderName(entry.cwd);
   if (folder) meta.push(folder);
   if (entry.host) meta.push(entry.host);
-  if (entry.id) meta.push(`#${shortId(entry.id)}`);
+  if (entry.id) meta.push(`#${entryShortId(entry, { ellipsis: false })}`);
   const wrapStatus = typeof locale.wrapStatus === "function"
     ? locale.wrapStatus(status)
     : `(${status})`;
@@ -247,13 +253,13 @@ function formatTelegramNotificationMessage(entry, options = {}) {
   const interrupted = entry.badge === "interrupted";
   const icon = interrupted ? "⚠️" : "✅";
   const status = interrupted ? locale.interrupted : locale.done;
-  const title = entry.displayTitle || (entry.id ? `${shortId(entry.id)}..` : locale.session);
+  const title = entry.displayTitle || (entry.id ? entryShortId(entry) : locale.session);
   const meta = [];
   if (entry.agentId) meta.push(entry.agentId);
   const folder = folderName(entry.cwd);
   if (folder) meta.push(folder);
   if (entry.host) meta.push(entry.host);
-  if (entry.id) meta.push(`#${shortId(entry.id)}`);
+  if (entry.id) meta.push(`#${entryShortId(entry, { ellipsis: false })}`);
   const wrapStatus = typeof locale.wrapStatus === "function"
     ? locale.wrapStatus(status)
     : `(${status})`;

--- a/src/telegram-companion.js
+++ b/src/telegram-companion.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { shortenSessionIdForDisplay } = require("./state-session-snapshot");
+const { getEntryDisplaySessionTag } = require("./state-session-snapshot");
 
 const {
   clipUtf16Safe,
@@ -118,15 +118,6 @@ function folderName(cwd) {
   return parts[parts.length - 1] || "";
 }
 
-// `entry.id` is the namespaced session key ("s1.<profile>.<raw>"), so slicing it
-// yields the envelope rather than the session: every local session collapses to
-// the same six characters. Shorten the raw id through the shared helper the
-// HUD/Dashboard already use, so the notification agrees with the app.
-function entryShortId(entry, options) {
-  const raw = (entry && entry.rawSessionId) || (entry && entry.id);
-  return shortenSessionIdForDisplay(raw, entry, options);
-}
-
 function getNotificationLocale(lang) {
   return NOTIFICATION_LOCALES[lang] || NOTIFICATION_LOCALES.en;
 }
@@ -227,13 +218,14 @@ function formatNotification(entry, options = {}) {
   const interrupted = entry.badge === "interrupted";
   const icon = interrupted ? "⚠️" : "✅"; // ⚠️ / ✅
   const status = interrupted ? locale.interrupted : locale.done;
-  const title = entry.displayTitle || (entry.id ? entryShortId(entry) : locale.session);
+  const title = entry.displayTitle || locale.session;
+  const displaySessionTag = getEntryDisplaySessionTag(entry);
   const meta = [];
   if (entry.agentId) meta.push(entry.agentId);
   const folder = folderName(entry.cwd);
   if (folder) meta.push(folder);
   if (entry.host) meta.push(entry.host);
-  if (entry.id) meta.push(`#${entryShortId(entry, { ellipsis: false })}`);
+  if (displaySessionTag) meta.push(`#${displaySessionTag}`);
   const wrapStatus = typeof locale.wrapStatus === "function"
     ? locale.wrapStatus(status)
     : `(${status})`;
@@ -253,13 +245,14 @@ function formatTelegramNotificationMessage(entry, options = {}) {
   const interrupted = entry.badge === "interrupted";
   const icon = interrupted ? "⚠️" : "✅";
   const status = interrupted ? locale.interrupted : locale.done;
-  const title = entry.displayTitle || (entry.id ? entryShortId(entry) : locale.session);
+  const title = entry.displayTitle || locale.session;
+  const displaySessionTag = getEntryDisplaySessionTag(entry);
   const meta = [];
   if (entry.agentId) meta.push(entry.agentId);
   const folder = folderName(entry.cwd);
   if (folder) meta.push(folder);
   if (entry.host) meta.push(entry.host);
-  if (entry.id) meta.push(`#${entryShortId(entry, { ellipsis: false })}`);
+  if (displaySessionTag) meta.push(`#${displaySessionTag}`);
   const wrapStatus = typeof locale.wrapStatus === "function"
     ? locale.wrapStatus(status)
     : `(${status})`;

--- a/src/telegram-direct-send.js
+++ b/src/telegram-direct-send.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { shortenSessionIdForDisplay } = require("./state-session-snapshot");
+const { getEntryDisplaySessionTag } = require("./state-session-snapshot");
 
 const { execFile: defaultExecFile } = require("child_process");
 const {
@@ -49,11 +49,8 @@ function normalizePromptText(value) {
   return text;
 }
 
-// See telegram-companion: entry.id is the namespaced key, so it must not be
-// sliced directly -- every local session would acknowledge the same id.
 function shortSessionId(entry) {
-  const raw = (entry && entry.rawSessionId) || (entry && entry.id);
-  return shortenSessionIdForDisplay(raw, entry) || "";
+  return getEntryDisplaySessionTag(entry);
 }
 
 function findSession(snapshot, sessionId) {

--- a/src/telegram-direct-send.js
+++ b/src/telegram-direct-send.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { shortenSessionIdForDisplay } = require("./state-session-snapshot");
+
 const { execFile: defaultExecFile } = require("child_process");
 const {
   getSessionFocusTarget,
@@ -47,9 +49,11 @@ function normalizePromptText(value) {
   return text;
 }
 
-function shortSessionId(sessionId) {
-  const id = String(sessionId || "");
-  return id.length > 12 ? `${id.slice(0, 12)}...` : id;
+// See telegram-companion: entry.id is the namespaced key, so it must not be
+// sliced directly -- every local session would acknowledge the same id.
+function shortSessionId(entry) {
+  const raw = (entry && entry.rawSessionId) || (entry && entry.id);
+  return shortenSessionIdForDisplay(raw, entry) || "";
 }
 
 function findSession(snapshot, sessionId) {
@@ -358,7 +362,7 @@ function interpolate(template, token, value) {
 }
 
 function formatDeliveryAck(status, entry, deliveryResult, t) {
-  const shortId = shortSessionId(entry && entry.id);
+  const shortId = shortSessionId(entry);
   switch (status) {
     case "sent_with_enter":
       return interpolate(t("directSendAckSent"), "{session}", shortId);
@@ -746,6 +750,7 @@ function createTelegramDirectSend({
 
 module.exports = {
   DEFAULT_MAPPING_TTL_MS,
+  formatDeliveryAck,
   DEFAULT_MAX_DELIVERIES,
   createTelegramDirectSend,
   createClipboardFallbackDeliveryAdapter,

--- a/test/state-session-snapshot.test.js
+++ b/test/state-session-snapshot.test.js
@@ -8,6 +8,8 @@ const {
   deriveSessionBadge,
   deriveSourceInfo,
   isSessionInProgress,
+  buildDisplaySessionTag,
+  buildSessionSnapshotEntry,
   buildSessionSnapshot,
   getActiveSessionAliasKeys,
   sessionSnapshotSignature,
@@ -153,6 +155,72 @@ describe("remote profile action ids", () => {
       Object.fromEntries(snapshot.sessions.map((entry) => [entry.profileId, entry.displayTitle])),
       { "profile-a": "Alpha", "profile-b": "Beta" },
     );
+  });
+});
+
+describe("display session tags", () => {
+  it("hashes legal canonical ids into stable 10-hex display tags", () => {
+    const canonical = makeSessionKey({
+      profileId: "local",
+      rawSessionId: "token-1234567890-abcdef",
+    });
+
+    assert.strictEqual(canonical, "s1.bG9jYWw.dG9rZW4tMTIzNDU2Nzg5MC1hYmNkZWY");
+    assert.strictEqual(buildDisplaySessionTag(canonical), "83aacb6af9");
+    assert.match(buildDisplaySessionTag(canonical), /^[0-9a-f]{10}$/);
+  });
+
+  it("returns an empty tag for missing, non-string, or blank ids", () => {
+    for (const value of [null, undefined, "", "   ", 42, true, {}, []]) {
+      assert.strictEqual(buildDisplaySessionTag(value), "", String(value));
+    }
+  });
+
+  it("distinguishes real Codex UUIDv7-shaped raw ids after canonicalization", () => {
+    const first = makeSessionKey({
+      profileId: "local",
+      rawSessionId: "codex:019e115a-4df2-7ed0-b90e-8e6345aca777",
+    });
+    const second = makeSessionKey({
+      profileId: "local",
+      rawSessionId: "codex:019e115b-4df2-7ed0-b90e-8e6345aca777",
+    });
+
+    assert.strictEqual(buildDisplaySessionTag(first), "732d7659d7");
+    assert.strictEqual(buildDisplaySessionTag(second), "b8a6f6f6ac");
+    assert.notStrictEqual(buildDisplaySessionTag(first), buildDisplaySessionTag(second));
+  });
+
+  it("distinguishes the same raw id in different remote profiles", () => {
+    const rawSessionId = "same-visible-id";
+    const a = makeSessionKey({ profileId: "profile-a", rawSessionId });
+    const b = makeSessionKey({ profileId: "profile-b", rawSessionId });
+
+    assert.notStrictEqual(buildDisplaySessionTag(a), buildDisplaySessionTag(b));
+  });
+
+  it("snapshot entries expose a tag derived only from the canonical id", () => {
+    const id = makeSessionKey({ profileId: "local", rawSessionId: "codex:019e115a-4df2-7ed0-b90e-8e6345aca777" });
+    const withRaw = buildSessionSnapshotEntry(id, session("working", {
+      rawSessionId: "codex:019e115a-4df2-7ed0-b90e-8e6345aca777",
+    }));
+    const withoutRaw = buildSessionSnapshotEntry(id, session("working"));
+
+    assert.strictEqual(withRaw.displaySessionTag, "732d7659d7");
+    assert.strictEqual(withoutRaw.displaySessionTag, withRaw.displaySessionTag);
+    for (const forbidden of ["s1.", "bG9", "codex:", "019e11"]) {
+      assert.strictEqual(withRaw.displaySessionTag.includes(forbidden), false, forbidden);
+    }
+  });
+
+  it("snapshot signature tracks the visible display session tag field", () => {
+    const snapshot = buildSessionSnapshot(new Map([
+      ["tagged", session("working")],
+    ]), { statePriority: STATE_PRIORITY });
+    const changed = JSON.parse(JSON.stringify(snapshot));
+    changed.sessions[0].displaySessionTag = "deadbeef00";
+
+    assert.notStrictEqual(sessionSnapshotSignature(snapshot), sessionSnapshotSignature(changed));
   });
 });
 

--- a/test/telegram-approval-runtime-status.test.js
+++ b/test/telegram-approval-runtime-status.test.js
@@ -353,7 +353,7 @@ test("R3 diagnostic formatter follows the Clawd language setting", () => {
   assert.match(text, /审批: 可用/);
   assert.match(text, /完成通知: 开启, 输出=完整回答, 裸通知=关闭/);
   assert.match(text, /待处理审批: 2/);
-  assert.match(text, /最新会话: claude-code #session- 状态=working 标记=running; 最近 hook: PreToolUse 3 秒前/);
+  assert.match(text, /最新会话: claude-code #sessio 状态=working 标记=running; 最近 hook: PreToolUse 3 秒前/);
   assert.doesNotMatch(text, /Transport:|Native polling:|Latest session:/);
 });
 
@@ -544,4 +544,67 @@ test("R2 diagnostic redacts token, Telegram ids, paths, and tool-like secrets fr
   assert.equal(text.includes("npm test -- --token"), false);
   assert.equal(text.includes("D:\\secret\\repo"), false);
   assert.equal(text.includes("do not leak prompt"), false);
+});
+
+// Regression: the fixture above uses a bare id, so the suite never saw a real
+// namespaced session key. Slicing that key returns the envelope, which is the
+// same for every local session.
+test("distinct local sessions get distinct short ids in the diagnostic", () => {
+  const { resolveSessionIdentity } = require("../src/session-key");
+
+  function lineFor(rawSessionId) {
+    const identity = resolveSessionIdentity(rawSessionId);
+    const diagnostic = buildTelegramStatusDiagnostic({
+      config: COMPLETE_CONFIG_OUTPUT_FULL,
+      token: TOKEN_STORED,
+      sessionSnapshot: {
+        sessions: [{
+          id: identity.sessionId,
+          rawSessionId: identity.rawSessionId,
+          agentId: "claude-code",
+          state: "working",
+          badge: "running",
+          updatedAt: 10_000,
+          lastEvent: { rawEvent: "PreToolUse", at: 9_000 },
+        }],
+      },
+      now: 12_000,
+    });
+    return diagnostic.sessions[0].id;
+  }
+
+  const a = lineFor("11111111-2222-3333-4444-555555555555");
+  const b = lineFor("99999999-8888-7777-6666-aaaaaaaaaaaa");
+  assert.notEqual(a, b, "two sessions must not render the same id");
+  assert.ok(!a.startsWith("s1."), `id must not be the key envelope: ${a}`);
+});
+
+// Six characters is the redaction: a six-character prefix of a token is not a
+// token, and sanitizing the full id first would redact the leading group of an
+// ordinary session UUID and collapse every session to the same marker.
+test("shortens a token-shaped session id to a non-secret prefix", () => {
+  const { resolveSessionIdentity } = require("../src/session-key");
+  const secret = "123456789:AAHqwertyuiopasdfghjklzxcvbnm123456";
+  const identity = resolveSessionIdentity(secret, "local");
+  const diagnostic = buildTelegramStatusDiagnostic({
+    config: COMPLETE_CONFIG_OUTPUT_FULL,
+    token: TOKEN_STORED,
+    sessionSnapshot: {
+      sessions: [{
+        id: identity.sessionId,
+        rawSessionId: identity.rawSessionId,
+        agentId: "claude-code",
+        state: "working",
+        badge: "running",
+        updatedAt: 10_000,
+        lastEvent: { rawEvent: "PreToolUse", at: 9_000 },
+      }],
+    },
+    now: 12_000,
+  });
+  const id = diagnostic.sessions[0].id;
+  assert.equal(id.length, 6, `must be cut to six characters, got: ${id}`);
+  assert.ok(secret.startsWith(id), "the prefix comes from the id, nothing else");
+  assert.ok(id.length < secret.length / 5, "the overwhelming majority of the id is withheld");
+  assert.ok(!id.includes(":"), `must not reach the token separator, got: ${id}`);
 });

--- a/test/telegram-approval-runtime-status.test.js
+++ b/test/telegram-approval-runtime-status.test.js
@@ -33,6 +33,7 @@ function sessionSnapshot() {
   return {
     sessions: [{
       id: "session-secret-abc123",
+      displaySessionTag: "deadbeef00",
       agentId: "claude-code",
       state: "working",
       badge: "running",
@@ -353,7 +354,7 @@ test("R3 diagnostic formatter follows the Clawd language setting", () => {
   assert.match(text, /审批: 可用/);
   assert.match(text, /完成通知: 开启, 输出=完整回答, 裸通知=关闭/);
   assert.match(text, /待处理审批: 2/);
-  assert.match(text, /最新会话: claude-code #sessio 状态=working 标记=running; 最近 hook: PreToolUse 3 秒前/);
+  assert.match(text, /最新会话: claude-code #deadbeef00 状态=working 标记=running; 最近 hook: PreToolUse 3 秒前/);
   assert.doesNotMatch(text, /Transport:|Native polling:|Latest session:/);
 });
 
@@ -575,14 +576,52 @@ test("distinct local sessions get distinct short ids in the diagnostic", () => {
 
   const a = lineFor("11111111-2222-3333-4444-555555555555");
   const b = lineFor("99999999-8888-7777-6666-aaaaaaaaaaaa");
+  assert.equal(a, "a0a040910c");
   assert.notEqual(a, b, "two sessions must not render the same id");
+  assert.match(a, /^[0-9a-f]{10}$/);
   assert.ok(!a.startsWith("s1."), `id must not be the key envelope: ${a}`);
+  assert.ok(!"11111111-2222-3333-4444-555555555555".startsWith(a), "id must not be a raw prefix");
 });
 
-// Six characters is the redaction: a six-character prefix of a token is not a
-// token, and sanitizing the full id first would redact the leading group of an
-// ordinary session UUID and collapse every session to the same marker.
-test("shortens a token-shaped session id to a non-secret prefix", () => {
+test("status all uses each snapshot display tag without leaking canonical ids", () => {
+  const diagnostic = buildTelegramStatusDiagnostic({
+    config: COMPLETE_CONFIG_OUTPUT_FULL,
+    token: TOKEN_STORED,
+    sessionSnapshot: {
+      sessions: [
+        {
+          id: "s1.bG9jYWw.MTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1NTU1NTU1NTU1",
+          rawSessionId: "11111111-2222-3333-4444-555555555555",
+          displaySessionTag: "deadbeef00",
+          agentId: "claude-code",
+          state: "working",
+          badge: "running",
+          updatedAt: 10_000,
+          lastEvent: { rawEvent: "PreToolUse", at: 9_000 },
+        },
+        {
+          id: "s1.bG9jYWw.OTk5OTk5OTktODg4OC03Nzc3LTY2NjYtYWFhYWFhYWFhYWFh",
+          rawSessionId: "99999999-8888-7777-6666-aaaaaaaaaaaa",
+          displaySessionTag: "feedface01",
+          agentId: "codex",
+          state: "idle",
+          badge: "done",
+          updatedAt: 9_000,
+          lastEvent: { rawEvent: "Stop", at: 8_000 },
+        },
+      ],
+    },
+    now: 12_000,
+    all: true,
+  });
+
+  const text = formatTelegramStatusDiagnostic(diagnostic, { all: true });
+  assert.match(text, /#deadbeef00/);
+  assert.match(text, /#feedface01/);
+  assert.doesNotMatch(text, /s1\.bG9jYWw|111111|999999|#a0a040910c|#83ff7f4baa/);
+});
+
+test("hashes a token-shaped session id without leaking a raw prefix", () => {
   const { resolveSessionIdentity } = require("../src/session-key");
   const secret = "123456789:AAHqwertyuiopasdfghjklzxcvbnm123456";
   const identity = resolveSessionIdentity(secret, "local");
@@ -603,8 +642,8 @@ test("shortens a token-shaped session id to a non-secret prefix", () => {
     now: 12_000,
   });
   const id = diagnostic.sessions[0].id;
-  assert.equal(id.length, 6, `must be cut to six characters, got: ${id}`);
-  assert.ok(secret.startsWith(id), "the prefix comes from the id, nothing else");
-  assert.ok(id.length < secret.length / 5, "the overwhelming majority of the id is withheld");
+  assert.equal(id, "a94b1a8e6c");
+  assert.match(id, /^[0-9a-f]{10}$/);
+  assert.ok(!secret.startsWith(id), "tag must not be a raw token prefix");
   assert.ok(!id.includes(":"), `must not reach the token separator, got: ${id}`);
 });

--- a/test/telegram-companion.test.js
+++ b/test/telegram-companion.test.js
@@ -372,12 +372,30 @@ test("forgets sessions that drop out of the snapshot", async () => {
   assert.equal(comp._lastNotified.size, 0);
 });
 
-test("formatNotification falls back to short id when title missing", () => {
+test("formatNotification falls back to the session label and uses the display tag when title missing", () => {
   const text = formatNotification({
-    id: "sess-zzzzzz9", badge: "done", lastEvent: { rawEvent: "Stop", at: 1 },
+    id: "s1.bG9jYWw.c2Vzcy16enp6eno5",
+    displaySessionTag: "deadbeef00",
+    badge: "done",
+    lastEvent: { rawEvent: "Stop", at: 1 },
   });
-  assert.match(text, /sess-z/);
-  assert.match(text, /#sess-z/);
+  assert.match(text, /session/);
+  assert.match(text, /#deadbeef00/);
+  assert.doesNotMatch(text, /s1\.bG9jYWw/);
+  assert.doesNotMatch(text, /sess-z/);
+});
+
+test("formatted completion falls back to the session label and display tag when title missing", () => {
+  const message = formatTelegramNotificationMessage({
+    id: "s1.bG9jYWw.c2Vzcy16enp6eno5",
+    displaySessionTag: "deadbeef00",
+    badge: "done",
+    lastEvent: { rawEvent: "Stop", at: 1 },
+  });
+  assert.match(message.plainText, /session/);
+  assert.match(message.plainText, /#deadbeef00/);
+  assert.doesNotMatch(message.plainText, /s1\.bG9jYWw/);
+  assert.doesNotMatch(message.plainText, /sess-z/);
 });
 
 test("formatted completion parses only Assistant output and escapes metadata", () => {
@@ -436,12 +454,7 @@ test("custom completion formatter keeps the legacy plain string contract", async
   assert.deepEqual(sent, ["<b>legacy wire</b>"]);
 });
 
-// Regression: every fixture above uses a bare id like "sess-aaaaaa1", so the
-// suite never saw a real namespaced session key ("s1.<profile>.<raw>"). Slicing
-// that key yields the envelope, not the session, and every local session
-// collapsed to the same tag. Build the ids through the real key builder so this
-// cannot pass again by fixture choice.
-test("distinct local sessions get distinct short ids", () => {
+test("completion notifications use the snapshot display tag, not raw or canonical prefixes", () => {
   const { resolveSessionIdentity } = require("../src/session-key");
   const { buildSessionSnapshotEntry } = require("../src/state-session-snapshot");
 
@@ -451,9 +464,9 @@ test("distinct local sessions get distinct short ids", () => {
       rawSessionId: identity.rawSessionId,
       agentId: "claude-code",
       state: "idle",
-      badge: "done",
       cwd: null,
-      lastEvent: { rawEvent: "Stop", at: Date.now() },
+      sessionTitle: "Known task",
+      recentEvents: [{ event: "Stop", state: "idle", at: Date.now() }],
     });
   }
 
@@ -461,35 +474,54 @@ test("distinct local sessions get distinct short ids", () => {
   const b = entryFor("99999999-8888-7777-6666-aaaaaaaaaaaa");
 
   assert.ok(a.id.startsWith("s1."), "fixture must use a real namespaced key");
-  const tagA = sentText(formatNotification(a)).match(/#(\S+)/);
-  const tagB = sentText(formatNotification(b)).match(/#(\S+)/);
+  const textA = sentText(formatNotification(a));
+  const richA = formatTelegramNotificationMessage(a);
+  const tagA = textA.match(/#([0-9a-f]{10})/);
+  const tagB = sentText(formatNotification(b)).match(/#([0-9a-f]{10})/);
   assert.ok(tagA && tagB, "both notifications carry a session tag");
+  assert.equal(tagA[1], a.displaySessionTag);
+  assert.equal(tagA[1], "a0a040910c");
   assert.notEqual(tagA[1], tagB[1], "two sessions must not render the same tag");
   assert.ok(!tagA[1].startsWith("s1."), `tag must not be the key envelope: ${tagA[1]}`);
-  assert.ok(a.rawSessionId.startsWith(tagA[1]), "tag is a prefix of the real session id");
+  assert.ok(!a.rawSessionId.startsWith(tagA[1]), "tag must not be a raw id prefix");
+  assert.doesNotMatch(textA, /111111|s1\.bG9jYWw/);
+  assert.doesNotMatch(richA.plainText, /111111|s1\.bG9jYWw/);
 });
 
-// A session created without an explicit rawSessionId falls back to its own
-// namespaced key (state.js), so the display helper must recover the raw id from
-// the envelope rather than slicing it. Every real route passes rawSessionId
-// today; this closes the fallback so the bug cannot return through it.
-test("distinct sessions get distinct short ids even without rawSessionId", () => {
+test("completion notification tags still distinguish sessions without rawSessionId", () => {
   const { resolveSessionIdentity } = require("../src/session-key");
   const { buildSessionSnapshotEntry } = require("../src/state-session-snapshot");
 
   function tagFor(rawSessionId) {
     const identity = resolveSessionIdentity(rawSessionId, "local");
     const entry = buildSessionSnapshotEntry(identity.sessionId, {
-      agentId: "codex", state: "idle", badge: "done", cwd: null,
-      lastEvent: { rawEvent: "Stop", at: Date.now() },
+      agentId: "codex",
+      state: "idle",
+      cwd: null,
+      recentEvents: [{ event: "Stop", state: "idle", at: Date.now() }],
     }); // deliberately no rawSessionId
     assert.equal(entry.rawSessionId, identity.sessionId, "fixture must exercise the fallback");
-    return sentText(formatNotification(entry)).match(/#(\S+)/)[1];
+    return sentText(formatNotification(entry)).match(/#([0-9a-f]{10})/)[1];
   }
 
   const a = tagFor("11111111-2222-3333-4444-555555555555");
   const b = tagFor("99999999-8888-7777-6666-aaaaaaaaaaaa");
   assert.notEqual(a, b, "two sessions must not render the same tag");
   assert.ok(!a.startsWith("s1."), `tag must not be the key envelope: ${a}`);
-  assert.equal(a, "111111");
+  assert.equal(a, "a0a040910c");
+});
+
+test("completion formatter prefers an explicit snapshot display tag", () => {
+  const entry = doneEntry({
+    id: "s1.bG9jYWw.MTExMTExMTEtMjIyMi0zMzMzLTQ0NDQtNTU1NTU1NTU1NTU1",
+    rawSessionId: "11111111-2222-3333-4444-555555555555",
+    displaySessionTag: "deadbeef00",
+  });
+
+  const text = sentText(formatNotification(entry));
+  const rich = formatTelegramNotificationMessage(entry);
+  assert.match(text, /#deadbeef00/);
+  assert.match(rich.plainText, /#deadbeef00/);
+  assert.doesNotMatch(text, /#a0a040910c|111111|s1\.bG9jYWw/);
+  assert.doesNotMatch(rich.plainText, /#a0a040910c|111111|s1\.bG9jYWw/);
 });

--- a/test/telegram-companion.test.js
+++ b/test/telegram-companion.test.js
@@ -435,3 +435,61 @@ test("custom completion formatter keeps the legacy plain string contract", async
 
   assert.deepEqual(sent, ["<b>legacy wire</b>"]);
 });
+
+// Regression: every fixture above uses a bare id like "sess-aaaaaa1", so the
+// suite never saw a real namespaced session key ("s1.<profile>.<raw>"). Slicing
+// that key yields the envelope, not the session, and every local session
+// collapsed to the same tag. Build the ids through the real key builder so this
+// cannot pass again by fixture choice.
+test("distinct local sessions get distinct short ids", () => {
+  const { resolveSessionIdentity } = require("../src/session-key");
+  const { buildSessionSnapshotEntry } = require("../src/state-session-snapshot");
+
+  function entryFor(rawSessionId) {
+    const identity = resolveSessionIdentity(rawSessionId);
+    return buildSessionSnapshotEntry(identity.sessionId, {
+      rawSessionId: identity.rawSessionId,
+      agentId: "claude-code",
+      state: "idle",
+      badge: "done",
+      cwd: null,
+      lastEvent: { rawEvent: "Stop", at: Date.now() },
+    });
+  }
+
+  const a = entryFor("11111111-2222-3333-4444-555555555555");
+  const b = entryFor("99999999-8888-7777-6666-aaaaaaaaaaaa");
+
+  assert.ok(a.id.startsWith("s1."), "fixture must use a real namespaced key");
+  const tagA = sentText(formatNotification(a)).match(/#(\S+)/);
+  const tagB = sentText(formatNotification(b)).match(/#(\S+)/);
+  assert.ok(tagA && tagB, "both notifications carry a session tag");
+  assert.notEqual(tagA[1], tagB[1], "two sessions must not render the same tag");
+  assert.ok(!tagA[1].startsWith("s1."), `tag must not be the key envelope: ${tagA[1]}`);
+  assert.ok(a.rawSessionId.startsWith(tagA[1]), "tag is a prefix of the real session id");
+});
+
+// A session created without an explicit rawSessionId falls back to its own
+// namespaced key (state.js), so the display helper must recover the raw id from
+// the envelope rather than slicing it. Every real route passes rawSessionId
+// today; this closes the fallback so the bug cannot return through it.
+test("distinct sessions get distinct short ids even without rawSessionId", () => {
+  const { resolveSessionIdentity } = require("../src/session-key");
+  const { buildSessionSnapshotEntry } = require("../src/state-session-snapshot");
+
+  function tagFor(rawSessionId) {
+    const identity = resolveSessionIdentity(rawSessionId, "local");
+    const entry = buildSessionSnapshotEntry(identity.sessionId, {
+      agentId: "codex", state: "idle", badge: "done", cwd: null,
+      lastEvent: { rawEvent: "Stop", at: Date.now() },
+    }); // deliberately no rawSessionId
+    assert.equal(entry.rawSessionId, identity.sessionId, "fixture must exercise the fallback");
+    return sentText(formatNotification(entry)).match(/#(\S+)/)[1];
+  }
+
+  const a = tagFor("11111111-2222-3333-4444-555555555555");
+  const b = tagFor("99999999-8888-7777-6666-aaaaaaaaaaaa");
+  assert.notEqual(a, b, "two sessions must not render the same tag");
+  assert.ok(!a.startsWith("s1."), `tag must not be the key envelope: ${a}`);
+  assert.equal(a, "111111");
+});

--- a/test/telegram-direct-send.test.js
+++ b/test/telegram-direct-send.test.js
@@ -1089,3 +1089,25 @@ test("direct send expires notification mappings", async () => {
 test("normalizePromptText keeps newlines but removes control characters", () => {
   assert.equal(normalizePromptText("  hi\r\nthere\u0007  "), "hi\nthere");
 });
+
+// The ack names the session it delivered to. entry.id is the namespaced key, so
+// slicing it acknowledged the same id for every local session.
+test("the delivery ack names the real session, not the key envelope", () => {
+  const { formatDeliveryAck } = require("../src/telegram-direct-send");
+  const { resolveSessionIdentity } = require("../src/session-key");
+  const t = (key) => (key === "directSendAckSent" ? "sent to {session}" : key);
+
+  function ackFor(rawSessionId) {
+    const identity = resolveSessionIdentity(rawSessionId, "local");
+    return formatDeliveryAck("sent_with_enter", {
+      id: identity.sessionId,
+      rawSessionId: identity.rawSessionId,
+    }, null, t);
+  }
+
+  const a = ackFor("11111111-2222-3333-4444-555555555555");
+  const b = ackFor("99999999-8888-7777-6666-aaaaaaaaaaaa");
+  assert.notEqual(a, b, "two sessions must not produce the same ack");
+  assert.ok(!a.includes("s1."), `ack must not carry the key envelope: ${a}`);
+  assert.equal(a, "sent to 111111..");
+});

--- a/test/telegram-direct-send.test.js
+++ b/test/telegram-direct-send.test.js
@@ -1090,24 +1090,28 @@ test("normalizePromptText keeps newlines but removes control characters", () => 
   assert.equal(normalizePromptText("  hi\r\nthere\u0007  "), "hi\nthere");
 });
 
-// The ack names the session it delivered to. entry.id is the namespaced key, so
-// slicing it acknowledged the same id for every local session.
-test("the delivery ack names the real session, not the key envelope", () => {
+test("the delivery ack names the display tag, not the key envelope or raw prefix", () => {
   const { formatDeliveryAck } = require("../src/telegram-direct-send");
   const { resolveSessionIdentity } = require("../src/session-key");
   const t = (key) => (key === "directSendAckSent" ? "sent to {session}" : key);
 
-  function ackFor(rawSessionId) {
+  function ackFor(rawSessionId, overrides = {}) {
     const identity = resolveSessionIdentity(rawSessionId, "local");
     return formatDeliveryAck("sent_with_enter", {
       id: identity.sessionId,
       rawSessionId: identity.rawSessionId,
+      ...overrides,
     }, null, t);
   }
 
   const a = ackFor("11111111-2222-3333-4444-555555555555");
   const b = ackFor("99999999-8888-7777-6666-aaaaaaaaaaaa");
+  const explicit = ackFor("11111111-2222-3333-4444-555555555555", {
+    displaySessionTag: "deadbeef00",
+  });
   assert.notEqual(a, b, "two sessions must not produce the same ack");
   assert.ok(!a.includes("s1."), `ack must not carry the key envelope: ${a}`);
-  assert.equal(a, "sent to 111111..");
+  assert.doesNotMatch(a, /111111/);
+  assert.equal(a, "sent to a0a040910c");
+  assert.equal(explicit, "sent to deadbeef00");
 });


### PR DESCRIPTION
## What breaks

`entry.id` is the namespaced canonical session key, built as an opaque action/focus identity rather than a user-facing id. Three Telegram-facing surfaces sliced it from the front to make a short display tag, so local sessions collapsed to the same visible prefix:

```text
local A   id=s1.bG9jYWw.<...>   ->   claude-code · #s1.bG9
local B   id=s1.bG9jYWw.<...>   ->   claude-code · #s1.bG9
remote    id=s1.cHJvZGJveA.<...> ->  claude-code · prodbox · #s1.cHJ
```

The old PR attempt fixed the envelope prefix bug by decoding back to raw ids and slicing those. That still collides for real agent shapes such as `codex:<uuid>`, `qoder:<uuid>`, and `qwenwork:<uuid>`, where the raw prefix is the agent namespace rather than a useful discriminator.

## Affected

| file | surface |
|---|---|
| `src/telegram-companion.js` | completion notifications, both plain and rich formatters |
| `src/telegram-approval-runtime-status.js` | Telegram `/status` diagnostic |
| `src/telegram-direct-send.js` | direct-send delivery ack |

## The fix

Session snapshots now expose a snapshot-owned `displaySessionTag`:

```text
displaySessionTag = sha256(trimmed canonical session id).hex.slice(0, 10)
```

The tag is derived from the canonical session identity, so:

- two real Codex UUIDv7-shaped sessions no longer collapse to `#codex:`;
- the same raw id in different remote profiles gets different tags;
- sessions with no `rawSessionId` still get a stable tag from the canonical key;
- Telegram consumers no longer decode the key or slice raw/canonical prefixes themselves.

Consumers add the leading `#` only when the tag is non-empty. Old hand-written fixtures that do not include `displaySessionTag` fall back to deriving it from `entry.id`, never from `entry.rawSessionId`.

This tag is only a stable display discriminator. It is not a secret, not a credential boundary, and not meant to be described as security-grade anonymization.

## Deliberate user-visible behavior change

When a completion notification has no `displayTitle`, the title now falls back to the localized generic session label (`session` / `会话` / `工作階段`) instead of a short id. Multiple untitled sessions are distinguished by the metadata tag, for example:

```text
✅ session (done)
claude-code · #a0a040910c
```

Existing Dashboard / HUD / session menu title fallback behavior is intentionally unchanged.

## Tests

Local harness evidence:

```text
NODE_PATH=/Users/rullerzhou/Developer/clawd-on-desk/node_modules node --test \
  test/session-key.test.js \
  test/state-session-snapshot.test.js \
  test/telegram-companion.test.js \
  test/telegram-approval-runtime-status.test.js \
  test/telegram-direct-send.test.js

155 pass / 0 fail

NODE_PATH=/Users/rullerzhou/Developer/clawd-on-desk/node_modules node --test test/state.test.js

305 pass / 0 fail

git diff --check

clean
```

The new tests pin:

- fixed canonical hash sample `83aacb6af9`;
- real Codex UUIDv7-shaped raw ids producing distinct tags;
- same raw id across different profiles producing distinct tags;
- missing `rawSessionId` still deriving from canonical identity;
- explicit snapshot `displaySessionTag` taking precedence in completion, status, and direct-send ack;
- completion title fallbacks not leaking `s1.bG9...` or raw id fragments.

## Out of scope

- No Slack dispatcher / queue / rate-limit changes are included here; future Slack notification work should consume `displaySessionTag` from the snapshot instead of inventing another string slice.
- No desktop permission bubble or Dashboard/HUD visual redesign is included.
- No real Telegram bot end-to-end run has been performed in this PR.
- The current pushed head needs fresh CI; old checks on the previous head do not prove this implementation.

Found by @shengmai-justin while validating #836.
