### PR TITLE
fix: canonicalize Windows DSH realpaths consistently

### DIFF
--- a/hooks/dsh-install.js
+++ b/hooks/dsh-install.js
@@ -47,6 +47,12 @@ function resolveDshProfileDir(dshHome) {
   return path.join(dshHome, "profiles", WEB_PROFILE_NAME);
 }
 
+function realpathSyncCanonical(fsImpl, value) {
+  return fsImpl.realpathSync.native
+    ? fsImpl.realpathSync.native(value)
+    : fsImpl.realpathSync(value);
+}
+
 function resolveCanonicalDshHome(options = {}) {
   const platform = options.platform || process.platform;
   const pathApi = platform === "win32" ? path.win32 : path.posix;
@@ -56,9 +62,7 @@ function resolveCanonicalDshHome(options = {}) {
   let canonical = pathApi.resolve(configured);
   if (platform === process.platform) {
     try {
-      canonical = fs.realpathSync.native
-        ? fs.realpathSync.native(canonical)
-        : fs.realpathSync(canonical);
+      canonical = realpathSyncCanonical(fs, canonical);
     } catch {}
   }
   return canonical;
@@ -78,9 +82,7 @@ function resolveCanonicalLocalPath(value, options = {}) {
   let cursor = resolved;
   while (true) {
     try {
-      const realpath = fsImpl.realpathSync.native
-        ? fsImpl.realpathSync.native(cursor)
-        : fsImpl.realpathSync(cursor);
+      const realpath = realpathSyncCanonical(fsImpl, cursor);
       return path.join(realpath, ...suffix);
     } catch {}
     const parent = path.dirname(cursor);
@@ -536,7 +538,7 @@ function inspectResolvedPackageSync(fsImpl, packageManifestPath, anchor) {
   }
   let realManifestPath = packageManifestPath;
   try {
-    realManifestPath = fsImpl.realpathSync(packageManifestPath);
+    realManifestPath = realpathSyncCanonical(fsImpl, packageManifestPath);
   } catch {}
   const packageManifest = readJsonSync(fsImpl, realManifestPath);
   const packageDir = path.dirname(realManifestPath);
@@ -575,7 +577,7 @@ function resolveDshInstallRootSync(options = {}) {
   const pathApi = platform === "win32" ? path.win32 : path.posix;
   for (const shim of dshCommandPathsSync(options)) {
     let realShim = shim;
-    try { realShim = fsImpl.realpathSync(shim); } catch {}
+    try { realShim = realpathSyncCanonical(fsImpl, shim); } catch {}
     const normalized = realShim.replace(/\\/g, "/");
     if (normalized.endsWith("/lib/bin.js")) return pathApi.dirname(pathApi.dirname(realShim));
     const candidates = [

--- a/test/agent-installation-detector.test.js
+++ b/test/agent-installation-detector.test.js
@@ -45,6 +45,12 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
+function canonicalRealpath(filePath) {
+  return fs.realpathSync.native
+    ? fs.realpathSync.native(filePath)
+    : fs.realpathSync(filePath);
+}
+
 function writeText(filePath, value = "") {
   mkdirp(path.dirname(filePath));
   fs.writeFileSync(filePath, value, "utf8");
@@ -188,7 +194,7 @@ describe("agent installation detector", () => {
     dsh = byId(report, "deepseek-harness");
     assert.strictEqual(dsh.clawdIntegration.detected, true);
     assert.strictEqual(dsh.clawdIntegration.reason, "managed-plugin");
-    assert.strictEqual(dsh.clawdIntegration.paths.pluginDir, fs.realpathSync(pluginDir));
+    assert.strictEqual(dsh.clawdIntegration.paths.pluginDir, canonicalRealpath(pluginDir));
   });
 
   it("detects a DSH CLI on PATH before the profile home is initialized", {

--- a/test/dsh-install-bridge.test.js
+++ b/test/dsh-install-bridge.test.js
@@ -37,6 +37,12 @@ function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
+function canonicalRealpath(filePath) {
+  return fs.realpathSync.native
+    ? fs.realpathSync.native(filePath)
+    : fs.realpathSync(filePath);
+}
+
 function makeHarness({ profile = true } = {}) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-dsh-managed-"));
   const dshHome = path.join(root, ".dsh");
@@ -691,7 +697,7 @@ test("a DSH_HOME alias is frozen to one real target for namespace, CLI env, and 
   fs.mkdirSync(targetB, { recursive: true });
   fs.symlinkSync(targetA, alias, process.platform === "win32" ? "junction" : "dir");
   t.after(() => fs.rmSync(root, { recursive: true, force: true }));
-  const canonicalA = fs.realpathSync.native ? fs.realpathSync.native(targetA) : fs.realpathSync(targetA);
+  const canonicalA = canonicalRealpath(targetA);
   const frozen = dshInstallTest.resolveCanonicalDshHome({ dshHome: alias });
   assert.strictEqual(frozen, canonicalA);
   const managedRoot = resolveManagedRoot({ dshHome: alias, homeDir: root });
@@ -719,7 +725,7 @@ test("a DSH_HOME alias is frozen to one real target for namespace, CLI env, and 
       return cli.runDshCommand(args);
     },
   }));
-  assert.strictEqual(observedDshHome, fs.realpathSync(harness.dshHome));
+  assert.strictEqual(observedDshHome, canonicalRealpath(harness.dshHome));
 });
 
 test("a managed-root alias remains owned after package inspection resolves its real path", async (t) => {
@@ -740,7 +746,7 @@ test("a managed-root alias remains owned after package inspection resolves its r
   assert.strictEqual(result.health.owned, true);
   assert.strictEqual(
     result.health.managedRoot,
-    path.join(fs.realpathSync(managedTarget), "deepseek-harness"),
+    path.join(canonicalRealpath(managedTarget), "deepseek-harness"),
   );
 });
 


### PR DESCRIPTION
## Summary

- use native synchronous realpath resolution consistently when freezing DSH homes, managed roots, package manifests, and CLI shims
- align Windows alias assertions with the same canonical-path contract
- prevent a healthy managed DSH bridge from being classified as foreign when Windows exposes both long and 8.3 paths

## Release blocker evidence

The exact-main Build & Release run https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/32620419448 exposed four Windows failures caused by mixed native long paths and legacy 8.3 paths. A first repair run exposed one remaining assertion with the same stale contract; no product-path failure remained.

## Validation

- node --test test/agent-installation-detector.test.js test/dsh-install-bridge.test.js test/doctor-agent-integrations.test.js (212 tests, 208 passed, 4 skipped)
- npm test (8621 tests, 8591 passed, 30 skipped)
- exact-head full Build & Release: https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/32621100706
  - Windows, macOS, and Linux full tests/builds passed
  - macOS Developer ID signing and notarization passed
  - darwin-arm64, darwin-x64, windows-x64, windows-arm64, and linux-x64 native package audits passed
  - release job skipped by design for workflow_dispatch; no release was published
- Repository Asset Audit passed
- git diff --check