### PR TITLE
修复 OpenCode 原生权限回复后的权限气泡残留

### DIFF
--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -133,6 +133,9 @@ opencode 状态同步（in-process plugin，~0ms 延迟）：
     → 同上状态机（agent_id: opencode）
   permission.asked 通过 plugin POST /permission 进入 Clawd；决定经随机 localhost 端口上的反向 bridge 返回，
   CLI/TUI bridge 使用 Bun.serve，Desktop bridge 使用 node:http，再由 plugin 调用宿主 SDK 的 permission reply route。
+  permission.replied 使用 current requestID/sessionID 契约回送 completion lifecycle；同一 request 的 asked/replied
+  在 plugin 内因果串行，lifecycle 最多投递 3 次。Clawd 只按 agent/request/canonical session/bridge generation
+  精确清理 pending UI、timer 与 notification，不向宿主反向发送第二次决定。
 
 MiMo Code 状态同步（in-process plugin，~0ms 延迟）：
   MiMo Code 触发事件（session.created / session.status / message.part.updated 等）
@@ -177,6 +180,11 @@ opencode 权限气泡（event hook + 反向 bridge，非阻塞）：
     → Clawd 创建 bubble 窗口 → 用户 Allow/Always/Deny
     → Clawd POST plugin 的反向 bridge → bridge 用 ctx.client._client.post() 调 opencode 内置 Hono 路由 /permission/:id/reply
     → opencode 执行对应行为（once/always/reject）
+  用户先在 opencode 原生 UI 回答 → event hook 收到 permission.replied（sessionID/requestID/reply）
+    → plugin 同步失效 request 的反向 target，并在同 request asked POST 之后发送 replied lifecycle
+    → lifecycle 使用 lifecycle_bridge_url/token（不复用普通 bridge 字段，对旧 Clawd fail-safe）
+    → Clawd exact-match 删除该 request 的本地 pending、bubble、timer 与 notification
+    → 不调用 reverse bridge，不复制 reply，不产生第二次宿主决定
 
 MiMo Code 权限气泡（event hook + 反向 bridge，非阻塞，与 opencode 同源协议）：
   MiMo Code 请求权限 → event hook 收到 permission.asked
@@ -184,6 +192,8 @@ MiMo Code 权限气泡（event hook + 反向 bridge，非阻塞，与 opencode �
     → Clawd 创建 bubble 窗口 → 用户 Allow/Always/Deny
     → Clawd POST plugin 的反向 bridge → bridge 用 ctx.client._client.post() 调 MiMo Code 内置 Hono 路由 /permission/:id/reply
     → MiMo Code 执行对应行为（once/always/reject）
+  MiMo Code 原生 UI 的 permission.replied 走同一 request-specific completion lifecycle；共享 core 与自动化已覆盖，
+  但发布物真机验证必须单列，不能从 OpenCode 真机结果推断。
 
 DeepSeek Harness 权限气泡（approval waterfall，阻塞）：
   DSH approval/request → bridge prepend listener 挂起 POST /permission

--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -74,6 +74,11 @@ const MAX_CONTEXT_USAGE_ENTRIES = 1024;
 // generous timeout is safe. 200ms was too tight when Clawd's IPC roundtrip
 // (main → renderer → main) ran under load and silently timed out.
 const POST_TIMEOUT_MS = 1000;
+// A native host reply is a completion signal for an already-forwarded
+// permission. Retry only long enough to cover a transient Clawd restart; the
+// request-scoped queue keeps every attempt behind the original asked POST.
+const PERMISSION_LIFECYCLE_MAX_ATTEMPTS = 3;
+const PERMISSION_LIFECYCLE_RETRY_DELAYS_MS = [100, 400];
 // Keep one in-flight request plus a bounded pending suffix for each session.
 // A localhost process can accept fetches without answering, and OpenCode keeps
 // emitting events while that request waits. Without a hard cap, even an
@@ -345,6 +350,10 @@ export function createOpencodeFamilyPlugin(config) {
   // Using the most recently initialized client here routes interleaved replies
   // into the wrong Instance and produces PermissionNotFound/502.
   const _permissionTargetByRequestId = new Map();
+  // asked/replied share one causal delivery tail per request. A Map.delete()
+  // cannot cancel a live promise, so tails remove themselves only after
+  // settlement and only when their identity is still current.
+  const _permissionPostTailByRequestId = new Map();
   // Reverse bridge state. Set by startBridge() at plugin init. Clawd receives
   // _bridgeUrl + _bridgeToken with every /permission forward and POSTs back.
   let _bridgeUrl = "";
@@ -992,19 +1001,6 @@ export function createOpencodeFamilyPlugin(config) {
     return { recognized: false, metadataAccepted: false };
   }
 
-  // Fire-and-forget direct channel used by /permission. Returning the settled
-  // promise is only for deterministic tests; production event hooks never await
-  // it.
-  function postToClawd(urlPath, body, logTag) {
-    const snapshot = snapshotPost(body, logTag);
-    return deliverPost(urlPath, snapshot)
-      .then((result) => result.recognized)
-      .catch((err) => {
-        debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} UNCAUGHT ${err && err.message}`);
-        return false;
-      });
-  }
-
   function isReplaceableStateSnapshot(snapshot) {
     const body = snapshot && snapshot.body;
     return !!body
@@ -1174,11 +1170,54 @@ export function createOpencodeFamilyPlugin(config) {
     return snapshot.completion;
   }
 
+  function waitForPermissionRetry(delayMs) {
+    return new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+
+  async function deliverPermissionSnapshot(snapshot, lifecycle) {
+    const maxAttempts = lifecycle ? PERMISSION_LIFECYCLE_MAX_ATTEMPTS : 1;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      const result = await deliverPost("/permission", snapshot);
+      if (result.recognized) return true;
+      if (attempt >= maxAttempts) break;
+      const delayMs = PERMISSION_LIFECYCLE_RETRY_DELAYS_MS[attempt - 1] || 0;
+      debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} retry=${attempt + 1}/${maxAttempts} delay=${delayMs}ms`);
+      if (delayMs > 0) await waitForPermissionRetry(delayMs);
+    }
+    return false;
+  }
+
+  function enqueuePermissionPost(requestId, body, options = {}) {
+    const lifecycle = options.lifecycle === true;
+    const logTag = lifecycle
+      ? `PERM lifecycle=replied req=${requestId}`
+      : `PERM tool=${body && body.tool_name} req=${requestId}`;
+    const snapshot = snapshotPost(body, logTag);
+    const previous = _permissionPostTailByRequestId.get(requestId) || Promise.resolve(true);
+    const current = previous
+      .catch(() => false)
+      .then(() => deliverPermissionSnapshot(snapshot, lifecycle))
+      .catch((err) => {
+        debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} UNCAUGHT ${err && err.message}`);
+        return false;
+      });
+    _permissionPostTailByRequestId.set(requestId, current);
+    void current.finally(() => {
+      if (_permissionPostTailByRequestId.get(requestId) === current) {
+        _permissionPostTailByRequestId.delete(requestId);
+      }
+    });
+    return current;
+  }
+
   // Fire-and-forget permission forward. Clawd decides allow/deny/always in its
   // bubble UI and replies through the reverse bridge (POST /reply with the
-  // request_id + decision). The plugin never waits.
-  function postPermissionToClawd(body) {
-    postToClawd("/permission", body, `PERM tool=${body.tool_name} req=${body.request_id}`);
+  // request_id + decision). The event hook never awaits this settled promise;
+  // it is returned for ordering and deterministic tests only.
+  function postPermissionToClawd(body, options = {}) {
+    const requestId = body && typeof body.request_id === "string" ? body.request_id : "";
+    if (!requestId) return Promise.resolve(false);
+    return enqueuePermissionPost(requestId, body, options);
   }
 
   function buildStateBody(state, eventName, sessionId) {
@@ -1341,6 +1380,9 @@ export function createOpencodeFamilyPlugin(config) {
     get _statePostQueueBySession() { return _statePostQueueBySession; },
     get _statePostMaxPending() { return STATE_POST_MAX_PENDING; },
     get _permissionTargetByRequestId() { return _permissionTargetByRequestId; },
+    get _permissionPostTailByRequestId() { return _permissionPostTailByRequestId; },
+    handlePermissionReplied,
+    enqueuePermissionPost,
     get _cachedPort() { return _cachedPort; },
     set _cachedPort(v) { _cachedPort = v; },
     get _bridgeUrl() { return _bridgeUrl; },
@@ -1644,6 +1686,70 @@ export function createOpencodeFamilyPlugin(config) {
     });
   }
 
+  function permissionShapeKeys(properties) {
+    if (!properties || typeof properties !== "object" || Array.isArray(properties)) return [];
+    return Object.keys(properties)
+      .filter((key) => /^[A-Za-z0-9_.-]{1,64}$/.test(key))
+      .slice(0, 12);
+  }
+
+  function boundedPermissionRequestId(value) {
+    if (typeof value !== "string") return "(invalid)";
+    const clean = value.replace(/[\u0000-\u001F\u007F-\u009F]/g, " ").trim();
+    if (!clean) return "(empty)";
+    return clean.length > 120 ? `${clean.slice(0, 119)}…` : clean;
+  }
+
+  // Current OpenCode/MiMo completion contract:
+  // { sessionID, requestID, reply }. Older permissionID/response shapes belong
+  // to a different upstream generation and intentionally fail closed.
+  function handlePermissionReplied(event) {
+    const properties = event && event.properties && typeof event.properties === "object"
+      ? event.properties
+      : {};
+    const requestId = typeof properties.requestID === "string" && properties.requestID.trim()
+      ? properties.requestID
+      : null;
+    if (!requestId) {
+      debugLog(`PERM lifecycle skip reason=unsupported-shape keys=[${permissionShapeKeys(properties).join(",")}]`);
+      return Promise.resolve(false);
+    }
+
+    const target = _permissionTargetByRequestId.get(requestId) || null;
+    const targetSessionId = normalizeSessionId(target && target.sessionId);
+    const eventSessionId = normalizeSessionId(properties.sessionID);
+    const sessionId = targetSessionId || eventSessionId;
+    const logRequestId = boundedPermissionRequestId(requestId);
+
+    if (targetSessionId && eventSessionId && targetSessionId !== eventSessionId) {
+      debugLog(`PERM lifecycle session mismatch req=${logRequestId} target=${boundedPermissionRequestId(targetSessionId)} event=${boundedPermissionRequestId(eventSessionId)}`);
+    }
+
+    // Native resolution makes the reverse bridge target stale immediately.
+    // Delete before any network wait so a late Clawd click receives 404 and
+    // never calls the host SDK a second time.
+    _permissionTargetByRequestId.delete(requestId);
+
+    if (!sessionId) {
+      debugLog(`PERM lifecycle skip reason=missing-session req=${logRequestId}`);
+      return Promise.resolve(false);
+    }
+    if (!_bridgeUrl || !_bridgeTokenHex) {
+      debugLog(`PERM lifecycle skip reason=bridge-unavailable req=${logRequestId}`);
+      return Promise.resolve(false);
+    }
+
+    return postPermissionToClawd({
+      agent_id: AGENT_ID,
+      hook_source: HOOK_SOURCE,
+      permission_event: "replied",
+      session_id: sessionId,
+      request_id: requestId,
+      lifecycle_bridge_url: _bridgeUrl,
+      lifecycle_bridge_token: _bridgeTokenHex,
+    }, { lifecycle: true });
+  }
+
   // Constant-time token comparison to thwart timing oracle attacks on the
   // bridge auth. Any local process can see 127.0.0.1 binds so the token is
   // the only thing keeping untrusted code from rubber-stamping tool calls.
@@ -1906,6 +2012,14 @@ export function createOpencodeFamilyPlugin(config) {
           if (!event || typeof event.type !== "string") return;
           if (instanceDisposed) return;
 
+          // Completion is cleanup-only. Handle it before session-directory and
+          // root/last-seen capture so a standalone permission.replied cannot
+          // pollute the fallback used by a later legacy permission.asked.
+          if (event.type === "permission.replied") {
+            void handlePermissionReplied(event);
+            return;
+          }
+
           // Phase 3: capture the root session on first sighting. Any later
           // sessionID is a subtask spawned by the parent's `task` tool, and
           // its session.idle will be downgraded to SessionEnd in translateEvent.
@@ -1959,9 +2073,9 @@ export function createOpencodeFamilyPlugin(config) {
             }
           }
 
-          // Phase 2: permission.asked rides a parallel channel — forward to Clawd
-          // and skip state translation. Clawd replies through the reverse bridge,
-          // so we don't need to watch permission.replied here.
+          // permission.asked rides a parallel channel and shares a request FIFO
+          // with permission.replied. Clawd replies through the reverse bridge
+          // only when its own bubble wins the race.
           if (event.type === "permission.asked") {
             handlePermissionAsked(event, {
               client: instanceClient,

--- a/src/main.js
+++ b/src/main.js
@@ -1765,7 +1765,7 @@ const _permCtx = {
   },
 };
 const _perm = initPermission(_permCtx);
-const { showPermissionBubble, resolvePermissionEntry, sendPermissionResponse, repositionBubbles, permLog, PASSTHROUGH_TOOLS, addPendingPermission, removePendingPermission, isPermissionEntryLive, canAutoResolvePendingPermission, beginSessionTrustConfirmation, endSessionTrustConfirmation, syncPermissionBubbleContent, maybeStartRemoteApproval, clearCodexNotifyBubbles, showCodexUserInputBubble, clearCodexUserInputBubbles, showKimiNotifyBubble, clearKimiNotifyBubbles, syncPermissionShortcuts, replyOpencodeFamilyPermission } = _perm;
+const { showPermissionBubble, resolvePermissionEntry, sendPermissionResponse, repositionBubbles, permLog, PASSTHROUGH_TOOLS, addPendingPermission, removePendingPermission, isPermissionEntryLive, canAutoResolvePendingPermission, beginSessionTrustConfirmation, endSessionTrustConfirmation, syncPermissionBubbleContent, maybeStartRemoteApproval, clearCodexNotifyBubbles, showCodexUserInputBubble, clearCodexUserInputBubbles, showKimiNotifyBubble, clearKimiNotifyBubbles, syncPermissionShortcuts, replyOpencodeFamilyPermission, dismissOpencodeFamilyPermissionResolvedExternally } = _perm;
 const pendingPermissions = _perm.pendingPermissions;
 let permDebugLog = null; // set after app.whenReady()
 let updateDebugLog = null; // set after app.whenReady()
@@ -2481,6 +2481,7 @@ const _serverCtx = {
   handleTestResult: (result, context) => handleTestResult(result, context),
   maybeStartRemoteApproval,
   replyOpencodeFamilyPermission,
+  dismissOpencodeFamilyPermissionResolvedExternally,
   syncPermissionShortcuts,
   permLog,
 };

--- a/src/permission.js
+++ b/src/permission.js
@@ -11,6 +11,7 @@ const { MAC_TOPMOST_LEVEL } = require("./topmost-runtime");
 const { redactSecrets } = require("./secret-redact");
 const path = require("path");
 const http = require("http");
+const { timingSafeEqual } = require("crypto");
 const {
   CLAWD_SERVER_HEADER,
   CLAWD_SERVER_ID,
@@ -3191,6 +3192,98 @@ function dismissInteractivePermissionWithoutDecision(perm, reason) {
   }
 }
 
+function opencodeFamilyBridgeTokensEqual(expected, candidate) {
+  if (
+    !isValidOpencodeFamilyBridgeToken(expected)
+    || !isValidOpencodeFamilyBridgeToken(candidate)
+  ) return false;
+  const expectedBytes = Buffer.from(expected, "utf8");
+  const candidateBytes = Buffer.from(candidate, "utf8");
+  if (expectedBytes.length !== candidateBytes.length) return false;
+  try {
+    return timingSafeEqual(expectedBytes, candidateBytes);
+  } catch {
+    return false;
+  }
+}
+
+function normalizeExternalFamilyPermissionIdentity(identity) {
+  if (!identity || typeof identity !== "object") return null;
+  const agentId = typeof identity.agentId === "string" ? identity.agentId : "";
+  if (!getFamilyConfig(agentId)) return null;
+  const requestId = typeof identity.requestId === "string" && identity.requestId
+    ? identity.requestId
+    : null;
+  const sessionId = typeof identity.sessionId === "string" && identity.sessionId
+    ? identity.sessionId
+    : null;
+  const bridgeUrl = normalizeOpencodeFamilyBridgeUrl(identity.bridgeUrl);
+  const bridgeToken = isValidOpencodeFamilyBridgeToken(identity.bridgeToken)
+    ? identity.bridgeToken
+    : null;
+  if (!requestId || !sessionId || !bridgeUrl || !bridgeToken) return null;
+  return { agentId, requestId, sessionId, bridgeUrl, bridgeToken };
+}
+
+function boundedPermissionIdentityForLog(value) {
+  if (typeof value !== "string") return "(invalid)";
+  const clean = value.replace(/[\u0000-\u001F\u007F-\u009F]/g, " ").trim();
+  if (!clean) return "(empty)";
+  return clean.length > 120 ? `${clean.slice(0, 119)}…` : clean;
+}
+
+// A native OpenCode-family UI already resolved this exact request. Remove all
+// exact duplicates locally, but never call resolvePermissionEntry(): that path
+// would send a second once/always/reject decision through the reverse bridge.
+function dismissOpencodeFamilyPermissionResolvedExternally(identity) {
+  const normalized = normalizeExternalFamilyPermissionIdentity(identity);
+  if (!normalized) {
+    permLog("opencode-family external resolve no-op: invalid identity");
+    return 0;
+  }
+
+  const matches = pendingPermissions.filter((entry) => {
+    if (!isOpencodeFamilyEntry(entry) || entry.agentId !== normalized.agentId) return false;
+    if (entry.familyRequestId !== normalized.requestId) return false;
+    if (entry.sessionId !== normalized.sessionId) return false;
+    const entryBridgeUrl = normalizeOpencodeFamilyBridgeUrl(entry.familyBridgeUrl);
+    if (!entryBridgeUrl || entryBridgeUrl !== normalized.bridgeUrl) return false;
+    return opencodeFamilyBridgeTokensEqual(entry.familyBridgeToken, normalized.bridgeToken);
+  });
+
+  if (matches.length === 0) {
+    permLog(`opencode-family external resolve no-op: agent=${normalized.agentId} request=${boundedPermissionIdentityForLog(normalized.requestId)}`);
+    return 0;
+  }
+
+  // Establish non-liveness first for every exact duplicate. A late click,
+  // hotkey, automation callback, or timer will now fail its pending-membership
+  // guard before any slower renderer/notification teardown runs.
+  for (const entry of matches) {
+    const index = pendingPermissions.indexOf(entry);
+    if (index !== -1) pendingPermissions.splice(index, 1);
+  }
+  notifyPermissionsChanged("resolved-externally");
+
+  for (const entry of matches) {
+    cancelRemoteApproval(entry, { reason: "resolved-externally" });
+    if (entry._delayTimer) { clearTimeout(entry._delayTimer); entry._delayTimer = null; }
+    if (entry.autoCloseTimer) { clearTimeout(entry.autoCloseTimer); entry.autoCloseTimer = null; }
+    if (entry.autoExpireTimer) { clearTimeout(entry.autoExpireTimer); entry.autoExpireTimer = null; }
+    if (entry.abortHandler && entry.res) {
+      try { entry.res.removeListener("close", entry.abortHandler); } catch {}
+    }
+    hidePermissionBubbleSafely(entry);
+    notifyPermissionResolved(entry, "resolved-externally");
+  }
+
+  repositionBubbles();
+  repositionDependentBubbles();
+  syncPermissionShortcuts();
+  permLog(`opencode-family external resolve matched: agent=${normalized.agentId} request=${boundedPermissionIdentityForLog(normalized.requestId)} count=${matches.length}`);
+  return matches.length;
+}
+
 // Mirrors the DND dispatcher: CC res.destroy() so it falls back to chat,
 // opencode skips the bridge reply so TUI takes over, codex just closes.
 // options.subagentOnly (#451) restricts the sweep to entries that came from a
@@ -3325,6 +3418,7 @@ return {
   refreshPermissionAutoCloseForPolicy,
   dismissPermissionsByAgent, dismissInteractivePermissionBubbles,
   dismissPermissionsForDnd,
+  dismissOpencodeFamilyPermissionResolvedExternally,
   syncPermissionShortcuts,
   replyOpencodeFamilyPermission,
   // Exposed for the payload↔renderer contract test (plan §3.5/§9): the

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -30,7 +30,7 @@ const {
 } = require("./server-permission-utils");
 const { resolveHookAgentId } = require("./server-agent-id");
 const { getAgent } = require("../agents/registry");
-const { isOpencodeFamily } = require("../agents/opencode-family");
+const { isOpencodeFamily, getFamilyConfig } = require("../agents/opencode-family");
 const {
   normalizeOpencodeFamilyBridgeUrl,
   isValidOpencodeFamilyBridgeToken,
@@ -178,6 +178,22 @@ function arePermissionBubblesEnabled(ctx) {
 
 function normalizeString(value) {
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function boundedPermissionLogValue(value) {
+  if (typeof value !== "string") return "(invalid)";
+  const clean = value.replace(/[\u0000-\u001F\u007F-\u009F]/g, " ").trim();
+  if (!clean) return "(empty)";
+  return clean.length > 120 ? `${clean.slice(0, 119)}…` : clean;
+}
+
+function normalizeOpencodeFamilySessionId(agentId, value) {
+  const config = getFamilyConfig(agentId);
+  if (!config || typeof value !== "string" || !value.trim()) return null;
+  const raw = value.trim();
+  return raw.startsWith(config.sessionIdPrefix)
+    ? raw
+    : `${config.sessionIdPrefix}${raw}`;
 }
 
 const DSH_REASON_MAX_CHARS = 500;
@@ -599,10 +615,24 @@ function handlePermissionPost(req, res, options) {
     const requestHeaders = req && req.headers && typeof req.headers === "object"
       ? req.headers
       : {};
+    const hasPermissionEventDiscriminator = !!data
+      && typeof data === "object"
+      && Object.prototype.hasOwnProperty.call(data, "permission_event");
     const hookIdentity = resolveHookAgentId(data, {
       customAgentIds: typeof ctx.getCustomAgentIds === "function" ? ctx.getCustomAgentIds() : [],
     });
-    const recordRequestHookEvent = createRequestHookRecorder(hookIdentity, data, "permission");
+    // Lifecycle cleanup is not a new PermissionRequest. Do not even construct a
+    // request recorder for it, otherwise a no-op completion can appear in the
+    // hook-event ring as user-facing permission activity.
+    const recordRequestHookEvent = hasPermissionEventDiscriminator
+      ? {
+        accepted() {},
+        droppedByDisabled() {},
+        droppedByDnd() {},
+        droppedInvalidAgent() {},
+        droppedUnsupported() {},
+      }
+      : createRequestHookRecorder(hookIdentity, data, "permission");
     if (hookIdentity.rejected) {
       recordRequestHookEvent.droppedInvalidAgent();
       sendGenericPermissionNoDecision(res);
@@ -614,6 +644,12 @@ function handlePermissionPost(req, res, options) {
       return;
     }
     const { agentId } = hookIdentity;
+    if (hasPermissionEventDiscriminator && !isOpencodeFamily(agentId)) {
+      res.writeHead(200, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
+      res.end("ok");
+      ctx.permLog(`permission lifecycle no-op: unsupported agent=${agentId || "unknown"}`);
+      return;
+    }
     const trustedProfileId = remoteProfile && typeof remoteProfile.profileId === "string"
       ? remoteProfile.profileId
       : "local";
@@ -660,6 +696,47 @@ function handlePermissionPost(req, res, options) {
       if (isOpencodeFamily(agentId)) {
         res.writeHead(200, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
         res.end("ok");
+
+        if (hasPermissionEventDiscriminator) {
+          if (data.permission_event !== "replied") {
+            ctx.permLog(`${agentId} permission lifecycle no-op: unsupported event`);
+            return;
+          }
+
+          const rawSessionId = normalizeOpencodeFamilySessionId(agentId, data.session_id);
+          const requestId = typeof data.request_id === "string" && data.request_id
+            ? data.request_id
+            : null;
+          const bridgeUrl = normalizeOpencodeFamilyBridgeUrl(data.lifecycle_bridge_url);
+          const bridgeToken = isValidOpencodeFamilyBridgeToken(data.lifecycle_bridge_token)
+            ? data.lifecycle_bridge_token
+            : null;
+          if (!rawSessionId || !requestId || !bridgeUrl || !bridgeToken) {
+            const reason = !rawSessionId
+              ? "missing session_id"
+              : !requestId
+                ? "missing request_id"
+                : !bridgeUrl
+                  ? "invalid lifecycle_bridge_url"
+                  : "invalid lifecycle_bridge_token";
+            ctx.permLog(`${agentId} permission lifecycle no-op: ${reason}`);
+            return;
+          }
+
+          const sessionIdentity = resolvePermissionSession(rawSessionId, rawSessionId);
+          const dismissed = typeof ctx.dismissOpencodeFamilyPermissionResolvedExternally === "function"
+            ? ctx.dismissOpencodeFamilyPermissionResolvedExternally({
+              agentId,
+              requestId,
+              sessionId: sessionIdentity.sessionId,
+              bridgeUrl,
+              bridgeToken,
+            })
+            : 0;
+          ctx.permLog(`${agentId} permission lifecycle replied: request=${boundedPermissionLogValue(requestId)} matched=${dismissed}`);
+          return;
+        }
+
         const toolName = typeof data.tool_name === "string" && data.tool_name ? data.tool_name : "unknown";
         const interaction = classifyPermissionInteraction({
           agentId,

--- a/test/opencode-family-bridge.test.js
+++ b/test/opencode-family-bridge.test.js
@@ -42,13 +42,31 @@ writeLiveRuntimeIdentity();
 let createOpencodeFamilyPlugin;
 const fetchCalls = [];
 let bridgePortCounter = 40000;
+let clawdResponseRecognized = false;
+let fetchBehavior = null;
+
+function fakeClawdResponse(recognized = clawdResponseRecognized) {
+  return {
+    status: 200,
+    headers: {
+      get(name) {
+        return recognized && String(name).toLowerCase() === "x-clawd-server"
+          ? "clawd-on-desk"
+          : null;
+      },
+    },
+    text: async () => "",
+  };
+}
 
 before(async () => {
   // Fake fetch: record every POST the plugin fires and answer as a non-Clawd
   // server (missing identity header) so the port scan exhausts harmlessly.
   globalThis.fetch = async (url, opts) => {
-    fetchCalls.push({ url: String(url), body: opts && opts.body ? JSON.parse(opts.body) : null });
-    return { status: 200, headers: { get: () => null }, text: async () => "" };
+    const call = { url: String(url), body: opts && opts.body ? JSON.parse(opts.body) : null };
+    fetchCalls.push(call);
+    if (typeof fetchBehavior === "function") return fetchBehavior(call);
+    return fakeClawdResponse();
   };
   const modulePath = path.join(__dirname, "..", "hooks", "opencode-family-plugin", "core.mjs");
   ({ createOpencodeFamilyPlugin } = await import(pathToFileURL(modulePath).href));
@@ -78,6 +96,7 @@ async function initInstance(params, { sdk, plugin: existingPlugin, directory = "
       _client: {
         post: async (args) => {
           sdkCalls.push(args);
+          if (sdk && typeof sdk.onPost === "function") await sdk.onPost(args);
           if (sdk && sdk.throw) throw new Error(sdk.throw);
           if (sdk && sdk.error) return { error: sdk.error };
           return { data: {} };
@@ -102,6 +121,26 @@ async function emitPermission(instance, requestId, sessionID = "ses_permission")
       },
     },
   });
+}
+
+async function emitPermissionReplied(instance, properties) {
+  await instance.hooks.event({
+    event: { type: "permission.replied", properties },
+  });
+}
+
+async function settlePermissionTail(plugin, requestId) {
+  const tail = plugin.__test._permissionPostTailByRequestId.get(requestId);
+  if (tail) await tail;
+  await Promise.resolve();
+}
+
+async function waitUntil(predicate, message, timeoutMs = 1000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
 }
 
 const OC = Object.freeze({
@@ -327,5 +366,306 @@ describe("opencode-family reverse bridge (plugin side, real handler)", () => {
     );
     assert.strictEqual(res2.status, 502);
     assert.deepStrictEqual(await res2.json(), { ok: false, error: "socket gone" });
+  });
+});
+
+describe("opencode-family permission completion lifecycle", () => {
+  it("forwards only the current requestID/reply generation and invalidates the reverse target first", async () => {
+    clawdResponseRecognized = true;
+    fetchBehavior = null;
+    try {
+      for (const params of [OC, MC]) {
+        const instance = await initInstance(params);
+        const requestId = `per_current_${params.agentId}`;
+        fetchCalls.length = 0;
+        await emitPermission(instance, requestId, "ses_current");
+        await settlePermissionTail(instance.plugin, requestId);
+        fetchCalls.length = 0;
+
+        await emitPermissionReplied(instance, {
+          sessionID: "ses_current",
+          requestID: requestId,
+          reply: "once",
+        });
+        assert.strictEqual(
+          instance.plugin.__test._permissionTargetByRequestId.has(requestId),
+          false,
+          "native resolution must synchronously invalidate the reverse target"
+        );
+        await settlePermissionTail(instance.plugin, requestId);
+
+        assert.strictEqual(fetchCalls.length, 1);
+        const body = fetchCalls[0].body;
+        assert.deepStrictEqual({
+          agent_id: body.agent_id,
+          hook_source: body.hook_source,
+          permission_event: body.permission_event,
+          session_id: body.session_id,
+          request_id: body.request_id,
+          lifecycle_bridge_url: body.lifecycle_bridge_url,
+          lifecycle_bridge_token: body.lifecycle_bridge_token,
+        }, {
+          agent_id: params.agentId,
+          hook_source: params.hookSource,
+          permission_event: "replied",
+          session_id: `${params.sessionIdPrefix}ses_current`,
+          request_id: requestId,
+          lifecycle_bridge_url: instance.plugin.__test._bridgeUrl,
+          lifecycle_bridge_token: instance.plugin.__test._bridgeTokenHex,
+        });
+        for (const forbidden of ["tool_name", "tool_input", "always", "patterns", "reply", "response", "bridge_url", "bridge_token"]) {
+          assert.strictEqual(Object.hasOwn(body, forbidden), false, forbidden);
+        }
+
+        const staleClick = await instance.captured.fetch(
+          bridgeRequest(instance.plugin, {
+            token: instance.plugin.__test._bridgeTokenHex,
+            body: { request_id: requestId, reply: "once" },
+          })
+        );
+        assert.strictEqual(staleClick.status, 404);
+        assert.strictEqual(instance.sdkCalls.length, 0, "external cleanup must never call the host SDK");
+      }
+    } finally {
+      clawdResponseRecognized = false;
+      fetchBehavior = null;
+    }
+  });
+
+  it("fails stale completion shapes closed and logs bounded key names without values", async () => {
+    const instance = await initInstance(OC);
+    fetchCalls.length = 0;
+    await emitPermissionReplied(instance, {
+      sessionID: "ses_stale",
+      permissionID: "secret-stale-permission-value",
+      response: "secret-stale-response-value",
+    });
+    await emitPermissionReplied(instance, { id: "secret-guessed-id-value" });
+    await instance.plugin.__test.flushDebugLog();
+
+    assert.strictEqual(fetchCalls.length, 0);
+    const log = fs.readFileSync(instance.plugin.__test._debugLogPath, "utf8");
+    assert.match(log, /unsupported-shape keys=\[sessionID,permissionID,response\]/);
+    assert.match(log, /unsupported-shape keys=\[id\]/);
+    assert.doesNotMatch(log, /secret-stale-permission-value|secret-stale-response-value|secret-guessed-id-value/);
+  });
+
+  it("uses the asked target session on mismatch, but still reports an evicted target from the event session", async () => {
+    clawdResponseRecognized = true;
+    try {
+      const instance = await initInstance(OC);
+      await emitPermission(instance, "per_target_session", "ses_target");
+      await settlePermissionTail(instance.plugin, "per_target_session");
+      fetchCalls.length = 0;
+
+      await emitPermissionReplied(instance, {
+        sessionID: "ses_other",
+        requestID: "per_target_session",
+        reply: "reject",
+      });
+      await settlePermissionTail(instance.plugin, "per_target_session");
+      assert.strictEqual(fetchCalls[0].body.session_id, "opencode:ses_target");
+
+      fetchCalls.length = 0;
+      await emitPermissionReplied(instance, {
+        sessionID: "ses_evicted",
+        requestID: "per_evicted",
+        reply: "always",
+      });
+      await settlePermissionTail(instance.plugin, "per_evicted");
+      assert.strictEqual(fetchCalls[0].body.session_id, "opencode:ses_evicted");
+
+      await instance.plugin.__test.flushDebugLog();
+      const log = fs.readFileSync(instance.plugin.__test._debugLogPath, "utf8");
+      assert.match(log, /session mismatch req=per_target_session/);
+    } finally {
+      clawdResponseRecognized = false;
+    }
+  });
+
+  it("does not let a standalone replied event pollute root/last-seen fallback state", async () => {
+    clawdResponseRecognized = true;
+    try {
+      const instance = await initInstance(OC);
+      await emitPermissionReplied(instance, {
+        sessionID: "ses_completion_only",
+        requestID: "per_completion_only",
+        reply: "once",
+      });
+      await settlePermissionTail(instance.plugin, "per_completion_only");
+      assert.strictEqual(instance.plugin.__test._rootSessionId, null);
+      assert.strictEqual(instance.plugin.__test._lastSeenSessionId, null);
+
+      fetchCalls.length = 0;
+      await emitPermission(instance, "per_missing_session", null);
+      await settlePermissionTail(instance.plugin, "per_missing_session");
+      assert.strictEqual(fetchCalls[0].body.session_id, "opencode:default");
+    } finally {
+      clawdResponseRecognized = false;
+    }
+  });
+
+  it("serializes asked→replied for one request while a different request remains parallel", async () => {
+    clawdResponseRecognized = true;
+    let releaseAsked;
+    const askedGate = new Promise((resolve) => { releaseAsked = resolve; });
+    fetchBehavior = async (call) => {
+      if (call.body && call.body.request_id === "per_fifo_a" && !call.body.permission_event) {
+        await askedGate;
+      }
+      return fakeClawdResponse(true);
+    };
+    try {
+      const instance = await initInstance(OC);
+      fetchCalls.length = 0;
+      await emitPermission(instance, "per_fifo_a", "ses_fifo");
+      await waitUntil(() => fetchCalls.length === 1, "asked POST did not start");
+      await emitPermissionReplied(instance, {
+        sessionID: "ses_fifo",
+        requestID: "per_fifo_a",
+        reply: "once",
+      });
+      await emitPermission(instance, "per_fifo_b", "ses_fifo");
+      await waitUntil(
+        () => fetchCalls.some((call) => call.body && call.body.request_id === "per_fifo_b"),
+        "different request was blocked behind stalled request"
+      );
+      assert.strictEqual(
+        fetchCalls.some((call) => call.body && call.body.request_id === "per_fifo_a" && call.body.permission_event === "replied"),
+        false,
+        "same-request lifecycle overtook its asked POST"
+      );
+
+      releaseAsked();
+      await settlePermissionTail(instance.plugin, "per_fifo_a");
+      await settlePermissionTail(instance.plugin, "per_fifo_b");
+      const aCalls = fetchCalls.filter((call) => call.body && call.body.request_id === "per_fifo_a");
+      assert.deepStrictEqual(aCalls.map((call) => call.body.permission_event || "asked"), ["asked", "replied"]);
+      assert.strictEqual(instance.plugin.__test._permissionPostTailByRequestId.size, 0);
+    } finally {
+      releaseAsked();
+      fetchBehavior = null;
+      clawdResponseRecognized = false;
+    }
+  });
+
+  it("stops lifecycle delivery after one recognized response and bounds persistent failure at three attempts", async () => {
+    const instance = await initInstance(OC);
+    try {
+      clawdResponseRecognized = true;
+      fetchCalls.length = 0;
+      await emitPermissionReplied(instance, {
+        sessionID: "ses_retry",
+        requestID: "per_retry_ok",
+        reply: "once",
+      });
+      await settlePermissionTail(instance.plugin, "per_retry_ok");
+      assert.strictEqual(fetchCalls.length, 1);
+
+      clawdResponseRecognized = false;
+      fetchCalls.length = 0;
+      const startedAt = Date.now();
+      await emitPermissionReplied(instance, {
+        sessionID: "ses_retry",
+        requestID: "per_retry_fail",
+        reply: "reject",
+      });
+      await settlePermissionTail(instance.plugin, "per_retry_fail");
+      const elapsed = Date.now() - startedAt;
+      assert.strictEqual(fetchCalls.length, 3);
+      assert.ok(elapsed >= 450 && elapsed < 1800, `retry duration out of bounds: ${elapsed}ms`);
+      assert.strictEqual(instance.plugin.__test._permissionPostTailByRequestId.size, 0);
+    } finally {
+      clawdResponseRecognized = false;
+      fetchBehavior = null;
+    }
+  });
+
+  it("keeps Clawd-first echo and multi-request cascades idempotent without a second host decision", async () => {
+    clawdResponseRecognized = true;
+    const sdk = {};
+    try {
+      const instance = await initInstance(OC, { sdk });
+      sdk.onPost = async () => {
+        await emitPermissionReplied(instance, {
+          sessionID: "ses_echo",
+          requestID: "per_echo",
+          reply: "always",
+        });
+      };
+      await emitPermission(instance, "per_echo", "ses_echo");
+      await settlePermissionTail(instance.plugin, "per_echo");
+      fetchCalls.length = 0;
+
+      const bridgeResponse = await instance.captured.fetch(
+        bridgeRequest(instance.plugin, {
+          token: instance.plugin.__test._bridgeTokenHex,
+          body: { request_id: "per_echo", reply: "always" },
+        })
+      );
+      assert.strictEqual(bridgeResponse.status, 200);
+      await settlePermissionTail(instance.plugin, "per_echo");
+      assert.strictEqual(instance.sdkCalls.length, 1, "Clawd decision reaches the host once");
+      assert.strictEqual(
+        fetchCalls.filter((call) => call.body && call.body.request_id === "per_echo" && call.body.permission_event === "replied").length,
+        1,
+        "host echo is one cleanup lifecycle"
+      );
+
+      sdk.onPost = null;
+      for (const requestId of ["per_cascade_a", "per_cascade_b"]) {
+        await emitPermission(instance, requestId, "ses_echo");
+        await settlePermissionTail(instance.plugin, requestId);
+      }
+      fetchCalls.length = 0;
+      await Promise.all([
+        emitPermissionReplied(instance, { sessionID: "ses_echo", requestID: "per_cascade_a", reply: "reject" }),
+        emitPermissionReplied(instance, { sessionID: "ses_echo", requestID: "per_cascade_b", reply: "always" }),
+      ]);
+      await Promise.all([
+        settlePermissionTail(instance.plugin, "per_cascade_a"),
+        settlePermissionTail(instance.plugin, "per_cascade_b"),
+      ]);
+      assert.deepStrictEqual(
+        fetchCalls.map((call) => call.body.request_id).sort(),
+        ["per_cascade_a", "per_cascade_b"]
+      );
+
+      fetchCalls.length = 0;
+      await emitPermissionReplied(instance, { sessionID: "ses_echo", requestID: "per_cascade_a", reply: "reject" });
+      await settlePermissionTail(instance.plugin, "per_cascade_a");
+      assert.strictEqual(fetchCalls.length, 1, "duplicate completion is an idempotent cleanup delivery");
+      assert.strictEqual(instance.plugin.__test._permissionPostTailByRequestId.size, 0);
+      assert.strictEqual(instance.sdkCalls.length, 1, "completion traffic never calls the SDK");
+    } finally {
+      clawdResponseRecognized = false;
+      fetchBehavior = null;
+    }
+  });
+
+  it("bounds target history and releases lifecycle tails after a large permission sequence", async () => {
+    clawdResponseRecognized = true;
+    try {
+      const instance = await initInstance(OC);
+      const requestIds = Array.from({ length: 270 }, (_, index) => `per_pressure_${index}`);
+      for (const requestId of requestIds) {
+        await emitPermission(instance, requestId, "ses_pressure");
+      }
+      await Promise.all(requestIds.map((requestId) => settlePermissionTail(instance.plugin, requestId)));
+      assert.strictEqual(instance.plugin.__test._permissionTargetByRequestId.size, 256);
+
+      for (const requestId of requestIds) {
+        await emitPermissionReplied(instance, {
+          sessionID: "ses_pressure",
+          requestID: requestId,
+          reply: "once",
+        });
+      }
+      await Promise.all(requestIds.map((requestId) => settlePermissionTail(instance.plugin, requestId)));
+      assert.strictEqual(instance.plugin.__test._permissionTargetByRequestId.size, 0);
+      assert.strictEqual(instance.plugin.__test._permissionPostTailByRequestId.size, 0);
+    } finally {
+      clawdResponseRecognized = false;
+    }
   });
 });

--- a/test/opencode-family-core.test.js
+++ b/test/opencode-family-core.test.js
@@ -129,9 +129,13 @@ describe("opencode-family plugin factory", () => {
     assert.notStrictEqual(oc.__test._statePostTailBySession, mc.__test._statePostTailBySession);
     assert.notStrictEqual(oc.__test._sessionInstanceDirectoryById, mc.__test._sessionInstanceDirectoryById);
     assert.notStrictEqual(oc.__test._permissionTargetByRequestId, mc.__test._permissionTargetByRequestId);
+    assert.notStrictEqual(oc.__test._permissionPostTailByRequestId, mc.__test._permissionPostTailByRequestId);
     oc.__test._lastStatePerSession.set("opencode:ses_x", "working");
     assert.strictEqual(mc.__test._lastStatePerSession.size, 0);
     oc.__test._lastStatePerSession.clear();
+    oc.__test._permissionPostTailByRequestId.set("per-shared", Promise.resolve(true));
+    assert.strictEqual(mc.__test._permissionPostTailByRequestId.has("per-shared"), false);
+    oc.__test._permissionPostTailByRequestId.clear();
 
     // Port cache: live getter/setter into the closure, isolated per instance.
     assert.strictEqual(oc.__test._cachedPort, null);

--- a/test/opencode-family-node-bridge.test.js
+++ b/test/opencode-family-node-bridge.test.js
@@ -27,6 +27,7 @@ if (process.platform !== "win32") fs.chmodSync(runtimePath, 0o600);
 
 let createOpencodeFamilyPlugin;
 const fetchCalls = [];
+let clawdResponseRecognized = false;
 
 before(async () => {
   delete globalThis.Bun;
@@ -35,7 +36,15 @@ before(async () => {
       url: String(url),
       body: opts && opts.body ? JSON.parse(opts.body) : null,
     });
-    return { status: 200, headers: { get: () => null }, text: async () => "" };
+    return {
+      status: 200,
+      headers: {
+        get: (name) => clawdResponseRecognized && String(name).toLowerCase() === "x-clawd-server"
+          ? "clawd-on-desk"
+          : null,
+      },
+      text: async () => "",
+    };
   };
   const modulePath = path.join(__dirname, "..", "hooks", "opencode-family-plugin", "core.mjs");
   ({ createOpencodeFamilyPlugin } = await import(pathToFileURL(modulePath).href));
@@ -86,6 +95,17 @@ async function emitPermission(instance, requestId, sessionID = "ses_node") {
       },
     },
   });
+}
+
+async function emitPermissionReplied(instance, requestId, sessionID = "ses_node") {
+  await instance.hooks.event({
+    event: {
+      type: "permission.replied",
+      properties: { requestID: requestId, sessionID, reply: "once" },
+    },
+  });
+  const tail = instance.plugin.__test._permissionPostTailByRequestId.get(requestId);
+  if (tail) await tail;
 }
 
 function requestBridge(url, { token, body, rawBody, chunked = false } = {}) {
@@ -216,5 +236,31 @@ describe("opencode-family Node reverse bridge", () => {
     assert.strictEqual(callsA.length, 1);
     assert.strictEqual(callsB.length, 0);
     assert.deepStrictEqual(callsA[0].query, { directory: "/tmp/project-a" });
+  });
+
+  it("forwards the same strict completion lifecycle from the Node Desktop host path", async (t) => {
+    clawdResponseRecognized = true;
+    const instance = await initNodeInstance();
+    t.after(() => instance.plugin.__test.closeBridgeForTest());
+    try {
+      await emitPermission(instance, "per_node_lifecycle", "ses_node_lifecycle");
+      const askedTail = instance.plugin.__test._permissionPostTailByRequestId.get("per_node_lifecycle");
+      if (askedTail) await askedTail;
+      fetchCalls.length = 0;
+
+      await emitPermissionReplied(instance, "per_node_lifecycle", "ses_node_lifecycle");
+
+      assert.strictEqual(fetchCalls.length, 1);
+      const body = fetchCalls[0].body;
+      assert.strictEqual(body.permission_event, "replied");
+      assert.strictEqual(body.request_id, "per_node_lifecycle");
+      assert.strictEqual(body.session_id, "opencode:ses_node_lifecycle");
+      assert.strictEqual(body.lifecycle_bridge_url, instance.plugin.__test._bridgeUrl);
+      assert.strictEqual(body.lifecycle_bridge_token, instance.plugin.__test._bridgeTokenHex);
+      assert.strictEqual(Object.hasOwn(body, "bridge_url"), false);
+      assert.strictEqual(Object.hasOwn(body, "bridge_token"), false);
+    } finally {
+      clawdResponseRecognized = false;
+    }
   });
 });

--- a/test/opencode-family-session-directory.test.js
+++ b/test/opencode-family-session-directory.test.js
@@ -445,7 +445,7 @@ describe("opencode-family session title (#829)", () => {
     assert.strictEqual(plugin.__test._sessionTitleById.get("opencode:ses_t"), "轻松问候");
     const metaPost = fetchCalls.find((c) => c.url.endsWith("/state") && c.body && c.body.metadata_only === true);
     assert.ok(metaPost, "expected a metadata-only POST for the title change");
-    // postToClawd enriches every POST with process-tree fields. Split those
+    // snapshotPost enriches every POST with process-tree fields. Split those
     // off and deepStrictEqual the rest against the EXACT title-push contract
     // so the complete metadata-only body is covered: a missing field or an
     // unexpected extra one both fail (#841 review).

--- a/test/permission-family-lifecycle.test.js
+++ b/test/permission-family-lifecycle.test.js
@@ -1,0 +1,476 @@
+"use strict";
+
+// #913: native OpenCode-family replies are lifecycle cleanup, never a second
+// decision. These tests combine the real /permission route with the real
+// permission runtime and separately lock the teardown/identity contract.
+
+const assert = require("node:assert");
+const { EventEmitter } = require("node:events");
+const fs = require("node:fs");
+const http = require("node:http");
+const Module = require("node:module");
+const os = require("node:os");
+const path = require("node:path");
+const { afterEach, describe, it } = require("node:test");
+const { makeSessionKey } = require("../src/session-key");
+
+const PERMISSION_MODULE_PATH = require.resolve("../src/permission");
+const tempLogPaths = new Set();
+
+afterEach(() => {
+  for (const logPath of tempLogPaths) {
+    try { fs.unlinkSync(logPath); } catch {}
+  }
+  tempLogPaths.clear();
+});
+
+function loadPermissionWithElectron(fakeElectron) {
+  delete require.cache[PERMISSION_MODULE_PATH];
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request) {
+    if (request === "electron") return fakeElectron;
+    return originalLoad.apply(this, arguments);
+  };
+  try {
+    return require("../src/permission");
+  } finally {
+    Module._load = originalLoad;
+  }
+}
+
+function makeFakeElectron(shortcutCalls) {
+  return {
+    BrowserWindow: Object.assign(class {}, {
+      fromWebContents(sender) { return sender && sender.__window ? sender.__window : null; },
+    }),
+    globalShortcut: {
+      register(accelerator) { shortcutCalls.push(["register", accelerator]); return true; },
+      unregister(accelerator) { shortcutCalls.push(["unregister", accelerator]); },
+      isRegistered() { return false; },
+    },
+  };
+}
+
+function makeBubble(onHide) {
+  const bubble = {
+    hidden: false,
+    destroyed: false,
+    webContents: {
+      send(eventName) {
+        if (eventName === "permission-hide") {
+          bubble.hidden = true;
+          if (onHide) onHide();
+        }
+      },
+      isDestroyed() { return false; },
+    },
+    isDestroyed() { return this.destroyed; },
+    isVisible() { return !this.destroyed; },
+    destroy() { this.destroyed = true; },
+  };
+  return bubble;
+}
+
+function makeRuntimeHarness() {
+  const shortcutCalls = [];
+  const resolved = [];
+  const changed = [];
+  const layout = { update: 0, hud: 0 };
+  const sessionTrustCancels = [];
+  const logs = [];
+  const permDebugLog = path.join(
+    os.tmpdir(),
+    `clawd-family-lifecycle-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.log`
+  );
+  tempLogPaths.add(permDebugLog);
+  const initPermission = loadPermissionWithElectron(makeFakeElectron(shortcutCalls));
+  const ctx = {
+    sessions: new Map(),
+    hideBubbles: false,
+    petHidden: false,
+    win: null,
+    lang: "en",
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
+    getSettingsSnapshot: () => ({}),
+    isAgentPermissionsEnabled: () => true,
+    focusTerminalForSession() {},
+    onPermissionsChanged: (reason) => changed.push(reason),
+    onPermissionResolved: (entry, meta) => resolved.push({ entry, meta }),
+    cancelSessionTrustCandidate: (entry, meta) => sessionTrustCancels.push({ entry, meta }),
+    repositionUpdateBubble: () => { layout.update += 1; },
+    repositionSessionHud: () => { layout.hud += 1; },
+    permDebugLog,
+  };
+  const api = initPermission(ctx);
+  return { api, ctx, shortcutCalls, resolved, changed, layout, sessionTrustCancels, logs, permDebugLog };
+}
+
+function readPermissionDebugLog(harness) {
+  try {
+    return fs.readFileSync(harness.permDebugLog, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function assertSecretAbsentFromLifecycleLogs(harness, secret) {
+  assert.strictEqual(harness.logs.join("\n").includes(secret), false);
+  assert.strictEqual(readPermissionDebugLog(harness).includes(secret), false);
+}
+
+function familyEntry(overrides = {}) {
+  return {
+    res: null,
+    abortHandler: null,
+    suggestions: [],
+    sessionId: makeSessionKey({ profileId: "local", rawSessionId: "opencode:ses-life" }),
+    bubble: null,
+    hideTimer: null,
+    toolName: "bash",
+    toolInput: { command: "echo life" },
+    resolvedSuggestion: null,
+    createdAt: Date.now(),
+    agentId: "opencode",
+    familyRequestId: "per-life",
+    familyBridgeUrl: "http://127.0.0.1:43210",
+    familyBridgeToken: "token_life",
+    familyAlwaysCandidates: [],
+    familyPatterns: [],
+    ...overrides,
+  };
+}
+
+function makeReq(body) {
+  const req = new EventEmitter();
+  req.headers = {};
+  setImmediate(() => {
+    req.emit("data", Buffer.from(JSON.stringify(body)));
+    req.emit("end");
+  });
+  return req;
+}
+
+function makeRes() {
+  const res = new EventEmitter();
+  res.statusCode = null;
+  res.headers = {};
+  res.body = "";
+  res.headersSent = false;
+  res.writableFinished = false;
+  res.destroyed = false;
+  res.writeHead = function writeHead(statusCode, headers) {
+    this.statusCode = statusCode;
+    this.headersSent = true;
+    if (headers) this.headers = headers;
+  };
+  res.end = function end(body) {
+    if (body) this.body += String(body);
+    this.writableFinished = true;
+  };
+  res.destroy = function destroy() {
+    this.destroyed = true;
+    this.emit("close");
+  };
+  return res;
+}
+
+function postPermission(ctx, body) {
+  const { handlePermissionPost } = require("../src/server-route-permission");
+  const res = makeRes();
+  const recorder = [];
+  handlePermissionPost(makeReq(body), res, {
+    ctx,
+    createRequestHookRecorder(identity, data, route) {
+      recorder.push({ identity, data, route });
+      return {
+        accepted: () => recorder.push({ outcome: "accepted" }),
+        droppedByDisabled: () => recorder.push({ outcome: "disabled" }),
+        droppedByDnd: () => recorder.push({ outcome: "dnd" }),
+        droppedInvalidAgent: () => recorder.push({ outcome: "invalid-agent" }),
+        droppedUnsupported: () => recorder.push({ outcome: "unsupported" }),
+      };
+    },
+  });
+  return new Promise((resolve) => {
+    setImmediate(() => setImmediate(() => resolve({ res, recorder })));
+  });
+}
+
+function makeRouteRuntimeHarness(overrides = {}) {
+  const harness = makeRuntimeHarness();
+  const calls = {
+    updateSession: [],
+    showPermissionBubble: [],
+    replyOpencodeFamilyPermission: [],
+    maybeStartRemoteApproval: [],
+  };
+  Object.assign(harness.ctx, {
+    doNotDisturb: false,
+    pendingPermissions: harness.api.pendingPermissions,
+    PASSTHROUGH_TOOLS: harness.api.PASSTHROUGH_TOOLS,
+    permLog: (message) => harness.logs.push(message),
+    isAgentEnabled: () => true,
+    isAgentPermissionsEnabled: () => true,
+    isAgentSubagentPermissionsEnabled: () => true,
+    getCustomAgentIds: () => [],
+    addPendingPermission: harness.api.addPendingPermission,
+    removePendingPermission: harness.api.removePendingPermission,
+    dismissOpencodeFamilyPermissionResolvedExternally:
+      harness.api.dismissOpencodeFamilyPermissionResolvedExternally,
+    updateSession: (...args) => calls.updateSession.push(args),
+    showPermissionBubble: (entry) => {
+      calls.showPermissionBubble.push(entry);
+      entry.bubble = makeBubble();
+    },
+    replyOpencodeFamilyPermission: (payload) => calls.replyOpencodeFamilyPermission.push(payload),
+    maybeStartRemoteApproval: (entry) => calls.maybeStartRemoteApproval.push(entry),
+    syncPermissionShortcuts: harness.api.syncPermissionShortcuts,
+    ...overrides,
+  });
+  harness.calls = calls;
+  return harness;
+}
+
+describe("opencode-family external lifecycle runtime", () => {
+  it("removes every exact duplicate before teardown, clears timers/notifications, and emits zero reverse traffic", async () => {
+    const harness = makeRuntimeHarness();
+    const { api } = harness;
+    let timerFires = 0;
+    let remoteAborts = 0;
+    let allExactWereDeadAtHide = false;
+    const exactA = familyEntry();
+    const exactB = familyEntry({
+      bubble: makeBubble(() => {
+        allExactWereDeadAtHide = !api.pendingPermissions.includes(exactA)
+          && !api.pendingPermissions.includes(exactB);
+      }),
+      _delayTimer: setTimeout(() => { timerFires += 1; }, 40),
+      autoCloseTimer: setTimeout(() => { timerFires += 1; }, 40),
+      autoExpireTimer: setTimeout(() => { timerFires += 1; }, 40),
+      remoteApprovalAbortController: { abort: () => { remoteAborts += 1; } },
+      sessionTrustCandidate: { mode: "always" },
+    });
+    exactA.bubble = makeBubble();
+    const sameSessionOtherRequest = familyEntry({ familyRequestId: "per-other" });
+    const otherAgent = familyEntry({ agentId: "mimocode" });
+    api.pendingPermissions.push(exactA, sameSessionOtherRequest, exactB, otherAgent);
+
+    let reverseRequests = 0;
+    const originalRequest = http.request;
+    http.request = function forbiddenReverseRequest() {
+      reverseRequests += 1;
+      throw new Error("external lifecycle attempted a reverse decision");
+    };
+    try {
+      const removed = api.dismissOpencodeFamilyPermissionResolvedExternally({
+        agentId: "opencode",
+        requestId: "per-life",
+        sessionId: exactA.sessionId,
+        bridgeUrl: "http://127.0.0.1:43210/",
+        bridgeToken: "token_life",
+      });
+      assert.strictEqual(removed, 2);
+    } finally {
+      http.request = originalRequest;
+    }
+
+    assertSecretAbsentFromLifecycleLogs(harness, "token_life");
+
+    assert.deepStrictEqual(api.pendingPermissions, [sameSessionOtherRequest, otherAgent]);
+    assert.strictEqual(allExactWereDeadAtHide, true, "all exact entries must be non-live before renderer teardown");
+    assert.strictEqual(exactA.bubble.hidden, true);
+    assert.strictEqual(exactB.bubble.hidden, true);
+    assert.strictEqual(exactB._delayTimer, null);
+    assert.strictEqual(exactB.autoCloseTimer, null);
+    assert.strictEqual(exactB.autoExpireTimer, null);
+    assert.strictEqual(remoteAborts, 1);
+    assert.strictEqual(harness.sessionTrustCancels.length, 1);
+    assert.strictEqual(reverseRequests, 0);
+    assert.deepStrictEqual(harness.changed, ["resolved-externally"]);
+    assert.strictEqual(harness.resolved.length, 2);
+    assert.ok(harness.resolved.every(({ meta }) => (
+      meta.reason === "resolved-externally" && meta.hasPendingForSession === true
+    )));
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    assert.strictEqual(timerFires, 0, "cleared timers must not resolve a second time");
+    api.cleanup();
+  });
+
+  it("requires the full agent/request/session/url/token identity and treats malformed values as no-op", () => {
+    const harness = makeRuntimeHarness();
+    const entry = familyEntry();
+    harness.api.pendingPermissions.push(entry);
+    const base = {
+      agentId: entry.agentId,
+      requestId: entry.familyRequestId,
+      sessionId: entry.sessionId,
+      bridgeUrl: entry.familyBridgeUrl,
+      bridgeToken: entry.familyBridgeToken,
+    };
+    const bad = [
+      { agentId: "mimocode" },
+      { requestId: "per-other" },
+      { sessionId: `${entry.sessionId}-other` },
+      { bridgeUrl: "http://127.0.0.1:43211" },
+      { bridgeUrl: "http://localhost:43210" },
+      { bridgeUrl: 42 },
+      { bridgeToken: "token_other" },
+      { bridgeToken: "x".repeat(129) },
+      { bridgeToken: { value: "token_life" } },
+    ];
+    for (const delta of bad) {
+      assert.doesNotThrow(() => {
+        assert.strictEqual(
+          harness.api.dismissOpencodeFamilyPermissionResolvedExternally({ ...base, ...delta }),
+          0,
+          JSON.stringify(delta)
+        );
+      });
+      assert.strictEqual(harness.api.pendingPermissions.includes(entry), true);
+    }
+    assertSecretAbsentFromLifecycleLogs(harness, "token_life");
+    assertSecretAbsentFromLifecycleLogs(harness, "token_other");
+    harness.api.cleanup();
+  });
+});
+
+describe("opencode-family lifecycle route → real runtime", () => {
+  it("canonicalizes raw/prefixed family sessions and clears only the exact pending request", async () => {
+    const harness = makeRouteRuntimeHarness({
+      doNotDisturb: true,
+      isAgentEnabled: () => false,
+      isAgentPermissionsEnabled: () => false,
+    });
+    // Create while gates are enabled, then flip every creation gate before the
+    // lifecycle to prove cleanup is not blocked by current policy.
+    harness.ctx.doNotDisturb = false;
+    harness.ctx.isAgentEnabled = () => true;
+    harness.ctx.isAgentPermissionsEnabled = () => true;
+    const asked = {
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+      session_id: "opencode:ses-route",
+      tool_name: "bash",
+      tool_input: { command: "echo route" },
+      request_id: "per-route",
+      bridge_url: "http://127.0.0.1:43210",
+      bridge_token: "token_route",
+    };
+    const askedResult = await postPermission(harness.ctx, asked);
+    assert.strictEqual(askedResult.res.statusCode, 200);
+    assert.strictEqual(harness.api.pendingPermissions.length, 1);
+    const entry = harness.api.pendingPermissions[0];
+
+    const unknownLifecycleResult = await postPermission(harness.ctx, {
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+      permission_event: "resolved-someday",
+      session_id: "ses-route",
+      request_id: "per-route",
+      lifecycle_bridge_url: "http://127.0.0.1:43210/",
+      lifecycle_bridge_token: "token_route",
+    });
+    assert.strictEqual(unknownLifecycleResult.res.statusCode, 200);
+    assert.strictEqual(harness.api.pendingPermissions.length, 1, "unknown lifecycle must not clean a live entry");
+
+    harness.ctx.doNotDisturb = true;
+    harness.ctx.isAgentEnabled = () => false;
+    harness.ctx.isAgentPermissionsEnabled = () => false;
+    const lifecycleResult = await postPermission(harness.ctx, {
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+      permission_event: "replied",
+      session_id: "ses-route",
+      request_id: "per-route",
+      lifecycle_bridge_url: "http://127.0.0.1:43210/",
+      lifecycle_bridge_token: "token_route",
+    });
+
+    assert.strictEqual(lifecycleResult.res.statusCode, 200);
+    assert.strictEqual(lifecycleResult.res.headers["x-clawd-server"], "clawd-on-desk");
+    assert.deepStrictEqual(lifecycleResult.recorder, []);
+    assert.strictEqual(harness.api.pendingPermissions.length, 0);
+    assert.strictEqual(entry.bubble.hidden, true);
+    assert.strictEqual(harness.calls.updateSession.length, 1, "lifecycle must not publish another PermissionRequest");
+    assert.strictEqual(harness.calls.showPermissionBubble.length, 1);
+    assert.deepStrictEqual(harness.calls.replyOpencodeFamilyPermission, []);
+    assert.deepStrictEqual(harness.calls.maybeStartRemoteApproval, []);
+    assert.deepStrictEqual(harness.resolved.map(({ meta }) => meta), [{
+      reason: "resolved-externally",
+      hasPendingForSession: false,
+    }]);
+    assertSecretAbsentFromLifecycleLogs(harness, "token_route");
+    harness.api.cleanup();
+  });
+
+  it("keeps new lifecycle credentials fail-safe for an old creator that only understands bridge_url/token", () => {
+    const lifecycleBody = {
+      agent_id: "opencode",
+      permission_event: "replied",
+      session_id: "opencode:legacy",
+      request_id: "per-legacy",
+      lifecycle_bridge_url: "http://127.0.0.1:43210",
+      lifecycle_bridge_token: "token_legacy",
+    };
+    assert.strictEqual(Object.hasOwn(lifecycleBody, "bridge_url"), false);
+    assert.strictEqual(Object.hasOwn(lifecycleBody, "bridge_token"), false);
+
+    const legacyPending = [];
+    const legacyCreate = (body) => {
+      if (!body.request_id || !body.bridge_url || !body.bridge_token) return false;
+      legacyPending.push(body);
+      return true;
+    };
+    assert.strictEqual(legacyCreate(lifecycleBody), false);
+    assert.deepStrictEqual(legacyPending, []);
+  });
+
+  it("clears all exact duplicate entries, stays cross-agent isolated, and makes repeats a no-op", async () => {
+    const harness = makeRouteRuntimeHarness();
+    const common = {
+      tool_name: "bash",
+      request_id: "per-duplicates",
+      bridge_url: "http://127.0.0.1:43210",
+      bridge_token: "token_duplicates",
+    };
+    await postPermission(harness.ctx, { agent_id: "opencode", session_id: "opencode:ses-duplicates", ...common });
+    await postPermission(harness.ctx, { agent_id: "opencode", session_id: "opencode:ses-duplicates", ...common });
+    await postPermission(harness.ctx, { agent_id: "mimocode", session_id: "mimocode:ses-duplicates", ...common });
+    assert.strictEqual(harness.api.pendingPermissions.length, 3);
+
+    await postPermission(harness.ctx, {
+      agent_id: "opencode",
+      permission_event: "replied",
+      session_id: "opencode:ses-duplicates",
+      request_id: "per-duplicates",
+      lifecycle_bridge_url: "http://127.0.0.1:43210",
+      lifecycle_bridge_token: "wrong_token",
+    });
+    assert.strictEqual(harness.api.pendingPermissions.length, 3, "wrong generation token cannot clean anything");
+
+    const opencodeCompletion = {
+      agent_id: "opencode",
+      permission_event: "replied",
+      session_id: "ses-duplicates",
+      request_id: "per-duplicates",
+      lifecycle_bridge_url: "http://127.0.0.1:43210/",
+      lifecycle_bridge_token: "token_duplicates",
+    };
+    await postPermission(harness.ctx, opencodeCompletion);
+    assert.strictEqual(harness.api.pendingPermissions.length, 1);
+    assert.strictEqual(harness.api.pendingPermissions[0].agentId, "mimocode");
+
+    await postPermission(harness.ctx, opencodeCompletion);
+    assert.strictEqual(harness.api.pendingPermissions.length, 1, "duplicate lifecycle is idempotent");
+
+    await postPermission(harness.ctx, {
+      ...opencodeCompletion,
+      agent_id: "mimocode",
+      session_id: "mimocode:ses-duplicates",
+    });
+    assert.strictEqual(harness.api.pendingPermissions.length, 0);
+    assert.deepStrictEqual(harness.calls.replyOpencodeFamilyPermission, []);
+    harness.api.cleanup();
+  });
+});

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -76,6 +76,7 @@ function makeCtx(overrides = {}) {
     showPermissionBubble: [],
     sendPermissionResponse: [],
     replyOpencodeFamilyPermission: [],
+    dismissOpencodeFamilyPermissionResolvedExternally: [],
     resolved: [],
     maybeStartRemoteApproval: [],
     addPendingPermission: [],
@@ -99,6 +100,10 @@ function makeCtx(overrides = {}) {
       res.end(behavior);
     },
     replyOpencodeFamilyPermission: (payload) => calls.replyOpencodeFamilyPermission.push(payload),
+    dismissOpencodeFamilyPermissionResolvedExternally: (payload) => {
+      calls.dismissOpencodeFamilyPermissionResolvedExternally.push(payload);
+      return 0;
+    },
     resolvePermissionEntry: (entry, behavior, message) => calls.resolved.push({ entry, behavior, message }),
     maybeStartRemoteApproval: (entry) => calls.maybeStartRemoteApproval.push(entry),
     addPendingPermission(entry) {
@@ -830,6 +835,140 @@ describe("server-route-permission POST", () => {
     assert.strictEqual(reply.requestId, "req-boom");
     assert.strictEqual(reply.bridgeUrl, "http://127.0.0.1:1234");
     assert.strictEqual(reply.bridgeToken, "token");
+  });
+
+  it("routes a strict family replied lifecycle before every create/decision gate and never records a request", async () => {
+    const lifecycleCalls = [];
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "opencode",
+      hook_source: "opencode-plugin",
+      permission_event: "replied",
+      session_id: "opencode:ses-life",
+      request_id: "per-life",
+      lifecycle_bridge_url: "http://127.0.0.1:43210",
+      lifecycle_bridge_token: "token_life",
+    }), {
+      ctx: {
+        doNotDisturb: true,
+        hideBubbles: true,
+        isAgentEnabled: () => false,
+        isAgentPermissionsEnabled: () => false,
+        dismissOpencodeFamilyPermissionResolvedExternally: (identity) => {
+          lifecycleCalls.push(identity);
+          return 1;
+        },
+      },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+    assert.strictEqual(res.body, "ok");
+    assert.deepStrictEqual(lifecycleCalls, [{
+      agentId: "opencode",
+      requestId: "per-life",
+      sessionId: localSessionKey("opencode:ses-life"),
+      bridgeUrl: "http://127.0.0.1:43210",
+      bridgeToken: "token_life",
+    }]);
+    assert.deepStrictEqual(res.recorder, [], "lifecycle must not create a PermissionRequest recorder");
+    assert.deepStrictEqual(res.ctx.calls.updateSession, []);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+    assert.deepStrictEqual(res.ctx.calls.addPendingPermission, []);
+    assert.deepStrictEqual(res.ctx.calls.replyOpencodeFamilyPermission, []);
+    assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, []);
+  });
+
+  it("200-no-ops malformed lifecycle identity without a default session or a thrown validator error", async () => {
+    const invalidBodies = [
+      { session_id: null },
+      { session_id: 42 },
+      { lifecycle_bridge_url: "http://localhost:43210" },
+      { lifecycle_bridge_url: { href: "http://127.0.0.1:43210" } },
+      { lifecycle_bridge_token: 42 },
+      { lifecycle_bridge_token: "x".repeat(129) },
+      { request_id: "" },
+    ];
+    for (const delta of invalidBodies) {
+      const res = await callPermissionPost(JSON.stringify({
+        agent_id: "opencode",
+        permission_event: "replied",
+        session_id: "opencode:strict",
+        request_id: "per-strict",
+        lifecycle_bridge_url: "http://127.0.0.1:43210",
+        lifecycle_bridge_token: "token_strict",
+        ...delta,
+      }));
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+      assert.deepStrictEqual(res.recorder, []);
+      assert.deepStrictEqual(
+        res.ctx.calls.dismissOpencodeFamilyPermissionResolvedExternally,
+        [],
+        JSON.stringify(delta)
+      );
+      assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+      assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+    }
+  });
+
+  it("fails closed for unknown permission_event instead of creating an unknown family bubble", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "opencode",
+      permission_event: "resolved-someday",
+      session_id: "opencode:unknown-event",
+      request_id: "per-unknown-event",
+      lifecycle_bridge_url: "http://127.0.0.1:1234",
+      lifecycle_bridge_token: "token-unknown-event",
+    }));
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.deepStrictEqual(res.recorder, []);
+    assert.deepStrictEqual(res.ctx.pendingPermissions, []);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+    assert.deepStrictEqual(res.ctx.calls.dismissOpencodeFamilyPermissionResolvedExternally, []);
+  });
+
+  it("keeps ACK and ordinary family enqueue in one synchronous execution segment", () => {
+    const body = JSON.stringify({
+      agent_id: "opencode",
+      session_id: "opencode:sync",
+      tool_name: "Bash",
+      request_id: "per-sync",
+      bridge_url: "http://127.0.0.1:1234",
+      bridge_token: "token",
+    });
+    const ctx = makeCtx();
+    let dataHandler = null;
+    const req = {
+      headers: {},
+      on(eventName, handler) {
+        if (eventName === "data") dataHandler = handler;
+        if (eventName === "end") {
+          dataHandler(Buffer.from(body));
+          handler();
+        }
+        return this;
+      },
+    };
+    const res = makeRes();
+    let pendingAtAck = null;
+    const originalEnd = res.end;
+    res.end = function endAndSnapshot(data) {
+      originalEnd.call(this, data);
+      pendingAtAck = ctx.pendingPermissions.length;
+    };
+
+    handlePermissionPost(req, res, {
+      ctx,
+      createRequestHookRecorder: () => ({
+        accepted() {}, droppedByDisabled() {}, droppedByDnd() {},
+        droppedInvalidAgent() {}, droppedUnsupported() {},
+      }),
+    });
+
+    assert.strictEqual(pendingAtAck, 0, "ACK is written immediately before enqueue");
+    assert.strictEqual(ctx.pendingPermissions.length, 1, "enqueue completes before the handler returns");
+    assert.strictEqual(ctx.pendingPermissions[0].familyRequestId, "per-sync");
   });
 
   it("destroys the Claude/CodeBuddy connection during DND", async () => {


### PR DESCRIPTION
## 修复内容

- 接收 OpenCode / MiMo Code 的 `permission.replied` completion，并把它作为 cleanup-only lifecycle 处理
- 以 agent、request、canonical session、bridge URL 和 generation token 精确匹配并清理 pending 气泡，不向宿主发送第二次权限决定
- 对同一 request 的 asked/replied POST 保证因果顺序，并为 lifecycle 使用有界重试
- 补齐 unknown event、token 日志卫生、factory 隔离、竞态与旧 Clawd 兼容测试
- 保持 ordinary asked 的既有 session-key 语义不变

Closes #913

## 自动化验证

- #913 精确 7 文件定向：167 passed / 0 failed
- 扩展定向：182 passed / 0 failed
- 完整测试：8629 passed / 0 failed / 30 skipped
- GitHub Actions：Five-target Package Audit 与 Repository Asset Audit 全部通过

## exact-head macOS Desktop 真机验证

- 受测提交：`641b8b035a08457dfec1abbd412540ef96bd3099`
- 环境：Clawd dev `0.16.0`；macOS `26.5.2` arm64；OpenCode Desktop `1.18.18`
- 受测 plugin：entry SHA-256 `7e89151148fcf2060aacf0a589ec76dd2a45ec7db14279d4bef52ee3a950eebc`；shared core SHA-256 `d9dcc96f1e2b88ff4b6720b041110374e1a9c13e2b1791c3fd9d7e663d3e47b9`
- OpenCode 原生 Reject：对应 Clawd 气泡立即消失，操作未执行；completion 精确命中当前 request（`matched=1`）
- OpenCode 原生 Allow once：对应 Clawd 气泡立即消失，操作成功；completion 精确命中当前 request（`matched=1`）
- OpenCode 原生 Always：`external_directory` 与 `bash` 形成两条级联 request；两只 Clawd 气泡都在各自原生决定后立即消失，日志分别为 `matched=1`，最终操作成功
- Clawd 气泡 Deny / Allow once：OpenCode 分别拒绝 / 执行；Clawd 对每条 request 只发送一次 reverse-bridge 决定，宿主随后 emitted completion 时幂等 no-op（`matched=0`），没有第二次决定或误清其他请求
- 测试后已恢复权限自动化模式、移除临时 OpenCode 项目配置及测试文件；工作树干净

## 其他既有真机证据

- OpenCode Desktop 1.18.18：并发请求、fast native reply、Clawd 不可达有界重试及重启场景通过
- OpenCode TUI 1.18.3：native Allow once / Reject、Clawd-first 和离线有界重试通过

## 证据边界

- 本次 exact-head GUI 复测覆盖 OpenCode Desktop 的 native Reject / Allow once / Always 以及 Clawd-first Deny / Allow once
- OpenCode TUI 的并发 / 离线矩阵完成于最终 review 收口前的同一核心实现，本次未在 exact head 重跑
- MiMo Code 发布物、报告者精确 OpenCode 版本，以及 Windows / Linux surface 仍未做真机验证
