### PR TITLE
fix(dsh): resolve the CLI and pnpm without relying on the GUI PATH

### DIFF
--- a/hooks/dsh-install.js
+++ b/hooks/dsh-install.js
@@ -300,6 +300,36 @@ async function resolveNodeRunner(options = {}) {
   return resolveNodeBinAsync(options);
 }
 
+// GUI 启动的 Electron 只继承 `/usr/bin:/bin:/usr/sbin:/sbin`，缺少 Homebrew / nvm 等
+// 用户级 bin 目录。`dsh plugin add` 内部会转发给 pnpm（见 dsh 的 plugin forwarder），
+// 所以除了定位 pnpm 本身，还必须把这份 PATH 传给 dsh 子进程，否则它自己也找不到 pnpm。
+// 用登录 shell 读一次真实 PATH，与 resolveDshCommand 的定位方式保持一致。
+async function resolveLoginPath(options = {}) {
+  if (typeof options.loginPath === "string") return options.loginPath;
+  if ((options.platform || process.platform) === "win32") return null;
+  const shell = typeof options.shellPath === "string" && options.shellPath.trim()
+    ? options.shellPath.trim()
+    : (process.env.SHELL || "/bin/sh");
+  const result = await runCommand(shell, ["-lc", "printf %s \"$PATH\""], {
+    ...options,
+    timeoutMs: 5000,
+  });
+  if (result.code !== 0) return null;
+  const value = result.stdout.trim();
+  return value || null;
+}
+
+// 在 options.env 之上叠加登录 shell 的 PATH，供探测和 dsh 子进程共用。
+async function withLoginPathEnv(options = {}) {
+  const baseEnv = options.env || process.env;
+  const loginPath = await resolveLoginPath(options);
+  if (!loginPath) return baseEnv;
+  const current = baseEnv.PATH || "";
+  // 保留调用方原有 PATH 的优先级，只在其后补充登录 shell 的条目。
+  const merged = [...new Set([...current.split(":"), ...loginPath.split(":")].filter(Boolean))];
+  return { ...baseEnv, PATH: merged.join(":") };
+}
+
 async function resolveDshCommand(options = {}) {
   if (options.commandInfo && typeof options.commandInfo === "object") {
     return options.commandInfo;
@@ -331,9 +361,8 @@ async function resolveDshCommand(options = {}) {
     let realBin = bin;
     try { realBin = await fsp.realpath(bin); } catch {}
     const normalized = realBin.replace(/\\/g, "/");
-    let installRoot = normalized.endsWith("/lib/bin.js")
-      ? path.dirname(path.dirname(realBin))
-      : null;
+    let entryBinJs = normalized.endsWith("/lib/bin.js") ? realBin : null;
+    let installRoot = entryBinJs ? path.dirname(path.dirname(entryBinJs)) : null;
     if (!installRoot) {
       const parsed = await readShimBinCandidates(bin, platform);
       let binJs = null;
@@ -343,7 +372,21 @@ async function resolveDshCommand(options = {}) {
           break;
         }
       }
-      if (binJs) installRoot = path.dirname(path.dirname(binJs));
+      if (binJs) {
+        entryBinJs = binJs;
+        installRoot = path.dirname(path.dirname(binJs));
+      }
+    }
+    // `dsh` 的入口是 `#!/usr/bin/env node` 脚本，靠 PATH 找 node。定位用的是登录 shell
+    // (`-lc`，PATH 完整)，但后续 spawn 用的是 process.env —— 从 Finder 启动的 Electron
+    // 只继承 `/usr/bin:/bin:/usr/sbin:/sbin`，不含 Homebrew/nvm 的 node，于是 shim 以
+    // 127 退出，版本被读成 "unknown"。与 win32 分支一致，显式用解析出的 node 绝对路径
+    // 执行 bin.js，绕开对 PATH 的隐式依赖。
+    if (entryBinJs) {
+      const nodeRunner = await resolveNodeRunner(options);
+      if (nodeRunner) {
+        return { command: nodeRunner, prefixArgs: [entryBinJs], installRoot };
+      }
     }
     return { command: bin, prefixArgs: [], installRoot };
   }
@@ -403,7 +446,12 @@ async function hasPnpm(options = {}) {
   if ((options.platform || process.platform) === "win32") {
     return !!(await whereCommand("pnpm", options));
   }
-  const result = await runCommand("pnpm", ["--version"], { ...options, timeoutMs: 5000 });
+  const result = await runCommand("pnpm", ["--version"], {
+    ...options,
+    // pnpm 通常也是 `#!/usr/bin/env node` 脚本，裸名 spawn 在 GUI 的贫瘠 PATH 下必然失败。
+    env: await withLoginPathEnv(options),
+    timeoutMs: 5000,
+  });
   return result.code === 0;
 }
 
@@ -425,7 +473,11 @@ async function runDshCommand(args, options = {}) {
     }
     const command = await resolveDshCommand(options);
     if (!command) return { code: 127, stdout: "", stderr: "dsh command is not available" };
-    return runCommand(command.command, [...command.prefixArgs, ...args], options);
+    // `dsh plugin ...` 会把参数转发给 pnpm，因此子进程自身也需要能在 PATH 上找到 pnpm。
+    return runCommand(command.command, [...command.prefixArgs, ...args], {
+      ...options,
+      env: await withLoginPathEnv(options),
+    });
   } catch (err) {
     return {
       code: 1,

--- a/test/dsh-install-bridge.test.js
+++ b/test/dsh-install-bridge.test.js
@@ -175,6 +175,51 @@ test("Windows CLI discovery follows a pnpm-style shim instead of assuming one gl
   assert.strictEqual(command.installRoot, path.dirname(path.dirname(binJs)));
 });
 
+test("POSIX CLI discovery runs bin.js through an absolute node instead of the PATH-dependent shim", {
+  skip: process.platform === "win32",
+}, async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-dsh-posix-shim-"));
+  const binJs = path.join(root, "lib", "node_modules", "@deepseek-ai", "dsh", "lib", "bin.js");
+  fs.mkdirSync(path.dirname(binJs), { recursive: true });
+  fs.writeFileSync(binJs, "#!/usr/bin/env node\nexport {};\n", "utf8");
+  const shim = path.join(root, "bin", "dsh");
+  fs.mkdirSync(path.dirname(shim), { recursive: true });
+  // 复刻 npm 全局安装的布局：PATH 上的 `dsh` 是指向 bin.js 的 symlink，而 bin.js
+  // 的 shebang 是 `#!/usr/bin/env node`，直接 spawn 会依赖调用方的 PATH。
+  fs.symlinkSync(binJs, shim);
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const command = await resolveDshCommand({
+    platform: "darwin",
+    shellPath: "/bin/sh",
+    resolveNodeBinAsyncImpl: async () => "/opt/homebrew/bin/node",
+    runCommand: async (program, args) => {
+      assert.deepStrictEqual(args, ["-lc", "command -v dsh"]);
+      return { code: 0, stdout: `${shim}\n` };
+    },
+  });
+  assert.strictEqual(command.command, "/opt/homebrew/bin/node");
+  assert.deepStrictEqual(command.prefixArgs, [fs.realpathSync(binJs)]);
+  assert.strictEqual(command.installRoot, path.dirname(path.dirname(fs.realpathSync(binJs))));
+});
+
+test("POSIX CLI discovery falls back to the shim when no node can be resolved", {
+  skip: process.platform === "win32",
+}, async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-dsh-posix-nonode-"));
+  const shim = path.join(root, "bin", "dsh");
+  fs.mkdirSync(path.dirname(shim), { recursive: true });
+  fs.writeFileSync(shim, "#!/bin/sh\nexec dsh-real \"$@\"\n", "utf8");
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const command = await resolveDshCommand({
+    platform: "darwin",
+    shellPath: "/bin/sh",
+    resolveNodeBinAsyncImpl: async () => null,
+    runCommand: async () => ({ code: 0, stdout: `${shim}\n` }),
+  });
+  assert.strictEqual(command.command, shim);
+  assert.deepStrictEqual(command.prefixArgs, []);
+});
+
 test("the cross-process DSH mutation lock rejects a concurrent owner and releases by token", async (t) => {
   const harness = makeHarness();
   t.after(() => fs.rmSync(harness.root, { recursive: true, force: true }));


### PR DESCRIPTION
### 修复了什么

修复 #939  。macOS/Linux 从 GUI 启动时，DeepSeek Harness 安装因 PATH 问题失败，表现为 DeepSeek Harness unknown is unsupported，绕过后变成 pnpm is required by dsh plugin add。

三个症状同一根因：Finder 启动的 Electron 只继承 /usr/bin:/bin:/usr/sbin:/sbin，不含 Homebrew / nvm。

### 怎么修的

1. resolveDshCommand：用绝对 node 执行 bin.js

原代码算出 installRoot 后就把解析到的 bin.js 路径丢弃了。改为保留它（两条来源——symlink 直指 bin.js、以及从 shim 脚本内解析——都覆盖），再用 resolveNodeRunner 解析出的绝对 node 执行：

if (entryBinJs) {
  const nodeRunner = await resolveNodeRunner(options);
  if (nodeRunner) {
    return { command: nodeRunner, prefixArgs: [entryBinJs], installRoot };
  }
}
return { command: bin, prefixArgs: [], installRoot };  // 无 node 可解析时按原逻辑兜底

这与 win32 分支既有做法一致。保留原返回作为 fallback，当前能正常工作的环境不受影响。

2 & 3. 新增 resolveLoginPath / withLoginPathEnv

用登录 shell 读一次真实 PATH（shell -lc 'printf %s "$PATH"'，与 resolveDshCommand 现有定位方式保持一致），叠加到调用方的 env 之上：

// 保留调用方原有 PATH 的优先级，只在其后补充登录 shell 的条目
const merged = [...new Set([...current.split(":"), ...loginPath.split(":")].filter(Boolean))];

用于两处：

- hasPnpm 的探测 —— 解决症状 2；
- runDshCommand spawn 子进程时的 env —— 解决症状 3，因为 dsh plugin add 会转发给 pnpm，子进程自己也得找得到。

win32 下 resolveLoginPath 返回 null，withLoginPathEnv 原样返回 options.env，Windows 行为完全不变。

### 测试

新增两个用例，对齐既有 Windows 用例的写法：

- POSIX symlink 布局应解析为 node + bin.js
- 无 node 可解析时应回退到裸 shim

node --test test/dsh-install-bridge.test.js：57 tests / 54 pass / 0 fail / 3 skipped。

本机原有 9 个失败用例也一并通过了——它们失败的原因与本 PR 修复的相同。

### 如何验证

从 GUI 启动才能复现，终端启动会继承完整 PATH 从而掩盖问题。模拟：

env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin HOME="$HOME" USER="$USER" \
  TMPDIR="$TMPDIR" LANG=zh_CN.UTF-8 SHELL="$SHELL" \
  /path/to/node launch.js

进 设置 → Agent 管理 → 发现并添加，点 DeepSeek Harness 安装。

修复前：DeepSeek Harness unknown is unsupported
修复后：安装成功（本机 dsh 0.1.0-rc.6 + pnpm 10.30.3 实测通过）