### PR TITLE
fix: restore Claude ExitPlanMode bubble approvals

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -2548,6 +2548,26 @@ function applyPermissionSuggestion(perm, index, options = {}) {
     }
   const idx = pendingPermissions.indexOf(permEntry);
   if (idx === -1) return;
+  let planReviewUpdatedInput = null;
+  let focusPlanReviewFallback = false;
+  if (
+    behavior === "allow"
+    && permEntry.agentId === "claude-code"
+    && isValidInteraction(permEntry.interaction)
+    && permEntry.interaction.intent === INTERACTION_INTENT.PLAN_REVIEW
+  ) {
+    const wireInput = permEntry.planReviewWireInput;
+    if (!wireInput || typeof wireInput !== "object" || Array.isArray(wireInput)) {
+      // Never approve a display/truncated copy. Dropping the hook response is
+      // Claude Code's documented non-blocking fallback to its native prompt.
+      permLog("plan-review allow missing exact tool_input -> no-decision native fallback");
+      behavior = "no-decision";
+      message = "Exact ExitPlanMode tool_input unavailable";
+      focusPlanReviewFallback = true;
+    } else {
+      planReviewUpdatedInput = wireInput;
+    }
+  }
   const remoteOutcome = permEntry.remoteApprovalResolution || {
     decision: behavior === "deny" ? "deny" : behavior === "no-decision" ? "no-decision" : "allow",
     actionLabel: remoteApprovalDecisionLabel(behavior === "deny" || behavior === "no-decision" ? behavior : "allow"),
@@ -2732,11 +2752,17 @@ function applyPermissionSuggestion(perm, index, options = {}) {
     // per the hooks doc — CC falls back to its built-in chat prompt rather
     // than treating it as an explicit deny.
     try { res.destroy(); } catch {}
+    if (focusPlanReviewFallback && typeof ctx.focusTerminalForSession === "function") {
+      ctx.focusTerminalForSession(permEntry.sessionId, {
+        fallbackEntry: buildPermissionFocusEntry(permEntry),
+      });
+    }
     return;
   }
 
   const decision = { behavior: behavior === "deny" ? "deny" : "allow" };
   if (behavior === "deny" && message) decision.message = message;
+  if (planReviewUpdatedInput) decision.updatedInput = planReviewUpdatedInput;
   if (permEntry.resolvedSuggestion) {
     decision.updatedPermissions = [permEntry.resolvedSuggestion];
   }

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -1972,8 +1972,19 @@ function handlePermissionPost(req, res, options) {
         return;
       }
 
-      const rawInput = data.tool_input && typeof data.tool_input === "object" ? data.tool_input : {};
+      const hasExactToolInput = data.tool_input !== null
+        && typeof data.tool_input === "object"
+        && !Array.isArray(data.tool_input);
+      const rawInput = hasExactToolInput ? data.tool_input : {};
       const toolInput = truncateDeep(rawInput);
+      // Claude Code's PermissionRequest contract needs updatedInput when an
+      // interactive built-in such as ExitPlanMode is allowed. Keep the exact
+      // parsed request object separate from the truncated display copy so an
+      // approval can never echo normalized, clipped, or otherwise unseen data.
+      const planReviewWireInput = interaction.intent === INTERACTION_INTENT.PLAN_REVIEW
+        && hasExactToolInput
+        ? rawInput
+        : null;
       const permissionDetail = preparePermissionDetail(toolName, rawInput);
       const toolUseId = normalizeHookToolUseId(
         data.tool_use_id ?? data.toolUseId ?? data.toolUseID
@@ -2138,6 +2149,7 @@ function handlePermissionPost(req, res, options) {
         hideTimer: null,
         toolName,
         toolInput,
+        planReviewWireInput,
         ...permissionDetail,
         toolUseId,
         toolInputFingerprint,

--- a/test/permission-plan-feedback.test.js
+++ b/test/permission-plan-feedback.test.js
@@ -111,6 +111,7 @@ function makeCtx(overrides = {}) {
 }
 
 function makePlanPermEntry(res, overrides = {}) {
+  const planReviewWireInput = { plan: "Build a React app" };
   const entry = {
     res,
     abortHandler: () => {},
@@ -119,7 +120,8 @@ function makePlanPermEntry(res, overrides = {}) {
     bubble: null,
     hideTimer: null,
     toolName: "ExitPlanMode",
-    toolInput: { plan: "Build a React app" },
+    toolInput: planReviewWireInput,
+    planReviewWireInput,
     resolvedSuggestion: null,
     createdAt: Date.now() - 5000,
     agentId: "claude-code",
@@ -144,6 +146,72 @@ function makeEventFor(bubble) {
 }
 
 describe("permission plan-feedback handleDecide", () => {
+  it("replays the exact original ExitPlanMode input when allowing a plan", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const res = createMockResponse();
+    const planReviewWireInput = {
+      plan: "Build a React app",
+      planFilePath: "C:\\Users\\Ruller\\.claude\\plans\\exact.md",
+      metadata: { source: "permission-hook", untouched: true },
+      steps: ["first", "second"],
+    };
+    const permEntry = makePlanPermEntry(res, {
+      toolInput: { plan: "Build a React app…" },
+      planReviewWireInput,
+    });
+    perm.pendingPermissions.push(permEntry);
+
+    perm.resolvePermissionEntry(permEntry, "allow");
+
+    assert.strictEqual(res.captured.body, JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: {
+          behavior: "allow",
+          updatedInput: planReviewWireInput,
+        },
+      },
+    }));
+  });
+
+  it("falls back to Claude's native prompt when exact plan input is unavailable", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const res = createMockResponse();
+    const permEntry = makePlanPermEntry(res, { planReviewWireInput: null });
+    perm.pendingPermissions.push(permEntry);
+
+    perm.resolvePermissionEntry(permEntry, "allow");
+
+    assert.strictEqual(res.captured.ended, false, "must not emit a false allow decision");
+    assert.strictEqual(res.captured.body, null, "fallback must not write a response body");
+    assert.strictEqual(res.destroyed, true, "socket drop returns control to Claude's native prompt");
+    assert.strictEqual(ctx.focusTerminalCalls.length, 1);
+    assert.strictEqual(perm.pendingPermissions.indexOf(permEntry), -1);
+  });
+
+  it("keeps ordinary Claude tool allows free of updatedInput", () => {
+    const ctx = makeCtx();
+    const perm = initPermission(ctx);
+    const res = createMockResponse();
+    const permEntry = makePlanPermEntry(res, {
+      toolName: "Bash",
+      toolInput: { command: "npm test" },
+      planReviewWireInput: null,
+    });
+    perm.pendingPermissions.push(permEntry);
+
+    perm.resolvePermissionEntry(permEntry, "allow");
+
+    assert.deepStrictEqual(JSON.parse(res.captured.body), {
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: { behavior: "allow" },
+      },
+    });
+  });
+
   it("resolves ExitPlanMode with deny + feedback message", () => {
     const ctx = makeCtx();
     const perm = initPermission(ctx);

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -212,6 +212,59 @@ function callPermissionPostThroughAutomation(body, mode, options = {}) {
   });
 }
 
+describe("Claude ExitPlanMode updatedInput compatibility", () => {
+  it("keeps the exact request input separate from the truncated display copy", async () => {
+    const rawInput = {
+      plan: `Start of plan ${"x".repeat(700)} end-of-plan`,
+      planFilePath: "C:\\Users\\Ruller\\.claude\\plans\\exact.md",
+      metadata: { source: "permission-hook", untouched: true },
+      steps: ["first", "second"],
+    };
+    const res = await callPermissionPostThroughAutomation(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "claude:exact-plan-input",
+      tool_name: "ExitPlanMode",
+      tool_input: rawInput,
+    }), "off", { showPermissionBubble() {} });
+
+    assert.strictEqual(res.permission.pendingPermissions.length, 1);
+    const entry = res.permission.pendingPermissions[0];
+    assert.notStrictEqual(entry.toolInput.plan, rawInput.plan, "display copy should remain truncated");
+    assert.deepStrictEqual(entry.planReviewWireInput, rawInput, "wire input must remain unmodified");
+
+    res.permission.resolvePermissionEntry(entry, "allow");
+
+    assert.strictEqual(res.body, JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PermissionRequest",
+        decision: {
+          behavior: "allow",
+          updatedInput: rawInput,
+        },
+      },
+    }));
+  });
+
+  it("drops the connection instead of allowing when the request omitted tool_input", async () => {
+    const res = await callPermissionPostThroughAutomation(JSON.stringify({
+      agent_id: "claude-code",
+      session_id: "claude:missing-plan-input",
+      tool_name: "ExitPlanMode",
+    }), "off", { showPermissionBubble() {} });
+
+    assert.strictEqual(res.permission.pendingPermissions.length, 1);
+    const entry = res.permission.pendingPermissions[0];
+    assert.strictEqual(entry.planReviewWireInput, null);
+
+    res.permission.resolvePermissionEntry(entry, "allow");
+
+    assert.strictEqual(res.body, "", "fallback must not write a decision payload");
+    assert.strictEqual(res.writableFinished, false, "fallback must not end with a false allow");
+    assert.strictEqual(res.destroyed, true, "connection drop returns control to Claude's native prompt");
+    assert.deepStrictEqual(res.permission.pendingPermissions, []);
+  });
+});
+
 describe("server-route-permission helpers", () => {
   it("preserves bubble bypass decisions for CC, Codex, and opencode", () => {
     assert.strictEqual(shouldBypassCCBubble({ hideBubbles: true }, interaction("claude-code", "Bash"), "claude-code"), true);


### PR DESCRIPTION
## Summary

- preserve the exact Claude `PermissionRequest.tool_input` separately from the truncated bubble display copy
- echo that unchanged object as `decision.updatedInput` when allowing `ExitPlanMode`
- fall back to Claude Code's native approval prompt when the exact input is unavailable, instead of emitting a false/bare allow
- keep ordinary Claude tool approvals and plan-deny feedback responses unchanged

## Why

Claude Code now ignores `allow` decisions for interactive built-ins such as `ExitPlanMode` when `updatedInput` is omitted. `AskUserQuestion` already returned `updatedInput`, which is why Ask cards worked while Plan approvals were discarded.

This follows the official PermissionRequest response contract without version branching. The compatibility behavior and workaround are also documented in upstream issue https://github.com/anthropics/claude-code/issues/74256.

## Validation

- `node --test test/permission-plan-feedback.test.js test/server-route-permission.test.js` — 115 passed
- verified the exact serialized response preserves a long, nested input while the bubble copy remains truncated
- verified missing/non-object plan input destroys the hook connection and returns control to Claude's native prompt without writing an allow decision
- real Windows roundtrip with Claude Code 2.1.246: clicked the Clawd Plan card, Claude reported `Allowed by PermissionRequest hook`, skipped the native selection, and returned `PLAN_APPROVED`