### PR TITLE
fix: keep Ask progress below overflowing form content

### DIFF
--- a/src/bubble.css
+++ b/src/bubble.css
@@ -316,9 +316,11 @@ body { padding: 6px; }
 /* ── Elicitation form ── */
 .elicitation-form {
   display: none;
+  /* The outer detail scroller owns overflow. Keep the form at its intrinsic
+     height so its children cannot paint through the following progress row. */
+  flex: 0 0 auto;
   flex-direction: column;
   gap: 10px;
-  min-height: 0;
 }
 .elicitation-form.visible { display: flex; }
 .card.elicitation-scrollable .elicitation-form {

--- a/test/bubble-elicitation-layout-electron.test.js
+++ b/test/bubble-elicitation-layout-electron.test.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+function electronExecutable() {
+  try {
+    const value = require("electron");
+    return typeof value === "string" && value ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+test("expanded Ask progress stays after overflowing form content", { timeout: 30_000 }, (t) => {
+  const executable = electronExecutable();
+  if (!executable) return t.skip("Electron executable is not installed");
+  if (process.platform === "linux" && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    return t.skip("Electron bubble layout audit needs an X11/Wayland display (CI can use xvfb-run)");
+  }
+
+  const fixture = path.join(__dirname, "fixtures", "bubble-elicitation-layout-electron.js");
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  const args = ["--disable-gpu"];
+  if (process.platform === "win32") args.push("--force-device-scale-factor=1.25");
+  if (process.platform === "linux") args.push("--no-sandbox");
+  args.push(fixture);
+  const result = spawnSync(executable, args, {
+    env,
+    encoding: "utf8",
+    timeout: 25_000,
+  });
+
+  assert.strictEqual(
+    result.status,
+    0,
+    [result.stdout, result.stderr].filter(Boolean).join("\n") || `Electron exited ${result.status}`
+  );
+});

--- a/test/bubble-elicitation-overflow.test.js
+++ b/test/bubble-elicitation-overflow.test.js
@@ -41,6 +41,11 @@ describe("AskUserQuestion bubble overflow", () => {
     assert.doesNotMatch(body, /card\.classList\.(?:add|toggle)\("elicitation-scrollable"/);
     assert.doesNotMatch(body, /elicitationForm\.style\.maxHeight\s*=/);
     assert.match(bubbleCss, /\.detail-scroll\s*\{[\s\S]*overflow-y:\s*auto/);
+    assert.match(
+      bubbleCss,
+      /\.elicitation-form\s*\{[^}]*flex:\s*0\s+0\s+auto\s*;/,
+      "the form must retain its intrinsic height so only the outer detail scroller overflows"
+    );
   });
 
   it("keeps permission quick actions outside the detail-only scroller", () => {

--- a/test/fixtures/bubble-elicitation-layout-electron.js
+++ b/test/fixtures/bubble-elicitation-layout-electron.js
@@ -1,0 +1,130 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const { app, BrowserWindow, protocol } = require("electron");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const BUBBLE_CSS = fs.readFileSync(path.join(ROOT, "src", "bubble.css"), "utf8");
+const TEXT_SCALE = 1.25;
+
+protocol.registerSchemesAsPrivileged([
+  { scheme: "clawd-bubble-layout", privileges: { standard: true, secure: true } },
+]);
+
+function option(label, description, inputType) {
+  return `<label class="option-item"><input type="${inputType}"><span class="option-item-copy">`
+    + `<span class="option-item-label">${label}</span>`
+    + `<span class="option-item-description">${description}</span></span></label>`;
+}
+
+function pageHtml(kind) {
+  const multi = kind === "multi";
+  const inputType = multi ? "checkbox" : "radio";
+  const title = multi
+    ? "Which validation targets should be required before release?"
+    : "Choose the preferred implementation approach for the expanded permission card.";
+  const options = [
+    ["Keep the existing layout", "Retain the current structure and verify its behavior on every supported desktop platform."],
+    ["Use one outer scroller", "Keep every part of the interactive form in normal document flow inside one scroll area."],
+    ["Test fractional scaling", "Cover Windows device scaling and the independent per-display Clawd text scale."],
+    ["Preserve keyboard input", "Keep radio, checkbox, textarea, and IME behavior intact while the detail content scrolls."],
+    ["Verify long content", "Exercise enough option content to exceed the expanded card's fixed viewport from first paint."],
+  ];
+  return `<!doctype html><html><head><meta charset="utf-8"><style>${BUBBLE_CSS}</style></head><body>`
+    + `<div class="card expanded visible" id="card">`
+    + `<div class="header"><div class="header-copy"><span class="header-title">Needs Input</span>`
+    + `<span class="tool-pill"><span class="tool-pill-text">AskUserQuestion</span></span></div>`
+    + `<button class="collapse-button">Collapse</button></div>`
+    + `<div class="session-tag visible">animation · #948</div>`
+    + `<div class="compact-block"></div><div class="detail-truncation"></div>`
+    + `<div class="detail-scroll" id="detailScroll"><div class="command-block" style="display:none"></div>`
+    + `<div class="elicitation-form visible" id="elicitationForm"><div class="question-card">`
+    + `<div class="question-header">Question ${multi ? "2" : "1"}</div>`
+    + `<div class="question-text">${title}</div>`
+    + `<div class="question-hint">${multi ? "Choose at least one option" : "Choose one option"}</div>`
+    + `<div class="option-list">${options.map(([label, description]) => (
+      option(label, description, inputType)
+    )).join("")}</div></div></div>`
+    + `<div class="elicitation-progress visible" id="elicitationProgress">${multi ? "2" : "1"} / 2</div></div>`
+    + `<button class="btn-expand"></button><div class="plan-feedback-form"></div>`
+    + `<div class="actions"><button class="btn btn-allow">${multi ? "Submit Answer" : "Next"}</button>`
+    + `<button class="btn btn-deny">Previous</button></div><div class="suggestions"></div>`
+    + `<div class="footer-secondary visible"><button class="btn-suggestion">Go to Terminal</button></div>`
+    + `</div></body></html>`;
+}
+
+async function readLayout(win) {
+  return win.webContents.executeJavaScript(`new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      const detail = document.getElementById("detailScroll");
+      const form = document.getElementById("elicitationForm");
+      const progress = document.getElementById("elicitationProgress");
+      const question = form.querySelector(".question-card");
+      const descendantBottom = (root) => Math.max(
+        root.getBoundingClientRect().bottom,
+        ...Array.from(root.querySelectorAll("*")).map((node) => node.getBoundingClientRect().bottom)
+      );
+      const formContentBottom = descendantBottom(form);
+      const questionContentBottom = descendantBottom(question);
+      resolve({
+        detailClientHeight: detail.clientHeight,
+        detailScrollHeight: detail.scrollHeight,
+        formContentBottom,
+        progressTop: progress.getBoundingClientRect().top,
+        questionBottom: question.getBoundingClientRect().bottom,
+        questionContentBottom,
+      });
+    }));
+  })`);
+}
+
+async function verifyKind(win, kind) {
+  await win.loadURL(`clawd-bubble-layout://fixture/${kind}`);
+  await win.webContents.insertCSS(
+    `:root { zoom: ${TEXT_SCALE} !important; --clawd-text-zoom: ${TEXT_SCALE}; }`
+  );
+  const layout = await readLayout(win);
+  assert.ok(
+    layout.detailScrollHeight > layout.detailClientHeight + 1,
+    `${kind}: fixture must exercise the outer overflow path (${JSON.stringify(layout)})`
+  );
+  assert.ok(
+    layout.progressTop + 0.5 >= layout.formContentBottom,
+    `${kind}: progress overlaps form descendants (${JSON.stringify(layout)})`
+  );
+  assert.ok(
+    layout.questionBottom + 0.5 >= layout.questionContentBottom,
+    `${kind}: options paint outside the question card (${JSON.stringify(layout)})`
+  );
+}
+
+async function main() {
+  await app.whenReady();
+  protocol.handle("clawd-bubble-layout", (request) => {
+    const kind = new URL(request.url).pathname.slice(1) === "multi" ? "multi" : "single";
+    return new Response(pageHtml(kind), {
+      headers: { "content-type": "text/html; charset=utf-8" },
+    });
+  });
+  const win = new BrowserWindow({
+    show: false,
+    width: 625,
+    height: 662,
+    webPreferences: { backgroundThrottling: false },
+  });
+  try {
+    await verifyKind(win, "single");
+    await verifyKind(win, "multi");
+  } finally {
+    if (!win.isDestroyed()) win.destroy();
+  }
+}
+
+main()
+  .then(() => app.quit())
+  .catch((err) => {
+    console.error(err && err.stack || err);
+    app.exit(1);
+  });


### PR DESCRIPTION
## Summary

- keep the expanded Ask form at its intrinsic flex height so its descendants cannot paint through the progress row
- preserve the single outer `detail-scroll` overflow owner and the fixed action/footer region
- add a source contract plus a real hidden-Electron layout regression for long single-select and multi-select Ask cards at 125% scaling

## Root cause

#937 placed the existing elicitation form inside a fixed-height column flex scroller. The form still had `min-height: 0` and default flex shrinking, so Chromium shortened the form box while its visible descendants kept painting at their natural height. The progress row followed the shortened box and was painted underneath the overflowing options/text area.

## Validation

- `node --test test/bubble-elicitation-layout-electron.test.js` — 1 pass, 0 fail
- Ask/expanded-bubble focused group — 25 pass, 0 fail
- `git diff --check` — pass
- `npm test` — 8709 pass, 8 fail, 25 cancelled, 39 skip; the failures are in baseline-identical Windows environment paths: Mobile Preview Server startup hangs before opening a listener, and two Codex installer nested PowerShell launches return `status: null` (isolated rerun: 39/41 pass). No changed file participates in either failing path.

Closes #948