### PR TITLE
style: polish permission automation segments

### DIFF
--- a/src/settings.css
+++ b/src/settings.css
@@ -1649,10 +1649,28 @@ html, body {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   width: 100%;
+  padding: 3px;
+  gap: 2px;
+  border-radius: 9px;
 }
 .permission-automation-segmented button {
-  white-space: nowrap;
-  padding-inline: 9px;
+  min-height: 34px;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  text-align: center;
+  line-height: 1.25;
+  white-space: normal;
+  transition: background-color 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+.permission-automation-segmented button.active {
+  font-weight: 600;
+}
+.permission-automation-segmented button:not(.active):not(:disabled):hover {
+  background: color-mix(in srgb, var(--text-primary) 5%, transparent);
+}
+.permission-automation-segmented button:focus-visible {
+  outline-offset: 1px;
 }
 .codex-permission-mode-segmented::before {
   content: "";

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -9293,6 +9293,19 @@ describe("settings renderer browser environment", () => {
     assert.ok(coreSource.includes('checkboxInput.type = "checkbox"'));
     assert.ok(coreSource.includes("checkboxChecked: !!(checkboxInput && checkboxInput.checked)"));
     assert.ok(css.includes("grid-template-columns: repeat(3, minmax(0, 1fr))"));
+    assert.match(
+      css,
+      /\.permission-automation-segmented button\s*\{[^}]*min-height:\s*34px;[^}]*align-items:\s*center;[^}]*justify-content:\s*center;[^}]*text-align:\s*center;/s
+    );
+    assert.match(
+      css,
+      /\.permission-automation-segmented button\.active\s*\{[^}]*font-weight:\s*600;/s
+    );
+    assert.ok(css.includes(".permission-automation-segmented button:not(.active):not(:disabled):hover"));
+    assert.match(
+      css,
+      /\.permission-automation-segmented button:focus-visible\s*\{[^}]*outline-offset:\s*1px;/s
+    );
     assert.ok(generalSource.includes("helpers.buildSegmentedRadio({"));
     assert.ok(generalSource.includes('ariaLabel: t("rowPermissionAutomation")'));
     assert.ok(generalSource.includes('className: "permission-automation-segmented"'));


### PR DESCRIPTION
## Summary
- Centers the three permission automation labels horizontally and vertically.
- Refines selected, hover, focus, spacing, and text-scaling behavior without changing the shared segmented-radio component.
- Adds a scoped CSS regression contract for the permission control.

## Problem context
The permission automation row uses the shared `buildSegmentedRadio()` helper. That shared component intentionally left-aligns options because some Settings segmented choices contain secondary descriptions. The permission automation choices contain only short labels, so inheriting that layout made all three labels appear pinned to the left edge of otherwise equal-width segments.

## What changed
- Scoped the visual override to `.permission-automation-segmented`; other segmented controls keep their existing layout.
- Centered labels on both axes and set a consistent 34px minimum target height.
- Increased the selected label weight to 600 while preserving the existing panel fill and shadow.
- Added a subtle inactive hover surface and a complete focus-visible outline offset.
- Allowed labels to wrap safely under narrow layouts or increased text scaling.
- Standardized this control's background, color, and shadow transitions at 150ms.
- Added browser-environment assertions for centering, selected weight, hover, and focus behavior.

## Behavior after this PR
- The three permission automation choices remain equal-width and now read as a balanced segmented control.
- Mouse, keyboard, radiogroup ARIA, pending state, confirmation gates, persistence, and rollback behavior remain unchanged.
- Long localized labels may wrap instead of clipping while remaining centered.
- Other Settings segmented radios are intentionally unchanged.

## Validation
- `node --test --test-name-pattern="renders three permission automation modes|patches confirmed permission automation changes" test/settings-renderer-browser-env.test.js` — 2/2 passed.
- `node --test test/settings-renderer-browser-env.test.js` — 302/302 passed.
- `npm run verify:electron` — passed with Electron 41.10.4.
- `node --check src/settings-tab-general.js` — passed.
- `git diff --check` — passed.
- Windows click-level QA passed for centered labels, selected/hover states, keyboard focus, switching, and scaled text.

## Platform note
Automated verification and manual QA ran on Windows. The CSS remains based on existing Settings tokens and supports light/dark system color schemes.

## Scope control
- This is a visual-only refinement of the General page permission automation segmented control.
- It does not change permission automation semantics, confirmation dialogs, preferences, IPC, or the shared segmented-radio defaults.
