### PR TITLE
fix: open tutorial language menu downward

### DIFF
--- a/src/tutorial.html
+++ b/src/tutorial.html
@@ -112,7 +112,8 @@ body { user-select: none; }
   display: flex;
   align-items: safe center;
   justify-content: center;
-  padding: 18px 26px 202px;
+  /* Keep the full seven-row menu below three-line pt-BR/es copy at the default 720x700 size. */
+  padding: 18px 26px 234px;
   scrollbar-width: none;
 }
 .body.step-welcome::-webkit-scrollbar { width: 0; height: 0; }

--- a/src/tutorial.html
+++ b/src/tutorial.html
@@ -112,7 +112,7 @@ body { user-select: none; }
   display: flex;
   align-items: safe center;
   justify-content: center;
-  padding: 18px 26px 154px;
+  padding: 18px 26px 202px;
   scrollbar-width: none;
 }
 .body.step-welcome::-webkit-scrollbar { width: 0; height: 0; }
@@ -169,6 +169,8 @@ body { user-select: none; }
   display: flex; align-items: center; justify-content: center; gap: 10px;
   margin-top: 22px; padding-top: 18px; border-top: 1px solid var(--border);
 }
+.step-welcome .language-picker { width: 160px; }
+.step-welcome .language-picker-option { white-space: nowrap; }
 .lang-label { font-size: 13px; color: var(--muted); font-weight: 600; }
 
 /* Agent setup */

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -8407,20 +8407,20 @@ describe("settings renderer browser environment", () => {
     assert.match(css, /\.language-picker\.open-up \.language-picker-menu\s*\{[\s\S]*bottom:\s*calc\(100% \+ 6px\);/);
   });
 
-  it("opens the seven-language tutorial picker upward when it no longer fits below the default welcome layout", () => {
+  it("opens the seven-language tutorial picker downward in the default welcome layout", () => {
     const harness = loadSharedLanguagePickerForTest({
       options: SUPPORTED_LANGS,
       innerHeight: 700,
     });
     harness.boundary.getBoundingClientRect = () => ({ top: 78, bottom: 635 });
-    harness.trigger.getBoundingClientRect = () => ({ top: 390, bottom: 426 });
+    harness.trigger.getBoundingClientRect = () => ({ top: 366, bottom: 402 });
     Object.defineProperty(harness.menu, "scrollHeight", { value: 220 });
     Object.defineProperty(harness.menu, "offsetHeight", { value: 222 });
     Object.defineProperty(harness.menu, "clientHeight", { value: 220 });
 
     harness.trigger.dispatchEvent({ type: "click" });
 
-    assert.strictEqual(harness.picker.classList.contains("open-up"), true);
+    assert.strictEqual(harness.picker.classList.contains("open-up"), false);
     assert.strictEqual(harness.picker.classList.contains("menu-scrollable"), false);
     assert.strictEqual(harness.menu.style.maxHeight, "222px");
   });

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -8407,13 +8407,14 @@ describe("settings renderer browser environment", () => {
     assert.match(css, /\.language-picker\.open-up \.language-picker-menu\s*\{[\s\S]*bottom:\s*calc\(100% \+ 6px\);/);
   });
 
-  it("opens the seven-language tutorial picker downward in the default welcome layout", () => {
+  it("opens downward for the captured three-line pt-BR/es default-window geometry", () => {
     const harness = loadSharedLanguagePickerForTest({
       options: SUPPORTED_LANGS,
-      innerHeight: 700,
+      innerHeight: 668,
     });
-    harness.boundary.getBoundingClientRect = () => ({ top: 78, bottom: 635 });
-    harness.trigger.getBoundingClientRect = () => ({ top: 366, bottom: 402 });
+    // Captured from real macOS Electron layout; this guards picker placement, not CSS layout.
+    harness.boundary.getBoundingClientRect = () => ({ top: 47, bottom: 603 });
+    harness.trigger.getBoundingClientRect = () => ({ top: 325, bottom: 361 });
     Object.defineProperty(harness.menu, "scrollHeight", { value: 220 });
     Object.defineProperty(harness.menu, "offsetHeight", { value: 222 });
     Object.defineProperty(harness.menu, "clientHeight", { value: 220 });

--- a/test/tutorial.test.js
+++ b/test/tutorial.test.js
@@ -158,7 +158,7 @@ describe("tutorial window shell", () => {
     assert.ok(!renderer.includes("lang-select"));
     assert.ok(html.includes(`href="language-picker.css"`));
     assert.ok(html.includes(`src="language-picker.js"`));
-    assert.match(html, /\.body\.step-welcome \{[^}]*padding:\s*18px 26px 202px;[^}]*scrollbar-width:\s*none;/s);
+    assert.match(html, /\.body\.step-welcome \{[^}]*padding:\s*18px 26px 234px;[^}]*scrollbar-width:\s*none;/s);
     assert.match(html, /\.body\.step-welcome::-webkit-scrollbar \{[^}]*width:\s*0;[^}]*height:\s*0;/);
     assert.doesNotMatch(html, /\.step-welcome \.welcome \{[^}]*transform:/);
     assert.match(html, /id="body" data-language-picker-boundary/);

--- a/test/tutorial.test.js
+++ b/test/tutorial.test.js
@@ -158,11 +158,13 @@ describe("tutorial window shell", () => {
     assert.ok(!renderer.includes("lang-select"));
     assert.ok(html.includes(`href="language-picker.css"`));
     assert.ok(html.includes(`src="language-picker.js"`));
-    assert.match(html, /\.body\.step-welcome \{[^}]*padding:\s*18px 26px 154px;[^}]*scrollbar-width:\s*none;/s);
+    assert.match(html, /\.body\.step-welcome \{[^}]*padding:\s*18px 26px 202px;[^}]*scrollbar-width:\s*none;/s);
     assert.match(html, /\.body\.step-welcome::-webkit-scrollbar \{[^}]*width:\s*0;[^}]*height:\s*0;/);
     assert.doesNotMatch(html, /\.step-welcome \.welcome \{[^}]*transform:/);
     assert.match(html, /id="body" data-language-picker-boundary/);
     assert.match(html, /\.body\.step-welcome \{[^}]*overflow-y: auto;[^}]*align-items: safe center;/s);
+    assert.match(html, /\.step-welcome \.language-picker \{[^}]*width:\s*160px;/s);
+    assert.match(html, /\.step-welcome \.language-picker-option \{[^}]*white-space:\s*nowrap;/s);
     assert.match(html, /style-src 'self' 'unsafe-inline'/);
   });
 


### PR DESCRIPTION
## Summary
- Make the first-run tutorial language menu open downward in the default window layout.
- Widen the tutorial-only picker so `Português (Brasil)` stays on one line.
- Preserve the shared picker's adaptive upward fallback for constrained windows and enlarged text.

## Problem context
The welcome screen centers its content inside the scrollable tutorial body and lets the shared language picker choose the side with more usable space. After the seventh locale was added, the 128px-wide tutorial menu wrapped `Português (Brasil)`, increasing the menu height. Even after the existing welcome-content offset was increased, the default Windows tutorial window still had slightly less room below the trigger than the menu needed, so the picker opened upward.

## What changed
- Increase the welcome step's bottom padding so the centered content sits 24px higher in the default layout.
- Set a tutorial-only 160px picker width and prevent option labels from wrapping.
- Update the default seven-language geometry regression to require downward placement.
- Keep minimum-window/enlarged-text coverage that requires upward placement and scrolling when space is genuinely constrained.

## Behavior after this PR
- In the default first-run tutorial window, all seven language options open below the trigger without overlapping the footer.
- The Portuguese label remains on one line.
- Small windows and 150%/160% text-scale layouts continue to use the shared adaptive placement and bounded scrolling behavior.
- Settings language-picker sizing and placement are unchanged.

## Validation
- `node --test test/tutorial.test.js` — 17 passed.
- `node --test --test-name-pattern="language picker|tutorial picker" test/settings-renderer-browser-env.test.js` — 9 passed.
- Windows hands-on QA — the user confirmed with a screenshot that the default tutorial window opens the complete menu downward, keeps `Português (Brasil)` on one line, and leaves clearance above the footer.
- `npm test` — did not start the suite because the current 422-file runner exceeds the Windows process command-length limit: `spawnSync D:\Program Files\nodejs\node.exe ENAMETOOLONG`.
- Batched full-suite follow-up — unrelated baseline/environment failures remain: Feishu SDK `1.73.0` versus a test expecting `1.71.1`; `minimatch is not a function` in asset/icon tests; and 13 Slack-related tests cancelled after the event loop resolved. The tutorial-specific tests above pass.

## Platform note
Automated checks and hands-on QA ran on Windows with Electron 41.10.6. macOS and Linux manual QA remain unperformed; the shared constrained-layout fallback retains automated coverage.

## Scope control
- This changes only the first-run tutorial layout and its regression coverage.
- It does not change the shared language-picker placement algorithm or the Settings UI.
