### PR TITLE
fix(claude): keep background subagent sessions active

### DIFF
--- a/hooks/claude-stop-disposition.js
+++ b/hooks/claude-stop-disposition.js
@@ -17,11 +17,16 @@ function getBackgroundTasksCompletionDebounceMs(headless, env = process.env) {
 
 function getClaudeStopDisposition(options = {}) {
   const backgroundTasksCount = Number(options.backgroundTasksCount) || 0;
+  const backgroundSubagentsCount = Number.isSafeInteger(options.backgroundSubagentsCount)
+    && options.backgroundSubagentsCount >= 0
+    ? options.backgroundSubagentsCount
+    : 0;
   const sessionCronsCount = Number(options.sessionCronsCount) || 0;
   const stopHookActive = options.stopHookActive === true;
   const hasFinalAssistantText = options.hasFinalAssistantText === true;
   const headless = options.headless === true;
-  const hardLiveWork = sessionCronsCount > 0
+  const hardLiveWork = backgroundSubagentsCount > 0
+    || sessionCronsCount > 0
     || stopHookActive
     || (backgroundTasksCount > 0 && !hasFinalAssistantText);
   if (hardLiveWork) return { kind: "hold", debounceMs: 0 };

--- a/hooks/clawd-hook.js
+++ b/hooks/clawd-hook.js
@@ -680,11 +680,34 @@ function buildStateBody(event, payload, resolve) {
       }
     }
   }
-  // #406 completion-gate inputs. A Stop that still has live background shells or
-  // cron wakeups, or a Stop-hook continuation (stop_hook_active), is not a real
-  // turn completion. Forward only counts + the boolean — never the task
-  // command/description — so state.js can suppress the celebration without
-  // leaking shell contents into Clawd state.
+  // #406/#952 completion-gate inputs. A Stop that still has live background
+  // shells, cron wakeups or an exact typed one-shot subagent is not a real turn
+  // completion. Forward only counts + the boolean — never task ids, status,
+  // command or description text — so state.js can suppress the celebration
+  // without leaking background-task details into Clawd state.
+  //
+  // Presence of background_subagents_count is meaningful: an omitted field
+  // means this Claude payload had no usable background_tasks snapshot, while 0
+  // is an authoritative snapshot that contains no exact `type: "subagent"`
+  // entry. Keep the classifier intentionally narrow: teammate entries have
+  // different lifecycle semantics and must not become a completion gate.
+  if (body.event === "Stop" || body.event === "SubagentStop") {
+    const backgroundTasks = Array.isArray(payload.background_tasks)
+      ? payload.background_tasks
+      : null;
+    if (backgroundTasks) {
+      const subagentCount = backgroundTasks.reduce((count, entry) => {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) return count;
+        const prototype = Object.getPrototypeOf(entry);
+        if (prototype !== Object.prototype && prototype !== null) return count;
+        const type = typeof entry.type === "string"
+          ? entry.type.trim().replace(/[A-Z]/g, (letter) => letter.toLowerCase())
+          : "";
+        return count + (type === "subagent" ? 1 : 0);
+      }, 0);
+      body.background_subagents_count = subagentCount;
+    }
+  }
   if (body.event === "Stop") {
     const bgCount = Array.isArray(payload.background_tasks) ? payload.background_tasks.length : 0;
     const cronCount = Array.isArray(payload.session_crons) ? payload.session_crons.length : 0;

--- a/hooks/session-recovery-lease.js
+++ b/hooks/session-recovery-lease.js
@@ -410,13 +410,18 @@ function classifyBody(body, options = {}) {
   if (!body || typeof body !== "object") return null;
   if (body.headless === true) return { active: false, state: null, terminal: false };
   if (body.event === "Stop") {
-    const disposition = getClaudeStopDisposition({
+    const stopOptions = {
       backgroundTasksCount: body.background_tasks_count,
       sessionCronsCount: body.session_crons_count,
       stopHookActive: body.stop_hook_active,
       hasFinalAssistantText: typeof body.assistant_last_output === "string" && !!body.assistant_last_output,
       headless: body.headless,
       env: options.env,
+    };
+    const baseDisposition = getClaudeStopDisposition(stopOptions);
+    const disposition = getClaudeStopDisposition({
+      ...stopOptions,
+      backgroundSubagentsCount: body.background_subagents_count,
     });
     if (disposition.kind === "complete") return { active: false, state: null, validForMs: 0, terminal: true };
     return {
@@ -424,6 +429,12 @@ function classifyBody(body, options = {}) {
       state: "working",
       validForMs: disposition.kind === "debounce" ? disposition.debounceMs : 0,
       terminal: false,
+      // A typed background-subagent snapshot is live evidence for this process,
+      // but a Stop hook must not turn that one observation into an unbounded
+      // startup-recovery lease. Preserve a lease written by earlier sustained
+      // lifecycle traffic byte-for-byte; create or refresh nothing when the
+      // typed count is the only reason this Stop became a hard hold.
+      preserveExistingEvidence: disposition.kind === "hold" && baseDisposition.kind !== "hold",
     };
   }
   if (SUSTAINED_STATES.has(body.state)) return { active: true, state: body.state, terminal: false };
@@ -442,6 +453,26 @@ function updateRecoveryLeaseFromStateBody(body, options = {}) {
   const classified = classifyBody(body, options);
   if (!agentId || !SUPPORTED_AGENT_IDS.has(agentId) || !sessionId || !classified) {
     return { written: false, reason: "unsupported" };
+  }
+  if (classified.preserveExistingEvidence === true) {
+    const filePath = getLeaseFilePath(agentId, sessionId, {
+      recoveryDir: getRecoveryDir(options),
+    });
+    if (!filePath) return { written: false, reason: "path" };
+    try {
+      if (!fs.existsSync(filePath)) return { written: false, reason: "no-existing-evidence" };
+      const stat = fs.lstatSync(filePath);
+      if (stat.isSymbolicLink() || !stat.isFile()) {
+        return { written: false, reason: "unsafe-file" };
+      }
+    } catch {
+      return { written: false, reason: "unsafe-file" };
+    }
+    const existing = readLeaseFile(filePath);
+    if (!existing || !existing.active || !SUSTAINED_STATES.has(existing.state)) {
+      return { written: false, reason: "no-active-evidence" };
+    }
+    return { written: false, reason: "preserved-existing-evidence", filePath, record: existing };
   }
   const dir = ensureRecoveryDir(options);
   const filePath = dir ? getLeaseFilePath(agentId, sessionId, { recoveryDir: dir }) : null;

--- a/src/server-route-state.js
+++ b/src/server-route-state.js
@@ -390,6 +390,10 @@ function handleStatePost(req, res, options) {
       // only — the hook never forwards task command or description text.
       const backgroundTasksCount = Number.isFinite(data.background_tasks_count)
         ? data.background_tasks_count : 0;
+      const backgroundSubagentsCount = Number.isSafeInteger(data.background_subagents_count)
+        && data.background_subagents_count >= 0
+        ? data.background_subagents_count
+        : null;
       const sessionCronsCount = Number.isFinite(data.session_crons_count)
         ? data.session_crons_count : 0;
       const stopHookActive = data.stop_hook_active === true;
@@ -886,6 +890,7 @@ function handleStatePost(req, res, options) {
             hookSource,
             ...(codexHookState.turnId ? { turnId: codexHookState.turnId } : {}),
             backgroundTasksCount,
+            ...(backgroundSubagentsCount !== null ? { backgroundSubagentsCount } : {}),
             sessionCronsCount,
             stopHookActive,
             stdinDiag,

--- a/src/state.js
+++ b/src/state.js
@@ -1518,15 +1518,14 @@ function isClaudeElicitationCompletionTool(toolName) {
 }
 
 function hasClaudeBackgroundSubagentCompletionHold(sessionOrTracker) {
+  // Only the authoritative typed-count marker may block completion producers.
+  // Tracker-only evidence keeps the pre-#952 recovery behavior: if an older or
+  // malformed hook misses SubagentStop and never sends a typed zero, a later
+  // parent completion must still be able to settle the session.
   return !!(
     sessionOrTracker
-    && (
-      (
-        Number.isFinite(sessionOrTracker.claudeBackgroundSubagentHoldAt)
-        && sessionOrTracker.claudeBackgroundSubagentHoldAt > 0
-      )
-      || hasSubagentHoldEvidence(sessionOrTracker)
-    )
+    && Number.isFinite(sessionOrTracker.claudeBackgroundSubagentHoldAt)
+    && sessionOrTracker.claudeBackgroundSubagentHoldAt > 0
   );
 }
 
@@ -1613,7 +1612,7 @@ function promoteCompletion(sessionId, completionPayload = undefined) {
   if (hasConfirmedPermissionAnimationLock()) {
     const display = resolveDisplayState();
     setState(display, getSvgOverride(display));
-    return;
+    return true;
   }
   // The completion's data (done badge + Telegram push) already landed via the
   // snapshot above. The celebration is visual-only, so let setState()'s
@@ -2035,10 +2034,8 @@ function updateSession(sessionId, state, event, opts = {}) {
     && Number.isFinite(existing.claudeBackgroundSubagentHoldAt)
     && existing.claudeBackgroundSubagentHoldAt > 0
   );
-  const existingTrackerHold = hasSubagentHoldEvidence(existing);
   const effectiveTypedSubagentHold = incomingTypedSubagentCount > 0
     || (existingTypedSubagentHold && !typedSubagentSnapshotKnown);
-  const effectiveTrackerHold = existingTrackerHold && !typedSubagentSnapshotIsZero;
   let claudeBackgroundSubagentHoldAt = existingTypedSubagentHold
     ? existing.claudeBackgroundSubagentHoldAt
     : null;
@@ -2081,8 +2078,7 @@ function updateSession(sessionId, state, event, opts = {}) {
       headless: srcHeadless,
     });
     const hardLiveWork = disposition.kind === "hold"
-      || effectiveTypedSubagentHold
-      || effectiveTrackerHold;
+      || effectiveTypedSubagentHold;
     const debounceMs = hardLiveWork ? 0 : disposition.debounceMs;
     if (hardLiveWork || debounceMs > 0) {
       // Hold the Stop as "working" and DROP the event to null so recentEvents
@@ -2202,6 +2198,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     && (sessionStartSource === "startup" || sessionStartSource === "clear")
   ) {
     clearSubagentTracker(subagentTracker);
+    claudeBackgroundSubagentHoldAt = null;
   }
 
   // A new parent prompt bounds only anonymous evidence. Trusted child ids may
@@ -2237,7 +2234,7 @@ function updateSession(sessionId, state, event, opts = {}) {
   }
 
   if (
-    isSubagentStop
+    (isSubagentStop || isSubagentScopedSessionEnd)
     && typedSubagentSnapshotIsZero
     && !hasSubagentHoldEvidence(subagentTracker)
   ) {
@@ -2306,6 +2303,15 @@ function updateSession(sessionId, state, event, opts = {}) {
         const dh = pickDisplayHint(resumeState, existing, displayHint);
         sessions.set(sessionId, { state: resumeState, updatedAt: Date.now(), displayHint: dh, ...base, resumeState: null });
         debugSession(`subagent-stop restore ${describeSession(sessionId, sessions.get(sessionId))}`);
+      } else if (typedSubagentHoldActive) {
+        sessions.set(sessionId, {
+          state: "working",
+          updatedAt: Date.now(),
+          displayHint: pickDisplayHint("working", existing, displayHint),
+          ...base,
+          resumeState: null,
+        });
+        debugSession(`subagent-stop typed-hold ${describeSession(sessionId, sessions.get(sessionId))}`);
       } else {
         deleteSessionWithCompletionCleanup(sessionId, "subagent-stop-no-resume");
         debugSession(`subagent-stop delete sid=${sessionId} reason=no-resume`);

--- a/src/state.js
+++ b/src/state.js
@@ -1517,6 +1517,19 @@ function isClaudeElicitationCompletionTool(toolName) {
   return CLAUDE_ELICITATION_COMPLETION_TOOLS.has(toolName);
 }
 
+function hasClaudeBackgroundSubagentCompletionHold(sessionOrTracker) {
+  return !!(
+    sessionOrTracker
+    && (
+      (
+        Number.isFinite(sessionOrTracker.claudeBackgroundSubagentHoldAt)
+        && sessionOrTracker.claudeBackgroundSubagentHoldAt > 0
+      )
+      || hasSubagentHoldEvidence(sessionOrTracker)
+    )
+  );
+}
+
 function scheduleClaudeTranscriptCompletionProbe(sessionId, transcriptPath) {
   const safePath = normalizeTranscriptPath(transcriptPath);
   if (!safePath) return;
@@ -1535,6 +1548,11 @@ function scheduleClaudeTranscriptCompletionProbe(sessionId, transcriptPath) {
     if (Date.now() - startedAt > CLAUDE_ELICITATION_COMPLETION_PROBE_MAX_MS) {
       claudeTranscriptCompletionProbes.delete(sessionId);
       debugSession(`claude-transcript-stop-probe expire sid=${sessionId}`);
+      return;
+    }
+    if (hasClaudeBackgroundSubagentCompletionHold(session)) {
+      probe.timer = setTimeout(runProbe, CLAUDE_ELICITATION_COMPLETION_PROBE_INTERVAL_MS);
+      claudeTranscriptCompletionProbes.set(sessionId, probe);
       return;
     }
 
@@ -1568,7 +1586,11 @@ function scheduleClaudeTranscriptCompletionProbe(sessionId, transcriptPath) {
 // permission lock is holding the pet.
 function promoteCompletion(sessionId, completionPayload = undefined) {
   const session = sessions.get(sessionId);
-  if (!session) return;
+  if (!session) return false;
+  if (hasClaudeBackgroundSubagentCompletionHold(session)) {
+    debugSession(`completion-promote hold sid=${sessionId} reason=background-subagent`);
+    return false;
+  }
   if (completionPayload !== undefined) {
     const text = normalizeAssistantOutput(completionPayload && completionPayload.text);
     session.assistantLastOutput = text;
@@ -1600,6 +1622,7 @@ function promoteCompletion(sessionId, completionPayload = undefined) {
   // global pending queue here; pendingTimer/pendingState are process-wide, not
   // per-session, so clearing them would swallow another session's visual.
   setState("attention");
+  return true;
 }
 
 // ── Session management ──
@@ -1724,6 +1747,7 @@ function updateSession(sessionId, state, event, opts = {}) {
     muteNotificationSound = false,
     transientPermissionEvent = false,
     backgroundTasksCount = 0,
+    backgroundSubagentsCount,
     sessionCronsCount = 0,
     stopHookActive = false,
     stdinDiag = null,
@@ -1874,6 +1898,12 @@ function updateSession(sessionId, state, event, opts = {}) {
         ),
         resumeState: (existing && existing.resumeState) || null,
         muteNotificationSound: muteNotificationSound === true,
+        subagentTracker: cloneSubagentTracker(existing),
+        claudeBackgroundSubagentHoldAt: existing
+          && Number.isFinite(existing.claudeBackgroundSubagentHoldAt)
+          && existing.claudeBackgroundSubagentHoldAt > 0
+          ? existing.claudeBackgroundSubagentHoldAt
+          : null,
       });
     }
     setState("notification", undefined, { muteNotificationSound: muteNotificationSound === true });
@@ -1987,6 +2017,40 @@ function updateSession(sessionId, state, event, opts = {}) {
   );
   const preservedState = preserveState && existing ? existing.state : null;
   const duplicateCompletionVisualAtEntry = shouldSuppressDuplicateCompletionVisual(existing, state, event);
+  const isClaudeMainStop = event === "Stop"
+    && state === "attention"
+    && srcAgentId === "claude-code"
+    && !normalizedSubagentId;
+  const typedSubagentSnapshotKnown = Object.prototype.hasOwnProperty.call(
+    opts,
+    "backgroundSubagentsCount",
+  ) && Number.isSafeInteger(backgroundSubagentsCount) && backgroundSubagentsCount >= 0;
+  const incomingTypedSubagentCount = typedSubagentSnapshotKnown
+    ? backgroundSubagentsCount
+    : 0;
+  const typedSubagentSnapshotIsZero = typedSubagentSnapshotKnown
+    && incomingTypedSubagentCount === 0;
+  const existingTypedSubagentHold = !!(
+    existing
+    && Number.isFinite(existing.claudeBackgroundSubagentHoldAt)
+    && existing.claudeBackgroundSubagentHoldAt > 0
+  );
+  const existingTrackerHold = hasSubagentHoldEvidence(existing);
+  const effectiveTypedSubagentHold = incomingTypedSubagentCount > 0
+    || (existingTypedSubagentHold && !typedSubagentSnapshotKnown);
+  const effectiveTrackerHold = existingTrackerHold && !typedSubagentSnapshotIsZero;
+  let claudeBackgroundSubagentHoldAt = existingTypedSubagentHold
+    ? existing.claudeBackgroundSubagentHoldAt
+    : null;
+  if (isClaudeMainStop && duplicateCompletionVisualAtEntry) {
+    // A late duplicate Stop must not reopen a completed session or leave a
+    // private hold behind that can block a later legitimate completion.
+    claudeBackgroundSubagentHoldAt = null;
+  } else if (isClaudeMainStop && incomingTypedSubagentCount > 0) {
+    claudeBackgroundSubagentHoldAt = Math.max(1, Date.now());
+  } else if (isClaudeMainStop && typedSubagentSnapshotIsZero) {
+    claudeBackgroundSubagentHoldAt = null;
+  }
 
   // #406 Stop completion gate — Claude Code only; other agents keep their own
   // completion semantics (Codex task_complete + remote exit probes, etc.). A
@@ -1999,13 +2063,14 @@ function updateSession(sessionId, state, event, opts = {}) {
   // text, can be debounced until a quiet window confirms the turn really ended.
   if (
     !duplicateCompletionVisualAtEntry
-    && event === "Stop"
-    && state === "attention"
-    && srcAgentId === "claude-code"
+    && isClaudeMainStop
   ) {
     cancelCompletionDebounce(sessionId, "stop-superseded");
     const disposition = getClaudeStopDisposition({
       backgroundTasksCount,
+      backgroundSubagentsCount: typedSubagentSnapshotKnown
+        ? incomingTypedSubagentCount
+        : undefined,
       sessionCronsCount,
       stopHookActive,
       // Incoming, never the carried-forward value: this asks whether THIS Stop
@@ -2015,8 +2080,10 @@ function updateSession(sessionId, state, event, opts = {}) {
       hasFinalAssistantText: !!incomingAssistantLastOutput,
       headless: srcHeadless,
     });
-    const hardLiveWork = disposition.kind === "hold";
-    const debounceMs = disposition.debounceMs;
+    const hardLiveWork = disposition.kind === "hold"
+      || effectiveTypedSubagentHold
+      || effectiveTrackerHold;
+    const debounceMs = hardLiveWork ? 0 : disposition.debounceMs;
     if (hardLiveWork || debounceMs > 0) {
       // Hold the Stop as "working" and DROP the event to null so recentEvents
       // keeps NO "Stop" tail while held. Why null and not "Stop": deriveSessionBadge
@@ -2030,7 +2097,7 @@ function updateSession(sessionId, state, event, opts = {}) {
       event = null;
       if (hardLiveWork) {
         debugSession(
-          `stop-gate sid=${sessionId} bg=${backgroundTasksCount} crons=${sessionCronsCount} active=${stopHookActive} action=hold-working`
+          `stop-gate sid=${sessionId} bg=${backgroundTasksCount} subagents=${typedSubagentSnapshotKnown ? incomingTypedSubagentCount : "unknown"} crons=${sessionCronsCount} active=${stopHookActive} action=hold-working`
         );
         // Hard live work never auto-promotes; a later plain Stop (no hard
         // blockers) will.
@@ -2169,17 +2236,37 @@ function updateSession(sessionId, state, event, opts = {}) {
     subagentTracker.confirmedIds.add(normalizedSubagentId);
   }
 
+  if (
+    isSubagentStop
+    && typedSubagentSnapshotIsZero
+    && !hasSubagentHoldEvidence(subagentTracker)
+  ) {
+    // SubagentStop is resolving evidence, not a completion event. It may clear
+    // the aggregate typed marker only after the identity tracker agrees that no
+    // child remains; the existing session state is preserved below.
+    claudeBackgroundSubagentHoldAt = null;
+  }
+
   // Reaching this point with a real main Stop means the completion gate above
   // accepted it. Held/debounced stops were rewritten to event=null.
-  if (event === "Stop" && !normalizedSubagentId) {
+  // An authoritative typed zero must release the tracker before a debounced
+  // completion timer can call promoteCompletion(); duplicate completion Stops
+  // likewise cannot retain hidden child evidence on an already-complete row.
+  if (
+    (event === "Stop" && !normalizedSubagentId)
+    || (isClaudeMainStop && typedSubagentSnapshotIsZero)
+    || (isClaudeMainStop && duplicateCompletionVisualAtEntry)
+  ) {
     clearSubagentTracker(subagentTracker);
   }
 
-  const base = { sourcePid: srcPid, wtHwnd: srcWtHwnd, cwd: srcCwd, editor: srcEditor, pidChain: srcPidChain, tmuxSocket: srcTmuxSocket, tmuxClient: srcTmuxClient, orcaPaneKey: srcOrcaPaneKey, agentPid: srcAgentPid, agentId: srcAgentId, profileId: (existing && existing.profileId) || profileId || "local", rawSessionId: (existing && existing.rawSessionId) || rawSessionId || sessionId, sessionAutomationIdentity: srcSessionAutomationIdentity, host: srcHost, wslDistro: srcWslDistro, headless: srcHeadless, platform: srcPlatform, model: srcModel, provider: srcProvider, codexOriginator: srcCodexOriginator, codexSource: srcCodexSource, ghosttyTerminalId: srcGhosttyTerminalId, sessionTitle: srcSessionTitle, contextUsage: srcContextUsage, contextUsageOrigin: srcContextUsageOrigin, metadataUpdatedAt: srcMetadataUpdatedAt, assistantLastOutput: srcAssistantLastOutput, assistantLastOutputTruncated: srcAssistantLastOutputTruncated, lastToolName: srcToolName, transcriptPath: srcTranscriptPath, recentEvents, pidReachable, lastToolBoundaryAt: srcLastToolBoundaryAt, lastStopAt: srcLastStopAt, awaitingInputSinceStop: resolveAwaitingInputSinceStop(existing, event), muteNotificationSound: state === "notification" && muteNotificationSound === true };
+  const base = { sourcePid: srcPid, wtHwnd: srcWtHwnd, cwd: srcCwd, editor: srcEditor, pidChain: srcPidChain, tmuxSocket: srcTmuxSocket, tmuxClient: srcTmuxClient, orcaPaneKey: srcOrcaPaneKey, agentPid: srcAgentPid, agentId: srcAgentId, profileId: (existing && existing.profileId) || profileId || "local", rawSessionId: (existing && existing.rawSessionId) || rawSessionId || sessionId, sessionAutomationIdentity: srcSessionAutomationIdentity, host: srcHost, wslDistro: srcWslDistro, headless: srcHeadless, platform: srcPlatform, model: srcModel, provider: srcProvider, codexOriginator: srcCodexOriginator, codexSource: srcCodexSource, ghosttyTerminalId: srcGhosttyTerminalId, sessionTitle: srcSessionTitle, contextUsage: srcContextUsage, contextUsageOrigin: srcContextUsageOrigin, metadataUpdatedAt: srcMetadataUpdatedAt, assistantLastOutput: srcAssistantLastOutput, assistantLastOutputTruncated: srcAssistantLastOutputTruncated, lastToolName: srcToolName, transcriptPath: srcTranscriptPath, recentEvents, pidReachable, lastToolBoundaryAt: srcLastToolBoundaryAt, lastStopAt: srcLastStopAt, awaitingInputSinceStop: resolveAwaitingInputSinceStop(existing, event), muteNotificationSound: state === "notification" && muteNotificationSound === true, claudeBackgroundSubagentHoldAt };
   if (preserveCompletionAck) base.requiresCompletionAck = true;
   // #862: every branch below rebuilds the session object from `base`; carry the
   // private identity tracker through without exposing it on snapshot surfaces.
   base.subagentTracker = subagentTracker;
+  const typedSubagentHoldActive = Number.isFinite(claudeBackgroundSubagentHoldAt)
+    && claudeBackgroundSubagentHoldAt > 0;
 
   // Evict oldest session if at capacity and this is a new session.
   evictOldestSessionIfNeeded(sessionId);
@@ -2282,6 +2369,14 @@ function updateSession(sessionId, state, event, opts = {}) {
         ...base,
         resumeState: (existing && existing.resumeState) || null,
       });
+    } else if (typedSubagentHoldActive) {
+      sessions.set(sessionId, {
+        state: "working",
+        updatedAt: Date.now(),
+        displayHint: pickDisplayHint("working", existing, displayHint),
+        ...base,
+        resumeState: (existing && existing.resumeState) || null,
+      });
     } else {
       sessions.set(sessionId, { state: "idle", updatedAt: Date.now(), displayHint: null, ...base, resumeState: null });
     }
@@ -2291,6 +2386,14 @@ function updateSession(sessionId, state, event, opts = {}) {
         state: "juggling",
         updatedAt: Date.now(),
         displayHint: pickDisplayHint("juggling", existing, displayHint),
+        ...base,
+        resumeState: (existing && existing.resumeState) || null,
+      });
+    } else if (typedSubagentHoldActive) {
+      sessions.set(sessionId, {
+        state: "working",
+        updatedAt: Date.now(),
+        displayHint: pickDisplayHint("working", existing, displayHint),
         ...base,
         resumeState: (existing && existing.resumeState) || null,
       });
@@ -2323,6 +2426,14 @@ function updateSession(sessionId, state, event, opts = {}) {
         resumeState: (existing && existing.resumeState) || null,
       });
       debugSession(`juggling-hold ${describeSession(sessionId, sessions.get(sessionId))} event=${event || "-"}`);
+    } else if (typedSubagentHoldActive && state === "idle") {
+      sessions.set(sessionId, {
+        state: "working",
+        updatedAt: Date.now(),
+        displayHint: pickDisplayHint("working", existing, displayHint),
+        ...base,
+        resumeState: (existing && existing.resumeState) || null,
+      });
     } else {
       const dh = pickDisplayHint(state, existing, displayHint);
       sessions.set(sessionId, { state, updatedAt: Date.now(), displayHint: dh, ...base, resumeState: null });
@@ -2613,6 +2724,9 @@ function cleanStaleSessions() {
       debugSession(`stale-idle ${decision.reason} ${describeSession(id, s)}`);
       s.state = "idle"; s.displayHint = null;
       s.subagentTracker = clearSubagentTracker(cloneSubagentTracker(s));
+      s.claudeBackgroundSubagentHoldAt = null;
+      cancelCompletionDebounce(id, `stale-idle-${decision.reason}`);
+      cancelClaudeTranscriptCompletionProbe(id, `stale-idle-${decision.reason}`);
       if (decision.updateTimestamp) s.updatedAt = now;
       changed = true;
     }
@@ -3173,6 +3287,7 @@ return {
   clearLocalKimiQuota,
   getQuotaSourceCount,
   clearPermissionNotification,
+  promoteCompletion,
   ackSessionCompletion,
   clearSessionsByAgent,
   disposeAllKimiPermissionState,

--- a/test/claude-stop-disposition.test.js
+++ b/test/claude-stop-disposition.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { getClaudeStopDisposition } = require("../hooks/claude-stop-disposition");
+
+describe("Claude Stop disposition typed background-subagent gate (#952)", () => {
+  it("hard-holds a positive typed count with or without final text, even when debounce is disabled", () => {
+    for (const hasFinalAssistantText of [false, true]) {
+      assert.deepStrictEqual(getClaudeStopDisposition({
+        backgroundSubagentsCount: 1,
+        hasFinalAssistantText,
+        env: { CLAWD_COMPLETION_DEBOUNCE_MS: "0" },
+      }), { kind: "hold", debounceMs: 0 });
+    }
+  });
+
+  it("keeps the existing total-background final-text compatibility debounce at typed zero", () => {
+    assert.deepStrictEqual(getClaudeStopDisposition({
+      backgroundTasksCount: 1,
+      backgroundSubagentsCount: 0,
+      hasFinalAssistantText: true,
+      env: {},
+    }), { kind: "debounce", debounceMs: 2000 });
+  });
+
+  it("does not turn malformed, zero, negative, or fractional typed values into hard holds", () => {
+    for (const value of [undefined, null, 0, -1, -0.5, 0.5, "invalid", {}, []]) {
+      assert.deepStrictEqual(getClaudeStopDisposition({
+        backgroundSubagentsCount: value,
+        env: { CLAWD_COMPLETION_DEBOUNCE_MS: "0" },
+      }), { kind: "complete", debounceMs: 0 });
+    }
+  });
+
+  it("retains cron and stop-hook hard-hold precedence", () => {
+    assert.strictEqual(getClaudeStopDisposition({ sessionCronsCount: 1 }).kind, "hold");
+    assert.strictEqual(getClaudeStopDisposition({ stopHookActive: true }).kind, "hold");
+  });
+});

--- a/test/clawd-hook.test.js
+++ b/test/clawd-hook.test.js
@@ -259,19 +259,96 @@ describe("buildStateBody", () => {
       mockResolve
     );
     assert.strictEqual(body.background_tasks_count, 2);
+    assert.strictEqual(body.background_subagents_count, 0);
     assert.strictEqual(body.session_crons_count, 1);
+  });
+
+  it("counts only exact typed one-shot background subagents and preserves known zero (#952)", () => {
+    const typed = buildStateBody(
+      "Stop",
+      {
+        session_id: "s",
+        background_tasks: [
+          { type: "subagent", id: "private-1", status: "running" },
+          { type: " SUBAGENT ", description: "private description" },
+          { type: "teammate" },
+          { type: "shell" },
+          { type: "monitor" },
+          { type: "subagent-extra" },
+          { type: 123 },
+          {},
+          null,
+          [],
+        ],
+      },
+      mockResolve
+    );
+    assert.strictEqual(typed.background_tasks_count, 10);
+    assert.strictEqual(typed.background_subagents_count, 2);
+
+    const knownZero = buildStateBody(
+      "Stop",
+      { session_id: "s", background_tasks: [{ type: "teammate" }] },
+      mockResolve
+    );
+    assert.strictEqual(knownZero.background_subagents_count, 0);
+
+    const empty = buildStateBody(
+      "Stop",
+      { session_id: "s", background_tasks: [] },
+      mockResolve
+    );
+    assert.strictEqual(empty.background_subagents_count, 0);
+
+    const absent = buildStateBody("Stop", { session_id: "s" }, mockResolve);
+    assert.ok(!Object.prototype.hasOwnProperty.call(absent, "background_subagents_count"));
+    const malformed = buildStateBody(
+      "Stop",
+      { session_id: "s", background_tasks: { type: "subagent" } },
+      mockResolve
+    );
+    assert.ok(!Object.prototype.hasOwnProperty.call(malformed, "background_subagents_count"));
+  });
+
+  it("derives the typed aggregate on SubagentStop without forwarding task details (#952)", () => {
+    const body = buildStateBody(
+      "SubagentStop",
+      {
+        session_id: "s",
+        background_tasks: [{ type: "subagent", id: "secret-child", command: "secret command" }],
+      },
+      mockResolve
+    );
+    assert.strictEqual(body.background_subagents_count, 1);
+    const serialized = JSON.stringify(body);
+    assert.ok(!serialized.includes("secret-child"));
+    assert.ok(!serialized.includes("secret command"));
   });
 
   it("forwards only counts — never background task command/description text (#406)", () => {
     const body = buildStateBody(
       "Stop",
-      { session_id: "s", background_tasks: [{ command: "npm run secret-dev", description: "do not leak" }] },
+      {
+        session_id: "s",
+        background_tasks: [{
+          type: "teammate",
+          id: "secret-task-id",
+          agent_type: "secret-agent-type",
+          status: "secret-status",
+          command: "npm run secret-dev",
+          description: "do not leak",
+        }],
+      },
       mockResolve
     );
     assert.strictEqual(body.background_tasks_count, 1);
+    assert.strictEqual(body.background_subagents_count, 0);
     const serialized = JSON.stringify(body);
     assert.ok(!serialized.includes("npm run secret-dev"), "task command must not leak");
     assert.ok(!serialized.includes("do not leak"), "task description must not leak");
+    assert.ok(!serialized.includes("secret-task-id"), "task id must not leak");
+    assert.ok(!serialized.includes("secret-agent-type"), "agent type must not leak");
+    assert.ok(!serialized.includes("secret-status"), "task status must not leak");
   });
 
   it("forwards stop_hook_active on Stop (#406)", () => {
@@ -282,6 +359,7 @@ describe("buildStateBody", () => {
   it("omits completion-gate fields on a plain Stop with no background work (#406)", () => {
     const body = buildStateBody("Stop", { session_id: "s" }, mockResolve);
     assert.ok(!("background_tasks_count" in body));
+    assert.ok(!("background_subagents_count" in body));
     assert.ok(!("session_crons_count" in body));
     assert.ok(!("stop_hook_active" in body));
   });

--- a/test/completion-notify-integration.test.js
+++ b/test/completion-notify-integration.test.js
@@ -12,6 +12,7 @@ const assert = require("node:assert");
 const path = require("path");
 const themeLoader = require("../src/theme-loader");
 const { createTelegramCompanion } = require("../src/telegram-companion");
+const { createSlackNotifyClient } = require("../src/slack-notify-client");
 
 themeLoader.init(path.join(__dirname, "..", "src"));
 const theme = themeLoader.loadTheme("clawd");
@@ -100,6 +101,25 @@ describe("#406 state -> Telegram completion integration", () => {
     assert.strictEqual(sent.length, 0, "background work pending -> no premature completion push");
   });
 
+  it("typed background subagents suppress Telegram until an authoritative-zero Stop completes (#952)", async () => {
+    stop(api, "s1", {
+      backgroundTasksCount: 1,
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response while child runs.",
+    });
+    mock.timers.tick(5000);
+    await flush();
+    assert.strictEqual(sent.length, 0, "typed child still running -> no Telegram completion");
+
+    stop(api, "s1", {
+      backgroundSubagentsCount: 0,
+      assistantLastOutput: "Final response after child exit.",
+    });
+    mock.timers.tick(1000);
+    await flush();
+    assert.strictEqual(sent.length, 1, "authoritative zero releases exactly one Telegram completion");
+  });
+
   it("bg-only Stop with final assistant text pushes exactly once after the quiet window", async () => {
     stop(api, "s1", { backgroundTasksCount: 1, assistantLastOutput: "All done." });
     await flush();
@@ -118,6 +138,68 @@ describe("#406 state -> Telegram completion integration", () => {
     mock.timers.tick(1000);
     await flush();
     assert.strictEqual(sent.length, 1, "the Notification does not bury the completion; exactly one push");
+  });
+});
+
+describe("#952 state -> Slack completion integration", () => {
+  let api;
+  let fetchCalls;
+  let slack;
+  let savedDebounceEnv;
+
+  beforeEach(() => {
+    mock.timers.enable({ apis: ["setTimeout", "setInterval", "Date"] });
+    savedDebounceEnv = process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    process.env.CLAWD_COMPLETION_DEBOUNCE_MS = "1000";
+    fetchCalls = [];
+    slack = createSlackNotifyClient({
+      getConfig: () => ({
+        enabled: true,
+        channelId: "",
+        notifyOnDone: true,
+        notifyOnError: true,
+        notifyOnPermission: false,
+        outputMode: "off",
+      }),
+      getSecrets: () => ({
+        webhookUrl: "https://hooks.slack.com/services/T/B/test",
+        botToken: "",
+      }),
+      getLang: () => "en",
+      fetchImpl: async (url, options) => {
+        fetchCalls.push({ url, options });
+        return { ok: true, status: 200, text: async () => "ok" };
+      },
+    });
+    slack.onSnapshot({ sessions: [] });
+    api = require("../src/state")(makeCtx({
+      broadcastSessionSnapshot: (snapshot) => slack.onSnapshot(snapshot),
+    }));
+  });
+
+  afterEach(() => {
+    api.cleanup();
+    mock.timers.reset();
+    if (savedDebounceEnv === undefined) delete process.env.CLAWD_COMPLETION_DEBOUNCE_MS;
+    else process.env.CLAWD_COMPLETION_DEBOUNCE_MS = savedDebounceEnv;
+  });
+
+  it("does not enqueue Slack completion while a typed child is live, then sends once after known zero", async () => {
+    stop(api, "s1", {
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response while child runs.",
+    });
+    mock.timers.tick(5000);
+    await slack.drained();
+    assert.strictEqual(fetchCalls.length, 0);
+
+    stop(api, "s1", {
+      backgroundSubagentsCount: 0,
+      assistantLastOutput: "Final response after child exit.",
+    });
+    mock.timers.tick(1000);
+    await slack.drained();
+    assert.strictEqual(fetchCalls.length, 1);
   });
 });
 

--- a/test/server-route-state.test.js
+++ b/test/server-route-state.test.js
@@ -636,6 +636,36 @@ describe("server-route-state POST", () => {
     ]]);
   });
 
+  it("preserves absent versus authoritative zero for typed Claude background subagents (#952)", async () => {
+    const post = (value, include = true) => callStatePost(JSON.stringify({
+      state: "attention",
+      event: "Stop",
+      agent_id: "claude-code",
+      session_id: `typed-${String(value)}`,
+      ...(include ? { background_subagents_count: value } : {}),
+    }));
+
+    const absent = await post(0, false);
+    assert.strictEqual(
+      Object.prototype.hasOwnProperty.call(absent.calls.updateSession[0][3], "backgroundSubagentsCount"),
+      false,
+    );
+
+    const zero = await post(0);
+    assert.strictEqual(zero.calls.updateSession[0][3].backgroundSubagentsCount, 0);
+
+    const positive = await post(2);
+    assert.strictEqual(positive.calls.updateSession[0][3].backgroundSubagentsCount, 2);
+
+    for (const invalid of [-1, 1.5, "1", Number.MAX_SAFE_INTEGER + 1]) {
+      const response = await post(invalid);
+      assert.strictEqual(
+        Object.prototype.hasOwnProperty.call(response.calls.updateSession[0][3], "backgroundSubagentsCount"),
+        false,
+      );
+    }
+  });
+
   it("shows and resolves a normalized remote Codex user-input request", async () => {
     const request = await callStatePost(JSON.stringify({
       state: "notification",

--- a/test/session-recovery-lease.test.js
+++ b/test/session-recovery-lease.test.js
@@ -147,6 +147,129 @@ describe("durable session recovery leases", () => {
     assert.strictEqual(complete.record.validUntil, null);
   });
 
+  it("does not create or refresh a durable lease when typed subagents alone upgrade Stop to hold (#952)", () => {
+    const filePath = getLeaseFilePath("claude-code", "real-session-1", { recoveryDir });
+    const withoutExisting = updateRecoveryLeaseFromStateBody(body({
+      event: "Stop",
+      state: "attention",
+      background_tasks_count: 1,
+      background_subagents_count: 1,
+      assistant_last_output: "parent finished",
+    }), winOptions(1000));
+    assert.deepStrictEqual(withoutExisting, {
+      written: false,
+      reason: "no-existing-evidence",
+    });
+    assert.strictEqual(fs.existsSync(filePath), false);
+
+    updateRecoveryLeaseFromStateBody(body({ state: "working" }), winOptions(2000));
+    const bytesBefore = fs.readFileSync(filePath);
+    const mtimeBefore = fs.statSync(filePath).mtimeMs;
+    const preserved = updateRecoveryLeaseFromStateBody(body({
+      event: "Stop",
+      state: "attention",
+      background_tasks_count: 1,
+      background_subagents_count: 1,
+      assistant_last_output: "parent finished",
+    }), winOptions(3000));
+    assert.strictEqual(preserved.written, false);
+    assert.strictEqual(preserved.reason, "preserved-existing-evidence");
+    assert.deepStrictEqual(fs.readFileSync(filePath), bytesBefore);
+    assert.strictEqual(fs.statSync(filePath).mtimeMs, mtimeBefore);
+    assert.strictEqual(readLeaseFile(filePath).eventAt, 2000);
+
+    const completed = updateRecoveryLeaseFromStateBody(body({
+      event: "Stop",
+      state: "attention",
+      background_tasks_count: 0,
+      background_subagents_count: 0,
+      assistant_last_output: "actually finished",
+    }), winOptions(4000));
+    assert.strictEqual(completed.written, true);
+    assert.strictEqual(completed.record.active, false);
+  });
+
+  it("preserves a provisional lease byte-for-byte and never creates a recovery directory for typed-only evidence (#952)", () => {
+    const provisional = updateRecoveryLeaseFromStateBody(body({
+      event: "Stop",
+      state: "attention",
+      background_tasks_count: 1,
+      assistant_last_output: "parent finished",
+    }), winOptions(1000));
+    assert.strictEqual(provisional.record.validUntil, 3000);
+    const filePath = provisional.filePath;
+    const bytesBefore = fs.readFileSync(filePath);
+
+    const preserved = updateRecoveryLeaseFromStateBody(body({
+      event: "Stop",
+      state: "attention",
+      background_tasks_count: 1,
+      background_subagents_count: 1,
+      assistant_last_output: "parent finished",
+    }), winOptions(1500));
+    assert.strictEqual(preserved.reason, "preserved-existing-evidence");
+    assert.deepStrictEqual(fs.readFileSync(filePath), bytesBefore);
+    assert.strictEqual(readLeaseFile(filePath).validUntil, 3000);
+
+    const missingDir = path.join(recoveryDir, "must-not-be-created");
+    const missing = updateRecoveryLeaseFromStateBody(body({
+      session_id: "typed-without-directory",
+      event: "Stop",
+      state: "attention",
+      background_subagents_count: 1,
+      assistant_last_output: "parent finished",
+    }), winOptions(2000, { recoveryDir: missingDir }));
+    assert.strictEqual(missing.reason, "no-existing-evidence");
+    assert.strictEqual(fs.existsSync(missingDir), false);
+  });
+
+  it("leaves an inactive tombstone untouched when typed-only evidence arrives late (#952)", () => {
+    const completed = updateRecoveryLeaseFromStateBody(body({
+      event: "Stop",
+      state: "attention",
+    }), winOptions(1000));
+    const bytesBefore = fs.readFileSync(completed.filePath);
+    const lateTyped = updateRecoveryLeaseFromStateBody(body({
+      event: "Stop",
+      state: "attention",
+      background_subagents_count: 1,
+      assistant_last_output: "late parent output",
+    }), winOptions(2000));
+    assert.strictEqual(lateTyped.reason, "no-active-evidence");
+    assert.deepStrictEqual(fs.readFileSync(completed.filePath), bytesBefore);
+  });
+
+  it("keeps ordinary durable hold behavior when another Stop signal is independently hard-live (#952)", () => {
+    const cases = [
+      {
+        background_tasks_count: 1,
+        background_subagents_count: 1,
+      },
+      {
+        background_subagents_count: 1,
+        assistant_last_output: "parent finished",
+        session_crons_count: 1,
+      },
+      {
+        background_subagents_count: 1,
+        assistant_last_output: "parent finished",
+        stop_hook_active: true,
+      },
+    ];
+    cases.forEach((fields, index) => {
+      const held = updateRecoveryLeaseFromStateBody(body({
+        session_id: `durable-hold-${index}`,
+        event: "Stop",
+        state: "attention",
+        ...fields,
+      }), winOptions(1000 + index));
+      assert.strictEqual(held.written, true);
+      assert.strictEqual(held.record.active, true);
+      assert.strictEqual(held.record.state, "working");
+      assert.strictEqual(held.record.validUntil, null);
+    });
+  });
+
   it("prevents a late older hook from resurrecting a terminal tombstone", () => {
     updateRecoveryLeaseFromStateBody(body({ event: "Stop", state: "attention" }), winOptions(2000));
     const late = updateRecoveryLeaseFromStateBody(body(), winOptions(1000));

--- a/test/state-payload-size.test.js
+++ b/test/state-payload-size.test.js
@@ -93,13 +93,14 @@ describe("state-payload-size fitStateBodyToByteBudget", () => {
       session_id: "sid",
       event: "Stop",
       background_tasks_count: 2,
+      background_subagents_count: 1,
       session_crons_count: 1,
       stop_hook_active: true,
       assistant_last_output: "字".repeat(50),
     };
     // Tight budget: the gate/completion fields alone nearly fill it, leaving no
     // usable room for any assistant text → drop it but keep everything else.
-    const r = fitStateBodyToByteBudget(body, { targetBytes: 150 });
+    const r = fitStateBodyToByteBudget(body, { targetBytes: 170 });
     assert.strictEqual(r.assistantDropped, true);
     assert.strictEqual(r.fitted, true);
     assert.strictEqual(r.body.assistant_last_output, undefined);
@@ -107,6 +108,7 @@ describe("state-payload-size fitStateBodyToByteBudget", () => {
     assert.strictEqual(r.body.state, "attention");
     assert.strictEqual(r.body.event, "Stop");
     assert.strictEqual(r.body.background_tasks_count, 2);
+    assert.strictEqual(r.body.background_subagents_count, 1);
     assert.strictEqual(r.body.session_crons_count, 1);
     assert.strictEqual(r.body.stop_hook_active, true);
   });

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -103,6 +103,9 @@ function update(api, o = {}) {
       toolName: o.toolName ?? null,
       transcriptPath: o.transcriptPath ?? null,
       backgroundTasksCount: o.backgroundTasksCount ?? 0,
+      ...(Object.prototype.hasOwnProperty.call(o, "backgroundSubagentsCount")
+        ? { backgroundSubagentsCount: o.backgroundSubagentsCount }
+        : {}),
       sessionCronsCount: o.sessionCronsCount ?? 0,
       stopHookActive: o.stopHookActive ?? false,
       transientPermissionEvent: o.transientPermissionEvent === true,
@@ -270,6 +273,10 @@ describe("restoreSessionFromLease()", () => {
     assert.strictEqual(api.sessions.size, 1);
     const sessionId = makeSessionKey({ profileId: "local", rawSessionId: "claude-real-session" });
     const session = api.sessions.get(sessionId);
+    assert.strictEqual(
+      Object.prototype.hasOwnProperty.call(session, "claudeBackgroundSubagentHoldAt"),
+      false,
+    );
     assert.strictEqual(session.state, "working");
     assert.strictEqual(session.profileId, "local");
     assert.strictEqual(session.rawSessionId, "claude-real-session");
@@ -717,7 +724,12 @@ describe("#862 juggling tier counts subagents, not sessions", () => {
   it("a new run resets the count when stops were lost", () => {
     work(); start("s1", "child-a"); start("s1", "child-b");
     // agent crashed — both stops never arrive; session leaves juggling normally
-    update(api, { id: "s1", state: "attention", event: "Stop" });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 0,
+    });
     work();
     start("s1", "child-c");
     assert.strictEqual(shown(), GROOVE, "stale count must not carry into the new run");
@@ -943,7 +955,12 @@ describe("#862 juggling tier counts subagents, not sessions", () => {
     assert.strictEqual(api.sessions.get("s1").subagentTracker.legacyFloor, true);
     assert.strictEqual(api.resolveDisplayState(), "juggling");
 
-    update(api, { id: "s1", state: "attention", event: "Stop" });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 0,
+    });
     assert.strictEqual(api.sessions.get("s1").subagentTracker.legacyFloor, false);
     assert.strictEqual(api.resolveDisplayState(), "idle");
   });
@@ -1338,7 +1355,9 @@ describe("cleanStaleSessions()", () => {
 
   it("agentPid dead → delete session", () => {
     api = require("../src/state")(makeCtx({ processKill: makePidKill(new Set()) }));
-    api.sessions.set("s1", rawSession("working", { agentPid: 9999, pidReachable: true }));
+    const session = rawSession("working", { agentPid: 9999, pidReachable: true });
+    session.claudeBackgroundSubagentHoldAt = Date.now();
+    api.sessions.set("s1", session);
     api.cleanStaleSessions();
     assert.strictEqual(api.sessions.size, 0);
   });
@@ -1388,7 +1407,7 @@ describe("cleanStaleSessions()", () => {
 
   it("agentPid alive + sourcePid alive + working > WORKING_STALE_MS → downgrade to idle", () => {
     api = require("../src/state")(makeCtx({ processKill: makePidKill(new Set([1000, 2000])) }));
-    api.sessions.set("s1", rawSession("working", {
+    const staleSession = rawSession("working", {
       agentPid: 1000, sourcePid: 2000, pidReachable: true,
       updatedAt: Date.now() - 310000,
       subagentTracker: {
@@ -1396,13 +1415,42 @@ describe("cleanStaleSessions()", () => {
         legacyFloor: true,
         recoveredFloor: true,
       },
-    }));
+    });
+    staleSession.claudeBackgroundSubagentHoldAt = Date.now() - 310000;
+    api.sessions.set("s1", staleSession);
     api.cleanStaleSessions();
     const session = api.sessions.get("s1");
     assert.strictEqual(session.state, "idle");
     assert.strictEqual(session.subagentTracker.confirmedIds.size, 0);
     assert.strictEqual(session.subagentTracker.legacyFloor, false);
     assert.strictEqual(session.subagentTracker.recoveredFloor, false);
+    assert.strictEqual(session.claudeBackgroundSubagentHoldAt, null);
+  });
+
+  it("parent progress postpones the configured silence fallback without clearing the typed marker", () => {
+    api = require("../src/state")(makeCtx({
+      processKill: makePidKill(new Set([1000, 2000])),
+      getStaleConfig: () => ({ sessionStaleMs: 1000, workingStaleMs: 100 }),
+    }));
+    const session = rawSession("working", {
+      agentId: "claude-code",
+      agentPid: 1000,
+      sourcePid: 2000,
+      pidReachable: true,
+      updatedAt: Date.now() - 99,
+    });
+    session.claudeBackgroundSubagentHoldAt = Date.now() - 1000;
+    api.sessions.set("s1", session);
+
+    assert.strictEqual(api.touchSessionActivity("s1", { agentId: "claude-code" }), true);
+    api.cleanStaleSessions();
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.ok(Number.isFinite(api.sessions.get("s1").claudeBackgroundSubagentHoldAt));
+
+    api.sessions.get("s1").updatedAt = Date.now() - 101;
+    api.cleanStaleSessions();
+    assert.strictEqual(api.sessions.get("s1").state, "idle");
+    assert.strictEqual(api.sessions.get("s1").claudeBackgroundSubagentHoldAt, null);
   });
 
   it("keeps local OpenCode blocker-facing work active past the generic session cutoff", () => {
@@ -3873,6 +3921,20 @@ describe("buildSessionSnapshot", () => {
     assert.doesNotThrow(() => JSON.stringify(snapshot));
   });
 
+  it("never exposes the private Claude background-subagent marker in snapshots (#952)", () => {
+    update(api, {
+      id: "typed-private",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent output.",
+    });
+    assert.ok(Number.isFinite(api.sessions.get("typed-private").claudeBackgroundSubagentHoldAt));
+    const serialized = JSON.stringify(api.buildSessionSnapshot());
+    assert.ok(!serialized.includes("claudeBackgroundSubagentHoldAt"));
+    assert.ok(!serialized.includes("backgroundSubagentsCount"));
+  });
+
   it("builds renderer-safe fields, groups, and both dashboard/menu orderings", () => {
     api.sessions.set("old-working", rawSession("working", {
       updatedAt: 1000,
@@ -4375,6 +4437,343 @@ describe("Stop completion gate (#406)", () => {
     assert.ok(!soundsPlayed.includes("complete"), "completion sound must not play");
   });
 
+  it("exact typed background subagents hard-hold even with final assistant text (#952)", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundTasksCount: 1,
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response finished.",
+    });
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "working");
+    assert.ok(Number.isFinite(session.claudeBackgroundSubagentHoldAt));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+    mock.timers.tick(5000);
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("direct completion promotion refuses typed markers and confirmed tracker evidence (#952)", () => {
+    update(api, {
+      id: "typed",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    const typedBroadcastsBefore = api.getLastSessionSnapshot();
+    assert.strictEqual(api.promoteCompletion("typed"), false);
+    assert.strictEqual(api.sessions.get("typed").state, "working");
+    assert.ok(Number.isFinite(api.sessions.get("typed").claudeBackgroundSubagentHoldAt));
+    assert.strictEqual(api.getLastSessionSnapshot(), typedBroadcastsBefore);
+
+    update(api, { id: "tracked", state: "working", event: "PreToolUse" });
+    update(api, {
+      id: "tracked",
+      state: "juggling",
+      event: "SubagentStart",
+      subagentId: "child-a",
+    });
+    assert.strictEqual(api.promoteCompletion("tracked"), false);
+    assert.strictEqual(api.sessions.get("tracked").state, "juggling");
+    assert.strictEqual(api.sessions.get("tracked").subagentTracker.confirmedIds.has("child-a"), true);
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("identity-backed typed background work remains juggling past the quiet window (#952)", () => {
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    update(api, {
+      id: "s1",
+      state: "juggling",
+      event: "SubagentStart",
+      subagentId: "child-a",
+    });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    mock.timers.tick(5000);
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "juggling");
+    assert.strictEqual(session.subagentTracker.confirmedIds.has("child-a"), true);
+    assert.ok(Number.isFinite(session.claudeBackgroundSubagentHoldAt));
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("disabling completion debounce cannot release a typed background subagent (#952)", () => {
+    process.env.CLAWD_COMPLETION_DEBOUNCE_MS = "0";
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    mock.timers.tick(5000);
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "running");
+    assert.ok(!soundsPlayed.includes("complete"));
+    process.env.CLAWD_COMPLETION_DEBOUNCE_MS = "1000";
+  });
+
+  it("an absent typed snapshot inherits the private hold instead of completing (#952)", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Intermediate parent response.",
+    });
+    const holdAt = api.sessions.get("s1").claudeBackgroundSubagentHoldAt;
+
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      assistantLastOutput: "Later Stop without a task snapshot.",
+    });
+    mock.timers.tick(5000);
+
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.claudeBackgroundSubagentHoldAt, holdAt);
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("ordinary parent progress and notifications neither clear nor idle a typed hold (#952)", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    const holdAt = api.sessions.get("s1").claudeBackgroundSubagentHoldAt;
+    update(api, { id: "s1", state: "thinking", event: "UserPromptSubmit" });
+    assert.strictEqual(api.sessions.get("s1").claudeBackgroundSubagentHoldAt, holdAt);
+    update(api, { id: "s1", state: "notification", event: "PermissionRequest" });
+    assert.strictEqual(api.sessions.get("s1").claudeBackgroundSubagentHoldAt, holdAt);
+    update(api, { id: "s1", state: "notification", event: "Notification" });
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.claudeBackgroundSubagentHoldAt, holdAt);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+  });
+
+  it("authoritative typed zero releases the marker before normal Stop debounce (#952)", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response while child runs.",
+    });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 0,
+      assistantLastOutput: "Final response after child exit.",
+    });
+
+    assert.strictEqual(api.sessions.get("s1").claudeBackgroundSubagentHoldAt, null);
+    assert.strictEqual(api.sessions.get("s1").state, "working");
+    mock.timers.tick(1000);
+    assert.strictEqual(api.sessions.get("s1").state, "idle");
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+    assert.ok(soundsPlayed.includes("complete"));
+  });
+
+  it("an absent typed snapshot also inherits confirmed child tracker evidence (#952)", () => {
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    update(api, {
+      id: "s1",
+      state: "juggling",
+      event: "SubagentStart",
+      subagentId: "child-a",
+    });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      assistantLastOutput: "Parent finished while child remains.",
+    });
+    mock.timers.tick(5000);
+
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "juggling");
+    assert.strictEqual(session.subagentTracker.confirmedIds.has("child-a"), true);
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("authoritative typed zero releases tracker evidence before debounced completion (#952)", () => {
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    update(api, {
+      id: "s1",
+      state: "juggling",
+      event: "SubagentStart",
+      subagentId: "child-a",
+    });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 0,
+      assistantLastOutput: "Final response after the authoritative snapshot.",
+    });
+    assert.strictEqual(api.sessions.get("s1").subagentTracker.confirmedIds.size, 0);
+    mock.timers.tick(1000);
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+  });
+
+  it("SubagentStop known-zero clears the typed marker only after the tracker empties and never completes (#952)", () => {
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    for (const child of ["child-a", "child-b"]) {
+      update(api, {
+        id: "s1",
+        state: "juggling",
+        event: "SubagentStart",
+        subagentId: child,
+      });
+    }
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 2,
+      assistantLastOutput: "Parent response.",
+    });
+
+    update(api, {
+      id: "s1",
+      state: "working",
+      event: "SubagentStop",
+      subagentId: "child-a",
+      backgroundSubagentsCount: 1,
+    });
+    assert.ok(Number.isFinite(api.sessions.get("s1").claudeBackgroundSubagentHoldAt));
+    assert.strictEqual(api.sessions.get("s1").subagentTracker.confirmedIds.size, 1);
+
+    update(api, {
+      id: "s1",
+      state: "working",
+      event: "SubagentStop",
+      subagentId: "child-b",
+      backgroundSubagentsCount: 0,
+    });
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.claudeBackgroundSubagentHoldAt, null);
+    assert.strictEqual(session.subagentTracker.confirmedIds.size, 0);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("SubagentStop followed by an older typed Stop can only become sticky-working, never prematurely complete (#952)", () => {
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    update(api, {
+      id: "s1",
+      state: "juggling",
+      event: "SubagentStart",
+      subagentId: "child-a",
+    });
+    update(api, {
+      id: "s1",
+      state: "working",
+      event: "SubagentStop",
+      subagentId: "child-a",
+      backgroundSubagentsCount: 0,
+    });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Late older Stop.",
+    });
+    mock.timers.tick(5000);
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "working");
+    assert.ok(Number.isFinite(session.claudeBackgroundSubagentHoldAt));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("SessionEnd and explicit dismissal remove typed holds instead of persisting them", () => {
+    update(api, {
+      id: "ended",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    update(api, { id: "ended", state: "sleeping", event: "SessionEnd" });
+    assert.strictEqual(api.sessions.has("ended"), false);
+
+    update(api, {
+      id: "dismissed",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    assert.strictEqual(api.dismissSession("dismissed"), true);
+    assert.strictEqual(api.sessions.has("dismissed"), false);
+  });
+
+  it("a duplicate typed Stop cannot reopen a completed row or leave a hidden marker (#952)", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 0,
+    });
+    mock.timers.tick(1000);
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("s1")), "done");
+
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Late duplicate payload.",
+    });
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "idle");
+    assert.strictEqual(api.deriveSessionBadge(session), "done");
+    assert.strictEqual(session.claudeBackgroundSubagentHoldAt, null);
+  });
+
+  it("a reordered typed Stop supersedes a pending plain-Stop completion without racing the timer (#952)", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      assistantLastOutput: "Tentative parent answer.",
+    });
+    mock.timers.tick(500);
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent answer while delayed child evidence arrives.",
+    });
+    mock.timers.tick(5000);
+
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "working");
+    assert.ok(Number.isFinite(session.claudeBackgroundSubagentHoldAt));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+    assert.ok(!soundsPlayed.includes("complete"));
+  });
+
   it("background_tasks with final assistant text debounce, then celebrate on a quiet window", () => {
     update(api, {
       id: "s1",
@@ -4464,7 +4863,11 @@ describe("Stop completion gate (#406)", () => {
   });
 
   it("debounce: a Stop followed by PreToolUse within the window never celebrates", () => {
-    update(api, { id: "s1", state: "attention", event: "Stop" });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+    });
     assert.strictEqual(api.sessions.get("s1").state, "working", "held working during the window");
     mock.timers.tick(500); // still within the 1000ms window
     update(api, { id: "s1", state: "working", event: "PreToolUse" });
@@ -4749,7 +5152,7 @@ describe("Stop completion gate (#406)", () => {
     assert.strictEqual(api.deriveSessionBadge(s), "done");
   });
 
-  it("promoted completion clears stale subagent evidence before the next turn", () => {
+  it("authoritative completion clears stale subagent evidence before the next turn", () => {
     update(api, { id: "s1", state: "working", event: "PreToolUse" });
     update(api, {
       id: "s1",
@@ -4760,8 +5163,13 @@ describe("Stop completion gate (#406)", () => {
     });
     assert.strictEqual(api.sessions.get("s1").subagentTracker.confirmedIds.size, 1);
 
-    update(api, { id: "s1", state: "attention", event: "Stop" });
-    assert.strictEqual(api.sessions.get("s1").state, "juggling", "the debounced Stop still holds the live tracker");
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 0,
+    });
+    assert.strictEqual(api.sessions.get("s1").state, "working", "authoritative zero releases the stale tracker during debounce");
     mock.timers.tick(1000);
 
     const completed = api.sessions.get("s1");
@@ -4858,6 +5266,42 @@ describe("Stop completion gate (#406)", () => {
     assert.strictEqual(api.getCurrentState(), "attention");
     assert.ok(soundsPlayed.includes("complete"));
     assert.strictEqual(api.deriveSessionBadge(session), "done");
+  });
+
+  it("Claude transcript completion cannot promote through a typed background-subagent hold (#952)", () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-claude-stop-fallback-"));
+    const transcript = path.join(dir, "transcript.jsonl");
+    const rawSessionId = "claude-probe-background-subagent";
+    const sessionId = resolveSessionIdentity(rawSessionId, "local").sessionId;
+    fs.writeFileSync(transcript, [
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "tool_use", name: "AskUserQuestion" }] } }),
+      JSON.stringify({ type: "user", message: { content: [{ type: "tool_result", content: "Allow" }] } }),
+      JSON.stringify({ type: "assistant", message: { content: "Parent answer while child runs." } }),
+    ].join("\n") + "\n");
+
+    update(api, {
+      id: sessionId,
+      rawSessionId,
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent answer while child runs.",
+    });
+    update(api, {
+      id: sessionId,
+      rawSessionId,
+      state: "working",
+      event: "PostToolUse",
+      toolName: "AskUserQuestion",
+      transcriptPath: transcript,
+    });
+
+    mock.timers.tick(10000);
+    const session = api.sessions.get(sessionId);
+    assert.strictEqual(session.state, "working");
+    assert.ok(Number.isFinite(session.claudeBackgroundSubagentHoldAt));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+    assert.ok(!soundsPlayed.includes("complete"));
   });
 
   it("Claude transcript fallback documents raw transcript sessionId mismatch", () => {

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -911,9 +911,17 @@ describe("#862 juggling tier counts subagents, not sessions", () => {
     );
   });
 
-  it("clears the tracker at a fresh startup/clear SessionStart boundary", () => {
+  it("clears tracker and typed marker at a fresh startup/clear SessionStart boundary", () => {
     work();
     start("s1", "child-a");
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    assert.ok(Number.isFinite(api.sessions.get("s1").claudeBackgroundSubagentHoldAt));
     update(api, {
       id: "s1",
       state: "idle",
@@ -922,8 +930,17 @@ describe("#862 juggling tier counts subagents, not sessions", () => {
     });
     assert.strictEqual(api.resolveDisplayState(), "idle");
     assert.strictEqual(api.sessions.get("s1").subagentTracker.confirmedIds.size, 0);
+    assert.strictEqual(api.sessions.get("s1").claudeBackgroundSubagentHoldAt, null);
 
     start("s1", "child-b");
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    assert.ok(Number.isFinite(api.sessions.get("s1").claudeBackgroundSubagentHoldAt));
     update(api, {
       id: "s1",
       state: "idle",
@@ -932,6 +949,7 @@ describe("#862 juggling tier counts subagents, not sessions", () => {
     });
     assert.strictEqual(api.resolveDisplayState(), "idle");
     assert.strictEqual(api.sessions.get("s1").subagentTracker.confirmedIds.size, 0);
+    assert.strictEqual(api.sessions.get("s1").claudeBackgroundSubagentHoldAt, null);
   });
 
   it("keeps one-shot presentation separate from the underlying juggling state", () => {
@@ -4455,7 +4473,7 @@ describe("Stop completion gate (#406)", () => {
     assert.ok(!soundsPlayed.includes("complete"));
   });
 
-  it("direct completion promotion refuses typed markers and confirmed tracker evidence (#952)", () => {
+  it("direct completion promotion refuses typed markers but preserves legacy tracker-only completion (#952)", () => {
     update(api, {
       id: "typed",
       state: "attention",
@@ -4476,10 +4494,31 @@ describe("Stop completion gate (#406)", () => {
       event: "SubagentStart",
       subagentId: "child-a",
     });
-    assert.strictEqual(api.promoteCompletion("tracked"), false);
-    assert.strictEqual(api.sessions.get("tracked").state, "juggling");
-    assert.strictEqual(api.sessions.get("tracked").subagentTracker.confirmedIds.has("child-a"), true);
-    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(api.promoteCompletion("tracked"), true);
+    assert.strictEqual(api.sessions.get("tracked").state, "idle");
+    assert.strictEqual(api.sessions.get("tracked").subagentTracker.confirmedIds.size, 0);
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("tracked")), "done");
+  });
+
+  it("reports successful completion when a confirmed permission lock suppresses only the visual", () => {
+    api.cleanup();
+    ctx = makeCtx({
+      processKill: () => true,
+      isAgentPermissionsEnabled: () => true,
+      showKimiNotifyBubble: () => {},
+      clearKimiNotifyBubbles: () => {},
+    });
+    api = require("../src/state")(ctx);
+    update(api, {
+      id: "kimi-permission",
+      state: "notification",
+      event: "PermissionRequest",
+      agentId: "kimi-cli",
+    });
+    update(api, { id: "completed", state: "working", event: "PreToolUse" });
+
+    assert.strictEqual(api.promoteCompletion("completed"), true);
+    assert.strictEqual(api.deriveSessionBadge(api.sessions.get("completed")), "done");
   });
 
   it("identity-backed typed background work remains juggling past the quiet window (#952)", () => {
@@ -4590,7 +4629,7 @@ describe("Stop completion gate (#406)", () => {
     assert.ok(soundsPlayed.includes("complete"));
   });
 
-  it("an absent typed snapshot also inherits confirmed child tracker evidence (#952)", () => {
+  it("an absent typed snapshot preserves legacy tracker-only completion (#952)", () => {
     update(api, { id: "s1", state: "working", event: "PreToolUse" });
     update(api, {
       id: "s1",
@@ -4607,9 +4646,10 @@ describe("Stop completion gate (#406)", () => {
     mock.timers.tick(5000);
 
     const session = api.sessions.get("s1");
-    assert.strictEqual(session.state, "juggling");
-    assert.strictEqual(session.subagentTracker.confirmedIds.has("child-a"), true);
-    assert.ok(!soundsPlayed.includes("complete"));
+    assert.strictEqual(session.state, "idle");
+    assert.strictEqual(session.subagentTracker.confirmedIds.size, 0);
+    assert.strictEqual(api.deriveSessionBadge(session), "done");
+    assert.ok(soundsPlayed.includes("complete"));
   });
 
   it("authoritative typed zero releases tracker evidence before debounced completion (#952)", () => {
@@ -4673,6 +4713,83 @@ describe("Stop completion gate (#406)", () => {
     assert.strictEqual(session.state, "working");
     assert.strictEqual(api.deriveSessionBadge(session), "running");
     assert.ok(!soundsPlayed.includes("complete"));
+  });
+
+  it("keeps a typed-only session when SubagentStop has no resume state but still reports live work (#952)", () => {
+    update(api, {
+      id: "s1",
+      state: "juggling",
+      event: "SubagentStart",
+      subagentId: "child-a",
+    });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    update(api, {
+      id: "s1",
+      state: "working",
+      event: "SubagentStop",
+      subagentId: "child-a",
+      backgroundSubagentsCount: 1,
+    });
+
+    const session = api.sessions.get("s1");
+    assert.ok(session);
+    assert.strictEqual(session.state, "working");
+    assert.strictEqual(session.subagentTracker.confirmedIds.size, 0);
+    assert.ok(Number.isFinite(session.claudeBackgroundSubagentHoldAt));
+    assert.strictEqual(api.deriveSessionBadge(session), "running");
+  });
+
+  it("subagent-scoped SessionEnd known-zero clears the typed marker after the tracker empties (#952)", () => {
+    update(api, { id: "s1", state: "working", event: "PreToolUse" });
+    update(api, {
+      id: "s1",
+      state: "juggling",
+      event: "SubagentStart",
+      subagentId: "child-a",
+    });
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    update(api, {
+      id: "s1",
+      state: "sleeping",
+      event: "SessionEnd",
+      subagentId: "child-a",
+      backgroundSubagentsCount: 0,
+    });
+
+    const session = api.sessions.get("s1");
+    assert.ok(session);
+    assert.strictEqual(session.claudeBackgroundSubagentHoldAt, null);
+    assert.strictEqual(session.subagentTracker.confirmedIds.size, 0);
+  });
+
+  it("typed holds keep aggregate work live while still presenting terminal errors", () => {
+    update(api, {
+      id: "s1",
+      state: "attention",
+      event: "Stop",
+      backgroundSubagentsCount: 1,
+      assistantLastOutput: "Parent response.",
+    });
+    stateChanges.length = 0;
+    update(api, { id: "s1", state: "error", event: "ApiError" });
+
+    const session = api.sessions.get("s1");
+    assert.strictEqual(session.state, "working");
+    assert.ok(Number.isFinite(session.claudeBackgroundSubagentHoldAt));
+    mock.timers.tick(1000);
+    assert.ok(stateChanges.includes("error"));
   });
 
   it("SubagentStop followed by an older typed Stop can only become sticky-working, never prematurely complete (#952)", () => {


### PR DESCRIPTION
## Summary

- classify exact Claude background task entries whose type is subagent and forward only the aggregate count
- keep the parent session active after Stop while typed background subagents remain; an authoritative zero releases the hold
- preserve recovery-lease and privacy boundaries while suppressing premature completion notifications
- add hook, route, state, recovery, payload-size, Telegram, and Slack regressions

Fixes #952

## Testing

- relevant Node test set passes on the latest main baseline
- node syntax checks pass for all changed implementation files
- git diff --check passes
- full npm test was also attempted: changed tests passed; the remaining local failures were Windows symlink EPERM cases and the live Clawd process already owning port 23334

## Manual validation

- real Claude Code 2.1.250 background-subagent smoke is still pending until the local Claude quota refreshes