### PR TITLE
fix(agents): harden installation residue detection

### DIFF
--- a/hooks/codebuddy-install.js
+++ b/hooks/codebuddy-install.js
@@ -330,6 +330,7 @@ module.exports = {
   DEFAULT_PARENT_DIR,
   DEFAULT_CONFIG_PATH,
   CLAWD_PERMISSION_HOOK_NAME,
+  isManagedPermissionHook,
   registerCodeBuddyHooks,
   unregisterCodeBuddyHooks,
   CODEBUDDY_HOOK_EVENTS,

--- a/hooks/openclaw-install.js
+++ b/hooks/openclaw-install.js
@@ -110,6 +110,10 @@ function findPluginPathIndex(paths, pluginDir) {
   return -1;
 }
 
+function isManagedPluginPath(value, pluginDir = resolvePluginDir()) {
+  return findPluginPathIndex([value], pluginDir) === 0;
+}
+
 function installViaCli(options = {}) {
   const spawnSync = options.spawnSync || childProcess.spawnSync;
   const command = options.openclawCommand || "openclaw";
@@ -360,6 +364,7 @@ module.exports = {
   ensureOpenClawConfigLinked,
   hasIncludeDirective,
   hasOpenClawCommand,
+  isManagedPluginPath,
   registerOpenClawPlugin,
   resolveOpenClawPaths,
   resolvePluginDir,

--- a/src/agent-installation-detector.js
+++ b/src/agent-installation-detector.js
@@ -7,10 +7,12 @@ const path = require("path");
 const { getAgentDescriptors } = require("./doctor-detectors/agent-descriptors");
 const { normalizePathList } = require("./prefs");
 const copilot = require("../hooks/copilot-install");
-const antigravity = require("../hooks/antigravity-install");
 const hermes = require("../hooks/hermes-install");
 const reasonix = require("../hooks/reasonix-install");
 const dsh = require("../hooks/dsh-install");
+const zcode = require("../hooks/zcode-install");
+const codebuddy = require("../hooks/codebuddy-install");
+const openclaw = require("../hooks/openclaw-install");
 const { commandMatchesMarker } = require("../hooks/json-utils");
 const { identifyCustomApplication } = require("./custom-applications");
 
@@ -31,35 +33,14 @@ const { identifyCustomApplication } = require("./custom-applications");
 // directory remains real evidence.
 const DEFAULT_AUTO_SYNC_CREATED_PARENT_DIR_AGENT_IDS = new Set(["claude-code"]);
 const LOW_CONFIDENCE = "low";
-const GEMINI_PARENT_DIR_NOISE_FILES = new Set([
-  ".DS_Store",
-  ".localized",
-  "Thumbs.db",
-  "desktop.ini",
-]);
-const GEMINI_PARENT_DIR_NOISE_SUFFIXES = [
-  ".bak",
-  ".backup",
-  ".old",
-  ".orig",
-  ".swp",
-  ".swo",
-  ".tmp",
-  "~",
-];
-// #895: Antigravity squats inside Gemini CLI's ~/.gemini. Google's docs assign
-// ~/.gemini/antigravity to the Antigravity app and ~/.gemini/antigravity-cli to
-// agy; installing the Antigravity app alone creates the former (its bundled
-// Resources/bin binaries are copied there), with no Gemini CLI anywhere. Only
-// `config` used to be excluded here, so either of the other two made the
-// detector report Gemini CLI as installed with medium confidence — enough to
-// raise the "connect this agent" banner. Derive the two Clawd already owns from
-// the installer so they cannot drift; `antigravity` has no constant because
-// Clawd never writes there.
-const GEMINI_PARENT_DIR_FOREIGN_DIRS = new Set([
-  path.basename(antigravity.DEFAULT_PARENT_DIR),
-  path.basename(path.dirname(antigravity.DEFAULT_STATUSLINE_SETTINGS_PATH)),
-  "antigravity",
+// Gemini CLI v0.55.1, commit 41327e407da58aa01c409ef6685b7b5d379f295e,
+// packages/core/src/config/storage.ts. Keep this closed: ~/.gemini is shared
+// with Antigravity and settings.json is a shared hook registry, so neither an
+// arbitrary child nor a settings key is product proof. Credential/token files
+// and read-only extension directories are deliberately excluded.
+const GEMINI_PRODUCT_ARTIFACT_FILES = Object.freeze([
+  "installation_id",
+  "projects.json",
 ]);
 
 function dirExists(fsImpl, dirPath) {
@@ -89,6 +70,22 @@ function statPath(fsImpl, filePath) {
     return "other";
   } catch {
     return null;
+  }
+}
+
+function lstatPath(fsImpl, filePath) {
+  if (!filePath) return { kind: "missing", size: 0 };
+  try {
+    const stat = fsImpl.lstatSync(filePath);
+    if (stat.isSymbolicLink()) return { kind: "symlink", size: stat.size };
+    if (stat.isDirectory()) return { kind: "dir", size: stat.size };
+    if (stat.isFile()) return { kind: "file", size: stat.size };
+    return { kind: "other", size: stat.size };
+  } catch (err) {
+    if (err && (err.code === "ENOENT" || err.code === "ENOTDIR")) {
+      return { kind: "missing", size: 0 };
+    }
+    return { kind: "unreadable", size: 0 };
   }
 }
 
@@ -263,6 +260,10 @@ function notFound(detail = "No local installation signal found") {
   return installationResult(false, LOW_CONFIDENCE, "not-found", detail);
 }
 
+function insufficient(detail = "Local files exist, but no accepted product installation signal was found") {
+  return installationResult(null, LOW_CONFIDENCE, "insufficient-evidence", detail);
+}
+
 function hasClawdMarkerText(text, marker) {
   if (typeof text !== "string" || typeof marker !== "string" || !marker) return false;
   if (commandMatchesMarker(text, marker)) return true;
@@ -286,88 +287,148 @@ function hasClawdMarkerText(text, marker) {
   return containsCommandMarker(parsed);
 }
 
-function hasNonClawdHookCommand(value, marker) {
-  if (!value || typeof value !== "object") return false;
-  if (Array.isArray(value)) return value.some((entry) => hasNonClawdHookCommand(entry, marker));
-  for (const [key, entry] of Object.entries(value)) {
-    if (key === "command" && typeof entry === "string" && !hasClawdMarkerText(entry, marker)) return true;
-    if (hasNonClawdHookCommand(entry, marker)) return true;
-  }
-  return false;
+function isObject(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
-function classifyGeminiSettings(fsImpl, settingsPath, marker) {
-  const raw = readText(fsImpl, settingsPath);
-  if (raw === null) return { exists: false, userContent: false, clawdOnly: false, unreadable: false };
-  let parsed;
+function parseExactJsonObject(fsImpl, configPath) {
+  const pathInfo = lstatPath(fsImpl, configPath);
+  if (pathInfo.kind !== "file") return { pathInfo, raw: null, parsed: null, status: pathInfo.kind };
+  if (pathInfo.size === 0) return { pathInfo, raw: "", parsed: null, status: "empty" };
+  const raw = readText(fsImpl, configPath);
+  if (raw === null) return { pathInfo, raw: null, parsed: null, status: "unreadable" };
   try {
-    parsed = JSON.parse(raw.charCodeAt(0) === 0xFEFF ? raw.slice(1) : raw);
+    const parsed = JSON.parse(raw.charCodeAt(0) === 0xFEFF ? raw.slice(1) : raw);
+    if (!isObject(parsed)) return { pathInfo, raw, parsed: null, status: "invalid-shape" };
+    return { pathInfo, raw, parsed, status: "parsed" };
   } catch {
-    return { exists: true, userContent: true, clawdOnly: false, unreadable: true };
+    return { pathInfo, raw, parsed: null, status: "parse-failed" };
   }
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-    return { exists: true, userContent: true, clawdOnly: false, unreadable: false };
-  }
-
-  const keys = Object.keys(parsed);
-  const nonClawdKeys = keys.filter((key) => key !== "hooks" && key !== "hooksConfig");
-  if (nonClawdKeys.length > 0) {
-    return { exists: true, userContent: true, clawdOnly: false, unreadable: false };
-  }
-  if (hasNonClawdHookCommand(parsed.hooks, marker)) {
-    return { exists: true, userContent: true, clawdOnly: false, unreadable: false };
-  }
-  if (parsed.hooksConfig && typeof parsed.hooksConfig === "object" && !Array.isArray(parsed.hooksConfig)) {
-    const hookConfigKeys = Object.keys(parsed.hooksConfig);
-    if (hookConfigKeys.some((key) => key !== "disabled")) {
-      return { exists: true, userContent: true, clawdOnly: false, unreadable: false };
-    }
-  }
-  return { exists: true, userContent: false, clawdOnly: keys.length > 0, unreadable: false };
 }
 
-function geminiDirHasNonClawdSignals(fsImpl, parentDir, settingsPath, marker) {
-  if (!dirExists(fsImpl, parentDir)) return false;
-  const entries = listDir(fsImpl, parentDir);
-  for (const entry of entries) {
-    if (!entry || typeof entry.name !== "string") continue;
-    if (GEMINI_PARENT_DIR_NOISE_FILES.has(entry.name)) continue;
-    if (GEMINI_PARENT_DIR_NOISE_SUFFIXES.some((suffix) => entry.name.endsWith(suffix))) continue;
-    // Directories only: a plain file that happens to be named `antigravity` is
-    // not Antigravity's, so it stays a Gemini CLI signal.
-    if (GEMINI_PARENT_DIR_FOREIGN_DIRS.has(entry.name)
-      && typeof entry.isDirectory === "function"
-      && entry.isDirectory()) continue;
-    if (entry.name === path.basename(settingsPath)) {
-      const classified = classifyGeminiSettings(fsImpl, settingsPath, marker);
-      if (classified.userContent) return true;
-      continue;
-    }
+function hookTreeHasForeignEntry(value, isOwnedHook) {
+  if (!value || typeof value !== "object") return false;
+  if (Array.isArray(value)) return value.some((entry) => hookTreeHasForeignEntry(entry, isOwnedHook));
+  const owned = isOwnedHook(value);
+  if (!owned
+    && (typeof value.command === "string" || typeof value.url === "string" || typeof value.type === "string")) {
     return true;
   }
+  // Ownership subtracts this hook leaf, not the whole object. Keep traversing
+  // in case a malformed/shared wrapper also carries a foreign nested hook.
+  return Object.values(value).some((entry) => hookTreeHasForeignEntry(entry, isOwnedHook));
+}
+
+function isOwnedZcodeHook(entry) {
+  if (zcode.isClawdZcodeHook(entry)) return true;
+  if (zcode.isClaudeHookCommand(entry && entry.command)) return true;
+  // ZCode can import Claude process hooks with the marker in args rather than
+  // command. Those are still Clawd residue and must not become product proof.
+  try {
+    return hasClawdMarkerText(JSON.stringify(entry), zcode.CLAUDE_MARKER);
+  } catch {
+    return false;
+  }
+}
+
+function isOwnedQoderHook(entry, marker) {
+  return !!(entry && commandMatchesMarker(entry.command, marker));
+}
+
+function isOwnedCodeBuddyHook(entry, marker) {
+  if (entry && commandMatchesMarker(entry.command, marker)) return true;
+  return !!(entry && codebuddy.isManagedPermissionHook(entry));
+}
+
+function hookConfigHasProductContent(agentId, parsed, marker) {
+  if (Object.keys(parsed).some((key) => key !== "hooks")) return true;
+  if (!isObject(parsed.hooks)) return false;
+
+  if (agentId === "zcode") {
+    if (Object.keys(parsed.hooks).some((key) => key !== "enabled" && key !== "events")) return true;
+    return hookTreeHasForeignEntry(parsed.hooks.events, isOwnedZcodeHook);
+  }
+  if (agentId === "qoder") {
+    return hookTreeHasForeignEntry(parsed.hooks, (entry) => isOwnedQoderHook(entry, marker));
+  }
+  return hookTreeHasForeignEntry(parsed.hooks, (entry) => isOwnedCodeBuddyHook(entry, marker));
+}
+
+function detectOwnedHookConfigInstallation(descriptor, paths, options) {
+  const fsImpl = options.fs;
+  const parentInfo = lstatPath(fsImpl, paths.parentDir);
+  if (parentInfo.kind === "missing") return notFound();
+  if (parentInfo.kind !== "dir") {
+    return insufficient(`${paths.parentDir} exists but is not a regular directory`);
+  }
+
+  const classified = parseExactJsonObject(fsImpl, paths.configPath);
+  if (classified.status === "parsed"
+    && hookConfigHasProductContent(descriptor.agentId, classified.parsed, descriptor.marker)) {
+    return installationResult(true, "high", "config-file", `${paths.configPath} contains product configuration`);
+  }
+  return insufficient(`${paths.parentDir} exists without accepted ${descriptor.agentName} product evidence`);
+}
+
+function openClawConfigHasProductContent(parsed) {
+  if (Object.keys(parsed).some((key) => key !== "plugins")) return true;
+  if (!isObject(parsed.plugins)) return false;
+  if (Object.keys(parsed.plugins).some((key) => key !== "entries" && key !== "load")) return true;
+
+  const entries = parsed.plugins.entries;
+  if (isObject(entries) && Object.keys(entries).some((key) => key !== openclaw.PLUGIN_ID)) return true;
+
+  const load = parsed.plugins.load;
+  if (isObject(load) && Object.keys(load).some((key) => key !== "paths")) return true;
+  if (isObject(load) && Array.isArray(load.paths)) {
+    const pluginDir = openclaw.resolvePluginDir();
+    if (load.paths.some((entry) => !openclaw.isManagedPluginPath(entry, pluginDir))) return true;
+  }
   return false;
 }
 
-function detectGeminiInstallation(descriptor, paths, options) {
+function detectOpenClawInstallation(paths, options) {
   const fsImpl = options.fs;
-  const classified = classifyGeminiSettings(fsImpl, paths.configPath, descriptor.marker);
-  if (classified.exists && classified.userContent) {
-    return installationResult(
-      true,
-      classified.unreadable ? "medium" : "high",
-      "config-file",
-      classified.unreadable
-        ? `${paths.configPath} exists but could not be classified`
-        : `${paths.configPath} contains non-Clawd Gemini settings`
-    );
+  const env = options.env || {};
+  const hasExplicitConfig = typeof env.OPENCLAW_CONFIG_PATH === "string" && !!env.OPENCLAW_CONFIG_PATH.trim();
+  const stateInfo = lstatPath(fsImpl, paths.stateDir);
+
+  // A default config below a symlinked state root is not exact local evidence.
+  // An explicit config is terminal and is classified independently.
+  if (!hasExplicitConfig && stateInfo.kind === "symlink") {
+    return insufficient(`${paths.stateDir} is a symbolic link and was not followed for product detection`);
   }
-  if (geminiDirHasNonClawdSignals(fsImpl, paths.parentDir, paths.configPath, descriptor.marker)) {
-    return installationResult(true, "medium", "parent-dir", `${paths.parentDir} contains Gemini CLI files`);
+
+  const classified = parseExactJsonObject(fsImpl, paths.configPath);
+  if (classified.status === "parsed" && openClawConfigHasProductContent(classified.parsed)) {
+    return installationResult(true, "high", "config-file", `${paths.configPath} contains OpenClaw configuration`);
   }
-  if (classified.exists && classified.clawdOnly) {
-    return notFound(`${paths.configPath} contains only Clawd-managed Gemini hook signals`);
+
+  if (classified.status === "missing" && stateInfo.kind === "missing") return notFound();
+  return insufficient(`${paths.stateDir} or ${paths.configPath} exists without accepted OpenClaw product evidence`);
+}
+
+function detectGeminiInstallation(_descriptor, paths, options) {
+  const fsImpl = options.fs;
+  const parentInfo = lstatPath(fsImpl, paths.parentDir);
+  if (parentInfo.kind === "missing") return notFound();
+  if (parentInfo.kind !== "dir") {
+    return insufficient(`${paths.parentDir} exists but is not a regular directory`);
   }
-  return notFound();
+
+  for (const artifact of GEMINI_PRODUCT_ARTIFACT_FILES) {
+    const artifactPath = path.join(paths.parentDir, artifact);
+    const artifactInfo = lstatPath(fsImpl, artifactPath);
+    if (artifactInfo.kind === "file" && artifactInfo.size > 0) {
+      return installationResult(
+        true,
+        "high",
+        "product-artifact",
+        `${artifactPath} is a non-empty Gemini CLI product artifact`
+      );
+    }
+  }
+  return insufficient(`${paths.parentDir} exists without an accepted Gemini CLI product artifact`);
 }
 
 function detectHermesInstallation(paths, options) {
@@ -417,18 +478,19 @@ function detectInstallation(descriptor, paths, options) {
       return notFound();
     case "copilot-cli":
     case "cursor-agent":
-    case "codebuddy":
     case "qwen-code":
-    case "zcode":
     case "codewhale":
     case "opencode":
     case "mimocode":
-    case "qoder":
     case "qoderwork":
     case "traecode":
     case "qwenwork":
       if (dirExists(fsImpl, paths.parentDir)) return installationResult(true, "high", "parent-dir", `${paths.parentDir} exists`);
       return notFound();
+    case "zcode":
+    case "qoder":
+    case "codebuddy":
+      return detectOwnedHookConfigInstallation(descriptor, paths, options);
     case "reasonix":
       for (const target of paths.configTargets || []) {
         if (dirExists(fsImpl, target.parentDir)) {
@@ -444,9 +506,7 @@ function detectInstallation(descriptor, paths, options) {
       if (dirExists(fsImpl, paths.parentDir)) return installationResult(true, "high", "parent-dir", `${paths.parentDir} exists`);
       return notFound();
     case "openclaw":
-      if (dirExists(fsImpl, paths.stateDir)) return installationResult(true, "high", "parent-dir", `${paths.stateDir} exists`);
-      if (fileExists(fsImpl, paths.configPath)) return installationResult(true, "high", "config-file", `${paths.configPath} exists`);
-      return notFound();
+      return detectOpenClawInstallation(paths, options);
     case "hermes":
       return detectHermesInstallation(paths, options);
     case "deepseek-harness":

--- a/test/agent-installation-detector.test.js
+++ b/test/agent-installation-detector.test.js
@@ -12,6 +12,11 @@ const {
 } = require("../src/agent-installation-detector");
 const { getAgentDescriptor } = require("../src/doctor-detectors/agent-descriptors");
 const { registerReasonixHooks } = require("../hooks/reasonix-install");
+const { registerZcodeHooks, unregisterZcodeHooks } = require("../hooks/zcode-install");
+const { registerQoderHooks, unregisterQoderHooks } = require("../hooks/qoder-install");
+const { registerCodeBuddyHooks, unregisterCodeBuddyHooks } = require("../hooks/codebuddy-install");
+const { registerOpenClawPlugin, unregisterOpenClawPlugin } = require("../hooks/openclaw-install");
+const { registerGeminiHooks, unregisterGeminiHooks } = require("../hooks/gemini-install");
 const {
   BRIDGE_PACKAGE_NAME,
   BRIDGE_PROTOCOL_VERSION,
@@ -280,48 +285,41 @@ describe("agent installation detector", () => {
     assert.strictEqual(reasonix.clawdIntegration.paths.configPath, settingsPath);
   });
 
-  it("does not confuse Antigravity's ~/.gemini/config with Gemini CLI", () => {
+  it("returns strict false for Gemini only when ~/.gemini is absent", () => {
     const homeDir = makeHome();
-    writeJson(path.join(homeDir, ".gemini", "config", "hooks.json"), {
-      clawd: {
-        PreInvocation: [{ type: "command", command: "node /app/hooks/antigravity-hook.js PreInvocation" }],
-      },
-    });
-    writeText(path.join(homeDir, ".gemini", ".DS_Store"), "Finder metadata");
-    writeText(path.join(homeDir, ".gemini", "session.tmp"), "temporary file");
-    writeText(path.join(homeDir, ".gemini", "settings.json.backup"), "backup file");
-    writeText(path.join(homeDir, ".gemini", ".config.swp"), "swap file");
-
-    const report = detectAgentInstallations({ homeDir, now: 1, env: {} });
-    const gemini = byId(report, "gemini-cli");
-    const antigravity = byId(report, "antigravity-cli");
+    const gemini = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), "gemini-cli");
 
     assert.strictEqual(gemini.detectedInstalled, false);
+    assert.strictEqual(gemini.confidence, "low");
     assert.strictEqual(gemini.reason, "not-found");
-    assert.strictEqual(antigravity.detectedInstalled, true);
-    assert.strictEqual(antigravity.confidence, "medium");
-    assert.strictEqual(antigravity.reason, "parent-dir");
   });
 
-  // #895 T1/T2/T3: `config` used to be the only Antigravity directory excluded,
-  // which read like a solved problem but covered one of three. Google assigns
-  // ~/.gemini/antigravity to the Antigravity app and ~/.gemini/antigravity-cli
-  // to agy, and installing the app alone creates the former — so a machine with
-  // no Gemini CLI at all was told to connect one. One case per directory: a
-  // single combined test would pass even if a name were dropped from the set.
-  for (const dirName of ["antigravity", "antigravity-cli"]) {
-    it(`does not treat Antigravity's ~/.gemini/${dirName} as a Gemini CLI install`, () => {
+  for (const [label, populate] of [
+    ["an empty shared parent", (g) => mkdirp(g)],
+    ["Antigravity's config directory", (g) => writeJson(path.join(g, "config", "hooks.json"), { clawd: {} })],
+    ["Antigravity's app directory", (g) => writeText(path.join(g, "antigravity", "state.pbtxt"), "")],
+    ["Antigravity CLI's directory", (g) => writeJson(path.join(g, "antigravity-cli", "settings.json"), {})],
+    ["an unknown file", (g) => writeText(path.join(g, "mystery"), "data")],
+    ["a credential file", (g) => writeJson(path.join(g, "oauth_creds.json"), { token: "not-read" })],
+    ["an extension directory", (g) => mkdirp(path.join(g, "extensions"))],
+    ["settings-only content", (g) => writeJson(path.join(g, "settings.json"), { selectedAuthType: "oauth-personal" })],
+    ["foreign hook-only settings", (g) => writeJson(path.join(g, "settings.json"), {
+      hooks: { SessionStart: [{ hooks: [{ type: "command", command: "node third-party.js" }] }] },
+    })],
+  ]) {
+    it(`treats Gemini ${label} as insufficient evidence`, () => {
       const homeDir = makeHome();
-      mkdirp(path.join(homeDir, ".gemini", dirName));
+      populate(path.join(homeDir, ".gemini"));
 
       const gemini = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), "gemini-cli");
 
-      assert.strictEqual(gemini.detectedInstalled, false);
-      assert.strictEqual(gemini.reason, "not-found");
+      assert.strictEqual(gemini.detectedInstalled, null);
+      assert.strictEqual(gemini.confidence, "low");
+      assert.strictEqual(gemini.reason, "insufficient-evidence");
     });
   }
 
-  it("does not report Gemini CLI from a full Antigravity-only layout", () => {
+  it("keeps Antigravity positive while Gemini is insufficient in the shared home", () => {
     const homeDir = makeHome();
     writeJson(path.join(homeDir, ".gemini", "config", "hooks.json"), { clawd: {} });
     writeText(path.join(homeDir, ".gemini", "antigravity", "antigravity_state.pbtxt"), "");
@@ -329,63 +327,76 @@ describe("agent installation detector", () => {
 
     const report = detectAgentInstallations({ homeDir, now: 1, env: {} });
 
-    assert.strictEqual(byId(report, "gemini-cli").detectedInstalled, false);
-    assert.strictEqual(byId(report, "gemini-cli").reason, "not-found");
-    // Antigravity itself must still be found — the point is telling them apart.
+    assert.strictEqual(byId(report, "gemini-cli").detectedInstalled, null);
+    assert.strictEqual(byId(report, "gemini-cli").reason, "insufficient-evidence");
     assert.strictEqual(byId(report, "antigravity-cli").detectedInstalled, true);
   });
 
-  // #895 T4/T4b: the guard above must not become "Gemini CLI is never detected
-  // from its directory". Each artifact gets its own home, so one still-working
-  // signal cannot mask another that broke. A file and a directory are both
-  // covered because the exclusion is directory-only.
-  for (const [label, make] of [
-    ["installation_id file", (g) => writeText(path.join(g, "installation_id"), "id")],
-    ["oauth_creds.json file", (g) => writeJson(path.join(g, "oauth_creds.json"), {})],
-    ["extensions/ directory", (g) => mkdirp(path.join(g, "extensions"))],
-  ]) {
-    it(`still detects Gemini CLI beside Antigravity from its ${label}`, () => {
+  for (const artifact of ["installation_id", "projects.json"]) {
+    it(`detects Gemini from the pinned non-empty ${artifact} artifact`, () => {
       const homeDir = makeHome();
-      const geminiDir = path.join(homeDir, ".gemini");
-      for (const dirName of ["config", "antigravity", "antigravity-cli"]) {
-        mkdirp(path.join(geminiDir, dirName));
-      }
-      make(geminiDir);
+      writeText(path.join(homeDir, ".gemini", artifact), "product-owned");
 
       const gemini = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), "gemini-cli");
 
       assert.strictEqual(gemini.detectedInstalled, true);
-      assert.strictEqual(gemini.confidence, "medium");
-      assert.strictEqual(gemini.reason, "parent-dir");
+      assert.strictEqual(gemini.confidence, "high");
+      assert.strictEqual(gemini.reason, "product-artifact");
     });
+
+    for (const shape of ["zero-byte", "directory", "symlink"]) {
+      it(`rejects Gemini ${artifact} when it is a ${shape}`, () => {
+        const homeDir = makeHome();
+        const geminiDir = path.join(homeDir, ".gemini");
+        const artifactPath = path.join(geminiDir, artifact);
+        if (shape === "zero-byte") writeText(artifactPath, "");
+        if (shape === "directory") mkdirp(artifactPath);
+        if (shape === "symlink") {
+          const targetPath = path.join(homeDir, "outside-artifact");
+          writeText(targetPath, "product-owned");
+          mkdirp(geminiDir);
+          fs.symlinkSync(targetPath, artifactPath);
+        }
+
+        const gemini = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), "gemini-cli");
+
+        assert.strictEqual(gemini.detectedInstalled, null);
+        assert.strictEqual(gemini.reason, "insufficient-evidence");
+      });
+    }
   }
 
-  // #895 T4c: the exclusion matches Antigravity's directories, not its names. A
-  // plain file that happens to be called `antigravity` is not Antigravity's.
-  it("only excludes the Antigravity names when they are directories", () => {
+  it("detects Gemini artifacts from lstat metadata without listing the shared parent or reading artifact contents", () => {
     const homeDir = makeHome();
-    writeText(path.join(homeDir, ".gemini", "antigravity"), "a file, not Antigravity's dir");
+    const artifactPath = path.join(homeDir, ".gemini", "projects.json");
+    writeText(artifactPath, "opaque-product-data");
+    const readPaths = [];
+    const fsImpl = {
+      lstatSync: fs.lstatSync,
+      statSync: fs.statSync,
+      readFileSync(filePath, ...args) {
+        readPaths.push(filePath);
+        if (filePath === artifactPath) throw new Error("artifact contents must not be read");
+        return fs.readFileSync(filePath, ...args);
+      },
+      readdirSync() {
+        throw new Error("Gemini product detection must not list ~/.gemini");
+      },
+    };
 
-    const gemini = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), "gemini-cli");
+    const entry = detectAgentInstallation(getAgentDescriptor("gemini-cli"), {
+      homeDir,
+      now: 1,
+      env: {},
+      fs: fsImpl,
+    });
 
-    assert.strictEqual(gemini.detectedInstalled, true);
-    assert.strictEqual(gemini.reason, "parent-dir");
+    assert.strictEqual(entry.detectedInstalled, true);
+    assert.strictEqual(entry.reason, "product-artifact");
+    assert.strictEqual(readPaths.includes(artifactPath), false);
   });
 
-  // #895 T4d: the higher-confidence settings.json path is untouched by all this.
-  it("still detects Gemini CLI from real settings beside Antigravity", () => {
-    const homeDir = makeHome();
-    mkdirp(path.join(homeDir, ".gemini", "antigravity"));
-    writeJson(path.join(homeDir, ".gemini", "settings.json"), { selectedAuthType: "oauth-personal" });
-
-    const gemini = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), "gemini-cli");
-
-    assert.strictEqual(gemini.detectedInstalled, true);
-    assert.strictEqual(gemini.confidence, "high");
-    assert.strictEqual(gemini.reason, "config-file");
-  });
-
-  it("treats Gemini Clawd-only settings as integration marker, not install proof", () => {
+  it("treats Gemini Clawd-only settings as integration evidence, not product proof", () => {
     const homeDir = makeHome();
     const settingsPath = path.join(homeDir, ".gemini", "settings.json");
     writeJson(settingsPath, {
@@ -394,24 +405,312 @@ describe("agent installation detector", () => {
       },
     });
 
-    let report = detectAgentInstallations({ homeDir, now: 1 });
-    let gemini = byId(report, "gemini-cli");
-    assert.strictEqual(gemini.detectedInstalled, false);
-    assert.match(gemini.detail, /only Clawd-managed/);
-    assert.strictEqual(gemini.clawdIntegration.detected, true);
+    const gemini = byId(detectAgentInstallations({ homeDir, now: 1 }), "gemini-cli");
 
-    writeJson(settingsPath, {
-      selectedAuthType: "oauth-personal",
+    assert.strictEqual(gemini.detectedInstalled, null);
+    assert.strictEqual(gemini.reason, "insufficient-evidence");
+    assert.strictEqual(gemini.clawdIntegration.detected, true);
+  });
+
+  it("keeps exact Clawd register/unregister residue non-actionable for all five repaired agents", () => {
+    const homeDir = makeHome();
+    const pluginDir = path.join(homeDir, "managed", "openclaw-plugin");
+    const openclawStateDir = path.join(homeDir, ".openclaw");
+    const openclawConfigPath = path.join(openclawStateDir, "openclaw.json");
+    for (const dirName of [".zcode", ".qoder", ".codebuddy", ".gemini", ".openclaw"]) {
+      mkdirp(path.join(homeDir, dirName));
+    }
+    writeJson(openclawConfigPath, {});
+
+    registerZcodeHooks({ homeDir, silent: true, nodeBin: process.execPath });
+    registerQoderHooks({ homeDir, silent: true, nodeBin: process.execPath });
+    registerCodeBuddyHooks({
+      settingsPath: path.join(homeDir, ".codebuddy", "settings.json"),
+      silent: true,
+      nodeBin: process.execPath,
+      permissionTarget: { mode: "local" },
+    });
+    registerGeminiHooks({ homeDir, silent: true, nodeBin: process.execPath });
+    registerOpenClawPlugin({
+      stateDir: openclawStateDir,
+      configPath: openclawConfigPath,
+      pluginDir,
+      silent: true,
+      openclawCommandAvailable: false,
+    });
+
+    const detect = (now) => detectAgentInstallations({ homeDir, now, env: {} });
+    let report = detect(1);
+    for (const agentId of ["zcode", "qoder", "codebuddy", "gemini-cli", "openclaw"]) {
+      const entry = byId(report, agentId);
+      assert.strictEqual(entry.detectedInstalled, null, `${agentId} installed Clawd-only config`);
+      assert.strictEqual(entry.reason, "insufficient-evidence", `${agentId} installed reason`);
+      assert.strictEqual(entry.clawdIntegration.detected, true, `${agentId} integration marker`);
+    }
+
+    unregisterZcodeHooks({ homeDir, silent: true });
+    unregisterQoderHooks({ homeDir, silent: true });
+    unregisterCodeBuddyHooks({ settingsPath: path.join(homeDir, ".codebuddy", "settings.json"), silent: true });
+    unregisterGeminiHooks({ homeDir, silent: true });
+    unregisterOpenClawPlugin({
+      stateDir: openclawStateDir,
+      configPath: openclawConfigPath,
+      pluginDir,
+      silent: true,
+      openclawCommandAvailable: false,
+    });
+
+    report = detect(2);
+    for (const agentId of ["zcode", "qoder", "codebuddy", "gemini-cli", "openclaw"]) {
+      const entry = byId(report, agentId);
+      assert.strictEqual(entry.detectedInstalled, null, `${agentId} unregister residue`);
+      assert.strictEqual(entry.reason, "insufficient-evidence", `${agentId} residue reason`);
+      assert.strictEqual(entry.clawdIntegration.detected, false, `${agentId} removed marker`);
+    }
+  });
+
+  for (const fixture of [
+    ["zcode", ".zcode/cli/config.json", { permissions: { defaultMode: "ask" } }],
+    ["qoder", ".qoder/settings.json", { language: "en" }],
+    ["codebuddy", ".codebuddy/settings.json", { model: "default" }],
+    ["openclaw", ".openclaw/openclaw.json", { gateway: { port: 18789 } }],
+  ]) {
+    const [agentId, relativeConfigPath, config] = fixture;
+    it(`detects source-pinned ${agentId} product config`, () => {
+      const homeDir = makeHome();
+      writeJson(path.join(homeDir, relativeConfigPath), config);
+
+      const entry = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), agentId);
+
+      assert.strictEqual(entry.detectedInstalled, true);
+      assert.strictEqual(entry.confidence, "high");
+      assert.strictEqual(entry.reason, "config-file");
+    });
+  }
+
+  for (const fixture of [
+    ["zcode", ".zcode/cli/config.json", { hooks: { enabled: true, events: { Stop: [{ type: "process", command: "node", args: ["third-party.js"] }] } } }],
+    ["qoder", ".qoder/settings.json", { hooks: { Stop: [{ matcher: "*", hooks: [{ name: "clawd", type: "command", command: "node third-party.js" }] }] } }],
+    ["codebuddy", ".codebuddy/settings.json", { hooks: { Stop: [{ matcher: "*", hooks: [{ type: "command", command: "node third-party.js" }] }] } }],
+    ["openclaw", ".openclaw/openclaw.json", { plugins: { load: { paths: ["/third-party/plugin"] }, entries: { third: {} } } }],
+  ]) {
+    const [agentId, relativeConfigPath, config] = fixture;
+    it(`preserves a foreign ${agentId} hook/plugin as positive product evidence`, () => {
+      const homeDir = makeHome();
+      writeJson(path.join(homeDir, relativeConfigPath), config);
+
+      const entry = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), agentId);
+
+      assert.strictEqual(entry.detectedInstalled, true);
+      assert.strictEqual(entry.confidence, "high");
+      assert.strictEqual(entry.reason, "config-file");
+    });
+  }
+
+  it("returns null for empty, malformed, and symlinked reporter config evidence", () => {
+    const fixtures = [
+      ["zcode", ".zcode/cli/config.json"],
+      ["qoder", ".qoder/settings.json"],
+      ["codebuddy", ".codebuddy/settings.json"],
+    ];
+    for (const [agentId, relativeConfigPath] of fixtures) {
+      for (const shape of ["missing", "empty", "malformed", "symlink"]) {
+        const homeDir = makeHome();
+        const configPath = path.join(homeDir, relativeConfigPath);
+        mkdirp(path.dirname(configPath));
+        if (shape === "empty") writeText(configPath, "");
+        if (shape === "malformed") writeText(configPath, "{");
+        if (shape === "symlink") {
+          const targetPath = path.join(homeDir, "outside.json");
+          writeJson(targetPath, { language: "en" });
+          fs.symlinkSync(targetPath, configPath);
+        }
+
+        const entry = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), agentId);
+        assert.strictEqual(entry.detectedInstalled, null, `${agentId} ${shape}`);
+        assert.strictEqual(entry.reason, "insufficient-evidence", `${agentId} ${shape} reason`);
+      }
+    }
+  });
+
+  it("fails an unreadable reporter config closed to insufficient evidence", () => {
+    const homeDir = makeHome();
+    const configPath = path.join(homeDir, ".qoder", "settings.json");
+    writeJson(configPath, { language: "en" });
+    const fsImpl = {
+      lstatSync: fs.lstatSync,
+      statSync: fs.statSync,
+      readdirSync: fs.readdirSync,
+      readFileSync(filePath, ...args) {
+        if (filePath === configPath) {
+          const err = new Error("permission denied");
+          err.code = "EACCES";
+          throw err;
+        }
+        return fs.readFileSync(filePath, ...args);
+      },
+    };
+
+    const entry = detectAgentInstallation(getAgentDescriptor("qoder"), {
+      homeDir,
+      now: 1,
+      env: {},
+      fs: fsImpl,
+    });
+
+    assert.strictEqual(entry.detectedInstalled, null);
+    assert.strictEqual(entry.reason, "insufficient-evidence");
+  });
+
+  it("subtracts migrated ZCode and both exact CodeBuddy permission ownership shapes", () => {
+    const zcodeHome = makeHome();
+    writeJson(path.join(zcodeHome, ".zcode", "cli", "config.json"), {
       hooks: {
-        SessionStart: [{ hooks: [{ name: "clawd", type: "command", command: "node /app/hooks/gemini-hook.js SessionStart" }] }],
+        enabled: true,
+        events: {
+          Stop: [{ type: "process", command: process.execPath, args: ["/app/hooks/clawd-hook.js", "Stop"] }],
+        },
+      },
+    });
+    const zcodeEntry = byId(detectAgentInstallations({ homeDir: zcodeHome, now: 1, env: {} }), "zcode");
+    assert.strictEqual(zcodeEntry.detectedInstalled, null);
+
+    for (const permissionHook of [
+      { name: "clawd-on-desk.permission.v1", type: "http", url: "https://preserved.example/permission" },
+      { name: "custom-name", type: "http", url: "http://127.0.0.1:23333/permission" },
+    ]) {
+      const codebuddyHome = makeHome();
+      writeJson(path.join(codebuddyHome, ".codebuddy", "settings.json"), {
+        hooks: { PermissionRequest: [{ hooks: [permissionHook] }] },
+      });
+      const entry = byId(detectAgentInstallations({ homeDir: codebuddyHome, now: 1, env: {} }), "codebuddy");
+      assert.strictEqual(entry.detectedInstalled, null, JSON.stringify(permissionHook));
+      assert.strictEqual(entry.reason, "insufficient-evidence");
+    }
+  });
+
+  it("keeps mixed Clawd and foreign content positive for each ownership adapter", () => {
+    const fixtures = [
+      ["zcode", ".zcode/cli/config.json", {
+        hooks: { enabled: true, events: { Stop: [
+          { type: "process", command: process.execPath, args: ["/app/hooks/zcode-hook.js", "Stop"] },
+          { type: "process", command: "node", args: ["third-party.js"] },
+        ] } },
+      }],
+      ["qoder", ".qoder/settings.json", {
+        hooks: { Stop: [{ hooks: [
+          { type: "command", command: "node /app/hooks/qoder-hook.js Stop" },
+          { type: "command", command: "node third-party.js" },
+        ] }] },
+      }],
+      ["codebuddy", ".codebuddy/settings.json", {
+        hooks: { PermissionRequest: [{ hooks: [
+          { name: "clawd-on-desk.permission.v1", type: "http", url: "http://127.0.0.1:23333/permission" },
+          { name: "third", type: "http", url: "https://third.example/permission" },
+        ] }] },
+      }],
+      ["openclaw", ".openclaw/openclaw.json", {
+        plugins: {
+          load: { paths: ["/app/hooks/openclaw-plugin", "/third-party/plugin"] },
+          entries: { "clawd-on-desk": { enabled: true }, third: { enabled: true } },
+        },
+      }],
+    ];
+    for (const [agentId, relativeConfigPath, config] of fixtures) {
+      const homeDir = makeHome();
+      writeJson(path.join(homeDir, relativeConfigPath), config);
+      const entry = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), agentId);
+      assert.strictEqual(entry.detectedInstalled, true, agentId);
+      assert.strictEqual(entry.reason, "config-file", agentId);
+    }
+  });
+
+  it("subtracts an owned hook leaf without hiding a foreign nested sibling", () => {
+    const homeDir = makeHome();
+    writeJson(path.join(homeDir, ".qoder", "settings.json"), {
+      hooks: {
+        Stop: [{
+          type: "command",
+          command: "node /app/hooks/qoder-hook.js Stop",
+          hooks: [{ type: "command", command: "node third-party.js" }],
+        }],
       },
     });
 
-    report = detectAgentInstallations({ homeDir, now: 2 });
-    gemini = byId(report, "gemini-cli");
-    assert.strictEqual(gemini.detectedInstalled, true);
-    assert.strictEqual(gemini.confidence, "high");
-    assert.strictEqual(gemini.reason, "config-file");
+    const entry = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), "qoder");
+    assert.strictEqual(entry.detectedInstalled, true);
+    assert.strictEqual(entry.reason, "config-file");
+  });
+
+  it("keeps mixed Clawd and foreign Gemini hooks insufficient", () => {
+    const homeDir = makeHome();
+    writeJson(path.join(homeDir, ".gemini", "settings.json"), {
+      hooks: {
+        Stop: [{ hooks: [
+          { type: "command", command: "node /app/hooks/gemini-hook.js Stop" },
+          { type: "command", command: "node third-party.js" },
+        ] }],
+      },
+    });
+
+    const entry = byId(detectAgentInstallations({ homeDir, now: 1, env: {} }), "gemini-cli");
+    assert.strictEqual(entry.detectedInstalled, null);
+    assert.strictEqual(entry.reason, "insufficient-evidence");
+    assert.strictEqual(entry.clawdIntegration.detected, true);
+  });
+
+  it("fails legal JSON5, malformed text, and config symlinks closed to insufficient OpenClaw evidence", () => {
+    const json5Home = makeHome();
+    writeText(path.join(json5Home, ".openclaw", "openclaw.json"), "{ gateway: { port: 18789 } }");
+    const json5 = byId(detectAgentInstallations({ homeDir: json5Home, now: 1, env: {} }), "openclaw");
+    assert.strictEqual(json5.detectedInstalled, null);
+    assert.strictEqual(json5.confidence, "low");
+    assert.strictEqual(json5.reason, "insufficient-evidence");
+
+    const clawdJson5Home = makeHome();
+    writeText(
+      path.join(clawdJson5Home, ".openclaw", "openclaw.json"),
+      '{ plugins: { load: { paths: ["/app/hooks/openclaw-plugin"] }, entries: { "clawd-on-desk": { enabled: true } } } }'
+    );
+    const clawdJson5 = byId(
+      detectAgentInstallations({ homeDir: clawdJson5Home, now: 1, env: {} }),
+      "openclaw"
+    );
+    assert.strictEqual(clawdJson5.detectedInstalled, null);
+    assert.strictEqual(clawdJson5.reason, "insufficient-evidence");
+
+    const malformedHome = makeHome();
+    writeText(path.join(malformedHome, ".openclaw", "openclaw.json"), "{ definitely broken");
+    const malformed = byId(detectAgentInstallations({ homeDir: malformedHome, now: 1, env: {} }), "openclaw");
+    assert.strictEqual(malformed.detectedInstalled, null);
+    assert.strictEqual(malformed.reason, "insufficient-evidence");
+
+    const symlinkHome = makeHome();
+    const configPath = path.join(symlinkHome, ".openclaw", "openclaw.json");
+    const targetPath = path.join(symlinkHome, "outside.json5");
+    writeText(targetPath, "{ gateway: { port: 18789 } }");
+    mkdirp(path.dirname(configPath));
+    fs.symlinkSync(targetPath, configPath);
+    const symlink = byId(detectAgentInstallations({ homeDir: symlinkHome, now: 1, env: {} }), "openclaw");
+    assert.strictEqual(symlink.detectedInstalled, null);
+    assert.strictEqual(symlink.reason, "insufficient-evidence");
+  });
+
+  it("does not fall back to the default OpenClaw config when OPENCLAW_CONFIG_PATH is set", () => {
+    const homeDir = makeHome();
+    const stateDir = path.join(homeDir, ".openclaw");
+    const explicitConfigPath = path.join(homeDir, "external", "openclaw.json");
+    writeJson(path.join(stateDir, "openclaw.json"), { gateway: { port: 18789 } });
+
+    const entry = byId(detectAgentInstallations({
+      homeDir,
+      now: 1,
+      env: { OPENCLAW_CONFIG_PATH: explicitConfigPath },
+    }), "openclaw");
+
+    assert.strictEqual(entry.paths.configPath, explicitConfigPath);
+    assert.strictEqual(entry.detectedInstalled, null);
+    assert.strictEqual(entry.reason, "insufficient-evidence");
   });
 
   it("re-resolves env-dependent paths at detection time", () => {
@@ -420,7 +719,7 @@ describe("agent installation detector", () => {
     const openclawConfigPath = path.join(homeDir, "custom-openclaw", "openclaw.json");
     const hermesHome = path.join(homeDir, "custom-hermes");
     mkdirp(copilotHome);
-    writeJson(openclawConfigPath, { plugins: {} });
+    writeJson(openclawConfigPath, { gateway: { port: 18789 } });
     writeText(path.join(hermesHome, "config.yaml"), "plugins: []\n");
 
     const report = detectAgentInstallations({
@@ -464,6 +763,7 @@ describe("agent installation detector", () => {
     mkdirp(path.join(homeDir, ".config", "opencode"));
     const fsReadOnly = new Proxy({
       statSync: fs.statSync,
+      lstatSync: fs.lstatSync,
       readFileSync: fs.readFileSync,
       readdirSync: fs.readdirSync,
     }, {

--- a/test/openclaw-install.test.js
+++ b/test/openclaw-install.test.js
@@ -9,6 +9,7 @@ const path = require("path");
 const {
   ensureOpenClawConfigLinked,
   hasIncludeDirective,
+  isManagedPluginPath,
   registerOpenClawPlugin,
   resolvePluginDir,
   unregisterOpenClawPlugin,
@@ -230,6 +231,14 @@ describe("openclaw plugin installer", () => {
 });
 
 describe("openclaw installer helpers", () => {
+  it("shares the installer's exact managed-path ownership rule", () => {
+    const current = "C:/current/hooks/openclaw-plugin";
+    assert.strictEqual(isManagedPluginPath(current, current), true);
+    assert.strictEqual(isManagedPluginPath("D:/stale/hooks/openclaw-plugin", current), true);
+    assert.strictEqual(isManagedPluginPath("relative/openclaw-plugin", current), false);
+    assert.strictEqual(isManagedPluginPath("C:/other/plugin", current), false);
+  });
+
   it("detects include directives recursively", () => {
     assert.strictEqual(hasIncludeDirective({ plugins: { entries: { x: { $include: "./x.json" } } } }), true);
     assert.strictEqual(hasIncludeDirective({ plugins: { entries: { x: { include: ["./x.json"] } } } }), true);

--- a/test/settings-renderer-browser-env.test.js
+++ b/test/settings-renderer-browser-env.test.js
@@ -12207,6 +12207,60 @@ describe("settings renderer browser environment", () => {
     assert.strictEqual(calls, 1);
   });
 
+  it("preserves fetched null verdicts and keeps them out of every Settings action surface", async () => {
+    const commandCalls = [];
+    const detectionResult = {
+      checkedAt: 895,
+      agents: [
+        { agentId: "qoder", detectedInstalled: null, confidence: "low", reason: "insufficient-evidence" },
+        { agentId: "zcode", detectedInstalled: null, confidence: "low", reason: "insufficient-evidence" },
+      ],
+      skippedAgentIds: [],
+    };
+    const harness = loadAgentsTabForTest({
+      snapshot: {
+        agents: {
+          qoder: { integrationInstalled: false, enabled: false },
+          zcode: { integrationInstalled: true, enabled: true },
+        },
+        dismissedAgentInstallHints: { qoder: true },
+        dismissedAgentCleanupHints: { zcode: true },
+      },
+      agentMetadata: [
+        { id: "qoder", name: "Qoder", eventSource: "hook", capabilities: {}, cleanupSuggestionExempt: false },
+        { id: "zcode", name: "ZCode", eventSource: "hook", capabilities: {}, cleanupSuggestionExempt: false },
+      ],
+      settingsAPI: {
+        detectAgentInstallations: () => Promise.resolve(detectionResult),
+        command: (action, payload) => {
+          commandCalls.push([action, payload]);
+          return Promise.resolve({ status: "ok" });
+        },
+      },
+    });
+
+    await harness.core.ops.fetchAgentInstallationHints();
+    harness.raf.flush();
+
+    assert.deepStrictEqual(
+      harness.core.runtime.agentInstallationHints.agents.map((entry) => entry.detectedInstalled),
+      [null, null],
+      "normalization must preserve tri-state null"
+    );
+    assert.strictEqual(harness.content.querySelector(".agent-install-hint-banner"), null);
+    assert.strictEqual(harness.content.querySelector(".agent-cleanup-hint-banner"), null);
+    const connectedPills = harness.content.querySelectorAll(".agents-subtabs .segmented button");
+    assert.strictEqual(connectedPills[1].querySelector(".agents-subtab-count"), null);
+
+    harness.core.runtime.agentsSubtab = "discover";
+    harness.core.ops.requestRender({ content: true });
+    harness.raf.flush();
+    assert.strictEqual(harness.content.querySelector(".agent-section-recommended"), null);
+    assert.strictEqual(harness.content.querySelector(".agent-install-hint-banner"), null);
+    assert.strictEqual(harness.content.querySelector(".agent-cleanup-hint-banner"), null);
+    assert.deepStrictEqual(commandCalls, [], "null must not clear either dismissal bucket");
+  });
+
   it("splits connected agents from detected and undetected ones across the subtabs", () => {
     const harness = loadAgentsTabForTest({
       snapshot: {

--- a/test/tutorial-agent-buckets.test.js
+++ b/test/tutorial-agent-buckets.test.js
@@ -134,6 +134,17 @@ describe("bucketAgentsForTutorial", () => {
     }
   });
 
+  it("keeps an explicit null verdict out of active, install, and cleanup", () => {
+    for (const integrationInstalled of [false, true]) {
+      const result = bucketAgentsForTutorial({
+        installableIds: ["qoder"],
+        detectionAgents: [detect("qoder", "Qoder", null, "low")],
+        agentsPref: { qoder: { integrationInstalled } },
+      });
+      assert.deepStrictEqual(result, { install: [], cleanup: [], active: [] });
+    }
+  });
+
   // #895 T7: the reporter's exact machine shape, fed by the REAL detector
   // rather than a hand-written fixture, so the two can't drift apart. Codex
   // installed via npm but never launched leaves no ~/.codex, and Clawd's own


### PR DESCRIPTION
## Summary

- separate product installation evidence from Clawd-owned hook/plugin residue for ZCode, Qoder, CodeBuddy, and OpenClaw
- replace open-ended Gemini home scanning with a closed, metadata-only artifact set
- preserve `null / insufficient-evidence` through Settings and onboarding so residue cannot trigger install, recommendation, badge, cleanup, or dismissal-reset actions
- keep `OPENCLAW_CONFIG_PATH` terminal and reject symlinked, unreadable, malformed, and JSON5-only config as actionable product evidence

## Evidence

- base locked to `d5f041dea7236e6de97a5d51e3ffe947eec67243`
- isolated register -> detect -> unregister -> detect round trips for all five affected integrations
- focused detector, installer, Settings renderer, and tutorial suites: 412 passed, 1 skipped, 0 failed
- full `npm test`: 8,837 passed, 31 skipped, 0 failed
- independent adversarial review: approved after closing the malformed OpenClaw config false-positive path
- GitHub package/audit matrix: 7 checks passed on head `8f25819ac8254fba38c05c88247e57b126224219`

## macOS physical-device validation

Validated the exact PR head on an Apple Silicon Mac running macOS 26.5.2 (25F84), with both `HOME` and Electron `userData` isolated from the user's real profiles.

- empty `.zcode`, `.openclaw`, `.codebuddy`, and `.qoder` parents produced no install banner, Recommended section, or Discover badge
- one source-pinned positive fixture at a time recommended only its intended agent: ZCode, Qoder, CodeBuddy, OpenClaw, or Gemini CLI
- Gemini empty-parent, Antigravity-only, foreign-hook-only, and unknown-residue layouts did not recommend Gemini; a non-empty regular `installation_id` did
- an explicit positive `OPENCLAW_CONFIG_PATH` won over an empty default state directory; legal JSON5 remained unknown and non-actionable as designed
- repeated detection/rescan left both the isolated-home metadata digest and file-content digest unchanged
- no Gemini account login, credential access, model request, or quota consumption was used or required

The installed Gemini CLI is v0.55.1. Under a separate isolated home, `gemini --version` did not leave a final accepted `installation_id` or `projects.json`, so binary presence alone remains unknown. This is the intended fail-closed boundary: it can require manual integration installation, but it cannot create a false recommendation or cleanup action.

## Remaining validation and limits

- Windows GUI validation is still pending
- WSL detection is unchanged and remains out of scope
- the reporter still needs to retest the released build with their stale `.gemini` contents and four empty directories
- real upstream initialization was not claimed for ZCode, Qoder, CodeBuddy, or OpenClaw because those products were not installed on the validation Mac
- OpenClaw installations represented only by legal JSON5 remain unknown until a direct JSON5 parser is explicitly adopted

Refs #895
