### PR TITLE
fix(dsh): support GUI-launched POSIX installs

### DIFF
--- a/docs/guides/dsh-setup.md
+++ b/docs/guides/dsh-setup.md
@@ -150,9 +150,17 @@ warnings, and rely on DSH's native web flow whenever Clawd yields no decision.
 
 - Windows x64 native DSH web is the first target. Real rc.6 install, config
   composition, web boot, uninstall, and packaged-app source loading were verified
-  on 2026-08-14; API-backed session and approval decisions remain pending and are
-  not yet described as Windows-verified. macOS, Linux, WSL, remote SSH, non-web
-  profiles, and ARM64 packaging are also unverified.
+  on 2026-08-14. On 2026-08-29, a Windows x64 real-machine smoke also verified a
+  real API-backed DSH web session and both manual Clawd **Allow Once** and **Deny**
+  approval round trips for the pinned native web target.
+- On 2026-08-29, a macOS source-checkout smoke under a Finder-like GUI `PATH`
+  verified Settings Install, managed plugin loading, a real API-backed DSH web
+  session, and both manual Clawd **Allow Once** and **Deny** approval round trips.
+  The allowed command completed with exit code 0 and the denied command produced
+  no side effect. This remains source-checkout evidence rather than macOS
+  packaged-app verification.
+- Linux, WSL, remote SSH, non-web profiles, macOS packaging, and ARM64 packaging
+  remain unverified.
 - There is no terminal-focus action because DSH web is a browser surface.
 - Closing the local bubble does not deny the request. If a configured Telegram
   or Feishu/Lark remote channel takes it, that channel may decide; otherwise DSH

--- a/hooks/dsh-install.js
+++ b/hooks/dsh-install.js
@@ -29,6 +29,7 @@ const MAX_MUTATION_LOCK_OPERATION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 const MANUAL_GENERATION_REFERENCE_FILE = "manual-generation-reference.json";
 const MANUAL_GENERATION_REFERENCE_SCHEMA_VERSION = 1;
 const MAX_COMMAND_OUTPUT_BYTES = 1024 * 1024;
+const POSIX_DISCOVERABLE_COMMANDS = new Set(["dsh", "pnpm"]);
 const BRIDGE_SOURCE_FILES = Object.freeze([
   "package.json",
   "cordis.patch.yml",
@@ -254,6 +255,78 @@ async function whereCommand(command, options = {}) {
   return (await whereCommands(command, options))[0] || null;
 }
 
+function posixShellCandidates(options = {}) {
+  const candidates = [];
+  const add = (value) => {
+    const candidate = typeof value === "string" ? value.trim() : "";
+    if (!candidate || !path.posix.isAbsolute(candidate) || candidates.includes(candidate)) return;
+    candidates.push(candidate);
+  };
+  add(options.shellPath);
+  add(options.env && options.env.SHELL);
+  add(process.env.SHELL);
+  add("/bin/zsh");
+  add("/bin/bash");
+  add("/bin/sh");
+  return candidates;
+}
+
+async function executablePathFromShellOutput(raw, options = {}) {
+  const access = options.access || fsp.access.bind(fsp);
+  const lines = String(raw || "").split(/\r?\n/);
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const candidate = lines[index].trim();
+    if (!candidate || !path.posix.isAbsolute(candidate) || candidate.includes("\0")) continue;
+    try {
+      await access(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch {}
+  }
+  return null;
+}
+
+async function resolvePosixExecutable(command, options = {}) {
+  if (!POSIX_DISCOVERABLE_COMMANDS.has(command)) return null;
+  for (const shell of posixShellCandidates(options)) {
+    for (const shellMode of ["-lc", "-lic"]) {
+      const located = await runCommand(shell, [shellMode, `command -v ${command}`], {
+        ...options,
+        timeoutMs: 5000,
+      });
+      if (located.code !== 0) continue;
+      const resolved = await executablePathFromShellOutput(located.stdout, options);
+      if (resolved) return resolved;
+    }
+  }
+  return null;
+}
+
+function buildPosixCommandEnv(options = {}, commandInfo = null, executables = []) {
+  const env = {
+    ...(options.env || process.env),
+    ...((commandInfo && commandInfo.env) || {}),
+  };
+  const currentEntries = typeof env.PATH === "string"
+    ? env.PATH.split(path.delimiter).map((entry) => entry.trim()).filter(Boolean)
+    : [];
+  const preferredEntries = executables
+    .filter((entry) => typeof entry === "string" && path.posix.isAbsolute(entry))
+    .map((entry) => path.posix.dirname(entry));
+  env.PATH = [...new Set([...preferredEntries, ...currentEntries])].join(path.delimiter);
+  return env;
+}
+
+function commandExecutionOptions(commandInfo, options = {}) {
+  if (!commandInfo || !commandInfo.env) return options;
+  return {
+    ...options,
+    env: {
+      ...(options.env || process.env),
+      ...commandInfo.env,
+    },
+  };
+}
+
 function expandShimCandidate(candidate, shim, platform) {
   const pathApi = platform === "win32" ? path.win32 : path.posix;
   const shimDir = pathApi.dirname(shim);
@@ -317,35 +390,28 @@ async function resolveDshCommand(options = {}) {
   }
   const platform = options.platform || process.platform;
   if (platform !== "win32") {
-    const shell = typeof options.shellPath === "string" && options.shellPath.trim()
-      ? options.shellPath.trim()
-      : (process.env.SHELL || "/bin/sh");
-    const located = await runCommand(shell, ["-lc", "command -v dsh"], {
-      ...options,
-      timeoutMs: 5000,
-    });
-    const bin = located.code === 0
-      ? located.stdout.split(/\r?\n/).map((line) => line.trim()).find(Boolean)
-      : null;
+    const bin = await resolvePosixExecutable("dsh", options);
     if (!bin) return null;
     let realBin = bin;
     try { realBin = await fsp.realpath(bin); } catch {}
     const normalized = realBin.replace(/\\/g, "/");
-    let installRoot = normalized.endsWith("/lib/bin.js")
-      ? path.dirname(path.dirname(realBin))
-      : null;
-    if (!installRoot) {
+    let binJs = normalized.endsWith("/lib/bin.js") ? realBin : null;
+    if (!binJs) {
       const parsed = await readShimBinCandidates(bin, platform);
-      let binJs = null;
       for (const candidate of parsed) {
         if (await exists(candidate)) {
           binJs = candidate;
           break;
         }
       }
-      if (binJs) installRoot = path.dirname(path.dirname(binJs));
     }
-    return { command: bin, prefixArgs: [], installRoot };
+    const installRoot = binJs ? path.dirname(path.dirname(binJs)) : null;
+    const nodeRunner = await resolveNodeRunner(options);
+    const env = buildPosixCommandEnv(options, null, [nodeRunner, bin]);
+    if (nodeRunner && binJs) {
+      return { command: nodeRunner, prefixArgs: [binJs], installRoot, env };
+    }
+    return { command: bin, prefixArgs: [], installRoot, env };
   }
   const shims = await whereCommands("dsh", options);
   if (shims.length === 0) return null;
@@ -380,7 +446,7 @@ async function readDshVersion(commandInfo, options = {}) {
   if (typeof options.dshVersion === "string") return parseDshVersion(options.dshVersion);
   if (!commandInfo) return null;
   const result = await runCommand(commandInfo.command, [...commandInfo.prefixArgs, "--version"], {
-    ...options,
+    ...commandExecutionOptions(commandInfo, options),
     timeoutMs: 5000,
   });
   if (result.code !== 0) return null;
@@ -392,19 +458,36 @@ async function hasDshCommand(options = {}) {
   const command = await resolveDshCommand(options);
   if (!command) return false;
   const result = await runCommand(command.command, [...command.prefixArgs, "--version"], {
-    ...options,
+    ...commandExecutionOptions(command, options),
     timeoutMs: 5000,
   });
   return result.code === 0;
 }
 
-async function hasPnpm(options = {}) {
-  if (typeof options.pnpmAvailable === "boolean") return options.pnpmAvailable;
-  if ((options.platform || process.platform) === "win32") {
-    return !!(await whereCommand("pnpm", options));
+async function resolvePnpmRuntime(commandInfo, options = {}) {
+  if (typeof options.pnpmAvailable === "boolean") {
+    return { available: options.pnpmAvailable, commandInfo };
   }
-  const result = await runCommand("pnpm", ["--version"], { ...options, timeoutMs: 5000 });
-  return result.code === 0;
+  if ((options.platform || process.platform) === "win32") {
+    return { available: !!(await whereCommand("pnpm", options)), commandInfo };
+  }
+  const pnpmCommand = await resolvePosixExecutable("pnpm", options);
+  if (!pnpmCommand) return { available: false, commandInfo };
+  const nodeRunner = await resolveNodeRunner(options);
+  const env = buildPosixCommandEnv(options, commandInfo, [pnpmCommand, nodeRunner]);
+  const result = await runCommand(pnpmCommand, ["--version"], {
+    ...options,
+    env,
+    timeoutMs: 5000,
+  });
+  return {
+    available: result.code === 0,
+    commandInfo: commandInfo ? { ...commandInfo, env } : commandInfo,
+  };
+}
+
+async function hasPnpm(options = {}) {
+  return (await resolvePnpmRuntime(null, options)).available;
 }
 
 async function isDshInstalled(options = {}) {
@@ -425,7 +508,11 @@ async function runDshCommand(args, options = {}) {
     }
     const command = await resolveDshCommand(options);
     if (!command) return { code: 127, stdout: "", stderr: "dsh command is not available" };
-    return runCommand(command.command, [...command.prefixArgs, ...args], options);
+    return runCommand(
+      command.command,
+      [...command.prefixArgs, ...args],
+      commandExecutionOptions(command, options),
+    );
   } catch (err) {
     return {
       code: 1,
@@ -1950,7 +2037,8 @@ async function syncDeepSeekHarnessIntegration(options = {}) {
         if (lockedLatch) await clearInspectionLatch(options);
         return { status: "ok", updated: false, health: locked, message: DSH_RESTART_HINT };
       }
-      if (!(await hasPnpm(options))) {
+      const pnpmRuntime = await resolvePnpmRuntime(commandInfo, options);
+      if (!pnpmRuntime.available) {
         return { status: "error", reason: "pnpm-unavailable", message: "pnpm is required by dsh plugin add" };
       }
       if (locked.owned && locked.marker) {
@@ -1965,7 +2053,7 @@ async function syncDeepSeekHarnessIntegration(options = {}) {
       const generation = await promoteGeneration(bundle, { ...options, dshVersion });
       const result = await runDshCommand([
         "plugin", "--profile", WEB_PROFILE_NAME, "add", generation.generationDir,
-      ], { ...options, commandInfo });
+      ], { ...options, commandInfo: pnpmRuntime.commandInfo });
       if (result.code !== 0) {
         const failedHealth = await inspectDeepSeekHarnessIntegration({ ...options, commandInfo });
         const unknown = isUnknownCommandResult(result);
@@ -2194,9 +2282,13 @@ async function uninstallDeepSeekHarnessBridge(options = {}) {
         if (lockedLatch) await clearInspectionLatch(options);
         return { status: "ok", removed: true, updated: true };
       }
+      const pnpmRuntime = await resolvePnpmRuntime(commandInfo, options);
+      if (!pnpmRuntime.available) {
+        return { status: "error", reason: "pnpm-unavailable", message: "pnpm is required by dsh plugin remove" };
+      }
       const result = await runDshCommand([
         "plugin", "--profile", WEB_PROFILE_NAME, "remove", BRIDGE_PACKAGE_NAME,
-      ], { ...options, commandInfo });
+      ], { ...options, commandInfo: pnpmRuntime.commandInfo });
       if (result.code !== 0) {
         const failedHealth = await inspectDeepSeekHarnessIntegration({ ...options, commandInfo });
         const unknown = isUnknownCommandResult(result);

--- a/test/dsh-install-bridge.test.js
+++ b/test/dsh-install-bridge.test.js
@@ -175,6 +175,156 @@ test("Windows CLI discovery follows a pnpm-style shim instead of assuming one gl
   assert.strictEqual(command.installRoot, path.dirname(path.dirname(binJs)));
 });
 
+test("POSIX CLI discovery resolves the DSH entrypoint through an absolute Node binary", {
+  skip: process.platform === "win32",
+}, async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-dsh-posix-cli-"));
+  const dshPath = path.join(root, "homebrew", "bin", "dsh");
+  const binJs = path.join(root, "homebrew", "lib", "node_modules", "@deepseek-ai", "dsh", "lib", "bin.js");
+  const nodePath = path.join(root, "homebrew", "opt", "node@22", "bin", "node");
+  fs.mkdirSync(path.dirname(dshPath), { recursive: true });
+  fs.mkdirSync(path.dirname(binJs), { recursive: true });
+  fs.mkdirSync(path.dirname(nodePath), { recursive: true });
+  fs.writeFileSync(binJs, "#!/usr/bin/env node\n", { mode: 0o755 });
+  fs.writeFileSync(nodePath, "#!/bin/sh\n", { mode: 0o755 });
+  fs.symlinkSync(binJs, dshPath);
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const command = await resolveDshCommand({
+    platform: "darwin",
+    shellPath: "/bin/zsh",
+    env: {
+      PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+      SHELL: "/bin/zsh",
+      DSH_HOME: path.join(root, ".dsh"),
+    },
+    resolveNodeBinAsyncImpl: async () => nodePath,
+    runCommand: async (program, args) => {
+      assert.strictEqual(program, "/bin/zsh");
+      assert.deepStrictEqual(args, ["-lc", "command -v dsh"]);
+      return { code: 0, stdout: `${dshPath}\n` };
+    },
+  });
+
+  assert.strictEqual(command.command, nodePath);
+  assert.deepStrictEqual(command.prefixArgs, [canonicalRealpath(binJs)]);
+  assert.strictEqual(command.installRoot, path.dirname(path.dirname(canonicalRealpath(binJs))));
+  assert.strictEqual(command.env.DSH_HOME, path.join(root, ".dsh"));
+  assert.deepStrictEqual(command.env.PATH.split(path.delimiter).slice(0, 2), [
+    path.dirname(nodePath),
+    path.dirname(dshPath),
+  ]);
+});
+
+test("POSIX CLI discovery uses interactive shell startup only as a fallback", {
+  skip: process.platform === "win32",
+}, async (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-dsh-posix-cli-fallback-"));
+  const dshPath = path.join(root, "interactive", "bin", "dsh");
+  const binJs = path.join(root, "interactive", "lib", "node_modules", "@deepseek-ai", "dsh", "lib", "bin.js");
+  const nodePath = path.join(root, "node", "bin", "node");
+  fs.mkdirSync(path.dirname(dshPath), { recursive: true });
+  fs.mkdirSync(path.dirname(binJs), { recursive: true });
+  fs.mkdirSync(path.dirname(nodePath), { recursive: true });
+  fs.writeFileSync(binJs, "#!/usr/bin/env node\n", { mode: 0o755 });
+  fs.writeFileSync(nodePath, "#!/bin/sh\n", { mode: 0o755 });
+  fs.symlinkSync(binJs, dshPath);
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  const discoveryCalls = [];
+  const command = await resolveDshCommand({
+    platform: "darwin",
+    shellPath: "/bin/zsh",
+    env: { PATH: "/usr/bin:/bin:/usr/sbin:/sbin", SHELL: "/bin/zsh" },
+    resolveNodeBinAsyncImpl: async () => nodePath,
+    runCommand: async (program, args) => {
+      assert.strictEqual(program, "/bin/zsh");
+      discoveryCalls.push(args);
+      if (args[0] === "-lc") return { code: 1, stderr: "dsh not found" };
+      return { code: 0, stdout: `[interactive startup]\n${dshPath}\n` };
+    },
+  });
+
+  assert.deepStrictEqual(discoveryCalls, [
+    ["-lc", "command -v dsh"],
+    ["-lic", "command -v dsh"],
+  ]);
+  assert.strictEqual(command.command, nodePath);
+  assert.deepStrictEqual(command.prefixArgs, [canonicalRealpath(binJs)]);
+});
+
+test("POSIX DSH install and uninstall reuse a GUI-safe PATH for pnpm mutations", {
+  skip: process.platform === "win32",
+}, async (t) => {
+  const harness = makeHarness();
+  const cli = makeOfficialCli(harness);
+  const toolRoot = path.join(harness.root, "toolchain");
+  const dshPath = path.join(toolRoot, "homebrew", "bin", "dsh");
+  const binJs = path.join(toolRoot, "homebrew", "lib", "node_modules", "@deepseek-ai", "dsh", "lib", "bin.js");
+  const nodePath = path.join(toolRoot, "node", "bin", "node");
+  const pnpmPath = path.join(toolRoot, "pnpm", "bin", "pnpm");
+  for (const filePath of [binJs, nodePath, pnpmPath]) {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, "#!/bin/sh\n", { mode: 0o755 });
+  }
+  fs.mkdirSync(path.dirname(dshPath), { recursive: true });
+  fs.symlinkSync(binJs, dshPath);
+  const canonicalBinJs = canonicalRealpath(binJs);
+  t.after(() => fs.rmSync(harness.root, { recursive: true, force: true }));
+
+  const guiPath = "/usr/bin:/bin:/usr/sbin:/sbin";
+  const mutationEnvs = [];
+  const runCommand = async (program, args, options) => {
+    if (program === "/bin/zsh" && args[1] === "command -v dsh") {
+      assert.deepStrictEqual(args, ["-lc", "command -v dsh"]);
+      return { code: 0, stdout: `${dshPath}\n` };
+    }
+    if (program === "/bin/zsh" && args[1] === "command -v pnpm") {
+      assert.deepStrictEqual(args, ["-lc", "command -v pnpm"]);
+      return { code: 0, stdout: `${pnpmPath}\n` };
+    }
+    if (program === pnpmPath && args[0] === "--version") {
+      assert.ok(options.env.PATH.split(path.delimiter).includes(path.dirname(nodePath)));
+      return { code: 0, stdout: "10.30.3\n" };
+    }
+    if (program === nodePath && args[0] === canonicalBinJs && args[1] === "--version") {
+      assert.ok(options.env.PATH.split(path.delimiter).includes(path.dirname(nodePath)));
+      return { code: 0, stdout: `${SUPPORTED_DSH_VERSION}\n` };
+    }
+    if (program === nodePath && args[0] === canonicalBinJs && args[1] === "plugin") {
+      mutationEnvs.push(options.env);
+      return cli.runDshCommand(args.slice(1));
+    }
+    return { code: 1, stderr: `unexpected command: ${program} ${args.join(" ")}` };
+  };
+  const options = installOptions(harness, cli, {
+    platform: "darwin",
+    env: { PATH: guiPath, SHELL: "/bin/zsh" },
+    shellPath: "/bin/zsh",
+    commandInfo: undefined,
+    dshVersion: undefined,
+    pnpmAvailable: undefined,
+    runDshCommand: undefined,
+    resolveNodeBinAsyncImpl: async () => nodePath,
+    runCommand,
+  });
+
+  const installed = await installDeepSeekHarnessBridge(options);
+  assert.strictEqual(installed.status, "ok", JSON.stringify(installed));
+  const uninstalled = await uninstallDeepSeekHarnessBridge(options);
+  assert.strictEqual(uninstalled.status, "ok", JSON.stringify(uninstalled));
+  assert.strictEqual(mutationEnvs.length, 2);
+  for (const env of mutationEnvs) {
+    const entries = env.PATH.split(path.delimiter);
+    assert.deepStrictEqual(entries.slice(0, 3), [
+      path.dirname(pnpmPath),
+      path.dirname(nodePath),
+      path.dirname(dshPath),
+    ]);
+    assert.strictEqual(env.DSH_HOME, canonicalRealpath(harness.dshHome));
+  }
+});
+
 test("the cross-process DSH mutation lock rejects a concurrent owner and releases by token", async (t) => {
   const harness = makeHarness();
   t.after(() => fs.rmSync(harness.root, { recursive: true, force: true }));


### PR DESCRIPTION
## Summary

- resolve dsh and pnpm from POSIX login-shell environments when Electron starts with a minimal GUI PATH
- execute DSH through an absolute Node binary and entrypoint while propagating the discovered toolchain PATH
- prefer non-interactive login-shell discovery and use interactive startup only as a fallback
- keep the existing Windows discovery path unchanged

Fixes #939

## Validation

- `node --test test/dsh-install-bridge.test.js`: 55 passed, 0 failed, 3 skipped
- `npm test`: 8977 passed, 0 failed, 31 skipped
- macOS real Electron smoke under a Finder-like minimal PATH: actual DSH install and uninstall both returned ok in an isolated `DSH_HOME`
- macOS real API-backed DSH web session: manual Clawd Allow Once and Deny approval round trips both passed
- Windows x64 real-machine API-backed DSH web session: manual Clawd Allow Once and Deny approval round trips both passed

## Scope

- Issue #933 version compatibility remains a separate audit
- Linux, WSL, remote SSH, non-web profiles, macOS packaging, and ARM64 packaging remain unverified
