### PR TITLE
fix(mac): defer Remote SSH keychain access until needed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -552,6 +552,7 @@ _settingsController.subscribeKey("agents", (_agents, snapshot) => {
   _syncCodexAutoStartGate(snapshot, "settings");
 });
 let _remoteSshInstallationIdentity = null;
+let _remoteSshInstallationIdentityPromise = null;
 
 async function initializeRemoteSshInstallationIdentity() {
   const remoteSsh = _settingsController.get("remoteSsh") || {};
@@ -586,6 +587,20 @@ async function initializeRemoteSshInstallationIdentity() {
     console.warn(`Clawd remote-ssh: installation binding uses weak storage backend (${identity.storageBackend})`);
   }
   return identity;
+}
+
+function ensureRemoteSshInstallationIdentity() {
+  if (_remoteSshInstallationIdentity) {
+    return Promise.resolve(_remoteSshInstallationIdentity);
+  }
+  if (_remoteSshInstallationIdentityPromise) {
+    return _remoteSshInstallationIdentityPromise;
+  }
+  _remoteSshInstallationIdentityPromise = initializeRemoteSshInstallationIdentity()
+    .finally(() => {
+      _remoteSshInstallationIdentityPromise = null;
+    });
+  return _remoteSshInstallationIdentityPromise;
 }
 
 // Mirror of `_settingsController.get("lang")` so existing sync read sites in
@@ -4195,7 +4210,7 @@ const _remoteSshIpc = registerRemoteSshIpc({
   transportCoordinator: _remoteSshTransportCoordinator,
   BrowserWindow,
   isPackaged: app.isPackaged,
-  getInstallationIdentity: () => _remoteSshInstallationIdentity,
+  getInstallationIdentity: ensureRemoteSshInstallationIdentity,
   enableProfileIsolation: process.env.CLAWD_ENABLE_EXPERIMENTAL_REMOTE_ISOLATION === "1",
 });
 
@@ -4970,14 +4985,14 @@ if (!gotTheLock) {
     // First-run only: seed UI language from the device locale, before createWindow
     // so the very first menu/tray render is already in the user's language.
     hydrateFreshInstallLanguage();
-    try {
-      await initializeRemoteSshInstallationIdentity();
-    } catch (err) {
-      _remoteSshInstallationIdentity = null;
-      console.error("Clawd remote-ssh: installation identity initialization failed:", err && err.message);
-    }
-    // safeStorage is only guaranteed after Electron is ready. This reconciles
-    // the local key/quota binding and never performs a Kimi network request.
+    // Remote SSH installation identity is intentionally lazy. Loading it uses
+    // macOS Keychain through safeStorage, so ordinary Clawd startup must not
+    // request credential access when no Remote SSH action is being performed.
+    // Explicit Remote SSH status/actions and connect-on-launch profiles load it
+    // through the single-flight provider injected into remote-ssh-ipc above.
+    // Kimi's separate local key/quota reconciliation still runs after ready.
+    // It may use safeStorage when a Kimi credential exists, but never performs
+    // a Kimi network request during this startup reconciliation.
     try {
       await _kimiQuotaRuntime.initialize();
     } catch (err) {

--- a/src/remote-ssh-ipc.js
+++ b/src/remote-ssh-ipc.js
@@ -203,7 +203,7 @@ function registerRemoteSshIpc(options = {}) {
   }
 
   async function withManagedTransport(requestedProfile, operation, policy, callback) {
-    const binding = requireVerifiedInstallationBinding();
+    const binding = await requireVerifiedInstallationBinding();
     const initialProfile = { ...requestedProfile, installId: binding.installId };
     if (!transportCoordinator) {
       if (policy && policy.disconnectOrdinary === true) {
@@ -439,8 +439,8 @@ function registerRemoteSshIpc(options = {}) {
     );
   }
 
-  function requireVerifiedInstallationBinding() {
-    const identity = getInstallationIdentity();
+  async function requireVerifiedInstallationBinding() {
+    const identity = await getInstallationIdentity();
     const snapshot = settingsController.getSnapshot();
     const expected = snapshot.remoteSsh && snapshot.remoteSsh.installId;
     if (!identity || typeof identity.installId !== "string" || identity.installId !== expected) {
@@ -544,7 +544,12 @@ function registerRemoteSshIpc(options = {}) {
       && typeof transportCoordinator.refreshProfileInspections === "function") {
       await transportCoordinator.refreshProfileInspections(listProfiles(settingsController));
     }
-    const identity = getInstallationIdentity();
+    let identity = null;
+    try {
+      identity = await getInstallationIdentity();
+    } catch (err) {
+      log("remote-ssh: installation identity unavailable:", err && err.message);
+    }
     return {
       status: "ok",
       statuses: remoteSshRuntime.listStatuses(),
@@ -601,7 +606,30 @@ function registerRemoteSshIpc(options = {}) {
       err.operation = destructiveProfileOperations.get(profile.id);
       throw err;
     }
-    const binding = requireVerifiedInstallationBinding();
+    const binding = await requireVerifiedInstallationBinding();
+    // The first lazy identity load may clone-recover Remote SSH settings and
+    // replace every profile while this Connect is awaiting Keychain access.
+    // Re-read the controller truth before checking deployment authority; the
+    // caller's snapshot may still contain routing credentials just revoked by
+    // clone recovery.
+    const currentProfile = findProfile(settingsController, profile.id);
+    if (!currentProfile) {
+      const err = new Error("Remote SSH profile disappeared before connection preparation");
+      err.reason = "profile_changed";
+      throw err;
+    }
+    if (!profileActionIsCurrent(profile.id, connectActionGeneration)) {
+      const err = new Error("Remote SSH Connect was superseded by a newer profile action");
+      err.reason = "transport_operation_busy";
+      throw err;
+    }
+    if (destructiveProfileOperations.has(profile.id)) {
+      const err = new Error("A destructive Remote SSH operation is already active for this profile");
+      err.reason = "transport_operation_busy";
+      err.operation = destructiveProfileOperations.get(profile.id);
+      throw err;
+    }
+    profile = currentProfile;
     if (profile.runtimeMode === "profile-isolated" && !enableProfileIsolation) {
       throw new Error(
         "Profile-isolated runtime is gated until the real SSH and CLI validation matrix is complete."
@@ -789,7 +817,7 @@ function registerRemoteSshIpc(options = {}) {
                   warning,
                 };
               }
-              const binding = requireVerifiedInstallationBinding();
+              const binding = await requireVerifiedInstallationBinding();
               const monitorProfile = { ...profile, installId: binding.installId };
               if (!profileActionIsCurrent(id, disconnectActionGeneration)) {
                 return {
@@ -884,7 +912,7 @@ function registerRemoteSshIpc(options = {}) {
             state,
           };
         }
-        const binding = requireVerifiedInstallationBinding();
+        const binding = await requireVerifiedInstallationBinding();
         const runtimeProfile = { ...profile, installId: binding.installId };
         const admitted = await transportCoordinator.acquireOwnedOperation(runtimeProfile, "disconnect");
         if (!admitted.ok) return coordinatorFailure(admitted);
@@ -939,7 +967,7 @@ function registerRemoteSshIpc(options = {}) {
       }
       // Best-effort cleanup of remote codex monitor if profile had it on.
       if (profile && profile.autoStartCodexMonitor === true && profile.remoteHome) {
-        const binding = requireVerifiedInstallationBinding();
+        const binding = await requireVerifiedInstallationBinding();
         stopCodexMonitorFn({
           profile: { ...profile, installId: binding.installId },
           runtime: remoteSshRuntime,
@@ -979,7 +1007,7 @@ function registerRemoteSshIpc(options = {}) {
     }
     destructiveProfileOperations.set(id, "cleanup");
     try {
-      const binding = requireVerifiedInstallationBinding();
+      const binding = await requireVerifiedInstallationBinding();
       if (profile.identityTxn && profile.identityTxn.phase !== "committed") {
         return {
           status: "error",
@@ -1106,7 +1134,7 @@ function registerRemoteSshIpc(options = {}) {
     }
     destructiveProfileOperations.set(id, "force-revoke");
     try {
-      requireVerifiedInstallationBinding();
+      await requireVerifiedInstallationBinding();
       await drainForDestructiveOperation(profile, "force-revoke-disconnect");
       return await withManagedTransport(
         profile,
@@ -1193,7 +1221,7 @@ function registerRemoteSshIpc(options = {}) {
     runtimeModeSwitches.add(id);
     destructiveProfileOperations.set(id, "runtime-mode-switch");
     try {
-      const binding = requireVerifiedInstallationBinding();
+      const binding = await requireVerifiedInstallationBinding();
       await drainForDestructiveOperation(profile, "runtime-mode-disconnect");
       let workingProfile = profile;
       if (!workingProfile.runtimeModeTxn) {
@@ -1417,7 +1445,6 @@ function registerRemoteSshIpc(options = {}) {
           suspendMessage: "Remote SSH is paused while hooks are deployed.",
         },
         async ({ profile, runtime, inspection, transportContext }) => {
-      const installationIdentity = requireVerifiedInstallationBinding();
       if (transportContext) transportContext.assertActive();
       const begin = await settingsController.applyCommand("remoteSsh.beginIdentityRotation", {
         id: profile.id,
@@ -1435,7 +1462,7 @@ function registerRemoteSshIpc(options = {}) {
       }
       const result = await deployFn({
         profile: deployProfile,
-        installId: installationIdentity.installId,
+        installId: profile.installId,
         identityTxn: deployProfile.identityTxn,
         legacyMigrationConfirmed,
         runtime,
@@ -1496,7 +1523,7 @@ function registerRemoteSshIpc(options = {}) {
             deployedAt: Date.now(),
             expectedTarget,
             remoteNode: result.remoteNode,
-            installId: installationIdentity.installId,
+            installId: profile.installId,
             remoteHome: result.layout && result.layout.remoteHome,
             isolation: result.isolation,
             sshTransportHint: transportHintFromInspection(inspection),
@@ -1717,9 +1744,26 @@ function registerRemoteSshIpc(options = {}) {
   async function connectOnLaunchProfiles() {
     const snap = settingsController.getSnapshot();
     const list = (snap.remoteSsh && Array.isArray(snap.remoteSsh.profiles)) ? snap.remoteSsh.profiles : [];
+    const initialLaunchProfiles = list.filter((profile) => profile && profile.connectOnLaunch === true);
     const started = [];
-    for (const profile of list) {
-      if (!profile || profile.connectOnLaunch !== true) continue;
+    if (!initialLaunchProfiles.length) return started;
+    try {
+      // One preflight per startup prevents several configured profiles from
+      // presenting the same Keychain prompt repeatedly after a denial.
+      await requireVerifiedInstallationBinding();
+    } catch (err) {
+      log("connect-on-launch skipped: installation identity unavailable", err && err.message);
+      return started;
+    }
+    // Identity initialization can commit clone recovery, and the user may
+    // change launch intent while Keychain access is pending. Only act on the
+    // post-initialization controller snapshot.
+    const currentSnap = settingsController.getSnapshot();
+    const currentList = (currentSnap.remoteSsh && Array.isArray(currentSnap.remoteSsh.profiles))
+      ? currentSnap.remoteSsh.profiles
+      : [];
+    const launchProfiles = currentList.filter((profile) => profile && profile.connectOnLaunch === true);
+    for (const profile of launchProfiles) {
       try {
         await connectProfile(profile);
         started.push(profile.id);

--- a/test/remote-ssh-identity.test.js
+++ b/test/remote-ssh-identity.test.js
@@ -51,6 +51,22 @@ function profile(over = {}) {
   };
 }
 
+test("main startup defers Remote SSH installation identity until IPC use", () => {
+  const mainSource = fs.readFileSync(path.join(__dirname, "..", "src", "main.js"), "utf8");
+  const readyStart = mainSource.indexOf("app.whenReady().then(async () => {");
+  const beforeQuit = mainSource.indexOf('app.on("before-quit"', readyStart);
+  assert.notEqual(readyStart, -1);
+  assert.notEqual(beforeQuit, -1);
+  assert.doesNotMatch(
+    mainSource.slice(readyStart, beforeQuit),
+    /(?:initialize|ensure)RemoteSshInstallationIdentity\s*\(/,
+  );
+  assert.match(
+    mainSource,
+    /getInstallationIdentity:\s*ensureRemoteSshInstallationIdentity/,
+  );
+});
+
 test("installation binding is separate from prefs and derives a stable public install id", () => {
   withTempDir((userDataDir) => {
     const first = loadOrCreateInstallationIdentity({

--- a/test/remote-ssh-ipc.test.js
+++ b/test/remote-ssh-ipc.test.js
@@ -342,6 +342,62 @@ test("remoteSsh:list-statuses returns runtime list", async () => {
   ipc.dispose();
 });
 
+test("remoteSsh:list-statuses waits for the lazy installation identity", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  let resolveIdentity;
+  const identityPending = new Promise((resolve) => { resolveIdentity = resolve; });
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController: mockSettingsController(),
+    remoteSshRuntime: mockRuntime(),
+    BrowserWindow,
+    getInstallationIdentity: () => identityPending,
+  });
+
+  let settled = false;
+  const statuses = ipcMain.invoke("remoteSsh:list-statuses").then((result) => {
+    settled = true;
+    return result;
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(settled, false);
+
+  resolveIdentity({
+    installId: TEST_INSTALL_ID,
+    strongStorage: true,
+    storageBackend: "safe-storage",
+  });
+  const result = await statuses;
+  assert.deepEqual(result.bindingSecurity, {
+    strongStorage: true,
+    storageBackend: "safe-storage",
+  });
+  ipc.dispose();
+});
+
+test("remoteSsh:list-statuses degrades to unavailable when lazy identity access is denied", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  const logs = [];
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController: mockSettingsController(),
+    remoteSshRuntime: mockRuntime(),
+    BrowserWindow,
+    getInstallationIdentity: async () => { throw new Error("keychain denied"); },
+    log: (...args) => logs.push(args.join(" ")),
+  });
+
+  const result = await ipcMain.invoke("remoteSsh:list-statuses");
+  assert.deepEqual(result.bindingSecurity, {
+    strongStorage: false,
+    storageBackend: "unavailable",
+  });
+  assert.equal(logs.some((line) => line.includes("keychain denied")), true);
+  ipc.dispose();
+});
+
 test("remoteSsh:list-statuses primes safe cross-profile serialized conflicts", async () => {
   const ipcMain = mockIpcMain();
   const { BrowserWindow } = mockBrowserWindow();
@@ -430,6 +486,87 @@ test("remoteSsh:connect calls runtime.connect with the resolved profile", async 
   const r = await ipcMain.invoke("remoteSsh:connect", "p1");
   assert.equal(r.status, "ok");
   assert.equal(connectArg.id, "p1");
+  ipc.dispose();
+});
+
+test("remoteSsh:connect waits for lazy identity verification before starting SSH", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  const rt = mockRuntime();
+  let resolveIdentity;
+  let connects = 0;
+  rt.connect = () => { connects += 1; };
+  const identityPending = new Promise((resolve) => { resolveIdentity = resolve; });
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController: mockSettingsController([readyProfile]),
+    remoteSshRuntime: rt,
+    BrowserWindow,
+    getInstallationIdentity: () => identityPending,
+  });
+
+  const pending = ipcMain.invoke("remoteSsh:connect", readyProfile.id);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(connects, 0);
+  resolveIdentity({ installId: TEST_INSTALL_ID });
+
+  const result = await pending;
+  assert.equal(result.status, "ok");
+  assert.equal(connects, 1);
+  ipc.dispose();
+});
+
+test("remoteSsh:connect fails closed when lazy identity verification mismatches prefs", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  const rt = mockRuntime();
+  let connects = 0;
+  rt.connect = () => { connects += 1; };
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController: mockSettingsController([readyProfile]),
+    remoteSshRuntime: rt,
+    BrowserWindow,
+    getInstallationIdentity: async () => ({ installId: "b".repeat(64) }),
+  });
+
+  const result = await ipcMain.invoke("remoteSsh:connect", readyProfile.id);
+  assert.equal(result.status, "error");
+  assert.match(result.message, /unavailable or mismatched/);
+  assert.equal(connects, 0);
+  ipc.dispose();
+});
+
+test("remoteSsh:connect re-reads clone-recovered profile authority after lazy identity load", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  const recoveredInstallId = "c".repeat(64);
+  const settingsController = actionBackedSettingsController([readyProfile]);
+  const rt = mockRuntime();
+  let connects = 0;
+  rt.connect = () => { connects += 1; };
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController,
+    remoteSshRuntime: rt,
+    BrowserWindow,
+    getInstallationIdentity: async () => {
+      const recovered = await settingsController.applyCommand("remoteSsh.applyInstallationIdentity", {
+        installId: recoveredInstallId,
+        cloneRecoveryRequired: true,
+      });
+      assert.equal(recovered.status, "ok");
+      return { installId: recoveredInstallId };
+    },
+  });
+
+  const result = await ipcMain.invoke("remoteSsh:connect", readyProfile.id);
+  assert.equal(result.status, "error");
+  assert.equal(result.reason, "deployment_required");
+  assert.equal(connects, 0);
+  const recoveredProfile = settingsController.getSnapshot().remoteSsh.profiles[0];
+  assert.equal(recoveredProfile.routingNonce, undefined);
+  assert.equal(recoveredProfile.lastDeployedAt, undefined);
   ipc.dispose();
 });
 
@@ -950,6 +1087,83 @@ test("settings remoteSsh updates refresh cached runtime profiles and stop remove
 });
 
 // ── connect-on-launch sweep ──
+
+test("connectOnLaunchProfiles does not load identity when no profile opted in", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  let identityLoads = 0;
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController: mockSettingsController([
+      { ...readyProfile, id: "p1", connectOnLaunch: false },
+    ]),
+    remoteSshRuntime: mockRuntime(),
+    BrowserWindow,
+    getInstallationIdentity: async () => {
+      identityLoads += 1;
+      return { installId: TEST_INSTALL_ID };
+    },
+  });
+
+  assert.deepEqual(await ipc.connectOnLaunchProfiles(), []);
+  assert.equal(identityLoads, 0);
+  ipc.dispose();
+});
+
+test("connectOnLaunchProfiles attempts denied identity only once for several profiles", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  const rt = mockRuntime();
+  let identityLoads = 0;
+  let connects = 0;
+  rt.connect = () => { connects += 1; };
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController: mockSettingsController([
+      { ...readyProfile, id: "p1", connectOnLaunch: true },
+      { ...readyProfile, id: "p2", connectOnLaunch: true },
+    ]),
+    remoteSshRuntime: rt,
+    BrowserWindow,
+    getInstallationIdentity: async () => {
+      identityLoads += 1;
+      throw new Error("keychain denied");
+    },
+  });
+
+  assert.deepEqual(await ipc.connectOnLaunchProfiles(), []);
+  assert.equal(identityLoads, 1);
+  assert.equal(connects, 0);
+  ipc.dispose();
+});
+
+test("connectOnLaunchProfiles re-reads launch intent after lazy identity load", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  let profile = { ...readyProfile, connectOnLaunch: true };
+  const settingsController = {
+    getSnapshot: () => ({
+      remoteSsh: { installId: TEST_INSTALL_ID, profiles: [profile] },
+    }),
+  };
+  const rt = mockRuntime();
+  let connects = 0;
+  rt.connect = () => { connects += 1; };
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController,
+    remoteSshRuntime: rt,
+    BrowserWindow,
+    getInstallationIdentity: async () => {
+      profile = { ...profile, connectOnLaunch: false };
+      return { installId: TEST_INSTALL_ID };
+    },
+  });
+
+  assert.deepEqual(await ipc.connectOnLaunchProfiles(), []);
+  assert.equal(connects, 0);
+  ipc.dispose();
+});
 
 test("connectOnLaunchProfiles connects only flagged profiles", async () => {
   const ipcMain = mockIpcMain();
@@ -2359,11 +2573,40 @@ test("profile isolation stays release-gated until the real SSH and CLI matrix is
 
 // ── Deploy stamp ──
 
+test("remoteSsh:deploy fails before admission when lazy identity access is denied", async () => {
+  const ipcMain = mockIpcMain();
+  const { BrowserWindow } = mockBrowserWindow();
+  const settingsController = mockSettingsController([baseProfile]);
+  let deploys = 0;
+  const ipc = registerRemoteSshIpc({
+    ipcMain,
+    settingsController,
+    remoteSshRuntime: mockRuntime(),
+    BrowserWindow,
+    getInstallationIdentity: async () => { throw new Error("keychain denied"); },
+    deployFn: async () => {
+      deploys += 1;
+      return { ok: true };
+    },
+  });
+
+  const result = await ipcMain.invoke("remoteSsh:deploy", baseProfile.id);
+  assert.equal(result.status, "error");
+  assert.match(result.message, /keychain denied/);
+  assert.equal(deploys, 0);
+  assert.equal(
+    settingsController._commandCalls.some((call) => call.action === "remoteSsh.beginIdentityRotation"),
+    false,
+  );
+  ipc.dispose();
+});
+
 test("remoteSsh:deploy stamps via markDeployed (not full update) on success", async () => {
   const ipcMain = mockIpcMain();
   const { BrowserWindow } = mockBrowserWindow();
   const settingsController = mockSettingsController([baseProfile]);
   const before = Date.now();
+  let deployInstallId = null;
   const ipc = registerRemoteSshIpc({
     ipcMain,
     settingsController,
@@ -2372,17 +2615,21 @@ test("remoteSsh:deploy stamps via markDeployed (not full update) on success", as
     spawn: makeSucceedingSpawn().spawn,
     // Inject a fake deploy that just resolves ok — we're testing the
     // post-success commit, not the deploy steps themselves.
-    deployFn: async () => ({
-      ok: true,
-      remoteNode: {
-        nodeBin: "/usr/local/bin/node",
-        version: "v20.10.0",
-        source: "path",
-      },
-    }),
+    deployFn: async ({ installId }) => {
+      deployInstallId = installId;
+      return {
+        ok: true,
+        remoteNode: {
+          nodeBin: "/usr/local/bin/node",
+          version: "v20.10.0",
+          source: "path",
+        },
+      };
+    },
   });
   const r = await ipcMain.invoke("remoteSsh:deploy", "p1");
   assert.equal(r.status, "ok");
+  assert.equal(deployInstallId, TEST_INSTALL_ID);
   const markCall = settingsController._commandCalls.find((call) => call.action === "remoteSsh.markDeployed");
   assert.ok(markCall, "secure deploy must stamp with markDeployed before transaction commit");
   const markIndex = settingsController._commandCalls.findIndex(


### PR DESCRIPTION
## Summary
- defer Remote SSH installation identity loading until Remote SSH status or an explicit action actually needs it
- keep first-use initialization single-flight and re-read authoritative profiles after identity reconciliation so clone recovery cannot leave a stale Connect snapshot
- preserve fail-closed identity checks, connect-on-launch intent, and the ordinary Disconnect safety valve
- reuse the binding already verified by managed transport during Deploy

## Verification
- node --test test/remote-ssh-identity.test.js test/remote-ssh-ipc.test.js: 98/98 passed
- node --test test/remote-ssh-*.test.js: 496 passed, 1 skipped, 0 failed
- npm run build:mac: x64 and arm64 builds succeeded
- real macOS arm64 smoke: ordinary startup showed no Keychain or SecurityAgent dialog; GET /state returned ok on 127.0.0.1:23333
- full suite retains 30 existing DSH failures reproduced from exact base 54480d10; no new failure cluster

## Scope
This addresses the Remote SSH safeStorage startup path reported in #911. Kimi credential storage, hook-triggered cold launch, and Developer ID signing remain separate boundaries pending reporter evidence.