### PR TITLE
fix: restore Codex Desktop focus for scoped sessions

### DIFF
--- a/src/session-focus.js
+++ b/src/session-focus.js
@@ -16,7 +16,9 @@ function normalizeOsPlatform(options) {
 function getCodexThreadId(entry) {
   if (!entry || entry.agentId !== "codex") return null;
   if (!isCodexDesktopOriginator(entry.codexOriginator || entry.originator)) return null;
-  const match = normalizeString(entry.id).match(CODEX_THREAD_SESSION_ID_RE);
+  const sessionId =
+    normalizeString(entry.rawSessionId) || normalizeString(entry.id);
+  const match = sessionId.match(CODEX_THREAD_SESSION_ID_RE);
   return match ? match[1] : null;
 }
 

--- a/test/session-focus.test.js
+++ b/test/session-focus.test.js
@@ -10,6 +10,7 @@ const {
   getSessionFocusTarget,
   isFocusableLocalHudSession,
 } = require("../src/session-focus");
+const { makeSessionKey } = require("../src/session-key");
 
 describe("session focus helpers", () => {
   it("selects local HUD-visible terminal and Codex Desktop thread sessions", () => {
@@ -77,6 +78,24 @@ describe("session focus helpers", () => {
       canFocus: false,
       type: null,
       url: null,
+    });
+  });
+
+  it("derives Codex Desktop thread focus targets from profile-scoped session entries", () => {
+    const rawSessionId = "codex:019e115a-4df2-7ed0-b90e-8e6345aca777";
+    const entry = {
+      id: makeSessionKey({ profileId: "local", rawSessionId }),
+      rawSessionId,
+      agentId: "codex",
+      codexOriginator: "Codex Desktop",
+    };
+
+    assert.strictEqual(getCodexThreadId(entry), "019e115a-4df2-7ed0-b90e-8e6345aca777");
+    assert.strictEqual(getCodexThreadUrl(entry), "codex://threads/019e115a-4df2-7ed0-b90e-8e6345aca777");
+    assert.deepStrictEqual(getSessionFocusTarget(entry, { osPlatform: "darwin" }), {
+      canFocus: true,
+      type: "codex-thread",
+      url: "codex://threads/019e115a-4df2-7ed0-b90e-8e6345aca777",
     });
   });
 

--- a/test/state-session-snapshot.test.js
+++ b/test/state-session-snapshot.test.js
@@ -723,6 +723,11 @@ describe("state-session-snapshot builder", () => {
   });
 
   it("exposes focus target metadata for terminal and Codex Desktop sessions", () => {
+    const rawCodexSessionId = "codex:019e115a-4df2-7ed0-b90e-8e6345aca777";
+    const scopedCodexSessionId = makeSessionKey({
+      profileId: "local",
+      rawSessionId: rawCodexSessionId,
+    });
     const snapshot = buildSessionSnapshot(new Map([
       ["terminal", session("working", { sourcePid: 123 })],
       ["webui", session("working", { sourcePid: 456, platform: "webui" })],
@@ -730,8 +735,9 @@ describe("state-session-snapshot builder", () => {
         host: "remote-box",
         orcaPaneKey: "tab-remote:leaf-remote",
       })],
-      ["codex:019e115a-4df2-7ed0-b90e-8e6345aca777", session("working", {
+      [scopedCodexSessionId, session("working", {
         agentId: "codex",
+        rawSessionId: rawCodexSessionId,
         codexOriginator: "codex_work_desktop",
         codexSource: "vscode",
       })],
@@ -744,12 +750,12 @@ describe("state-session-snapshot builder", () => {
     assert.strictEqual(byId.get("webui").focusTarget, null);
     assert.strictEqual(byId.get("remote-orca").canFocus, true);
     assert.deepStrictEqual(byId.get("remote-orca").focusTarget, { type: "terminal", url: null });
-    assert.strictEqual(byId.get("codex:019e115a-4df2-7ed0-b90e-8e6345aca777").canFocus, true);
-    assert.deepStrictEqual(byId.get("codex:019e115a-4df2-7ed0-b90e-8e6345aca777").focusTarget, {
+    assert.strictEqual(byId.get(scopedCodexSessionId).canFocus, true);
+    assert.deepStrictEqual(byId.get(scopedCodexSessionId).focusTarget, {
       type: "codex-thread",
       url: "codex://threads/019e115a-4df2-7ed0-b90e-8e6345aca777",
     });
-    assert.strictEqual(byId.get("codex:019e115a-4df2-7ed0-b90e-8e6345aca777").codexSource, "vscode");
+    assert.strictEqual(byId.get(scopedCodexSessionId).codexSource, "vscode");
   });
 
   it("downgrades Codex Desktop focus targets on Windows snapshots", () => {


### PR DESCRIPTION
## Summary

- resolve Codex Desktop thread IDs from rawSessionId before falling back to id
- cover the profile-scoped runtime session shape in focus helper tests
- update the snapshot focus test to use a canonical scoped session key

## Why

Remote profile isolation introduced canonical session keys in #736 while retaining the original provider ID in rawSessionId. Codex Desktop focus still parsed entry.id as codex:<uuid>, so local scoped entries were marked unfocusable and the HUD/dashboard could not open their threads.

The fallback to id preserves compatibility with legacy unscoped entries. Existing local-only, originator, remote-host, platform, and malformed-input guards remain unchanged.

## Tests

- node --test test/session-focus.test.js test/session-focus-handoff.test.js test/state-session-snapshot.test.js test/session-ipc.test.js
- 86 passed, 0 failed