### PR TITLE
fix: restore idle visual picker options

### DIFF
--- a/src/settings-tab-anim-overrides.js
+++ b/src/settings-tab-anim-overrides.js
@@ -953,152 +953,51 @@
     wrap.className = "anim-idle-visual-row";
     const row = document.createElement("div");
     row.className = "row";
-    row.innerHTML =
-      `<div class="row-text">` +
-        `<span class="row-label"></span>` +
-        `<span class="row-desc"></span>` +
-      `</div>` +
-      `<div class="row-control">` +
-        `<div class="language-picker">` +
-          `<button type="button" class="language-picker-trigger" aria-haspopup="listbox" aria-expanded="false">` +
-            `<span class="language-picker-value"></span>` +
-            `<span class="language-picker-chevron" aria-hidden="true"></span>` +
-          `</button>` +
-          `<div class="language-picker-menu" role="listbox" aria-hidden="true"></div>` +
-        `</div>` +
-      `</div>`;
-    row.querySelector(".row-label").textContent = t("animIdleVisualLabel");
-    row.querySelector(".row-desc").textContent = t("animIdleVisualDesc");
-    const picker = row.querySelector(".language-picker");
-    const trigger = row.querySelector(".language-picker-trigger");
-    const valueEl = row.querySelector(".language-picker-value");
-    const menu = row.querySelector(".language-picker-menu");
-    trigger.setAttribute("aria-label", t("animIdleVisualLabel"));
-
     const getLabel = (option) => (option.isThemeDefault ? t("animIdleVisualThemeDefault") : option.label || option.file);
     const currentFile = info.selectedFile || defaultOption.file;
-    let activeFile = currentFile;
-    const options = [];
-    for (const optionInfo of info.options) {
-      const option = document.createElement("button");
-      option.type = "button";
-      option.className = "language-picker-option";
-      option.setAttribute("role", "option");
-      option.setAttribute("data-file", optionInfo.file);
-      option.setAttribute("aria-selected", optionInfo.file === currentFile ? "true" : "false");
-      option.textContent = getLabel(optionInfo);
-      menu.appendChild(option);
-      options.push(option);
-    }
-    function getOption(file) {
-      return options.find((option) => option.dataset.file === file) || options[0] || null;
-    }
-    function syncDisplay(file) {
-      const selected = info.options.some((option) => option.file === file) ? file : defaultOption.file;
-      activeFile = selected;
-      const selectedInfo = info.options.find((option) => option.file === selected) || defaultOption;
-      valueEl.textContent = getLabel(selectedInfo);
-      const open = picker.classList.contains("open");
-      for (const option of options) {
-        const isSelected = option.dataset.file === selected;
-        option.classList.toggle("selected", isSelected);
-        option.setAttribute("aria-selected", isSelected ? "true" : "false");
-        option.tabIndex = open && isSelected ? 0 : -1;
-      }
-    }
-    function setOpen(open) {
-      picker.classList.toggle("open", open);
-      trigger.setAttribute("aria-expanded", open ? "true" : "false");
-      menu.setAttribute("aria-hidden", open ? "false" : "true");
-      syncDisplay(activeFile);
-      if (!open) return;
-      const option = getOption(activeFile);
-      if (option && typeof option.focus === "function") option.focus();
-    }
-    function chooseIdleVisual(next) {
-      if (next === activeFile) {
-        setOpen(false);
-        return;
-      }
-      syncDisplay(next);
-      setOpen(false);
-      const revertIfStillPending = () => {
-        const latest = runtime.animationOverridesData && runtime.animationOverridesData.idleDefaultVisual;
-        if (activeFile === next) syncDisplay((latest && latest.selectedFile) || defaultOption.file);
-      };
-      // Success needs no explicit refresh: the idleVisual broadcast lands in
-      // patchInPlace, which updates the cached selection and re-syncs this row.
-      window.settingsAPI.command("setIdleVisual", { themeId: info.themeId, file: next }).then((result) => {
-        if (!result || result.status !== "ok") {
+    const text = document.createElement("div");
+    text.className = "row-text";
+    const label = document.createElement("span");
+    label.className = "row-label";
+    label.textContent = t("animIdleVisualLabel");
+    const desc = document.createElement("span");
+    desc.className = "row-desc";
+    desc.textContent = t("animIdleVisualDesc");
+    text.appendChild(label);
+    text.appendChild(desc);
+
+    const control = helpers.buildSettingsSelect({
+      value: currentFile,
+      options: info.options.map((option) => ({ value: option.file, label: getLabel(option) })),
+      ariaLabel: t("animIdleVisualLabel"),
+      onChange(next) {
+        // Success needs no explicit refresh: the idleVisual broadcast lands in
+        // patchInPlace, which updates the cached selection and re-syncs this row.
+        return window.settingsAPI.command("setIdleVisual", { themeId: info.themeId, file: next }).then((result) => {
+          if (result && result.status === "ok") return true;
           const msg = (result && result.message) || "unknown error";
           ops.showToast(t("toastSaveFailed") + msg, { error: true });
-          revertIfStillPending();
-        }
-      }).catch((err) => {
-        ops.showToast(t("toastSaveFailed") + ((err && err.message) || "unknown error"), { error: true });
-        revertIfStillPending();
-      });
-    }
-    trigger.addEventListener("click", () => {
-      setOpen(!picker.classList.contains("open"));
+          return false;
+        }).catch((err) => {
+          ops.showToast(t("toastSaveFailed") + ((err && err.message) || "unknown error"), { error: true });
+          return false;
+        });
+      },
     });
-    trigger.addEventListener("keydown", (event) => {
-      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-        event.preventDefault();
-        setOpen(true);
-      }
-    });
-    for (const option of options) {
-      option.addEventListener("click", () => chooseIdleVisual(option.dataset.file));
-      option.addEventListener("keydown", (event) => {
-        const index = options.indexOf(option);
-        if (event.key === "Escape") {
-          event.preventDefault();
-          setOpen(false);
-          if (typeof trigger.focus === "function") trigger.focus();
-          return;
-        }
-        if (event.key === "Enter" || event.key === " ") {
-          event.preventDefault();
-          chooseIdleVisual(option.dataset.file);
-          return;
-        }
-        if (event.key === "ArrowDown" || event.key === "ArrowUp") {
-          event.preventDefault();
-          const delta = event.key === "ArrowDown" ? 1 : -1;
-          const nextOption = options[(index + delta + options.length) % options.length];
-          if (nextOption && typeof nextOption.focus === "function") nextOption.focus();
-        }
-      });
-    }
-    const closeOnOutsideClick = (event) => {
-      if (!picker.classList.contains("open")) return;
-      if (picker.contains(event.target)) return;
-      setOpen(false);
+    const rowControl = document.createElement("div");
+    rowControl.className = "row-control";
+    rowControl.appendChild(control.element);
+    row.appendChild(text);
+    row.appendChild(rowControl);
+
+    state.mountedControls.idleVisualPicker = {
+      syncFromData: () => {
+        if (!document.body || !document.body.contains(row)) return;
+        const latest = runtime.animationOverridesData && runtime.animationOverridesData.idleDefaultVisual;
+        control.setValue((latest && latest.selectedFile) || defaultOption.file);
+      },
+      dispose: () => control.dispose(),
     };
-    const closeOnEscape = (event) => {
-      if (event.key !== "Escape" || !picker.classList.contains("open")) return;
-      event.preventDefault();
-      setOpen(false);
-    };
-    if (document && typeof document.addEventListener === "function") {
-      document.addEventListener("click", closeOnOutsideClick);
-      document.addEventListener("keydown", closeOnEscape);
-      state.mountedControls.idleVisualPicker = {
-        syncFromData: () => {
-          if (!document.body || !document.body.contains(row)) return;
-          const latest = runtime.animationOverridesData && runtime.animationOverridesData.idleDefaultVisual;
-          syncDisplay((latest && latest.selectedFile) || defaultOption.file);
-        },
-        dispose: () => {
-          if (typeof document.removeEventListener === "function") {
-            document.removeEventListener("click", closeOnOutsideClick);
-            document.removeEventListener("keydown", closeOnEscape);
-          }
-        },
-      };
-    }
-    syncDisplay(currentFile);
     wrap.appendChild(row);
     return wrap;
   }

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -2089,6 +2089,7 @@ function loadAnimOverridesTabForTest({
   };
   context.globalThis = context;
   vm.createContext(context);
+  vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "language-picker.js"), "utf8"), context);
   vm.runInContext(fs.readFileSync(path.join(SRC_DIR, "settings-tab-anim-overrides.js"), "utf8"), context);
   const core = {
     state: { activeTab: "animOverrides", mountedControls: {} },
@@ -2105,6 +2106,7 @@ function loadAnimOverridesTabForTest({
         if (typeof invoke === "function") el.addEventListener("click", () => invoke());
         return el;
       },
+      buildSettingsSelect: (config) => context.ClawdLanguagePicker.createSettingsSelect(config),
       ...helpersOverrides,
     },
     ops: {
@@ -13859,6 +13861,33 @@ describe("settings renderer browser environment", () => {
       { themeId: "clawd", file: "clawd-idle-reading.svg" }
     );
     assert.strictEqual(valueEl.textContent, "Idle Reading", "optimistic display should show the pick immediately");
+  });
+
+  it("mounts the idle visual menu while open and removes it from layout after close", () => {
+    const runtime = createIdleVisualRuntime();
+    const modalRoot = new FakeElement("div");
+    const { core, document } = loadAnimOverridesTabForTest({ runtime, modalRoot });
+    const parent = new FakeElement("main");
+    document.body.appendChild(parent);
+    core.tabs.animOverrides.render(parent, core);
+
+    const picker = parent.querySelector(".anim-idle-visual-row .language-picker");
+    const trigger = picker.querySelector(".language-picker-trigger");
+    const menu = picker.querySelector(".language-picker-menu");
+
+    trigger.dispatchEvent({ type: "click" });
+    assert.strictEqual(trigger.getAttribute("aria-expanded"), "true");
+    assert.strictEqual(menu.getAttribute("aria-hidden"), "false");
+    assert.strictEqual(
+      picker.classList.contains("menu-mounted"),
+      true,
+      "the shared CSS only displays mounted picker menus",
+    );
+
+    trigger.dispatchEvent({ type: "click" });
+    assert.strictEqual(trigger.getAttribute("aria-expanded"), "false");
+    assert.strictEqual(menu.getAttribute("aria-hidden"), "true");
+    assert.strictEqual(picker.classList.contains("menu-mounted"), false);
   });
 
   it("patches idleVisual-only broadcasts in place and re-syncs the mounted picker", () => {


### PR DESCRIPTION
## Summary

- Restore the missing choices in Settings → Animation / Sound → Animation → Default idle animation.
- Replace the special-purpose picker state machine with the existing shared Settings select control.
- Preserve the existing `setIdleVisual` command, broadcast-driven synchronization, error toast, and failed-save rollback behavior.

## Problem context

The idle visual picker still toggled only `.open` after the shared picker CSS adopted a separate `.menu-mounted` lifecycle. The trigger and ARIA state changed, and all option nodes existed, but the menu remained `display: none` because it was never mounted.

The duplicated picker implementation also risked drifting further from shared keyboard, dismissal, animation, and cleanup behavior.

## Design provenance and maintainer decision

Related to #509. The default-idle feature was originally implemented in #679.

The maintainer direction recorded in #509 was to offer the theme-default idle visual plus supported idle variants while keeping task, permission, completion, and sleep states unchanged. The implementation in #679 therefore derives this picker from `states.idle + idleAnimations`; for the bundled Clawd theme that currently produces Theme default, Idle Look, Idle Bubble, and Idle Reading. `Free roam walk` is a separate `roam` state and is intentionally not a persistent idle-visual choice.

This PR does not redefine that product scope—it restores access to the choices established by #679. Please confirm during review whether the original #509 behavior should remain, or whether the product should be narrowed in a separate follow-up decision.

## What changed

- Build the idle visual control through the shared `buildSettingsSelect` helper.
- Delegate menu mounting, Escape and arrow-key handling, outside-click dismissal, pending state, failed-change rollback, reduced-motion behavior, and listener cleanup to the shared picker.
- Keep the mounted control adapter so idle-visual broadcasts continue to update the current selection in place.
- Add a browser-environment regression test proving the menu mounts when opened and leaves layout when closed.

## Behavior after this PR

- Opening “Theme default” displays every idle visual option provided by the active theme.
- Closing the picker removes the menu from layout instead of leaving hidden overflow behind.
- Successful selections continue to update through the existing Settings command and broadcast path.
- Failed selections retain the previous value and show the existing save-failure toast.

## Validation

- `node --test --test-name-pattern='idle visual picker|idleVisual-only|idle visual menu' test/settings-renderer-browser-env.test.js` — 4/4 passed.
- `node --test test/settings-renderer-browser-env.test.js` — 303/303 passed.
- `node --check src/settings-tab-anim-overrides.js` — passed.
- `npm run verify:electron` — Electron 41.10.4 verified.
- `git diff --check` — passed.
- Windows click-level check — the menu opens and displays Theme default, Idle Look, Idle Bubble, and Idle Reading.
- `npm test` — could not start on this Windows checkout because `node test/run-tests.js` hit `spawnSync ... ENAMETOOLONG`; targeted Settings coverage above passed.

## Scope control

- This PR only changes the default idle visual picker and its regression coverage.
- It does not change theme data, preference schema, IPC, animation assets, or other Settings controls.
