### PR TITLE
test: give the runner a per-test timeout so a hang fails instead of stalling

### DIFF
--- a/test/run-tests-timeout.test.js
+++ b/test/run-tests-timeout.test.js
@@ -1,0 +1,30 @@
+"use strict";
+
+// A hung test is not a failure unless the runner imposes a per-test timeout:
+// `node --test` waits forever, the remaining files never run, and no summary is
+// printed. Verified once by hand — a deliberately hanging test turned the run
+// from an indefinite stall into "✖ deliberately hangs" with exit code 1.
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { DEFAULT_TEST_TIMEOUT_MS, resolveTimeoutArgs } = require("./run-tests");
+
+test("the runner always passes a per-test timeout by default", () => {
+  assert.deepStrictEqual(resolveTimeoutArgs({}), [`--test-timeout=${DEFAULT_TEST_TIMEOUT_MS}`]);
+  assert.ok(DEFAULT_TEST_TIMEOUT_MS >= 60000, "the ceiling must be generous enough for slow suites");
+});
+
+test("CLAWD_TEST_TIMEOUT_MS overrides it, and 0 disables it", () => {
+  assert.deepStrictEqual(resolveTimeoutArgs({ CLAWD_TEST_TIMEOUT_MS: "5000" }), ["--test-timeout=5000"]);
+  assert.deepStrictEqual(resolveTimeoutArgs({ CLAWD_TEST_TIMEOUT_MS: "0" }), []);
+});
+
+test("a malformed override falls back to the default rather than disabling the timeout", () => {
+  for (const value of ["", "abc", "-1", "NaN", undefined]) {
+    assert.deepStrictEqual(
+      resolveTimeoutArgs({ CLAWD_TEST_TIMEOUT_MS: value }),
+      [`--test-timeout=${DEFAULT_TEST_TIMEOUT_MS}`],
+      `CLAWD_TEST_TIMEOUT_MS=${JSON.stringify(value)} must not silently remove the timeout`,
+    );
+  }
+});

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -2,6 +2,30 @@ const { spawnSync } = require("node:child_process");
 const { readdirSync } = require("node:fs");
 const path = require("node:path");
 
+const DEFAULT_TEST_TIMEOUT_MS = 120000;
+
+// Without a per-test timeout a hung test is not a failure: `node --test` waits
+// on it forever, the remaining files never run, and no summary is printed -- so
+// a regression that deadlocks one test reads as "the suite is still going"
+// locally and as a stalled job in CI. A generous ceiling turns that into a
+// normal red. Raise it with CLAWD_TEST_TIMEOUT_MS if a legitimately slow test
+// ever needs more; 0 disables it.
+function resolveTimeoutArgs(env = process.env) {
+  // Number("") is 0, and 0 means "no timeout" -- so an empty or whitespace
+  // override would silently remove the protection instead of falling back.
+  const raw = env.CLAWD_TEST_TIMEOUT_MS;
+  const configured = raw === undefined || String(raw).trim() === "" ? NaN : Number(raw);
+  const timeoutMs = Number.isFinite(configured) && configured >= 0
+    ? configured
+    : DEFAULT_TEST_TIMEOUT_MS;
+  return timeoutMs > 0 ? [`--test-timeout=${timeoutMs}`] : [];
+}
+
+module.exports = { DEFAULT_TEST_TIMEOUT_MS, resolveTimeoutArgs };
+
+// Requiring this file must not scan the directory or exit the process.
+if (require.main !== module) return;
+
 const testDir = __dirname;
 const files = readdirSync(testDir)
   .filter((name) => name.endsWith(".test.js"))
@@ -13,7 +37,13 @@ if (files.length === 0) {
   process.exit(1);
 }
 
-const result = spawnSync(process.execPath, ["--test", ...files], {
+// Without a per-test timeout a hung test is not a failure: `node --test` waits
+// on it forever, the remaining files never run, and no summary is printed -- so
+// a regression that deadlocks one test reads as "the suite is still going"
+// locally and as a stalled job in CI. A generous ceiling turns that into a
+// normal red. Raise it with CLAWD_TEST_TIMEOUT_MS if a legitimately slow test
+// ever needs more; 0 disables it.
+const result = spawnSync(process.execPath, ["--test", ...resolveTimeoutArgs(), ...files], {
   stdio: "inherit",
 });
 


### PR DESCRIPTION
## What breaks

`test/run-tests.js` spawns `node --test` with no `--test-timeout`. A test that deadlocks is therefore **not a failure**: node waits on it forever, the remaining files never run, and no summary is printed.

Locally that reads as "the suite is still going". In CI it is a stalled job with no indication of which test is at fault.

## Verified by hand

Dropping a deliberately hanging test into `test/` on this branch:

```
✖ deliberately hangs (3000.98ms)
ℹ tests 8335   pass 8275   fail 30   cancelled 4
exit code 1
```

Before this change the same file hangs the run indefinitely. (The 4 cancelled above are collateral from running the experiment at `CLAWD_TEST_TIMEOUT_MS=3000`; at the 120s default nothing is cancelled.)

## The ceiling

120s per test by default — generous enough that the current suite is untouched: **8334 tests, the same 30 pre-existing failures, 0 cancelled**, identical to `main`. Override with `CLAWD_TEST_TIMEOUT_MS`; `0` disables it.

## A hole the test caught

The timeout computation is exported so it can be tested directly rather than grepped for. Writing that test immediately found a bug in it: `Number("")` is `0`, and `0` means "no timeout" — so `CLAWD_TEST_TIMEOUT_MS=` would have **silently removed the protection** instead of falling back. Empty and whitespace values now fall back, as do `NaN` and negatives. Removing the timeout argument turns all three cases red.

## Suite note

One full run reported 31 failures and a rerun reported 30, with **identical failing-test names** on both and an empty diff against a clean-`main` baseline built the same way. That is a pre-existing flake in the suite, not a regression from this change; I have not chased down which test it is.

## Context

Found while reviewing #836, where a queue regression hung the suite rather than failing it, so the remaining files never reported and the run had to be diagnosed by hand.