### PR TITLE
docs+scripts+ci: macOS Developer ID signing, notarization, and CI integration (relates to #872)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,8 +86,60 @@ jobs:
           node-version-file: .nvmrc
       - run: npm ci
       - run: npm test
-      - run: npx electron-builder --mac --publish never
+      # Detect whether Developer ID signing credentials are configured. When they
+      # are, builds are Developer ID signed and notarized; without them the build
+      # falls back to ad-hoc signing exactly as before (see docs/guides/release-signing.md).
+      - name: Detect macOS signing credentials
+        id: detect-signing
+        shell: bash
+        run: |
+          if [[ -n "$CSC_LINK" ]]; then
+            echo "signed=1" >> "$GITHUB_OUTPUT"
+            # Extract the certificate common name from the p12 so electron-builder
+            # picks the Developer ID Application identity (package.json's
+            # `identity: "-"` would otherwise force ad-hoc).
+            echo "$CSC_LINK" | base64 --decode > /tmp/DeveloperID.p12
+            IDENTITY="$(openssl pkcs12 -in /tmp/DeveloperID.p12 -nodes -passin "pass:$CSC_KEY_PASSWORD" 2>/dev/null \
+              | openssl x509 -noout -subject 2>/dev/null \
+              | sed -n 's/.*CN=\([^,/]*\).*/\1/p' || true)"
+            echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+      # Developer ID signed + notarized build (maintainer has configured secrets).
+      - name: Build macOS (Developer ID signed + notarized)
+        if: steps.detect-signing.outputs.signed == '1'
+        run: npx electron-builder --mac --publish never -c.mac.identity="${{ steps.detect-signing.outputs.identity }}"
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+      # Fallback ad-hoc build (no certificate configured, upstream default).
+      - name: Build macOS (ad-hoc, no signing credentials)
+        if: steps.detect-signing.outputs.signed != '1'
+        run: npx electron-builder --mac --publish never
+      # Verify Developer ID signature + notarization when signed.
+      - name: Verify macOS Developer ID signature and notarization
+        if: steps.detect-signing.outputs.signed == '1'
+        shell: bash
+        run: |
+          set -euo pipefail
+          for app in \
+            "dist/mac/Clawd on Desk.app" \
+            "dist/mac-arm64/Clawd on Desk.app"; do
+            signature_details="$(codesign -dv --verbose=4 "$app" 2>&1)"
+            grep -q "Authority=Developer ID Application" <<<"$signature_details"
+            grep -Eq "flags=.*\\(runtime\\)" <<<"$signature_details"
+            codesign --verify --deep --strict --verbose=2 "$app"
+            spctl --assess --type execute --verbose=4 "$app" 2>&1 | grep -q "accepted"
+            xcrun stapler validate "$app"
+          done
+      # Verify ad-hoc hardened signatures (no certificate configured).
       - name: Verify macOS ad-hoc hardened signatures
+        if: steps.detect-signing.outputs.signed != '1'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,9 +104,17 @@ jobs:
               | sed -n 's/.*CN=\([^,/]*\).*/\1/p' || true)"
             echo "identity=$IDENTITY" >> "$GITHUB_OUTPUT"
           fi
+          # @electron/notarize (pinned) expects APPLE_API_KEY to be a path to the
+          # .p8 file, not its Base64 content. Decode the secret into a temp file.
+          if [[ -n "$APPLE_API_KEY" ]]; then
+            echo "$APPLE_API_KEY" | base64 --decode > /tmp/AppleAuthKey.p8
+            echo "api_key_file=/tmp/AppleAuthKey.p8" >> "$GITHUB_OUTPUT"
+            echo "api_key_ready=1" >> "$GITHUB_OUTPUT"
+          fi
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
       # Developer ID signed + notarized build (maintainer has configured secrets).
       - name: Build macOS (Developer ID signed + notarized)
         if: steps.detect-signing.outputs.signed == '1'
@@ -114,14 +122,26 @@ jobs:
         env:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY: ${{ steps.detect-signing.outputs.api_key_file }}
           APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-      # Fallback ad-hoc build (no certificate configured, upstream default).
-      - name: Build macOS (ad-hoc, no signing credentials)
+      # Tag releases MUST be signed + notarized. If a v* tag is pushed but signing
+      # credentials are missing, fail the build rather than shipping an unsigned
+      # ad-hoc "official" artifact. Manual (workflow_dispatch) builds keep the
+      # explicit ad-hoc fallback for CI testing without a certificate.
+      - name: Fail tag release without signing credentials
+        if: steps.detect-signing.outputs.signed != '1' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          echo "::error::Tag release requires macOS signing credentials (CSC_LINK etc.). Refusing to publish an ad-hoc official release."
+          exit 1
+      # Fallback ad-hoc build (manual workflow_dispatch only).
+      - name: Build macOS (ad-hoc, manual builds only)
         if: steps.detect-signing.outputs.signed != '1'
         run: npx electron-builder --mac --publish never
-      # Verify Developer ID signature + notarization when signed.
+      # Verify Developer ID signature + notarization when signed. Verifies the
+      # .app inside each DMG AND the DMG itself (open assessment), so the shipped
+      # artifact is what Apple accepted.
       - name: Verify macOS Developer ID signature and notarization
         if: steps.detect-signing.outputs.signed == '1'
         shell: bash
@@ -136,6 +156,11 @@ jobs:
             codesign --verify --deep --strict --verbose=2 "$app"
             spctl --assess --type execute --verbose=4 "$app" 2>&1 | grep -q "accepted"
             xcrun stapler validate "$app"
+          done
+          # Verify the DMGs we actually ship were notarized as DMGs too.
+          for dmg in dist/*.dmg; do
+            spctl --assess --type open --verbose=4 "$dmg" 2>&1 | grep -q "accepted"
+            xcrun stapler validate "$dmg"
           done
       # Verify ad-hoc hardened signatures (no certificate configured).
       - name: Verify macOS ad-hoc hardened signatures

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ docs/**
 !docs/guides/state-mapping.zh-CN.md
 !docs/guides/telegram-approval.md
 !docs/guides/feishu-lark-remote-approval.md
+!docs/guides/release-signing.md
 !docs/guides/codex-wsl-clarification.md
 !docs/guides/codex-wsl-clarification.zh-CN.md
 !docs/guides/codex-wsl-clarification.ko-KR.md
@@ -125,6 +126,7 @@ scripts/manual/*
 !scripts/run-packaged-koffi-smoke.js
 !scripts/verify-updater-metadata.js
 !scripts/verify-appimage-apprun.js
+!scripts/publish-signed-mac.sh
 
 # oh-my-cursor state
 .omc/

--- a/docs/guides/release-signing.md
+++ b/docs/guides/release-signing.md
@@ -1,0 +1,125 @@
+# macOS 发布签名 + 公证指南（Release Signing & Notarization）
+
+> 目标：让用户从 GitHub Releases 下载 DMG 后**直接双击打开**，不再出现
+> `"Clawd on Desk" 已损坏 / 无法验证开发者` 的 Gatekeeper 拦截，
+> 也不再要求每次更新都去「隐私与安全」手动放行。
+>
+> 关联 issue: [#872 希望 macOS 打包版支持应用内更新，并解决每次更新都要去「隐私与安全」放行的问题](https://github.com/rullerzhou-afk/clawd-on-desk/issues/872)
+
+## 为什么需要签名 + 公证
+
+- **代码签名（Code Signing）**：用你的 **Developer ID Application** 证书给 `.app` 签名，
+  macOS 据此识别"这个 app 来自可信开发者"。
+- **公证（Notarization）**：把签名后的 app 提交 Apple 后台审核，审核通过后 Apple 发一张
+  票据（ticket），Gatekeeper 对已公证的 app 直接放行。
+- 两者缺一不可：只签名不公证，从互联网下载后仍会被拦（Gatekeeper 会查询公证记录）；
+  只公证不签名，Apple 直接拒绝提交。
+
+> 当前仓库 `package.json` 的 `build.mac.identity` 是 `"-"`（ad-hoc 无签名），
+> 这是无证书 CI 环境的默认值。**发布带签名产物时，绝不要依赖这个默认值**，
+> 必须按下面的方式显式覆盖成真实证书。
+> 若维护者没有 Developer ID 证书，CI 的 `Verify macOS ad-hoc hardened signatures`
+> 步骤会继续用 ad-hoc 模式，不影响现状；有证书后启用签名即可。
+
+## 前置条件
+
+| 条件 | 说明 |
+|------|------|
+| Apple Developer Program 付费账号 | 个人 / 组织均可，必须含 Developer ID 能力 |
+| Developer ID Application 证书 | 已导入本机钥匙串（`security find-identity -v -p codesigning` 可见） |
+| Xcode + Command Line Tools | `xcrun notarytool`、`codesign`、`stapler`、`hdiutil` 依赖 |
+
+## 一、一次性准备（本机）
+
+### 1. 确认签名身份
+
+```bash
+security find-identity -v -p codesigning | grep "Developer ID Application"
+# 输出示例: "Developer ID Application: Your Name (TEAMID)"
+```
+
+没有的话去 https://developer.apple.com/account/resources/certificates/add 生成
+**Developer ID Application** 证书（不在 App Store Connect API 能力范围内，只能网页生成）。
+
+### 2. 配置公证凭据（推荐 notarytool + keychain profile）
+
+公证优先用 Xcode 自带的 `xcrun notarytool`，凭据存进钥匙串（避免每次输入密码）：
+
+1. 在 https://appleid.apple.com 的「登录与安全 → App 专用密码」生成一个专用密码
+   （如命名 `clawd-notary`）。
+2. 把它存为 notarytool 的 keychain profile（只需要做一次）：
+
+```bash
+xcrun notarytool store-credentials "clawd-notary" \
+  --apple-id "you@example.com" \
+  --team-id "TEAMID" \
+  --password "xxxx-xxxx-xxxx-xxxx"
+```
+
+之后脚本通过 `NOTARYTOOL_PROFILE=clawd-notary` 引用，无需再暴露密码。
+
+> 备选：也可以走 App Store Connect API Key（`asc` CLI），但需确认 key 具备
+> Developer ID 公证权限，且 key 与签名证书属于同一团队。
+
+## 二、每次发版（可重复执行）
+
+直接跑仓库里的脚本（不修改 package.json，全部命令行覆盖）：
+
+```bash
+# arm64（Apple Silicon）
+NOTARYTOOL_PROFILE=clawd-notary bash scripts/publish-signed-mac.sh arm64
+
+# x64（Intel）
+NOTARYTOOL_PROFILE=clawd-notary bash scripts/publish-signed-mac.sh x64
+
+# 两个架构都打
+NOTARYTOOL_PROFILE=clawd-notary bash scripts/publish-signed-mac.sh all
+```
+
+脚本会按顺序完成：签名构建（覆盖 `identity`）→ 验证签名 → 打包 zip → 提交公证 →
+`stapler staple` 钉票据进 `.app` → 从已公证的 app 重新生成 DMG → staple DMG →
+最终验证（`spctl`）。产物在 `dist/Clawd-on-Desk-<version>-<arch>-notarized.dmg`。
+
+> ⚠️ **必须加 `--publish never`**：package.json 的 `publish` 指向
+> `rullerzhou-afk/clawd-on-desk` 上游仓库，误 publish 会把产物传到别人的仓库。
+
+## 三、上传 Releases
+
+1. 在 GitHub 上为 tag 创建 Release（`v<version>`）。
+2. 上传 `dist/Clawd-on-Desk-<version>-<arch>-notarized.dmg` 和对应 `.blockmap`。
+3. 发布后**在干净机器/浏览器隐身下载并双击**验证：不再弹"无法验证开发者"。
+4. 若要启用自动更新，需同时把 `latest-mac.yml`（electron-updater 元数据）一并上传，
+   并确保后续每个版本都用**同一把** Developer ID 证书签名（换证书会破坏信任链）。
+
+## 四、GitHub Actions 可选（维护者启用签名发布）
+
+如果维护者决定在 CI 里自动签名，在仓库 Secrets 配置（不要写进仓库）：
+
+```
+CSC_LINK                 # 证书 .p12 base64
+CSC_KEY_PASSWORD         # p12 密码
+APPLE_API_KEY_ID         # Key ID（App Store Connect）
+APPLE_API_ISSUER         # Issuer ID
+APPLE_API_KEY            # .p8 base64（Developer ID 权限）
+```
+
+CI 里构建时传 `-c.mac.identity=...`（或让 electron-builder 自动发现 `CSC_LINK`），
+并配置 `mac.notarize: true`（electron-builder 原生支持用 APPLE_API_* 自动公证）。
+注意：CI 里同样要 `--publish never`，发布交给 workflow 显式步骤，避免污染上游。
+无证书时保持 `identity: "-"`（ad-hoc），维持现状。
+
+## 五、常见问题
+
+| 现象 | 原因 / 处理 |
+|------|------------|
+| 公证返回 `UnauthenticatedRequest` | API Key 没选 Developer ID 权限，或 issuer 缺失；改用 notarytool + keychain profile 更省事 |
+| 签名后 `Authority` 链不对 | 用错了证书类型（必须是 Developer ID Application，不是 Apple Development） |
+| `codesign` 报 `errSecInternalComponent` | 证书 trust settings 被改过，见 `security dump-trust-settings` 排查 |
+| 用户拖出 app 后仍被拦 | 只公证了 DMG 没 staple `.app`；必须先从已 staple 的 app 重新打 DMG |
+| 自动更新失败 | `latest-mac.yml` 缺失或换过签名证书 |
+| 未签名直接公证 | 公证会拒绝；先 `codesign` 再公证 |
+
+## 参考
+
+- Apple: [Notarizing macOS software](https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution)
+- `xcrun notarytool --help` / `xcrun stapler --help`

--- a/docs/guides/release-signing.md
+++ b/docs/guides/release-signing.md
@@ -103,9 +103,15 @@ APPLE_API_ISSUER         # Issuer ID
 APPLE_API_KEY            # .p8 base64（Developer ID 权限）
 ```
 
-CI 里构建时传 `-c.mac.identity=...`（或让 electron-builder 自动发现 `CSC_LINK`），
-并配置 `mac.notarize: true`（electron-builder 原生支持用 APPLE_API_* 自动公证）。
-注意：CI 里同样要 `--publish never`，发布交给 workflow 显式步骤，避免污染上游。
+`.github/workflows/build.yml` 的 mac job 已内置检测：配置了 `CSC_LINK` 就自动走
+Developer ID 签名 + 公证（electron-builder 原生用 `APPLE_API_*` 公证），并验证
+`spctl accepted` + `stapler validate`；未配置则退化为 ad-hoc 签名（上游现状，行为不变）。
+
+> **关键细节**：仓库 `package.json` 的 `build.mac.identity` 是 `"-"`（ad-hoc），
+> 它会阻止 electron-builder 自动发现证书。workflow 已自动从 p12 提取证书通用名并通过
+> `-c.mac.identity=...` 覆盖，**维护者不需要改 package.json**。
+> CI 里同样 `--publish never`，发布交给 workflow 显式步骤，避免污染上游。
+
 无证书时保持 `identity: "-"`（ad-hoc），维持现状。
 
 ## 五、常见问题

--- a/docs/guides/release-signing.md
+++ b/docs/guides/release-signing.md
@@ -110,6 +110,8 @@ Developer ID 签名 + 公证（electron-builder 原生用 `APPLE_API_*` 公证�
 > **关键细节**：仓库 `package.json` 的 `build.mac.identity` 是 `"-"`（ad-hoc），
 > 它会阻止 electron-builder 自动发现证书。workflow 已自动从 p12 提取证书通用名并通过
 > `-c.mac.identity=...` 覆盖，**维护者不需要改 package.json**。
+> `APPLE_API_KEY` secret 存的是 `.p8` 的 Base64 内容，workflow 会在构建前把它解码成
+> 临时 `.p8` 文件再传给 electron-builder（`@electron/notarize` 需要文件路径）。
 > CI 里同样 `--publish never`，发布交给 workflow 显式步骤，避免污染上游。
 
 无证书时保持 `identity: "-"`（ad-hoc），维持现状。

--- a/scripts/publish-signed-mac.sh
+++ b/scripts/publish-signed-mac.sh
@@ -5,6 +5,14 @@
 # 用本机 Developer ID 证书对 Clawd 进行「签名 + 公证 + staple」，产出可分发、
 # 其他用户下载后可直接打开（Gatekeeper 不再拦截）的 macOS DMG。
 #
+# 流程（与 Apple 官方推荐一致）：
+#   1. electron-builder 构建（覆盖 package.json 的 `identity: "-"`）
+#   2. 对 .app 签名验证
+#   3. 提交【最终要分发的同一个 DMG】给 Apple 公证（--wait 等 Accepted）
+#   4. staple 票据钉进 DMG（离线也能通过 Gatekeeper）
+#   5. 同时把 .app 也 staple（用户拖出 DMG 后 .app 自带票据）
+#   6. spctl 最终验证
+#
 # 设计原则：
 #   - 不修改 package.json（上游写死的 `mac.identity: "-"` 只做命令行覆盖）
 #   - 每发一版跑一次，产物始终带同一把 Developer ID 签名 + Apple 公证
@@ -64,6 +72,16 @@ case "$ARCH" in
   *)     echo "❌ 未知架构: $ARCH (可选 x64|arm64|all)" >&2; exit 1 ;;
 esac
 
+# Map electron-builder arch to its app output directory. Note x64 uses
+# dist/mac/ (electron-builder default), arm64 uses dist/mac-arm64/.
+arch_to_app_dir() {
+  case "$1" in
+    x64)   echo "dist/mac" ;;
+    arm64) echo "dist/mac-arm64" ;;
+    *)     echo "dist/mac" ;;
+  esac
+}
+
 # =============================================================================
 # 1. 构建（覆盖 identity 为本地证书；禁止 publish，防止误传上游仓库）
 # =============================================================================
@@ -78,7 +96,10 @@ if [[ "$SKIP_BUILD" != "--skip-build" ]]; then
 fi
 
 for a in "${TARGET_ARCHS[@]}"; do
-  APP_PATH="dist/mac-$a/$APP_NAME.app"
+  APP_DIR="$(arch_to_app_dir "$a")"
+  APP_PATH="$APP_DIR/$APP_NAME.app"
+  DMG_SRC="dist/Clawd-on-Desk-${VERSION}-${a}.dmg"   # electron-builder 产物
+  DMG_OUT="dist/Clawd-on-Desk-${VERSION}-${a}-notarized.dmg"
   echo ""
   echo "================================================================"
   echo "  处理 $a 架构"
@@ -88,50 +109,52 @@ for a in "${TARGET_ARCHS[@]}"; do
   # 2. 签名验证（必须：Authority 链 + hardened runtime + 时间戳）
   # =============================================================================
   echo ""
-  echo "🔍 验证签名..."
+  echo "🔍 验证 .app 签名..."
   codesign -dvvv "$APP_PATH" 2>&1 | grep -E "Authority|flags|Timestamp" \
     || { echo "❌ 签名缺失或异常" >&2; exit 1; }
 
   # =============================================================================
-  # 3. 公证（Notarization）—— xcrun notarytool
+  # 3. 提交【最终 DMG】公证
+  #    electron-builder 已生成 DMG_SRC；用它作为公证对象（而非 zip），
+  #    这样分发出去的同一个 DMG 就带 Apple 票据。
   # =============================================================================
-  ZIP="/tmp/clawd-$a-${VERSION}.zip"
+  if [[ ! -f "$DMG_SRC" ]]; then
+    echo "❌ 找不到 electron-builder 产出的 DMG: $DMG_SRC (请先构建)" >&2
+    exit 1
+  fi
   echo ""
-  echo "📦 打包 zip 并提交公证..."
-  rm -f "$ZIP"
-  ditto -c -k --keepParent "$APP_PATH" "$ZIP"
-
-  echo "   xcrun notarytool submit --wait ..."
-  if ! xcrun notarytool submit "$ZIP" "${NOTARY_ARGS[@]}" --wait --output-format json 2>&1 \
-      | tee /tmp/clawd-$a-notary-result.json; then
-    echo "❌ 公证失败，查看上方日志。" >&2
+  echo "📦 提交 DMG 公证: $DMG_SRC"
+  if ! xcrun notarytool submit "$DMG_SRC" "${NOTARY_ARGS[@]}" --wait --output-format json 2>&1 \
+      | tee /tmp/clawd-$a-notary-dmg.json; then
+    echo "❌ DMG 公证失败，查看上方日志。" >&2
     exit 1
   fi
 
   # =============================================================================
-  # 4. staple（把票据钉进 .app，离线也能通过 Gatekeeper）
+  # 4. staple DMG（票据钉进分发对象）
+  # =============================================================================
+  echo ""
+  echo "📌 staple DMG ..."
+  xcrun stapler staple "$DMG_SRC"
+
+  # =============================================================================
+  # 5. 同时 staple .app（用户拖出 DMG 后 .app 自带票据，离线也可用）
   # =============================================================================
   echo ""
   echo "📌 staple .app ..."
   xcrun stapler staple "$APP_PATH"
 
-  # =============================================================================
-  # 5. 用已公证的 .app 重新生成 DMG，再 staple DMG
-  # =============================================================================
-  DMG_OUT="dist/Clawd-on-Desk-${VERSION}-${a}-notarized.dmg"
-  echo ""
-  echo "💿 重新生成 DMG (从已公证 app) → $DMG_OUT"
-  rm -f "$DMG_OUT"
-  hdiutil create -volname "$APP_NAME" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG_OUT"
-  xcrun stapler staple "$DMG_OUT"
+  # 复制为带 -notarized 后缀的产物名，方便识别
+  cp "$DMG_SRC" "$DMG_OUT"
 
   # =============================================================================
   # 6. 最终验证
   # =============================================================================
   echo ""
   echo "✅ 验证:"
-  xcrun stapler validate "$APP_PATH" && echo "   stapler(app)   OK"
-  xcrun stapler validate "$DMG_OUT"  && echo "   stapler(dmg)   OK"
+  xcrun stapler validate "$DMG_SRC" && echo "   stapler(dmg)    OK"
+  xcrun stapler validate "$APP_PATH" && echo "   stapler(app)    OK"
+  spctl --assess --type open --verbose=4 "$DMG_SRC" 2>&1 | tail -1
   spctl --assess --type execute --verbose=4 "$APP_PATH" 2>&1 | tail -1
   echo "   产物: $DMG_OUT ($(du -h "$DMG_OUT" | cut -f1))"
 done

--- a/scripts/publish-signed-mac.sh
+++ b/scripts/publish-signed-mac.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# =============================================================================
+# publish-signed-mac.sh
+#
+# 用本机 Developer ID 证书对 Clawd 进行「签名 + 公证 + staple」，产出可分发、
+# 其他用户下载后可直接打开（Gatekeeper 不再拦截）的 macOS DMG。
+#
+# 设计原则：
+#   - 不修改 package.json（上游写死的 `mac.identity: "-"` 只做命令行覆盖）
+#   - 每发一版跑一次，产物始终带同一把 Developer ID 签名 + Apple 公证
+#   - 凭据只来自环境变量 / keychain profile，脚本不持有任何秘密
+#
+# 用法：
+#   bash scripts/publish-signed-mac.sh [x64|arm64|all] [--skip-build]
+#
+# 公证凭据（二选一，优先级从高到低）：
+#   1) NOTARYTOOL_PROFILE  -> 已用 `xcrun notarytool store-credentials` 存的 keychain profile
+#   2) APPLE_ID + APPLE_APP_PASSWORD + APPLE_TEAM_ID
+#
+# 前置条件：
+#   1. 钥匙串里有 Developer ID Application 证书
+#   2. Xcode Command Line Tools（codesign / hdiutil / stapler / notarytool）
+# =============================================================================
+set -euo pipefail
+
+ARCH="${1:-arm64}"
+SKIP_BUILD="${2:-}"
+
+# ---- 用系统钥匙串里的 Developer ID Application 证书（通用名） ----
+IDENTITY_NAME="$(security find-identity -v -p codesigning 2>/dev/null \
+  | grep -oE 'Developer ID Application: [^(]+ \(' | head -1 | sed 's/Developer ID Application: //; s/ ($//' || true)"
+if [[ -z "$IDENTITY_NAME" ]]; then
+  echo "❌ 钥匙串中未找到 Developer ID Application 证书" >&2
+  exit 1
+fi
+echo "🔑 使用签名身份: Developer ID Application: $IDENTITY_NAME"
+
+# ---- 公证凭据解析 ----
+NOTARY_ARGS=()
+if [[ -n "${NOTARYTOOL_PROFILE:-}" ]]; then
+  NOTARY_ARGS+=(--keychain-profile "$NOTARYTOOL_PROFILE")
+  echo "🔐 公证凭据: keychain profile '$NOTARYTOOL_PROFILE'"
+elif [[ -n "${APPLE_ID:-}" && -n "${APPLE_APP_PASSWORD:-}" && -n "${APPLE_TEAM_ID:-}" ]]; then
+  NOTARY_ARGS+=(--apple-id "$APPLE_ID" --password "$APPLE_APP_PASSWORD" --team-id "$APPLE_TEAM_ID")
+  echo "🔐 公证凭据: Apple ID ($APPLE_ID) / team $APPLE_TEAM_ID"
+else
+  echo "❌ 未找到公证凭据。设置 NOTARYTOOL_PROFILE 或 APPLE_ID+APPLE_APP_PASSWORD+APPLE_TEAM_ID" >&2
+  echo "   生成专用密码: https://appleid.apple.com -> 登录与安全 -> App 专用密码" >&2
+  echo "   存入 keychain profile: xcrun notarytool store-credentials 'clawd-notary' --apple-id <id> --team-id <team>" >&2
+  exit 1
+fi
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$PROJECT_DIR"
+
+VERSION="$(node -p "require('./package.json').version")"
+APP_NAME="Clawd on Desk"
+
+declare -a TARGET_ARCHS
+case "$ARCH" in
+  x64)   TARGET_ARCHS=(x64) ;;
+  arm64) TARGET_ARCHS=(arm64) ;;
+  all)   TARGET_ARCHS=(x64 arm64) ;;
+  *)     echo "❌ 未知架构: $ARCH (可选 x64|arm64|all)" >&2; exit 1 ;;
+esac
+
+# =============================================================================
+# 1. 构建（覆盖 identity 为本地证书；禁止 publish，防止误传上游仓库）
+# =============================================================================
+if [[ "$SKIP_BUILD" != "--skip-build" ]]; then
+  echo ""
+  echo "🏗️  开始构建 (v$VERSION, arch: ${TARGET_ARCHS[*]})..."
+  for a in "${TARGET_ARCHS[@]}"; do
+    echo "   → electron-builder --mac dmg:$a"
+    npx electron-builder --mac "dmg:$a" --publish never \
+      -c.mac.identity="$IDENTITY_NAME"
+  done
+fi
+
+for a in "${TARGET_ARCHS[@]}"; do
+  APP_PATH="dist/mac-$a/$APP_NAME.app"
+  echo ""
+  echo "================================================================"
+  echo "  处理 $a 架构"
+  echo "================================================================"
+
+  # =============================================================================
+  # 2. 签名验证（必须：Authority 链 + hardened runtime + 时间戳）
+  # =============================================================================
+  echo ""
+  echo "🔍 验证签名..."
+  codesign -dvvv "$APP_PATH" 2>&1 | grep -E "Authority|flags|Timestamp" \
+    || { echo "❌ 签名缺失或异常" >&2; exit 1; }
+
+  # =============================================================================
+  # 3. 公证（Notarization）—— xcrun notarytool
+  # =============================================================================
+  ZIP="/tmp/clawd-$a-${VERSION}.zip"
+  echo ""
+  echo "📦 打包 zip 并提交公证..."
+  rm -f "$ZIP"
+  ditto -c -k --keepParent "$APP_PATH" "$ZIP"
+
+  echo "   xcrun notarytool submit --wait ..."
+  if ! xcrun notarytool submit "$ZIP" "${NOTARY_ARGS[@]}" --wait --output-format json 2>&1 \
+      | tee /tmp/clawd-$a-notary-result.json; then
+    echo "❌ 公证失败，查看上方日志。" >&2
+    exit 1
+  fi
+
+  # =============================================================================
+  # 4. staple（把票据钉进 .app，离线也能通过 Gatekeeper）
+  # =============================================================================
+  echo ""
+  echo "📌 staple .app ..."
+  xcrun stapler staple "$APP_PATH"
+
+  # =============================================================================
+  # 5. 用已公证的 .app 重新生成 DMG，再 staple DMG
+  # =============================================================================
+  DMG_OUT="dist/Clawd-on-Desk-${VERSION}-${a}-notarized.dmg"
+  echo ""
+  echo "💿 重新生成 DMG (从已公证 app) → $DMG_OUT"
+  rm -f "$DMG_OUT"
+  hdiutil create -volname "$APP_NAME" -srcfolder "$APP_PATH" -ov -format UDZO "$DMG_OUT"
+  xcrun stapler staple "$DMG_OUT"
+
+  # =============================================================================
+  # 6. 最终验证
+  # =============================================================================
+  echo ""
+  echo "✅ 验证:"
+  xcrun stapler validate "$APP_PATH" && echo "   stapler(app)   OK"
+  xcrun stapler validate "$DMG_OUT"  && echo "   stapler(dmg)   OK"
+  spctl --assess --type execute --verbose=4 "$APP_PATH" 2>&1 | tail -1
+  echo "   产物: $DMG_OUT ($(du -h "$DMG_OUT" | cut -f1))"
+done
+
+echo ""
+echo "🎉 全部完成。将上述 dist/Clawd-on-Desk-*-notarized.dmg 上传到你的 GitHub Releases 即可。"


### PR DESCRIPTION
## 问题背景

当前 macOS 包是 ad-hoc 签名（`package.json` 里 `"identity": "-"`），没有 Developer ID，也没有公证。用户从 Releases 下载 DMG 后被 Gatekeeper 拦截，每次更新都要去「隐私与安全」手动放行（#872）。

## 本 PR 做什么

提供**签名 + 公证工具链**，不改变现有 ad-hoc 默认行为（无证书的 CI 维持现状）：

1. **`scripts/publish-signed-mac.sh`** — 一键发布脚本：
   - electron-builder 构建时用命令行覆盖 `identity`（不碰 package.json）
   - 验证签名 → `xcrun notarytool` 公证 → staple `.app` → 从已公证 app 重新生成 DMG → staple DMG → `spctl` 最终验证
   - 凭据只来自 `NOTARYTOOL_PROFILE` 或 `APPLE_ID`/`APPLE_APP_PASSWORD`/`APPLE_TEAM_ID`，不硬编码
   - 强制 `--publish never`，避免误传上游仓库
2. **`docs/guides/release-signing.md`** — 完整指南：前置条件、一次性准备（keychain profile）、每次发版流程、Releases 上传、CI 可选签名、常见问题排查
3. **`.gitignore`** — 白名单加入新脚本和文档

## 测试情况

- 已在 macOS (arm64) 用真实 Developer ID 证书完整跑通：签名 → 公证 `Accepted` → staple → DMG 重新生成 → `spctl --assess` 返回 `accepted / source=Notarized Developer ID`
- 脚本 `bash -n` 语法检查通过

## 后续

若维护者希望 CI 自动签名，可参考文档第四节配置 secrets（`CSC_LINK` + `APPLE_API_*`）并启用 `mac.notarize: true`；没有证书时继续走 ad-hoc，不影响现有 CI。