### PR TITLE
fix: align settings focus rings with card corners

### DIFF
--- a/src/settings.css
+++ b/src/settings.css
@@ -327,6 +327,7 @@ html, body {
   align-items: center;
   gap: 4px;
   padding: 12px 16px;
+  border-radius: inherit;
   cursor: pointer;
   user-select: none;
   overflow: hidden;
@@ -336,6 +337,10 @@ html, body {
   padding: 0;
   cursor: default;
 }
+.collapsible-group:not(.collapsed) > .collapsible-group-header {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
 .collapsible-group-disclosure {
   display: flex;
   align-items: center;
@@ -344,6 +349,7 @@ html, body {
   min-width: 0;
   gap: 4px;
   padding: 12px 0 12px 16px;
+  border-radius: inherit;
   cursor: pointer;
 }
 .collapsible-group-header-action {

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -7656,6 +7656,25 @@ describe("settings renderer browser environment", () => {
     assert.ok(!i18nSource.includes('doctorOpenLogOpened: "デバッグログを開きました。"'));
   });
 
+  it("keeps collapsible focus outlines aligned with the card's rounded corners", () => {
+    const css = fs.readFileSync(SETTINGS_CSS, "utf8");
+    assert.match(
+      css,
+      /\.collapsible-group-header\s*\{[^}]*border-radius:\s*inherit;/,
+      "the full-card disclosure trigger must inherit the card radius so its inset focus outline is not clipped into white corners",
+    );
+    assert.match(
+      css,
+      /\.collapsible-group-disclosure\s*\{[^}]*border-radius:\s*inherit;/,
+      "a disclosure beside a header action must inherit the header radius for the same reason",
+    );
+    assert.match(
+      css,
+      /\.collapsible-group:not\(\.collapsed\)\s*>\s*\.collapsible-group-header\s*\{[^}]*border-bottom-left-radius:\s*0;[^}]*border-bottom-right-radius:\s*0;/,
+      "an expanded trigger must keep square bottom corners where its body continues",
+    );
+  });
+
   it("unifies the size slider on the simple volume-style control (no floating bubble, no ticks)", () => {
     const css = fs.readFileSync(SETTINGS_CSS, "utf8");
     const tabSource = fs.readFileSync(SETTINGS_TAB_GENERAL, "utf8");


### PR DESCRIPTION
## Summary
- Align keyboard focus outlines with the rounded corners of shared Settings collapsible cards.
- Apply the fix at the shared collapsible header/disclosure layer so every current caller receives it.
- Preserve square lower header corners while a collapsible body is expanded.

## Problem context
The collapsible card owns the 10px corner radius, while keyboard focus lands on an inner header or disclosure element. Those focus targets used an inset outline but had a computed zero radius. The section container then clipped the square outline through its rounded overflow, leaving white wedges at the four card corners.

An audit of Settings focus-visible rules found this exact combination only on `.collapsible-group-header` and `.collapsible-group-disclosure`. Other rounded card controls either carry their own radius or use an outward focus outline.

## What changed
- Let full-card collapsible headers inherit the card radius.
- Let the optional disclosure region beside a header action inherit the header radius.
- Clear the two lower header radii while expanded, where the body continues below.
- Add a CSS contract regression test covering all three states.

## Behavior after this PR
- Tab focus follows all visible rounded corners on collapsed shared disclosure cards.
- Expanded headers keep rounded top corners and square lower corners.
- Disclosure behavior, ARIA, persistence, animation, layout, and mouse interaction are unchanged.

## Validation
- `node --test test/settings-renderer-browser-env.test.js` — 303/303 passed
- focused regression test was observed failing before the CSS fix and passing afterward
- `npm run verify:electron` — passed after installing this worktree dependencies
- `git diff --check` — passed
- `npm test` — blocked before test execution by the existing Windows runner `spawnSync ... ENAMETOOLONG` limitation

## Platform note
Automated checks ran on Windows. Hands-on keyboard focus QA is pending.

## Scope control
This PR only fixes shared Settings collapsible focus-ring geometry. It does not change disclosure motion or button components.