### PR TITLE
refactor: unify settings language picker

### DIFF
--- a/src/settings-tab-general.js
+++ b/src/settings-tab-general.js
@@ -89,7 +89,6 @@
   let helpers = null;
   let ops = null;
   let i18n = null;
-  const languagePickerApi = root.ClawdLanguagePicker || {};
 
   const LANGUAGE_OPTIONS = ["en", "zh", "zh-TW", "ko", "ja", "pt-BR", "es"];
   const ROAM_MOVEMENT_NATURAL = "natural";
@@ -643,13 +642,11 @@
     row.querySelector(".row-desc").textContent = t("rowLanguageDesc");
     const currentLang = readers.getLang();
     const getLabel = (lang) => t(LANGUAGE_LABEL_KEYS[lang] || "langEnglish");
-    if (typeof languagePickerApi.createLanguagePicker !== "function") {
-      throw new Error("language-picker.js failed to load before settings-tab-general.js");
-    }
-    const pickerControl = languagePickerApi.createLanguagePicker({
+    const pickerControl = helpers.buildSettingsSelect({
       value: currentLang,
       options: LANGUAGE_OPTIONS.map((lang) => ({ value: lang, label: getLabel(lang) })),
       ariaLabel: t("rowLanguage"),
+      className: "settings-language-select",
       onChange: (next) => {
         // Selecting the already committed language only closes the menu. This
         // also avoids sending a duplicate update while an earlier save settles.
@@ -675,7 +672,6 @@
       },
     });
     row.querySelector(".row-control").appendChild(pickerControl.element);
-    state.mountedControls.languagePicker = pickerControl;
     return row;
   }
 

--- a/src/settings-ui-core.js
+++ b/src/settings-ui-core.js
@@ -79,7 +79,6 @@
       idleVisualPicker: null,
       bubblePolicySummary: null,
       sessionHudSummary: null,
-      languagePicker: null,
       size: null,
       soundSummary: null,
       soundVolume: null,
@@ -1114,9 +1113,6 @@
   }
 
   function clearMountedControls() {
-    if (state.mountedControls.languagePicker && typeof state.mountedControls.languagePicker.dispose === "function") {
-      state.mountedControls.languagePicker.dispose();
-    }
     if (state.mountedControls.idleVisualPicker && typeof state.mountedControls.idleVisualPicker.dispose === "function") {
       state.mountedControls.idleVisualPicker.dispose();
     }
@@ -1151,7 +1147,6 @@
     state.mountedControls.animOverrideTimingSliders.clear();
     state.mountedControls.bubblePolicySummary = null;
     state.mountedControls.sessionHudSummary = null;
-    state.mountedControls.languagePicker = null;
     state.mountedControls.idleVisualPicker = null;
     state.mountedControls.size = null;
     state.mountedControls.soundSummary = null;

--- a/src/settings.css
+++ b/src/settings.css
@@ -1408,6 +1408,10 @@ html, body {
   max-width: 240px;
   width: 220px;
 }
+.settings-language-select {
+  min-width: 128px;
+  width: 128px;
+}
 .settings-select .language-picker-trigger {
   height: 38px;
 }

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -7825,7 +7825,9 @@ describe("settings renderer browser environment", () => {
       SUPPORTED_LANGS.map((lang) => String.raw`"${lang}"`).join(String.raw`,\s*`) +
       String.raw`\];`
     ).test(generalSource));
-    assert.ok(generalSource.includes("createLanguagePicker"));
+    assert.ok(generalSource.includes("helpers.buildSettingsSelect"));
+    assert.ok(generalSource.includes('className: "settings-language-select"'));
+    assert.ok(!generalSource.includes("createLanguagePicker"));
     assert.ok(pickerSource.includes("picker.className = `language-picker"));
     assert.ok(pickerSource.includes(`role", "combobox"`));
     assert.ok(pickerSource.includes(`aria-haspopup", "listbox"`));
@@ -7837,6 +7839,7 @@ describe("settings renderer browser environment", () => {
     assert.ok(settingsHtml.includes(`src="language-picker.js"`));
     assert.match(settingsHtml, /<main class="content" id="content" data-language-picker-boundary><\/main>/);
     assert.match(settingsCss, /\.content\s*\{[^}]*overflow-y:\s*auto;[^}]*scrollbar-gutter:\s*stable;/);
+    assert.match(settingsCss, /\.settings-language-select\s*\{[^}]*min-width:\s*128px;[^}]*width:\s*128px;/);
     assert.ok(!generalSource.includes("language-segmented"));
     assert.ok(!generalSource.includes("runtime.languageTransition"));
     assert.ok(!generalSource.includes("--language-active-index"));
@@ -7882,6 +7885,9 @@ describe("settings renderer browser environment", () => {
     const trigger = harness.getLangTrigger();
     assert.ok(picker, "language picker should be rendered");
     assert.ok(trigger, "language picker trigger should be rendered");
+    assert.strictEqual(picker.classList.contains("settings-select"), true);
+    assert.strictEqual(picker.classList.contains("settings-language-select"), true);
+    assert.strictEqual(harness.core.state.mountedControls.settingsSelects.size, 1);
     assert.strictEqual(harness.getLangValue().textContent, "English");
     assert.strictEqual(trigger.attributes["aria-label"], "Language: English");
     assert.strictEqual(harness.getLangMenu().attributes["aria-hidden"], "true");
@@ -7910,25 +7916,18 @@ describe("settings renderer browser environment", () => {
     for (const option of options) assert.strictEqual(option.tabIndex, -1);
     assert.strictEqual(harness.getLangValue().textContent, "Chinese");
     assert.strictEqual(trigger.attributes["aria-label"], "Language: Chinese");
-
+    assert.strictEqual(trigger.getAttribute("aria-disabled"), "true");
     trigger.dispatchEvent({ type: "click" });
-    options[1].dispatchEvent({ type: "click" });
-    assert.deepStrictEqual(
-      harness.updateCalls,
-      [{ key: "lang", value: "zh" }],
-      "clicking the already displayed pending language should not submit a duplicate update"
-    );
-
-    trigger.dispatchEvent({ type: "click" });
+    assert.strictEqual(picker.classList.contains("open"), false);
     options[0].dispatchEvent({ type: "click" });
     assert.deepStrictEqual(
       harness.updateCalls,
       [{ key: "lang", value: "zh" }],
-      "clicking back to the committed language while pending should not submit a duplicate update"
+      "the shared Settings picker should block further changes while saving"
     );
-    assert.strictEqual(harness.getLangValue().textContent, "English");
-    assert.strictEqual(trigger.attributes["aria-label"], "Language: English");
-    assert.strictEqual(options[0].attributes["aria-selected"], "true");
+    assert.strictEqual(harness.getLangValue().textContent, "Chinese");
+    assert.strictEqual(trigger.attributes["aria-label"], "Language: Chinese");
+    assert.strictEqual(options[1].attributes["aria-selected"], "true");
 
     harness.core.ops.applyChanges({
       changes: { lang: "zh" },
@@ -8722,6 +8721,7 @@ describe("settings renderer browser environment", () => {
     harness.core.ops.requestRender({ content: true });
     assert.strictEqual(harness.getDocumentListenerCount("click"), 1);
     assert.strictEqual(harness.getDocumentListenerCount("keydown"), 1);
+    assert.strictEqual(harness.core.state.mountedControls.settingsSelects.size, 1);
 
     staleOption.dispatchEvent({ type: "click" });
     assert.deepStrictEqual(harness.updateCalls, []);


### PR DESCRIPTION
## Summary

- Route the General-page language picker through the shared Settings select builder.
- Remove its dedicated mounted-control lifecycle in favor of the common Settings picker collection.
- Preserve the language control's existing compact width and save/rollback behavior.

## Problem context

Settings dropdowns share the same low-level picker engine, but the language row was the remaining Settings caller that invoked `createLanguagePicker()` directly. That bypassed Settings-specific defaults and required a separate `mountedControls.languagePicker` cleanup path.

This is a small follow-up to the picker consistency discussion around #930; it is independently based on the latest `main` and does not depend on #930.

## What changed

- Build the language dropdown with `helpers.buildSettingsSelect()`.
- Apply the shared pending lock so another language change cannot start while persistence is unresolved.
- Register and dispose the language picker through `mountedControls.settingsSelects`.
- Remove the obsolete language-only mounted-control field and cleanup branch.
- Add a `settings-language-select` layout class so the shared builder does not widen the existing 128px control.
- Update browser-environment coverage for shared registration, pending locking, cleanup, and width preservation.

## Behavior after this PR

- The language picker uses the same Settings construction and cleanup path as timeout, theme customization, Remote SSH, and other Settings selects.
- Mouse, keyboard, ARIA, menu placement, failed-save rollback, and outside-click behavior remain provided by the existing shared picker engine.
- While a language save is pending, further choices are ignored consistently with other Settings selects.
- The visible control retains its existing compact width.

## Validation

- `node --test --test-name-pattern='Settings language picker|language picker|language saves|shared picker' test/settings-renderer-browser-env.test.js` — 8/8 passed.
- `node --test test/settings-renderer-browser-env.test.js` — 302/302 passed.
- `node --check src/settings-tab-general.js` — passed.
- `node --check src/settings-ui-core.js` — passed.
- `npm run verify:electron` — Electron 41.10.4 verified.
- `git diff --check` — passed.
- `npm test` — could not start on this Windows checkout because `node test/run-tests.js` hit `spawnSync ... ENAMETOOLONG`; targeted Settings coverage above passed.

Windows click-level QA passed for mouse selection, keyboard navigation, Escape/outside-click dismissal, page-switch cleanup, repeated open/close, language persistence, and compact-width preservation.

## Scope control

- This PR only consolidates the Settings language dropdown.
- The onboarding tutorial continues to use the shared low-level picker directly because it is outside Settings.
- Dashboard native selects and non-select controls are unchanged.

