### PR TITLE
fix: add expandable permission bubble details

### DIFF
--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -324,7 +324,7 @@ CodeBuddy 的 PermissionRequest HTTP 所有权只认严格的本机 managed URL�
 - Codex 的 PermissionRequest 是 official command hook；hook 脚本挂起等待 `/permission`，再把 sanitized allow/deny JSON 写到 stdout
 - `POST /permission` 接收 `{ tool_name, tool_input, session_id, permission_suggestions }`；Codex 额外带 `turn_id`、`tool_input_description`、`tool_input_fingerprint`
 - 每个权限请求都会创建独立 `BrowserWindow`。卡片默认保持约 340 CSS px 的三行摘要；长内容和次级操作通过用户点击进入约 500 CSS px 的详情态，详情正文独立滚动，标题与决定按钮固定可见。桌面同时最多一个详情态，其他请求仍是摘要卡；切换详情不会销毁窗口，因此 Ask/Plan 的选择、输入草稿、步骤和滚动位置都保留
-- 普通工具摘要态保留 Allow/Deny；Plan 摘要态只提供「查看计划」，Ask 摘要态只提供「回答」，避免未读正文的盲决定。Plan/Ask 到达时不抢焦点，只在用户点击展开后聚焦；Win/Linux 由创建期 `focusable` 覆盖其潜在输入需求
+- 普通工具摘要态保留 Allow/Deny、permission suggestions（含 Always）和可用的会话授权；Plan 摘要态同时提供「查看计划」与快速批准，反馈/回终端等次级操作只在详情态出现；Ask 摘要态只提供「回答」。Plan/Ask 到达时不抢焦点，只在用户点击展开后聚焦；Win/Linux 由创建期 `focusable` 覆盖其潜在输入需求
 - bubble 通过 IPC `bubble-height` 回报 `{state, measurementEpoch, height}`。主进程只接受当前摘要/详情 epoch 的测量，避免展开→收起→展开期间的旧高度覆盖新布局；详情高度以 `min(60% workArea, 620 CSS px)` 为偏好，并以实测 chrome + 5 行正文为可读下限、当前 workArea 为硬上限
 - 多宽度 stack 仍保持最老请求在上。详情卡必须完整留在目标 workArea 内；当摘要兄弟太多时允许兄弟向边缘外溢，不缩小一个已在阅读中的详情卡。Follow 模式详情朝远离桌宠的一侧扩展，Fixed 模式保持所选角的边缘对齐
 - 本地详情数据与网络/决策数据分离：route 在生成有界摘要的同时保留最多 128 KiB 的仅本地显示详情；fingerprint、automation、HTTP 回包、Telegram/飞书/Slack payload 继续使用原有数据。Ask 的 wire question/answer key 保持上游原文，长正文和选项说明只影响详情显示

--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -323,8 +323,11 @@ CodeBuddy 的 PermissionRequest HTTP 所有权只认严格的本机 managed URL�
 - DeepSeek Harness 普通 approval 进入独立 blocking adapter；人工 Allow/Deny 可用，但 auto-tools、unattended 与 per-session grant 全部 DEFER。`ask_user_question` 返回 204 交给 DSH 原生 provider
 - Codex 的 PermissionRequest 是 official command hook；hook 脚本挂起等待 `/permission`，再把 sanitized allow/deny JSON 写到 stdout
 - `POST /permission` 接收 `{ tool_name, tool_input, session_id, permission_suggestions }`；Codex 额外带 `turn_id`、`tool_input_description`、`tool_input_fingerprint`
-- 每个权限请求都会创建独立 `BrowserWindow`，多个 bubble 从右下向上堆叠
-- bubble 会通过 IPC `bubble-height` 回报真实高度，主进程据此重排
+- 每个权限请求都会创建独立 `BrowserWindow`。卡片默认保持约 340 CSS px 的三行摘要；长内容和次级操作通过用户点击进入约 500 CSS px 的详情态，详情正文独立滚动，标题与决定按钮固定可见。桌面同时最多一个详情态，其他请求仍是摘要卡；切换详情不会销毁窗口，因此 Ask/Plan 的选择、输入草稿、步骤和滚动位置都保留
+- 普通工具摘要态保留 Allow/Deny；Plan 摘要态只提供「查看计划」，Ask 摘要态只提供「回答」，避免未读正文的盲决定。Plan/Ask 到达时不抢焦点，只在用户点击展开后聚焦；Win/Linux 由创建期 `focusable` 覆盖其潜在输入需求
+- bubble 通过 IPC `bubble-height` 回报 `{state, measurementEpoch, height}`。主进程只接受当前摘要/详情 epoch 的测量，避免展开→收起→展开期间的旧高度覆盖新布局；详情高度以 `min(60% workArea, 620 CSS px)` 为偏好，并以实测 chrome + 5 行正文为可读下限、当前 workArea 为硬上限
+- 多宽度 stack 仍保持最老请求在上。详情卡必须完整留在目标 workArea 内；当摘要兄弟太多时允许兄弟向边缘外溢，不缩小一个已在阅读中的详情卡。Follow 模式详情朝远离桌宠的一侧扩展，Fixed 模式保持所选角的边缘对齐
+- 本地详情数据与网络/决策数据分离：route 在生成有界摘要的同时保留最多 128 KiB 的仅本地显示详情；fingerprint、automation、HTTP 回包、Telegram/飞书/Slack payload 继续使用原有数据。Ask 的 wire question/answer key 保持上游原文，长正文和选项说明只影响详情显示
 - 支持 Allow / Deny / suggestion 决策，以及 `addRules` / `setMode` suggestion 类型
 - `permission-automation-policy.js` 的 off / auto-tools / unattended 与 `session-automation-coordinator.js` 的 per-session grant 会在 bubble 渲染前产生真实决定。auto-tools 对 Claude/Qwen 的未知 built-in（除有效 namespaced MCP）fail closed，但其他已知 adapter 对非空工具名不都使用逐工具 allowlist；unattended 在识别已知 decision tools 后仍有意对可作 Allow/Deny 的未知请求保留“handle every request”行为。新增 agent/tool/interaction 必须同时审查 policy 与 tests，不能笼统假设 unknown 一律 defer
 - Telegram 与飞书 / Lark 是和本地 bubble 并行的远程决策通道；关闭本地 bubble 不等于关闭远程审批。远程 client 超时、断连、未配置或启动失败不得产生决定或 deny：本地 bubble 存在时请求继续 pending；仅在 remote-only 且所有可用 client 都无决定时，整体请求才 no-decision 并让 agent 回原生 UI 重问

--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -80,7 +80,7 @@ Settings 是独立 `BrowserWindow`，采用 5 层结构：
 - 固定模式读取 `bubbleFixedCorner=top-left|top-right|bottom-left|bottom-right`，锚定 primary display 的 `workArea`。主屏查询不可用时回退桌宠所在显示器，再失败才使用 synthetic work area。
 - permission stack 先定位并避让可见 Session HUD；update bubble 随后读取真实可见 permission/HUD 外窗矩形再定位；Orbit 最后读取更新后的几何。
 - 跟随模式使用桌宠所在显示器的 text scale；固定模式使用主屏 text scale。窗口 bounds、CSS px → DIP 与 renderer zoom 必须基于同一个目标显示器。
-- 权限气泡默认是约 340 CSS px 的三行摘要卡；普通工具在摘要态可直接 Allow/Deny，长正文或次级操作经「查看详情/更多选项」进入约 500 CSS px 的详情卡。Plan 摘要只可「查看计划」，Ask 摘要只可「回答」；详情正文滚动，标题和决定区固定，不提供自由拖拽改尺寸。
+- 权限气泡默认是约 340 CSS px 的三行摘要卡；普通工具在摘要态保留原有 Allow/Deny、Always/suggestion 和会话授权快捷操作，长正文经「查看详情」进入约 500 CSS px 的详情卡。Plan 摘要同时保留「查看计划」和快速批准，反馈/回终端等次级操作在展开后出现；Ask 摘要只可「回答」。详情正文滚动，标题和全部决定区固定，不提供自由拖拽改尺寸。
 - 桌面同时最多一个权限详情卡，切换时其他气泡恢复摘要，但各自 BrowserWindow/DOM 不销毁，因此 Ask 选择、Other 文本、Plan 修改草稿、步骤和滚动位置保留；IME composition 未结束时拒绝切换详情。petHidden 只隐藏窗口，不清空详情 owner 或草稿。
 - 多气泡始终保持最老请求在上；详情卡必须完整留在当前目标工作区，摘要兄弟过多时可向工作区外溢，不能把正在阅读的详情压到不可读。macOS IME 编辑中的气泡冻结位置，blur 后只执行一次现有 floating-bubble 重排序列。
 

--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -80,7 +80,9 @@ Settings 是独立 `BrowserWindow`，采用 5 层结构：
 - 固定模式读取 `bubbleFixedCorner=top-left|top-right|bottom-left|bottom-right`，锚定 primary display 的 `workArea`。主屏查询不可用时回退桌宠所在显示器，再失败才使用 synthetic work area。
 - permission stack 先定位并避让可见 Session HUD；update bubble 随后读取真实可见 permission/HUD 外窗矩形再定位；Orbit 最后读取更新后的几何。
 - 跟随模式使用桌宠所在显示器的 text scale；固定模式使用主屏 text scale。窗口 bounds、CSS px → DIP 与 renderer zoom 必须基于同一个目标显示器。
-- 多气泡始终保持最老请求在上；超高 stack 优先保住最老请求，允许较新的请求向下溢出。macOS IME 编辑中的气泡冻结位置，blur 后只执行一次现有 floating-bubble 重排序列。
+- 权限气泡默认是约 340 CSS px 的三行摘要卡；普通工具在摘要态可直接 Allow/Deny，长正文或次级操作经「查看详情/更多选项」进入约 500 CSS px 的详情卡。Plan 摘要只可「查看计划」，Ask 摘要只可「回答」；详情正文滚动，标题和决定区固定，不提供自由拖拽改尺寸。
+- 桌面同时最多一个权限详情卡，切换时其他气泡恢复摘要，但各自 BrowserWindow/DOM 不销毁，因此 Ask 选择、Other 文本、Plan 修改草稿、步骤和滚动位置保留；IME composition 未结束时拒绝切换详情。petHidden 只隐藏窗口，不清空详情 owner 或草稿。
+- 多气泡始终保持最老请求在上；详情卡必须完整留在当前目标工作区，摘要兄弟过多时可向工作区外溢，不能把正在阅读的详情压到不可读。macOS IME 编辑中的气泡冻结位置，blur 后只执行一次现有 floating-bubble 重排序列。
 
 ## Mini Mode
 

--- a/src/bubble-format.js
+++ b/src/bubble-format.js
@@ -18,12 +18,17 @@
     return "";
   }
 
-  function formatAntigravityDetail(name, input) {
+  function maybeTruncate(value, max) {
+    return Number.isFinite(max) ? truncate(value, max) : String(value == null ? "" : value);
+  }
+
+  function formatAntigravityDetail(name, input, options) {
     const toolName = typeof name === "string" ? name.trim().toLowerCase() : "";
     if (!toolName) return "";
+    const max = options && options.mode === "detail" ? Infinity : 160;
 
     if (toolName === "run_command" || toolName === "bash" || toolName === "shell") {
-      return truncate(firstStringValue(input, ["CommandLine", "command", "Command", "cmd"]), 160);
+      return maybeTruncate(firstStringValue(input, ["CommandLine", "command", "Command", "cmd"]), max);
     }
     if (
       toolName === "write_to_file" ||
@@ -35,40 +40,74 @@
     ) {
       const filePath = firstStringValue(input, ["TargetFile", "AbsolutePath", "file_path", "path", "filePath", "FilePath"]);
       const description = firstStringValue(input, ["Description", "Instruction"]);
-      return truncate(description && filePath ? `${filePath}: ${description}` : (filePath || description), 160);
+      return maybeTruncate(description && filePath ? `${filePath}: ${description}` : (filePath || description), max);
     }
     if (toolName === "view_file" || toolName === "read") {
-      return truncate(firstStringValue(input, ["AbsolutePath", "file_path", "path", "filePath", "FilePath"]), 160);
+      return maybeTruncate(firstStringValue(input, ["AbsolutePath", "file_path", "path", "filePath", "FilePath"]), max);
     }
     if (toolName === "list_dir") {
-      return truncate(firstStringValue(input, ["DirectoryPath", "path", "directory"]), 160);
+      return maybeTruncate(firstStringValue(input, ["DirectoryPath", "path", "directory"]), max);
     }
     if (toolName === "find_by_name") {
       const searchPath = firstStringValue(input, ["SearchDirectory", "DirectoryPath", "path"]);
       const pattern = firstStringValue(input, ["Pattern", "pattern"]);
-      return truncate(pattern && searchPath ? `${searchPath}: ${pattern}` : (searchPath || pattern), 160);
+      return maybeTruncate(pattern && searchPath ? `${searchPath}: ${pattern}` : (searchPath || pattern), max);
     }
     if (toolName === "grep_search") {
       const searchPath = firstStringValue(input, ["SearchPath", "SearchDirectory", "DirectoryPath", "path"]);
       const query = firstStringValue(input, ["Query", "query"]);
-      return truncate(query && searchPath ? `${searchPath}: ${query}` : (searchPath || query), 160);
+      return maybeTruncate(query && searchPath ? `${searchPath}: ${query}` : (searchPath || query), max);
     }
     if (toolName === "ask_permission") {
       const target = firstStringValue(input, ["Target", "target", "Permission", "permission"]);
       const reason = firstStringValue(input, ["Reason", "reason", "Description", "description"]);
-      return truncate(reason && target ? `${target}: ${reason}` : (target || reason), 160);
+      return maybeTruncate(reason && target ? `${target}: ${reason}` : (target || reason), max);
     }
     if (toolName === "read_url_content") {
-      return truncate(firstStringValue(input, ["Url", "url"]), 160);
+      return maybeTruncate(firstStringValue(input, ["Url", "url"]), max);
     }
     if (toolName === "search_web") {
-      return truncate(firstStringValue(input, ["query", "Query"]), 160);
+      return maybeTruncate(firstStringValue(input, ["query", "Query"]), max);
     }
     return "";
   }
 
   function formatDetail(name, input, options) {
     if (!input || typeof input !== "object") return "";
+    const detailMode = !!(options && options.mode === "detail");
+    const normalizedName = typeof name === "string" ? name.trim().toLowerCase() : "";
+
+    if (detailMode) {
+      if (normalizedName === "exitplanmode" && typeof input.plan === "string") return input.plan.trim();
+      if (
+        (normalizedName === "bash" || normalizedName === "shell" || normalizedName === "run_command")
+      ) {
+        const command = firstStringValue(input, ["command", "CommandLine", "Command", "cmd"]);
+        if (command) return command;
+      }
+      if (normalizedName === "edit" || normalizedName === "write" || normalizedName === "read") {
+        const filePath = firstStringValue(input, ["file_path", "filepath", "path", "AbsolutePath", "TargetFile"]);
+        if (filePath) return filePath;
+      }
+      if (normalizedName === "glob" || normalizedName === "grep") {
+        const pattern = firstStringValue(input, ["pattern", "Pattern", "query", "Query"]);
+        if (pattern) return pattern;
+      }
+      if (options && options.isAntigravity) {
+        const antigravityDetail = formatAntigravityDetail(name, input, { mode: "detail" });
+        if (antigravityDetail) return antigravityDetail;
+      }
+      if (options && typeof options.formatUnknownDetail === "function") {
+        return options.formatUnknownDetail(input);
+      }
+      try {
+        return JSON.stringify(input, null, 2);
+      } catch {
+        return "";
+      }
+    }
+
+    if (normalizedName === "exitplanmode" && typeof input.plan === "string") return truncate(input.plan.trim(), 120);
     if (typeof input.description === "string" && input.description.trim()) return truncate(input.description.trim(), 120);
     if (name === "Bash" && typeof input.command === "string") return truncate(input.command, 120);
     if ((name === "Edit" || name === "Write" || name === "Read") && typeof input.file_path === "string")

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -15,6 +15,11 @@ function startMarqueeIfOverflowing() {
 toolPill.addEventListener("mouseenter", startMarqueeIfOverflowing);
 toolPill.addEventListener("mouseleave", stopMarquee);
 const commandBlock = document.getElementById("commandBlock");
+const compactBlock = document.getElementById("compactBlock");
+const detailScroll = document.getElementById("detailScroll");
+const detailTruncation = document.getElementById("detailTruncation");
+const btnExpand = document.getElementById("btnExpand");
+const btnCollapse = document.getElementById("btnCollapse");
 const irreversibleBadge = document.getElementById("irreversibleBadge");
 const elicitationForm = document.getElementById("elicitationForm");
 const elicitationProgress = document.getElementById("elicitationProgress");
@@ -25,6 +30,8 @@ const planFeedbackSubmit = document.getElementById("planFeedbackSubmit");
 const btnAllow = document.getElementById("btnAllow");
 const btnDeny = document.getElementById("btnDeny");
 const suggestionsContainer = document.getElementById("suggestions");
+const actionsContainer = document.getElementById("actions");
+const footerSecondary = document.getElementById("footerSecondary");
 const headerTitle = document.querySelector(".header-title");
 const sessionTag = document.getElementById("sessionTag");
 let elicitationMode = false;
@@ -34,6 +41,14 @@ let elicitationAnswers = {};
 let activeQuestionIndex = 0;
 let currentLang = "en";
 let heightReportFrame = 0;
+let currentData = null;
+let currentExpanded = false;
+let measurementEpoch = 0;
+let currentIsPlanReview = false;
+let planFeedbackMode = false;
+let pendingRestoreState = null;
+let sessionTrustErrorElement = null;
+let compactContentOverflow = false;
 
 // Mirrors body { padding: 6px; } above. Keep this in sync if the body padding changes.
 const BUBBLE_BODY_PADDING_Y = 12;
@@ -98,6 +113,13 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "What should be changed?",
     submitFeedback: "Send",
     back: "Back",
+    viewDetails: "View details",
+    moreOptions: "More options",
+    viewPlan: "View plan",
+    answer: "Answer",
+    collapse: "Collapse",
+    contentTruncated: "Content is too large and has been truncated.",
+    questionCount: "Questions: {count}",
   },
   zh: {
     irreversibleHint: "\u7834\u574F\u6027\u64CD\u4F5C\u2014\u2014\u53EF\u80FD\u65E0\u6CD5\u6062\u590D",
@@ -141,6 +163,13 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "\u54EA\u91CC\u9700\u8981\u6539?",
     submitFeedback: "\u53D1\u9001",
     back: "\u8FD4\u56DE",
+    viewDetails: "\u67E5\u770B\u8BE6\u60C5",
+    moreOptions: "\u66F4\u591A\u9009\u9879",
+    viewPlan: "\u67E5\u770B\u8BA1\u5212",
+    answer: "\u56DE\u7B54",
+    collapse: "\u6536\u8D77",
+    contentTruncated: "\u5185\u5BB9\u8FC7\u5927\uFF0C\u5DF2\u622A\u65AD\u3002",
+    questionCount: "{count} \u4E2A\u95EE\u9898",
   },
   "zh-TW": {
     irreversibleHint: "\u7834\u58DE\u6027\u64CD\u4F5C\u2014\u2014\u53EF\u80FD\u7121\u6CD5\u5FA9\u539F",
@@ -184,6 +213,13 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "哪裡需要改?",
     submitFeedback: "傳送",
     back: "返回",
+    viewDetails: "查看詳情",
+    moreOptions: "更多選項",
+    viewPlan: "查看計畫",
+    answer: "回答",
+    collapse: "收合",
+    contentTruncated: "內容過大，已截斷。",
+    questionCount: "{count} 個問題",
   },
   ko: {
     irreversibleHint: "\uD30C\uAD34\uC801 \uC791\uC5C5 \u2014 \uBCF5\uAD6C\uB418\uC9C0 \uC54A\uC744 \uC218 \uC788\uC2B5\uB2C8\uB2E4",
@@ -227,6 +263,13 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "\uC5B4\uB514\uB97C \uBC14\uAFD4\uC57C \uD558\uB098\uC694?",
     submitFeedback: "\uBCF4\uB0B4\uAE30",
     back: "\uB4A4\uB85C",
+    viewDetails: "\uC790\uC138\uD788 \uBCF4\uAE30",
+    moreOptions: "\uB354 \uBCF4\uAE30",
+    viewPlan: "\uACC4\uD68D \uBCF4\uAE30",
+    answer: "\uB2F5\uBCC0",
+    collapse: "\uC811\uAE30",
+    contentTruncated: "\uB0B4\uC6A9\uC774 \uB108\uBB34 \uCEE4\uC11C \uC798\uB838\uC2B5\uB2C8\uB2E4.",
+    questionCount: "\uC9C8\uBB38 {count}\uAC1C",
   },
   ja: {
     irreversibleHint: "\u7834\u58CA\u7684\u306A\u64CD\u4F5C \u2014 \u5FA9\u5143\u3067\u304D\u306A\u3044\u53EF\u80FD\u6027\u304C\u3042\u308A\u307E\u3059",
@@ -270,6 +313,13 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "どこを変更すべき?",
     submitFeedback: "送信",
     back: "戻る",
+    viewDetails: "詳細を表示",
+    moreOptions: "その他の選択肢",
+    viewPlan: "計画を表示",
+    answer: "回答",
+    collapse: "閉じる",
+    contentTruncated: "内容が大きすぎるため、省略されました。",
+    questionCount: "質問 {count} 件",
   },
   "pt-BR": {
     irreversibleHint: "Ação destrutiva — pode não ter volta",
@@ -313,6 +363,13 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "O que deveria mudar?",
     submitFeedback: "Enviar",
     back: "Voltar",
+    viewDetails: "Ver detalhes",
+    moreOptions: "Mais opções",
+    viewPlan: "Ver plano",
+    answer: "Responder",
+    collapse: "Recolher",
+    contentTruncated: "O conteúdo é muito grande e foi truncado.",
+    questionCount: "Perguntas: {count}",
   },
   es: {
     irreversibleHint: "Acción destructiva — puede ser irreversible",
@@ -356,6 +413,13 @@ const BUBBLE_STRINGS = {
     planFeedbackPlaceholder: "¿Qué habría que cambiar?",
     submitFeedback: "Enviar",
     back: "Atrás",
+    viewDetails: "Ver detalles",
+    moreOptions: "Más opciones",
+    viewPlan: "Ver plan",
+    answer: "Responder",
+    collapse: "Contraer",
+    contentTruncated: "El contenido es demasiado grande y se ha truncado.",
+    questionCount: "Preguntas: {count}",
   },
 };
 
@@ -398,7 +462,9 @@ function getSuggestionLabel(s, lang) {
 function disableAll() {
   btnAllow.disabled = true;
   btnDeny.disabled = true;
+  btnExpand.disabled = true;
   for (const btn of suggestionsContainer.children) btn.disabled = true;
+  for (const btn of footerSecondary.children) btn.disabled = true;
   for (const el of elicitationForm.querySelectorAll("input, textarea, button")) el.disabled = true;
 }
 
@@ -419,24 +485,20 @@ function withUnconstrainedElicitationForm(fn) {
 
 function measureNaturalBubbleHeight() {
   return withUnconstrainedElicitationForm(() => {
-    return Math.ceil(Math.max(card.offsetHeight, card.scrollHeight) + BUBBLE_BODY_PADDING_Y);
+    card.classList.add("measuring");
+    const height = Math.ceil(Math.max(card.offsetHeight, card.scrollHeight) + BUBBLE_BODY_PADDING_Y);
+    card.classList.remove("measuring");
+    return height;
   });
 }
 
 function applyElicitationViewport() {
   // Intentionally a no-op.
   //
-  // Previously this function clamped the elicitation form's maxHeight and added
-  // the `elicitation-scrollable` class (overflow-y: auto). The scroll container
-  // caused arrow keys to scroll the div instead of navigating between radio
-  // options — even with preventDefault()/stopPropagation() on keydown — because
-  // Chromium's scroll-on-arrow default action fires before JS handlers in the
-  // bubble phase, not after.
-  //
-  // The correct approach: let the form grow to its natural height and drive
-  // window size through reportHeight() → IPC bubble-height → setBounds().
-  // permission.js clampBubbleHeight() already caps the window at workArea.height
-  // so content-heavy bubbles will never exceed the screen.
+  // The expanded interaction model owns overflow in one outer detail scroller.
+  // Keeping the form itself unconstrained preserves radio-key navigation and
+  // avoids nested scroll regions; main still receives the natural height and
+  // caps the BrowserWindow against its target work area.
   //
   // Safety: "User answered in terminal" cannot be triggered by elicitation
   // bubbles. That denial path is wired to PostToolUse/Stop hook events matched
@@ -449,12 +511,26 @@ function scheduleBubbleHeightReport() {
   if (heightReportFrame) cancelAnimationFrame(heightReportFrame);
   heightReportFrame = requestAnimationFrame(() => {
     heightReportFrame = 0;
-    window.bubbleAPI.reportHeight(measureNaturalBubbleHeight());
+    const height = measureNaturalBubbleHeight();
+    const computed = typeof window.getComputedStyle === "function"
+      ? window.getComputedStyle(commandBlock)
+      : null;
+    const detailLineHeight = Number.parseFloat(computed && computed.lineHeight) || 18;
+    const detailHeight = Math.max(detailScroll.scrollHeight || 0, commandBlock.scrollHeight || 0);
+    window.bubbleAPI.reportHeight({
+      height,
+      state: currentExpanded ? "expanded" : "compact",
+      measurementEpoch,
+      chromeHeight: currentExpanded ? Math.max(0, height - detailHeight) : 0,
+      detailLineHeight,
+    });
     applyElicitationViewport();
   });
 }
 
 function revealCard() {
+  restoreDraftStateIfNeeded();
+  applyPresentationView();
   card.classList.remove("hiding");
   card.classList.add("visible");
   scheduleBubbleHeightReport();
@@ -497,6 +573,155 @@ function resetBubbleContent() {
   btnDeny.style.display = "";
   btnDeny.disabled = false;
   suggestionsContainer.innerHTML = "";
+  footerSecondary.innerHTML = "";
+  footerSecondary.classList.remove("visible");
+  sessionTrustErrorElement = null;
+  suggestionsContainer.style.display = "";
+  compactBlock.textContent = "";
+  detailTruncation.textContent = "";
+  detailTruncation.classList.remove("visible");
+  btnExpand.classList.remove("visible");
+  btnExpand.disabled = false;
+  planFeedbackMode = false;
+  compactContentOverflow = false;
+}
+
+function getCompactPreview(data) {
+  if (elicitationMode || data.isCodexUserInputNotify) {
+    const questions = data.toolInput && Array.isArray(data.toolInput.questions)
+      ? data.toolInput.questions
+      : [];
+    const first = questions[0];
+    return first && first.question ? first.question : bubbleText(data.lang, "needsInput");
+  }
+  return formatDetail(data.toolName, data.toolInput, { isAntigravity: !!data.isAntigravity })
+    || commandBlock.textContent
+    || "";
+}
+
+function restoreDraftStateIfNeeded() {
+  const state = pendingRestoreState;
+  pendingRestoreState = null;
+  if (!state) return;
+  if (elicitationMode) {
+    elicitationAnswers = state.elicitationAnswers;
+    activeQuestionIndex = state.activeQuestionIndex;
+    renderElicitationStep();
+  } else if (codexUserInputMode) {
+    activeQuestionIndex = state.activeQuestionIndex;
+    renderCodexUserInputStep(currentData);
+  }
+  planFeedbackTextarea.value = state.planFeedbackText;
+  planFeedbackMode = state.planFeedbackMode;
+  planFeedbackSubmit.disabled = !planFeedbackTextarea.value.trim();
+  requestAnimationFrame(() => {
+    detailScroll.scrollTop = state.scrollTop;
+  });
+}
+
+function focusActiveElicitationControl() {
+  const alreadyChecked = elicitationForm.querySelector(
+    `input[name="elicitation-${activeQuestionIndex}"]:checked`
+  );
+  const first = alreadyChecked || elicitationForm.querySelector(
+    `input[name="elicitation-${activeQuestionIndex}"]:not([data-other])`
+  );
+  if (first) first.focus();
+}
+
+function scheduleCompactOverflowMeasurement() {
+  requestAnimationFrame(() => {
+    if (currentExpanded || !(compactBlock.clientHeight > 0)) return;
+    const overflow = compactBlock.scrollHeight > compactBlock.clientHeight + 1;
+    if (overflow === compactContentOverflow) return;
+    compactContentOverflow = overflow;
+    applyPresentationView();
+  });
+}
+
+function applyPresentationView() {
+  if (!currentData) return;
+  const data = currentData;
+  const wasExpanded = card.classList.contains("expanded");
+  card.classList.toggle("expanded", currentExpanded);
+  btnCollapse.title = bubbleText(data.lang, "collapse");
+  btnCollapse.setAttribute("aria-label", bubbleText(data.lang, "collapse"));
+  btnCollapse.textContent = bubbleText(data.lang, "collapse");
+
+  const compactPreview = getCompactPreview(data);
+  compactBlock.textContent = compactPreview;
+  if (!elicitationMode && !codexUserInputMode && typeof data.detailText === "string" && data.detailText) {
+    commandBlock.textContent = data.detailText;
+  }
+  detailTruncation.textContent = data.detailTruncated
+    ? bubbleText(data.lang, "contentTruncated")
+    : "";
+  detailTruncation.classList.toggle("visible", data.detailTruncated === true);
+
+  const hiddenOptions = suggestionsContainer.children.length > 0 || footerSecondary.children.length > 0;
+  const detailDiffers = typeof data.detailText === "string"
+    && data.detailText
+    && data.detailText !== compactPreview;
+  const needsExpansion = currentIsPlanReview
+    || elicitationMode
+    || codexUserInputMode
+    || detailDiffers
+    || compactContentOverflow
+    || data.detailTruncated === true
+    || hiddenOptions;
+  const expandLabel = currentIsPlanReview
+    ? "viewPlan"
+    : (elicitationMode
+      ? "answer"
+      : (hiddenOptions && !detailDiffers && !compactContentOverflow ? "moreOptions" : "viewDetails"));
+  btnExpand.textContent = bubbleText(data.lang, expandLabel);
+  if (elicitationMode) {
+    const questions = data.toolInput && Array.isArray(data.toolInput.questions)
+      ? data.toolInput.questions.length
+      : 0;
+    if (questions > 0) {
+      btnExpand.textContent += ` · ${bubbleText(data.lang, "questionCount", { count: questions })}`;
+    }
+  }
+  btnExpand.classList.toggle("visible", !currentExpanded && needsExpansion);
+
+  if (!currentExpanded) {
+    actionsContainer.style.display = (currentIsPlanReview || elicitationMode) ? "none" : "";
+    suggestionsContainer.style.display = "none";
+    footerSecondary.classList.remove("visible");
+    planFeedbackForm.classList.remove("visible");
+  } else if (planFeedbackMode) {
+    actionsContainer.style.display = "none";
+    suggestionsContainer.style.display = "none";
+    footerSecondary.classList.remove("visible");
+    planFeedbackForm.classList.add("visible");
+  } else {
+    actionsContainer.style.display = "";
+    suggestionsContainer.style.display = "";
+    footerSecondary.classList.toggle("visible", footerSecondary.children.length > 0);
+    planFeedbackForm.classList.remove("visible");
+  }
+
+  if (currentExpanded && !wasExpanded && elicitationMode) {
+    requestAnimationFrame(focusActiveElicitationControl);
+  }
+  scheduleCompactOverflowMeasurement();
+  scheduleBubbleHeightReport();
+}
+
+function renderSessionTrustError(message) {
+  if (sessionTrustErrorElement && typeof sessionTrustErrorElement.remove === "function") {
+    sessionTrustErrorElement.remove();
+  }
+  sessionTrustErrorElement = null;
+  if (typeof message !== "string" || !message) return;
+  const error = document.createElement("div");
+  error.className = "session-trust-error";
+  error.textContent = message;
+  error.setAttribute("role", "alert");
+  footerSecondary.appendChild(error);
+  footerSecondary.classList.toggle("visible", currentExpanded);
+  sessionTrustErrorElement = error;
 }
 
 function getQuestionLabel(question, questionIndex) {
@@ -784,7 +1009,8 @@ function renderElicitationTerminalFallback(data) {
     // which lets Hermes open its native clarification UI.
     window.bubbleAPI.decide(data && data.isHermes ? "deny-and-focus" : "deny");
   });
-  suggestionsContainer.appendChild(btn);
+  footerSecondary.appendChild(btn);
+  footerSecondary.classList.toggle("visible", currentExpanded);
 }
 
 function renderRegularTerminalFallback(lang) {
@@ -820,28 +1046,12 @@ function renderElicitationStep() {
 
   updateElicitationSubmitState();
   scheduleBubbleHeightReport();
-
-  // Auto-focus the first preset radio on render so arrow keys work immediately
-  // without requiring a click first. Uses rAF so the DOM is painted before we
-  // query it. If a radio is already checked (navigating back to a previously
-  // answered question), keep that selection instead of resetting it.
-  requestAnimationFrame(() => {
-    const question = elicitationQuestions[activeQuestionIndex];
-    if (!question) return;
-    const alreadyChecked = elicitationForm.querySelector(
-      `input[name="elicitation-${activeQuestionIndex}"]:checked`
-    );
-    if (alreadyChecked) { alreadyChecked.focus(); return; }
-    const first = elicitationForm.querySelector(
-      `input[name="elicitation-${activeQuestionIndex}"]:not([data-other])`
-    );
-    if (first) first.focus();
-  });
 }
 
 function renderElicitationForm(data) {
-  elicitationQuestions = data.toolInput && Array.isArray(data.toolInput.questions)
-    ? data.toolInput.questions
+  const input = data.elicitationDetailInput || data.toolInput;
+  elicitationQuestions = input && Array.isArray(input.questions)
+    ? input.questions
     : [];
   elicitationAnswers = {};
   activeQuestionIndex = 0;
@@ -957,6 +1167,54 @@ function renderCodexUserInputPreview(data) {
 }
 
 function show(data) {
+  const isPassiveRefresh = data.toolName === "CodexExec"
+    || data.toolName === "KimiPermission"
+    || data.isCodexUserInputNotify === true;
+  if (currentData && !isPassiveRefresh) {
+    currentData = {
+      ...currentData,
+      lang: data.lang,
+      sessionFolder: data.sessionFolder,
+      sessionShortId: data.sessionShortId,
+      canOfferSessionTrust: data.canOfferSessionTrust,
+      sessionTrustError: data.sessionTrustError,
+      presentation: data.presentation,
+    };
+    currentLang = currentData.lang || "en";
+    setSessionTag(currentData);
+    const presentation = currentData.presentation && typeof currentData.presentation === "object"
+      ? currentData.presentation
+      : {};
+    currentExpanded = presentation.expanded === true;
+    measurementEpoch = Number.isInteger(presentation.measurementEpoch)
+      ? presentation.measurementEpoch
+      : measurementEpoch;
+    renderSessionTrustError(currentData.sessionTrustError);
+    btnAllow.disabled = false;
+    btnDeny.disabled = false;
+    btnExpand.disabled = false;
+    for (const button of suggestionsContainer.querySelectorAll("button")) button.disabled = false;
+    for (const button of footerSecondary.querySelectorAll("button")) button.disabled = false;
+    applyPresentationView();
+    return;
+  }
+  if (currentData) {
+    pendingRestoreState = {
+      elicitationAnswers,
+      activeQuestionIndex,
+      planFeedbackText: planFeedbackTextarea.value,
+      planFeedbackMode,
+      scrollTop: detailScroll.scrollTop || 0,
+    };
+  }
+  currentData = data;
+  const presentation = data.presentation && typeof data.presentation === "object"
+    ? data.presentation
+    : {};
+  currentExpanded = presentation.expanded === true;
+  measurementEpoch = Number.isInteger(presentation.measurementEpoch)
+    ? presentation.measurementEpoch
+    : 0;
   resetBubbleContent();
   currentLang = data.lang || "en";
   const interaction = data.interaction && typeof data.interaction === "object"
@@ -966,6 +1224,7 @@ function show(data) {
     ? interaction.capabilities
     : {};
   const interactionIntent = interaction ? interaction.intent : "unknown";
+  currentIsPlanReview = interactionIntent === "plan-review";
   elicitationMode = interactionIntent === "human-question"
     && interactionCapabilities.answerQuestions === true;
   setSessionTag(data);
@@ -1217,15 +1476,10 @@ function show(data) {
         disableAll();
         window.bubbleAPI.decide("session-trust");
       });
-      suggestionsContainer.appendChild(trustBtn);
+      footerSecondary.appendChild(trustBtn);
+      footerSecondary.classList.add("visible");
     }
-    if (typeof data.sessionTrustError === "string" && data.sessionTrustError) {
-      const error = document.createElement("div");
-      error.className = "session-trust-error";
-      error.textContent = data.sessionTrustError;
-      error.setAttribute("role", "alert");
-      suggestionsContainer.appendChild(error);
-    }
+    renderSessionTrustError(data.sessionTrustError);
     // Hermes and DSH permission cards get no generic terminal action. Hermes
     // has no native approval prompt; DSH's native web answerer is reached by
     // an explicit no-decision fallback, not a user allow/deny action.
@@ -1319,6 +1573,7 @@ window.addEventListener("resize", applyElicitationViewport);
 // ── Plan Feedback Mode ──
 
 function enterPlanFeedbackMode(lang) {
+  planFeedbackMode = true;
   // Hide action buttons and suggestions
   btnAllow.style.display = "none";
   btnDeny.style.display = "none";
@@ -1335,8 +1590,8 @@ function enterPlanFeedbackMode(lang) {
 }
 
 function exitPlanFeedbackMode() {
+  planFeedbackMode = false;
   planFeedbackForm.classList.remove("visible");
-  planFeedbackTextarea.value = "";
   // Restore plan review layout: Approve visible, Deny hidden, suggestions visible
   btnAllow.style.display = "";
   btnDeny.style.display = "none";
@@ -1373,6 +1628,35 @@ planFeedbackSubmit.addEventListener("click", () => {
 planFeedbackBack.addEventListener("click", () => {
   exitPlanFeedbackMode();
 });
+
+btnExpand.addEventListener("click", () => {
+  if (btnExpand.disabled) return;
+  window.bubbleAPI.setExpanded(true);
+});
+
+btnCollapse.addEventListener("click", () => {
+  window.bubbleAPI.setExpanded(false);
+});
+
+if (typeof window.bubbleAPI.onPresentation === "function") {
+  window.bubbleAPI.onPresentation((presentation) => {
+    if (!presentation || typeof presentation !== "object") return;
+    const nextEpoch = Number(presentation.measurementEpoch);
+    if (!Number.isInteger(nextEpoch) || nextEpoch < measurementEpoch) return;
+    measurementEpoch = nextEpoch;
+    currentExpanded = presentation.expanded === true;
+    applyPresentationView();
+  });
+}
+
+if (typeof window.bubbleAPI.setCompositionActive === "function") {
+  document.addEventListener("compositionstart", () => {
+    window.bubbleAPI.setCompositionActive(true);
+  });
+  document.addEventListener("compositionend", () => {
+    window.bubbleAPI.setCompositionActive(false);
+  });
+}
 
 // While a text input inside the bubble is focused, tell the main process so it
 // can drop the bubble out of always-on-top on macOS — otherwise the OS IME

--- a/src/bubble-renderer.js
+++ b/src/bubble-renderer.js
@@ -658,7 +658,9 @@ function applyPresentationView() {
     : "";
   detailTruncation.classList.toggle("visible", data.detailTruncated === true);
 
-  const hiddenOptions = suggestionsContainer.children.length > 0 || footerSecondary.children.length > 0;
+  const compactHidesSupplementaryActions = currentIsPlanReview || elicitationMode || codexUserInputMode;
+  const hiddenOptions = compactHidesSupplementaryActions
+    && (suggestionsContainer.children.length > 0 || footerSecondary.children.length > 0);
   const detailDiffers = typeof data.detailText === "string"
     && data.detailText
     && data.detailText !== compactPreview;
@@ -686,9 +688,16 @@ function applyPresentationView() {
   btnExpand.classList.toggle("visible", !currentExpanded && needsExpansion);
 
   if (!currentExpanded) {
-    actionsContainer.style.display = (currentIsPlanReview || elicitationMode) ? "none" : "";
-    suggestionsContainer.style.display = "none";
-    footerSecondary.classList.remove("visible");
+    // Compact cards keep every pre-detail quick action. Ordinary permissions
+    // retain Allow/Deny, permission suggestions (including Always Allow), and
+    // session trust. Plan keeps its quick Approve path, while its feedback and
+    // terminal actions remain behind View plan. Ask still requires expansion.
+    actionsContainer.style.display = elicitationMode ? "none" : "";
+    suggestionsContainer.style.display = compactHidesSupplementaryActions ? "none" : "";
+    footerSecondary.classList.toggle(
+      "visible",
+      !compactHidesSupplementaryActions && footerSecondary.children.length > 0
+    );
     planFeedbackForm.classList.remove("visible");
   } else if (planFeedbackMode) {
     actionsContainer.style.display = "none";

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -90,6 +90,18 @@ body { padding: 6px; }
   transition: opacity 0.35s var(--ease-spring), transform 0.4s var(--ease-spring);
   overflow: hidden;
 }
+.card.expanded {
+  height: calc(100vh - 12px);
+  min-height: 0;
+}
+.card.measuring {
+  height: auto;
+  max-height: none;
+}
+.card.measuring .detail-scroll {
+  flex: none;
+  overflow: visible;
+}
 
 .card.visible {
   opacity: 1;
@@ -103,13 +115,37 @@ body { padding: 6px; }
 /* ── Header ── */
 .header {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: flex-start;
+  justify-content: space-between;
   gap: 4px;
   width: 100%;
   min-width: 0;
   margin-bottom: 0;
 }
+.header-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 0;
+}
+.collapse-button {
+  display: none;
+  flex: 0 0 auto;
+  min-width: 42px;
+  height: 26px;
+  margin: -4px -6px 0 8px;
+  border: 0;
+  border-radius: 8px;
+  color: var(--cmd-color);
+  background: transparent;
+  padding: 0 7px;
+  font: 600 11px/1 inherit;
+  cursor: pointer;
+}
+.collapse-button:hover { background: var(--sug-hover-bg); }
+.card.expanded .collapse-button { display: block; }
 .header-title {
   font-size: 13px;
   font-weight: 600;
@@ -191,7 +227,41 @@ body { padding: 6px; }
 }
 .session-tag.visible { display: block; }
 
-/* ── Command block ── */
+/* ── Compact preview / expanded detail ── */
+.compact-block {
+  display: -webkit-box;
+  padding: 10px 12px;
+  background: var(--cmd-bg);
+  border: 1px solid var(--cmd-border);
+  border-radius: 10px;
+  font-family: "SF Mono", "ui-monospace", "Cascadia Code", "Fira Code", monospace;
+  font-size: 12px;
+  color: var(--cmd-color);
+  line-height: 1.5;
+  overflow: hidden;
+  word-break: break-word;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  box-shadow: var(--cmd-shadow);
+}
+.card.expanded .compact-block { display: none !important; }
+
+.detail-scroll {
+  display: none;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding-right: 2px;
+}
+.card.expanded .detail-scroll { display: flex; }
+.detail-scroll::-webkit-scrollbar { width: 6px; }
+.detail-scroll::-webkit-scrollbar-track { background: transparent; }
+.detail-scroll::-webkit-scrollbar-thumb { background: var(--scroll-thumb); border-radius: 3px; }
+.detail-scroll::-webkit-scrollbar-thumb:hover { background: var(--scroll-thumb-hover); }
+
 .command-block {
   padding: 12px;
   background: var(--cmd-bg);
@@ -201,15 +271,36 @@ body { padding: 6px; }
   font-size: 12px;
   color: var(--cmd-color);
   line-height: 1.5;
-  max-height: 80px;
-  overflow-y: auto;
+  max-height: none;
+  overflow: visible;
   word-break: break-all;
   box-shadow: var(--cmd-shadow);
 }
-.command-block::-webkit-scrollbar { width: 6px; }
-.command-block::-webkit-scrollbar-track { background: transparent; }
-.command-block::-webkit-scrollbar-thumb { background: var(--scroll-thumb); border-radius: 3px; }
-.command-block::-webkit-scrollbar-thumb:hover { background: var(--scroll-thumb-hover); }
+.detail-truncation {
+  display: none;
+  font-size: 11px;
+  line-height: 1.35;
+  color: var(--irreversible-color);
+}
+.detail-truncation.visible { display: block; }
+
+.btn-expand {
+  display: none;
+  width: 100%;
+  padding: 7px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--sug-border);
+  color: var(--sug-hover-color);
+  background: var(--sug-bg);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+  cursor: pointer;
+}
+.btn-expand.visible { display: block; }
+.btn-expand:hover { background: var(--sug-hover-bg); border-color: var(--sug-hover-border); }
+.card.expanded .btn-expand { display: none !important; }
 
 /* ── Elicitation form ── */
 .elicitation-form {
@@ -398,6 +489,13 @@ body { padding: 6px; }
   display: flex;
   gap: 8px;
 }
+.footer-secondary {
+  display: none;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 6px;
+}
+.card.expanded .footer-secondary.visible { display: flex; }
 .btn {
   flex: 1;
   padding: 7px 0;

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -91,12 +91,21 @@ body { padding: 6px; }
   overflow: hidden;
 }
 .card.expanded {
-  height: calc(100vh - 12px);
+  /* Root CSS zoom leaves vh tied to the unzoomed BrowserWindow. Divide by the
+     injected text scale so the painted card still fits the actual window. */
+  height: calc(100vh / var(--clawd-text-zoom, 1) - 12px);
   min-height: 0;
 }
 .card.measuring {
   height: auto;
   max-height: none;
+}
+.card.expanded.measuring {
+  height: auto;
+  max-height: none;
+}
+.card.expanded > :not(.detail-scroll) {
+  flex-shrink: 0;
 }
 .card.measuring .detail-scroll {
   flex: none;

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -471,6 +471,13 @@ body { padding: 6px; }
   color: var(--cmd-color);
 }
 
+.question-text,
+.option-item-description {
+  white-space: pre-wrap;
+  word-break: normal;
+  overflow-wrap: anywhere;
+}
+
 .option-item-other { align-items: center; }
 
 .option-item-textarea {

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -495,7 +495,7 @@ body { padding: 6px; }
   flex-direction: column;
   gap: 6px;
 }
-.card.expanded .footer-secondary.visible { display: flex; }
+.footer-secondary.visible { display: flex; }
 .btn {
   flex: 1;
   padding: 7px 0;

--- a/src/bubble.css
+++ b/src/bubble.css
@@ -282,7 +282,9 @@ body { padding: 6px; }
   line-height: 1.5;
   max-height: none;
   overflow: visible;
-  word-break: break-all;
+  white-space: pre-wrap;
+  word-break: normal;
+  overflow-wrap: anywhere;
   box-shadow: var(--cmd-shadow);
 }
 .detail-truncation {
@@ -291,7 +293,7 @@ body { padding: 6px; }
   line-height: 1.35;
   color: var(--irreversible-color);
 }
-.detail-truncation.visible { display: block; }
+.card.expanded .detail-truncation.visible { display: block; }
 
 .btn-expand {
   display: none;
@@ -344,6 +346,7 @@ body { padding: 6px; }
   opacity: 0.8;
   text-align: center;
   font-family: "SF Mono", "ui-monospace", "Cascadia Code", "Fira Code", monospace;
+  padding: 4px 0;
 }
 .elicitation-progress.visible { display: block; }
 

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -24,7 +24,6 @@
     <div class="detail-truncation" id="detailTruncation"></div>
     <div class="elicitation-form" id="elicitationForm"></div>
     <div class="elicitation-progress" id="elicitationProgress"></div>
-    <div class="suggestions" id="suggestions"></div>
   </div>
 
   <button class="btn-expand" id="btnExpand" type="button"></button>
@@ -40,6 +39,7 @@
     <button class="btn btn-allow" id="btnAllow">Allow</button>
     <button class="btn btn-deny" id="btnDeny">Deny</button>
   </div>
+  <div class="suggestions" id="suggestions"></div>
   <div class="footer-secondary" id="footerSecondary"></div>
 </div>
 

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -8,16 +8,26 @@
 <body>
 <div class="card" id="card">
   <div class="header">
-    <span class="header-title">Permission Request</span>
-    <span class="tool-pill" id="toolPill"><span class="tool-pill-text" id="toolPillText"></span></span>
+    <div class="header-copy">
+      <span class="header-title">Permission Request</span>
+      <span class="tool-pill" id="toolPill"><span class="tool-pill-text" id="toolPillText"></span></span>
+    </div>
+    <button class="collapse-button" id="btnCollapse" type="button" aria-label="Collapse">Collapse</button>
   </div>
 
   <div class="session-tag" id="sessionTag"></div>
 
   <div class="irreversible-badge" id="irreversibleBadge" style="display:none"></div>
-  <div class="command-block" id="commandBlock"></div>
-  <div class="elicitation-form" id="elicitationForm"></div>
-  <div class="elicitation-progress" id="elicitationProgress"></div>
+  <div class="compact-block" id="compactBlock"></div>
+  <div class="detail-scroll" id="detailScroll">
+    <div class="command-block" id="commandBlock"></div>
+    <div class="detail-truncation" id="detailTruncation"></div>
+    <div class="elicitation-form" id="elicitationForm"></div>
+    <div class="elicitation-progress" id="elicitationProgress"></div>
+    <div class="suggestions" id="suggestions"></div>
+  </div>
+
+  <button class="btn-expand" id="btnExpand" type="button"></button>
   <div class="plan-feedback-form" id="planFeedbackForm">
     <textarea class="plan-feedback-textarea" id="planFeedbackTextarea" rows="3" maxlength="4000"></textarea>
     <div class="plan-feedback-actions">
@@ -26,12 +36,11 @@
     </div>
   </div>
   
-  <div class="actions">
+  <div class="actions" id="actions">
     <button class="btn btn-allow" id="btnAllow">Allow</button>
     <button class="btn btn-deny" id="btnDeny">Deny</button>
   </div>
-  
-  <div class="suggestions" id="suggestions"></div>
+  <div class="footer-secondary" id="footerSecondary"></div>
 </div>
 
 <script src="bubble-format.js"></script>

--- a/src/bubble.html
+++ b/src/bubble.html
@@ -19,9 +19,9 @@
 
   <div class="irreversible-badge" id="irreversibleBadge" style="display:none"></div>
   <div class="compact-block" id="compactBlock"></div>
+  <div class="detail-truncation" id="detailTruncation"></div>
   <div class="detail-scroll" id="detailScroll">
     <div class="command-block" id="commandBlock"></div>
-    <div class="detail-truncation" id="detailTruncation"></div>
     <div class="elicitation-form" id="elicitationForm"></div>
     <div class="elicitation-progress" id="elicitationProgress"></div>
   </div>

--- a/src/permission.js
+++ b/src/permission.js
@@ -64,6 +64,12 @@ const BUBBLE_HEIGHT_RESERVE = 24;
 // integer DIP width, so the CSS viewport width (and therefore renderer-side
 // height measurements) stays exact across scale changes.
 const BUBBLE_BASE_WIDTH = 340;
+const BUBBLE_EXPANDED_BASE_WIDTH = 500;
+const BUBBLE_EXPANDED_PREFERRED_HEIGHT = 620;
+const BUBBLE_EXPANDED_WORK_AREA_RATIO = 0.6;
+const BUBBLE_EXPANDED_CHROME_FALLBACK = 190;
+const BUBBLE_EXPANDED_DETAIL_LINE_FALLBACK = 18;
+const BUBBLE_EXPANDED_MIN_DETAIL_LINES = 5;
 // Hard cap so a scaled bubble can't swallow a small work area.
 const BUBBLE_MAX_WORK_AREA_WIDTH_RATIO = 0.9;
 const PLAN_FEEDBACK_MAX_LENGTH = 4000;
@@ -96,6 +102,12 @@ function registerPermissionIpc(options = {}) {
   on("permission-decide", (event, behavior) => permission.handleDecide(event, behavior));
   if (typeof permission.handleImeEditing === "function") {
     on("bubble-ime-editing", (event, editing) => permission.handleImeEditing(event, editing));
+  }
+  if (typeof permission.handleBubbleExpanded === "function") {
+    on("permission-set-expanded", (event, expanded) => permission.handleBubbleExpanded(event, expanded));
+  }
+  if (typeof permission.handleCompositionActive === "function") {
+    on("bubble-composition-active", (event, active) => permission.handleCompositionActive(event, active));
   }
 
   return {
@@ -330,6 +342,49 @@ function stackBoundsFromTop(bubbleHeights, x, yTop, width, gap) {
   return bounds;
 }
 
+function alignVariableBubbleBounds(bounds, bubbleSizes, options) {
+  if (!Array.isArray(bounds) || !Array.isArray(bubbleSizes) || bounds.length !== bubbleSizes.length) {
+    return bounds;
+  }
+  const maxWidth = Math.max(...bubbleSizes.map((size) => size.width));
+  const first = bounds[0];
+  let alignment = "right";
+  if (options.followPet && options.hitRect) {
+    const hitLeft = Math.round(options.hitRect.left);
+    const hitRight = Math.round(options.hitRect.right);
+    const fallbackRight = options.workArea.x + options.workArea.width - maxWidth - options.margin;
+    if (first.x === hitRight) alignment = "left";
+    else if (first.x + maxWidth === hitLeft) alignment = "right";
+    else if (first.x === fallbackRight) alignment = "right";
+    else alignment = "center";
+  } else {
+    alignment = normalizeFixedCorner(options.fixedCorner).endsWith("left") ? "left" : "right";
+  }
+
+  const result = bounds.map((bound, index) => {
+    const size = bubbleSizes[index];
+    let x = bound.x;
+    if (alignment === "right") x += maxWidth - size.width;
+    else if (alignment === "center") x += Math.round((maxWidth - size.width) / 2);
+    return { x, y: bound.y, width: size.width, height: size.height };
+  });
+
+  const expandedIndex = Number.isInteger(options.expandedIndex) ? options.expandedIndex : -1;
+  const expanded = result[expandedIndex];
+  if (!expanded) return result;
+  const minTop = options.workArea.y + options.margin;
+  const maxBottom = options.workArea.y + options.workArea.height - options.margin;
+  let shiftY = 0;
+  if (expanded.y < minTop) shiftY = minTop - expanded.y;
+  if (expanded.y + expanded.height + shiftY > maxBottom) {
+    shiftY += maxBottom - (expanded.y + expanded.height + shiftY);
+  }
+  if (shiftY !== 0) {
+    for (const bound of result) bound.y += shiftY;
+  }
+  return result;
+}
+
 function findNonOverlappingStackTop({
   x,
   width,
@@ -406,7 +461,38 @@ function computeBubbleStackLayout({
   hitRect,
   hudReservedOffset = 0,
   avoidRects = [],
+  bubbleSizes = null,
+  expandedIndex = -1,
 }) {
+  if (Array.isArray(bubbleSizes)) {
+    const sizes = bubbleSizes.map((size) => ({
+      width: Math.max(1, Math.round(Number(size && size.width) || 0)),
+      height: Math.max(1, Math.round(Number(size && size.height) || 0)),
+    }));
+    if (sizes.length === 0) return [];
+    const maxWidth = Math.max(...sizes.map((size) => size.width));
+    const uniformBounds = computeBubbleStackLayout({
+      followPet,
+      followPreference,
+      fixedCorner,
+      bubbleHeights: sizes.map((size) => size.height),
+      bubbleWidth: maxWidth,
+      margin,
+      gap,
+      workArea: wa,
+      hitRect,
+      hudReservedOffset,
+      avoidRects,
+    });
+    return alignVariableBubbleBounds(uniformBounds, sizes, {
+      followPet,
+      fixedCorner,
+      hitRect,
+      expandedIndex,
+      workArea: wa,
+      margin,
+    });
+  }
   const N = bubbleHeights.length;
   if (N === 0) return [];
 
@@ -643,6 +729,7 @@ const t = createTranslator(() => ctx.lang);
 
 // Each entry: { res, abortHandler, suggestions, sessionId, bubble, hideTimer, toolName, toolInput, resolvedSuggestion, createdAt, measuredHeight }
 const pendingPermissions = [];
+let expandedPermissionEntry = null;
 // Keep windows independently of pendingPermissions so Orbit continues avoiding
 // a bubble during its 250ms fade-out after the request has already been removed
 // from the pending list.
@@ -689,6 +776,8 @@ function getActionablePermissions() {
     p => !isPassiveNotifyEntry(p)
       && isValidInteraction(p.interaction)
       && p.interaction.capabilities.allowDeny === true
+      && p.textInputActive !== true
+      && (p.interaction.intent !== INTERACTION_INTENT.PLAN_REVIEW || p.expanded === true)
       && !isDecisionInteraction(p.interaction)
   );
 }
@@ -818,6 +907,75 @@ function getBubbleWidth(scale, workArea) {
   return Math.min(scaled, Math.floor(waWidth * BUBBLE_MAX_WORK_AREA_WIDTH_RATIO));
 }
 
+function getExpandedBubbleWidth(scale, workArea) {
+  const scaled = scaleWidth(BUBBLE_EXPANDED_BASE_WIDTH, scale);
+  const waWidth = Math.floor(Number(workArea && workArea.width) || 0);
+  if (waWidth <= 0) return scaled;
+  return Math.min(scaled, Math.floor(waWidth * BUBBLE_MAX_WORK_AREA_WIDTH_RATIO));
+}
+
+function ensureBubblePresentationState(perm) {
+  if (!perm || typeof perm !== "object") return;
+  if (!Number.isInteger(perm.measurementEpoch) || perm.measurementEpoch < 0) {
+    perm.measurementEpoch = 0;
+  }
+  if (perm.expanded !== true) perm.expanded = false;
+  if (perm.compositionActive !== true) perm.compositionActive = false;
+}
+
+function getCompactBubbleHeight(perm, scale, workArea) {
+  return clampBubbleHeight(
+    scaleHeight(
+      perm.compactMeasuredHeight
+        || perm.measuredHeight
+        || estimateBubbleHeight((perm.suggestions || []).length),
+      scale
+    ),
+    workArea.height
+  );
+}
+
+function computeExpandedHeightBudget(perm, scale, workArea, margin, gap) {
+  const otherEntries = pendingPermissions.filter((entry) => entry !== perm && !entry.remoteOnly);
+  const compactSiblingHeight = otherEntries.reduce(
+    (sum, entry) => sum + getCompactBubbleHeight(entry, scale, workArea),
+    0
+  );
+  const stackGaps = Math.max(0, pendingPermissions.filter((entry) => !entry.remoteOnly).length - 1) * gap;
+  const preferred = Math.min(
+    scaleHeight(BUBBLE_EXPANDED_PREFERRED_HEIGHT, scale),
+    Math.floor(workArea.height * BUBBLE_EXPANDED_WORK_AREA_RATIO)
+  );
+  const chromeHeight = scaleHeight(
+    perm.expandedChromeHeight || BUBBLE_EXPANDED_CHROME_FALLBACK,
+    scale
+  );
+  const detailLineHeight = scaleHeight(
+    perm.expandedDetailLineHeight || BUBBLE_EXPANDED_DETAIL_LINE_FALLBACK,
+    scale
+  );
+  const readableFloor = chromeHeight + detailLineHeight * BUBBLE_EXPANDED_MIN_DETAIL_LINES;
+  const stackBudget = workArea.height - margin * 2 - compactSiblingHeight - stackGaps;
+  const workAreaCap = Math.max(1, workArea.height - margin * 2);
+  return Math.min(workAreaCap, Math.max(readableFloor, Math.min(preferred, stackBudget)));
+}
+
+function getExpandedBubbleHeight(perm, scale, workArea, margin, gap) {
+  const budget = Math.min(
+    perm.expandedHeightBudget || computeExpandedHeightBudget(perm, scale, workArea, margin, gap),
+    Math.max(1, workArea.height - margin * 2)
+  );
+  const natural = scaleHeight(
+    perm.expandedMeasuredHeight || BUBBLE_EXPANDED_PREFERRED_HEIGHT,
+    scale
+  );
+  return Math.max(1, Math.min(natural, budget));
+}
+
+function getExpandedBudgetKey(workArea, scale) {
+  return [workArea.x, workArea.y, workArea.width, workArea.height, scale].join(":");
+}
+
 function getAnchorWorkArea(petBounds) {
   const bounds = petBounds || ctx.getPetWindowBounds();
   if (typeof ctx.getBubbleWorkArea === "function") {
@@ -847,28 +1005,44 @@ function repositionBubbles() {
   const scale = getTextScale(wa);
   const margin = Math.round(8 * scale);
   const gap = Math.round(6 * scale);
-  const bw = getBubbleWidth(scale, wa);
+  const compactWidth = getBubbleWidth(scale, wa);
+  const expandedWidth = getExpandedBubbleWidth(scale, wa);
   const hitRect = ctx.bubbleFollowPet ? ctx.getHitRectScreen(petBounds) : null;
   const hudAvoidRects = getHudAvoidRects();
 
   const layoutPermissions = pendingPermissions.filter((perm) => !perm.remoteOnly);
-  const bubbleHeights = layoutPermissions.map(perm =>
-    clampBubbleHeight(
-      // measuredHeight/estimate are CSS px; the window needs DIP.
-      scaleHeight(
-        perm.measuredHeight || estimateBubbleHeight((perm.suggestions || []).length),
-        scale
-      ),
-      wa.height
-    )
-  );
+  const bubbleSizes = layoutPermissions.map((perm) => {
+    ensureBubblePresentationState(perm);
+    if (perm.expanded) {
+      const budgetKey = getExpandedBudgetKey(wa, scale);
+      if (perm.expandedBudgetKey && perm.expandedBudgetKey !== budgetKey) {
+        perm.expandedHeightBudget = computeExpandedHeightBudget(perm, scale, wa, margin, gap);
+        perm.expandedHeightBudgetMeasured = false;
+        perm.measurementEpoch += 1;
+        sendPermissionPresentation(perm);
+      }
+      perm.expandedBudgetKey = budgetKey;
+    }
+    return perm.expanded
+      ? {
+          width: expandedWidth,
+          height: getExpandedBubbleHeight(perm, scale, wa, margin, gap),
+        }
+      : {
+          width: compactWidth,
+          height: getCompactBubbleHeight(perm, scale, wa),
+        };
+  });
+  const expandedIndex = layoutPermissions.findIndex((perm) => perm.expanded === true);
 
   const bounds = computeBubbleStackLayout({
     followPet: !!ctx.bubbleFollowPet,
     followPreference: ctx.bubbleFollowPreference,
     fixedCorner: ctx.bubbleFixedCorner,
-    bubbleHeights,
-    bubbleWidth: bw,
+    bubbleHeights: bubbleSizes.map((size) => size.height),
+    bubbleWidth: compactWidth,
+    bubbleSizes,
+    expandedIndex,
     margin,
     gap,
     workArea: wa,
@@ -1103,6 +1277,7 @@ function handlePermissionBubbleFailure(permEntry, reason) {
 function showPermissionBubble(permEntry) {
   // Auto-pilot: if enabled, approve immediately and never render a bubble.
   if (maybeAutoApprovePermission(permEntry)) return;
+  ensureBubblePresentationState(permEntry);
 
   const canOfferSessionTrust = typeof ctx.canOfferSessionTrust === "function"
     && ctx.canOfferSessionTrust(permEntry) === true;
@@ -1177,12 +1352,8 @@ function showPermissionBubble(permEntry) {
       // stale partition-persisted factor must never win over prefs.
       applyZoomToWindow(bub, getTextScale(getAnchorWorkArea()));
       syncPermissionBubbleContent(permEntry);
-      // Elicitation bubbles need keyboard focus so arrow keys and Enter work.
-      // Regular permission bubbles must NOT steal focus from the terminal —
-      // doing so triggers false "User answered in terminal" denials in Claude Code.
-      if (interactionCapabilities.answerQuestions === true) {
-        bub.focus();
-      }
+      // Arrival never steals focus. Plan/Ask receive focus only after the user
+      // explicitly expands the bubble (handleBubbleExpanded).
     });
 
     bub.on("closed", () => {
@@ -1314,6 +1485,9 @@ function dismissPermissionWithoutDecision(permEntry, message) {
 }
 
 function notifyPermissionsChanged(reason) {
+  if (expandedPermissionEntry && !pendingPermissions.includes(expandedPermissionEntry)) {
+    expandedPermissionEntry = null;
+  }
   // #640: every path that adds or removes a pendingPermissions entry funnels
   // through here — including resolvePermissionEntry's inline splice, which is
   // what Allow/Deny clicks, Enter submits, and the auto-close timer all use.
@@ -1385,6 +1559,7 @@ function refreshPermissionAutoCloseForPolicy() {
 }
 
 function buildPermissionBubblePayload(permEntry) {
+  ensureBubblePresentationState(permEntry);
   const sess = ctx.sessions.get(permEntry.sessionId);
   const sessionFolder = sess && sess.cwd ? path.basename(sess.cwd) : null;
   const sessionShortId = permEntry.sessionId
@@ -1393,6 +1568,15 @@ function buildPermissionBubblePayload(permEntry) {
   return {
     toolName: permEntry.toolName,
     toolInput: permEntry.toolInput,
+    detailText: typeof permEntry.detailText === "string"
+      ? permEntry.detailText
+      : null,
+    detailTruncated: permEntry.detailTruncated === true,
+    elicitationDetailInput: permEntry.elicitationDetailInput || null,
+    presentation: {
+      expanded: permEntry.expanded === true,
+      measurementEpoch: permEntry.measurementEpoch,
+    },
     suggestions: permEntry.suggestions || [],
     canOfferSessionTrust: typeof ctx.canOfferSessionTrust === "function"
       && ctx.canOfferSessionTrust(permEntry) === true,
@@ -1442,6 +1626,17 @@ function syncPermissionBubbleContent(permEntry) {
   const bub = permEntry && permEntry.bubble;
   if (!bub || bub.isDestroyed() || !permEntry.bubbleReady) return false;
   bub.webContents.send("permission-show", buildPermissionBubblePayload(permEntry));
+  return true;
+}
+
+function sendPermissionPresentation(permEntry) {
+  const bub = permEntry && permEntry.bubble;
+  if (!bub || bub.isDestroyed() || !permEntry.bubbleReady) return false;
+  ensureBubblePresentationState(permEntry);
+  bub.webContents.send("permission-presentation", {
+    expanded: permEntry.expanded === true,
+    measurementEpoch: permEntry.measurementEpoch,
+  });
   return true;
 }
 
@@ -2778,23 +2973,114 @@ function sendHermesPermissionResponse(res, responseObj) {
   return true;
 }
 
-function handleBubbleHeight(event, height) {
+function handleBubbleHeight(event, measurement) {
   const senderWin = BrowserWindow.fromWebContents(event.sender);
   const perm = pendingPermissions.find(p => p.bubble === senderWin);
-  if (perm && typeof height === "number" && height > 0) {
-    perm.measuredHeight = Math.ceil(height);
-    // revealCard() reports height on the next animation frame, so this is the
-    // first main-process acknowledgement that the exact interaction was loaded,
-    // received through permission-show, rendered, and made visible. Announcing
-    // earlier (even at did-finish-load) can strand an unretractable Slack card
-    // when content sync or the renderer fails. Later resize reports are safe:
-    // announceSlackPermission is once-guarded per entry.
-    announceSlackPermission(perm);
-    // Geometry updates happen after the delivery acknowledgement. If either
-    // reflow throws, the already-rendered card must still be announced.
-    repositionBubbles();
-    repositionDependentBubbles();
+  if (!perm) return;
+  ensureBubblePresentationState(perm);
+  const legacyHeight = typeof measurement === "number" ? measurement : null;
+  const height = legacyHeight !== null ? legacyHeight : Number(measurement && measurement.height);
+  const state = legacyHeight !== null ? "compact" : measurement && measurement.state;
+  const epoch = legacyHeight !== null ? 0 : Number(measurement && measurement.measurementEpoch);
+  if (!(height > 0)) return;
+  if (state !== (perm.expanded ? "expanded" : "compact")) return;
+  if (!Number.isInteger(epoch) || epoch !== perm.measurementEpoch) return;
+
+  if (state === "expanded") {
+    perm.expandedMeasuredHeight = Math.ceil(height);
+    const chromeHeight = Number(measurement && measurement.chromeHeight);
+    const detailLineHeight = Number(measurement && measurement.detailLineHeight);
+    if (chromeHeight > 0) perm.expandedChromeHeight = Math.ceil(chromeHeight);
+    if (detailLineHeight > 0) perm.expandedDetailLineHeight = Math.ceil(detailLineHeight);
+    if (!perm.expandedHeightBudgetMeasured) {
+      const wa = getAnchorWorkArea();
+      const scale = getTextScale(wa);
+      const margin = Math.round(8 * scale);
+      const gap = Math.round(6 * scale);
+      perm.expandedHeightBudget = computeExpandedHeightBudget(perm, scale, wa, margin, gap);
+      perm.expandedBudgetKey = getExpandedBudgetKey(wa, scale);
+      perm.expandedHeightBudgetMeasured = true;
+    }
+  } else {
+    perm.compactMeasuredHeight = Math.ceil(height);
+    // Keep the legacy field during the transition because several tests and
+    // older callers inspect it directly.
+    perm.measuredHeight = perm.compactMeasuredHeight;
   }
+  // revealCard() reports height on the next animation frame, so this is the
+  // first main-process acknowledgement that the exact interaction was loaded,
+  // received through permission-show, rendered, and made visible. Announcing
+  // earlier (even at did-finish-load) can strand an unretractable Slack card
+  // when content sync or the renderer fails. Later resize reports are safe:
+  // announceSlackPermission is once-guarded per entry.
+  announceSlackPermission(perm);
+  // Geometry updates happen after the delivery acknowledgement. If either
+  // reflow throws, the already-rendered card must still be announced.
+  repositionBubbles();
+  repositionDependentBubbles();
+}
+
+function handleBubbleExpanded(event, expanded) {
+  const senderWin = BrowserWindow.fromWebContents(event.sender);
+  const perm = pendingPermissions.find((entry) => entry.bubble === senderWin);
+  if (!perm) return false;
+  ensureBubblePresentationState(perm);
+  const wantsExpanded = expanded === true;
+  if (wantsExpanded === perm.expanded) {
+    sendPermissionPresentation(perm);
+    return true;
+  }
+
+  if (wantsExpanded) {
+    const previous = expandedPermissionEntry;
+    if (previous && previous !== perm) {
+      ensureBubblePresentationState(previous);
+      if (previous.compositionActive) {
+        sendPermissionPresentation(previous);
+        sendPermissionPresentation(perm);
+        return false;
+      }
+      previous.expanded = false;
+      previous.measurementEpoch += 1;
+      sendPermissionPresentation(previous);
+    }
+    const wa = getAnchorWorkArea();
+    const scale = getTextScale(wa);
+    const margin = Math.round(8 * scale);
+    const gap = Math.round(6 * scale);
+    perm.expanded = true;
+    perm.measurementEpoch += 1;
+    perm.expandedHeightBudget = computeExpandedHeightBudget(perm, scale, wa, margin, gap);
+    perm.expandedBudgetKey = getExpandedBudgetKey(wa, scale);
+    perm.expandedHeightBudgetMeasured = false;
+    expandedPermissionEntry = perm;
+    repositionBubbles();
+    sendPermissionPresentation(perm);
+
+    const capabilities = isValidInteraction(perm.interaction)
+      ? perm.interaction.capabilities
+      : {};
+    if (capabilities.answerQuestions === true || capabilities.planFeedback === true) {
+      try { senderWin.focus(); } catch {}
+    }
+  } else {
+    perm.expanded = false;
+    perm.measurementEpoch += 1;
+    if (expandedPermissionEntry === perm) expandedPermissionEntry = null;
+    sendPermissionPresentation(perm);
+    repositionBubbles();
+  }
+  repositionDependentBubbles();
+  syncPermissionShortcuts();
+  return true;
+}
+
+function handleCompositionActive(event, active) {
+  const senderWin = BrowserWindow.fromWebContents(event.sender);
+  const perm = pendingPermissions.find((entry) => entry.bubble === senderWin);
+  if (!perm) return;
+  ensureBubblePresentationState(perm);
+  perm.compositionActive = active === true;
 }
 
 // macOS only: while a text input inside the bubble is focused, the bubble must
@@ -2807,10 +3093,12 @@ function handleBubbleHeight(event, height) {
 // The renderer clears the flag on element blur AND on window blur (e.g. Cmd-Tab
 // away mid-composition), so it can't get stuck and strand the bubble.
 function handleImeEditing(event, editing) {
-  if (!isMac) return;
   const senderWin = BrowserWindow.fromWebContents(event.sender);
   const perm = pendingPermissions.find(p => p.bubble === senderWin);
   if (!perm || !perm.bubble || perm.bubble.isDestroyed()) return;
+  perm.textInputActive = editing === true;
+  syncPermissionShortcuts();
+  if (!isMac) return;
   const wasEditing = perm.bubble.__clawdMacImeEditing === true;
   if (editing) perm.bubble.__clawdMacImeEditing = true;
   else delete perm.bubble.__clawdMacImeEditing;
@@ -3554,7 +3842,8 @@ return {
   // Test seam: lets wire-level tests pin which provenance flags reach the
   // renderer (isHermes suppresses the go-to-terminal action — issue #689).
   buildPermissionBubblePayload,
-  handleBubbleHeight, handleDecide, handleImeEditing, handleBubbleRendererGone, cleanup,
+  handleBubbleHeight, handleBubbleExpanded, handleCompositionActive,
+  handleDecide, handleImeEditing, handleBubbleRendererGone, cleanup,
   showCodexNotifyBubble, clearCodexNotifyBubbles,
   showCodexUserInputBubble, clearCodexUserInputBubbles,
   showKimiNotifyBubble, clearKimiNotifyBubbles,

--- a/src/preload-bubble.js
+++ b/src/preload-bubble.js
@@ -2,8 +2,11 @@ const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("bubbleAPI", {
   onPermissionShow: (cb) => ipcRenderer.on("permission-show", (_, data) => cb(data)),
+  onPresentation: (cb) => ipcRenderer.on("permission-presentation", (_, data) => cb(data)),
   decide: (behavior) => ipcRenderer.send("permission-decide", behavior),
+  setExpanded: (expanded) => ipcRenderer.send("permission-set-expanded", !!expanded),
   onPermissionHide: (cb) => ipcRenderer.on("permission-hide", () => cb()),
   reportHeight: (h) => ipcRenderer.send("bubble-height", h),
   setImeEditing: (editing) => ipcRenderer.send("bubble-ime-editing", !!editing),
+  setCompositionActive: (active) => ipcRenderer.send("bubble-composition-active", !!active),
 });

--- a/src/server-permission-utils.js
+++ b/src/server-permission-utils.js
@@ -1,9 +1,12 @@
 "use strict";
 
 const crypto = require("crypto");
+const { formatDetail } = require("./bubble-format");
 
 // Truncate large string values in objects (recursive) — bubble only needs a preview
 const PREVIEW_MAX = 500;
+const DETAIL_TEXT_MAX_BYTES = 128 * 1024;
+const ELICITATION_DETAIL_CONTENT_BYTES = DETAIL_TEXT_MAX_BYTES - (8 * 1024);
 const MAX_PERMISSION_SUGGESTIONS = 20;
 const MAX_ELICITATION_QUESTIONS = 5;
 const MAX_ELICITATION_OPTIONS = 5;
@@ -15,6 +18,9 @@ const TOOL_MATCH_STRING_MAX = 240;
 const TOOL_MATCH_ARRAY_MAX = 16;
 const TOOL_MATCH_OBJECT_KEYS_MAX = 32;
 const TOOL_MATCH_DEPTH_MAX = 6;
+const DETAIL_JSON_DEPTH_MAX = 8;
+const DETAIL_JSON_ARRAY_MAX = 64;
+const DETAIL_JSON_OBJECT_KEYS_MAX = 64;
 
 function truncateDeep(obj, depth) {
   if ((depth || 0) > 10) return obj;
@@ -33,6 +39,118 @@ function clampPreviewText(value, max) {
   const trimmed = value.trim();
   if (!trimmed) return "";
   return trimmed.length > max ? `${trimmed.slice(0, Math.max(0, max - 1))}\u2026` : trimmed;
+}
+
+function clampUtf8Text(value, maxBytes = DETAIL_TEXT_MAX_BYTES) {
+  const text = typeof value === "string" ? value : String(value == null ? "" : value);
+  const limit = Math.max(0, Math.floor(Number(maxBytes) || 0));
+  if (Buffer.byteLength(text, "utf8") <= limit) return { text, truncated: false };
+  if (limit === 0) return { text: "", truncated: text.length > 0 };
+
+  const suffix = "…";
+  const suffixBytes = Buffer.byteLength(suffix, "utf8");
+  if (limit <= suffixBytes) return { text: "", truncated: true };
+
+  let low = 0;
+  let high = text.length;
+  const contentLimit = limit - suffixBytes;
+  while (low < high) {
+    const mid = Math.ceil((low + high) / 2);
+    if (Buffer.byteLength(text.slice(0, mid), "utf8") <= contentLimit) low = mid;
+    else high = mid - 1;
+  }
+  // Do not leave a dangling UTF-16 high surrogate before the ellipsis.
+  if (low > 0) {
+    const last = text.charCodeAt(low - 1);
+    if (last >= 0xD800 && last <= 0xDBFF) low -= 1;
+  }
+  return { text: `${text.slice(0, low)}${suffix}`, truncated: true };
+}
+
+function serializeBoundedDetailJson(value) {
+  let truncated = false;
+  const seen = new WeakSet();
+
+  function clone(current, depth) {
+    if (depth > DETAIL_JSON_DEPTH_MAX) {
+      truncated = true;
+      return "[Depth limit]";
+    }
+    if (Array.isArray(current)) {
+      if (seen.has(current)) {
+        truncated = true;
+        return "[Circular]";
+      }
+      seen.add(current);
+      if (current.length > DETAIL_JSON_ARRAY_MAX) truncated = true;
+      const result = current.slice(0, DETAIL_JSON_ARRAY_MAX).map((item) => clone(item, depth + 1));
+      seen.delete(current);
+      return result;
+    }
+    if (current && typeof current === "object") {
+      if (seen.has(current)) {
+        truncated = true;
+        return "[Circular]";
+      }
+      seen.add(current);
+      const keys = Object.keys(current).sort();
+      if (keys.length > DETAIL_JSON_OBJECT_KEYS_MAX) truncated = true;
+      const result = {};
+      for (const key of keys.slice(0, DETAIL_JSON_OBJECT_KEYS_MAX)) {
+        result[key] = clone(current[key], depth + 1);
+      }
+      seen.delete(current);
+      return result;
+    }
+    if (typeof current === "bigint") return String(current);
+    if (typeof current === "undefined") return null;
+    return current;
+  }
+
+  let text = "";
+  try {
+    text = JSON.stringify(clone(value, 0), null, 2);
+  } catch {
+    truncated = true;
+  }
+  return { text, truncated };
+}
+
+function preparePermissionDetail(toolName, rawInput, options = {}) {
+  const input = rawInput && typeof rawInput === "object" && !Array.isArray(rawInput)
+    ? rawInput
+    : {};
+  const description = typeof options.description === "string" && options.description.trim()
+    ? options.description.trim()
+    : null;
+  const detailInput = description ? { ...input, description } : input;
+  let structuralTruncated = false;
+  const rawText = formatDetail(toolName, detailInput, {
+    mode: "detail",
+    isAntigravity: options.isAntigravity === true,
+    formatUnknownDetail(value) {
+      const serialized = serializeBoundedDetailJson(value);
+      structuralTruncated = serialized.truncated;
+      return serialized.text;
+    },
+  });
+  const maxBytes = options.maxBytes === undefined ? DETAIL_TEXT_MAX_BYTES : options.maxBytes;
+  const bounded = clampUtf8Text(rawText, maxBytes);
+  return {
+    detailText: bounded.text,
+    detailTruncated: structuralTruncated || bounded.truncated,
+  };
+}
+
+function createUtf8Budget(maxBytes) {
+  let remaining = Math.max(0, Math.floor(Number(maxBytes) || 0));
+  return {
+    take(value) {
+      const bounded = clampUtf8Text(value, remaining);
+      remaining = Math.max(0, remaining - Buffer.byteLength(bounded.text, "utf8"));
+      return bounded;
+    },
+  };
 }
 
 function normalizePermissionSuggestions(rawSuggestions) {
@@ -88,6 +206,7 @@ function prepareElicitationToolInput(toolInput) {
   const answerKeys = new Set();
   const displayQuestions = new Set();
   const questions = [];
+  const detailQuestions = [];
   for (let index = 0; index < rawQuestions.length; index++) {
     const question = rawQuestions[index];
     if (!question || typeof question !== "object" || Array.isArray(question)) {
@@ -101,12 +220,23 @@ function prepareElicitationToolInput(toolInput) {
       return { displayInput: { questions: [] }, wireInput, canAnswer: false, reason: "duplicate-answer-key" };
     }
     answerKeys.add(answerKey);
+    const detailBudget = createUtf8Budget(
+      Math.floor(ELICITATION_DETAIL_CONTENT_BYTES / rawQuestions.length)
+    );
+
+    // The question itself is the context the user must understand before any
+    // option description, so it gets first claim on the shared detail budget.
+    const detailHeader = detailBudget.take(
+      typeof question.header === "string" ? question.header.trim() : ""
+    );
+    const detailQuestion = detailBudget.take(answerKey.trim());
 
     const rawOptions = Array.isArray(question.options) ? question.options : [];
     if (rawOptions.length > MAX_ELICITATION_OPTIONS) {
       return { displayInput: { questions: [] }, wireInput, canAnswer: false, reason: "too-many-options" };
     }
     const options = [];
+    const detailOptions = [];
     const optionAnswerKeys = new Set();
     for (const option of rawOptions) {
       if (!option || typeof option !== "object" || Array.isArray(option)) {
@@ -131,6 +261,14 @@ function prepareElicitationToolInput(toolInput) {
         label: displayLabel,
         description: clampPreviewText(option.description, MAX_ELICITATION_OPTION_DESCRIPTION),
       });
+      const detailDescription = detailBudget.take(
+        typeof option.description === "string" ? option.description.trim() : ""
+      );
+      detailOptions.push({
+        label: rawLabel,
+        description: detailDescription.text,
+        detailTruncated: detailDescription.truncated,
+      });
     }
     const displayQuestion = clampPreviewText(answerKey, MAX_ELICITATION_PROMPT);
     if (displayQuestions.has(displayQuestion)) {
@@ -145,10 +283,24 @@ function prepareElicitationToolInput(toolInput) {
       multiSelect: question.multiSelect === true,
       options,
     });
+    detailQuestions.push({
+      id: String(index),
+      header: detailHeader.text,
+      question: detailQuestion.text,
+      displayQuestion: detailQuestion.text,
+      multiSelect: question.multiSelect === true,
+      options: detailOptions,
+      detailTruncated: detailHeader.truncated || detailQuestion.truncated,
+    });
   }
 
   return {
     displayInput: { questions },
+    detailDisplayInput: { questions: detailQuestions },
+    detailTruncated: detailQuestions.some((question) => (
+      question.detailTruncated === true
+      || question.options.some((option) => option.detailTruncated === true)
+    )),
     wireInput,
     canAnswer: true,
     reason: null,
@@ -249,6 +401,7 @@ function findPendingPermissionForStateEvent(pendingPermissions, options) {
 
 module.exports = {
   PREVIEW_MAX,
+  DETAIL_TEXT_MAX_BYTES,
   MAX_PERMISSION_SUGGESTIONS,
   MAX_ELICITATION_QUESTIONS,
   MAX_ELICITATION_OPTIONS,
@@ -262,6 +415,9 @@ module.exports = {
   TOOL_MATCH_DEPTH_MAX,
   truncateDeep,
   clampPreviewText,
+  clampUtf8Text,
+  serializeBoundedDetailJson,
+  preparePermissionDetail,
   normalizePermissionSuggestions,
   normalizeElicitationToolInput,
   prepareElicitationToolInput,

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -22,6 +22,7 @@ const {
 } = require("../hooks/codex-originator");
 const {
   truncateDeep,
+  preparePermissionDetail,
   normalizePermissionSuggestions,
   prepareElicitationToolInput,
   normalizeHookToolUseId,
@@ -755,6 +756,7 @@ function handlePermissionPost(req, res, options) {
 
         const rawInput = data.tool_input && typeof data.tool_input === "object" ? data.tool_input : {};
         const toolInput = truncateDeep(rawInput);
+        const permissionDetail = preparePermissionDetail(toolName, rawInput);
         const sessionIdentity = resolvePermissionSession(data.session_id, "default");
         const sessionId = sessionIdentity.sessionId;
         const requestId = typeof data.request_id === "string" ? data.request_id : null;
@@ -813,6 +815,7 @@ function handlePermissionPost(req, res, options) {
           hideTimer: null,
           toolName,
           toolInput,
+          ...permissionDetail,
           resolvedSuggestion: null,
           createdAt: Date.now(),
           interaction,
@@ -896,6 +899,7 @@ function handlePermissionPost(req, res, options) {
           ? data.tool_input_description
           : (typeof rawInput.description === "string" ? rawInput.description : "");
         const toolInput = normalizeCodexPermissionToolInput(rawInput, description);
+        const permissionDetail = preparePermissionDetail(toolName, rawInput, { description });
         const sessionIdentity = resolvePermissionSession(data.session_id, "codex:default");
         const sessionId = sessionIdentity.sessionId;
         const toolUseId = normalizeHookToolUseId(
@@ -1069,6 +1073,7 @@ function handlePermissionPost(req, res, options) {
           hideTimer: null,
           toolName,
           toolInput,
+          ...permissionDetail,
           toolUseId,
           toolInputFingerprint,
           resolvedSuggestion: null,
@@ -1139,6 +1144,7 @@ function handlePermissionPost(req, res, options) {
         });
         const rawInput = data.tool_input && typeof data.tool_input === "object" ? data.tool_input : {};
         const toolInput = truncateDeep(rawInput);
+        const permissionDetail = preparePermissionDetail(toolName, rawInput);
         const sessionIdentity = resolvePermissionSession(data.session_id, "qwen-code:default");
         const sessionId = sessionIdentity.sessionId;
         const toolUseId = normalizeHookToolUseId(
@@ -1194,6 +1200,7 @@ function handlePermissionPost(req, res, options) {
           hideTimer: null,
           toolName,
           toolInput,
+          ...permissionDetail,
           toolUseId,
           toolInputFingerprint,
           resolvedSuggestion: null,
@@ -1255,6 +1262,7 @@ function handlePermissionPost(req, res, options) {
         });
         const rawInput = data.tool_input && typeof data.tool_input === "object" ? data.tool_input : {};
         const toolInput = truncateDeep(rawInput);
+        const permissionDetail = preparePermissionDetail(toolName, rawInput);
         const sessionIdentity = resolvePermissionSession(data.session_id, "zcode:default");
         const sessionId = sessionIdentity.sessionId;
         const toolUseId = normalizeHookToolUseId(
@@ -1351,6 +1359,7 @@ function handlePermissionPost(req, res, options) {
           hideTimer: null,
           toolName,
           toolInput,
+          ...permissionDetail,
           toolUseId,
           toolInputFingerprint,
           resolvedSuggestion: null,
@@ -1440,6 +1449,7 @@ function handlePermissionPost(req, res, options) {
         });
         const rawInput = data.tool_input && typeof data.tool_input === "object" ? data.tool_input : {};
         const toolInput = truncateDeep(rawInput);
+        const permissionDetail = preparePermissionDetail(toolName, rawInput);
         const sessionIdentity = resolvePermissionSession(data.session_id, "copilot-cli:default");
         const sessionId = sessionIdentity.sessionId;
         const toolUseId = normalizeHookToolUseId(
@@ -1495,6 +1505,7 @@ function handlePermissionPost(req, res, options) {
           hideTimer: null,
           toolName,
           toolInput,
+          ...permissionDetail,
           toolUseId,
           toolInputFingerprint,
           resolvedSuggestion: null,
@@ -1732,6 +1743,7 @@ function handlePermissionPost(req, res, options) {
         });
         const rawInput = data.tool_input && typeof data.tool_input === "object" ? data.tool_input : {};
         const toolInput = truncateDeep(rawInput);
+        const permissionDetail = preparePermissionDetail(toolName, rawInput);
         const sessionIdentity = resolvePermissionSession(data.session_id, "hermes:default");
         const sessionId = sessionIdentity.sessionId;
         const toolUseId = normalizeHookToolUseId(
@@ -1799,6 +1811,8 @@ function handlePermissionPost(req, res, options) {
             hideTimer: null,
             toolName,
             toolInput: elicitationInput,
+            elicitationDetailInput: elicitation.detailDisplayInput,
+            detailTruncated: elicitation.detailTruncated,
             elicitationWireInput: elicitation.wireInput,
             toolUseId,
             toolInputFingerprint,
@@ -1867,6 +1881,7 @@ function handlePermissionPost(req, res, options) {
           hideTimer: null,
           toolName,
           toolInput,
+          ...permissionDetail,
           toolUseId,
           toolInputFingerprint,
           resolvedSuggestion: null,
@@ -1959,6 +1974,7 @@ function handlePermissionPost(req, res, options) {
 
       const rawInput = data.tool_input && typeof data.tool_input === "object" ? data.tool_input : {};
       const toolInput = truncateDeep(rawInput);
+      const permissionDetail = preparePermissionDetail(toolName, rawInput);
       const toolUseId = normalizeHookToolUseId(
         data.tool_use_id ?? data.toolUseId ?? data.toolUseID
       );
@@ -2068,6 +2084,8 @@ function handlePermissionPost(req, res, options) {
           hideTimer: null,
           toolName,
           toolInput: elicitationInput,
+          elicitationDetailInput: elicitation.detailDisplayInput,
+          detailTruncated: elicitation.detailTruncated,
           elicitationWireInput: elicitation.wireInput,
           toolUseId,
           toolInputFingerprint,
@@ -2120,6 +2138,7 @@ function handlePermissionPost(req, res, options) {
         hideTimer: null,
         toolName,
         toolInput,
+        ...permissionDetail,
         toolUseId,
         toolInputFingerprint,
         resolvedSuggestion: null,

--- a/test/bubble-elicitation-overflow.test.js
+++ b/test/bubble-elicitation-overflow.test.js
@@ -54,19 +54,19 @@ describe("AskUserQuestion bubble overflow", () => {
     assert.doesNotMatch(bubbleCss, /\.card\.expanded\s+\.footer-secondary\.visible/);
   });
 
-  it("keeps the expanded card inside a CSS-zoomed window and reserves shrink for detail", () => {
-    assert.match(
-      bubbleCss,
-      /\.card\.expanded\s*\{[\s\S]*height:\s*calc\(100vh\s*\/\s*var\(--clawd-text-zoom,\s*1\)\s*-\s*12px\)/
+  it("keeps the truncation warning before and outside the detail scroller", () => {
+    const detailStart = bubbleHtml.indexOf('id="detailScroll"');
+    const detailEnd = bubbleHtml.indexOf('id="btnExpand"');
+    const truncation = bubbleHtml.indexOf('id="detailTruncation"');
+
+    assert.ok(detailStart >= 0 && detailEnd > detailStart);
+    assert.ok(
+      truncation >= 0 && truncation < detailStart,
+      "the warning must be visible before the user starts scrolling detail"
     );
-    assert.match(
-      bubbleCss,
-      /\.card\.expanded\.measuring\s*\{[\s\S]*height:\s*auto;/
+    assert.ok(
+      !(truncation > detailStart && truncation < detailEnd),
+      "the warning must not scroll with the detail content"
     );
-    assert.match(
-      bubbleCss,
-      /\.card\.expanded\s*>\s*:not\(\.detail-scroll\)\s*\{\s*flex-shrink:\s*0;/
-    );
-    assert.match(bubbleCss, /\.detail-scroll\s*\{[\s\S]*flex:\s*1\s+1\s+auto;/);
   });
 });

--- a/test/bubble-elicitation-overflow.test.js
+++ b/test/bubble-elicitation-overflow.test.js
@@ -53,4 +53,20 @@ describe("AskUserQuestion bubble overflow", () => {
     assert.match(bubbleCss, /\.footer-secondary\.visible\s*\{\s*display:\s*flex;/);
     assert.doesNotMatch(bubbleCss, /\.card\.expanded\s+\.footer-secondary\.visible/);
   });
+
+  it("keeps the expanded card inside a CSS-zoomed window and reserves shrink for detail", () => {
+    assert.match(
+      bubbleCss,
+      /\.card\.expanded\s*\{[\s\S]*height:\s*calc\(100vh\s*\/\s*var\(--clawd-text-zoom,\s*1\)\s*-\s*12px\)/
+    );
+    assert.match(
+      bubbleCss,
+      /\.card\.expanded\.measuring\s*\{[\s\S]*height:\s*auto;/
+    );
+    assert.match(
+      bubbleCss,
+      /\.card\.expanded\s*>\s*:not\(\.detail-scroll\)\s*\{\s*flex-shrink:\s*0;/
+    );
+    assert.match(bubbleCss, /\.detail-scroll\s*\{[\s\S]*flex:\s*1\s+1\s+auto;/);
+  });
 });

--- a/test/bubble-elicitation-overflow.test.js
+++ b/test/bubble-elicitation-overflow.test.js
@@ -5,6 +5,7 @@ const path = require("node:path");
 
 const bubbleCss = fs.readFileSync(path.join(__dirname, "..", "src", "bubble.css"), "utf8");
 const bubbleRenderer = fs.readFileSync(path.join(__dirname, "..", "src", "bubble-renderer.js"), "utf8");
+const bubbleHtml = fs.readFileSync(path.join(__dirname, "..", "src", "bubble.html"), "utf8");
 
 function functionBody(name) {
   const start = bubbleRenderer.indexOf(`function ${name}(`);
@@ -40,5 +41,16 @@ describe("AskUserQuestion bubble overflow", () => {
     assert.doesNotMatch(body, /card\.classList\.(?:add|toggle)\("elicitation-scrollable"/);
     assert.doesNotMatch(body, /elicitationForm\.style\.maxHeight\s*=/);
     assert.match(bubbleCss, /\.detail-scroll\s*\{[\s\S]*overflow-y:\s*auto/);
+  });
+
+  it("keeps permission quick actions outside the detail-only scroller", () => {
+    const detailStart = bubbleHtml.indexOf('id="detailScroll"');
+    const detailEnd = bubbleHtml.indexOf('id="btnExpand"');
+    const suggestions = bubbleHtml.indexOf('id="suggestions"');
+
+    assert.ok(detailStart >= 0 && detailEnd > detailStart);
+    assert.ok(suggestions > detailEnd, "suggestions must remain visible when compact detail is hidden");
+    assert.match(bubbleCss, /\.footer-secondary\.visible\s*\{\s*display:\s*flex;/);
+    assert.doesNotMatch(bubbleCss, /\.card\.expanded\s+\.footer-secondary\.visible/);
   });
 });

--- a/test/bubble-elicitation-overflow.test.js
+++ b/test/bubble-elicitation-overflow.test.js
@@ -14,32 +14,31 @@ function functionBody(name) {
 }
 
 describe("AskUserQuestion bubble overflow", () => {
-  it("documents applyElicitationViewport as a no-op until the overflow redesign lands", () => {
+  it("keeps the legacy elicitation viewport hook inert", () => {
     const body = functionBody("applyElicitationViewport");
 
     assert.match(body, /Intentionally a no-op/);
-    assert.match(body, /The correct approach: let the form grow to its natural height/);
-    assert.match(body, /permission\.js clampBubbleHeight\(\) already caps the window/);
+    assert.match(body, /one outer detail scroller/);
+    assert.match(body, /caps the BrowserWindow against its target work area/);
   });
 
-  it("reports natural content height before calling the no-op viewport hook", () => {
+  it("reports state-owned natural height before calling the legacy viewport hook", () => {
     assert.match(bubbleRenderer, /function measureNaturalBubbleHeight\(\)/);
     assert.match(bubbleRenderer, /card\.classList\.remove\("elicitation-scrollable"\);/);
     assert.match(bubbleRenderer, /elicitationForm\.style\.maxHeight = "";/);
     assert.match(
       bubbleRenderer,
-      /window\.bubbleAPI\.reportHeight\(measureNaturalBubbleHeight\(\)\);[\s\S]*applyElicitationViewport\(\);/
+      /const height = measureNaturalBubbleHeight\(\);[\s\S]*window\.bubbleAPI\.reportHeight\(\{[\s\S]*state: currentExpanded \? "expanded" : "compact"[\s\S]*measurementEpoch[\s\S]*applyElicitationViewport\(\);/
     );
     assert.doesNotMatch(bubbleCss, /max-height:\s*calc\(100vh/);
     assert.doesNotMatch(bubbleRenderer, /max-height:\s*calc\(100vh/);
   });
 
-  it("does not make the no-op viewport hook add internal scrolling or a max-height clamp", () => {
+  it("uses one expanded detail scroller instead of nesting scroll inside the form", () => {
     const body = functionBody("applyElicitationViewport");
 
-    // Long-prompt overflow remains deferred to the #222 redesign; this guard only
-    // prevents tests from implying the current no-op provides runtime scrolling.
     assert.doesNotMatch(body, /card\.classList\.(?:add|toggle)\("elicitation-scrollable"/);
     assert.doesNotMatch(body, /elicitationForm\.style\.maxHeight\s*=/);
+    assert.match(bubbleCss, /\.detail-scroll\s*\{[\s\S]*overflow-y:\s*auto/);
   });
 });

--- a/test/bubble-elicitation-stepper.test.js
+++ b/test/bubble-elicitation-stepper.test.js
@@ -28,18 +28,12 @@ describe("AskUserQuestion bubble stepper", () => {
     assert.doesNotMatch(body, /forEach\(\(question, questionIndex\)/);
   });
 
-  it("does not auto-select the first option on initial focus (form-like elicitation)", () => {
+  it("does not focus or auto-select an option until the user expands the bubble", () => {
     const body = functionBody("renderElicitationStep");
-
-    // B route: form-like elicitation for both single-choice and multi-select.
-    // Initial focus puts the cursor on the first preset so arrow keys / Tab work
-    // immediately, but it must not call .click() and must not pre-select.
-    //
-    // Source guard only. If first.click() appears in any rewritten form
-    // (first.click({preventScroll:true}), first?.click(), inputs[0].click(), …)
-    // update the guard or replace it with a renderer behavior test.
-    assert.doesNotMatch(body, /first\.click\(/);
-    assert.match(body, /if \(first\) first\.focus\(\);/);
+    const focusBody = functionBody("focusActiveElicitationControl");
+    assert.doesNotMatch(body, /\.focus\(/);
+    assert.doesNotMatch(focusBody, /\.click\(/);
+    assert.match(focusBody, /if \(first\) first\.focus\(\);/);
   });
 
   it("lets answered summary rows reopen their question", () => {

--- a/test/bubble-format.test.js
+++ b/test/bubble-format.test.js
@@ -37,6 +37,30 @@ describe("bubble-format formatDetail builtin tools", () => {
     assert.strictEqual(formatDetail("Bash", { command: "npm test" }), "npm test");
   });
 
+  it("uses explicit full-text fields in detail mode", () => {
+    const command = `echo ${"x".repeat(300)}`;
+    const plan = `Plan\n${"step\n".repeat(80)}END_MARKER`;
+    assert.strictEqual(
+      formatDetail("Bash", { description: "short preview", command }, { mode: "detail" }),
+      command
+    );
+    assert.strictEqual(
+      formatDetail("ExitPlanMode", { note: "wrong first string", plan }, { mode: "detail" }),
+      plan
+    );
+    assert.strictEqual(
+      formatDetail("ExitPlanMode", { note: "wrong first string", plan }),
+      truncate(plan, 120)
+    );
+  });
+
+  it("uses readable JSON for unknown tools in detail mode", () => {
+    assert.strictEqual(
+      formatDetail("mcp__server__tool", { first: "a", nested: { second: "b" } }, { mode: "detail" }),
+      '{\n  "first": "a",\n  "nested": {\n    "second": "b"\n  }\n}'
+    );
+  });
+
   it("formats Edit/Write/Read file_path", () => {
     assert.strictEqual(formatDetail("Edit", { file_path: "/repo/app.js" }), "/repo/app.js");
     assert.strictEqual(formatDetail("Write", { file_path: "/repo/out.txt" }), "/repo/out.txt");

--- a/test/bubble-go-to-terminal.test.js
+++ b/test/bubble-go-to-terminal.test.js
@@ -277,20 +277,32 @@ describe("permission bubble compact/detail presentation", () => {
     assert.strictEqual(harness.element("card").classList.contains("expanded"), false);
   });
 
-  it("keeps direct Allow/Deny on the compact card and reveals the full detail only after expansion", () => {
+  it("keeps every ordinary quick action on the compact card and reveals only the full detail after expansion", () => {
     const harness = createHarness();
     const full = `${"echo long; ".repeat(40)}END_MARKER`;
     harness.show({
       toolName: "Bash",
       toolInput: { command: "echo long; …" },
       detailText: full,
-      interaction: interaction("tool-approval", { allowDeny: true }),
+      suggestions: [{ type: "addRules", ruleContent: "npm test" }],
+      canOfferSessionTrust: true,
+      interaction: interaction("tool-approval", { allowDeny: true, nativeFallback: true }),
       presentation: { expanded: false, measurementEpoch: 0 },
     });
 
     assert.strictEqual(harness.element("compactBlock").textContent, "detail");
     assert.strictEqual(harness.element("commandBlock").textContent, full);
     assert.strictEqual(harness.element("actions").style.display, "");
+    assert.strictEqual(harness.element("suggestions").style.display, "");
+    assert.deepStrictEqual(
+      harness.element("suggestions").children.map((button) => button.textContent),
+      ["Always allow `npm test`", "Go to Terminal"]
+    );
+    assert.strictEqual(harness.element("footerSecondary").classList.contains("visible"), true);
+    assert.strictEqual(
+      harness.element("footerSecondary").children[0].textContent,
+      "Don’t ask again in this session"
+    );
     assert.strictEqual(harness.element("btnExpand").classList.contains("visible"), true);
 
     harness.element("btnExpand").click();
@@ -300,7 +312,7 @@ describe("permission bubble compact/detail presentation", () => {
     assert.strictEqual(harness.element("actions").style.display, "");
   });
 
-  it("hides Plan decisions until View plan and preserves feedback through collapse/re-expand", () => {
+  it("keeps Plan approval compact while feedback waits for View plan and preserves its draft", () => {
     const harness = createHarness();
     harness.show({
       toolName: "ExitPlanMode",
@@ -313,7 +325,10 @@ describe("permission bubble compact/detail presentation", () => {
       presentation: { expanded: false, measurementEpoch: 0 },
     });
 
-    assert.strictEqual(harness.element("actions").style.display, "none");
+    assert.strictEqual(harness.element("actions").style.display, "");
+    assert.strictEqual(harness.element("btnAllow").textContent, "Approve");
+    assert.strictEqual(harness.element("btnDeny").style.display, "none");
+    assert.strictEqual(harness.element("suggestions").style.display, "none");
     assert.strictEqual(harness.element("btnExpand").textContent, "View plan");
     harness.element("btnExpand").click();
     harness.present({ expanded: true, measurementEpoch: 1 });

--- a/test/bubble-go-to-terminal.test.js
+++ b/test/bubble-go-to-terminal.test.js
@@ -62,6 +62,9 @@ class FakeElement {
     if (this.disabled) return;
     for (const listener of this.listeners.get("click") || []) listener({ target: this, preventDefault() {} });
   }
+  dispatch(type, event = {}) {
+    for (const listener of this.listeners.get(type) || []) listener({ target: this, ...event });
+  }
   focus() {}
   setAttribute(name, value) { this.attributes.set(name, String(value)); }
   getAttribute(name) { return this.attributes.get(name) || null; }
@@ -76,6 +79,8 @@ function createHarness() {
     "card", "toolPill", "toolPillText", "commandBlock", "irreversibleBadge",
     "elicitationForm", "elicitationProgress", "planFeedbackForm", "planFeedbackTextarea",
     "planFeedbackBack", "planFeedbackSubmit", "btnAllow", "btnDeny", "suggestions", "sessionTag",
+    "compactBlock", "detailScroll", "detailTruncation", "btnExpand", "btnCollapse", "actions",
+    "footerSecondary",
   ]) elements.set(id, new FakeElement(id.includes("Textarea") ? "textarea" : "div"));
   elements.set("btnAllow", new FakeElement("button"));
   elements.set("btnDeny", new FakeElement("button"));
@@ -83,7 +88,9 @@ function createHarness() {
   elements.set("planFeedbackSubmit", new FakeElement("button"));
   const headerTitle = new FakeElement("span");
   const decisions = [];
+  const expandedRequests = [];
   let showPermission;
+  let showPresentation;
 
   const document = {
     activeElement: null,
@@ -97,6 +104,8 @@ function createHarness() {
     reportHeight() {},
     onPermissionShow: (callback) => { showPermission = callback; },
     onPermissionHide() {},
+    onPresentation: (callback) => { showPresentation = callback; },
+    setExpanded: (expanded) => expandedRequests.push(expanded),
   };
   const context = {
     window: {
@@ -120,8 +129,14 @@ function createHarness() {
   return {
     show(data) { showPermission({ lang: "en", toolInput: {}, suggestions: [], ...data }); },
     decisions,
+    expandedRequests,
+    present(data) { showPresentation(data); },
+    element(id) { return elements.get(id); },
     terminalButtons() {
-      return elements.get("suggestions").children.filter((button) => button.textContent === "Go to Terminal");
+      return [
+        ...elements.get("suggestions").children,
+        ...elements.get("footerSecondary").children,
+      ].filter((button) => button.textContent === "Go to Terminal");
     },
     actionTexts() { return elements.get("suggestions").children.map((button) => button.textContent); },
   };
@@ -240,5 +255,90 @@ describe("permission bubble terminal fallback (issue #689)", () => {
     assert.strictEqual(buttons.length, 1);
     buttons[0].click();
     assert.deepStrictEqual(harness.decisions, ["deny-and-focus"]);
+  });
+});
+
+describe("permission bubble compact/detail presentation", () => {
+  it("keeps Ask compact, unfocused, and shows the question count on its Answer entry", () => {
+    const harness = createHarness();
+    harness.show({
+      toolName: "AskUserQuestion",
+      toolInput: {
+        questions: [
+          { id: "0", question: "First?", options: [] },
+          { id: "1", question: "Second?", options: [] },
+        ],
+      },
+      interaction: interaction("human-question", { answerQuestions: true }),
+      presentation: { expanded: false, measurementEpoch: 0 },
+    });
+    assert.strictEqual(harness.element("actions").style.display, "none");
+    assert.strictEqual(harness.element("btnExpand").textContent, "Answer · Questions: 2");
+    assert.strictEqual(harness.element("card").classList.contains("expanded"), false);
+  });
+
+  it("keeps direct Allow/Deny on the compact card and reveals the full detail only after expansion", () => {
+    const harness = createHarness();
+    const full = `${"echo long; ".repeat(40)}END_MARKER`;
+    harness.show({
+      toolName: "Bash",
+      toolInput: { command: "echo long; …" },
+      detailText: full,
+      interaction: interaction("tool-approval", { allowDeny: true }),
+      presentation: { expanded: false, measurementEpoch: 0 },
+    });
+
+    assert.strictEqual(harness.element("compactBlock").textContent, "detail");
+    assert.strictEqual(harness.element("commandBlock").textContent, full);
+    assert.strictEqual(harness.element("actions").style.display, "");
+    assert.strictEqual(harness.element("btnExpand").classList.contains("visible"), true);
+
+    harness.element("btnExpand").click();
+    assert.deepStrictEqual(harness.expandedRequests, [true]);
+    harness.present({ expanded: true, measurementEpoch: 1 });
+    assert.strictEqual(harness.element("card").classList.contains("expanded"), true);
+    assert.strictEqual(harness.element("actions").style.display, "");
+  });
+
+  it("hides Plan decisions until View plan and preserves feedback through collapse/re-expand", () => {
+    const harness = createHarness();
+    harness.show({
+      toolName: "ExitPlanMode",
+      toolInput: { plan: "Compact plan preview" },
+      detailText: "Full plan\n".repeat(80),
+      interaction: interaction("plan-review", {
+        allowDeny: true,
+        planFeedback: true,
+      }),
+      presentation: { expanded: false, measurementEpoch: 0 },
+    });
+
+    assert.strictEqual(harness.element("actions").style.display, "none");
+    assert.strictEqual(harness.element("btnExpand").textContent, "View plan");
+    harness.element("btnExpand").click();
+    harness.present({ expanded: true, measurementEpoch: 1 });
+    assert.strictEqual(harness.element("actions").style.display, "");
+
+    const feedbackButton = harness.element("suggestions").children[0];
+    assert.strictEqual(feedbackButton.textContent, "Suggest changes");
+    feedbackButton.click();
+    const textarea = harness.element("planFeedbackTextarea");
+    textarea.value = "Keep this draft";
+    textarea.dispatch("input");
+
+    // A same-entry refresh (for example session-trust failure copy) must not
+    // rebuild the Plan DOM or clear the draft.
+    harness.show({
+      toolName: "ExitPlanMode",
+      sessionTrustError: "Retry",
+      presentation: { expanded: true, measurementEpoch: 1 },
+    });
+    assert.strictEqual(textarea.value, "Keep this draft");
+
+    harness.element("btnCollapse").click();
+    harness.present({ expanded: false, measurementEpoch: 2 });
+    harness.present({ expanded: true, measurementEpoch: 3 });
+    assert.strictEqual(textarea.value, "Keep this draft");
+    assert.strictEqual(harness.element("planFeedbackForm").classList.contains("visible"), true);
   });
 });

--- a/test/permission-expanded-bubble.test.js
+++ b/test/permission-expanded-bubble.test.js
@@ -38,7 +38,7 @@ function interaction(capabilities = {}) {
   };
 }
 
-function makeCtx() {
+function makeCtx(overrides = {}) {
   return {
     lang: "en",
     sessions: new Map(),
@@ -52,6 +52,7 @@ function makeCtx() {
     bubbleFollowPet: false,
     bubbleFixedCorner: "bottom-right",
     win: null,
+    ...overrides,
   };
 }
 
@@ -60,9 +61,15 @@ function makeBubble() {
   return {
     sends,
     focusCount: 0,
+    bounds: null,
     isDestroyed: () => false,
-    webContents: { send: (...args) => sends.push(args) },
+    webContents: {
+      send: (...args) => sends.push(args),
+      insertCSS: () => undefined,
+      setZoomFactor() {},
+    },
     focus() { this.focusCount += 1; },
+    setBounds(bounds) { this.bounds = bounds; },
   };
 }
 
@@ -137,5 +144,35 @@ describe("permission expanded presentation owner", () => {
     });
     assert.strictEqual(entry.expandedMeasuredHeight, 600);
     assert.strictEqual(entry.expandedChromeHeight, 180);
+  });
+
+  it("replaces the 620px expansion fallback with a shorter reported natural height", () => {
+    const owner = { isDestroyed: () => false };
+    const permission = initPermission(makeCtx({
+      win: owner,
+      getTextScale: () => 1,
+    }));
+    const bubble = makeBubble();
+    const entry = {
+      bubble,
+      bubbleReady: true,
+      interaction: interaction(),
+      suggestions: [],
+    };
+    permission.pendingPermissions.push(entry);
+
+    permission.handleBubbleExpanded(eventFor(bubble), true);
+    assert.strictEqual(bubble.bounds.height, 620, "first layout uses the provisional fallback");
+
+    permission.handleBubbleHeight(eventFor(bubble), {
+      height: 360,
+      state: "expanded",
+      measurementEpoch: 1,
+      chromeHeight: 180,
+      detailLineHeight: 18,
+    });
+
+    assert.strictEqual(entry.expandedMeasuredHeight, 360);
+    assert.strictEqual(bubble.bounds.height, 360, "accepted natural height must immediately resize the window");
   });
 });

--- a/test/permission-expanded-bubble.test.js
+++ b/test/permission-expanded-bubble.test.js
@@ -1,0 +1,141 @@
+"use strict";
+
+const assert = require("node:assert");
+const Module = require("node:module");
+const { describe, it } = require("node:test");
+
+const modulePath = require.resolve("../src/permission");
+delete require.cache[modulePath];
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request) {
+  if (request === "electron") {
+    return {
+      BrowserWindow: { fromWebContents: (sender) => sender && sender.__win },
+      globalShortcut: {
+        register: () => true,
+        unregister() {},
+        isRegistered: () => false,
+      },
+    };
+  }
+  return originalLoad.apply(this, arguments);
+};
+const initPermission = require("../src/permission");
+Module._load = originalLoad;
+
+function interaction(capabilities = {}) {
+  return {
+    intent: capabilities.answerQuestions ? "human-question"
+      : (capabilities.planFeedback ? "plan-review" : "tool-approval"),
+    automationEligibility: { autoTools: false, unattended: false },
+    capabilities: {
+      allowDeny: true,
+      answerQuestions: false,
+      planFeedback: false,
+      nativeFallback: true,
+      ...capabilities,
+    },
+  };
+}
+
+function makeCtx() {
+  return {
+    lang: "en",
+    sessions: new Map(),
+    getSettingsSnapshot: () => ({}),
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: 0 }),
+    getPetWindowBounds: () => ({ x: 800, y: 400, width: 120, height: 120 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1920, height: 1080 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    subscribeShortcuts: () => () => {},
+    bubbleFollowPet: false,
+    bubbleFixedCorner: "bottom-right",
+    win: null,
+  };
+}
+
+function makeBubble() {
+  const sends = [];
+  return {
+    sends,
+    focusCount: 0,
+    isDestroyed: () => false,
+    webContents: { send: (...args) => sends.push(args) },
+    focus() { this.focusCount += 1; },
+  };
+}
+
+function eventFor(bubble) {
+  return { sender: { __win: bubble } };
+}
+
+describe("permission expanded presentation owner", () => {
+  it("keeps one expanded owner, focuses Plan/Ask only after the user expands, and honors IME composition lock", () => {
+    const permission = initPermission(makeCtx());
+    const planBubble = makeBubble();
+    const ordinaryBubble = makeBubble();
+    const plan = {
+      bubble: planBubble,
+      bubbleReady: true,
+      interaction: interaction({ planFeedback: true }),
+      suggestions: [],
+    };
+    const ordinary = {
+      bubble: ordinaryBubble,
+      bubbleReady: true,
+      interaction: interaction(),
+      suggestions: [],
+    };
+    permission.pendingPermissions.push(plan, ordinary);
+
+    assert.strictEqual(permission.handleBubbleExpanded(eventFor(planBubble), true), true);
+    assert.strictEqual(plan.expanded, true);
+    assert.strictEqual(planBubble.focusCount, 1);
+
+    permission.handleCompositionActive(eventFor(planBubble), true);
+    assert.strictEqual(permission.handleBubbleExpanded(eventFor(ordinaryBubble), true), false);
+    assert.strictEqual(plan.expanded, true);
+    assert.strictEqual(ordinary.expanded, false);
+
+    permission.handleCompositionActive(eventFor(planBubble), false);
+    assert.strictEqual(permission.handleBubbleExpanded(eventFor(ordinaryBubble), true), true);
+    assert.strictEqual(plan.expanded, false);
+    assert.strictEqual(ordinary.expanded, true);
+    assert.strictEqual(ordinaryBubble.focusCount, 0);
+    assert.ok(planBubble.sends.some(([channel, payload]) =>
+      channel === "permission-presentation" && payload.expanded === false
+    ));
+  });
+
+  it("rejects stale height acknowledgements from the previous presentation epoch", () => {
+    const permission = initPermission(makeCtx());
+    const bubble = makeBubble();
+    const entry = {
+      bubble,
+      bubbleReady: true,
+      interaction: interaction(),
+      suggestions: [],
+    };
+    permission.pendingPermissions.push(entry);
+    permission.handleBubbleExpanded(eventFor(bubble), true);
+    assert.strictEqual(entry.measurementEpoch, 1);
+
+    permission.handleBubbleHeight(eventFor(bubble), {
+      height: 900,
+      state: "expanded",
+      measurementEpoch: 0,
+    });
+    assert.strictEqual(entry.expandedMeasuredHeight, undefined);
+
+    permission.handleBubbleHeight(eventFor(bubble), {
+      height: 600,
+      state: "expanded",
+      measurementEpoch: 1,
+      chromeHeight: 180,
+      detailLineHeight: 18,
+    });
+    assert.strictEqual(entry.expandedMeasuredHeight, 600);
+    assert.strictEqual(entry.expandedChromeHeight, 180);
+  });
+});

--- a/test/permission-family-payload.test.js
+++ b/test/permission-family-payload.test.js
@@ -80,6 +80,17 @@ function buildPayload(entryOverrides) {
 }
 
 describe("opencode-family bubble payload", () => {
+  it("forwards local detail and an explicit compact presentation epoch", () => {
+    const payload = buildPayload({
+      agentId: "claude-code",
+      detailText: "full local detail",
+      detailTruncated: true,
+    });
+    assert.strictEqual(payload.detailText, "full local detail");
+    assert.strictEqual(payload.detailTruncated, true);
+    assert.deepStrictEqual(payload.presentation, { expanded: false, measurementEpoch: 0 });
+  });
+
   it("family entries emit the neutral family* vocabulary", () => {
     const payload = buildPayload({
       agentId: "opencode",

--- a/test/permission-reposition.test.js
+++ b/test/permission-reposition.test.js
@@ -60,6 +60,53 @@ describe("permission bubble Orbit avoidance bounds", () => {
 });
 
 describe("permission bubble stack layout", () => {
+  it("right-aligns mixed compact/expanded widths and keeps the expanded card in the work area", () => {
+    const bounds = layout({
+      followPet: false,
+      fixedCorner: "bottom-right",
+      bubbleHeights: [140, 600, 140],
+      bubbleSizes: [
+        { width: 340, height: 140 },
+        { width: 500, height: 600 },
+        { width: 340, height: 140 },
+      ],
+      expandedIndex: 1,
+      workArea: { x: 0, y: 0, width: 900, height: 700 },
+    });
+
+    assert.strictEqual(bounds[0].x + bounds[0].width, 892);
+    assert.strictEqual(bounds[1].x + bounds[1].width, 892);
+    assert.strictEqual(bounds[2].x + bounds[2].width, 892);
+    assert.ok(bounds[1].y >= 8);
+    assert.ok(bounds[1].y + bounds[1].height <= 692);
+    assert.ok(bounds[0].y < bounds[1].y && bounds[1].y < bounds[2].y);
+  });
+
+  it("expands away from the pet on either side", () => {
+    const right = layout({
+      followPet: true,
+      followPreference: "right",
+      bubbleHeights: [140, 400],
+      bubbleSizes: [{ width: 340, height: 140 }, { width: 500, height: 400 }],
+      expandedIndex: 1,
+      workArea: FHD,
+      hitRect: { left: 700, top: 800, right: 820, bottom: 920 },
+    });
+    assert.strictEqual(right[0].x, 820);
+    assert.strictEqual(right[1].x, 820);
+
+    const left = layout({
+      followPet: true,
+      followPreference: "left",
+      bubbleHeights: [140, 400],
+      bubbleSizes: [{ width: 340, height: 140 }, { width: 500, height: 400 }],
+      expandedIndex: 1,
+      workArea: FHD,
+      hitRect: { left: 1000, top: 800, right: 1120, bottom: 920 },
+    });
+    assert.strictEqual(left[0].x + left[0].width, 1000);
+    assert.strictEqual(left[1].x + left[1].width, 1000);
+  });
   it("hangs the stack from the pet hitbox when there is room below", () => {
     // 3 short bubbles, pet in upper-middle of a 1080p screen → below branch.
     const bounds = layout({

--- a/test/permission-update-bubble-ipc.test.js
+++ b/test/permission-update-bubble-ipc.test.js
@@ -57,20 +57,28 @@ test("permission IPC registers owned channels, delegates, and disposes", () => {
     permission: {
       handleBubbleHeight: (event, height) => calls.push(["height", event.sender, height]),
       handleDecide: (event, behavior) => calls.push(["decide", event.sender, behavior]),
+      handleBubbleExpanded: (event, expanded) => calls.push(["expanded", event.sender, expanded]),
+      handleCompositionActive: (event, active) => calls.push(["composition", event.sender, active]),
     },
   });
 
   assert.deepStrictEqual([...ipcMain.listeners.keys()].sort(), [
+    "bubble-composition-active",
     "bubble-height",
     "permission-decide",
+    "permission-set-expanded",
   ]);
 
   ipcMain.send("bubble-height", 240);
   ipcMain.send("permission-decide", "deny-and-focus");
+  ipcMain.send("permission-set-expanded", true);
+  ipcMain.send("bubble-composition-active", true);
 
   assert.deepStrictEqual(calls, [
     ["height", "sender-web-contents", 240],
     ["decide", "sender-web-contents", "deny-and-focus"],
+    ["expanded", "sender-web-contents", true],
+    ["composition", "sender-web-contents", true],
   ]);
 
   runtime.dispose();

--- a/test/server-permission-input.test.js
+++ b/test/server-permission-input.test.js
@@ -3,6 +3,9 @@ const assert = require("node:assert");
 
 const {
   truncateDeep,
+  DETAIL_TEXT_MAX_BYTES,
+  clampUtf8Text,
+  preparePermissionDetail,
   normalizePermissionSuggestions,
   normalizeElicitationToolInput,
   prepareElicitationToolInput,
@@ -85,7 +88,78 @@ describe("permission input normalization", () => {
     assert.notStrictEqual(prepared.displayInput.questions[0].question, rawQuestion);
     assert.strictEqual(prepared.displayInput.questions[0].options[0].label, "Option A");
     assert.strictEqual(prepared.displayInput.questions[0].options[0].description.length, 160);
+    assert.strictEqual(prepared.detailDisplayInput.questions[0].question, rawQuestion.trim());
+    assert.strictEqual(
+      prepared.detailDisplayInput.questions[0].options[0].description,
+      rawInput.questions[0].options[0].description
+    );
+    assert.strictEqual(prepared.detailDisplayInput.questions[0].detailTruncated, false);
     assert.deepStrictEqual(normalizeElicitationToolInput(rawInput), prepared.displayInput);
+  });
+
+  it("marks an Ask detail when the expanded question itself exceeds its local budget", () => {
+    const prepared = prepareElicitationToolInput({
+      questions: [{
+        question: "q".repeat(140 * 1024),
+        header: "Long prompt",
+        options: [{ label: "Continue", description: "Proceed" }],
+      }],
+    });
+    assert.strictEqual(prepared.canAnswer, true);
+    assert.strictEqual(prepared.detailTruncated, true);
+    assert.strictEqual(prepared.detailDisplayInput.questions[0].detailTruncated, true);
+  });
+
+  it("keeps preview truncation separate from the bounded local detail text", () => {
+    const command = `${"x".repeat(2000)}END_MARKER`;
+    const rawInput = { command };
+    const preview = truncateDeep(rawInput);
+    const detail = preparePermissionDetail("Bash", rawInput);
+
+    assert.strictEqual(preview.command.endsWith("…"), true);
+    assert.strictEqual(preview.command.includes("END_MARKER"), false);
+    assert.strictEqual(detail.detailText, command);
+    assert.strictEqual(detail.detailText.endsWith("END_MARKER"), true);
+    assert.strictEqual(detail.detailTruncated, false);
+  });
+
+  it("marks truncation only when the selected detail text exceeds the byte budget", () => {
+    const selected = preparePermissionDetail("Bash", {
+      command: "echo complete",
+      unrelated: "x".repeat(DETAIL_TEXT_MAX_BYTES + 100),
+    });
+    assert.strictEqual(selected.detailText, "echo complete");
+    assert.strictEqual(selected.detailTruncated, false);
+
+    const oversized = preparePermissionDetail("Bash", {
+      command: "猫".repeat(DETAIL_TEXT_MAX_BYTES),
+    });
+    assert.strictEqual(oversized.detailTruncated, true);
+    assert.ok(Buffer.byteLength(oversized.detailText, "utf8") <= DETAIL_TEXT_MAX_BYTES);
+    assert.strictEqual(oversized.detailText.endsWith("…"), true);
+  });
+
+  it("bounds structural depth and key counts only for an unknown tool's displayed JSON", () => {
+    const manyKeys = Object.fromEntries(
+      Array.from({ length: 80 }, (_, index) => [`key-${index}`, index])
+    );
+    const unknown = preparePermissionDetail("custom_tool", { manyKeys });
+    assert.strictEqual(unknown.detailTruncated, true);
+    assert.strictEqual(Object.keys(JSON.parse(unknown.detailText).manyKeys).length, 64);
+
+    const known = preparePermissionDetail("Bash", {
+      command: "echo complete",
+      manyKeys,
+    });
+    assert.strictEqual(known.detailText, "echo complete");
+    assert.strictEqual(known.detailTruncated, false);
+  });
+
+  it("clamps UTF-8 text without splitting a surrogate pair", () => {
+    const bounded = clampUtf8Text("abc😀def", 8);
+    assert.strictEqual(bounded.truncated, true);
+    assert.strictEqual(bounded.text.includes("�"), false);
+    assert.ok(Buffer.byteLength(bounded.text, "utf8") <= 8);
   });
 
   it("refuses duplicate raw answer keys because indexed answers cannot map unambiguously", () => {

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -331,7 +331,20 @@ describe("server-route-permission POST", () => {
 
   it("keeps long Ask text for the expanded view without changing the wire answer keys", async () => {
     const marker = "__CLAWD_ASK_DETAIL_END__";
-    const question = `${"Compare the tradeoffs carefully. ".repeat(20)}${marker}`;
+    const question = [
+      "Compare the tradeoffs carefully.",
+      "",
+      "1. Keep the compact window.",
+      "2. Open a scrollable detail view.",
+      "",
+      `${"Include every relevant constraint. ".repeat(20)}${marker}`,
+    ].join("\n");
+    const optionDescription = [
+      "Open the detail view.",
+      "",
+      "- Preserve paragraphs.",
+      "- Preserve list structure.",
+    ].join("\n");
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "claude-code",
       session_id: "claude-code:ask-detail",
@@ -343,7 +356,7 @@ describe("server-route-permission POST", () => {
           multiSelect: false,
           options: [
             { label: "Option A", description: "Keep the compact window." },
-            { label: "Option B", description: "Open a scrollable detail view." },
+            { label: "Option B", description: optionDescription },
           ],
         }],
       },
@@ -352,7 +365,8 @@ describe("server-route-permission POST", () => {
     assert.strictEqual(res.ctx.pendingPermissions.length, 1);
     const entry = res.ctx.pendingPermissions[0];
     assert.strictEqual(entry.toolInput.questions[0].question.includes(marker), false);
-    assert.strictEqual(entry.elicitationDetailInput.questions[0].question.endsWith(marker), true);
+    assert.strictEqual(entry.elicitationDetailInput.questions[0].question, question);
+    assert.strictEqual(entry.elicitationDetailInput.questions[0].options[1].description, optionDescription);
     assert.strictEqual(entry.elicitationWireInput.questions[0].question, question);
   });
 

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -292,6 +292,70 @@ describe("server-route-permission POST", () => {
     }
   });
 
+  it("keeps a bounded compact preview and a complete local detail across permission adapters", async () => {
+    const marker = "__CLAWD_PERMISSION_DETAIL_END__";
+    const command = `${"printf x; ".repeat(260)}${marker}`;
+    const cases = [
+      { agentId: "claude-code", body: {} },
+      { agentId: "codebuddy", body: {} },
+      { agentId: "codex", body: { tool_input_description: "Run a generated command" } },
+      { agentId: "qwen-code", body: {} },
+      { agentId: "zcode", body: {} },
+      { agentId: "copilot-cli", body: {} },
+      { agentId: "hermes", body: {} },
+      {
+        agentId: "opencode",
+        body: {
+          request_id: "req-detail",
+          bridge_url: "http://127.0.0.1:9",
+          bridge_token: "detail-token",
+        },
+      },
+    ];
+
+    for (const { agentId, body } of cases) {
+      const res = await callPermissionPost(JSON.stringify({
+        agent_id: agentId,
+        session_id: `${agentId}:detail`,
+        tool_name: "Bash",
+        tool_input: { command },
+        ...body,
+      }));
+      assert.strictEqual(res.ctx.pendingPermissions.length, 1, agentId);
+      const entry = res.ctx.pendingPermissions[0];
+      assert.strictEqual(entry.detailText.endsWith(marker), true, agentId);
+      assert.strictEqual(entry.detailTruncated, false, agentId);
+      assert.strictEqual(JSON.stringify(entry.toolInput).includes(marker), false, agentId);
+    }
+  });
+
+  it("keeps long Ask text for the expanded view without changing the wire answer keys", async () => {
+    const marker = "__CLAWD_ASK_DETAIL_END__";
+    const question = `${"Compare the tradeoffs carefully. ".repeat(20)}${marker}`;
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "claude-code:ask-detail",
+      tool_name: "AskUserQuestion",
+      tool_input: {
+        questions: [{
+          question,
+          header: "Approach",
+          multiSelect: false,
+          options: [
+            { label: "Option A", description: "Keep the compact window." },
+            { label: "Option B", description: "Open a scrollable detail view." },
+          ],
+        }],
+      },
+    }));
+
+    assert.strictEqual(res.ctx.pendingPermissions.length, 1);
+    const entry = res.ctx.pendingPermissions[0];
+    assert.strictEqual(entry.toolInput.questions[0].question.includes(marker), false);
+    assert.strictEqual(entry.elicitationDetailInput.questions[0].question.endsWith(marker), true);
+    assert.strictEqual(entry.elicitationWireInput.questions[0].question, question);
+  });
+
   it("uses the raw permission session id and ignores sender eligibility claims", async () => {
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "claude-code",


### PR DESCRIPTION
## Summary

- keep each permission request as a compact three-line bubble by default
- preserve the original compact quick actions: ordinary Allow/Deny, Always/suggestions, terminal fallback, and session trust; Plan keeps quick Approve beside View plan
- let one bubble expand into a wider, independently scrollable detail view while siblings stay compact
- keep expanded cards inside CSS-zoomed BrowserWindows, reserve flex shrinking for the detail scroller, and leave the fixed action/footer area fully visible
- preserve Plan and Ask paragraph/list formatting, surface truncation warnings before scrolling, and give Ask progress labels readable spacing
- preserve Ask and Plan drafts across collapse, switching, and same-request refreshes
- carry bounded local-only detail data across all seven permission routes without changing fingerprints, automation, remote payloads, or wire answer keys
- add variable-width layout, stale measurement rejection, IME switching protection, tests, and localized labels

## Validation

- [x] `NODE_PATH=<main-checkout>/node_modules node test/run-tests.js` — 8701 tests, 8671 pass, 0 fail, 30 skip
- [x] macOS real-machine permission-bubble pass at 135% text scale — natural-height sizing, long-detail scrolling, fixed actions/corners, one-expanded-owner behavior, draft preservation, IME switching lock, focus behavior, fixed/follow placement, truncation/depth indicators, and dangerous-action labels
- [x] real Claude Code `AskUserQuestion` and `ExitPlanMode` round trips — original question/option keys preserved; multi-question answers do not cross; quoted plan feedback reaches the upstream response unchanged
- [x] targeted macOS Electron check at 135% text scale — Plan and multiline Ask questions/options keep paragraph/list line breaks; truncation warning is hidden when compact and fixed above the detail scroller when expanded; Ask progress has 4px vertical CSS padding
- [x] isolated macOS Electron quick-action capture — ordinary compact card visibly retains Allow/Deny, Always, terminal fallback, and session trust; Plan compact card visibly retains View plan and Approve
- [x] macOS mixed-scale multi-display validation — Fixed keeps the bubble stack on the primary display while the pet is on the secondary display; Follow moves the expanded/compact stack with the pet in both directions between a 3440×1440 1× primary display and a 1710×1107 2× secondary display, without clipping, misplaced windows, or inaccessible actions
- [ ] Windows/Linux GUI validation

## Test boundary

The Node test suite has no browser layout engine. It behaviorally covers the expanded-height acknowledgement, multiline Ask detail/wire preservation, and the truncation-warning DOM ownership, but it cannot prove CSS layout at a non-default text scale. The zoom-corrected viewport, preserved Plan/Ask whitespace, Ask progress spacing, and mixed-scale multi-display behavior are therefore backed by the macOS Electron/real-machine checks above. A prior source-regex assertion for the zoom CSS was removed because matching stylesheet text is not layout proof.

Windows/Linux GUI validation remains unverified and is recorded as residual risk. The second-step multi-request list model is intentionally outside this PR.

Closes #918
