### PR TITLE
fix(test): pin the cigarette Electron audit to a 1x device scale factor

### DIFF
--- a/test/cigarette-accessory-electron.test.js
+++ b/test/cigarette-accessory-electron.test.js
@@ -30,7 +30,9 @@ test("cigarette SMIL advances and restarts in the production mouth object channe
   const profile = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-cigarette-electron-"));
   const env = { ...process.env };
   delete env.ELECTRON_RUN_AS_NODE;
-  const args = ["--disable-gpu", `--user-data-dir=${profile}`];
+  // Fractional scale factors round the embedded SVG viewport to whole device
+  // pixels (50x90 css at 125% lands at 50.4x90.4), breaking the fixture's 0.1px fill check.
+  const args = ["--disable-gpu", "--force-device-scale-factor=1", `--user-data-dir=${profile}`];
   if (process.platform === "linux") args.push("--no-sandbox");
   args.push(fixture);
   let result;


### PR DESCRIPTION
On a Windows host with 125% display scaling, `test/cigarette-accessory-electron.test.js` (from #811) fails deterministically:

```
Error: cigarette SVG root did not fill object width
```

## Cause

The fixture compares the `<object>` box with the embedded SVG root's box to 0.1px. The cigarette object is 50×90 CSS px; at a device scale factor of 1.25 that is 62.5×112.5 device px. Chromium rounds the embedded document's viewport to whole device pixels (63×113), so the SVG root reports **50.4×90.4** CSS px while the `<object>` box stays at 50×90 — a 0.4px gap. Measured with the fixture's own layout query:

| device scale factor | outer (`<object>`) | inner (SVG root) |
|---|---|---|
| 1 | 50×90 | 50×90 |
| **1.25** | 50×90 | **50.4×90.4** |
| 1.5 | 50×90 | 50×90 |
| 2 | 50×90 | 50×90 |

Only the fractional case rounds, so CI (Linux under xvfb, Retina macOS) never sees it, while any 125%-scaled Windows machine fails the whole suite. The accessory CSS itself (`width/height: 100%`) is correct.

## Fix

Pass `--force-device-scale-factor=1` to the spawned Electron, so the fixture's exactness check exercises the accessory CSS rather than device-pixel rounding. `bubble-elicitation-layout-electron.test.js` already pins the scale factor the same way (to 1.25 on win32). The flag is unconditional: where the check was already exact it changes nothing.

## Verification

- Unmodified fixture on a 125% Windows 11 host: `--force-device-scale-factor=1` → exit 0; `--force-device-scale-factor=1.25` → exit 1 with the error above; native → exit 1.
- The test fails before the change and passes after it on that same host (`node --test test/cigarette-accessory-electron.test.js`).
- Full suite on that host, on top of current main: **9381 tests, 9341 pass, 0 fail, 40 skipped** (was 9340 pass / 1 fail).
