### PR TITLE
refactor: animate settings collapsibles with grid

### DIFF
--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -880,6 +880,7 @@
           if (Number(count) <= 1) return;
           const revealMergeRow = () => {
             mergeRow.style.display = "";
+            return mergeRow;
           };
           if (typeof group.mutateCollapsibleBody === "function") {
             group.mutateCollapsibleBody(revealMergeRow);
@@ -985,6 +986,7 @@
               element.appendChild(buildProviderRow(provider));
             }
             element.style.display = "";
+            return element;
           };
           if (group && typeof group.mutateCollapsibleBody === "function") {
             group.mutateCollapsibleBody(reveal);

--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -872,7 +872,6 @@
       desc: t("rowQuotaRingGroupDesc"),
       defaultCollapsed: true,
       className: "quota-ring-collapsible",
-      animateExpansion: false,
       children: [optionList],
     });
     if (window.settingsAPI && typeof window.settingsAPI.getQuotaSourceCount === "function") {
@@ -1248,7 +1247,6 @@
       summary: summaryControl.element,
       defaultCollapsed: true,
       className: "sound-collapsible",
-      animateExpansion: false,
       children: [buildOptionList("sound-option-list", [
         buildSoundEnabledRow(summaryControl),
         buildVolumeSliderRow(),
@@ -1263,7 +1261,6 @@
       desc: t("rowFlashDesc"),
       defaultCollapsed: true,
       className: "flash-collapsible",
-      animateExpansion: false,
       children: [buildOptionList("flash-option-list", [
         helpers.buildSwitchRow({
           key: "flashTaskbarOnComplete",

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -819,8 +819,10 @@
       if (ev.target !== body || ev.propertyName !== "grid-template-rows") return;
       finishTransition();
     };
+    // Reversing a CSS transition cancels the previous generation after the
+    // next one has started. Ignore that stale cancel and let the current end
+    // event (or the watchdog) release inert state.
     body.addEventListener("transitionend", finishBodyTransition);
-    body.addEventListener("transitioncancel", finishBodyTransition);
     applyCollapsedState();
     group.expand = ({
       persist = true,

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -668,51 +668,62 @@
 
     const body = document.createElement("div");
     body.className = "collapsible-group-body";
-    for (const child of children) body.appendChild(child);
+    const bodyInner = document.createElement("div");
+    bodyInner.className = "collapsible-group-body-inner";
+    for (const child of children) bodyInner.appendChild(child);
+    body.appendChild(bodyInner);
 
-    function measureCollapsibleBodyHeight() {
-      return `${body.scrollHeight}px`;
+    let transitionTimer = null;
+    let contentAnimationTimer = null;
+
+    function scheduleTimeout(callback, delay) {
+      if (typeof setTimeout === "function") return setTimeout(callback, delay);
+      requestAnimationFrame(callback);
+      return null;
     }
 
-    function setExpandedBodyHeight() {
-      body.style.setProperty("--collapsible-body-height", measureCollapsibleBodyHeight());
+    function cancelTimeout(timer) {
+      if (timer !== null && typeof clearTimeout === "function") clearTimeout(timer);
+    }
+
+    function prefersReducedMotion() {
+      return typeof window.matchMedia === "function"
+        && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    }
+
+    function clearTransitionTimer() {
+      if (transitionTimer === null) return;
+      cancelTimeout(transitionTimer);
+      transitionTimer = null;
+    }
+
+    function finishTransition() {
+      clearTransitionTimer();
+      group.classList.remove("expanding", "collapsing");
     }
 
     function refreshCollapsibleHeight() {
-      if (collapsed || !group.classList.contains("expanding")) return;
-      requestAnimationFrame(() => {
-        if (!collapsed && group.classList.contains("expanding")) setExpandedBodyHeight();
-      });
+      // Compatibility shim: the grid-based body follows its natural height.
     }
 
     function mutateCollapsibleBody(mutate) {
       if (typeof mutate !== "function") return;
-      if (collapsed || group.classList.contains("collapsing")) {
-        mutate();
-        return;
-      }
-      if (group.classList.contains("expanding")) {
-        mutate();
-        refreshCollapsibleHeight();
-        return;
-      }
-
-      const beforeHeight = body.scrollHeight;
       mutate();
-      const afterHeight = body.scrollHeight;
-      const prefersReducedMotion = typeof window.matchMedia === "function"
-        && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
-      if (beforeHeight === afterHeight || prefersReducedMotion) return;
+      if (collapsed || group.classList.contains("collapsing") || prefersReducedMotion()) return;
+      cancelTimeout(contentAnimationTimer);
+      group.classList.remove("collapsible-content-entering");
+      void bodyInner.offsetWidth;
+      group.classList.add("collapsible-content-entering");
+      contentAnimationTimer = scheduleTimeout(() => {
+        contentAnimationTimer = null;
+        group.classList.remove("collapsible-content-entering");
+      }, 240);
+    }
 
-      // The settled-open body normally uses max-height:none so reflow can grow
-      // freely. Pin its pre-mutation height for one frame, then animate to the
-      // new measured height instead of letting async rows cause a layout jump.
-      body.style.setProperty("--collapsible-body-height", `${beforeHeight}px`);
-      group.classList.add("resizing");
-      void body.offsetHeight;
+    function suppressTransitionOnce() {
+      group.classList.add("collapsible-no-motion");
       requestAnimationFrame(() => {
-        if (collapsed || !group.classList.contains("resizing")) return;
-        body.style.setProperty("--collapsible-body-height", `${afterHeight}px`);
+        group.classList.remove("collapsible-no-motion");
       });
     }
 
@@ -744,44 +755,22 @@
       });
     }
 
-    function applyCollapsedState({ animate = false } = {}) {
+    function applyCollapsedState({ animate = false, suppressTransition = false } = {}) {
       disclosure.setAttribute("aria-expanded", collapsed ? "false" : "true");
       const actionLabel = collapsed ? t("collapsibleExpand") : t("collapsibleCollapse");
       disclosure.setAttribute("aria-label", disclosureLabel ? `${actionLabel}: ${disclosureLabel}` : actionLabel);
-      group.classList.remove("expanding", "collapsing", "resizing");
-      if (!animate) {
+      clearTransitionTimer();
+      group.classList.remove("expanding", "collapsing");
+      setBodyInteractivity(collapsed);
+      if (!animate || prefersReducedMotion()) {
+        if (suppressTransition && !prefersReducedMotion()) suppressTransitionOnce();
         group.classList.toggle("collapsed", collapsed);
-        setBodyInteractivity(collapsed);
-        if (collapsed) {
-          body.style.setProperty("--collapsible-body-height", "0px");
-        } else {
-          // Settled-open groups must NOT keep a pinned max-height: text zoom
-          // or window-width changes rewrap descriptions and grow the content,
-          // and a stale pinned height clips the bottom rows (overflow:
-          // hidden). A measured height is only needed while animating.
-          body.style.setProperty("--collapsible-body-height", "none");
-        }
         return;
       }
 
-      if (collapsed) {
-        group.classList.add("collapsing");
-        setBodyInteractivity(true);
-        setExpandedBodyHeight();
-        requestAnimationFrame(() => {
-          group.classList.add("collapsed");
-          body.style.setProperty("--collapsible-body-height", "0px");
-        });
-        return;
-      }
-
-      group.classList.add("expanding", "collapsed");
-      setBodyInteractivity(false);
-      body.style.setProperty("--collapsible-body-height", "0px");
-      requestAnimationFrame(() => {
-        group.classList.remove("collapsed");
-        setExpandedBodyHeight();
-      });
+      group.classList.add(collapsed ? "collapsing" : "expanding");
+      group.classList.toggle("collapsed", collapsed);
+      transitionTimer = scheduleTimeout(finishTransition, 300);
     }
 
     function setCollapsed(
@@ -795,7 +784,7 @@
         nextState[id] = collapsed;
         writeCollapsedGroupState(nextState);
       }
-      preserveScrollAnchor(() => applyCollapsedState({ animate }));
+      preserveScrollAnchor(() => applyCollapsedState({ animate, suppressTransition: !animate }));
     }
 
     function toggleCollapsed() {
@@ -812,17 +801,13 @@
 
     group.appendChild(header);
     group.appendChild(body);
-    body.addEventListener("transitionend", (ev) => {
-      if (ev.target !== body || ev.propertyName !== "max-height") return;
-      group.classList.remove("expanding", "collapsing", "resizing");
-      // Release the pinned height once settled so later reflows (text zoom,
-      // window resize) can grow the body instead of clipping at the bottom.
-      if (!collapsed) body.style.setProperty("--collapsible-body-height", "none");
-    });
+    const finishBodyTransition = (ev) => {
+      if (ev.target !== body || ev.propertyName !== "grid-template-rows") return;
+      finishTransition();
+    };
+    body.addEventListener("transitionend", finishBodyTransition);
+    body.addEventListener("transitioncancel", finishBodyTransition);
     applyCollapsedState();
-    requestAnimationFrame(() => {
-      if (!collapsed) body.style.setProperty("--collapsible-body-height", "none");
-    });
     group.expand = ({
       persist = true,
       animate = animateExpansion,

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -674,7 +674,7 @@
     body.appendChild(bodyInner);
 
     let transitionTimer = null;
-    let contentAnimationTimer = null;
+    const contentAnimationTimers = new Map();
 
     function scheduleTimeout(callback, delay) {
       if (typeof setTimeout === "function") return setTimeout(callback, delay);
@@ -700,6 +700,7 @@
     function finishTransition() {
       clearTransitionTimer();
       group.classList.remove("expanding", "collapsing");
+      setBodyInteractivity(collapsed);
     }
 
     function refreshCollapsibleHeight() {
@@ -708,16 +709,26 @@
 
     function mutateCollapsibleBody(mutate) {
       if (typeof mutate !== "function") return;
-      mutate();
+      // Callers return the newly inserted or revealed elements so existing
+      // controls do not replay their entrance animation on every async update.
+      const result = mutate();
       if (collapsed || group.classList.contains("collapsing") || prefersReducedMotion()) return;
-      cancelTimeout(contentAnimationTimer);
-      group.classList.remove("collapsible-content-entering");
-      void bodyInner.offsetWidth;
-      group.classList.add("collapsible-content-entering");
-      contentAnimationTimer = scheduleTimeout(() => {
-        contentAnimationTimer = null;
-        group.classList.remove("collapsible-content-entering");
-      }, 240);
+      const targets = Array.isArray(result) ? result : [result];
+      for (const target of targets) {
+        if (!target || !target.classList) continue;
+        if (contentAnimationTimers.has(target)) {
+          cancelTimeout(contentAnimationTimers.get(target));
+          contentAnimationTimers.delete(target);
+        }
+        target.classList.remove("collapsible-content-entering");
+        void target.offsetWidth;
+        target.classList.add("collapsible-content-entering");
+        const timer = scheduleTimeout(() => {
+          contentAnimationTimers.delete(target);
+          target.classList.remove("collapsible-content-entering");
+        }, 240);
+        if (timer !== null) contentAnimationTimers.set(target, timer);
+      }
     }
 
     function suppressTransitionOnce() {
@@ -727,11 +738,12 @@
       });
     }
 
-    function setBodyInteractivity(isCollapsed) {
+    function setBodyInteractivity(isCollapsed, isTransitioning = false) {
       body.setAttribute("aria-hidden", isCollapsed ? "true" : "false");
+      const bodyInert = isCollapsed || isTransitioning;
       if ("inert" in body) {
-        body.inert = isCollapsed;
-      } else if (isCollapsed) {
+        body.inert = bodyInert;
+      } else if (bodyInert) {
         body.setAttribute("inert", "");
       } else {
         body.removeAttribute("inert");
@@ -761,9 +773,11 @@
       disclosure.setAttribute("aria-label", disclosureLabel ? `${actionLabel}: ${disclosureLabel}` : actionLabel);
       clearTransitionTimer();
       group.classList.remove("expanding", "collapsing");
-      setBodyInteractivity(collapsed);
-      if (!animate || prefersReducedMotion()) {
-        if (suppressTransition && !prefersReducedMotion()) suppressTransitionOnce();
+      const reducedMotion = prefersReducedMotion();
+      const shouldAnimate = animate && !reducedMotion;
+      setBodyInteractivity(collapsed, shouldAnimate);
+      if (!shouldAnimate) {
+        if (suppressTransition && !reducedMotion) suppressTransitionOnce();
         group.classList.toggle("collapsed", collapsed);
         return;
       }

--- a/src/settings.css
+++ b/src/settings.css
@@ -553,17 +553,26 @@ html, body {
   }
 }
 .collapsible-group-body {
-  max-height: var(--collapsible-body-height, 0px);
+  display: grid;
+  grid-template-rows: 1fr;
+  overflow: hidden;
+  transition: grid-template-rows 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: grid-template-rows;
+}
+.collapsible-group-body-inner {
+  min-height: 0;
   overflow: hidden;
   border-top: 1px solid var(--row-border);
   padding: 10px 16px 12px 40px;
   opacity: 1;
   transform: translateY(0);
-  transition: max-height 0.22s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.16s ease, transform 0.18s ease, padding 0.18s ease, border-color 0.18s ease;
-  will-change: max-height, opacity, transform;
+  transition: opacity 0.16s ease, transform 0.18s ease, padding 0.18s ease, border-color 0.18s ease;
+  will-change: opacity, transform;
 }
 .collapsible-group.collapsed > .collapsible-group-body {
-  max-height: 0;
+  grid-template-rows: 0fr;
+}
+.collapsible-group.collapsed > .collapsible-group-body > .collapsible-group-body-inner {
   border-top-color: transparent;
   padding-top: 0;
   padding-bottom: 0;
@@ -571,14 +580,26 @@ html, body {
   transform: translateY(-4px);
 }
 .collapsible-group.expanding .collapsible-group-body,
-.collapsible-group.collapsing .collapsible-group-body,
-.collapsible-group.resizing .collapsible-group-body {
+.collapsible-group.collapsing .collapsible-group-body {
   pointer-events: none;
 }
-.collapsible-group:not(.collapsed):has(.language-picker.menu-mounted) > .collapsible-group-body {
+.collapsible-group:not(.collapsed):not(.expanding):not(.collapsing) > .collapsible-group-body,
+.collapsible-group:not(.collapsed):has(.language-picker.menu-mounted) > .collapsible-group-body,
+.collapsible-group:not(.collapsed):has(.language-picker.menu-mounted) > .collapsible-group-body > .collapsible-group-body-inner {
   overflow: visible;
 }
-.agent-subgroup .collapsible-group-body {
+.collapsible-group.collapsible-no-motion > .collapsible-group-body,
+.collapsible-group.collapsible-no-motion > .collapsible-group-body > .collapsible-group-body-inner {
+  transition: none;
+}
+.collapsible-group.collapsible-content-entering > .collapsible-group-body > .collapsible-group-body-inner {
+  animation: collapsibleContentEnter 0.18s ease;
+}
+@keyframes collapsibleContentEnter {
+  from { opacity: 0.72; }
+  to { opacity: 1; }
+}
+.agent-subgroup .collapsible-group-body-inner {
   padding: 0;
 }
 .agent-subgroup .collapsible-group-body .row:last-child {
@@ -677,8 +698,12 @@ html, body {
   .collapsible-group-chevron,
   .anim-override-chevron,
   .collapsible-group-summary,
-  .collapsible-group-body {
+  .collapsible-group-body,
+  .collapsible-group-body-inner {
     transition: none;
+  }
+  .collapsible-group.collapsible-content-entering > .collapsible-group-body > .collapsible-group-body-inner {
+    animation: none;
   }
 }
 

--- a/src/settings.css
+++ b/src/settings.css
@@ -592,7 +592,7 @@ html, body {
 .collapsible-group.collapsible-no-motion > .collapsible-group-body > .collapsible-group-body-inner {
   transition: none;
 }
-.collapsible-group.collapsible-content-entering > .collapsible-group-body > .collapsible-group-body-inner {
+.collapsible-group-body .collapsible-content-entering {
   animation: collapsibleContentEnter 0.18s ease;
 }
 @keyframes collapsibleContentEnter {
@@ -702,7 +702,7 @@ html, body {
   .collapsible-group-body-inner {
     transition: none;
   }
-  .collapsible-group.collapsible-content-entering > .collapsible-group-body > .collapsible-group-body-inner {
+  .collapsible-group-body .collapsible-content-entering {
     animation: none;
   }
 }

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -10861,9 +10861,16 @@ describe("settings renderer browser environment", () => {
       propertyName: "grid-template-rows",
       bubbles: false,
     });
-    assert.equal(freshGroup.classList.contains("expanding"), false);
+    assert.equal(freshGroup.classList.contains("expanding"), true);
     assert.equal(freshGroup.classList.contains("collapsing"), false);
     assert.equal(freshBody.getAttribute("aria-hidden"), "false");
+    assert.equal(freshBody.inert, true);
+    freshBody.dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.equal(freshGroup.classList.contains("expanding"), false);
     assert.equal(freshBody.inert, false);
 
     freshHeader.dispatchEvent({ type: "keydown", key: "Enter" });
@@ -11547,7 +11554,7 @@ describe("settings renderer browser environment", () => {
     assert.ok(coreSource.includes("collapsing"));
     assert.ok(coreSource.includes("expanding"));
     assert.ok(coreSource.includes('ev.propertyName !== "grid-template-rows"'));
-    assert.ok(coreSource.includes("transitioncancel"));
+    assert.ok(!coreSource.includes('body.addEventListener("transitioncancel"'));
     assert.ok(coreSource.includes("function setBodyInteractivity(isCollapsed, isTransitioning = false)"));
     assert.ok(coreSource.includes('body.setAttribute("aria-hidden"'));
     assert.ok(coreSource.includes("const bodyInert = isCollapsed || isTransitioning"));

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -7875,7 +7875,7 @@ describe("settings renderer browser environment", () => {
     const sectionRowsRule = css.match(/\.section-rows\s*\{([^}]*)\}/);
     const mountedSectionRule = css.match(/\.section:has\(\.language-picker\.menu-mounted\)\s*\{([^}]*)\}/);
     const mountedRowsRule = css.match(/\.section-rows:has\(\.language-picker\.menu-mounted\)\s*\{([^}]*)\}/);
-    const mountedCollapsibleRule = css.match(/\.collapsible-group:not\(\.collapsed\):has\(\.language-picker\.menu-mounted\)\s*>\s*\.collapsible-group-body\s*\{([^}]*)\}/);
+    const mountedCollapsibleRule = css.match(/\.collapsible-group:not\(\.collapsed\):has\(\.language-picker\.menu-mounted\)\s*>\s*\.collapsible-group-body,\s*\.collapsible-group:not\(\.collapsed\):has\(\.language-picker\.menu-mounted\)\s*>\s*\.collapsible-group-body\s*>\s*\.collapsible-group-body-inner\s*\{([^}]*)\}/);
 
     assert.ok(sectionRowsRule, "settings cards should retain their base clipping rule");
     assert.match(sectionRowsRule[1], /overflow:\s*hidden;/);
@@ -9280,7 +9280,7 @@ describe("settings renderer browser environment", () => {
     assert.ok(/@media \(max-width:\s*720px\)\s*\{[\s\S]*\.session-hud-collapsible \.collapsible-group-summary\s*\{[\s\S]*flex:\s*0 0 calc\(100% - 22px\);[\s\S]*margin-left:\s*22px;/.test(css));
     assert.ok(/@media \(max-width:\s*720px\)\s*\{[\s\S]*\.session-hud-summary-control\s*\{[\s\S]*grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\);[\s\S]*width:\s*min\(238px,\s*100%\);/.test(css));
     assert.ok(/@media \(max-width:\s*720px\)\s*\{[\s\S]*\.session-hud-summary-control\s*\{[\s\S]*justify-self:\s*start;/.test(css));
-    assert.ok(/function buildFlashGroup\(\)[\s\S]*id:\s*"general:flash",[\s\S]*animateExpansion:\s*false,/.test(generalSource));
+    assert.ok(!generalSource.includes("animateExpansion: false"));
     assert.ok(/\.collapsible-group-text \.row-label\s*\{[\s\S]*text-overflow:\s*ellipsis;[\s\S]*white-space:\s*nowrap;/.test(css));
     assert.ok(/\.collapsible-group-text \.row-desc\s*\{[\s\S]*white-space:\s*normal;[\s\S]*-webkit-line-clamp:\s*2;/.test(css));
     assert.ok(/\.sound-summary-control\s*\{[\s\S]*display:\s*inline-flex;/.test(css));
@@ -10054,7 +10054,7 @@ describe("settings renderer browser environment", () => {
     assert.equal(toasts[0].options.error, true);
   });
 
-  it("reveals existing quota options immediately and absorbs async sources without a second expansion", async () => {
+  it("reveals quota options with the shared grid animation and absorbs async sources without measuring height", async () => {
     const sourceCount = createDeferred();
     const animationFrames = [];
     const flushAnimationFrame = () => {
@@ -10075,37 +10075,28 @@ describe("settings renderer browser environment", () => {
     const header = group.querySelector(".collapsible-group-header");
     const body = group.querySelector(".collapsible-group-body");
     const mergeRow = harness.getSwitchMeta("quotaMergeSources").row;
-    Object.defineProperty(body, "scrollHeight", {
-      configurable: true,
-      get: () => (mergeRow.style.display === "none" ? 80 : 120),
-    });
     header.dispatchEvent({ type: "click" });
-    assert.equal(group.classList.contains("expanding"), false);
+    assert.equal(group.classList.contains("expanding"), true);
     assert.equal(group.classList.contains("collapsed"), false);
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "");
     assert.equal(body.attributes["aria-hidden"], "false");
-    flushAnimationFrame();
 
     sourceCount.resolve(2);
     await new Promise((resolve) => setImmediate(resolve));
-    assert.equal(group.classList.contains("expanding"), false);
-    assert.equal(group.classList.contains("resizing"), true);
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "80px");
+    assert.equal(group.classList.contains("collapsible-content-entering"), true);
     assert.equal(mergeRow.style.display, "");
-
-    flushAnimationFrame();
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "120px");
 
     body.dispatchEvent({
       type: "transitionend",
-      propertyName: "max-height",
+      propertyName: "grid-template-rows",
       bubbles: false,
     });
-    assert.equal(group.classList.contains("resizing"), false);
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
+    assert.equal(group.classList.contains("expanding"), false);
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "");
+    flushAnimationFrame();
   });
 
-  it("reveals sound controls immediately without waiting for an expansion animation frame", () => {
+  it("makes sound controls interactive immediately while the shared grid animation runs", () => {
     const animationFrames = [];
     const harness = loadGeneralTabForTest({
       snapshot: makeGeneralSnapshot({ soundMuted: false, soundVolume: 0.5 }),
@@ -10123,9 +10114,9 @@ describe("settings renderer browser environment", () => {
 
     header.dispatchEvent({ type: "click" });
 
-    assert.equal(group.classList.contains("expanding"), false);
+    assert.equal(group.classList.contains("expanding"), true);
     assert.equal(group.classList.contains("collapsed"), false);
-    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "none");
+    assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "");
     assert.equal(body.attributes["aria-hidden"], "false");
   });
 
@@ -10787,7 +10778,12 @@ describe("settings renderer browser environment", () => {
       createElement: (tagName) => new FakeElement(tagName),
       getElementById: (id) => id === "content" ? content : null,
     };
-    const core = loadSettingsCoreForTest({}, { document, localStorage });
+    const raf = createQueuedRaf();
+    const core = loadSettingsCoreForTest({}, {
+      document,
+      localStorage,
+      requestAnimationFrame: raf.requestAnimationFrame,
+    });
     const buildGroup = () => {
       const group = core.helpers.buildCollapsibleGroup({
         id: "remote-approval.feishu.api-explorer",
@@ -10808,14 +10804,16 @@ describe("settings renderer browser environment", () => {
     assert.equal(body.inert, true);
 
     const originalRaw = storedRaw;
-    group.expand({ persist: false });
+    group.expand({ persist: false, animate: false });
     assert.equal(group.classList.contains("collapsed"), false);
+    assert.equal(group.classList.contains("expanding"), false);
     assert.equal(header.getAttribute("aria-expanded"), "true");
     assert.equal(body.getAttribute("aria-hidden"), "false");
     assert.equal(body.inert, false);
     assert.equal(storedRaw, originalRaw);
     assert.deepStrictEqual(JSON.parse(storedRaw), originalStoredState);
     assert.equal(storageWrites.length, 0);
+    raf.flush();
 
     group.remove();
     const freshGroup = buildGroup();
@@ -10828,6 +10826,7 @@ describe("settings renderer browser environment", () => {
 
     freshHeader.click();
     assert.equal(freshGroup.classList.contains("collapsed"), false);
+    assert.equal(freshGroup.classList.contains("expanding"), true);
     assert.equal(freshHeader.getAttribute("aria-expanded"), "true");
     assert.equal(freshBody.getAttribute("aria-hidden"), "false");
     assert.equal(freshBody.inert, false);
@@ -10838,12 +10837,30 @@ describe("settings renderer browser environment", () => {
       "unrelated-group": false,
     });
 
+    freshHeader.click();
+    assert.equal(freshGroup.classList.contains("collapsed"), true);
+    assert.equal(freshGroup.classList.contains("collapsing"), true);
+    assert.equal(freshBody.getAttribute("aria-hidden"), "true");
+    assert.equal(freshBody.inert, true);
+    freshHeader.click();
+    assert.equal(freshGroup.classList.contains("collapsed"), false);
+    assert.equal(freshGroup.classList.contains("expanding"), true);
+    freshBody.dispatchEvent({
+      type: "transitioncancel",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.equal(freshGroup.classList.contains("expanding"), false);
+    assert.equal(freshGroup.classList.contains("collapsing"), false);
+    assert.equal(freshBody.getAttribute("aria-hidden"), "false");
+    assert.equal(freshBody.inert, false);
+
     freshHeader.dispatchEvent({ type: "keydown", key: "Enter" });
     assert.equal(freshHeader.getAttribute("aria-expanded"), "false");
     assert.equal(freshBody.getAttribute("aria-hidden"), "true");
     assert.equal(freshBody.inert, true);
-    assert.equal(storageWrites.length, 2);
-    assert.deepStrictEqual(JSON.parse(storageWrites[1].value), {
+    assert.equal(storageWrites.length, 4);
+    assert.deepStrictEqual(JSON.parse(storageWrites[3].value), {
       "remote-approval.feishu.api-explorer": true,
       "unrelated-group": false,
     });
@@ -10852,8 +10869,8 @@ describe("settings renderer browser environment", () => {
     assert.equal(freshHeader.getAttribute("aria-expanded"), "true");
     assert.equal(freshBody.getAttribute("aria-hidden"), "false");
     assert.equal(freshBody.inert, false);
-    assert.equal(storageWrites.length, 3);
-    assert.deepStrictEqual(JSON.parse(storageWrites[2].value), {
+    assert.equal(storageWrites.length, 5);
+    assert.deepStrictEqual(JSON.parse(storageWrites[4].value), {
       "remote-approval.feishu.api-explorer": false,
       "unrelated-group": false,
     });
@@ -11501,22 +11518,28 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(originalHolidaySwitch.getAttribute("aria-checked"), "true");
   });
 
-  it("animates collapsible Settings groups with measured height instead of instant hidden jumps", () => {
+  it("animates collapsible Settings groups with natural-height grid rows", () => {
     const coreSource = fs.readFileSync(SETTINGS_UI_CORE, "utf8");
     const css = fs.readFileSync(SETTINGS_CSS, "utf8");
-    assert.ok(coreSource.includes("function measureCollapsibleBodyHeight("));
+    assert.ok(coreSource.includes('bodyInner.className = "collapsible-group-body-inner"'));
+    assert.ok(coreSource.includes("body.appendChild(bodyInner)"));
     assert.ok(coreSource.includes("function preserveScrollAnchor("));
-    assert.ok(coreSource.includes('body.style.setProperty("--collapsible-body-height"'));
-    assert.ok(coreSource.includes("requestAnimationFrame(() => {"));
+    assert.ok(!coreSource.includes("measureCollapsibleBodyHeight"));
+    assert.ok(!coreSource.includes("body.scrollHeight"));
+    assert.ok(!coreSource.includes("--collapsible-body-height"));
     assert.ok(coreSource.includes("collapsing"));
     assert.ok(coreSource.includes("expanding"));
+    assert.ok(coreSource.includes('ev.propertyName !== "grid-template-rows"'));
+    assert.ok(coreSource.includes("transitioncancel"));
     assert.ok(coreSource.includes("function setBodyInteractivity(isCollapsed)"));
     assert.ok(coreSource.includes('body.setAttribute("aria-hidden"'));
     assert.ok(coreSource.includes("body.inert = isCollapsed"));
     assert.ok(!coreSource.includes("body.hidden = collapsed;"));
-    assert.ok(/\.collapsible-group-body\s*\{[\s\S]*max-height:\s*var\(--collapsible-body-height,\s*0px\);/.test(css));
-    assert.ok(/\.collapsible-group-body\s*\{[\s\S]*transition:\s*max-height 0\.22s cubic-bezier\(0\.22,\s*1,\s*0\.36,\s*1\),\s*opacity 0\.16s ease,\s*transform 0\.18s ease,\s*padding 0\.18s ease,\s*border-color 0\.18s ease;/.test(css));
-    assert.ok(/\.collapsible-group\.collapsed\s*>\s*\.collapsible-group-body\s*\{[\s\S]*opacity:\s*0;[\s\S]*transform:\s*translateY\(-4px\);/.test(css));
+    assert.ok(/\.collapsible-group-body\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-rows:\s*1fr;[\s\S]*transition:\s*grid-template-rows 0\.22s cubic-bezier/.test(css));
+    assert.ok(/\.collapsible-group-body-inner\s*\{[\s\S]*min-height:\s*0;[\s\S]*overflow:\s*hidden;/.test(css));
+    assert.ok(/\.collapsible-group\.collapsed\s*>\s*\.collapsible-group-body\s*\{[\s\S]*grid-template-rows:\s*0fr;/.test(css));
+    assert.ok(/\.collapsible-group\.collapsed\s*>\s*\.collapsible-group-body\s*>\s*\.collapsible-group-body-inner\s*\{[\s\S]*opacity:\s*0;[\s\S]*transform:\s*translateY\(-4px\);/.test(css));
+    assert.ok(!css.includes("max-height: var(--collapsible-body-height"));
     assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.collapsible-group-body/.test(css));
   });
 

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -10083,7 +10083,9 @@ describe("settings renderer browser environment", () => {
 
     sourceCount.resolve(2);
     await new Promise((resolve) => setImmediate(resolve));
-    assert.equal(group.classList.contains("collapsible-content-entering"), true);
+    assert.equal(group.classList.contains("collapsible-content-entering"), false);
+    assert.equal(body.querySelector(".collapsible-group-body-inner").classList.contains("collapsible-content-entering"), false);
+    assert.equal(mergeRow.classList.contains("collapsible-content-entering"), true);
     assert.equal(mergeRow.style.display, "");
 
     body.dispatchEvent({
@@ -10096,7 +10098,7 @@ describe("settings renderer browser environment", () => {
     flushAnimationFrame();
   });
 
-  it("makes sound controls interactive immediately while the shared grid animation runs", () => {
+  it("keeps sound controls inert until the shared grid animation finishes", () => {
     const animationFrames = [];
     const harness = loadGeneralTabForTest({
       snapshot: makeGeneralSnapshot({ soundMuted: false, soundVolume: 0.5 }),
@@ -10118,6 +10120,15 @@ describe("settings renderer browser environment", () => {
     assert.equal(group.classList.contains("collapsed"), false);
     assert.equal(body.style.getPropertyValue("--collapsible-body-height"), "");
     assert.equal(body.attributes["aria-hidden"], "false");
+    assert.equal(body.inert, true);
+
+    body.dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.equal(group.classList.contains("expanding"), false);
+    assert.equal(body.inert, false);
   });
 
   it("groups sound and volume into one collapsible control with in-place summary updates", () => {
@@ -10829,7 +10840,7 @@ describe("settings renderer browser environment", () => {
     assert.equal(freshGroup.classList.contains("expanding"), true);
     assert.equal(freshHeader.getAttribute("aria-expanded"), "true");
     assert.equal(freshBody.getAttribute("aria-hidden"), "false");
-    assert.equal(freshBody.inert, false);
+    assert.equal(freshBody.inert, true);
     assert.equal(storageWrites.length, 1);
     assert.equal(storageWrites[0].key, collapsedGroupsKey);
     assert.deepStrictEqual(JSON.parse(storageWrites[0].value), {
@@ -10868,12 +10879,18 @@ describe("settings renderer browser environment", () => {
     freshHeader.dispatchEvent({ type: "keydown", key: " " });
     assert.equal(freshHeader.getAttribute("aria-expanded"), "true");
     assert.equal(freshBody.getAttribute("aria-hidden"), "false");
-    assert.equal(freshBody.inert, false);
+    assert.equal(freshBody.inert, true);
     assert.equal(storageWrites.length, 5);
     assert.deepStrictEqual(JSON.parse(storageWrites[4].value), {
       "remote-approval.feishu.api-explorer": false,
       "unrelated-group": false,
     });
+    freshBody.dispatchEvent({
+      type: "transitionend",
+      propertyName: "grid-template-rows",
+      bubbles: false,
+    });
+    assert.equal(freshBody.inert, false);
   });
 
   it("groups Theme cards and exposes theme import actions in Settings", () => {
@@ -11531,14 +11548,16 @@ describe("settings renderer browser environment", () => {
     assert.ok(coreSource.includes("expanding"));
     assert.ok(coreSource.includes('ev.propertyName !== "grid-template-rows"'));
     assert.ok(coreSource.includes("transitioncancel"));
-    assert.ok(coreSource.includes("function setBodyInteractivity(isCollapsed)"));
+    assert.ok(coreSource.includes("function setBodyInteractivity(isCollapsed, isTransitioning = false)"));
     assert.ok(coreSource.includes('body.setAttribute("aria-hidden"'));
-    assert.ok(coreSource.includes("body.inert = isCollapsed"));
+    assert.ok(coreSource.includes("const bodyInert = isCollapsed || isTransitioning"));
     assert.ok(!coreSource.includes("body.hidden = collapsed;"));
     assert.ok(/\.collapsible-group-body\s*\{[\s\S]*display:\s*grid;[\s\S]*grid-template-rows:\s*1fr;[\s\S]*transition:\s*grid-template-rows 0\.22s cubic-bezier/.test(css));
     assert.ok(/\.collapsible-group-body-inner\s*\{[\s\S]*min-height:\s*0;[\s\S]*overflow:\s*hidden;/.test(css));
     assert.ok(/\.collapsible-group\.collapsed\s*>\s*\.collapsible-group-body\s*\{[\s\S]*grid-template-rows:\s*0fr;/.test(css));
     assert.ok(/\.collapsible-group\.collapsed\s*>\s*\.collapsible-group-body\s*>\s*\.collapsible-group-body-inner\s*\{[\s\S]*opacity:\s*0;[\s\S]*transform:\s*translateY\(-4px\);/.test(css));
+    assert.ok(/\.collapsible-group-body\s+\.collapsible-content-entering\s*\{[\s\S]*animation:\s*collapsibleContentEnter/.test(css));
+    assert.ok(!css.includes(".collapsible-group.collapsible-content-entering"));
     assert.ok(!css.includes("max-height: var(--collapsible-body-height"));
     assert.ok(/@media \(prefers-reduced-motion:\s*reduce\)\s*\{[\s\S]*\.collapsible-group-body/.test(css));
   });


### PR DESCRIPTION
## Summary
- Replace measured-height Settings collapsible animations with natural-height CSS Grid transitions.
- Apply the shared expansion animation to quota, sound, and taskbar-flash groups that previously opted out.
- Preserve programmatic expansion, persistence, accessibility, picker overflow, scroll anchoring, and asynchronous content mutation contracts.

Supersedes #884
Part of #857

## Problem context
PR #884 was based on an old Settings implementation and conflicted with newer contracts such as `group.expand({ persist, animate })`. The current shared component still measured `scrollHeight`, pinned `max-height`, and needed per-group animation exceptions, which made reflow-sensitive content vulnerable to clipping and inconsistent motion.

## What changed
- Added a nested collapsible body wrapper and animate `grid-template-rows` between `0fr` and `1fr`.
- Removed runtime height measurement, pinned height CSS variables, and resize-state bookkeeping.
- Kept `refreshCollapsibleHeight()` as a compatibility no-op and kept `mutateCollapsibleBody()` as the mutation seam.
- Scoped asynchronous content entrance animation to the newly inserted or revealed node instead of replaying it across the whole expanded body.
- Kept an expanding body inert until its Grid transition ends or the watchdog settles it, so pointer and keyboard interaction unlock together.
- Ignored stale `transitioncancel` events from reversed CSS transitions so they cannot unlock a newer transition generation early.
- Added transition-end and timeout cleanup for rapid reversals.
- Kept immediate `expand({ animate: false })` behavior and non-persisting expansion semantics.
- Updated browser-environment tests for Grid behavior, rapid reversals, stale transition cancellation, asynchronous content, keyboard operation, ARIA, and inert state.

## Behavior after this PR
- User-triggered shared Settings groups use the same expansion motion.
- Open bodies follow natural content height across async updates, text wrapping, zoom, and window resizing.
- Collapsed content remains hidden from assistive technology and keyboard interaction.
- During animated expansion, content is exposed to assistive technology but remains inert until the motion settles.
- Reduced-motion and explicit non-animated expansion remain immediate.
- Language picker overflow remains visible while its mounted close lifecycle completes.

## Validation
- `node --test test/settings-renderer-browser-env.test.js` — passed, 308/308 on maintainer follow-up head `517cbe43`.
- `node --check src/settings-ui-core.js` — passed.
- `node --check src/settings-tab-general.js` — passed.
- Full `npm test` launched in the maintainer's isolated Windows worktree. Its unrelated failures were Windows symlink-privilege `EPERM` cases and Mobile Preview tests encountering `EADDRINUSE` because an existing Clawd instance owned port 23334; the existing application was intentionally left running.
- Independent follow-up review found and fixed a rapid-reversal `transitioncancel` race; two independent re-reviews found no remaining blocker.
- GitHub Actions on `517cbe43` — unit, audit, and all five packaging targets passed.
- Windows 11 click-level QA passed in two isolated source-app instances without touching the existing Clawd instance:
  - Default motion: General Sound effects, Quota ring, and Flash tray icon disclosures; rapid reversal and interaction latching; Agents nested disclosures; Remote Approval nested cards.
  - Forced reduced motion: immediate disclosure updates with no slide/fade/transform delay; narrow Settings at 135% text scale; Remote Approval provider and timeout dropdown overflow.
  - Both isolated test instances exited normally from within their own sessions; no shared process was terminated.

## Platform note
Automated validation and the manual smoke above ran on Windows 11. An explicit light/dark two-theme visual pair was not recorded, so that part of the broader #857 visual matrix remains open. No named-profile, system-service, or other platform behavior is implied by this Settings-only QA.

## Scope control
This PR changes only the shared Settings collapsible component. Doctor, Animation Overrides, and About disclosures are intentionally reserved for the follow-up motion-unification PR. Dropdowns, switches, segmented controls, preferences, IPC, and theme data are unchanged.
