### PR TITLE
feat: show permission requests in one scrollable bubble

### DIFF
--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -323,8 +323,12 @@ CodeBuddy 的 PermissionRequest HTTP 所有权只认严格的本机 managed URL�
 - DeepSeek Harness 普通 approval 进入独立 blocking adapter；人工 Allow/Deny 可用，但 auto-tools、unattended 与 per-session grant 全部 DEFER。`ask_user_question` 返回 204 交给 DSH 原生 provider
 - Codex 的 PermissionRequest 是 official command hook；hook 脚本挂起等待 `/permission`，再把 sanitized allow/deny JSON 写到 stdout
 - `POST /permission` 接收 `{ tool_name, tool_input, session_id, permission_suggestions }`；Codex 额外带 `turn_id`、`tool_input_description`、`tool_input_fingerprint`
-- 每个权限请求都会创建独立 `BrowserWindow`，多个 bubble 从右下向上堆叠
-- bubble 会通过 IPC `bubble-height` 回报真实高度，主进程据此重排
+- 本地权限 UI 是一个进程级共享 surface：只完整展示一个 active 请求，其他请求显示为可切换的等待摘要；当前 active 默认保持稳定，新的交互型请求可抢占被动通知，但不会自动打断另一个交互型请求
+- 共享 surface 正常只持有一个可见 `BrowserWindow`。普通审批与带文本输入的审批需要不同的创建期 native window mode；切换 mode 时先创建隐藏候选窗口，候选加载并回报高度后再原子替换旧窗口，失败则保留旧窗口与全部 pending 请求
+- renderer 的 `permission-show` envelope 同时携带 `surfaceRevision` 与 `activeContentRevision`：队列变化只递增前者，不能重置 active 输入或让仍然有效的审批按钮失效；决定与队列切换都校验 active identity/revision，过期操作只触发重绘恢复，不产生决定
+- bubble 通过 IPC `bubble-height` 回报真实高度、surface revision、active entry 和本次实际承载的 entry ids；主进程只在 ACK 与当前 surface 匹配后定位并显示窗口，Slack 通知也复用这次可见性确认
+- 问答、计划反馈和 elicitation 等有草稿状态的 active 请求会锁住队列切换，避免切换时静默丢失输入；普通 Allow/Deny 请求可从等待摘要切换，不会顺带决定原请求
+- 隐藏桌宠时用 entry ordinal 记录一次 cutoff：cutoff 前的 pending 请求从共享 surface 收起，隐藏期间新到的请求仍可显示；surface 崩溃只 no-decision 本次实际交给 renderer 的 entry ids，不能波及被 cutoff 隐藏或 remote-only 的请求
 - 支持 Allow / Deny / suggestion 决策，以及 `addRules` / `setMode` suggestion 类型
 - `permission-automation-policy.js` 的 off / auto-tools / unattended 与 `session-automation-coordinator.js` 的 per-session grant 会在 bubble 渲染前产生真实决定。auto-tools 对 Claude/Qwen 的未知 built-in（除有效 namespaced MCP）fail closed，但其他已知 adapter 对非空工具名不都使用逐工具 allowlist；unattended 在识别已知 decision tools 后仍有意对可作 Allow/Deny 的未知请求保留“handle every request”行为。新增 agent/tool/interaction 必须同时审查 policy 与 tests，不能笼统假设 unknown 一律 defer
 - Telegram 与飞书 / Lark 是和本地 bubble 并行的远程决策通道；关闭本地 bubble 不等于关闭远程审批。远程 client 超时、断连、未配置或启动失败不得产生决定或 deny：本地 bubble 存在时请求继续 pending；仅在 remote-only 且所有可用 client 都无决定时，整体请求才 no-decision 并让 agent 回原生 UI 重问

--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -22,7 +22,7 @@ This document holds the state machine, theme system, UI runtime, and platform ca
 - 睡眠序列：20s 鼠标静止 → idle-look → 60s → yawning(3s) → dozing → 10min → collapsing(0.8s) → sleeping；鼠标移动触发 waking(1.5s) → 恢复
 - 逻辑 `idle` 与静置视觉分离：Settings 可为当前主题选择一个常驻 idle 变体，但不改变状态优先级；thinking / working / permission / completion / sleep / reaction / roam 仍会覆盖它，结束后再回到所选视觉
 - DND 模式：跳过 dozing，直接 yawning → collapsing → sleeping；同时屏蔽 hook 事件
-- 隐藏桌宠（petHidden，入口：托盘 / 右键菜单 / 快捷键）：语义是「看不见宠物」而非免打扰——隐藏时收起宠物、Session HUD、update bubble 和当时 pending 的权限气泡（恢复显示时回来），但隐藏期间新到的权限请求仍照常弹气泡，这是有意设计、不要当 bug 修；要连权限气泡都静默是 DND 的职责（它有回终端确认的 fallback）。Allow/Deny 全局快捷键跟随「可见气泡」：隐藏期间只要有可见气泡就保持注册，但只作用于可见的请求，收起的旧气泡不会被盲操作（#601）。petHidden 不持久化，重启恢复显示
+- 隐藏桌宠（petHidden，入口：托盘 / 右键菜单 / 快捷键）：语义是「看不见宠物」而非免打扰——隐藏瞬间记录权限队列 cutoff，并收起宠物、Session HUD、update bubble 与 cutoff 前的 pending 请求；隐藏期间新到的权限请求仍可占用共享 bubble surface，这是有意设计、不要当 bug 修。恢复显示后，旧请求重新进入同一 active + waiting 队列。要连权限气泡都静默是 DND 的职责（它有回终端确认的 fallback）。Allow/Deny 全局快捷键只跟随共享 surface 当前可见的 active 请求：cutoff 前被收起的旧请求不会被盲操作（#601）。petHidden 不持久化，重启恢复显示
 - working 子动画：Clawd 主题为 1 个会话 → typing，2 个 → headphones groove，3+ → building；Calico / Cloudling 仍为 typing / juggling / building
 - juggling 子动画：1 个 subagent → juggling，2+ → conducting
 

--- a/src/bubble-format.js
+++ b/src/bubble-format.js
@@ -18,12 +18,12 @@
     return "";
   }
 
-  function formatAntigravityDetail(name, input) {
+  function formatAntigravityDetail(name, input, maxLength = 160) {
     const toolName = typeof name === "string" ? name.trim().toLowerCase() : "";
     if (!toolName) return "";
 
     if (toolName === "run_command" || toolName === "bash" || toolName === "shell") {
-      return truncate(firstStringValue(input, ["CommandLine", "command", "Command", "cmd"]), 160);
+      return truncate(firstStringValue(input, ["CommandLine", "command", "Command", "cmd"]), maxLength);
     }
     if (
       toolName === "write_to_file" ||
@@ -35,54 +35,60 @@
     ) {
       const filePath = firstStringValue(input, ["TargetFile", "AbsolutePath", "file_path", "path", "filePath", "FilePath"]);
       const description = firstStringValue(input, ["Description", "Instruction"]);
-      return truncate(description && filePath ? `${filePath}: ${description}` : (filePath || description), 160);
+      return truncate(description && filePath ? `${filePath}: ${description}` : (filePath || description), maxLength);
     }
     if (toolName === "view_file" || toolName === "read") {
-      return truncate(firstStringValue(input, ["AbsolutePath", "file_path", "path", "filePath", "FilePath"]), 160);
+      return truncate(firstStringValue(input, ["AbsolutePath", "file_path", "path", "filePath", "FilePath"]), maxLength);
     }
     if (toolName === "list_dir") {
-      return truncate(firstStringValue(input, ["DirectoryPath", "path", "directory"]), 160);
+      return truncate(firstStringValue(input, ["DirectoryPath", "path", "directory"]), maxLength);
     }
     if (toolName === "find_by_name") {
       const searchPath = firstStringValue(input, ["SearchDirectory", "DirectoryPath", "path"]);
       const pattern = firstStringValue(input, ["Pattern", "pattern"]);
-      return truncate(pattern && searchPath ? `${searchPath}: ${pattern}` : (searchPath || pattern), 160);
+      return truncate(pattern && searchPath ? `${searchPath}: ${pattern}` : (searchPath || pattern), maxLength);
     }
     if (toolName === "grep_search") {
       const searchPath = firstStringValue(input, ["SearchPath", "SearchDirectory", "DirectoryPath", "path"]);
       const query = firstStringValue(input, ["Query", "query"]);
-      return truncate(query && searchPath ? `${searchPath}: ${query}` : (searchPath || query), 160);
+      return truncate(query && searchPath ? `${searchPath}: ${query}` : (searchPath || query), maxLength);
     }
     if (toolName === "ask_permission") {
       const target = firstStringValue(input, ["Target", "target", "Permission", "permission"]);
       const reason = firstStringValue(input, ["Reason", "reason", "Description", "description"]);
-      return truncate(reason && target ? `${target}: ${reason}` : (target || reason), 160);
+      return truncate(reason && target ? `${target}: ${reason}` : (target || reason), maxLength);
     }
     if (toolName === "read_url_content") {
-      return truncate(firstStringValue(input, ["Url", "url"]), 160);
+      return truncate(firstStringValue(input, ["Url", "url"]), maxLength);
     }
     if (toolName === "search_web") {
-      return truncate(firstStringValue(input, ["query", "Query"]), 160);
+      return truncate(firstStringValue(input, ["query", "Query"]), maxLength);
     }
     return "";
   }
 
   function formatDetail(name, input, options) {
     if (!input || typeof input !== "object") return "";
-    if (typeof input.description === "string" && input.description.trim()) return truncate(input.description.trim(), 120);
-    if (name === "Bash" && typeof input.command === "string") return truncate(input.command, 120);
+    const maxLength = Number.isFinite(options && options.maxLength)
+      ? Math.max(1, Math.floor(options.maxLength))
+      : 120;
+    const fallbackMaxLength = Number.isFinite(options && options.fallbackMaxLength)
+      ? Math.max(1, Math.floor(options.fallbackMaxLength))
+      : 100;
+    if (typeof input.description === "string" && input.description.trim()) return truncate(input.description.trim(), maxLength);
+    if (name === "Bash" && typeof input.command === "string") return truncate(input.command, maxLength);
     if ((name === "Edit" || name === "Write" || name === "Read") && typeof input.file_path === "string")
-      return truncate(input.file_path, 120);
+      return truncate(input.file_path, maxLength);
     if ((name === "Glob" || name === "Grep") && typeof input.pattern === "string")
-      return truncate(input.pattern, 120);
+      return truncate(input.pattern, maxLength);
     if (options && options.isAntigravity) {
-      const antigravityDetail = formatAntigravityDetail(name, input);
+      const antigravityDetail = formatAntigravityDetail(name, input, maxLength);
       if (antigravityDetail) return antigravityDetail;
     }
     for (const v of Object.values(input)) {
-      if (typeof v === "string" && v.trim()) return truncate(v.trim(), 100);
+      if (typeof v === "string" && v.trim()) return truncate(v.trim(), fallbackMaxLength);
     }
-    return truncate(JSON.stringify(input), 100);
+    return truncate(JSON.stringify(input), fallbackMaxLength);
   }
 
   // Issue #445: MCP tool names arrive as opaque, scary-looking identifiers
@@ -200,6 +206,12 @@
     }
   }
 
+  function isIrreversibleScanPartial(name, input) {
+    const toolName = typeof name === "string" ? name.trim().toLowerCase() : "";
+    if (!SHELL_TOOLS.has(toolName) || !input || typeof input !== "object") return false;
+    return firstStringValue(input, ["command", "CommandLine", "Command", "cmd", "script"]).length > 4096;
+  }
+
   function parseMcpToolName(toolName) {
     if (typeof toolName !== "string" || !toolName) return null;
     const segs = toolName.split("__");
@@ -215,7 +227,15 @@
     return { server, tool, display };
   }
 
-  const api = { formatDetail, formatAntigravityDetail, truncate, firstStringValue, parseMcpToolName, detectIrreversible };
+  const api = {
+    formatDetail,
+    formatAntigravityDetail,
+    truncate,
+    firstStringValue,
+    parseMcpToolName,
+    detectIrreversible,
+    isIrreversibleScanPartial,
+  };
 
   if (typeof module === "object" && module.exports) {
     module.exports = api;

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -1,5 +1,12 @@
-const { formatDetail, truncate, parseMcpToolName, detectIrreversible } = window.ClawdBubbleFormat;
+const {
+  formatDetail,
+  truncate,
+  parseMcpToolName,
+  detectIrreversible,
+  isIrreversibleScanPartial,
+} = window.ClawdBubbleFormat;
 const card = document.getElementById("card");
+const activeDetail = document.getElementById("activeDetail");
 const toolPill = document.getElementById("toolPill");
 const toolPillText = document.getElementById("toolPillText");
 function stopMarquee() {
@@ -16,6 +23,7 @@ toolPill.addEventListener("mouseenter", startMarqueeIfOverflowing);
 toolPill.addEventListener("mouseleave", stopMarquee);
 const commandBlock = document.getElementById("commandBlock");
 const irreversibleBadge = document.getElementById("irreversibleBadge");
+const riskCoverageNote = document.getElementById("riskCoverageNote");
 const elicitationForm = document.getElementById("elicitationForm");
 const elicitationProgress = document.getElementById("elicitationProgress");
 const planFeedbackForm = document.getElementById("planFeedbackForm");
@@ -27,6 +35,13 @@ const btnDeny = document.getElementById("btnDeny");
 const suggestionsContainer = document.getElementById("suggestions");
 const headerTitle = document.querySelector(".header-title");
 const sessionTag = document.getElementById("sessionTag");
+const queueCount = document.getElementById("queueCount");
+const permissionQueue = document.getElementById("permissionQueue");
+const queueHeading = document.getElementById("queueHeading");
+const queuePreview = document.getElementById("queuePreview");
+const queueMore = document.getElementById("queueMore");
+const queueDrawer = document.getElementById("queueDrawer");
+const queueLockHint = document.getElementById("queueLockHint");
 let elicitationMode = false;
 let codexUserInputMode = false;
 let elicitationQuestions = [];
@@ -34,11 +49,15 @@ let elicitationAnswers = {};
 let activeQuestionIndex = 0;
 let currentLang = "en";
 let heightReportFrame = 0;
+let currentSurfaceEnvelope = null;
+let queueDrawerOpen = false;
 
 // Mirrors body { padding: 6px; } above. Keep this in sync if the body padding changes.
 const BUBBLE_BODY_PADDING_Y = 12;
 const MIN_ELICITATION_FORM_HEIGHT = 80;
 const ELICITATION_OTHER_KEY = "__other__";
+const ACTIVE_DETAIL_MAX_LENGTH = 64 * 1024;
+const ACTIVE_DETAIL_FALLBACK_MAX_LENGTH = 4 * 1024;
 
 function setSessionTag(data) {
   const parts = [];
@@ -98,6 +117,10 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "What should be changed?",
     submitFeedback: "Send",
     back: "Back",
+    waitingRequests: "Waiting",
+    moreRequests: "View all {count}",
+    finishCurrentInput: "Finish the current input before switching.",
+    riskScanPartial: "Safety hints only scan the first 4 KB; review the remaining command carefully.",
   },
   zh: {
     irreversibleHint: "\u7834\u574F\u6027\u64CD\u4F5C\u2014\u2014\u53EF\u80FD\u65E0\u6CD5\u6062\u590D",
@@ -141,6 +164,10 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "\u54EA\u91CC\u9700\u8981\u6539?",
     submitFeedback: "\u53D1\u9001",
     back: "\u8FD4\u56DE",
+    waitingRequests: "\u7B49\u5F85\u5904\u7406",
+    moreRequests: "\u67E5\u770B\u5168\u90E8 {count} \u4E2A",
+    finishCurrentInput: "\u8BF7\u5148\u5B8C\u6210\u5F53\u524D\u8F93\u5165\uFF0C\u518D\u5207\u6362\u8BF7\u6C42\u3002",
+    riskScanPartial: "\u5B89\u5168\u63D0\u793A\u4EC5\u626B\u63CF\u547D\u4EE4\u524D 4 KB\uFF0C\u8BF7\u4ED4\u7EC6\u68C0\u67E5\u540E\u7EED\u5185\u5BB9\u3002",
   },
   "zh-TW": {
     irreversibleHint: "\u7834\u58DE\u6027\u64CD\u4F5C\u2014\u2014\u53EF\u80FD\u7121\u6CD5\u5FA9\u539F",
@@ -184,6 +211,10 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "哪裡需要改?",
     submitFeedback: "傳送",
     back: "返回",
+    waitingRequests: "等待處理",
+    moreRequests: "查看全部 {count} 個",
+    finishCurrentInput: "請先完成目前輸入，再切換請求。",
+    riskScanPartial: "安全提示只掃描命令前 4 KB，請仔細檢查後續內容。",
   },
   ko: {
     irreversibleHint: "\uD30C\uAD34\uC801 \uC791\uC5C5 \u2014 \uBCF5\uAD6C\uB418\uC9C0 \uC54A\uC744 \uC218 \uC788\uC2B5\uB2C8\uB2E4",
@@ -227,6 +258,10 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "\uC5B4\uB514\uB97C \uBC14\uAFD4\uC57C \uD558\uB098\uC694?",
     submitFeedback: "\uBCF4\uB0B4\uAE30",
     back: "\uB4A4\uB85C",
+    waitingRequests: "\uB300\uAE30 \uC911",
+    moreRequests: "\uC694\uCCAD {count}\uAC1C \uBAA8\uB450 \uBCF4\uAE30",
+    finishCurrentInput: "\uC694\uCCAD\uC744 \uC804\uD658\uD558\uAE30 \uC804\uC5D0 \uD604\uC7AC \uC785\uB825\uC744 \uB9C8\uBB34\uB9AC\uD558\uC138\uC694.",
+    riskScanPartial: "\uC548\uC804 \uC54C\uB9BC\uC740 \uBA85\uB839\uC758 \uCC98\uC74C 4KB\uB9CC \uAC80\uC0AC\uD569\uB2C8\uB2E4. \uB098\uBA38\uC9C0 \uB0B4\uC6A9\uC744 \uC8FC\uC758 \uAE4A\uAC8C \uD655\uC778\uD558\uC138\uC694.",
   },
   ja: {
     irreversibleHint: "\u7834\u58CA\u7684\u306A\u64CD\u4F5C \u2014 \u5FA9\u5143\u3067\u304D\u306A\u3044\u53EF\u80FD\u6027\u304C\u3042\u308A\u307E\u3059",
@@ -270,6 +305,10 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "どこを変更すべき?",
     submitFeedback: "送信",
     back: "戻る",
+    waitingRequests: "待機中",
+    moreRequests: "{count} 件すべて表示",
+    finishCurrentInput: "現在の入力を完了してからリクエストを切り替えてください。",
+    riskScanPartial: "安全性のヒントはコマンドの先頭 4 KB だけを確認します。残りの内容も注意して確認してください。",
   },
   "pt-BR": {
     irreversibleHint: "Ação destrutiva — pode não ter volta",
@@ -313,6 +352,10 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "O que deveria mudar?",
     submitFeedback: "Enviar",
     back: "Voltar",
+    waitingRequests: "Aguardando",
+    moreRequests: "Ver todas as {count}",
+    finishCurrentInput: "Conclua a entrada atual antes de trocar de pedido.",
+    riskScanPartial: "Os alertas de segurança verificam apenas os primeiros 4 KB; revise com cuidado o restante do comando.",
   },
   es: {
     irreversibleHint: "Acción destructiva — puede ser irreversible",
@@ -356,6 +399,10 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "¿Qué habría que cambiar?",
     submitFeedback: "Enviar",
     back: "Atrás",
+    waitingRequests: "En espera",
+    moreRequests: "Ver las {count}",
+    finishCurrentInput: "Termina la entrada actual antes de cambiar de solicitud.",
+    riskScanPartial: "Los avisos de seguridad solo revisan los primeros 4 KB; comprueba con cuidado el resto del comando.",
   },
 };
 
@@ -370,6 +417,32 @@ function bubbleText(lang, key, vars) {
     value = value.split(`{${name}}`).join(replacement);
   }
   return value;
+}
+
+function formatActiveDetail(toolName, toolInput, options = {}) {
+  return formatDetail(toolName, toolInput, {
+    ...options,
+    maxLength: ACTIVE_DETAIL_MAX_LENGTH,
+    fallbackMaxLength: ACTIVE_DETAIL_FALLBACK_MAX_LENGTH,
+  });
+}
+
+function renderRiskCoverage(toolName, toolInput, lang) {
+  const partial = typeof isIrreversibleScanPartial === "function"
+    && isIrreversibleScanPartial(toolName, toolInput);
+  riskCoverageNote.textContent = partial ? bubbleText(lang, "riskScanPartial") : "";
+  riskCoverageNote.style.display = partial ? "" : "none";
+}
+
+function applySurfaceMeasurementCeiling(envelope) {
+  const ceiling = Math.max(320, Math.floor(Number(envelope?.measureCeiling) || 1200));
+  // measureCeiling is two work-area heights in CSS pixels. Reserve the fixed
+  // header/actions/queue area from one work-area height; only detail + drawer
+  // become scroll containers when the window is clamped by main.
+  const workAreaCssHeight = Math.max(240, Math.floor(ceiling / 2));
+  activeDetail.style.maxHeight = `${Math.max(120, workAreaCssHeight - 250)}px`;
+  queueDrawer.style.maxHeight = `${Math.max(88, Math.min(180, Math.floor(workAreaCssHeight * 0.28)))}px`;
+  card.style.maxHeight = `${ceiling}px`;
 }
 
 function getSuggestionLabel(s, lang) {
@@ -476,20 +549,19 @@ function resetBubbleContent() {
   irreversibleBadge.style.display = "none";
   irreversibleBadge.textContent = "";
   irreversibleBadge.removeAttribute("data-reason");
+  riskCoverageNote.style.display = "none";
+  riskCoverageNote.textContent = "";
   elicitationForm.innerHTML = "";
   elicitationForm.style.maxHeight = "";
   elicitationForm.classList.remove("visible");
   elicitationProgress.textContent = "";
   elicitationProgress.classList.remove("visible");
-  // NOTE: this resets the feedback form's visibility + textarea value only, not
-  // the other side effects of enterPlanFeedbackMode() (suggestionsContainer
-  // display:none and the disabled flags on textarea/back/submit). That's safe
-  // today because every ExitPlanMode bubble is a fresh BrowserWindow/document —
-  // show() runs once per window so resetBubbleContent never has to undo a prior
-  // feedback session. If plan bubbles ever start reusing a window, restore those
-  // here too (suggestionsContainer.style.display + the disabled flags).
   planFeedbackForm.classList.remove("visible");
   planFeedbackTextarea.value = "";
+  planFeedbackTextarea.disabled = false;
+  planFeedbackBack.disabled = false;
+  planFeedbackSubmit.disabled = true;
+  suggestionsContainer.style.display = "";
   toolPill.style.display = "";
   stopMarquee();
   btnAllow.style.display = "";
@@ -497,6 +569,7 @@ function resetBubbleContent() {
   btnDeny.style.display = "";
   btnDeny.disabled = false;
   suggestionsContainer.innerHTML = "";
+  activeDetail.scrollTop = 0;
 }
 
 function getQuestionLabel(question, questionIndex) {
@@ -956,6 +1029,96 @@ function renderCodexUserInputPreview(data) {
   renderCodexUserInputStep(data);
 }
 
+function createQueueRow(item, switchingLocked) {
+  const row = document.createElement("button");
+  row.type = "button";
+  row.className = "queue-row";
+  row.setAttribute("data-entry-id", item.entryId || "");
+  row.setAttribute("aria-label", [item.toolLabel, item.sessionLabel, item.summary].filter(Boolean).join(" · "));
+  row.disabled = switchingLocked;
+
+  const top = document.createElement("span");
+  top.className = "queue-row-top";
+  const tool = document.createElement("span");
+  tool.className = "queue-row-tool";
+  tool.textContent = item.toolLabel || bubbleText(currentLang, "permissionRequest");
+  top.appendChild(tool);
+  if (item.sessionLabel) {
+    const session = document.createElement("span");
+    session.className = "queue-row-session";
+    session.textContent = item.sessionLabel;
+    top.appendChild(session);
+  }
+  const summary = document.createElement("span");
+  summary.className = "queue-row-summary";
+  summary.textContent = item.summary || "";
+  row.appendChild(top);
+  row.appendChild(summary);
+  row.addEventListener("click", () => {
+    if (switchingLocked || !item.entryId) return;
+    for (const button of permissionQueue.querySelectorAll("button")) button.disabled = true;
+    window.bubbleAPI.select(item.entryId);
+  });
+  return row;
+}
+
+function renderPermissionQueue(envelope) {
+  const queue = Array.isArray(envelope.queue) ? envelope.queue : [];
+  const total = Math.max(1, Number(envelope.totalCount) || queue.length + 1);
+  const activeIndex = Math.max(0, Number(envelope.activeIndex) || 0);
+  queueCount.textContent = total > 1 ? `${Math.min(total, activeIndex + 1)} / ${total}` : "";
+  permissionQueue.style.display = queue.length ? "" : "none";
+  queuePreview.innerHTML = "";
+  queueDrawer.innerHTML = "";
+  if (!queue.length) {
+    queueDrawerOpen = false;
+    queueMore.style.display = "none";
+    queueLockHint.textContent = "";
+    return;
+  }
+
+  queueHeading.textContent = bubbleText(currentLang, "waitingRequests");
+  queueLockHint.textContent = envelope.switchingLocked
+    ? bubbleText(currentLang, "finishCurrentInput")
+    : "";
+  queueLockHint.style.display = envelope.switchingLocked ? "" : "none";
+  for (const item of queue.slice(0, 2)) {
+    queuePreview.appendChild(createQueueRow(item, envelope.switchingLocked === true));
+  }
+  for (const item of queue) {
+    queueDrawer.appendChild(createQueueRow(item, envelope.switchingLocked === true));
+  }
+  const hasDrawer = queue.length > 2;
+  if (!hasDrawer) queueDrawerOpen = false;
+  queueMore.style.display = hasDrawer ? "" : "none";
+  queueMore.textContent = hasDrawer
+    ? bubbleText(currentLang, "moreRequests", { count: queue.length })
+    : "";
+  queueMore.setAttribute("aria-expanded", queueDrawerOpen ? "true" : "false");
+  queuePreview.style.display = queueDrawerOpen ? "none" : "";
+  queueDrawer.classList.toggle("visible", queueDrawerOpen);
+}
+
+queueMore.addEventListener("click", () => {
+  queueDrawerOpen = !queueDrawerOpen;
+  if (currentSurfaceEnvelope) renderPermissionQueue(currentSurfaceEnvelope);
+  scheduleBubbleHeightReport();
+});
+
+function restoreInteractionControls() {
+  for (const input of elicitationForm.querySelectorAll("input, textarea, button")) input.disabled = false;
+  for (const button of suggestionsContainer.querySelectorAll("button")) button.disabled = false;
+  if (elicitationMode) updateElicitationSubmitState();
+  else {
+    btnAllow.disabled = false;
+    btnDeny.disabled = false;
+  }
+  planFeedbackTextarea.disabled = false;
+  planFeedbackBack.disabled = false;
+  planFeedbackSubmit.disabled = !planFeedbackTextarea.value.trim();
+  if (currentSurfaceEnvelope) renderPermissionQueue(currentSurfaceEnvelope);
+}
+
 function show(data) {
   resetBubbleContent();
   currentLang = data.lang || "en";
@@ -969,6 +1132,7 @@ function show(data) {
   elicitationMode = interactionIntent === "human-question"
     && interactionCapabilities.answerQuestions === true;
   setSessionTag(data);
+  renderRiskCoverage(data.toolName, data.toolInput, data.lang);
 
   if (interactionIntent === "human-question" && !elicitationMode) {
     // The adapter identified a real user decision but cannot safely encode an
@@ -976,7 +1140,7 @@ function show(data) {
     // hand the request back to the agent's native UI.
     headerTitle.textContent = bubbleText(data.lang, "needsInput");
     toolPill.style.display = "none";
-    commandBlock.textContent = formatDetail(data.toolName, data.toolInput);
+    commandBlock.textContent = formatActiveDetail(data.toolName, data.toolInput);
     btnAllow.style.display = "none";
     btnDeny.style.display = "none";
     suggestionsContainer.innerHTML = "";
@@ -1019,7 +1183,7 @@ function show(data) {
     } else {
       try { detail = JSON.stringify(input); } catch { detail = "(n/a)"; }
     }
-    commandBlock.textContent = truncate(detail, 200);
+    commandBlock.textContent = truncate(detail, ACTIVE_DETAIL_MAX_LENGTH);
 
     btnAllow.textContent = bubbleText(data.lang, "allow");
     btnDeny.textContent = bubbleText(data.lang, "deny");
@@ -1086,7 +1250,10 @@ function show(data) {
     toolPillText.textContent = "CODEX";
     toolPill.setAttribute("data-tool", "CodexExec");
     toolPill.style.display = "";
-    commandBlock.textContent = (data.toolInput && data.toolInput.command) || "(unknown)";
+    commandBlock.textContent = truncate(
+      (data.toolInput && data.toolInput.command) || "(unknown)",
+      ACTIVE_DETAIL_MAX_LENGTH
+    );
     btnAllow.textContent = bubbleText(data.lang, "gotIt");
     btnAllow.disabled = false;
     btnDeny.style.display = "none";
@@ -1111,9 +1278,10 @@ function show(data) {
       toolPill.setAttribute("data-tool", kimiTool);
       // The fallbacks are defense-in-depth only: formatDetail's generic
       // last-resort loop returns non-empty for any server-normalized input.
-      commandBlock.textContent = formatDetail(kimiTool, kimiInput)
+      commandBlock.textContent = formatActiveDetail(kimiTool, kimiInput)
         || (data.toolInput && data.toolInput.command)
         || bubbleText(data.lang, "checkKimiTerminal");
+      renderRiskCoverage(kimiTool, kimiInput, data.lang);
       const kimiIrreversible = detectIrreversible(kimiTool, kimiInput);
       if (kimiIrreversible) {
         irreversibleBadge.textContent = "\u26A0 " + bubbleText(data.lang, "irreversibleHint");
@@ -1157,7 +1325,7 @@ function show(data) {
   toolPill.setAttribute("data-tool", data.toolName || "");
 
   // Command block (textContent only — never innerHTML)
-  commandBlock.textContent = formatDetail(data.toolName, data.toolInput, { isAntigravity: !!data.isAntigravity });
+  commandBlock.textContent = formatActiveDetail(data.toolName, data.toolInput, { isAntigravity: !!data.isAntigravity });
 
   // Irreversible-action hint — display-only (like the MCP relabel above): routes the
   // human's attention to destructive decisions. Allow/Deny semantics, the
@@ -1309,12 +1477,13 @@ document.addEventListener("keydown", (e) => {
   if (!elicitationMode) return;
   if (e.key !== "Enter" || e.shiftKey || e.isComposing) return;
   if (e.target && e.target.tagName === "TEXTAREA") return;
+  if (e.target && typeof e.target.closest === "function" && e.target.closest(".permission-queue")) return;
   if (btnAllow.disabled) return;
   e.preventDefault();
   btnAllow.click();
 });
 
-window.addEventListener("resize", applyElicitationViewport);
+window.addEventListener("resize", scheduleBubbleHeightReport);
 
 // ── Plan Feedback Mode ──
 
@@ -1418,5 +1587,31 @@ if (window.bubbleAPI && typeof window.bubbleAPI.setImeEditing === "function") {
   });
 }
 
-window.bubbleAPI.onPermissionShow(show);
+function handlePermissionSurfaceShow(envelope) {
+  // Legacy payload support keeps focused renderer tests and older preload
+  // fixtures useful while production always sends the surface envelope.
+  if (!envelope || typeof envelope !== "object" || !envelope.active) {
+    show(envelope || {});
+    return;
+  }
+  const previous = currentSurfaceEnvelope;
+  const activeChanged = !previous || previous.activeEntryId !== envelope.activeEntryId;
+  const activeContentChanged = !previous
+    || previous.activeContentRevision !== envelope.activeContentRevision;
+  currentSurfaceEnvelope = envelope;
+  currentLang = envelope.active.lang || "en";
+  applySurfaceMeasurementCeiling(envelope);
+
+  if (activeChanged) {
+    queueDrawerOpen = false;
+    show(envelope.active);
+  } else if (activeContentChanged && envelope.switchingLocked !== true) {
+    show(envelope.active);
+  }
+  renderPermissionQueue(envelope);
+  if (envelope.restoreInteractionControls === true) restoreInteractionControls();
+  scheduleBubbleHeightReport();
+}
+
+window.bubbleAPI.onPermissionShow(handlePermissionSurfaceShow);
 window.bubbleAPI.onPermissionHide(hide);

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -110,6 +110,20 @@ body { padding: 6px; }
   min-width: 0;
   margin-bottom: 0;
 }
+.header-line {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+}
+.queue-count {
+  flex: none;
+  color: var(--cmd-color);
+  font-family: "SF Mono", "ui-monospace", "Cascadia Code", monospace;
+  font-size: 11px;
+  opacity: 0.75;
+}
 .header-title {
   font-size: 13px;
   font-weight: 600;
@@ -128,6 +142,35 @@ body { padding: 6px; }
   color: var(--irreversible-color);
   background: var(--irreversible-bg);
   border: 1px solid var(--irreversible-border);
+}
+
+.risk-coverage-note {
+  margin: 0 2px;
+  padding: 6px 8px;
+  border-left: 3px solid var(--irreversible-border);
+  color: var(--cmd-color);
+  font-size: 11px;
+  line-height: 1.35;
+  user-select: text;
+}
+
+.active-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 2px;
+}
+.active-detail::-webkit-scrollbar,
+.queue-drawer::-webkit-scrollbar { width: 6px; }
+.active-detail::-webkit-scrollbar-track,
+.queue-drawer::-webkit-scrollbar-track { background: transparent; }
+.active-detail::-webkit-scrollbar-thumb,
+.queue-drawer::-webkit-scrollbar-thumb {
+  background: var(--scroll-thumb);
+  border-radius: 3px;
 }
 
 /* ── Tool pill ── */
@@ -201,7 +244,7 @@ body { padding: 6px; }
   font-size: 12px;
   color: var(--cmd-color);
   line-height: 1.5;
-  max-height: 80px;
+  max-height: 240px;
   overflow-y: auto;
   word-break: break-all;
   box-shadow: var(--cmd-shadow);
@@ -487,6 +530,109 @@ body { padding: 6px; }
   font-size: 11px;
   line-height: 1.35;
   padding: 2px 4px;
+}
+
+/* ── Shared permission queue ── */
+.permission-queue {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--card-border);
+  min-height: 0;
+}
+.queue-heading {
+  color: var(--cmd-color);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.queue-preview,
+.queue-drawer {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.queue-drawer {
+  display: none;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 2px;
+}
+.queue-drawer.visible { display: flex; }
+.queue-row {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 7px 9px;
+  color: var(--text-primary);
+  background: var(--sug-bg);
+  border: 1px solid var(--sug-border);
+  border-radius: 8px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  outline: none;
+}
+.queue-row:hover:not(:disabled),
+.queue-row:focus-visible:not(:disabled) {
+  background: var(--sug-hover-bg);
+  border-color: var(--sug-hover-border);
+}
+.queue-row:disabled { cursor: not-allowed; opacity: 0.58; }
+.queue-row-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+.queue-row-tool {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--header-color);
+  font-size: 11px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.queue-row-session {
+  margin-left: auto;
+  max-width: 45%;
+  overflow: hidden;
+  color: var(--cmd-color);
+  font-family: "SF Mono", "ui-monospace", "Cascadia Code", monospace;
+  font-size: 10px;
+  opacity: 0.75;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.queue-row-summary {
+  overflow: hidden;
+  color: var(--cmd-color);
+  font-size: 11px;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.queue-more {
+  padding: 3px 2px;
+  color: #d97757;
+  background: transparent;
+  border: 0;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+.queue-more:focus-visible { outline: 2px solid #d97757; outline-offset: 2px; }
+.queue-lock-hint {
+  color: var(--cmd-color);
+  font-size: 10px;
+  line-height: 1.3;
+  opacity: 0.8;
 }
 
 /* ── Plan feedback form ── */

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -8,21 +8,27 @@
 <body>
 <div class="card" id="card">
   <div class="header">
-    <span class="header-title">Permission Request</span>
+    <div class="header-line">
+      <span class="header-title">Permission Request</span>
+      <span class="queue-count" id="queueCount"></span>
+    </div>
     <span class="tool-pill" id="toolPill"><span class="tool-pill-text" id="toolPillText"></span></span>
   </div>
 
-  <div class="session-tag" id="sessionTag"></div>
+  <div class="active-detail" id="activeDetail">
+    <div class="session-tag" id="sessionTag"></div>
 
-  <div class="irreversible-badge" id="irreversibleBadge" style="display:none"></div>
-  <div class="command-block" id="commandBlock"></div>
-  <div class="elicitation-form" id="elicitationForm"></div>
-  <div class="elicitation-progress" id="elicitationProgress"></div>
-  <div class="plan-feedback-form" id="planFeedbackForm">
-    <textarea class="plan-feedback-textarea" id="planFeedbackTextarea" rows="3" maxlength="4000"></textarea>
-    <div class="plan-feedback-actions">
-      <button class="btn btn-deny plan-feedback-back" id="planFeedbackBack">Back</button>
-      <button class="btn btn-allow plan-feedback-submit" id="planFeedbackSubmit">Send</button>
+    <div class="irreversible-badge" id="irreversibleBadge" style="display:none"></div>
+    <div class="risk-coverage-note" id="riskCoverageNote" style="display:none"></div>
+    <div class="command-block" id="commandBlock"></div>
+    <div class="elicitation-form" id="elicitationForm"></div>
+    <div class="elicitation-progress" id="elicitationProgress"></div>
+    <div class="plan-feedback-form" id="planFeedbackForm">
+      <textarea class="plan-feedback-textarea" id="planFeedbackTextarea" rows="3" maxlength="4000"></textarea>
+      <div class="plan-feedback-actions">
+        <button class="btn btn-deny plan-feedback-back" id="planFeedbackBack">Back</button>
+        <button class="btn btn-allow plan-feedback-submit" id="planFeedbackSubmit">Send</button>
+      </div>
     </div>
   </div>
   
@@ -32,6 +38,14 @@
   </div>
   
   <div class="suggestions" id="suggestions"></div>
+
+  <div class="permission-queue" id="permissionQueue" style="display:none">
+    <div class="queue-heading" id="queueHeading"></div>
+    <div class="queue-preview" id="queuePreview"></div>
+    <button class="queue-more" id="queueMore" type="button"></button>
+    <div class="queue-drawer" id="queueDrawer"></div>
+    <div class="queue-lock-hint" id="queueLockHint"></div>
+  </div>
 </div>
 
 <script src="bubble-format.js"></script>

--- a/src/floating-window-runtime.js
+++ b/src/floating-window-runtime.js
@@ -13,6 +13,11 @@ function getPendingList(getPendingPermissions) {
 
 function createFloatingWindowRuntime(options = {}) {
   const getPendingPermissions = options.getPendingPermissions || (() => []);
+  const getPermissionBubbleWindows = options.getPermissionBubbleWindows || (() => (
+    getPendingList(getPendingPermissions).map((entry) => entry && entry.bubble).filter(Boolean)
+  ));
+  const ownsSharedPermissionSurface = typeof options.setPermissionPetHidden === "function";
+  const setPermissionPetHidden = options.setPermissionPetHidden || (() => false);
   const keepOutOfTaskbar = options.keepOutOfTaskbar || noop;
   const repositionPermissionBubbles = options.repositionPermissionBubbles || noop;
   const repositionUpdateBubble = options.repositionUpdateBubble || noop;
@@ -23,7 +28,7 @@ function createFloatingWindowRuntime(options = {}) {
   const hideUpdateBubble = options.hideUpdateBubble || noop;
 
   function repositionFloatingBubbles() {
-    if (getPendingList(getPendingPermissions).length) repositionPermissionBubbles();
+    if (getPermissionBubbleWindows().length) repositionPermissionBubbles();
     repositionUpdateBubble();
     // Orbit reads both permission and update-bubble bounds. Reposition it last
     // so it never avoids the previous update-bubble position.
@@ -41,19 +46,25 @@ function createFloatingWindowRuntime(options = {}) {
   }
 
   function showFloatingSurfacesForPet() {
-    for (const perm of getPendingList(getPendingPermissions)) {
-      const bubble = perm && perm.bubble;
-      if (isLiveWindow(bubble) && typeof bubble.showInactive === "function") {
-        bubble.showInactive();
-        keepOutOfTaskbar(bubble);
+    // The permission runtime republishes the shared surface and reveals it
+    // only after the renderer acknowledges the new payload height.
+    setPermissionPetHidden(false);
+    if (!ownsSharedPermissionSurface) {
+      for (const bubble of getPermissionBubbleWindows()) {
+        if (isLiveWindow(bubble) && typeof bubble.showInactive === "function") {
+          bubble.showInactive();
+          keepOutOfTaskbar(bubble);
+        }
       }
     }
     syncUpdateBubbleVisibility();
   }
 
   function hideFloatingSurfacesForPet() {
-    for (const perm of getPendingList(getPendingPermissions)) {
-      const bubble = perm && perm.bubble;
+    // Record the cutoff before hiding any window. Requests that arrive after
+    // this point are intentionally allowed to surface while the pet is hidden.
+    setPermissionPetHidden(true);
+    for (const bubble of getPermissionBubbleWindows()) {
       if (isLiveWindow(bubble) && typeof bubble.hide === "function") {
         bubble.hide();
       }

--- a/src/main.js
+++ b/src/main.js
@@ -1652,6 +1652,7 @@ const topmostRuntime = createTopmostRuntime({
   getHitWin: () => hitWin,
   recoverCloakedPet: () => petWindowRuntime.recoverIfCloaked(),
   getPendingPermissions: () => pendingPermissions,
+  getPermissionBubbleWindows: () => _perm.getPermissionBubbleWindows(),
   getUpdateBubbleWindow: () => _updateBubble.getBubbleWindow(),
   getSessionHudWindow: () => getSessionHudWindow(),
   getQuotaRingWindow: () => getQuotaRingWindow(),
@@ -1865,6 +1866,8 @@ const {
 
 floatingWindowRuntime = createFloatingWindowRuntime({
   getPendingPermissions: () => pendingPermissions,
+  getPermissionBubbleWindows: () => _perm.getPermissionBubbleWindows(),
+  setPermissionPetHidden: (hidden) => _perm.setPermissionPetHidden(hidden),
   repositionPermissionBubbles: () => repositionBubbles(),
   repositionUpdateBubble: () => repositionUpdateBubble(),
   repositionSessionHud: () => repositionSessionHud(),
@@ -2067,6 +2070,7 @@ const sessions = _state.sessions;
 async function showSessionAutomationWarning(entry) {
   const parent = selectSessionAutomationDialogParent({
     entry,
+    permissionSurfaceWindow: _perm.getPermissionSurfaceWindow(),
     petWindow: win,
   });
   return permissionAutomationConfirmationRuntime.confirmPermissionAutomation({

--- a/src/permission.js
+++ b/src/permission.js
@@ -6,7 +6,7 @@ const { getDefaultShortcuts } = require("./shortcut-actions");
 const { keepOutOfTaskbar } = require("./taskbar");
 const { clampTextScale, scaleWidth, scaleHeight, applyZoomToWindow } = require("./text-scale");
 const { createTranslator } = require("./i18n");
-const { firstStringValue } = require("./bubble-format");
+const { firstStringValue, formatDetail, truncate } = require("./bubble-format");
 const { MAC_TOPMOST_LEVEL } = require("./topmost-runtime");
 const { redactSecrets } = require("./secret-redact");
 const path = require("path");
@@ -63,7 +63,9 @@ const BUBBLE_HEIGHT_RESERVE = 24;
 // CSS px. Multiple of 20 on purpose: every 5% textScale step scales it to an
 // integer DIP width, so the CSS viewport width (and therefore renderer-side
 // height measurements) stays exact across scale changes.
-const BUBBLE_BASE_WIDTH = 340;
+const BUBBLE_BASE_WIDTH = 420;
+const BUBBLE_COMPACT_WIDTH = 380;
+const BUBBLE_COMPACT_WORK_AREA_RATIO = 0.42;
 // Hard cap so a scaled bubble can't swallow a small work area.
 const BUBBLE_MAX_WORK_AREA_WIDTH_RATIO = 0.9;
 const PLAN_FEEDBACK_MAX_LENGTH = 4000;
@@ -74,6 +76,17 @@ const PLAN_FEEDBACK_MAX_LENGTH = 4000;
 // endpoint or server-side identity injection first (WorkBuddy's native events
 // carry client:"WorkBuddy", not an agent_id server-agent-id.js recognizes).
 const REMOTE_RICH_APPROVAL_AGENT_IDS = new Set(["claude-code", "codebuddy"]);
+
+function computePermissionBubbleWidth(scale, workAreaWidth) {
+  const waWidth = Math.floor(Number(workAreaWidth) || 0);
+  const fullWidth = scaleWidth(BUBBLE_BASE_WIDTH, scale);
+  const compactWidth = scaleWidth(BUBBLE_COMPACT_WIDTH, scale);
+  const scaled = waWidth > 0 && fullWidth > waWidth * BUBBLE_COMPACT_WORK_AREA_RATIO
+    ? compactWidth
+    : fullWidth;
+  if (waWidth <= 0) return scaled;
+  return Math.min(scaled, Math.floor(waWidth * BUBBLE_MAX_WORK_AREA_WIDTH_RATIO));
+}
 
 function requiredDependency(value, name, owner) {
   if (!value) throw new Error(`${owner} requires ${name}`);
@@ -94,6 +107,9 @@ function registerPermissionIpc(options = {}) {
 
   on("bubble-height", (event, height) => permission.handleBubbleHeight(event, height));
   on("permission-decide", (event, behavior) => permission.handleDecide(event, behavior));
+  if (typeof permission.handleSelect === "function") {
+    on("permission-select", (event, payload) => permission.handleSelect(event, payload));
+  }
   if (typeof permission.handleImeEditing === "function") {
     on("bubble-ime-editing", (event, editing) => permission.handleImeEditing(event, editing));
   }
@@ -641,12 +657,31 @@ module.exports = function initPermission(ctx) {
 // by the next remote-approval payload without recreating this module.
 const t = createTranslator(() => ctx.lang);
 
-// Each entry: { res, abortHandler, suggestions, sessionId, bubble, hideTimer, toolName, toolInput, resolvedSuggestion, createdAt, measuredHeight }
+// Each entry owns its protocol/timer state. BrowserWindow ownership lives in
+// permissionSurface below; an entry never owns or aliases the shared window.
 const pendingPermissions = [];
 // Keep windows independently of pendingPermissions so Orbit continues avoiding
 // a bubble during its 250ms fade-out after the request has already been removed
 // from the pending list.
 const permissionBubbleWindows = new Set();
+let nextSurfaceEntryId = 1;
+let nextSurfaceOrdinal = 1;
+const permissionSurface = {
+  window: null,
+  ready: false,
+  nativeMode: null,
+  activeEntryId: null,
+  surfaceRevision: 0,
+  activeContentRevision: 0,
+  measuredHeight: 0,
+  hideTimer: null,
+  handover: null,
+  expectedDestroyWindows: new Set(),
+  pendingShowRevision: null,
+  deliveryEntryIds: new Set(),
+  petHidden: !!ctx.petHidden,
+  petHiddenCutoffOrdinal: null,
+};
 // Pure-metadata tools auto-allowed without showing a bubble (zero side effects)
 const PASSTHROUGH_TOOLS = new Set([
   "TaskCreate", "TaskUpdate", "TaskGet", "TaskList", "TaskStop", "TaskOutput",
@@ -701,16 +736,14 @@ function getActionablePermissions() {
 // visible, keep the plain actionable list: entries without a bubble window
 // (creation failed / not yet created) must stay hotkey-reachable.
 function getHotkeyActionablePermissions() {
-  const actionable = getActionablePermissions();
-  if (!ctx.petHidden) return actionable;
-  return actionable.filter((p) => {
-    const bub = p.bubble;
-    try {
-      return !!bub && !bub.isDestroyed() && bub.isVisible();
-    } catch {
-      return false;
-    }
-  });
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (!active || !getActionablePermissions().includes(active)) return [];
+  const bub = permissionSurface.window;
+  try {
+    return bub && !bub.isDestroyed() && bub.isVisible() ? [active] : [];
+  } catch {
+    return [];
+  }
 }
 
 function syncSingle(actionId, current, target, handler, setState) {
@@ -783,7 +816,7 @@ function getVisibleBubbleBounds() {
 function hotkeyResolve(behavior, message) {
   const targets = getHotkeyActionablePermissions();
   if (!targets.length) return;
-  const perm = targets[targets.length - 1]; // newest
+  const perm = targets[0];
   captureFrontApp((appName) => {
     resolvePermissionEntry(perm, behavior, message);
     if (appName) {
@@ -812,10 +845,7 @@ function getTextScale(workArea) {
 }
 
 function getBubbleWidth(scale, workArea) {
-  const scaled = scaleWidth(BUBBLE_BASE_WIDTH, scale);
-  const waWidth = Math.floor(Number(workArea && workArea.width) || 0);
-  if (waWidth <= 0) return scaled;
-  return Math.min(scaled, Math.floor(waWidth * BUBBLE_MAX_WORK_AREA_WIDTH_RATIO));
+  return computePermissionBubbleWidth(scale, workArea && workArea.width);
 }
 
 function getAnchorWorkArea(petBounds) {
@@ -851,17 +881,16 @@ function repositionBubbles() {
   const hitRect = ctx.bubbleFollowPet ? ctx.getHitRectScreen(petBounds) : null;
   const hudAvoidRects = getHudAvoidRects();
 
-  const layoutPermissions = pendingPermissions.filter((perm) => !perm.remoteOnly);
-  const bubbleHeights = layoutPermissions.map(perm =>
-    clampBubbleHeight(
-      // measuredHeight/estimate are CSS px; the window needs DIP.
-      scaleHeight(
-        perm.measuredHeight || estimateBubbleHeight((perm.suggestions || []).length),
-        scale
-      ),
-      wa.height
-    )
-  );
+  const bub = permissionSurface.window;
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (!bub || bub.isDestroyed() || !active) return;
+  const bubbleHeights = [clampBubbleHeight(
+    scaleHeight(
+      permissionSurface.measuredHeight || estimateBubbleHeight((active.suggestions || []).length),
+      scale
+    ),
+    wa.height
+  )];
 
   const bounds = computeBubbleStackLayout({
     followPet: !!ctx.bubbleFollowPet,
@@ -882,21 +911,10 @@ function repositionBubbles() {
     avoidRects: hudAvoidRects,
   });
 
-  for (let i = 0; i < layoutPermissions.length; i++) {
-    const perm = layoutPermissions[i];
-    if (perm.bubble && !perm.bubble.isDestroyed() && bounds[i]) {
-      // Re-resolve zoom here too: the pet may have crossed onto a display
-      // with a different textScale (applyZoomToWindow memoizes, so this is
-      // a no-op when nothing changed).
-      applyZoomToWindow(perm.bubble, scale);
-      // #640: a bubble whose text field is being typed into holds its
-      // position — followPet anchoring must not yank the input box around
-      // mid-composition (pet drag; roam is separately paused while editing).
-      // Fresh bubbles never carry the flag, so they still get placed.
-      if (perm.bubble.__clawdMacImeEditing) continue;
-      perm.bubble.setBounds(bounds[i]);
-    }
-  }
+  if (!bounds[0]) return;
+  applyZoomToWindow(bub, scale);
+  if (bub.__clawdMacImeEditing) return;
+  bub.setBounds(bounds[0]);
 }
 
 // Permission-automation chokepoint. Every agent branch in the /permission route
@@ -1100,181 +1118,465 @@ function handlePermissionBubbleFailure(permEntry, reason) {
   return true;
 }
 
-function showPermissionBubble(permEntry) {
-  // Auto-pilot: if enabled, approve immediately and never render a bubble.
-  if (maybeAutoApprovePermission(permEntry)) return;
+function ensureSurfaceEntryIdentity(permEntry) {
+  if (!permEntry.surfaceEntryId) {
+    permEntry.surfaceEntryId = `permission-${nextSurfaceEntryId++}`;
+  }
+  if (!Number.isFinite(permEntry.surfaceOrdinal)) {
+    permEntry.surfaceOrdinal = nextSurfaceOrdinal++;
+  }
+  return permEntry;
+}
 
-  const canOfferSessionTrust = typeof ctx.canOfferSessionTrust === "function"
-    && ctx.canOfferSessionTrust(permEntry) === true;
-  const sugCount = (permEntry.suggestions || []).length + (canOfferSessionTrust ? 1 : 0);
-  const wa = getAnchorWorkArea();
-  const scale = getTextScale(wa);
-  const bh = clampBubbleHeight(scaleHeight(estimateBubbleHeight(sugCount), scale), wa.height);
-  // Temporary position — repositionBubbles() will finalize after renderer reports real height
-  const pos = { x: 0, y: 0, width: getBubbleWidth(scale, wa), height: bh };
+function getSurfaceEntryById(entryId) {
+  if (!entryId) return null;
+  return pendingPermissions.find((entry) => entry && entry.surfaceEntryId === entryId) || null;
+}
 
-  // Bubbles that host a text input (elicitation "Other", ExitPlanMode
-  // feedback) need keyboard focus. On macOS, the topmost level is dropped
-  // per-edit at runtime instead (see handleImeEditing) so the IME candidate
-  // window isn't occluded.
-  const interactionCapabilities = isValidInteraction(permEntry.interaction)
+function isSurfaceEntrySuppressed(permEntry) {
+  return !!(
+    permissionSurface.petHidden
+    && Number.isFinite(permissionSurface.petHiddenCutoffOrdinal)
+    && Number.isFinite(permEntry && permEntry.surfaceOrdinal)
+    && permEntry.surfaceOrdinal <= permissionSurface.petHiddenCutoffOrdinal
+  );
+}
+
+function getSurfaceEligibleEntries() {
+  return pendingPermissions.filter((entry) => entry
+    && entry.surfaceEligible === true
+    && entry.remoteOnly !== true
+    && !isSurfaceEntrySuppressed(entry));
+}
+
+function getEntryCapabilities(permEntry) {
+  return isValidInteraction(permEntry && permEntry.interaction)
     ? permEntry.interaction.capabilities
     : {};
-  const needsTextInput = interactionCapabilities.answerQuestions === true
-    || interactionCapabilities.planFeedback === true;
+}
 
-  const bub = new BrowserWindow({
-    width: pos.width,
-    height: pos.height,
-    x: pos.x,
-    y: pos.y,
-    show: false, // Fix lost focus
-    frame: false,
-    transparent: true,
-    alwaysOnTop: !isMac,
-    resizable: false,
-    skipTaskbar: true,
-    hasShadow: false,
-    ...(isLinux ? { type: LINUX_WINDOW_TYPE } : {}),
-    ...(isMac ? { type: "panel", acceptFirstMouse: true } : {}),
-    // Elicitation needs keyboard focus for the Other/textarea input path.
-    // Permission prompts need focusable: true on macOS to receive clicks,
-    // while acceptFirstMouse lets the first click hit the inactive panel.
-    // ExitPlanMode needs keyboard focus for the "Tell Claude what to change"
-    // textarea feedback path on other platforms.
-    focusable: isMac ? true : needsTextInput,
-    webPreferences: {
-      preload: path.join(__dirname, "preload-bubble.js"),
-      nodeIntegration: false,
-      contextIsolation: true,
-    },
+function getPermissionNativeMode(permEntry) {
+  const capabilities = getEntryCapabilities(permEntry);
+  return capabilities.answerQuestions === true
+    || capabilities.planFeedback === true
+    || permEntry?.isElicitation === true
+    ? "text-input"
+    : "default";
+}
+
+function isSurfaceSwitchingLocked(permEntry) {
+  return getPermissionNativeMode(permEntry) === "text-input";
+}
+
+function selectSurfaceActiveEntry(entries) {
+  if (!entries.length) return null;
+  const current = getSurfaceEntryById(permissionSurface.activeEntryId);
+  const firstInteractive = entries.find((entry) => !isPassiveNotifyEntry(entry)) || null;
+  if (current && entries.includes(current)) {
+    if (isPassiveNotifyEntry(current) && firstInteractive) return firstInteractive;
+    return current;
+  }
+  return firstInteractive || entries[0];
+}
+
+function getSurfaceQueueSummary(permEntry) {
+  const detail = formatDetail(permEntry.toolName, permEntry.toolInput, {
+    isAntigravity: !!permEntry.isAntigravity,
+    maxLength: 140,
+    fallbackMaxLength: 140,
   });
+  return truncate(detail || permEntry.toolName || "Permission request", 140);
+}
 
-  // Partial-create rollback: a synchronous throw after the BrowserWindow
-  // exists (setAlwaysOnTop/showInactive/repositioning on exotic platforms,
-  // shortcut sync, autoclose arming) must not orphan a live window with
-  // registered close handlers while the route-level catch drops the pending
-  // entry — nothing would ever close that window. Strip listeners, destroy
-  // the window, and rethrow so the caller finishes the rollback.
+function getSurfaceSessionLabel(permEntry) {
+  const sess = ctx.sessions.get(permEntry.sessionId);
+  if (sess && sess.cwd) return path.basename(sess.cwd);
+  return permEntry.sessionId ? String(permEntry.sessionId).slice(-3) : "";
+}
+
+function buildPermissionSurfacePayload(activeEntry, options = {}) {
+  const entries = getSurfaceEligibleEntries();
+  const queue = entries
+    .filter((entry) => entry !== activeEntry)
+    .map((entry) => ({
+      entryId: entry.surfaceEntryId,
+      kind: isPassiveNotifyEntry(entry) ? "notification" : "permission",
+      toolLabel: entry.toolName || "Permission",
+      sessionLabel: getSurfaceSessionLabel(entry),
+      summary: getSurfaceQueueSummary(entry),
+    }));
+  const wa = getAnchorWorkArea();
+  const scale = getTextScale(wa);
+  const activeIndex = Math.max(0, entries.indexOf(activeEntry));
+  return {
+    surfaceRevision: options.surfaceRevision ?? permissionSurface.surfaceRevision,
+    activeContentRevision: options.activeContentRevision ?? permissionSurface.activeContentRevision,
+    activeEntryId: activeEntry.surfaceEntryId,
+    active: buildPermissionBubblePayload(activeEntry),
+    queue,
+    entryIds: entries.map((entry) => entry.surfaceEntryId),
+    totalCount: entries.length,
+    activeIndex,
+    switchingLocked: isSurfaceSwitchingLocked(activeEntry),
+    restoreInteractionControls: options.restoreInteractionControls === true,
+    measureCeiling: Math.max(1, Math.ceil((wa.height * 2) / scale)),
+  };
+}
+
+function sendPermissionSurfacePayload(win, activeEntry, options = {}) {
+  if (!win || win.isDestroyed() || !win.webContents) return null;
+  if (typeof win.webContents.isDestroyed === "function" && win.webContents.isDestroyed()) return null;
+  const surfaceRevision = options.surfaceRevision ?? ++permissionSurface.surfaceRevision;
+  const payload = buildPermissionSurfacePayload(activeEntry, {
+    ...options,
+    surfaceRevision,
+  });
+  win.webContents.send("permission-show", payload);
+  if (win === permissionSurface.window) {
+    permissionSurface.deliveryEntryIds = new Set(payload.entryIds);
+    let visible = false;
+    try { visible = win.isVisible(); } catch {}
+    if (!visible) permissionSurface.pendingShowRevision = surfaceRevision;
+  }
+  return payload;
+}
+
+function clearPermissionSurfaceWindow(win) {
+  permissionBubbleWindows.delete(win);
+  if (permissionSurface.window !== win) return;
+  permissionSurface.window = null;
+  permissionSurface.ready = false;
+  permissionSurface.nativeMode = null;
+  permissionSurface.measuredHeight = 0;
+  permissionSurface.pendingShowRevision = null;
+  permissionSurface.deliveryEntryIds = new Set();
+}
+
+function clearPermissionSurfaceImeEditing(win = permissionSurface.window) {
+  if (!win || win.__clawdMacImeEditing !== true) return;
+  delete win.__clawdMacImeEditing;
+  if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
+  if (typeof ctx.syncImeEditingPetDodge === "function") {
+    try { ctx.syncImeEditingPetDodge(); } catch {}
+  }
+}
+
+let surfaceFailureSweepActive = false;
+
+function handleServingSurfaceFailure(win, reason) {
+  if (!win || win.__clawdSurfaceFailureHandled || permissionSurface.window !== win) return false;
+  win.__clawdSurfaceFailureHandled = true;
+  handleBubbleRendererGone(win);
+  const deliveryEntries = [...permissionSurface.deliveryEntryIds]
+    .map((entryId) => getSurfaceEntryById(entryId))
+    .filter(Boolean);
+  permissionSurface.expectedDestroyWindows.add(win);
+  clearPermissionSurfaceWindow(win);
   try {
-    permEntry.bubble = bub;
-    permissionBubbleWindows.add(bub);
-    permEntry.bubbleReady = false;
-    // macOS: text-input bubbles skip the native stationary treatment (SkyLight
-    // private space) that occludes the OS IME candidate window. They stay
-    // cross-space visible via Electron and drop out of always-on-top while a text
-    // field is focused (handleImeEditing) so CJK input popups can surface.
-    if (isMac && needsTextInput) bub.__clawdMacTextInputBubble = true;
-
-    if (isWin) {
-      bub.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+    if (!win.isDestroyed()) win.destroy();
+  } catch {}
+  surfaceFailureSweepActive = true;
+  try {
+    for (const entry of deliveryEntries) {
+      if (pendingPermissions.includes(entry)) handlePermissionBubbleFailure(entry, reason);
     }
+  } finally {
+    surfaceFailureSweepActive = false;
+  }
+  repositionDependentBubbles();
+  syncPermissionShortcuts();
+  return true;
+}
 
-    bub.webContents.once("did-finish-load", () => {
-      if (pendingPermissions.indexOf(permEntry) === -1 || permEntry.bubble !== bub) return;
-      permEntry.bubbleReady = true;
-      // Explicit even though same-origin propagation usually covers it — a
-      // stale partition-persisted factor must never win over prefs.
-      applyZoomToWindow(bub, getTextScale(getAnchorWorkArea()));
-      syncPermissionBubbleContent(permEntry);
-      // Elicitation bubbles need keyboard focus so arrow keys and Enter work.
-      // Regular permission bubbles must NOT steal focus from the terminal —
-      // doing so triggers false "User answered in terminal" denials in Claude Code.
-      if (interactionCapabilities.answerQuestions === true) {
-        bub.focus();
-      }
+function failPermissionSurfaceHandover(win, reason) {
+  const handover = permissionSurface.handover;
+  if (!handover || handover.window !== win) return false;
+  permissionSurface.handover = null;
+  permissionSurface.expectedDestroyWindows.add(win);
+  try { if (!win.isDestroyed()) win.destroy(); } catch {}
+  permLog(`permission surface handover failed: ${reason}`);
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (active && permissionSurface.window && permissionSurface.ready) {
+    sendPermissionSurfacePayload(permissionSurface.window, active, {
+      restoreInteractionControls: true,
     });
+  }
+  return true;
+}
 
-    bub.on("closed", () => {
-      permissionBubbleWindows.delete(bub);
-      const idx = pendingPermissions.indexOf(permEntry);
-      if (idx !== -1) {
-        // Qwen + Copilot + ZCode + DSH can hand no-decision back to their native
-        // flow. Hermes has no native permission UI, so its opt-in plugin gate
-        // treats this as a retryable block. In every case we avoid fabricating a
-        // user denial. CC/CodeBuddy still get an explicit deny for this
-        // user-close action.
-        const behavior = (
-          permEntry.isQwenCode
-          || permEntry.isCopilotCli
-          || permEntry.isHermes
-          || permEntry.isZcode
-          || permEntry.isDsh
-        ) ? "no-decision" : "deny";
-        resolvePermissionEntry(permEntry, behavior, "Bubble window closed by user");
-      }
-      repositionDependentBubbles();
-    });
+function behaviorForUserClosedEntry(permEntry) {
+  return (
+    permEntry?.isQwenCode
+    || permEntry?.isCopilotCli
+    || permEntry?.isHermes
+    || permEntry?.isZcode
+    || permEntry?.isDsh
+  ) ? "no-decision" : "deny";
+}
 
-    function failPermissionBubble(reason) {
-      if (
-        permEntry._bubbleFatalHandled
-        || pendingPermissions.indexOf(permEntry) === -1
-        || permEntry.bubble !== bub
-      ) {
-        return false;
-      }
-      handleBubbleRendererGone(bub);
-      return handlePermissionBubbleFailure(permEntry, reason);
-    }
-
-    // Loading or renderer failure must release the blocking hook. Returning
-    // no-decision lets agents with a native approval flow take over and avoids
-    // fabricating either an allow or a deny.
-    bub.webContents.once("did-fail-load", (_event, errorCode, errorDescription) => {
-      failPermissionBubble(
-        `Permission bubble failed to load (${errorCode || "unknown"}: ${errorDescription || "unknown error"})`
-      );
-    });
-    bub.webContents.on("render-process-gone", (_event, details) => {
-      const reason = details && details.reason ? details.reason : "unknown";
-      failPermissionBubble(`Permission bubble renderer exited (${reason})`);
-    });
-
-    let loadFailedSynchronously = false;
-    try {
-      const loadResult = bub.loadFile(path.join(__dirname, "bubble.html"));
-      if (loadResult && typeof loadResult.catch === "function") {
-        loadResult.catch((err) => {
-          failPermissionBubble(
-            `Permission bubble failed to load: ${err && err.message ? err.message : String(err)}`
-          );
+function onPermissionSurfaceClosed(win, userInitiatedClose) {
+  const expected = permissionSurface.expectedDestroyWindows.delete(win);
+  if (permissionSurface.handover && permissionSurface.handover.window === win) {
+    if (!expected) {
+      permissionSurface.handover = null;
+      permLog("permission surface handover failed: candidate window closed");
+      const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+      if (active && permissionSurface.window && permissionSurface.ready) {
+        sendPermissionSurfacePayload(permissionSurface.window, active, {
+          restoreInteractionControls: true,
         });
       }
-    } catch (err) {
-      loadFailedSynchronously = failPermissionBubble(
-        `Permission bubble failed to load: ${err && err.message ? err.message : String(err)}`
-      );
     }
-    if (loadFailedSynchronously) return;
-
-    // macOS: set alwaysOnTop BEFORE showInactive to prevent bubble from sinking.
-    // (Text-input bubbles later drop out of always-on-top per-edit — and skip the
-    // native SkyLight path — so their IME candidate window can surface; that's
-    // handled by handleImeEditing + reapplyMacVisibility, not a lower level here.)
-    if (isMac) {
-      bub.setAlwaysOnTop(true, MAC_TOPMOST_LEVEL);
-    }
-
-    repositionBubbles();
-    bub.showInactive();
-    repositionDependentBubbles();
-    keepOutOfTaskbar(bub);
-    // macOS: defer full visibility restoration to avoid activating Clawd
-    if (isMac) deferMacFloatingVisibility(ctx, bub);
-    else ctx.reapplyMacVisibility();
-
-    ctx.guardAlwaysOnTop(bub);
-    syncPermissionShortcuts();
-
-    armPermissionAutoCloseTimer(permEntry);
-  } catch (createErr) {
-    try { bub.removeAllListeners("closed"); } catch {}
-    try { bub.destroy(); } catch {}
-    permissionBubbleWindows.delete(bub);
-    permEntry.bubble = null;
-    throw createErr;
+    return;
   }
+  if (permissionSurface.window !== win) {
+    permissionBubbleWindows.delete(win);
+    return;
+  }
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (expected) {
+    clearPermissionSurfaceWindow(win);
+    return;
+  }
+  if (userInitiatedClose) {
+    clearPermissionSurfaceWindow(win);
+    if (active && pendingPermissions.includes(active)) {
+      resolvePermissionEntry(active, behaviorForUserClosedEntry(active), "Bubble window closed by user");
+    } else {
+      syncPermissionSurface("user-close-empty");
+    }
+    return;
+  }
+  handleServingSurfaceFailure(win, "Permission bubble window closed unexpectedly");
+}
+
+function createPermissionSurfaceWindow(nativeMode, role = "serving") {
+  const wa = getAnchorWorkArea();
+  const scale = getTextScale(wa);
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  const sugCount = active ? (active.suggestions || []).length : 0;
+  const height = clampBubbleHeight(scaleHeight(estimateBubbleHeight(sugCount), scale), wa.height);
+  let bub = null;
+  try {
+    bub = new BrowserWindow({
+      width: getBubbleWidth(scale, wa),
+      height,
+      x: 0,
+      y: 0,
+      show: false,
+      frame: false,
+      transparent: true,
+      alwaysOnTop: !isMac,
+      resizable: false,
+      skipTaskbar: true,
+      hasShadow: false,
+      ...(isLinux ? { type: LINUX_WINDOW_TYPE } : {}),
+      ...(isMac ? { type: "panel", acceptFirstMouse: true } : {}),
+      focusable: isMac ? true : nativeMode === "text-input",
+      webPreferences: {
+        preload: path.join(__dirname, "preload-bubble.js"),
+        nodeIntegration: false,
+        contextIsolation: true,
+      },
+    });
+    if (role === "handover") {
+      if (!permissionSurface.handover) throw new Error("Missing permission surface handover owner");
+      permissionSurface.handover.window = bub;
+    } else {
+      permissionSurface.window = bub;
+      permissionSurface.ready = false;
+      permissionBubbleWindows.add(bub);
+    }
+    if (isMac && nativeMode === "text-input") bub.__clawdMacTextInputBubble = true;
+    if (isWin) bub.setAlwaysOnTop(true, WIN_TOPMOST_LEVEL);
+    if (isMac) bub.setAlwaysOnTop(true, MAC_TOPMOST_LEVEL);
+    let userInitiatedClose = false;
+    bub.on("close", () => {
+      if (!permissionSurface.expectedDestroyWindows.has(bub)) userInitiatedClose = true;
+    });
+    bub.on("closed", () => onPermissionSurfaceClosed(bub, userInitiatedClose));
+    bub.webContents.once("did-finish-load", () => {
+      applyZoomToWindow(bub, getTextScale(getAnchorWorkArea()));
+      if (permissionSurface.handover && permissionSurface.handover.window === bub) {
+        const target = getSurfaceEntryById(permissionSurface.handover.toActiveEntryId);
+        if (!target) {
+          failPermissionSurfaceHandover(bub, "target no longer pending");
+          return;
+        }
+        permissionSurface.handover.ready = true;
+        const payload = sendPermissionSurfacePayload(bub, target, {
+          activeContentRevision: permissionSurface.handover.activeContentRevision,
+        });
+        if (payload) permissionSurface.handover.surfaceRevision = payload.surfaceRevision;
+        return;
+      }
+      if (permissionSurface.window !== bub) return;
+      permissionSurface.ready = true;
+      syncPermissionSurface("did-finish-load");
+    });
+    bub.webContents.once("did-fail-load", (_event, errorCode, errorDescription) => {
+      const reason = `Permission bubble failed to load (${errorCode || "unknown"}: ${errorDescription || "unknown error"})`;
+      if (!failPermissionSurfaceHandover(bub, reason)) handleServingSurfaceFailure(bub, reason);
+    });
+    bub.webContents.on("render-process-gone", (_event, details) => {
+      const reason = `Permission bubble renderer exited (${details?.reason || "unknown"})`;
+      if (!failPermissionSurfaceHandover(bub, reason)) handleServingSurfaceFailure(bub, reason);
+    });
+    const loadResult = bub.loadFile(path.join(__dirname, "bubble.html"));
+    if (loadResult && typeof loadResult.catch === "function") {
+      loadResult.catch((err) => {
+        const reason = `Permission bubble failed to load: ${err?.message || String(err)}`;
+        if (!failPermissionSurfaceHandover(bub, reason)) handleServingSurfaceFailure(bub, reason);
+      });
+    }
+    keepOutOfTaskbar(bub);
+    ctx.guardAlwaysOnTop(bub);
+    return bub;
+  } catch (err) {
+    if (bub) {
+      permissionSurface.expectedDestroyWindows.add(bub);
+      try { bub.destroy(); } catch {}
+      permissionBubbleWindows.delete(bub);
+      if (permissionSurface.window === bub) clearPermissionSurfaceWindow(bub);
+      if (permissionSurface.handover?.window === bub) permissionSurface.handover.window = null;
+    }
+    throw err;
+  }
+}
+
+function beginPermissionSurfaceHandover(targetEntry) {
+  const current = getSurfaceEntryById(permissionSurface.activeEntryId);
+  const fromActiveEntryId = current?.surfaceEntryId || permissionSurface.activeEntryId;
+  if (!fromActiveEntryId || !permissionSurface.window || permissionSurface.handover) return false;
+  const nativeMode = getPermissionNativeMode(targetEntry);
+  const handover = {
+    window: null,
+    ready: false,
+    fromActiveEntryId,
+    toActiveEntryId: targetEntry.surfaceEntryId,
+    nativeMode,
+    surfaceRevision: null,
+    activeContentRevision: permissionSurface.activeContentRevision + 1,
+  };
+  permissionSurface.handover = handover;
+  try {
+    createPermissionSurfaceWindow(nativeMode, "handover");
+    return true;
+  } catch (err) {
+    permissionSurface.handover = null;
+    permLog(`permission surface handover create failed: ${err?.message || String(err)}`);
+    if (current && permissionSurface.window && permissionSurface.ready) {
+      sendPermissionSurfacePayload(permissionSurface.window, current, {
+        restoreInteractionControls: true,
+      });
+    } else if (pendingPermissions.includes(targetEntry)) {
+      handlePermissionBubbleFailure(targetEntry, "Permission bubble mode switch failed");
+    }
+    return false;
+  }
+}
+
+function schedulePermissionSurfaceExit({ destroy }) {
+  const win = permissionSurface.window;
+  if (!win || win.isDestroyed()) return;
+  try { win.webContents?.send("permission-hide"); } catch {}
+  if (permissionSurface.hideTimer) clearTimeout(permissionSurface.hideTimer);
+  permissionSurface.hideTimer = setTimeout(() => {
+    permissionSurface.hideTimer = null;
+    if (permissionSurface.window !== win || win.isDestroyed()) return;
+    if (destroy) {
+      permissionSurface.expectedDestroyWindows.add(win);
+      clearPermissionSurfaceWindow(win);
+      try { win.destroy(); } catch {}
+    } else {
+      try { win.hide(); } catch {}
+    }
+    syncPermissionShortcuts();
+    repositionDependentBubbles();
+  }, 250);
+}
+
+function syncPermissionSurface(reason = "sync", options = {}) {
+  if (surfaceFailureSweepActive) return false;
+  const entries = getSurfaceEligibleEntries();
+  const hasSuppressedEntries = pendingPermissions.some((entry) => entry?.surfaceEligible && isSurfaceEntrySuppressed(entry));
+  if (entries.length === 0) {
+    permissionSurface.deliveryEntryIds = new Set();
+    if (!hasSuppressedEntries) permissionSurface.activeEntryId = null;
+    if (permissionSurface.window) schedulePermissionSurfaceExit({ destroy: !hasSuppressedEntries });
+    syncPermissionShortcuts();
+    return false;
+  }
+
+  if (permissionSurface.hideTimer) {
+    clearTimeout(permissionSurface.hideTimer);
+    permissionSurface.hideTimer = null;
+  }
+  let target = options.targetEntry && entries.includes(options.targetEntry)
+    ? options.targetEntry
+    : selectSurfaceActiveEntry(entries);
+  if (!target) return false;
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  const targetMode = getPermissionNativeMode(target);
+
+  if (permissionSurface.window && !permissionSurface.window.isDestroyed()
+      && permissionSurface.nativeMode && permissionSurface.nativeMode !== targetMode) {
+    if (!permissionSurface.handover || permissionSurface.handover.toActiveEntryId !== target.surfaceEntryId) {
+      beginPermissionSurfaceHandover(target);
+    }
+    return true;
+  }
+
+  if (!permissionSurface.window || permissionSurface.window.isDestroyed()) {
+    permissionSurface.activeEntryId = target.surfaceEntryId;
+    permissionSurface.activeContentRevision += 1;
+    permissionSurface.nativeMode = targetMode;
+    permissionSurface.deliveryEntryIds = new Set(entries.map((entry) => entry.surfaceEntryId));
+    try {
+      createPermissionSurfaceWindow(targetMode, "serving");
+    } catch (err) {
+      const reason = `Permission bubble failed to create: ${err?.message || String(err)}`;
+      surfaceFailureSweepActive = true;
+      try {
+        for (const entry of entries) {
+          if (pendingPermissions.includes(entry)) handlePermissionBubbleFailure(entry, reason);
+        }
+      } finally {
+        surfaceFailureSweepActive = false;
+      }
+      syncPermissionShortcuts();
+      repositionDependentBubbles();
+      return false;
+    }
+    syncPermissionShortcuts();
+    return true;
+  }
+
+  const activeChanged = !active || active.surfaceEntryId !== target.surfaceEntryId;
+  if (activeChanged) {
+    clearPermissionSurfaceImeEditing();
+    permissionSurface.activeEntryId = target.surfaceEntryId;
+    permissionSurface.activeContentRevision += 1;
+    permissionSurface.measuredHeight = 0;
+  } else if (options.activeContentChanged === true) {
+    permissionSurface.activeContentRevision += 1;
+  }
+  if (!permissionSurface.ready) return true;
+  sendPermissionSurfacePayload(permissionSurface.window, target, {
+    restoreInteractionControls: options.restoreInteractionControls === true,
+  });
+  repositionBubbles();
+  repositionDependentBubbles();
+  syncPermissionShortcuts();
+  return true;
+}
+
+function showPermissionBubble(permEntry) {
+  if (maybeAutoApprovePermission(permEntry)) return;
+  ensureSurfaceEntryIdentity(permEntry);
+  permEntry.surfaceEligible = true;
+  syncPermissionSurface("show", { targetEntry: selectSurfaceActiveEntry(getSurfaceEligibleEntries()) });
+  armPermissionAutoCloseTimer(permEntry);
 }
 // Autoclose: set up the dismiss-without-decision timer for a single pending
 // permission. Passive notification entries (codex/kimi) own their own
@@ -1328,6 +1630,7 @@ function notifyPermissionsChanged(reason) {
       permLog(`syncImeEditingPetDodge failed: ${err && err.message ? err.message : err}`);
     }
   }
+  syncPermissionSurface(reason || "permissions-changed");
   if (typeof ctx.onPermissionsChanged !== "function") return;
   try {
     ctx.onPermissionsChanged(reason);
@@ -1438,11 +1741,16 @@ function buildPermissionBubblePayload(permEntry) {
   };
 }
 
+function refreshPermissionEntry(permEntry) {
+  if (!permEntry || !pendingPermissions.includes(permEntry) || permEntry.surfaceEligible !== true) return false;
+  const isActive = permEntry.surfaceEntryId === permissionSurface.activeEntryId;
+  return syncPermissionSurface("entry-refresh", {
+    activeContentChanged: isActive,
+  });
+}
+
 function syncPermissionBubbleContent(permEntry) {
-  const bub = permEntry && permEntry.bubble;
-  if (!bub || bub.isDestroyed() || !permEntry.bubbleReady) return false;
-  bub.webContents.send("permission-show", buildPermissionBubblePayload(permEntry));
-  return true;
+  return refreshPermissionEntry(permEntry);
 }
 
 function beginSessionTrustConfirmation(permEntry) {
@@ -1911,52 +2219,9 @@ function cancelRemoteApproval(permEntry, options = {}) {
 // A renderer crash may leave the BrowserWindow alive while webContents is
 // already gone, so never assume either object can still receive IPC.
 function hidePermissionBubbleSafely(permEntry) {
-  const bub = permEntry && permEntry.bubble;
-  if (!bub) return false;
-
-  let bubbleDestroyed = false;
-  try {
-    bubbleDestroyed = typeof bub.isDestroyed === "function" && bub.isDestroyed();
-  } catch (err) {
-    permLog(`permission bubble state check failed: ${err && err.message ? err.message : String(err)}`);
-    bubbleDestroyed = true;
-  }
-  if (bubbleDestroyed) return false;
-
-  try {
-    const bubbleContents = bub.webContents;
-    if (
-      bubbleContents
-      && typeof bubbleContents.send === "function"
-      && (
-        typeof bubbleContents.isDestroyed !== "function"
-        || !bubbleContents.isDestroyed()
-      )
-    ) {
-      bubbleContents.send("permission-hide");
-    }
-  } catch (err) {
-    permLog(`permission bubble hide failed: ${err && err.message ? err.message : String(err)}`);
-  }
-
-  if (permEntry.hideTimer) clearTimeout(permEntry.hideTimer);
-  permEntry.hideTimer = setTimeout(() => {
-    try {
-      if (
-        bub
-        && (
-          typeof bub.isDestroyed !== "function"
-          || !bub.isDestroyed()
-        )
-        && typeof bub.destroy === "function"
-      ) {
-        bub.destroy();
-      }
-    } catch (err) {
-      permLog(`permission bubble destroy failed: ${err && err.message ? err.message : String(err)}`);
-    }
-  }, 250);
-  return true;
+  if (permEntry) permEntry.surfaceEligible = false;
+  syncPermissionSurface("entry-hidden");
+  return !!permissionSurface.window;
 }
 
 // A remote-only entry (bubbles disabled, decided over Feishu/Telegram) has no
@@ -2366,9 +2631,10 @@ function applyPermissionSuggestion(perm, index, options = {}) {
   // Minimum display time: if bubble just appeared and dismiss is automatic
   // (client disconnect / terminal answer), delay so user can see it briefly
   const MIN_BUBBLE_DISPLAY_MS = 2000;
-  const age = Date.now() - (permEntry.createdAt || 0);
+  const age = Date.now() - (permEntry.firstActivePresentedAt || permEntry.createdAt || 0);
   const isAutoResolve = message === "Client disconnected";
-  if (isAutoResolve && permEntry.bubble && age < MIN_BUBBLE_DISPLAY_MS && !permEntry._delayedResolve) {
+  if (isAutoResolve && Number.isFinite(permEntry.firstActivePresentedAt)
+      && age < MIN_BUBBLE_DISPLAY_MS && !permEntry._delayedResolve) {
     permEntry._delayedResolve = true;
     permEntry._delayTimer = setTimeout(() => resolvePermissionEntry(permEntry, behavior, message), MIN_BUBBLE_DISPLAY_MS - age);
     return;
@@ -2778,23 +3044,156 @@ function sendHermesPermissionResponse(res, responseObj) {
   return true;
 }
 
-function handleBubbleHeight(event, height) {
-  const senderWin = BrowserWindow.fromWebContents(event.sender);
-  const perm = pendingPermissions.find(p => p.bubble === senderWin);
-  if (perm && typeof height === "number" && height > 0) {
-    perm.measuredHeight = Math.ceil(height);
-    // revealCard() reports height on the next animation frame, so this is the
-    // first main-process acknowledgement that the exact interaction was loaded,
-    // received through permission-show, rendered, and made visible. Announcing
-    // earlier (even at did-finish-load) can strand an unretractable Slack card
-    // when content sync or the renderer fails. Later resize reports are safe:
-    // announceSlackPermission is once-guarded per entry.
-    announceSlackPermission(perm);
-    // Geometry updates happen after the delivery acknowledgement. If either
-    // reflow throws, the already-rendered card must still be announced.
-    repositionBubbles();
-    repositionDependentBubbles();
+function normalizeSurfaceHeightReport(payload) {
+  if (typeof payload === "number") {
+    return {
+      height: payload,
+      surfaceRevision: null,
+      activeEntryId: null,
+      entryIds: null,
+    };
   }
+  if (!payload || typeof payload !== "object") return null;
+  return {
+    height: payload.height,
+    surfaceRevision: Number.isFinite(payload.surfaceRevision) ? payload.surfaceRevision : null,
+    activeEntryId: typeof payload.activeEntryId === "string" ? payload.activeEntryId : null,
+    entryIds: Array.isArray(payload.entryIds)
+      ? payload.entryIds.filter((entryId) => typeof entryId === "string")
+      : null,
+  };
+}
+
+function isSurfaceReportCurrent(report, expectedRevision, expectedActiveEntryId) {
+  if (!report) return false;
+  if (!Number.isFinite(Number(report.height)) || Number(report.height) <= 0) return false;
+  if (report.surfaceRevision !== null && report.surfaceRevision !== expectedRevision) return false;
+  if (report.activeEntryId !== null && report.activeEntryId !== expectedActiveEntryId) return false;
+  return true;
+}
+
+function acknowledgeSurfaceEntries(entryIds) {
+  for (const entryId of entryIds) {
+    const entry = getSurfaceEntryById(entryId);
+    if (!entry || entry.surfaceEligible !== true || isSurfaceEntrySuppressed(entry)) continue;
+    announceSlackPermission(entry);
+  }
+}
+
+function showMeasuredPermissionSurface(win, activeEntry, surfaceRevision, entryIds) {
+  if (!win || win.isDestroyed() || !activeEntry) return false;
+  // The renderer acknowledgement is authoritative even if a subsequent
+  // platform geometry operation fails. Slack is once-guarded per entry.
+  acknowledgeSurfaceEntries(entryIds);
+  repositionBubbles();
+  try {
+    win.showInactive();
+    keepOutOfTaskbar(win);
+  } catch (err) {
+    handleServingSurfaceFailure(win, `Permission bubble failed to show: ${err?.message || String(err)}`);
+    return false;
+  }
+  if (!Number.isFinite(activeEntry.firstActivePresentedAt)) {
+    activeEntry.firstActivePresentedAt = Date.now();
+  }
+  permissionSurface.pendingShowRevision = permissionSurface.pendingShowRevision === surfaceRevision
+    ? null
+    : permissionSurface.pendingShowRevision;
+  if (isMac) deferMacFloatingVisibility(ctx, win);
+  else if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
+  if (getEntryCapabilities(activeEntry).answerQuestions === true && typeof win.focus === "function") {
+    try { win.focus(); } catch {}
+  }
+  repositionDependentBubbles();
+  syncPermissionShortcuts();
+  return true;
+}
+
+function commitPermissionSurfaceHandover(win, report) {
+  const handover = permissionSurface.handover;
+  if (!handover || handover.window !== win) return false;
+  const target = getSurfaceEntryById(handover.toActiveEntryId);
+  if (
+    permissionSurface.activeEntryId !== handover.fromActiveEntryId
+    || !target
+    || !getSurfaceEligibleEntries().includes(target)
+    || getPermissionNativeMode(target) !== handover.nativeMode
+  ) {
+    failPermissionSurfaceHandover(win, "handover state changed before renderer acknowledgement");
+    return false;
+  }
+  if (!isSurfaceReportCurrent(report, handover.surfaceRevision, target.surfaceEntryId)) return false;
+  // The old serving surface may have received a queue-only refresh while the
+  // hidden candidate was loading. Republish the latest queue to the candidate
+  // and wait for its matching acknowledgement before swapping windows.
+  if (handover.surfaceRevision !== permissionSurface.surfaceRevision) {
+    const payload = sendPermissionSurfacePayload(win, target, {
+      activeContentRevision: handover.activeContentRevision,
+    });
+    if (payload) handover.surfaceRevision = payload.surfaceRevision;
+    return false;
+  }
+
+  const oldWindow = permissionSurface.window;
+  const deliveredEntryIds = report.entryIds || getSurfaceEligibleEntries().map((entry) => entry.surfaceEntryId);
+  permissionSurface.handover = null;
+  permissionSurface.window = win;
+  permissionSurface.ready = true;
+  permissionSurface.nativeMode = handover.nativeMode;
+  permissionSurface.activeEntryId = target.surfaceEntryId;
+  permissionSurface.activeContentRevision = handover.activeContentRevision;
+  permissionSurface.measuredHeight = Math.ceil(Number(report.height));
+  permissionSurface.deliveryEntryIds = new Set(deliveredEntryIds);
+  permissionSurface.pendingShowRevision = handover.surfaceRevision;
+  permissionBubbleWindows.add(win);
+
+  clearPermissionSurfaceImeEditing(oldWindow);
+  try { if (oldWindow && !oldWindow.isDestroyed()) oldWindow.hide(); } catch {}
+  if (!showMeasuredPermissionSurface(win, target, handover.surfaceRevision, deliveredEntryIds)) return false;
+
+  if (oldWindow && oldWindow !== win) {
+    permissionSurface.expectedDestroyWindows.add(oldWindow);
+    try { if (!oldWindow.isDestroyed()) oldWindow.destroy(); } catch {}
+  }
+
+  const currentEntryIds = getSurfaceEligibleEntries().map((entry) => entry.surfaceEntryId);
+  if (
+    currentEntryIds.length !== deliveredEntryIds.length
+    || currentEntryIds.some((entryId, index) => entryId !== deliveredEntryIds[index])
+  ) {
+    syncPermissionSurface("handover-queue-refresh");
+  }
+  return true;
+}
+
+function handleBubbleHeight(event, payload) {
+  const senderWin = BrowserWindow.fromWebContents(event.sender);
+  const report = normalizeSurfaceHeightReport(payload);
+  if (!senderWin || !report) return;
+  if (permissionSurface.handover && permissionSurface.handover.window === senderWin) {
+    commitPermissionSurfaceHandover(senderWin, report);
+    return;
+  }
+  if (permissionSurface.window !== senderWin || !permissionSurface.ready) return;
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (!active || !isSurfaceReportCurrent(report, permissionSurface.surfaceRevision, active.surfaceEntryId)) return;
+
+  permissionSurface.measuredHeight = Math.ceil(Number(report.height));
+  const deliveredEntryIds = [...permissionSurface.deliveryEntryIds];
+  // revealCard() reports height on the next animation frame, so this is the
+  // renderer acknowledgement for the entire currently delivered surface.
+  if (permissionSurface.pendingShowRevision === permissionSurface.surfaceRevision) {
+    showMeasuredPermissionSurface(
+      senderWin,
+      active,
+      permissionSurface.surfaceRevision,
+      deliveredEntryIds
+    );
+    return;
+  }
+  acknowledgeSurfaceEntries(deliveredEntryIds);
+  repositionBubbles();
+  repositionDependentBubbles();
 }
 
 // macOS only: while a text input inside the bubble is focused, the bubble must
@@ -2806,14 +3205,21 @@ function handleBubbleHeight(event, height) {
 // through one place (topmost-runtime.js) instead of being hand-rolled twice.
 // The renderer clears the flag on element blur AND on window blur (e.g. Cmd-Tab
 // away mid-composition), so it can't get stuck and strand the bubble.
-function handleImeEditing(event, editing) {
+function handleImeEditing(event, payload) {
   if (!isMac) return;
   const senderWin = BrowserWindow.fromWebContents(event.sender);
-  const perm = pendingPermissions.find(p => p.bubble === senderWin);
-  if (!perm || !perm.bubble || perm.bubble.isDestroyed()) return;
-  const wasEditing = perm.bubble.__clawdMacImeEditing === true;
-  if (editing) perm.bubble.__clawdMacImeEditing = true;
-  else delete perm.bubble.__clawdMacImeEditing;
+  if (!senderWin || permissionSurface.window !== senderWin || senderWin.isDestroyed()) return;
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (!active) return;
+  const isEnvelope = payload && typeof payload === "object";
+  if (isEnvelope) {
+    if (payload.entryId !== active.surfaceEntryId) return;
+    if (payload.activeContentRevision !== permissionSurface.activeContentRevision) return;
+  }
+  const editing = isEnvelope ? payload.editing === true : payload === true;
+  const wasEditing = senderWin.__clawdMacImeEditing === true;
+  if (editing) senderWin.__clawdMacImeEditing = true;
+  else delete senderWin.__clawdMacImeEditing;
   if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
   if (!editing && wasEditing) {
     if (typeof ctx.repositionFloatingBubbles === "function") {
@@ -2841,12 +3247,65 @@ function handleBubbleRendererGone(bubble) {
   if (typeof ctx.reapplyMacVisibility === "function") ctx.reapplyMacVisibility();
 }
 
-function handleDecide(event, behavior) {
-  // Identify which permission this bubble belongs to via sender webContents
+function recoverPermissionSurfaceInteraction() {
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (!active || !permissionSurface.window || !permissionSurface.ready) return;
+  sendPermissionSurfacePayload(permissionSurface.window, active, {
+    restoreInteractionControls: true,
+  });
+}
+
+function getCurrentSurfaceInteraction(event, payload) {
   const senderWin = BrowserWindow.fromWebContents(event.sender);
-  const perm = pendingPermissions.find(p => p.bubble === senderWin);
-  permLog(`IPC permission-decide: behavior=${behavior} matched=${!!perm}`);
-  if (!perm) return;
+  const perm = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (!senderWin || senderWin !== permissionSurface.window || !permissionSurface.ready || !perm) return null;
+  const isEnvelope = payload
+    && typeof payload === "object"
+    && Object.prototype.hasOwnProperty.call(payload, "behavior");
+  if (isEnvelope) {
+    if (payload.entryId !== perm.surfaceEntryId) return null;
+    if (payload.activeContentRevision !== permissionSurface.activeContentRevision) return null;
+  }
+  return {
+    perm,
+    behavior: isEnvelope ? payload.behavior : payload,
+  };
+}
+
+function handleSelect(event, payload) {
+  const senderWin = BrowserWindow.fromWebContents(event.sender);
+  const active = getSurfaceEntryById(permissionSurface.activeEntryId);
+  if (!senderWin || senderWin !== permissionSurface.window || !permissionSurface.ready || !active) return;
+  if (!payload || typeof payload !== "object") {
+    recoverPermissionSurfaceInteraction();
+    return;
+  }
+  const target = getSurfaceEntryById(payload.targetEntryId);
+  const valid = payload.observedActiveEntryId === active.surfaceEntryId
+    && payload.activeContentRevision === permissionSurface.activeContentRevision
+    && target
+    && getSurfaceEligibleEntries().includes(target)
+    && !isSurfaceSwitchingLocked(active);
+  if (!valid) {
+    recoverPermissionSurfaceInteraction();
+    return;
+  }
+  if (target === active) {
+    recoverPermissionSurfaceInteraction();
+    return;
+  }
+  syncPermissionSurface("manual-select", { targetEntry: target });
+}
+
+function handleDecide(event, payload) {
+  const interaction = getCurrentSurfaceInteraction(event, payload);
+  const behaviorForLog = interaction ? interaction.behavior : payload;
+  permLog(`IPC permission-decide: behavior=${String(behaviorForLog)} matched=${!!interaction}`);
+  if (!interaction) {
+    recoverPermissionSurfaceInteraction();
+    return;
+  }
+  const { perm, behavior } = interaction;
   if (perm.isCodexUserInputNotify) {
     dismissPassiveNotify(perm, "ipc-decide");
     if (behavior === "codex-user-input-focus" && !perm.host) {
@@ -3514,6 +3973,40 @@ function clearKimiNotifyBubbles(sessionId, reason = sessionId ? "kimi-session-re
   for (const perm of toRemove) dismissPassiveNotify(perm, reason);
 }
 
+function getPermissionBubbleWindows() {
+  const windows = [];
+  if (permissionSurface.window && !permissionSurface.window.isDestroyed()) {
+    windows.push(permissionSurface.window);
+  }
+  const candidate = permissionSurface.handover?.window;
+  if (candidate && candidate !== permissionSurface.window && !candidate.isDestroyed()) {
+    windows.push(candidate);
+  }
+  return windows;
+}
+
+function getPermissionSurfaceWindow() {
+  return permissionSurface.window && !permissionSurface.window.isDestroyed()
+    ? permissionSurface.window
+    : null;
+}
+
+function setPermissionPetHidden(hidden) {
+  const targetHidden = hidden === true;
+  if (targetHidden === permissionSurface.petHidden) return false;
+  permissionSurface.petHidden = targetHidden;
+  if (targetHidden) {
+    const ordinals = pendingPermissions
+      .filter((entry) => entry?.surfaceEligible === true && Number.isFinite(entry.surfaceOrdinal))
+      .map((entry) => entry.surfaceOrdinal);
+    permissionSurface.petHiddenCutoffOrdinal = ordinals.length ? Math.max(...ordinals) : null;
+  } else {
+    permissionSurface.petHiddenCutoffOrdinal = null;
+  }
+  syncPermissionSurface(targetHidden ? "pet-hidden" : "pet-shown");
+  return true;
+}
+
 function cleanup() {
   // Unregister hotkeys
   if (registeredAllowAccel !== null) {
@@ -3531,13 +4024,33 @@ function cleanup() {
   // behalf. Each protocol gets its normal no-decision fallback: bodyless
   // replies for supported hooks, socket close for Claude/CodeBuddy, and no
   // bridge reply for opencode-family requests.
-  for (const perm of [...pendingPermissions]) {
-    if (perm._delayTimer) clearTimeout(perm._delayTimer);
-    if (perm.autoExpireTimer) clearTimeout(perm.autoExpireTimer);
-    if (isPassiveNotifyEntry(perm)) dismissPassiveNotify(perm, "Clawd is quitting");
-    else dismissInteractivePermissionWithoutDecision(perm, "Clawd is quitting");
+  surfaceFailureSweepActive = true;
+  try {
+    for (const perm of [...pendingPermissions]) {
+      if (perm._delayTimer) clearTimeout(perm._delayTimer);
+      if (perm.autoExpireTimer) clearTimeout(perm.autoExpireTimer);
+      if (isPassiveNotifyEntry(perm)) dismissPassiveNotify(perm, "Clawd is quitting");
+      else dismissInteractivePermissionWithoutDecision(perm, "Clawd is quitting");
+    }
+  } finally {
+    surfaceFailureSweepActive = false;
+  }
+  if (permissionSurface.hideTimer) {
+    clearTimeout(permissionSurface.hideTimer);
+    permissionSurface.hideTimer = null;
+  }
+  for (const bubble of getPermissionBubbleWindows()) {
+    permissionSurface.expectedDestroyWindows.add(bubble);
+    try { bubble.destroy(); } catch {}
   }
   permissionBubbleWindows.clear();
+  permissionSurface.window = null;
+  permissionSurface.handover = null;
+  permissionSurface.ready = false;
+  permissionSurface.nativeMode = null;
+  permissionSurface.activeEntryId = null;
+  permissionSurface.measuredHeight = 0;
+  permissionSurface.deliveryEntryIds = new Set();
 }
 
 return {
@@ -3548,13 +4061,14 @@ return {
   addPendingPermission, removePendingPermission,
   isPermissionEntryLive, canAutoResolvePendingPermission,
   beginSessionTrustConfirmation, endSessionTrustConfirmation,
-  syncPermissionBubbleContent,
+  syncPermissionBubbleContent, refreshPermissionEntry,
   maybeStartRemoteApproval,
   dismissPermissionForTerminal,
   // Test seam: lets wire-level tests pin which provenance flags reach the
   // renderer (isHermes suppresses the go-to-terminal action — issue #689).
   buildPermissionBubblePayload,
-  handleBubbleHeight, handleDecide, handleImeEditing, handleBubbleRendererGone, cleanup,
+  handleBubbleHeight, handleDecide, handleSelect, handleImeEditing, handleBubbleRendererGone, cleanup,
+  getPermissionBubbleWindows, getPermissionSurfaceWindow, setPermissionPetHidden,
   showCodexNotifyBubble, clearCodexNotifyBubbles,
   showCodexUserInputBubble, clearCodexUserInputBubbles,
   showKimiNotifyBubble, clearKimiNotifyBubbles,
@@ -3592,4 +4106,5 @@ module.exports.__test = {
   remapIndexedElicitationAnswers,
   validateAndRemapIndexedElicitationAnswers,
   collectVisibleWindowBounds,
+  computePermissionBubbleWidth,
 };

--- a/src/preload-bubble.js
+++ b/src/preload-bubble.js
@@ -1,9 +1,47 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
+let surfaceMeta = {
+  surfaceRevision: null,
+  activeContentRevision: null,
+  activeEntryId: null,
+  entryIds: [],
+};
+
+function updateSurfaceMeta(data) {
+  if (!data || typeof data !== "object") return;
+  surfaceMeta = {
+    surfaceRevision: data.surfaceRevision,
+    activeContentRevision: data.activeContentRevision,
+    activeEntryId: data.activeEntryId,
+    entryIds: Array.isArray(data.entryIds) ? [...data.entryIds] : [],
+  };
+}
+
 contextBridge.exposeInMainWorld("bubbleAPI", {
-  onPermissionShow: (cb) => ipcRenderer.on("permission-show", (_, data) => cb(data)),
-  decide: (behavior) => ipcRenderer.send("permission-decide", behavior),
+  onPermissionShow: (cb) => ipcRenderer.on("permission-show", (_, data) => {
+    updateSurfaceMeta(data);
+    cb(data);
+  }),
+  decide: (behavior) => ipcRenderer.send("permission-decide", {
+    behavior,
+    entryId: surfaceMeta.activeEntryId,
+    activeContentRevision: surfaceMeta.activeContentRevision,
+  }),
+  select: (targetEntryId) => ipcRenderer.send("permission-select", {
+    targetEntryId,
+    observedActiveEntryId: surfaceMeta.activeEntryId,
+    activeContentRevision: surfaceMeta.activeContentRevision,
+  }),
   onPermissionHide: (cb) => ipcRenderer.on("permission-hide", () => cb()),
-  reportHeight: (h) => ipcRenderer.send("bubble-height", h),
-  setImeEditing: (editing) => ipcRenderer.send("bubble-ime-editing", !!editing),
+  reportHeight: (height) => ipcRenderer.send("bubble-height", {
+    height,
+    surfaceRevision: surfaceMeta.surfaceRevision,
+    activeEntryId: surfaceMeta.activeEntryId,
+    entryIds: [...surfaceMeta.entryIds],
+  }),
+  setImeEditing: (editing) => ipcRenderer.send("bubble-ime-editing", {
+    editing: !!editing,
+    entryId: surfaceMeta.activeEntryId,
+    activeContentRevision: surfaceMeta.activeContentRevision,
+  }),
 });

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -1385,9 +1385,6 @@ function handlePermissionPost(req, res, options) {
         // failure leaves nothing behind.
         const rollbackZcodePermission = (reason) => {
           removePendingPermission(ctx, permEntry, reason);
-          if (permEntry.bubble) {
-            try { permEntry.bubble.destroy(); } catch {}
-          }
           if (permEntry.hideTimer) {
             try { clearTimeout(permEntry.hideTimer); } catch {}
           }
@@ -1680,10 +1677,6 @@ function handlePermissionPost(req, res, options) {
 
         const rollbackDshPermission = (reason) => {
           removePendingPermission(ctx, permEntry, reason);
-          if (permEntry.bubble && !permEntry.bubble.isDestroyed()) {
-            try { permEntry.bubble.destroy(); } catch {}
-          }
-          permEntry.bubble = null;
           if (permEntry.autoCloseTimer) {
             try { clearTimeout(permEntry.autoCloseTimer); } catch {}
             permEntry.autoCloseTimer = null;
@@ -1835,10 +1828,6 @@ function handlePermissionPost(req, res, options) {
             if (permEntry.abortHandler) res.removeListener("close", permEntry.abortHandler);
             if (permEntry.autoCloseTimer) { clearTimeout(permEntry.autoCloseTimer); permEntry.autoCloseTimer = null; }
             if (permEntry.hideTimer) { clearTimeout(permEntry.hideTimer); permEntry.hideTimer = null; }
-            if (permEntry.bubble && !permEntry.bubble.isDestroyed()) {
-              try { permEntry.bubble.destroy(); } catch {}
-            }
-            permEntry.bubble = null;
             sendHermesPermissionNoDecision(res);
             return;
           }
@@ -1901,10 +1890,6 @@ function handlePermissionPost(req, res, options) {
           if (permEntry.abortHandler) res.removeListener("close", permEntry.abortHandler);
           if (permEntry.autoCloseTimer) { clearTimeout(permEntry.autoCloseTimer); permEntry.autoCloseTimer = null; }
           if (permEntry.hideTimer) { clearTimeout(permEntry.hideTimer); permEntry.hideTimer = null; }
-          if (permEntry.bubble && !permEntry.bubble.isDestroyed()) {
-            try { permEntry.bubble.destroy(); } catch {}
-          }
-          permEntry.bubble = null;
           sendHermesPermissionNoDecision(res);
         }
         return;
@@ -2097,10 +2082,6 @@ function handlePermissionPost(req, res, options) {
           if (permEntry.abortHandler) res.removeListener("close", permEntry.abortHandler);
           if (permEntry.autoCloseTimer) { clearTimeout(permEntry.autoCloseTimer); permEntry.autoCloseTimer = null; }
           if (permEntry.hideTimer) { clearTimeout(permEntry.hideTimer); permEntry.hideTimer = null; }
-          if (permEntry.bubble && !permEntry.bubble.isDestroyed()) {
-            try { permEntry.bubble.destroy(); } catch {}
-          }
-          permEntry.bubble = null;
           ctx.sendPermissionResponse(res, "deny", "Elicitation bubble unavailable; answer in terminal", "Elicitation");
           return;
         }
@@ -2161,19 +2142,13 @@ function handlePermissionPost(req, res, options) {
         // abortHandler only fires on res close. Pop the entry explicitly and
         // destroy the socket so CC falls back to its built-in chat prompt
         // (non-blocking error per hooks doc) instead of hanging on a stale
-        // bubble that was never visible. showPermissionBubble assigns
-        // permEntry.bubble before loadFile/showInactive/reposition, so a
-        // throw after that point leaves a partially-constructed window —
-        // tear it down along with any timers we've armed.
+        // bubble that was never visible. The permission runtime owns its
+        // shared surface, so rollback removes only this failed entry.
         ctx.permLog(`bubble failed: ${bubbleErr && bubbleErr.message} -> drop connection, chat fallback`);
         removePendingPermission(ctx, permEntry, "bubble-failed");
         if (permEntry.abortHandler) res.removeListener("close", permEntry.abortHandler);
         if (permEntry.autoCloseTimer) { clearTimeout(permEntry.autoCloseTimer); permEntry.autoCloseTimer = null; }
         if (permEntry.hideTimer) { clearTimeout(permEntry.hideTimer); permEntry.hideTimer = null; }
-        if (permEntry.bubble && !permEntry.bubble.isDestroyed()) {
-          try { permEntry.bubble.destroy(); } catch {}
-        }
-        permEntry.bubble = null;
         try { res.destroy(); } catch {}
         return;
       }

--- a/src/session-automation-dialog-parent.js
+++ b/src/session-automation-dialog-parent.js
@@ -9,9 +9,18 @@ function usableWindow(candidate) {
   }
 }
 
-function selectSessionAutomationDialogParent({ entry, petWindow } = {}) {
-  const bubble = entry && entry.bubble;
-  if (usableWindow(bubble)) return bubble;
+function selectSessionAutomationDialogParent({ entry, permissionSurfaceWindow, petWindow } = {}) {
+  if (usableWindow(permissionSurfaceWindow)) {
+    try {
+      if (typeof permissionSurfaceWindow.isVisible !== "function" || permissionSurfaceWindow.isVisible()) {
+        return permissionSurfaceWindow;
+      }
+    } catch {}
+  }
+  // Compatibility for callers outside the shared-surface runtime. Production
+  // passes permissionSurfaceWindow and no longer assigns entry.bubble.
+  const legacyBubble = entry && entry.bubble;
+  if (usableWindow(legacyBubble)) return legacyBubble;
 
   // Dashboard requests carry the BrowserWindow resolved from the invoking
   // webContents. Parenting the native warning to the always-on-top pet leaves

--- a/src/topmost-runtime.js
+++ b/src/topmost-runtime.js
@@ -60,6 +60,9 @@ function createTopmostRuntime(options = {}) {
   const getWin = defaultGetter(options.getWin || null);
   const getHitWin = defaultGetter(options.getHitWin || null);
   const getPendingPermissions = options.getPendingPermissions || (() => []);
+  const getPermissionBubbleWindows = options.getPermissionBubbleWindows || (() => (
+    (getPendingPermissions() || []).map((entry) => entry && entry.bubble).filter(Boolean)
+  ));
   const getUpdateBubbleWindow = options.getUpdateBubbleWindow || (() => null);
   const getSessionHudWindow = options.getSessionHudWindow || (() => null);
   const getQuotaRingWindow = options.getQuotaRingWindow || (() => null);
@@ -251,9 +254,7 @@ function createTopmostRuntime(options = {}) {
 
     apply(getWin());
     apply(getHitWin());
-    for (const perm of getPendingPermissions()) {
-      apply(perm && perm.bubble);
-    }
+    for (const bubble of getPermissionBubbleWindows()) apply(bubble);
     apply(getUpdateBubbleWindow());
     apply(getSessionHudWindow());
     apply(getQuotaRingWindow());
@@ -276,9 +277,9 @@ function createTopmostRuntime(options = {}) {
   function petOverlapsTextInputBubble() {
     let petRect = null;
     let petRectComputed = false;
-    for (const perm of getPendingPermissions() || []) {
-      const bubble = perm && perm.bubble;
+    for (const bubble of getPermissionBubbleWindows() || []) {
       if (!isLiveWindow(bubble) || !bubble.__clawdMacTextInputBubble) continue;
+      if (typeof bubble.isVisible === "function" && !bubble.isVisible()) continue;
       if (typeof bubble.getBounds !== "function") continue;
       if (!petRectComputed) {
         const petBounds = getPetWindowBounds();
@@ -510,8 +511,7 @@ function createTopmostRuntime(options = {}) {
       // the interference stand-down exists to avoid (§8.3).
       if (!skipTopmost) recoverCloakedPet();
 
-      for (const perm of getPendingPermissions()) {
-        const bubble = perm && perm.bubble;
+      for (const bubble of getPermissionBubbleWindows()) {
         if (isLiveWindow(bubble) && bubble.isVisible()) {
           reassertWindowAndTaskbar(bubble);
         }

--- a/test/bubble-family-render.test.js
+++ b/test/bubble-family-render.test.js
@@ -62,6 +62,7 @@ function fakeEl(tag = "div") {
 function makeRenderer() {
   const byId = new Map();
   const decideCalls = [];
+  const selectCalls = [];
   const captured = { show: null, hide: null };
 
   const documentStub = {
@@ -82,6 +83,7 @@ function makeRenderer() {
       onPermissionShow(fn) { captured.show = fn; },
       onPermissionHide(fn) { captured.hide = fn; },
       decide(behavior) { decideCalls.push(behavior); },
+      select(entryId) { selectCalls.push(entryId); },
       reportHeight() {},
       setImeEditing() {},
     },
@@ -107,6 +109,7 @@ function makeRenderer() {
   return {
     show: captured.show,
     decideCalls,
+    selectCalls,
     el: (id) => byId.get(id) || fakeEl(),
   };
 }
@@ -229,5 +232,77 @@ describe("bubble-renderer family branch (executed)", () => {
     const r = makeRenderer();
     r.show(familyPayload({ familyDisplayName: null }));
     assert.ok(r.el("suggestions").children[0].title.includes("opencode"));
+  });
+});
+
+describe("bubble-renderer shared queue envelope (executed)", () => {
+  function envelope(active, overrides = {}) {
+    return {
+      surfaceRevision: 1,
+      activeContentRevision: 1,
+      activeEntryId: "entry-a",
+      active,
+      queue: [],
+      entryIds: ["entry-a"],
+      totalCount: 1,
+      activeIndex: 0,
+      switchingLocked: false,
+      restoreInteractionControls: false,
+      measureCeiling: 1600,
+      ...overrides,
+    };
+  }
+
+  it("renders two preview rows plus a complete drawer and routes row selection", () => {
+    const r = makeRenderer();
+    const active = familyPayload();
+    r.show(envelope(active, {
+      queue: [
+        { entryId: "entry-b", toolLabel: "Read", sessionLabel: "repo", summary: "a.txt" },
+        { entryId: "entry-c", toolLabel: "Bash", sessionLabel: "repo", summary: "npm test" },
+        { entryId: "entry-d", toolLabel: "Write", sessionLabel: "docs", summary: "plan.md" },
+      ],
+      entryIds: ["entry-a", "entry-b", "entry-c", "entry-d"],
+      totalCount: 4,
+    }));
+
+    assert.strictEqual(r.el("queuePreview").children.length, 2);
+    assert.strictEqual(r.el("queueDrawer").children.length, 3);
+    assert.strictEqual(r.el("queueMore").style.display, "");
+    r.el("queuePreview").children[0].click();
+    assert.deepStrictEqual(r.selectCalls, ["entry-b"]);
+  });
+
+  it("keeps queue-only updates from resetting the active detail", () => {
+    const r = makeRenderer();
+    const active = familyPayload({ toolInput: { command: "first" } });
+    r.show(envelope(active));
+    r.el("commandBlock").textContent = "draft sentinel";
+
+    r.show(envelope(active, {
+      surfaceRevision: 2,
+      queue: [{ entryId: "entry-b", toolLabel: "Read", sessionLabel: "repo", summary: "b.txt" }],
+      entryIds: ["entry-a", "entry-b"],
+      totalCount: 2,
+    }));
+
+    assert.strictEqual(r.el("commandBlock").textContent, "draft sentinel");
+    assert.strictEqual(r.el("queuePreview").children.length, 1);
+  });
+
+  it("disables switching and explains the lock while the active card owns input", () => {
+    const r = makeRenderer();
+    r.show(envelope(familyPayload(), {
+      switchingLocked: true,
+      queue: [{ entryId: "entry-b", toolLabel: "Bash", sessionLabel: "repo", summary: "queued" }],
+      entryIds: ["entry-a", "entry-b"],
+      totalCount: 2,
+    }));
+
+    const row = r.el("queuePreview").children[0];
+    assert.strictEqual(row.disabled, true);
+    row.click();
+    assert.deepStrictEqual(r.selectCalls, []);
+    assert.match(r.el("queueLockHint").textContent, /Finish the current input/);
   });
 });

--- a/test/bubble-format.test.js
+++ b/test/bubble-format.test.js
@@ -3,7 +3,14 @@
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 
-const { formatDetail, formatAntigravityDetail, truncate, firstStringValue, parseMcpToolName } = require("../src/bubble-format");
+const {
+  formatDetail,
+  formatAntigravityDetail,
+  truncate,
+  firstStringValue,
+  parseMcpToolName,
+  isIrreversibleScanPartial,
+} = require("../src/bubble-format");
 
 describe("bubble-format truncate", () => {
   it("returns input unchanged when within max", () => {
@@ -197,5 +204,29 @@ describe("bubble-format parseMcpToolName (issue #445)", () => {
     ]) {
       assert.strictEqual(parseMcpToolName(bad), null, `${JSON.stringify(bad)} must be raw fallback (null)`);
     }
+  });
+});
+
+describe("bubble-format shared-surface length budgets", () => {
+  it("uses caller-owned active and queue limits through the same formatter", () => {
+    const command = `${"a".repeat(5000)}TAIL`;
+    const active = formatDetail("Bash", { command }, {
+      maxLength: 64 * 1024,
+      fallbackMaxLength: 4 * 1024,
+    });
+    const queue = formatDetail("Bash", { command }, {
+      maxLength: 140,
+      fallbackMaxLength: 140,
+    });
+
+    assert.ok(active.endsWith("TAIL"), "active detail should retain the long command tail");
+    assert.strictEqual(queue.length, 140);
+    assert.ok(queue.endsWith("…"));
+  });
+
+  it("marks shell detail beyond the fixed 4 KB irreversible scan coverage", () => {
+    assert.strictEqual(isIrreversibleScanPartial("Bash", { command: "a".repeat(4096) }), false);
+    assert.strictEqual(isIrreversibleScanPartial("Bash", { command: "a".repeat(4097) }), true);
+    assert.strictEqual(isIrreversibleScanPartial("Read", { command: "a".repeat(5000) }), false);
   });
 });

--- a/test/bubble-go-to-terminal.test.js
+++ b/test/bubble-go-to-terminal.test.js
@@ -73,9 +73,10 @@ class FakeElement {
 function createHarness() {
   const elements = new Map();
   for (const id of [
-    "card", "toolPill", "toolPillText", "commandBlock", "irreversibleBadge",
+    "card", "activeDetail", "toolPill", "toolPillText", "commandBlock", "irreversibleBadge", "riskCoverageNote",
     "elicitationForm", "elicitationProgress", "planFeedbackForm", "planFeedbackTextarea",
     "planFeedbackBack", "planFeedbackSubmit", "btnAllow", "btnDeny", "suggestions", "sessionTag",
+    "queueCount", "permissionQueue", "queueHeading", "queuePreview", "queueMore", "queueDrawer", "queueLockHint",
   ]) elements.set(id, new FakeElement(id.includes("Textarea") ? "textarea" : "div"));
   elements.set("btnAllow", new FakeElement("button"));
   elements.set("btnDeny", new FakeElement("button"));
@@ -94,6 +95,7 @@ function createHarness() {
   };
   const bubbleAPI = {
     decide: (decision) => decisions.push(decision),
+    select() {},
     reportHeight() {},
     onPermissionShow: (callback) => { showPermission = callback; },
     onPermissionHide() {},

--- a/test/bubble-kimi-cue.test.js
+++ b/test/bubble-kimi-cue.test.js
@@ -46,7 +46,7 @@ describe("bubble-renderer Kimi tool-aware cue", () => {
 
   it("reuses the standard cue path: formatDetail, MCP relabel, irreversible hint", () => {
     const branch = kimiBranch();
-    assert.match(branch, /formatDetail\(kimiTool, kimiInput\)/);
+    assert.match(branch, /formatActiveDetail\(kimiTool, kimiInput\)/);
     assert.match(branch, /parseMcpToolName\(kimiTool\)/);
     assert.match(branch, /detectIrreversible\(kimiTool, kimiInput\)/);
     // The pill shows the real tool so per-tool CSS (data-tool="Bash" etc.)
@@ -75,7 +75,7 @@ describe("bubble-renderer Kimi tool-aware cue", () => {
     // returns nothing.
     assert.match(
       branch,
-      /formatDetail\(kimiTool, kimiInput\)\s*\|\| \(data\.toolInput && data\.toolInput\.command\)\s*\|\| bubbleText\(data\.lang, "checkKimiTerminal"\)/
+      /formatActiveDetail\(kimiTool, kimiInput\)\s*\|\| \(data\.toolInput && data\.toolInput\.command\)\s*\|\| bubbleText\(data\.lang, "checkKimiTerminal"\)/
     );
   });
 
@@ -95,7 +95,7 @@ describe("bubble-renderer Kimi tool-aware cue", () => {
       branch.replace('suggestionsContainer.innerHTML = "";', ""),
       /innerHTML/
     );
-    assert.match(branch, /commandBlock\.textContent = formatDetail/);
+    assert.match(branch, /commandBlock\.textContent = formatActiveDetail/);
   });
 });
 

--- a/test/floating-window-runtime.test.js
+++ b/test/floating-window-runtime.test.js
@@ -107,4 +107,39 @@ describe("floating-window-runtime", () => {
       ["hideUpdate"],
     ]);
   });
+
+  it("records the shared-surface cutoff before hiding its window", () => {
+    const calls = [];
+    const shared = makeWindow("shared", calls);
+    const runtime = createFloatingWindowRuntime({
+      getPermissionBubbleWindows: () => [shared],
+      setPermissionPetHidden: (hidden) => calls.push(["petHidden", hidden]),
+      hideUpdateBubble: () => calls.push(["hideUpdate"]),
+    });
+
+    runtime.hideFloatingSurfacesForPet();
+
+    assert.deepStrictEqual(calls, [
+      ["petHidden", true],
+      ["hide", "shared"],
+      ["hideUpdate"],
+    ]);
+  });
+
+  it("lets the permission runtime republish before syncing the update bubble", () => {
+    const calls = [];
+    const shared = makeWindow("shared", calls);
+    const runtime = createFloatingWindowRuntime({
+      getPermissionBubbleWindows: () => [shared],
+      setPermissionPetHidden: (hidden) => calls.push(["petHidden", hidden]),
+      syncUpdateBubbleVisibility: () => calls.push(["syncUpdate"]),
+    });
+
+    runtime.showFloatingSurfacesForPet();
+
+    assert.deepStrictEqual(calls, [
+      ["petHidden", false],
+      ["syncUpdate"],
+    ]);
+  });
 });

--- a/test/permission-640-editing-freeze.test.js
+++ b/test/permission-640-editing-freeze.test.js
@@ -8,8 +8,39 @@ const { describe, it } = require("node:test");
 // permission-ime-editing.test.js): handleImeEditing and friends resolve IPC
 // senders via BrowserWindow.fromWebContents, and the test runtime's
 // require("electron") returns a path string.
+class FakePermissionWindow {
+  constructor() {
+    this.destroyed = false;
+    this.visible = false;
+    this.listeners = new Map();
+    this.sentEvents = [];
+    this.setBoundsCalls = [];
+    this.webContents = {
+      once: (name, listener) => this.listeners.set(name, listener),
+      on: (name, listener) => this.listeners.set(name, listener),
+      send: (...args) => this.sentEvents.push(args),
+      isDestroyed: () => this.destroyed,
+    };
+  }
+  static fromWebContents(sender) { return sender && sender.__win ? sender.__win : null; }
+  setAlwaysOnTop() {}
+  setBounds(bounds) { this.bounds = bounds; this.setBoundsCalls.push(bounds); }
+  getBounds() { return this.bounds || { x: 0, y: 0, width: 420, height: 240 }; }
+  setSkipTaskbar() {}
+  showInactive() { this.visible = true; }
+  hide() { this.visible = false; }
+  isVisible() { return this.visible; }
+  isDestroyed() { return this.destroyed; }
+  on(name, listener) { this.listeners.set(name, listener); }
+  loadFile() { this.listeners.get("did-finish-load")?.(); }
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.listeners.get("closed")?.();
+  }
+}
 const __electronMock = {
-  BrowserWindow: { fromWebContents: (sender) => (sender && sender.__win) || null },
+  BrowserWindow: FakePermissionWindow,
   globalShortcut: {
     register: () => {}, unregister: () => {}, unregisterAll: () => {}, isRegistered: () => false,
   },
@@ -61,40 +92,55 @@ function makeBubble(overrides = {}) {
   };
 }
 
+function presentPermission(api) {
+  const entry = {
+    res: null,
+    suggestions: [],
+    sessionId: "ime-session",
+    toolName: "AskUserQuestion",
+    toolInput: { questions: [{ question: "Choose", options: [] }] },
+    agentId: "claude-code",
+    isElicitation: true,
+    createdAt: Date.now(),
+  };
+  api.addPendingPermission(entry, "test-present");
+  api.showPermissionBubble(entry);
+  const surface = api.getPermissionSurfaceWindow();
+  const envelope = [...surface.sentEvents].reverse().find(([name]) => name === "permission-show")[1];
+  api.handleBubbleHeight({ sender: { __win: surface } }, {
+    height: 240,
+    surfaceRevision: envelope.surfaceRevision,
+    activeEntryId: envelope.activeEntryId,
+    entryIds: envelope.entryIds,
+  });
+  surface.setBoundsCalls.length = 0;
+  return surface;
+}
+
 describe("repositionBubbles freeze while editing (#640)", () => {
-  it("skips the bubble being typed into and still places the others", () => {
+  it("keeps the shared surface fixed while its active input is being edited", () => {
     const ctx = makeCtx();
-    const { repositionBubbles, pendingPermissions } = initPermission(ctx);
-
-    const frozen = makeBubble();
+    const api = initPermission(ctx);
+    const frozen = presentPermission(api);
     frozen.__clawdMacImeEditing = true;
-    const normal = makeBubble();
-    pendingPermissions.push(
-      { bubble: frozen, suggestions: [], measuredHeight: 120 },
-      { bubble: normal, suggestions: [], measuredHeight: 120 },
-    );
 
-    repositionBubbles();
+    api.repositionBubbles();
 
     assert.strictEqual(frozen.setBoundsCalls.length, 0,
-      "the editing bubble must hold its position");
-    assert.strictEqual(normal.setBoundsCalls.length, 1,
-      "non-editing bubbles still get placed");
+      "the editing shared surface must hold its position");
   });
 
-  it("places every bubble again once editing ends", () => {
+  it("places the shared surface again once editing ends", () => {
     const ctx = makeCtx();
-    const { repositionBubbles, pendingPermissions } = initPermission(ctx);
-
-    const bubble = makeBubble();
+    const api = initPermission(ctx);
+    const bubble = presentPermission(api);
     bubble.__clawdMacImeEditing = true;
-    pendingPermissions.push({ bubble, suggestions: [], measuredHeight: 120 });
 
-    repositionBubbles();
+    api.repositionBubbles();
     assert.strictEqual(bubble.setBoundsCalls.length, 0);
 
     delete bubble.__clawdMacImeEditing;
-    repositionBubbles();
+    api.repositionBubbles();
     assert.strictEqual(bubble.setBoundsCalls.length, 1);
   });
 });

--- a/test/permission-auto-approve.test.js
+++ b/test/permission-auto-approve.test.js
@@ -129,22 +129,18 @@ describe("permission automation: showPermissionBubble chokepoint", () => {
     assert.equal(parsed.hookSpecificOutput.decision.behavior, "allow");
   });
 
-  it("does nothing special when the mode is off (would build a bubble)", () => {
-    // With auto-approve off and win=null, showPermissionBubble proceeds to
-    // BrowserWindow construction. We only assert the early-return did NOT
-    // fire by checking the entry stays pending up to the point of bubble
-    // creation throwing (no Electron in tests).
+  it("falls through to the human surface path when the mode is off", () => {
+    // This suite intentionally has no Electron BrowserWindow. Reaching the
+    // shared-surface path therefore ends in its no-decision fallback; the
+    // surfaceEligible marker proves automation did not consume the request.
     const ctx = makeCtx({ getPermissionAutomationMode: () => "off" });
     const perm = initPermission(ctx);
     const permEntry = makePermEntry();
     perm.pendingPermissions.push(permEntry);
 
-    assert.throws(() => perm.showPermissionBubble(permEntry));
-    assert.equal(
-      perm.pendingPermissions.indexOf(permEntry),
-      0,
-      "entry should still be pending (auto-approve did not consume it)"
-    );
+    assert.doesNotThrow(() => perm.showPermissionBubble(permEntry));
+    assert.equal(typeof permEntry.surfaceEntryId, "string");
+    assert.equal(perm.pendingPermissions.includes(permEntry), false);
   });
 
   it("does NOT auto-approve passive codex notifications", () => {
@@ -153,11 +149,11 @@ describe("permission automation: showPermissionBubble chokepoint", () => {
     const permEntry = makePermEntry({ isCodexNotify: true, res: null });
     perm.pendingPermissions.push(permEntry);
 
-    // Passive notify entries route to dismissPassiveNotify on resolve, never
-    // to an allow. Auto-approve must skip them: with win=null the subsequent
-    // bubble build throws, proving the early-return did not consume it.
-    assert.throws(() => perm.showPermissionBubble(permEntry));
-    assert.equal(perm.pendingPermissions.indexOf(permEntry), 0);
+    // Passive notify entries route to dismissPassiveNotify on surface failure,
+    // never to an allow. The marker proves automation skipped it first.
+    assert.doesNotThrow(() => perm.showPermissionBubble(permEntry));
+    assert.equal(typeof permEntry.surfaceEntryId, "string");
+    assert.equal(perm.pendingPermissions.includes(permEntry), false);
   });
 
   it("answers elicitation questions with a deferral reply so allow is a real allow", () => {
@@ -209,13 +205,14 @@ describe("permission automation: showPermissionBubble chokepoint", () => {
     ]) {
       const decision = makePermEntry({ toolName, toolInput });
       perm.pendingPermissions.push(decision);
-      assert.throws(() => perm.showPermissionBubble(decision));
+      assert.doesNotThrow(() => perm.showPermissionBubble(decision));
       assert.strictEqual(
-        perm.pendingPermissions.includes(decision),
-        true,
-        `${toolName} must remain pending for a human`
+        typeof decision.surfaceEntryId,
+        "string",
+        `${toolName} must reach the human surface instead of automation`
       );
-      perm.pendingPermissions.splice(perm.pendingPermissions.indexOf(decision), 1);
+      assert.strictEqual(perm.pendingPermissions.includes(decision), false,
+        "the unavailable test surface returns no-decision instead of throwing");
     }
   });
 
@@ -236,9 +233,11 @@ describe("permission automation: showPermissionBubble chokepoint", () => {
     const entry = makePermEntry(base);
     perm.pendingPermissions.push(entry);
 
-    assert.throws(() => perm.showPermissionBubble(entry));
-    assert.equal(perm.pendingPermissions.includes(entry), true);
+    assert.doesNotThrow(() => perm.showPermissionBubble(entry));
+    assert.equal(typeof entry.surfaceEntryId, "string");
+    assert.equal(perm.pendingPermissions.includes(entry), false);
     assert.equal(res.captured.statusCode, null);
+    assert.equal(res.captured.destroyCalls, 1);
   });
 
   it("allows an immediate session override only after the shared live gate passes", () => {
@@ -283,9 +282,10 @@ describe("permission automation: showPermissionBubble chokepoint", () => {
     });
     perm.pendingPermissions.push(entry);
 
-    assert.throws(() => perm.showPermissionBubble(entry));
-    assert.equal(perm.pendingPermissions.includes(entry), true);
-    assert.equal(res.captured.statusCode, null);
+    assert.doesNotThrow(() => perm.showPermissionBubble(entry));
+    assert.equal(typeof entry.surfaceEntryId, "string");
+    assert.equal(perm.pendingPermissions.includes(entry), false);
+    assert.equal(res.captured.statusCode, 204);
   });
 
   it("lets an eligible TUI Agent thread inherit global auto-tools", () => {
@@ -326,8 +326,9 @@ describe("permission automation: showPermissionBubble chokepoint", () => {
     const entry = makePermEntry({ interaction: { intent: "tool-approval" } });
     perm.pendingPermissions.push(entry);
 
-    assert.throws(() => perm.showPermissionBubble(entry));
-    assert.strictEqual(perm.pendingPermissions.includes(entry), true);
+    assert.doesNotThrow(() => perm.showPermissionBubble(entry));
+    assert.strictEqual(typeof entry.surfaceEntryId, "string");
+    assert.strictEqual(perm.pendingPermissions.includes(entry), false);
   });
 });
 

--- a/test/permission-codex-response.test.js
+++ b/test/permission-codex-response.test.js
@@ -31,10 +31,39 @@ function loadPermissionWithElectron(fakeElectron = null) {
 
 function createCodexDecisionHarness() {
   const focusCalls = [];
+  class FakeBrowserWindow {
+    constructor() {
+      this.destroyed = false;
+      this.visible = false;
+      this.listeners = new Map();
+      this.sentEvents = [];
+      this.webContents = {
+        once: (name, listener) => this.listeners.set(name, listener),
+        on: (name, listener) => this.listeners.set(name, listener),
+        send: (...args) => this.sentEvents.push(args),
+        isDestroyed: () => this.destroyed,
+      };
+    }
+    static fromWebContents(sender) { return sender && sender.__window ? sender.__window : null; }
+    setAlwaysOnTop() {}
+    setBounds(bounds) { this.bounds = bounds; }
+    getBounds() { return this.bounds || { x: 0, y: 0, width: 420, height: 240 }; }
+    setSkipTaskbar() {}
+    showInactive() { this.visible = true; }
+    hide() { this.visible = false; }
+    focus() {}
+    isVisible() { return this.visible; }
+    isDestroyed() { return this.destroyed; }
+    on(name, listener) { this.listeners.set(name, listener); }
+    loadFile() { this.listeners.get("did-finish-load")?.(); }
+    destroy() {
+      if (this.destroyed) return;
+      this.destroyed = true;
+      this.listeners.get("closed")?.();
+    }
+  }
   const fakeElectron = {
-    BrowserWindow: Object.assign(class {}, {
-      fromWebContents(sender) { return sender && sender.__window ? sender.__window : null; },
-    }),
+    BrowserWindow: FakeBrowserWindow,
     globalShortcut: {
       register() { return true; },
       unregister() {},
@@ -46,13 +75,38 @@ function createCodexDecisionHarness() {
     sessions: new Map(),
     hideBubbles: false,
     petHidden: false,
-    win: null,
+    win: { isDestroyed: () => false },
     lang: "en",
     getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
+    getSettingsSnapshot: () => ({ shortcuts: {} }),
+    isAgentPermissionsEnabled: () => true,
+    subscribeShortcuts: () => () => {},
+    clearShortcutFailure() {},
+    reportShortcutFailure() {},
+    getPetWindowBounds: () => ({ x: 0, y: 0, width: 128, height: 128 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop() {},
+    reapplyMacVisibility() {},
+    repositionUpdateBubble() {},
     focusTerminalForSession: (sessionId, options) => focusCalls.push([sessionId, options]),
     permDebugLog: null,
   });
-  return { api, focusCalls };
+  function present(entry) {
+    api.addPendingPermission(entry, "test-present");
+    api.showPermissionBubble(entry);
+    const surface = api.getPermissionSurfaceWindow();
+    const envelope = [...surface.sentEvents].reverse().find(([name]) => name === "permission-show")[1];
+    api.handleBubbleHeight({ sender: { __window: surface } }, {
+      height: 240,
+      surfaceRevision: envelope.surfaceRevision,
+      activeEntryId: envelope.activeEntryId,
+      entryIds: envelope.entryIds,
+    });
+    return { sender: { __window: surface } };
+  }
+  return { api, focusCalls, present };
 }
 
 function createFakeRes() {
@@ -197,7 +251,7 @@ describe("Codex permission response sanitizer", () => {
   });
 
   it("treats Codex deny-and-focus as immediate no-decision instead of hanging the socket", () => {
-    const { api, focusCalls } = createCodexDecisionHarness();
+    const { api, focusCalls, present } = createCodexDecisionHarness();
     const res = createFakeRes();
     const bubble = createFakeBubble();
     const permEntry = {
@@ -221,9 +275,9 @@ describe("Codex permission response sanitizer", () => {
       codexOriginator: "Codex Desktop",
       codexSource: "vscode",
     };
-    api.pendingPermissions.push(permEntry);
+    const event = present(permEntry);
 
-    api.handleDecide({ sender: { __window: bubble } }, "deny-and-focus");
+    api.handleDecide(event, "deny-and-focus");
 
     assert.strictEqual(res.statusCode, 204);
     assert.strictEqual(res.writableEnded, true);
@@ -249,10 +303,10 @@ describe("Codex permission response sanitizer", () => {
   });
 
   it("treats Qwen deny-and-focus as immediate no-decision and focuses terminal", () => {
-    const { api, focusCalls } = createCodexDecisionHarness();
+    const { api, focusCalls, present } = createCodexDecisionHarness();
     const res = createFakeRes();
     const bubble = createFakeBubble();
-    api.pendingPermissions.push({
+    const permEntry = {
       res,
       abortHandler: () => {},
       suggestions: [],
@@ -269,9 +323,9 @@ describe("Codex permission response sanitizer", () => {
       agentPid: 456,
       pidChain: [789, 456],
       model: "qwen3-coder-plus",
-    });
+    };
 
-    api.handleDecide({ sender: { __window: bubble } }, "deny-and-focus");
+    api.handleDecide(present(permEntry), "deny-and-focus");
 
     assert.strictEqual(res.statusCode, 204);
     assert.strictEqual(res.body, "");
@@ -293,7 +347,7 @@ describe("Codex permission response sanitizer", () => {
   });
 
   it("focuses the originating terminal when the Kimi cue's Got it button is clicked", () => {
-    const { api, focusCalls } = createCodexDecisionHarness();
+    const { api, focusCalls, present } = createCodexDecisionHarness();
     const bubble = createFakeBubble();
     const permEntry = {
       res: null,
@@ -308,25 +362,24 @@ describe("Codex permission response sanitizer", () => {
       agentId: "kimi-cli",
       isKimiNotify: true,
     };
-    api.pendingPermissions.push(permEntry);
+    const event = present(permEntry);
 
     // The renderer sends "allow" for the relabeled "Got it" button; the passive
     // branch dismisses regardless of the behavior value, and Kimi additionally
     // brings the terminal forward so the native approve/reject prompt is in view.
-    api.handleDecide({ sender: { __window: bubble } }, "allow");
+    api.handleDecide(event, "allow");
 
     assert.deepStrictEqual(focusCalls, [[
       "kimi-cli:s1",
       { fallbackEntry: { id: "kimi-cli:s1", agentId: "kimi-cli" } },
     ]]);
-    assert.strictEqual(bubble.hidden, true);
     assert.strictEqual(api.pendingPermissions.length, 0);
   });
 
   it("dismisses a Codex passive notify without focusing the terminal", () => {
-    const { api, focusCalls } = createCodexDecisionHarness();
+    const { api, focusCalls, present } = createCodexDecisionHarness();
     const bubble = createFakeBubble();
-    api.pendingPermissions.push({
+    const permEntry = {
       res: null,
       abortHandler: null,
       suggestions: [],
@@ -338,24 +391,23 @@ describe("Codex permission response sanitizer", () => {
       createdAt: Date.now(),
       agentId: "codex",
       isCodexNotify: true,
-    });
+    };
 
-    api.handleDecide({ sender: { __window: bubble } }, "allow");
+    api.handleDecide(present(permEntry), "allow");
 
     // The focus-on-dismiss affordance is Kimi-only: Codex notify stays a plain
     // acknowledge. Pins the shared passive-notify branch against accidental
     // scope creep.
     assert.deepStrictEqual(focusCalls, []);
-    assert.strictEqual(bubble.hidden, true);
     assert.strictEqual(api.pendingPermissions.length, 0);
   });
 
   it("does not let Codex take suggestion or opencode-only decision paths", () => {
     for (const behavior of ["suggestion:0", "family-always"]) {
-      const { api } = createCodexDecisionHarness();
+      const { api, present } = createCodexDecisionHarness();
       const res = createFakeRes();
       const bubble = createFakeBubble();
-      api.pendingPermissions.push({
+      const permEntry = {
         res,
         abortHandler: () => {},
         suggestions: [{ type: "setMode", mode: "default" }],
@@ -367,9 +419,9 @@ describe("Codex permission response sanitizer", () => {
         createdAt: Date.now(),
         agentId: "codex",
         isCodex: true,
-      });
+      };
 
-      api.handleDecide({ sender: { __window: bubble } }, behavior);
+      api.handleDecide(present(permEntry), behavior);
 
       assert.strictEqual(res.statusCode, 204);
       assert.strictEqual(res.body, "");
@@ -378,7 +430,7 @@ describe("Codex permission response sanitizer", () => {
   });
 
   it("treats Antigravity deny-and-focus as immediate no-decision instead of hanging the socket", () => {
-    const { api, focusCalls } = createCodexDecisionHarness();
+    const { api, focusCalls, present } = createCodexDecisionHarness();
     const res = createFakeRes();
     const bubble = createFakeBubble();
     const permEntry = {
@@ -399,9 +451,9 @@ describe("Codex permission response sanitizer", () => {
       pidChain: [789, 456],
       platform: "win32",
     };
-    api.pendingPermissions.push(permEntry);
+    const event = present(permEntry);
 
-    api.handleDecide({ sender: { __window: bubble } }, "deny-and-focus");
+    api.handleDecide(event, "deny-and-focus");
 
     assert.strictEqual(res.statusCode, 204);
     assert.strictEqual(res.writableEnded, true);
@@ -425,10 +477,10 @@ describe("Codex permission response sanitizer", () => {
 
   it("responds to Antigravity allow and deny with direct hook stdout shape", () => {
     for (const behavior of ["allow", "deny"]) {
-      const { api } = createCodexDecisionHarness();
+      const { api, present } = createCodexDecisionHarness();
       const res = createFakeRes();
       const bubble = createFakeBubble();
-      api.pendingPermissions.push({
+      const permEntry = {
         res,
         abortHandler: () => {},
         suggestions: [],
@@ -440,9 +492,9 @@ describe("Codex permission response sanitizer", () => {
         createdAt: Date.now(),
         agentId: "antigravity-cli",
         isAntigravity: true,
-      });
+      };
 
-      api.handleDecide({ sender: { __window: bubble } }, behavior);
+      api.handleDecide(present(permEntry), behavior);
 
       assert.strictEqual(res.statusCode, 200);
       const parsed = JSON.parse(res.body);
@@ -534,12 +586,6 @@ describe("Codex permission response sanitizer", () => {
     assert.strictEqual(claudeRes.destroyed, true);
     assert.strictEqual(opencodeRes.destroyed, false);
     assert.strictEqual(opencodeRes.statusCode, null);
-    assert.strictEqual(codexBubble.hidden, true);
-    assert.strictEqual(qwenBubble.hidden, true);
-    assert.strictEqual(claudeBubble.hidden, true);
-    assert.strictEqual(opencodeBubble.hidden, true);
-    assert.strictEqual(antigravityBubble.hidden, true);
-    assert.strictEqual(notifyBubble.hidden, true);
     assert.strictEqual(api.pendingPermissions.length, 0);
   });
 

--- a/test/permission-family-lifecycle.test.js
+++ b/test/permission-family-lifecycle.test.js
@@ -237,13 +237,9 @@ describe("opencode-family external lifecycle runtime", () => {
     const { api } = harness;
     let timerFires = 0;
     let remoteAborts = 0;
-    let allExactWereDeadAtHide = false;
     const exactA = familyEntry();
     const exactB = familyEntry({
-      bubble: makeBubble(() => {
-        allExactWereDeadAtHide = !api.pendingPermissions.includes(exactA)
-          && !api.pendingPermissions.includes(exactB);
-      }),
+      bubble: makeBubble(),
       _delayTimer: setTimeout(() => { timerFires += 1; }, 40),
       autoCloseTimer: setTimeout(() => { timerFires += 1; }, 40),
       autoExpireTimer: setTimeout(() => { timerFires += 1; }, 40),
@@ -277,9 +273,6 @@ describe("opencode-family external lifecycle runtime", () => {
     assertSecretAbsentFromLifecycleLogs(harness, "token_life");
 
     assert.deepStrictEqual(api.pendingPermissions, [sameSessionOtherRequest, otherAgent]);
-    assert.strictEqual(allExactWereDeadAtHide, true, "all exact entries must be non-live before renderer teardown");
-    assert.strictEqual(exactA.bubble.hidden, true);
-    assert.strictEqual(exactB.bubble.hidden, true);
     assert.strictEqual(exactB._delayTimer, null);
     assert.strictEqual(exactB.autoCloseTimer, null);
     assert.strictEqual(exactB.autoExpireTimer, null);
@@ -391,7 +384,6 @@ describe("opencode-family lifecycle route → real runtime", () => {
     assert.strictEqual(lifecycleResult.res.headers["x-clawd-server"], "clawd-on-desk");
     assert.deepStrictEqual(lifecycleResult.recorder, []);
     assert.strictEqual(harness.api.pendingPermissions.length, 0);
-    assert.strictEqual(entry.bubble.hidden, true);
     assert.strictEqual(harness.calls.updateSession.length, 1, "lifecycle must not publish another PermissionRequest");
     assert.strictEqual(harness.calls.showPermissionBubble.length, 1);
     assert.deepStrictEqual(harness.calls.replyOpencodeFamilyPermission, []);

--- a/test/permission-family-payload.test.js
+++ b/test/permission-family-payload.test.js
@@ -138,7 +138,7 @@ describe("bubble-renderer family contract (static)", () => {
     assert.match(branch, /detail = input\.url;/);
     assert.match(branch, /Array\.isArray\(data\.familyPatterns\) && data\.familyPatterns\.length/);
     assert.match(branch, /detail = \[\.\.\.new Set\(data\.familyPatterns\)\]\.join\(", "\);/);
-    assert.match(branch, /commandBlock\.textContent = truncate\(detail, 200\);/);
+    assert.match(branch, /commandBlock\.textContent = truncate\(detail, ACTIVE_DETAIL_MAX_LENGTH\);/);
   });
 
   it("wires the Always button: candidates gate, {agent} tooltip vars, family-always decide", () => {

--- a/test/permission-family-roundtrip.test.js
+++ b/test/permission-family-roundtrip.test.js
@@ -32,10 +32,38 @@ function loadPermissionWithElectron(fakeElectron) {
 }
 
 function makeHarness() {
+  class FakeBrowserWindow {
+    constructor() {
+      this.destroyed = false;
+      this.visible = false;
+      this.listeners = new Map();
+      this.sentEvents = [];
+      this.webContents = {
+        once: (name, listener) => this.listeners.set(name, listener),
+        on: (name, listener) => this.listeners.set(name, listener),
+        send: (...args) => this.sentEvents.push(args),
+        isDestroyed: () => this.destroyed,
+      };
+    }
+    static fromWebContents(sender) { return sender && sender.__window ? sender.__window : null; }
+    setAlwaysOnTop() {}
+    setBounds(bounds) { this.bounds = bounds; }
+    getBounds() { return this.bounds || { x: 0, y: 0, width: 420, height: 240 }; }
+    setSkipTaskbar() {}
+    showInactive() { this.visible = true; }
+    hide() { this.visible = false; }
+    isVisible() { return this.visible; }
+    isDestroyed() { return this.destroyed; }
+    on(name, listener) { this.listeners.set(name, listener); }
+    loadFile() { this.listeners.get("did-finish-load")?.(); }
+    destroy() {
+      if (this.destroyed) return;
+      this.destroyed = true;
+      this.listeners.get("closed")?.();
+    }
+  }
   const fakeElectron = {
-    BrowserWindow: Object.assign(class {}, {
-      fromWebContents(sender) { return sender && sender.__window ? sender.__window : null; },
-    }),
+    BrowserWindow: FakeBrowserWindow,
     globalShortcut: {
       register() { return true; },
       unregister() {},
@@ -47,15 +75,38 @@ function makeHarness() {
     sessions: new Map(),
     hideBubbles: false,
     petHidden: false,
-    win: null,
+    win: { isDestroyed: () => false },
     lang: "en",
     getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
     focusTerminalForSession: () => {},
     getSettingsSnapshot: () => ({}),
     isAgentPermissionsEnabled: () => true,
+    subscribeShortcuts: () => () => {},
+    clearShortcutFailure() {},
+    reportShortcutFailure() {},
+    getPetWindowBounds: () => ({ x: 0, y: 0, width: 128, height: 128 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop() {},
+    reapplyMacVisibility() {},
+    repositionUpdateBubble() {},
     permDebugLog: null,
   });
-  return { api };
+  function present(entry) {
+    api.addPendingPermission(entry, "test-present");
+    api.showPermissionBubble(entry);
+    const surface = api.getPermissionSurfaceWindow();
+    const envelope = [...surface.sentEvents].reverse().find(([name]) => name === "permission-show")[1];
+    api.handleBubbleHeight({ sender: { __window: surface } }, {
+      height: 240,
+      surfaceRevision: envelope.surfaceRevision,
+      activeEntryId: envelope.activeEntryId,
+      entryIds: envelope.entryIds,
+    });
+    return { sender: { __window: surface } };
+  }
+  return { api, present };
 }
 
 // A real localhost listener standing in for the plugin's reverse bridge.
@@ -139,12 +190,10 @@ describe("opencode-family bridge round-trips", () => {
   it("Always Allow: handleDecide('family-always') reaches the bridge as reply='always'", async () => {
     const bridge = await startBridge();
     try {
-      const { api } = makeHarness();
-      const fakeWin = makeFakeBubble();
-      const entry = makeFamilyEntry(bridge, { bubble: fakeWin });
-      api.pendingPermissions.push(entry);
+      const { api, present } = makeHarness();
+      const entry = makeFamilyEntry(bridge);
 
-      api.handleDecide({ sender: { __window: fakeWin } }, "family-always");
+      api.handleDecide(present(entry), "family-always");
 
       await bridge.firstRequest();
       assert.strictEqual(bridge.requests.length, 1);
@@ -161,12 +210,10 @@ describe("opencode-family bridge round-trips", () => {
   it("Deny: handleDecide('deny') reaches the bridge as reply='reject'", async () => {
     const bridge = await startBridge();
     try {
-      const { api } = makeHarness();
-      const fakeWin = makeFakeBubble();
-      const entry = makeFamilyEntry(bridge, { bubble: fakeWin });
-      api.pendingPermissions.push(entry);
+      const { api, present } = makeHarness();
+      const entry = makeFamilyEntry(bridge);
 
-      api.handleDecide({ sender: { __window: fakeWin } }, "deny");
+      api.handleDecide(present(entry), "deny");
 
       await bridge.firstRequest();
       assert.deepStrictEqual(bridge.requests[0].body, { request_id: "per_rt_1", reply: "reject" });
@@ -178,12 +225,10 @@ describe("opencode-family bridge round-trips", () => {
   it("Allow without the Always pick degrades to reply='once'", async () => {
     const bridge = await startBridge();
     try {
-      const { api } = makeHarness();
-      const fakeWin = makeFakeBubble();
-      const entry = makeFamilyEntry(bridge, { bubble: fakeWin });
-      api.pendingPermissions.push(entry);
+      const { api, present } = makeHarness();
+      const entry = makeFamilyEntry(bridge);
 
-      api.handleDecide({ sender: { __window: fakeWin } }, "allow");
+      api.handleDecide(present(entry), "allow");
 
       await bridge.firstRequest();
       assert.deepStrictEqual(bridge.requests[0].body, { request_id: "per_rt_1", reply: "once" });

--- a/test/permission-go-to-terminal-wire.test.js
+++ b/test/permission-go-to-terminal-wire.test.js
@@ -21,8 +21,38 @@ const Module = require("node:module");
 
 // ── Mock electron before requiring permission.js (same seam as
 // permission-plan-feedback.test.js) ──
+class FakePermissionWindow {
+  constructor() {
+    this.destroyed = false;
+    this.visible = false;
+    this.listeners = new Map();
+    this.sentEvents = [];
+    this.webContents = {
+      once: (name, listener) => this.listeners.set(name, listener),
+      on: (name, listener) => this.listeners.set(name, listener),
+      send: (...args) => this.sentEvents.push(args),
+      isDestroyed: () => this.destroyed,
+    };
+  }
+  static fromWebContents(sender) { return sender && sender.__win ? sender.__win : null; }
+  setAlwaysOnTop() {}
+  setBounds(bounds) { this.bounds = bounds; }
+  getBounds() { return this.bounds || { x: 0, y: 0, width: 420, height: 240 }; }
+  setSkipTaskbar() {}
+  showInactive() { this.visible = true; }
+  hide() { this.visible = false; }
+  isVisible() { return this.visible; }
+  isDestroyed() { return this.destroyed; }
+  on(name, listener) { this.listeners.set(name, listener); }
+  loadFile() { this.listeners.get("did-finish-load")?.(); }
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.listeners.get("closed")?.();
+  }
+}
 const __electronMock = {
-  BrowserWindow: { fromWebContents: (sender) => (sender && sender.__win) || null },
+  BrowserWindow: FakePermissionWindow,
   globalShortcut: {
     register: () => {}, unregister: () => {}, unregisterAll: () => {}, isRegistered: () => false,
   },
@@ -91,7 +121,7 @@ function makeCtx(overrides = {}) {
     updateDebugLog: null,
     sessionDebugLog: null,
     repositionUpdateBubble: () => {},
-    win: null,
+    win: { isDestroyed: () => false },
     bubbleFollowPet: false,
     petHidden: false,
     doNotDisturb: false,
@@ -115,6 +145,20 @@ function makeFakeBubble() {
 }
 function makeEventFor(bubble) {
   return { sender: { __win: bubble } };
+}
+
+function presentPermission(perm, entry) {
+  perm.addPendingPermission(entry, "test-present");
+  perm.showPermissionBubble(entry);
+  const surface = perm.getPermissionSurfaceWindow();
+  const envelope = [...surface.sentEvents].reverse().find(([name]) => name === "permission-show")[1];
+  perm.handleBubbleHeight(makeEventFor(surface), {
+    height: 240,
+    surfaceRevision: envelope.surfaceRevision,
+    activeEntryId: envelope.activeEntryId,
+    entryIds: envelope.entryIds,
+  });
+  return makeEventFor(surface);
 }
 
 function makePermEntry(res, overrides = {}) {
@@ -143,11 +187,10 @@ describe("go-to-terminal wire semantics (issue #689)", () => {
     const { pendingPermissions, handleDecide } = perm;
 
     const res = createMockResponse();
-    const bubble = makeFakeBubble();
-    const permEntry = makePermEntry(res, { bubble });
-    pendingPermissions.push(permEntry);
+    const permEntry = makePermEntry(res);
+    const event = presentPermission(perm, permEntry);
 
-    handleDecide(makeEventFor(bubble), "deny-and-focus");
+    handleDecide(event, "deny-and-focus");
 
     // Dropped, not parked; empty, not denied.
     assert.strictEqual(res.destroyed, true, "hook socket must be destroyed immediately");
@@ -167,12 +210,11 @@ describe("go-to-terminal wire semantics (issue #689)", () => {
     const { pendingPermissions, handleDecide } = perm;
 
     const res = createMockResponse();
-    const bubble = makeFakeBubble();
-    const permEntry = makePermEntry(res, { bubble });
-    pendingPermissions.push(permEntry);
+    const permEntry = makePermEntry(res);
+    const event = presentPermission(perm, permEntry);
 
-    handleDecide(makeEventFor(bubble), "deny-and-focus");
-    handleDecide(makeEventFor(bubble), "deny-and-focus");
+    handleDecide(event, "deny-and-focus");
+    handleDecide(event, "deny-and-focus");
 
     assert.strictEqual(ctx.focusTerminalCalls.length, 1, "second IPC must not focus again");
     assert.strictEqual(pendingPermissions.length, 0);
@@ -183,9 +225,7 @@ describe("go-to-terminal wire semantics (issue #689)", () => {
       const ctx = makeCtx();
       const perm = initPermission(ctx);
       const { pendingPermissions, handleDecide } = perm;
-      const bubble = makeFakeBubble();
       const permEntry = makePermEntry(createMockResponse(), {
-        bubble,
         agentId,
         familyRequestId: `per_${agentId}`,
         familyBridgeUrl: "http://127.0.0.1:1/reply",
@@ -193,9 +233,7 @@ describe("go-to-terminal wire semantics (issue #689)", () => {
         toolName: "bash",
       });
       permEntry.res = null;
-      pendingPermissions.push(permEntry);
-
-      handleDecide(makeEventFor(bubble), "deny-and-focus");
+      handleDecide(presentPermission(perm, permEntry), "deny-and-focus");
 
       assert.strictEqual(pendingPermissions.indexOf(permEntry), -1, "entry must be removed");
       assert.strictEqual(ctx.focusTerminalCalls.length, 1);
@@ -223,14 +261,12 @@ describe("go-to-terminal wire semantics (issue #689)", () => {
     const { pendingPermissions, handleDecide } = perm;
 
     const res = createMockResponse();
-    const bubble = makeFakeBubble();
-    const permEntry = makePermEntry(res, { bubble, isHermes: true });
-    pendingPermissions.push(permEntry);
+    const permEntry = makePermEntry(res, { isHermes: true });
 
     // No UI offers this on Hermes cards anymore; if it ever arrives anyway
     // (legacy renderer, future regression), the answer must stay a bodyless
     // no-decision — a deny here would decide on the user's behalf.
-    handleDecide(makeEventFor(bubble), "deny-and-focus");
+    handleDecide(presentPermission(perm, permEntry), "deny-and-focus");
 
     assert.strictEqual(res.captured.statusCode, 204, "must answer 204 no-decision");
     const body = res.captured.body || "";

--- a/test/permission-hidden-pet-hotkeys.test.js
+++ b/test/permission-hidden-pet-hotkeys.test.js
@@ -94,7 +94,7 @@ function createContext() {
     getSettingsSnapshot: () => ({ shortcuts: {} }),
     subscribeShortcuts: () => () => {},
     getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
-    getPetWindowBounds: () => null,
+    getPetWindowBounds: () => ({ x: 100, y: 100, width: 128, height: 128 }),
     getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
     getHitRectScreen: () => null,
     getHudReservedOffset: () => 0,
@@ -115,9 +115,33 @@ function createContext() {
 
 function loadPermission() {
   const globalShortcut = createGlobalShortcut();
+  class FakeBrowserWindow {
+    constructor() {
+      this.destroyed = false;
+      this.visible = false;
+      this.listeners = new Map();
+      this.webContents = {
+        once: (event, listener) => this.listeners.set(event, listener),
+        on: (event, listener) => this.listeners.set(event, listener),
+        send() {},
+      };
+    }
+    setAlwaysOnTop() {}
+    setBounds() {}
+    setSkipTaskbar() {}
+    showInactive() { this.visible = true; }
+    hide() { this.visible = false; }
+    isVisible() { return this.visible; }
+    isDestroyed() { return this.destroyed; }
+    on(event, listener) { this.listeners.set(event, listener); }
+    loadFile() { this.listeners.get("did-finish-load")?.(); }
+    destroy() { this.destroyed = true; this.listeners.get("closed")?.(); }
+  }
   const initPermission = loadPermissionWithMocks({
     electron: {
-      BrowserWindow: Object.assign(class {}, { fromWebContents() { return null; } }),
+      BrowserWindow: Object.assign(FakeBrowserWindow, {
+        fromWebContents(sender) { return sender && sender.__window || null; },
+      }),
       globalShortcut,
     },
   });
@@ -144,19 +168,28 @@ function pushPending(permission, { bubble = null, res = createResponse() } = {})
   return entry;
 }
 
+function present(permission, options = {}) {
+  const entry = pushPending(permission, options);
+  permission.showPermissionBubble(entry);
+  const surface = permission.getPermissionSurfaceWindow();
+  assert.ok(surface);
+  permission.handleBubbleHeight({ sender: { __window: surface } }, 180);
+  return { entry, surface };
+}
+
 afterEach(() => {
   delete require.cache[PERMISSION_MODULE_PATH];
 });
 
 test("pet hidden: hotkeys unregister when only collapsed bubbles remain", () => {
   const { permission, context, globalShortcut } = loadPermission();
-  pushPending(permission, { bubble: createFakeBubble({ visible: true }) });
-  permission.syncPermissionShortcuts();
+  const { surface } = present(permission);
   assert.ok(globalShortcut.registered.has(ALLOW_ACCEL));
 
   // Hiding the pet collapses the pending bubble, then re-syncs the shortcuts.
   context.petHidden = true;
-  permission.pendingPermissions[0].bubble.hide();
+  permission.setPermissionPetHidden(true);
+  surface.hide();
   permission.syncPermissionShortcuts();
 
   assert.strictEqual(globalShortcut.registered.size, 0);
@@ -164,9 +197,11 @@ test("pet hidden: hotkeys unregister when only collapsed bubbles remain", () => 
 
 test("pet hidden: a new visible bubble keeps the hotkeys registered", () => {
   const { permission, context, globalShortcut } = loadPermission();
+  const old = present(permission);
   context.petHidden = true;
-  pushPending(permission, { bubble: createFakeBubble({ visible: true }) });
-  permission.syncPermissionShortcuts();
+  permission.setPermissionPetHidden(true);
+  old.surface.hide();
+  present(permission);
 
   assert.ok(globalShortcut.registered.has(ALLOW_ACCEL));
   assert.ok(globalShortcut.registered.has(DENY_ACCEL));
@@ -176,16 +211,11 @@ test("pet hidden: hotkey resolves the visible request, never the collapsed one",
   const { permission, context, globalShortcut } = loadPermission();
   const collapsedRes = createResponse();
   const visibleRes = createResponse();
-  const collapsed = pushPending(permission, {
-    bubble: createFakeBubble({ visible: false }),
-    res: collapsedRes,
-  });
-  pushPending(permission, {
-    bubble: createFakeBubble({ visible: true }),
-    res: visibleRes,
-  });
+  const collapsed = present(permission, { res: collapsedRes }).entry;
   context.petHidden = true;
-  permission.syncPermissionShortcuts();
+  permission.setPermissionPetHidden(true);
+  permission.getPermissionSurfaceWindow().hide();
+  present(permission, { res: visibleRes });
 
   const handler = globalShortcut.registered.get(ALLOW_ACCEL);
   assert.strictEqual(typeof handler, "function");
@@ -200,39 +230,28 @@ test("pet hidden: hotkey resolves the visible request, never the collapsed one",
   assert.strictEqual(globalShortcut.registered.size, 0);
 });
 
-// Defensive: real hide semantics only produce collapsed-older + visible-newer,
-// but the invariant is "newest VISIBLE wins", not "newest pending" — lock it in
-// against a future reordering or an out-of-band collapsed newer bubble.
-test("pet hidden: hotkey targets the newest visible request even when a newer one is collapsed", () => {
-  const { permission, context, globalShortcut } = loadPermission();
-  const visibleRes = createResponse();
-  const collapsedRes = createResponse();
-  pushPending(permission, {
-    bubble: createFakeBubble({ visible: true }),
-    res: visibleRes,
-  });
-  pushPending(permission, {
-    bubble: createFakeBubble({ visible: false }),
-    res: collapsedRes,
-  });
-  context.petHidden = true;
-  permission.syncPermissionShortcuts();
+test("pet visible: a newer queued request does not steal the active hotkey", () => {
+  const { permission, globalShortcut } = loadPermission();
+  const activeRes = createResponse();
+  const queuedRes = createResponse();
+  present(permission, { res: activeRes });
+  const queued = pushPending(permission, { res: queuedRes });
+  permission.showPermissionBubble(queued);
 
   const handler = globalShortcut.registered.get(ALLOW_ACCEL);
   assert.strictEqual(typeof handler, "function");
   handler();
 
-  assert.strictEqual(visibleRes.statusCode, 200);
-  assert.match(visibleRes.body, /"behavior":"allow"/);
-  assert.strictEqual(collapsedRes.statusCode, null);
+  assert.strictEqual(activeRes.statusCode, 200);
+  assert.match(activeRes.body, /"behavior":"allow"/);
+  assert.strictEqual(queuedRes.statusCode, null);
   assert.strictEqual(permission.pendingPermissions.length, 1);
 });
 
-test("pet visible: a pending entry without a bubble window still registers hotkeys", () => {
+test("pet visible: a pending entry not yet presented does not register hotkeys", () => {
   const { permission, globalShortcut } = loadPermission();
   pushPending(permission, { bubble: null });
   permission.syncPermissionShortcuts();
 
-  assert.ok(globalShortcut.registered.has(ALLOW_ACCEL));
-  assert.ok(globalShortcut.registered.has(DENY_ACCEL));
+  assert.strictEqual(globalShortcut.registered.size, 0);
 });

--- a/test/permission-hotkey-focus.test.js
+++ b/test/permission-hotkey-focus.test.js
@@ -7,6 +7,37 @@ const { classifyPermissionInteraction } = require("../src/permission-automation-
 
 const PERMISSION_MODULE_PATH = require.resolve("../src/permission");
 
+class FakePermissionWindow {
+  constructor() {
+    this.destroyed = false;
+    this.visible = false;
+    this.listeners = new Map();
+    this.sentEvents = [];
+    this.webContents = {
+      once: (name, listener) => this.listeners.set(name, listener),
+      on: (name, listener) => this.listeners.set(name, listener),
+      send: (...args) => this.sentEvents.push(args),
+      isDestroyed: () => this.destroyed,
+    };
+  }
+  static fromWebContents(sender) { return sender && sender.__window ? sender.__window : null; }
+  setAlwaysOnTop() {}
+  setBounds(bounds) { this.bounds = bounds; }
+  getBounds() { return this.bounds || { x: 0, y: 0, width: 420, height: 240 }; }
+  setSkipTaskbar() {}
+  showInactive() { this.visible = true; }
+  hide() { this.visible = false; }
+  isVisible() { return this.visible; }
+  isDestroyed() { return this.destroyed; }
+  on(name, listener) { this.listeners.set(name, listener); }
+  loadFile() { this.listeners.get("did-finish-load")?.(); }
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.listeners.get("closed")?.();
+  }
+}
+
 function loadPermissionWithMocks({ electron, childProcess, platform = "darwin" }) {
   delete require.cache[PERMISSION_MODULE_PATH];
   const originalLoad = Module._load;
@@ -81,7 +112,7 @@ function createContext(focusCalls) {
     getSettingsSnapshot: () => ({ shortcuts: {} }),
     subscribeShortcuts: () => () => {},
     getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
-    getPetWindowBounds: () => null,
+    getPetWindowBounds: () => ({ x: 0, y: 0, width: 128, height: 128 }),
     getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
     getHitRectScreen: () => null,
     getHudReservedOffset: () => 0,
@@ -91,13 +122,26 @@ function createContext(focusCalls) {
     clearShortcutFailure: () => {},
     reportShortcutFailure: () => {},
     permDebugLog: null,
-    win: null,
+    win: { isDestroyed: () => false },
     bubbleFollowPet: false,
     petHidden: false,
     doNotDisturb: false,
     hideBubbles: false,
     sessions: new Map(),
   };
+}
+
+function presentPermission(permission, entry) {
+  permission.addPendingPermission(entry, "test-present");
+  permission.showPermissionBubble(entry);
+  const surface = permission.getPermissionSurfaceWindow();
+  const envelope = [...surface.sentEvents].reverse().find(([name]) => name === "permission-show")[1];
+  permission.handleBubbleHeight({ sender: { __window: surface } }, {
+    height: 240,
+    surfaceRevision: envelope.surfaceRevision,
+    activeEntryId: envelope.activeEntryId,
+    entryIds: envelope.entryIds,
+  });
 }
 
 afterEach(() => {
@@ -113,7 +157,7 @@ async function assertHotkeyLeavesFocusUntouchedOnCaptureFailure({ accelerator, e
   const globalShortcut = createGlobalShortcut();
   const initPermission = loadPermissionWithMocks({
     electron: {
-      BrowserWindow: Object.assign(class {}, { fromWebContents() { return null; } }),
+      BrowserWindow: FakePermissionWindow,
       globalShortcut,
     },
     childProcess: {
@@ -126,7 +170,7 @@ async function assertHotkeyLeavesFocusUntouchedOnCaptureFailure({ accelerator, e
   const permission = initPermission(createContext(focusCalls));
   const res = createResponse();
 
-  permission.pendingPermissions.push({
+  const entry = {
     res,
     abortHandler: () => {},
     suggestions: [],
@@ -139,8 +183,8 @@ async function assertHotkeyLeavesFocusUntouchedOnCaptureFailure({ accelerator, e
     interaction: classifyPermissionInteraction({ agentId: "claude-code", toolName: "Bash" }),
     resolvedSuggestion: null,
     createdAt: Date.now() - 5000,
-  });
-  permission.syncPermissionShortcuts();
+  };
+  presentPermission(permission, entry);
 
   const handler = globalShortcut.registered.get(accelerator);
   assert.strictEqual(typeof handler, "function");
@@ -176,13 +220,13 @@ test("opencode unknown permissions keep the global Allow/Deny shortcuts", () => 
   const globalShortcut = createGlobalShortcut();
   const initPermission = loadPermissionWithMocks({
     electron: {
-      BrowserWindow: Object.assign(class {}, { fromWebContents() { return null; } }),
+      BrowserWindow: FakePermissionWindow,
       globalShortcut,
     },
     childProcess: { execFile() {} },
   });
   const permission = initPermission(createContext([]));
-  permission.pendingPermissions.push({
+  const entry = {
     res: createResponse(),
     abortHandler: () => {},
     suggestions: [],
@@ -199,9 +243,8 @@ test("opencode unknown permissions keep the global Allow/Deny shortcuts", () => 
     }),
     resolvedSuggestion: null,
     createdAt: Date.now() - 5000,
-  });
-
-  permission.syncPermissionShortcuts();
+  };
+  presentPermission(permission, entry);
 
   assert.strictEqual(
     typeof globalShortcut.registered.get("CommandOrControl+Shift+Y"),

--- a/test/permission-ime-editing.test.js
+++ b/test/permission-ime-editing.test.js
@@ -5,6 +5,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const Module = require("node:module");
 const { describe, it } = require("node:test");
+const { classifyPermissionInteraction } = require("../src/permission-automation-policy");
 
 // ── Mock electron before requiring permission.js ──
 // permission.js does `const { BrowserWindow, globalShortcut } = require("electron")`
@@ -12,8 +13,31 @@ const { describe, it } = require("node:test");
 // to map the IPC sender back to its perm entry. The test runtime's
 // require("electron") returns a path string (no BrowserWindow), so mock it: a
 // sender resolves to its window via a `__win` sentinel.
+class FakeBrowserWindow {
+  constructor() {
+    this.destroyed = false;
+    this.visible = false;
+    this.listeners = new Map();
+    this.webContents = {
+      once: (event, listener) => this.listeners.set(event, listener),
+      on: (event, listener) => this.listeners.set(event, listener),
+      send() {},
+    };
+  }
+  static fromWebContents(sender) { return (sender && sender.__win) || null; }
+  setAlwaysOnTop() {}
+  setBounds() {}
+  setSkipTaskbar() {}
+  showInactive() { this.visible = true; }
+  hide() { this.visible = false; }
+  isVisible() { return this.visible; }
+  isDestroyed() { return this.destroyed; }
+  on(event, listener) { this.listeners.set(event, listener); }
+  loadFile() { this.listeners.get("did-finish-load")?.(); }
+  destroy() { this.destroyed = true; this.listeners.get("closed")?.(); }
+}
 const __electronMock = {
-  BrowserWindow: { fromWebContents: (sender) => (sender && sender.__win) || null },
+  BrowserWindow: FakeBrowserWindow,
   globalShortcut: {
     register: () => {}, unregister: () => {}, unregisterAll: () => {}, isRegistered: () => false,
   },
@@ -104,6 +128,26 @@ function eventFor(bubble) {
   return { sender: { __win: bubble } };
 }
 
+function presentTextSurface(api) {
+  const entry = {
+    sessionId: "claude-ime",
+    agentId: "claude-code",
+    toolName: "AskUserQuestion",
+    toolInput: { questions: [] },
+    suggestions: [],
+    createdAt: Date.now(),
+    isElicitation: true,
+    interaction: classifyPermissionInteraction({
+      agentId: "claude-code",
+      eventKind: "elicitation",
+      toolName: "AskUserQuestion",
+    }),
+  };
+  api.pendingPermissions.push(entry);
+  api.showPermissionBubble(entry);
+  return api.getPermissionSurfaceWindow();
+}
+
 describe("handleImeEditing (macOS)", () => {
   it("sets the flag on focus and clears it on blur, reapplying each time", macOnly, () => {
     const calls = [];
@@ -112,10 +156,9 @@ describe("handleImeEditing (macOS)", () => {
       () => calls.push("reposition"),
       () => calls.push("dodge")
     );
-    const { handleImeEditing, pendingPermissions } = initPermission(ctx);
-
-    const bubble = makeBubble();
-    pendingPermissions.push({ bubble });
+    const api = initPermission(ctx);
+    const { handleImeEditing } = api;
+    const bubble = presentTextSurface(api);
 
     handleImeEditing(eventFor(bubble), true);
     assert.strictEqual(bubble.__clawdMacImeEditing, true);
@@ -136,8 +179,9 @@ describe("handleImeEditing (macOS)", () => {
   it("ignores a sender that matches no pending permission", macOnly, () => {
     const reapply = [];
     const ctx = makeCtx(() => reapply.push(true));
-    const { handleImeEditing, pendingPermissions } = initPermission(ctx);
-    pendingPermissions.push({ bubble: makeBubble() });
+    const api = initPermission(ctx);
+    const { handleImeEditing } = api;
+    presentTextSurface(api);
 
     handleImeEditing(eventFor(makeBubble()), true); // different, unmatched window
     assert.strictEqual(reapply.length, 0);
@@ -146,9 +190,10 @@ describe("handleImeEditing (macOS)", () => {
   it("ignores a destroyed bubble instead of touching it", macOnly, () => {
     const reapply = [];
     const ctx = makeCtx(() => reapply.push(true));
-    const { handleImeEditing, pendingPermissions } = initPermission(ctx);
-    const bubble = makeBubble({ isDestroyed: () => true });
-    pendingPermissions.push({ bubble });
+    const api = initPermission(ctx);
+    const { handleImeEditing } = api;
+    const bubble = presentTextSurface(api);
+    bubble.destroyed = true;
 
     handleImeEditing(eventFor(bubble), true);
     assert.strictEqual(bubble.__clawdMacImeEditing, undefined);

--- a/test/permission-notify-autoclose.test.js
+++ b/test/permission-notify-autoclose.test.js
@@ -87,7 +87,10 @@ function createPermissionHarness({
       }
       if (typeof this._didFinishLoad === "function") this._didFinishLoad();
     }
-    showInactive() {}
+    showInactive() { this.visible = true; }
+    hide() { this.visible = false; }
+    isVisible() { return this.visible === true; }
+    focus() {}
     setSkipTaskbar() {}
     on(event, cb) {
       if (event === "closed") this._closedHandler = cb;
@@ -290,7 +293,7 @@ describe("permission passive notify auto-close refresh", () => {
     assert.strictEqual(api.refreshPassiveNotifyAutoClose(), 0);
     assert.strictEqual(api.pendingPermissions.length, 1);
 
-    api.handleDecide({ sender: { __window: entry.bubble } }, "codex-user-input-focus");
+    api.handleDecide({ sender: { __window: api.getPermissionSurfaceWindow() } }, "codex-user-input-focus");
     assert.strictEqual(api.pendingPermissions.length, 0);
     assert.strictEqual(harness.focused.length, 1);
     assert.strictEqual(harness.focused[0][0], "codex-a");
@@ -384,7 +387,7 @@ describe("permission passive notify auto-close refresh", () => {
     assert.strictEqual(api.pendingPermissions.length, 1);
 
     const existing = api.pendingPermissions[0];
-    const originalBubble = existing.bubble;
+    const originalBubble = api.getPermissionSurfaceWindow();
     const firstCreatedAt = existing.createdAt;
 
     mock.timers.tick(500);
@@ -392,7 +395,7 @@ describe("permission passive notify auto-close refresh", () => {
 
     assert.strictEqual(api.pendingPermissions.length, 1);
     assert.strictEqual(api.pendingPermissions[0], existing);
-    assert.strictEqual(existing.bubble, originalBubble);
+    assert.strictEqual(api.getPermissionSurfaceWindow(), originalBubble);
     assert.strictEqual(existing.toolInput.command, "second");
     assert.ok(existing.createdAt > firstCreatedAt);
 
@@ -447,7 +450,7 @@ describe("permission passive notify auto-close refresh", () => {
     });
     assert.strictEqual(api.pendingPermissions.length, 1);
     const existing = api.pendingPermissions[0];
-    const originalBubble = existing.bubble;
+    const originalBubble = api.getPermissionSurfaceWindow();
     const firstCreatedAt = existing.createdAt;
 
     // Request #2 for the same session: the stale cue must be replaced, not
@@ -462,7 +465,7 @@ describe("permission passive notify auto-close refresh", () => {
 
     assert.strictEqual(api.pendingPermissions.length, 1);
     assert.strictEqual(api.pendingPermissions[0], existing);
-    assert.strictEqual(existing.bubble, originalBubble);
+    assert.strictEqual(api.getPermissionSurfaceWindow(), originalBubble);
     assert.strictEqual(existing.toolInput.command, "rm -rf build");
     assert.strictEqual(existing.kimiToolName, "Bash");
     assert.deepStrictEqual(existing.kimiToolInput, { command: "rm -rf build" });
@@ -474,9 +477,9 @@ describe("permission passive notify auto-close refresh", () => {
     assert.ok(shows.length >= 2, "refresh should re-send permission-show");
     const lastShow = shows[shows.length - 1];
     const payload = lastShow[1];
-    assert.strictEqual(payload.toolName, "KimiPermission");
-    assert.strictEqual(payload.kimiToolName, "Bash");
-    assert.deepStrictEqual(payload.kimiToolInput, { command: "rm -rf build" });
+    assert.strictEqual(payload.active.toolName, "KimiPermission");
+    assert.strictEqual(payload.active.kimiToolName, "Bash");
+    assert.deepStrictEqual(payload.active.kimiToolInput, { command: "rm -rf build" });
 
     // A legacy-shaped refresh downgrades to the generic copy — the generic
     // line can't be wrong; a stale rich cue can.
@@ -521,10 +524,11 @@ describe("Kimi passive cue rebuild after dismissal (gate-ledger joint lifecycle)
     });
     assert.strictEqual(api.pendingPermissions.length, 1);
     const first = api.pendingPermissions[0];
-    assert.ok(first.bubble, "first cue should own a bubble window");
+    const firstSurface = api.getPermissionSurfaceWindow();
+    assert.ok(firstSurface, "first cue should be presented by the shared surface");
 
     // "Got it" travels the production ipc-decide path.
-    api.handleDecide({ sender: { __window: first.bubble } }, "allow");
+    api.handleDecide({ sender: { __window: firstSurface } }, "allow");
     assert.strictEqual(api.pendingPermissions.length, 0);
 
     // state.js re-arms ~800ms later with the next gate's detail.
@@ -540,7 +544,8 @@ describe("Kimi passive cue rebuild after dismissal (gate-ledger joint lifecycle)
     assert.strictEqual(second.isKimiNotify, true);
     assert.strictEqual(second.kimiToolName, "shell");
     assert.deepStrictEqual(second.kimiToolInput, { command: "Remove-Item a.txt" });
-    assert.ok(second.bubble && !second.bubble.destroyed, "re-armed cue should own a live bubble window");
+    assert.ok(api.getPermissionSurfaceWindow() && !api.getPermissionSurfaceWindow().destroyed,
+      "re-armed cue should use a live permission surface");
   });
 
   it("rebuilds a fresh card after the previous cue auto-expired", () => {
@@ -570,7 +575,7 @@ describe("Kimi passive cue rebuild after dismissal (gate-ledger joint lifecycle)
     const second = api.pendingPermissions[0];
     assert.notStrictEqual(second, first);
     assert.strictEqual(second.kimiToolName, "shell");
-    assert.ok(second.bubble && !second.bubble.destroyed);
+    assert.ok(api.getPermissionSurfaceWindow() && !api.getPermissionSurfaceWindow().destroyed);
   });
 });
 
@@ -620,10 +625,12 @@ describe("interactive permission bubble fatal fallback", () => {
 
   it("does not announce when BrowserWindow construction fails", () => {
     const harness = createPermissionHarness({ loadBehavior: "constructor-throw" });
-    const { entry } = makeBlockingEntry();
+    const { entry, response } = makeBlockingEntry();
     harness.api.pendingPermissions.push(entry);
 
-    assert.throws(() => harness.api.showPermissionBubble(entry), /BrowserWindow unavailable/);
+    assert.doesNotThrow(() => harness.api.showPermissionBubble(entry));
+    assert.strictEqual(harness.api.pendingPermissions.length, 0);
+    assert.strictEqual(response.destroyed, true);
     assert.deepStrictEqual(harness.slackAnnouncements, []);
   });
 
@@ -686,7 +693,7 @@ describe("interactive permission bubble fatal fallback", () => {
     entry.createdAt = Date.now() - 5000;
     harness.api.pendingPermissions.push(entry);
     harness.api.showPermissionBubble(entry);
-    entry.bubble.webContents = null;
+    harness.api.getPermissionSurfaceWindow().webContents = null;
 
     assert.doesNotThrow(() => {
       harness.api.resolvePermissionEntry(entry, "no-decision", "test cleanup");
@@ -726,7 +733,7 @@ describe("interactive permission bubble fatal fallback", () => {
     assert.strictEqual(harness.api.pendingPermissions.length, 1);
 
     const entry = harness.api.pendingPermissions[0];
-    const bubble = entry.bubble;
+    const bubble = harness.api.getPermissionSurfaceWindow();
     bubble.webContents.isDestroyed = () => true;
     bubble.webContents.send = () => {
       throw new Error("send must not target destroyed webContents");

--- a/test/permission-partial-create-rollback.test.js
+++ b/test/permission-partial-create-rollback.test.js
@@ -1,13 +1,13 @@
 "use strict";
 
-// Partial-create rollback for showPermissionBubble: a synchronous throw after
-// the BrowserWindow exists (platform APIs, shortcut sync, autoclose arming)
-// must destroy the window instead of orphaning it with live close handlers
-// while the route-level catch drops the pending entry.
+// Shared-surface rollback: a platform throw after renderer acknowledgement
+// drains only the delivered entry and destroys the failed serving surface.
 
 const { describe, it } = require("node:test");
 const assert = require("node:assert");
 const Module = require("module");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const PERMISSION_MODULE_PATH = require.resolve("../src/permission");
 const { classifyPermissionInteraction } = require("../src/permission-automation-policy");
@@ -50,7 +50,10 @@ function createRollbackHarness({ throwAt }) {
     }
     showInactive() {
       if (throwAt === "showInactive") throw new Error("showInactive boom");
+      this.visible = true;
     }
+    hide() { this.visible = false; }
+    isVisible() { return this.visible === true; }
     setSkipTaskbar() {}
     on(event, cb) {
       if (event === "closed") this._closedHandler = cb;
@@ -64,7 +67,7 @@ function createRollbackHarness({ throwAt }) {
 
   const fakeElectron = {
     BrowserWindow: Object.assign(FakeBrowserWindow, {
-      fromWebContents() { return null; },
+      fromWebContents(sender) { return sender && sender.__window || null; },
     }),
     globalShortcut: {
       register() { return true; },
@@ -115,18 +118,31 @@ function makeZcodeEntry(api) {
 }
 
 describe("showPermissionBubble partial-create rollback", () => {
-  it("destroys the window and rethrows when a post-create step throws", () => {
+  it("never destroys a shared surface from one route entry's rollback", () => {
+    const routeSource = fs.readFileSync(
+      path.join(__dirname, "..", "src", "server-route-permission.js"),
+      "utf8"
+    );
+
+    assert.doesNotMatch(routeSource, /permEntry\.bubble\.destroy\s*\(/);
+  });
+
+  it("destroys the serving surface and releases its entry when reveal throws", () => {
     const { api, createdWindows } = createRollbackHarness({ throwAt: "showInactive" });
     const entry = makeZcodeEntry(api);
 
-    assert.throws(() => api.showPermissionBubble(entry), /showInactive boom/);
+    assert.doesNotThrow(() => api.showPermissionBubble(entry));
+    const surface = api.getPermissionSurfaceWindow();
+    assert.ok(surface);
+    assert.doesNotThrow(() => {
+      api.handleBubbleHeight({ sender: { __window: surface } }, 180);
+    });
 
     // The window was torn down — no orphaned BrowserWindow with live handlers.
     assert.strictEqual(createdWindows.length, 1);
     assert.strictEqual(createdWindows[0].destroyed, true);
-    // The entry no longer points at the destroyed window; the route-level
-    // catch owns removing it from pendingPermissions and answering 204.
-    assert.strictEqual(entry.bubble, null);
+    assert.strictEqual(api.pendingPermissions.length, 0);
+    assert.strictEqual(api.getPermissionSurfaceWindow(), null);
   });
 
   it("leaves no window behind when nothing throws (control)", () => {
@@ -137,6 +153,7 @@ describe("showPermissionBubble partial-create rollback", () => {
 
     assert.strictEqual(createdWindows.length, 1);
     assert.strictEqual(createdWindows[0].destroyed, false);
-    assert.strictEqual(entry.bubble, createdWindows[0]);
+    assert.strictEqual(api.getPermissionSurfaceWindow(), createdWindows[0]);
+    assert.strictEqual(createdWindows[0].visible, undefined, "surface stays hidden before height acknowledgement");
   });
 });

--- a/test/permission-plan-feedback.test.js
+++ b/test/permission-plan-feedback.test.js
@@ -17,8 +17,31 @@ const { classifyPermissionInteraction } = require("../src/permission-automation-
 // returns the binary path string (no BrowserWindow), so without this mock the
 // handleDecide-driven tests below would throw. The mock resolves a sender to its
 // window via a `__win` sentinel; globalShortcut is stubbed to harmless no-ops.
+class FakeBrowserWindow {
+  constructor() {
+    this.destroyed = false;
+    this.visible = false;
+    this.listeners = new Map();
+    this.webContents = {
+      once: (event, listener) => this.listeners.set(event, listener),
+      on: (event, listener) => this.listeners.set(event, listener),
+      send() {},
+    };
+  }
+  static fromWebContents(sender) { return (sender && sender.__win) || null; }
+  setAlwaysOnTop() {}
+  setBounds() {}
+  setSkipTaskbar() {}
+  showInactive() { this.visible = true; }
+  hide() { this.visible = false; }
+  isVisible() { return this.visible; }
+  isDestroyed() { return this.destroyed; }
+  on(event, listener) { this.listeners.set(event, listener); }
+  loadFile() { this.listeners.get("did-finish-load")?.(); }
+  destroy() { this.destroyed = true; this.listeners.get("closed")?.(); }
+}
 const __electronMock = {
-  BrowserWindow: { fromWebContents: (sender) => (sender && sender.__win) || null },
+  BrowserWindow: FakeBrowserWindow,
   globalShortcut: {
     register: () => {}, unregister: () => {}, unregisterAll: () => {}, isRegistered: () => false,
   },
@@ -132,10 +155,8 @@ function makePlanPermEntry(res, overrides = {}) {
   return entry;
 }
 
-// Fake bubble window + IPC event. handleDecide() calls
-// BrowserWindow.fromWebContents(event.sender) (mocked above) which resolves
-// event.sender.__win back to the perm's bubble, so the lookup
-// pendingPermissions.find(p => p.bubble === senderWin) matches.
+// Fake window + IPC event. handleDecide() resolves event.sender.__win back to
+// the current shared permission surface.
 function makeFakeBubble() {
   return { isDestroyed: () => false, webContents: { send: () => {} }, destroy: () => {} };
 }
@@ -282,9 +303,10 @@ describe("permission plan-feedback handleDecide routing (IPC entry point)", () =
     const ctx = makeCtx();
     const perm = initPermission(ctx);
     const res = createMockResponse();
-    const bubble = makeFakeBubble();
-    const permEntry = makePlanPermEntry(res, { bubble, ...permOverrides });
+    const permEntry = makePlanPermEntry(res, permOverrides);
     perm.pendingPermissions.push(permEntry);
+    perm.showPermissionBubble(permEntry);
+    const bubble = perm.getPermissionSurfaceWindow();
     return { ctx, perm, res, bubble, permEntry };
   }
 

--- a/test/permission-reposition.test.js
+++ b/test/permission-reposition.test.js
@@ -2,7 +2,12 @@ const { describe, it } = require("node:test");
 const assert = require("node:assert");
 
 const permission = require("../src/permission");
-const { computeBubbleStackLayout, clampBubbleHeight, collectVisibleWindowBounds } = permission.__test;
+const {
+  computeBubbleStackLayout,
+  clampBubbleHeight,
+  collectVisibleWindowBounds,
+  computePermissionBubbleWidth,
+} = permission.__test;
 
 // Common defaults so each test only spells out what's interesting.
 const BW = 340;
@@ -385,97 +390,19 @@ describe("permission bubble stack layout", () => {
     for (let i = 0; i < bounds.length - 1; i++) assert.ok(bounds[i].y < bounds[i + 1].y);
   });
 
-  it("ignores Hardware Buddy test entries when stacking visible bubbles", () => {
-    const runtime = permission({
-      win: { isDestroyed: () => false },
-      bubbleFollowPet: false,
-      getPetWindowBounds: () => ({ x: 0, y: 0, width: 80, height: 80 }),
-      getNearestWorkArea: () => FHD,
-      getHitRectScreen: () => null,
-      getHudReservedOffset: () => 0,
-    });
-    const assigned = [];
-    const bubble = (name) => ({
-      isDestroyed: () => false,
-      setBounds: (bounds) => assigned.push([name, bounds]),
-    });
+});
 
-    runtime.addPendingPermission({ bubble: bubble("old"), measuredHeight: 200, suggestions: [] }, "test");
-    runtime.addPendingPermission({
-      bubble: null,
-      measuredHeight: 200,
-      suggestions: [],
-      remoteOnly: true,
-    }, "test");
-    runtime.addPendingPermission({ bubble: bubble("new"), measuredHeight: 200, suggestions: [] }, "test");
-
-    runtime.repositionBubbles();
-
-    assert.deepStrictEqual(assigned, [
-      ["old", { x: 1572, y: 666, width: 340, height: 200 }],
-      ["new", { x: 1572, y: 872, width: 340, height: 200 }],
-    ]);
+describe("permission shared-surface width", () => {
+  it("uses the 420px product width on ordinary work areas", () => {
+    assert.strictEqual(computePermissionBubbleWidth(1, 1920), 420);
   });
 
-  it("uses one fixed target work area for scale, width, height, and corner bounds", () => {
-    const primary = { x: -1600, y: 40, width: 1600, height: 900 };
-    const scaleCalls = [];
-    const runtime = permission({
-      win: { isDestroyed: () => false },
-      bubbleFollowPet: false,
-      bubbleFixedCorner: "top-left",
-      getPetWindowBounds: () => ({ x: 100, y: 100, width: 80, height: 80 }),
-      getBubbleWorkArea: (followPet) => {
-        assert.strictEqual(followPet, false);
-        return primary;
-      },
-      getTextScale: (workArea) => {
-        scaleCalls.push(workArea);
-        return 1.5;
-      },
-      getHitRectScreen: () => null,
-      getHudReservedOffset: () => 0,
-    });
-    const assigned = [];
-    runtime.addPendingPermission({
-      measuredHeight: 200,
-      suggestions: [],
-      bubble: {
-        isDestroyed: () => false,
-        setBounds: (bounds) => assigned.push(bounds),
-      },
-    }, "test");
-
-    runtime.repositionBubbles();
-
-    assert.deepStrictEqual(scaleCalls, [primary]);
-    assert.deepStrictEqual(assigned, [{ x: -1588, y: 52, width: 510, height: 300 }]);
+  it("uses the 380px compact width when scaling would consume the side lane", () => {
+    assert.strictEqual(computePermissionBubbleWidth(1, 800), 380);
   });
 
-  it("wires live HUD bounds into fixed permission bubble repositioning", () => {
-    const workArea = { x: 0, y: 0, width: 1200, height: 800 };
-    const runtime = permission({
-      win: { isDestroyed: () => false },
-      bubbleFollowPet: false,
-      bubbleFixedCorner: "bottom-right",
-      getPetWindowBounds: () => ({ x: 0, y: 0, width: 80, height: 80 }),
-      getBubbleWorkArea: () => workArea,
-      getHitRectScreen: () => null,
-      getSessionHudBounds: () => [{ x: 850, y: 600, width: 350, height: 100 }],
-      getHudReservedOffset: () => 0,
-    });
-    const assigned = [];
-    runtime.addPendingPermission({
-      measuredHeight: 200,
-      suggestions: [],
-      bubble: {
-        isDestroyed: () => false,
-        setBounds: (bounds) => assigned.push(bounds),
-      },
-    }, "test");
-
-    runtime.repositionBubbles();
-
-    assert.deepStrictEqual(assigned, [{ x: 852, y: 394, width: 340, height: 200 }]);
+  it("applies text scale once and keeps the 90% work-area hard cap", () => {
+    assert.strictEqual(computePermissionBubbleWidth(1.5, 1600), 630);
+    assert.strictEqual(computePermissionBubbleWidth(2, 600), 540);
   });
 });

--- a/test/permission-slack-announce.test.js
+++ b/test/permission-slack-announce.test.js
@@ -39,7 +39,9 @@ class FakeBrowserWindow {
   setAlwaysOnTop() {}
   setBounds(bounds) { this.bounds = bounds; }
   setSkipTaskbar() {}
-  showInactive() {}
+  showInactive() { this.visible = true; }
+  hide() { this.visible = false; }
+  isVisible() { return this.visible === true; }
   focus() {}
   on(event, callback) { this.listeners.set(event, callback); }
   isDestroyed() { return this.destroyed; }
@@ -170,8 +172,10 @@ function makePermEntry(overrides = {}) {
 
 function renderAndAcknowledge(perm, entry, height = 180) {
   perm.showPermissionBubble(entry);
-  assert.ok(entry.bubble, "precondition: a desktop bubble was constructed");
-  perm.handleBubbleHeight({ sender: { __window: entry.bubble } }, height);
+  const surface = perm.getPermissionSurfaceWindow();
+  assert.ok(surface, "precondition: a desktop permission surface was constructed");
+  perm.handleBubbleHeight({ sender: { __window: surface } }, height);
+  return surface;
 }
 
 describe("slack permission announce: only for requests a human must answer", () => {
@@ -191,7 +195,8 @@ describe("slack permission announce: only for requests a human must answer", () 
     perm.showPermissionBubble(entry);
     assert.deepEqual(ctx.announced, [], "loading a BrowserWindow is not yet a rendered card");
 
-    perm.handleBubbleHeight({ sender: { __window: entry.bubble } }, 180);
+    const surface = perm.getPermissionSurfaceWindow();
+    perm.handleBubbleHeight({ sender: { __window: surface } }, 180);
     assert.equal(ctx.announced.length, 1);
     assert.equal(typeof ctx.announceOptions[0].isStillRelevant, "function");
     assert.equal(ctx.announceOptions[0].isStillRelevant(), true);
@@ -200,7 +205,7 @@ describe("slack permission announce: only for requests a human must answer", () 
     assert.equal(ctx.announced[0].agentId, "claude-code");
 
     // Renderer reflows (stepper/feedback/text-size) must not ping Slack twice.
-    perm.handleBubbleHeight({ sender: { __window: entry.bubble } }, 220);
+    perm.handleBubbleHeight({ sender: { __window: surface } }, 220);
     assert.equal(ctx.announced.length, 1);
   });
 
@@ -215,7 +220,7 @@ describe("slack permission announce: only for requests a human must answer", () 
     ctx.getNearestWorkArea = () => { throw new Error("display disappeared"); };
 
     assert.throws(
-      () => perm.handleBubbleHeight({ sender: { __window: entry.bubble } }, 180),
+      () => perm.handleBubbleHeight({ sender: { __window: perm.getPermissionSurfaceWindow() } }, 180),
       /display disappeared/
     );
     assert.equal(ctx.announced.length, 1,
@@ -331,8 +336,9 @@ describe("slack permission announce: only for requests a human must answer", () 
     const resolvedEntry = makePermEntry();
     resolvedPerm.addPendingPermission(resolvedEntry, "added");
     resolvedPerm.showPermissionBubble(resolvedEntry);
+    const resolvedSurface = resolvedPerm.getPermissionSurfaceWindow();
     resolvedPerm.removePendingPermission(resolvedEntry, "resolved-before-render");
-    resolvedPerm.handleBubbleHeight({ sender: { __window: resolvedEntry.bubble } }, 180);
+    resolvedPerm.handleBubbleHeight({ sender: { __window: resolvedSurface } }, 180);
     assert.deepEqual(resolvedCtx.announced, []);
 
     const dndCtx = makeCtx();
@@ -341,7 +347,7 @@ describe("slack permission announce: only for requests a human must answer", () 
     dndPerm.addPendingPermission(dndEntry, "added");
     dndPerm.showPermissionBubble(dndEntry);
     dndCtx.doNotDisturb = true;
-    dndPerm.handleBubbleHeight({ sender: { __window: dndEntry.bubble } }, 180);
+    dndPerm.handleBubbleHeight({ sender: { __window: dndPerm.getPermissionSurfaceWindow() } }, 180);
     assert.deepEqual(dndCtx.announced, []);
   });
 

--- a/test/permission-surface-queue.test.js
+++ b/test/permission-surface-queue.test.js
@@ -1,0 +1,372 @@
+"use strict";
+
+const assert = require("node:assert");
+const Module = require("node:module");
+const { describe, it, afterEach } = require("node:test");
+const { classifyPermissionInteraction } = require("../src/permission-automation-policy");
+
+const PERMISSION_MODULE_PATH = require.resolve("../src/permission");
+
+function createHarness({ failLoadWindowIndex = null } = {}) {
+  const windows = [];
+  class FakeBrowserWindow {
+    constructor(options) {
+      this.options = options;
+      this.destroyed = false;
+      this.visible = false;
+      this.listeners = new Map();
+      this.sentEvents = [];
+      this.bounds = null;
+      this.webContents = {
+        once: (event, listener) => this.listeners.set(event, listener),
+        on: (event, listener) => this.listeners.set(event, listener),
+        send: (...args) => this.sentEvents.push(args),
+        isDestroyed: () => false,
+      };
+      windows.push(this);
+    }
+    static fromWebContents(sender) { return sender && sender.__window || null; }
+    setAlwaysOnTop() {}
+    setBounds(bounds) { this.bounds = bounds; }
+    getBounds() { return this.bounds || { x: 0, y: 0, width: 420, height: 200 }; }
+    setSkipTaskbar() {}
+    showInactive() { this.visible = true; }
+    hide() { this.visible = false; }
+    focus() {}
+    isVisible() { return this.visible; }
+    isDestroyed() { return this.destroyed; }
+    on(event, listener) { this.listeners.set(event, listener); }
+    loadFile() {
+      if (windows.indexOf(this) + 1 === failLoadWindowIndex) {
+        throw new Error("candidate load failed");
+      }
+      this.listeners.get("did-finish-load")?.();
+    }
+    destroy() {
+      if (this.destroyed) return;
+      this.destroyed = true;
+      this.listeners.get("closed")?.();
+    }
+    closeByUser() {
+      this.listeners.get("close")?.();
+      this.destroyed = true;
+      this.listeners.get("closed")?.();
+    }
+  }
+
+  const originalLoad = Module._load;
+  Module._load = function patchedLoad(request) {
+    if (request === "electron") {
+      return {
+        BrowserWindow: FakeBrowserWindow,
+        globalShortcut: {
+          register: () => true,
+          unregister() {},
+          isRegistered: () => false,
+        },
+      };
+    }
+    return originalLoad.apply(this, arguments);
+  };
+  delete require.cache[PERMISSION_MODULE_PATH];
+  let initPermission;
+  try {
+    initPermission = require("../src/permission");
+  } finally {
+    Module._load = originalLoad;
+  }
+
+  const api = initPermission({
+    win: { isDestroyed: () => false },
+    lang: "en",
+    bubbleFollowPet: false,
+    petHidden: false,
+    doNotDisturb: false,
+    sessions: new Map(),
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: null }),
+    getSettingsSnapshot: () => ({ shortcuts: {} }),
+    isAgentEnabled: () => true,
+    isAgentPermissionsEnabled: () => true,
+    isAgentSubagentPermissionsEnabled: () => true,
+    getPermissionAutomationMode: () => "off",
+    getPetWindowBounds: () => ({ x: 120, y: 120, width: 128, height: 128 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop() {},
+    reapplyMacVisibility() {},
+    repositionUpdateBubble() {},
+    focusTerminalForSession() {},
+    subscribeShortcuts: () => () => {},
+    clearShortcutFailure() {},
+    reportShortcutFailure() {},
+  });
+
+  function response() {
+    return {
+      statusCode: null,
+      body: "",
+      writableEnded: false,
+      destroyed: false,
+      headersSent: false,
+      on() {},
+      removeListener() {},
+      writeHead(statusCode) { this.statusCode = statusCode; this.headersSent = true; },
+      end(chunk) { if (chunk != null) this.body += String(chunk); this.writableEnded = true; },
+      destroy() { this.destroyed = true; },
+    };
+  }
+
+  let sequence = 0;
+  function entry({ input = false, command, passive = false } = {}) {
+    const id = ++sequence;
+    const res = passive ? null : response();
+    const toolName = input ? "AskUserQuestion" : (passive ? "CodexExec" : "Bash");
+    const value = {
+      res,
+      abortHandler() {},
+      suggestions: [],
+      sessionId: `session-${id}`,
+      toolName,
+      toolInput: input
+        ? { questions: [{ id: "0", question: "Choose", options: [] }] }
+        : { command: command || `echo ${id}` },
+      createdAt: Date.now() - 5000,
+      agentId: passive ? "codex" : "claude-code",
+      isCodexNotify: passive,
+      isElicitation: input,
+      interaction: classifyPermissionInteraction({
+        agentId: passive ? "codex" : "claude-code",
+        eventKind: input ? "elicitation" : (passive ? "notification" : "permission"),
+        toolName,
+      }),
+    };
+    return value;
+  }
+
+  function add(value) {
+    api.addPendingPermission(value, "test-added");
+    api.showPermissionBubble(value);
+    return value;
+  }
+
+  function lastEnvelope(win = api.getPermissionSurfaceWindow()) {
+    const event = [...win.sentEvents].reverse().find(([channel]) => channel === "permission-show");
+    assert.ok(event, "permission surface did not receive a payload");
+    return event[1];
+  }
+
+  function acknowledge(win = api.getPermissionSurfaceWindow()) {
+    const envelope = lastEnvelope(win);
+    api.handleBubbleHeight({ sender: { __window: win } }, {
+      height: 240,
+      surfaceRevision: envelope.surfaceRevision,
+      activeEntryId: envelope.activeEntryId,
+      entryIds: envelope.entryIds,
+    });
+    return envelope;
+  }
+
+  return { api, windows, entry, add, lastEnvelope, acknowledge };
+}
+
+afterEach(() => {
+  delete require.cache[PERMISSION_MODULE_PATH];
+});
+
+describe("permission shared surface queue", () => {
+  it("keeps one window, preserves the active request, and ignores queue-only revision for decide", () => {
+    const h = createHarness();
+    const first = h.add(h.entry({ command: "first" }));
+    const firstEnvelope = h.acknowledge();
+    const second = h.add(h.entry({ command: "second" }));
+
+    assert.strictEqual(h.windows.length, 1);
+    const queuedEnvelope = h.lastEnvelope();
+    assert.strictEqual(queuedEnvelope.activeEntryId, first.surfaceEntryId);
+    assert.deepStrictEqual(queuedEnvelope.queue.map((item) => item.entryId), [second.surfaceEntryId]);
+
+    h.api.handleDecide({ sender: { __window: h.api.getPermissionSurfaceWindow() } }, {
+      behavior: "allow",
+      entryId: first.surfaceEntryId,
+      activeContentRevision: firstEnvelope.activeContentRevision,
+    });
+
+    assert.match(first.res.body, /"behavior":"allow"/);
+    assert.strictEqual(second.res.statusCode, null);
+    assert.strictEqual(h.api.pendingPermissions.length, 1);
+    assert.strictEqual(h.lastEnvelope().activeEntryId, second.surfaceEntryId);
+  });
+
+  it("refreshes a queued request without changing the active-content revision", () => {
+    const h = createHarness();
+    const first = h.add(h.entry({ command: "first" }));
+    h.acknowledge();
+    const second = h.add(h.entry({ command: "before" }));
+    const before = h.lastEnvelope();
+
+    second.toolInput.command = "after";
+    h.api.refreshPermissionEntry(second);
+    const after = h.lastEnvelope();
+
+    assert.strictEqual(after.activeEntryId, first.surfaceEntryId);
+    assert.strictEqual(after.activeContentRevision, before.activeContentRevision);
+    assert.notStrictEqual(after.surfaceRevision, before.surfaceRevision);
+    assert.match(after.queue[0].summary, /after/);
+  });
+
+  it("rejects a stale active-content decision and republishes control recovery", () => {
+    const h = createHarness();
+    const first = h.add(h.entry());
+    const oldEnvelope = h.acknowledge();
+    h.api.refreshPermissionEntry(first);
+
+    h.api.handleDecide({ sender: { __window: h.api.getPermissionSurfaceWindow() } }, {
+      behavior: "deny",
+      entryId: first.surfaceEntryId,
+      activeContentRevision: oldEnvelope.activeContentRevision,
+    });
+
+    assert.strictEqual(first.res.statusCode, null);
+    assert.strictEqual(h.api.pendingPermissions.length, 1);
+    assert.strictEqual(h.lastEnvelope().restoreInteractionControls, true);
+  });
+
+  it("switches ordinary queued requests without deciding either one", () => {
+    const h = createHarness();
+    const first = h.add(h.entry({ command: "first" }));
+    h.acknowledge();
+    const second = h.add(h.entry({ command: "second" }));
+    const envelope = h.lastEnvelope();
+
+    h.api.handleSelect({ sender: { __window: h.api.getPermissionSurfaceWindow() } }, {
+      targetEntryId: second.surfaceEntryId,
+      observedActiveEntryId: first.surfaceEntryId,
+      activeContentRevision: envelope.activeContentRevision,
+    });
+
+    assert.strictEqual(first.res.statusCode, null);
+    assert.strictEqual(second.res.statusCode, null);
+    assert.strictEqual(h.lastEnvelope().activeEntryId, second.surfaceEntryId);
+  });
+
+  it("locks request switching while the active card owns an input draft", () => {
+    const h = createHarness();
+    const input = h.add(h.entry({ input: true }));
+    h.acknowledge();
+    const queued = h.add(h.entry());
+    const envelope = h.lastEnvelope();
+    assert.strictEqual(envelope.switchingLocked, true);
+
+    h.api.handleSelect({ sender: { __window: h.api.getPermissionSurfaceWindow() } }, {
+      targetEntryId: queued.surfaceEntryId,
+      observedActiveEntryId: input.surfaceEntryId,
+      activeContentRevision: envelope.activeContentRevision,
+    });
+
+    assert.strictEqual(h.lastEnvelope().activeEntryId, input.surfaceEntryId);
+    assert.strictEqual(h.lastEnvelope().restoreInteractionControls, true);
+  });
+
+  it("uses a hidden candidate and swaps only after native-mode acknowledgement", () => {
+    const h = createHarness();
+    const first = h.add(h.entry());
+    h.acknowledge();
+    const input = h.add(h.entry({ input: true }));
+    const envelope = h.lastEnvelope();
+    const oldWindow = h.api.getPermissionSurfaceWindow();
+
+    h.api.handleSelect({ sender: { __window: oldWindow } }, {
+      targetEntryId: input.surfaceEntryId,
+      observedActiveEntryId: first.surfaceEntryId,
+      activeContentRevision: envelope.activeContentRevision,
+    });
+
+    assert.strictEqual(h.windows.length, 2);
+    const candidate = h.windows[1];
+    assert.strictEqual(candidate.visible, false);
+    assert.strictEqual(h.api.getPermissionSurfaceWindow(), oldWindow);
+    h.acknowledge(candidate);
+
+    assert.strictEqual(h.api.getPermissionSurfaceWindow(), candidate);
+    assert.strictEqual(candidate.visible, true);
+    assert.strictEqual(oldWindow.destroyed, true);
+    assert.strictEqual(h.lastEnvelope(candidate).activeEntryId, input.surfaceEntryId);
+  });
+
+  it("keeps the serving surface and every request when a handover candidate fails", () => {
+    const h = createHarness({ failLoadWindowIndex: 2 });
+    const first = h.add(h.entry());
+    h.acknowledge();
+    const input = h.add(h.entry({ input: true }));
+    const envelope = h.lastEnvelope();
+    const oldWindow = h.api.getPermissionSurfaceWindow();
+
+    h.api.handleSelect({ sender: { __window: oldWindow } }, {
+      targetEntryId: input.surfaceEntryId,
+      observedActiveEntryId: first.surfaceEntryId,
+      activeContentRevision: envelope.activeContentRevision,
+    });
+
+    assert.strictEqual(h.windows.length, 2);
+    assert.strictEqual(h.windows[1].destroyed, true);
+    assert.strictEqual(h.api.getPermissionSurfaceWindow(), oldWindow);
+    assert.strictEqual(oldWindow.destroyed, false);
+    assert.deepStrictEqual(h.api.pendingPermissions, [first, input]);
+    assert.strictEqual(first.res.statusCode, null);
+    assert.strictEqual(input.res.statusCode, null);
+    assert.strictEqual(h.lastEnvelope(oldWindow).restoreInteractionControls, true);
+  });
+
+  it("returns no-decision for every request delivered to a failed serving surface", () => {
+    const h = createHarness();
+    const first = h.add(h.entry({ command: "first" }));
+    h.acknowledge();
+    const second = h.add(h.entry({ command: "second" }));
+    h.acknowledge();
+    const surface = h.api.getPermissionSurfaceWindow();
+
+    surface.listeners.get("render-process-gone")({}, { reason: "crashed" });
+
+    assert.strictEqual(first.res.destroyed, true);
+    assert.strictEqual(second.res.destroyed, true);
+    assert.deepStrictEqual(h.api.pendingPermissions, []);
+    assert.strictEqual(h.api.getPermissionSurfaceWindow(), null);
+  });
+
+  it("excludes the pet-hidden cutoff from a newly delivered surface failure", () => {
+    const h = createHarness();
+    const oldEntry = h.add(h.entry({ command: "old" }));
+    const surface = h.api.getPermissionSurfaceWindow();
+    h.acknowledge(surface);
+    h.api.setPermissionPetHidden(true);
+    surface.hide();
+
+    const newEntry = h.add(h.entry({ command: "new" }));
+    const hiddenEnvelope = h.lastEnvelope(surface);
+    assert.deepStrictEqual(hiddenEnvelope.entryIds, [newEntry.surfaceEntryId]);
+    assert.strictEqual(surface.visible, false, "hidden surface must wait for matching content acknowledgement");
+    h.acknowledge(surface);
+    assert.strictEqual(surface.visible, true);
+
+    surface.listeners.get("render-process-gone")({}, { reason: "crashed" });
+    assert.deepStrictEqual(h.api.pendingPermissions, [oldEntry]);
+    assert.strictEqual(oldEntry.res.destroyed, false);
+    assert.strictEqual(newEntry.res.destroyed, true);
+  });
+
+  it("treats a user close as a decision for active only", () => {
+    const h = createHarness();
+    const active = h.add(h.entry({ command: "active" }));
+    h.acknowledge();
+    const queued = h.add(h.entry({ command: "queued" }));
+    const surface = h.api.getPermissionSurfaceWindow();
+
+    surface.closeByUser();
+
+    assert.match(active.res.body, /"behavior":"deny"/);
+    assert.strictEqual(queued.res.statusCode, null);
+    assert.deepStrictEqual(h.api.pendingPermissions, [queued]);
+    assert.notStrictEqual(h.api.getPermissionSurfaceWindow(), surface);
+  });
+});

--- a/test/permission-update-bubble-ipc.test.js
+++ b/test/permission-update-bubble-ipc.test.js
@@ -57,20 +57,24 @@ test("permission IPC registers owned channels, delegates, and disposes", () => {
     permission: {
       handleBubbleHeight: (event, height) => calls.push(["height", event.sender, height]),
       handleDecide: (event, behavior) => calls.push(["decide", event.sender, behavior]),
+      handleSelect: (event, selection) => calls.push(["select", event.sender, selection]),
     },
   });
 
   assert.deepStrictEqual([...ipcMain.listeners.keys()].sort(), [
     "bubble-height",
     "permission-decide",
+    "permission-select",
   ]);
 
   ipcMain.send("bubble-height", 240);
   ipcMain.send("permission-decide", "deny-and-focus");
+  ipcMain.send("permission-select", { targetEntryId: "entry-2" });
 
   assert.deepStrictEqual(calls, [
     ["height", "sender-web-contents", 240],
     ["decide", "sender-web-contents", "deny-and-focus"],
+    ["select", "sender-web-contents", { targetEntryId: "entry-2" }],
   ]);
 
   runtime.dispose();


### PR DESCRIPTION
## Summary

- replace the one-window-per-request permission stack with one shared permission surface containing an active request and a waiting queue
- keep long content inside a bounded, internally scrollable bubble, with a two-item preview and an expandable full queue
- preserve input drafts, IME ownership, close semantics, remote notification delivery, pet-hidden behavior, and native focus modes while requests arrive or switch
- update the runtime architecture docs and add shared-surface lifecycle, renderer, formatting, and regression coverage

This is a follow-up to #918 and the reporter's request to make long permission content easier to inspect.

## Validation

- `npm test`: 8,669 passed, 0 failed, 30 skipped
- focused final run: 40 passed, 0 failed (`permission-surface-queue` + Slack delivery acknowledgement)
- `git diff --check`
- `node --check src/permission.js`

### macOS real-device smoke

- one permission window displayed seven simultaneous requests
- adding a request updated the queue count without clearing the active Chinese draft
- the full waiting drawer expanded and scrolled independently while the input and decision controls remained fixed
- ordinary requests switched in place without resolving either request
- submitting an input request handed the shared surface over to the normal non-input window mode without a crash or duplicate window
- the submitted Chinese answer and all test decisions completed their HTTP round trips; temporary test requests were cleared and the original permission mode was restored

## Residual validation limits

- Windows real-device behavior for this follow-up has not yet been re-run
- Deskflow intercepted synthetic Chinese typing on the test Mac, so the native IME candidate popup itself was not independently verified; Chinese draft persistence and answer round-trip behavior were verified through the live input surface
