### PR TITLE
experiment(linux): inspect niri XWayland window coupling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -181,6 +181,11 @@ const createThemeRuntime = require("./theme-runtime");
 const createAgentRuntimeMain = require("./agent-runtime-main");
 const createFloatingWindowRuntime = require("./floating-window-runtime");
 const createPetWindowRuntime = require("./pet-window-runtime");
+const { findRenderMarkerRect } = require("./niri-inspect-artifact");
+const {
+  createNiriPlacementInspect,
+  resolveNiriInspectRequest,
+} = require("./niri-placement-inspect");
 const { collectRequiredAssetFiles } = require("./theme-schema");
 const { describeGeometrySync } = require("./pet-accessory-state");
 const { createDisplayedVisualProjection } = require("./displayed-visual-projection");
@@ -461,6 +466,11 @@ let discordPresenceBridge = null;
 let lastDiscordPresenceVisual = null;
 let displayedVisualProjection = null;
 let lastAppliedVisualGeneration = 0;
+let niriPlacementInspect = null;
+let niriInspectVisualLeaseActive = false;
+let niriInspectPreviousIdlePaused = false;
+let niriInspectPreviousRoamEnabled = false;
+let niriInspectWindowGeneration = 0;
 let suppressTelegramMigrationReconcile = 0;
 let _remoteSshTransportCoordinator = null;
 let feishuApprovalClient = null;
@@ -1399,6 +1409,7 @@ function inferVisualSource(displayState, file) {
 }
 
 function requestDisplayedVisual(displayState, file, options = {}) {
+  if (niriInspectVisualLeaseActive) return null;
   if (!displayedVisualProjection) return null;
   const activeTheme = getActiveTheme();
   return displayedVisualProjection.request({
@@ -4756,7 +4767,90 @@ registerSessionIpc({
   getLanWsServer: () => _lanWss,
 });
 
+function isRuntimeWindowVisible(candidate) {
+  try {
+    return !!candidate
+      && (typeof candidate.isDestroyed !== "function" || !candidate.isDestroyed())
+      && (typeof candidate.isVisible !== "function" || candidate.isVisible());
+  } catch {
+    return false;
+  }
+}
+
+function setNiriInspectVisualLease(active) {
+  const next = active === true;
+  if (niriInspectVisualLeaseActive === next) return;
+  if (next) {
+    niriInspectPreviousIdlePaused = idlePaused;
+    niriInspectPreviousRoamEnabled = !!(_roam && _roam.enabled);
+    idlePaused = true;
+    niriInspectVisualLeaseActive = true;
+    try { _roam.cancelRoam(); } catch {}
+    try { _roam.setEnabled(false); } catch {}
+    return;
+  }
+
+  niriInspectVisualLeaseActive = false;
+  idlePaused = niriInspectPreviousIdlePaused;
+  if (isQuitting) return;
+  try { _roam.setEnabled(niriInspectPreviousRoamEnabled); } catch {}
+  try {
+    const displayState = resolveDisplayState();
+    applyState(displayState, getSvgOverride(displayState));
+    syncHitWin();
+  } catch {}
+}
+
+function createNiriInspectPrerequisiteChecker() {
+  let baselineSignature = null;
+  return () => {
+    if (_mini.getMiniMode() || _mini.getMiniTransitioning() || _mini.getIsAnimating()) {
+      return { ok: false, reason: "mini-mode-active" };
+    }
+    if (_roam.isRoamAnimating()) return { ok: false, reason: "roam-active" };
+    if (themeRuntime.isReloadInProgress()) return { ok: false, reason: "theme-reload-active" };
+    if (petWindowRuntime.isDragLocked()) return { ok: false, reason: "drag-active" };
+    if (petWindowRuntime.isPetEffectivelyHidden()) return { ok: false, reason: "pet-hidden" };
+    if (menuOpen) return { ok: false, reason: "pet-menu-open" };
+    if (isRuntimeWindowVisible(getSettingsWindow())) return { ok: false, reason: "settings-window-visible" };
+    if (pendingPermissions.length > 0 || _perm.getVisibleBubbleBounds().length > 0) {
+      return { ok: false, reason: "permission-surface-active" };
+    }
+    if (getVisibleSessionHudBounds().length > 0) return { ok: false, reason: "session-hud-visible" };
+    if (isRuntimeWindowVisible(_updateBubble.getBubbleWindow())) {
+      return { ok: false, reason: "update-bubble-visible" };
+    }
+    if (isRuntimeWindowVisible(getQuotaRingWindow())) {
+      return { ok: false, reason: "quota-ring-visible" };
+    }
+    const snapshot = _state.buildSessionSnapshot();
+    if (snapshot.sessions.some((session) => isSessionInProgress(session))) {
+      return { ok: false, reason: "active-agent-session" };
+    }
+
+    const theme = getActiveTheme();
+    const visual = getDisplayedVisualTuple();
+    const signature = JSON.stringify({
+      themeId: theme && theme._id,
+      variantId: theme && theme._variantId,
+      size: currentSize,
+      accessories: getEffectivePetAccessoryIds(),
+      displayState: visual && visual.displayState,
+      file: visual && visual.file,
+      hitBox: visual && visual.hitBox,
+    });
+    if (baselineSignature === null) baselineSignature = signature;
+    else if (signature !== baselineSignature) return { ok: false, reason: "inspect-visual-mutated" };
+    return { ok: true };
+  };
+}
+
 function createWindow() {
+  if (niriPlacementInspect) {
+    niriPlacementInspect.dispose();
+    niriPlacementInspect = null;
+  }
+  const inspectWindowGeneration = ++niriInspectWindowGeneration;
   // Read everything from the settings controller. The mirror caches above
   // (lang/showTray/etc.) were already initialized at module-load time, so
   // here we just need the position/mini fields plus the legacy size migration.
@@ -4805,6 +4899,87 @@ function createWindow() {
     restoreMiniFromPrefs: (prefsSnapshot, pixelSize) => _mini.restoreFromPrefs(prefsSnapshot, pixelSize),
   });
 
+  const rawNiriInspectConfig = resolveNiriInspectRequest({
+    platform: process.platform,
+    env: process.env,
+    argv: process.argv,
+  });
+  let niriInspectConfig = rawNiriInspectConfig;
+  let renderInspectMarker = null;
+  if (rawNiriInspectConfig.enabled) {
+    const plannedHitBounds = petWindowRuntime.getInitialHitWindowBounds(initialVirtualBounds);
+    renderInspectMarker = findRenderMarkerRect(initialVirtualBounds, plannedHitBounds);
+    if (!renderInspectMarker) {
+      niriInspectConfig = {
+        ...rawNiriInspectConfig,
+        enabled: false,
+        reason: "render-marker-overlaps-hit-region",
+      };
+    }
+  }
+  if (niriInspectConfig.requested && !niriInspectConfig.enabled) {
+    console.warn(`Clawd niri inspect: unavailable (${niriInspectConfig.reason}) — using the normal Electron placement path.`);
+  }
+
+  let inspectRuntime = null;
+  function ensurePetHitWindow() {
+    if (hitWin && !hitWin.isDestroyed()) return hitWin;
+    hitWin = petWindowRuntime.createHitWindow({
+      BrowserWindow,
+      preloadPath: path.join(__dirname, "preload-hit.js"),
+      loadFilePath: path.join(__dirname, "hit.html"),
+      hitThemeConfig: themeRuntime.getHitRendererConfig(),
+      additionalArguments: niriInspectConfig.enabled
+        ? ["--niri-inspect-role=hit", "--niri-inspect-corner=top-left"]
+        : [],
+      deferShow: niriInspectConfig.enabled,
+      guardAlwaysOnTop,
+      onDidFinishLoad: () => {
+        sendToHitWin("theme-config", themeRuntime.getHitRendererConfig());
+        if (themeRuntime.isReloadInProgress()) return;
+        syncHitStateAfterLoad();
+      },
+      onRenderProcessGone: (details, ownedHitWin) => {
+        safeConsoleError("hitWin renderer crashed:", details.reason);
+        petWindowRuntime.setDragLocked(false);
+        petWindowRuntime.clearDragSnapshot();
+        idlePaused = false;
+        mouseOverPet = false;
+        petWindowRuntime.reloadWindowWebContents(ownedHitWin, { crashKey: "hitWin", details });
+      },
+    });
+    if (inspectRuntime) inspectRuntime.attachHitWindow(hitWin);
+    hitWin.on("move", () => petWindowRuntime.onHitNativeGeometryEvent());
+    hitWin.on("resize", () => petWindowRuntime.onHitNativeGeometryEvent());
+    return hitWin;
+  }
+
+  inspectRuntime = createNiriPlacementInspect({
+    config: niriInspectConfig,
+    ipcMain,
+    screen,
+    nativeImage,
+    pid: process.pid,
+    generation: inspectWindowGeneration,
+    isTrustedEvent: (event, contents) => isTrustedMainFrameEvent(event, contents),
+    getRenderWindow: () => win,
+    getHitWindow: () => hitWin,
+    getExpectedHitBounds: () => petWindowRuntime.getInitialHitWindowBounds(),
+    getLogicalRenderBounds: () => petWindowRuntime.getPetWindowBounds(),
+    getPhysicalRenderBounds: () => petWindowRuntime.getPhysicalRenderBounds(),
+    getViewportOffsets: () => ({
+      x: petWindowRuntime.getViewportOffsetX(),
+      y: petWindowRuntime.getViewportOffsetY(),
+    }),
+    checkDynamicPrerequisites: createNiriInspectPrerequisiteChecker(),
+    ensureHitWindow: ensurePetHitWindow,
+    showDeferredHit: () => petWindowRuntime.showHitWindow(hitWin),
+    startMainTick: () => startMainTick(),
+    setVisualLease: setNiriInspectVisualLease,
+  });
+  niriPlacementInspect = inspectRuntime;
+  inspectRuntime.registerIpc();
+
   const initialAccessoryDelivery = prepareCurrentAccessorySlotsDelivery();
   petWindowRuntime.createRenderWindow({
     BrowserWindow,
@@ -4814,10 +4989,17 @@ function createWindow() {
     preloadPath: path.join(__dirname, "preload.js"),
     loadFilePath: path.join(__dirname, "index.html"),
     themeConfig: buildRendererThemeConfig(initialAccessoryDelivery.snapshot),
+    additionalArguments: niriInspectConfig.enabled
+      ? [
+          "--niri-inspect-role=render",
+          `--niri-inspect-corner=${renderInspectMarker.corner}`,
+        ]
+      : [],
     setRenderWindow: (createdWindow) => { win = createdWindow; },
     isQuitting: () => isQuitting,
     applyDockVisibility,
   });
+  inspectRuntime.attachRenderWindow(win);
   finalizePetAccessorySlotsDelivery(initialAccessoryDelivery, true);
 
   buildContextMenu();
@@ -4825,26 +5007,10 @@ function createWindow() {
   ensureContextMenuOwner();
 
   // ── Create input window (hitWin) — small rect over hitbox, receives all pointer events ──
-  hitWin = petWindowRuntime.createHitWindow({
-    BrowserWindow,
-    preloadPath: path.join(__dirname, "preload-hit.js"),
-    loadFilePath: path.join(__dirname, "hit.html"),
-    hitThemeConfig: themeRuntime.getHitRendererConfig(),
-    guardAlwaysOnTop,
-    onDidFinishLoad: () => {
-      sendToHitWin("theme-config", themeRuntime.getHitRendererConfig());
-      if (themeRuntime.isReloadInProgress()) return;
-      syncHitStateAfterLoad();
-    },
-    onRenderProcessGone: (details, ownedHitWin) => {
-      safeConsoleError("hitWin renderer crashed:", details.reason);
-      petWindowRuntime.setDragLocked(false);
-      petWindowRuntime.clearDragSnapshot();
-      idlePaused = false;
-      mouseOverPet = false;
-      petWindowRuntime.reloadWindowWebContents(ownedHitWin, { crashKey: "hitWin", details });
-    },
-  });
+  // The inspect experiment deliberately waits for a trusted render hover
+  // before it creates/maps hitWin. Default-off retains the historical
+  // synchronous creation order exactly.
+  if (!inspectRuntime.shouldDeferHitMapping()) ensurePetHitWindow();
 
   // Issue #690 plan §4.3.9: these replace (not supplement) the previous
   // synchronous "move"/"resize" -> syncFloatingWindowsAfterPetBoundsChange()
@@ -4855,10 +5021,8 @@ function createWindow() {
   // it has classified the settled geometry.
   win.on("move", () => petWindowRuntime.onNativeGeometryEvent());
   win.on("resize", () => petWindowRuntime.onNativeGeometryEvent());
-  // §4.3.11: the hit window gets the same geometry-blind debounced treatment,
-  // on its own (longer) HIT_QUIET_MS quiet period.
-  hitWin.on("move", () => petWindowRuntime.onHitNativeGeometryEvent());
-  hitWin.on("resize", () => petWindowRuntime.onHitNativeGeometryEvent());
+  // §4.3.11 hit-window move/resize wiring is installed by
+  // ensurePetHitWindow(), including the deferred inspect path.
 
   syncSessionHudVisibility();
 
@@ -4938,7 +5102,11 @@ function createWindow() {
   });
 
   initFocusHelper();
-  startMainTick();
+  if (inspectRuntime.shouldDeferHitMapping()) {
+    void inspectRuntime.start();
+  } else {
+    startMainTick();
+  }
   // Silently connect any remote SSH profile flagged "connect on launch" once
   // the hook server is ACTUALLY listening and its real port is known.
   // runtime.connect() reads getHookServerPort() synchronously to build the SSH
@@ -5604,6 +5772,7 @@ if (!gotTheLock) {
     trayBalloonOwner.dispose();
     holidayAccessoryRuntime.dispose();
     if (systemWakeRecovery) systemWakeRecovery.dispose();
+    if (niriPlacementInspect) niriPlacementInspect.dispose();
     // #525: release the IVirtualDesktopManager COM ref and pay back our own
     // CoInitializeEx count (see win-cloak-recovery.js dispose()).
     _cloakInspector.dispose();

--- a/src/niri-inspect-artifact.js
+++ b/src/niri-inspect-artifact.js
@@ -1,0 +1,300 @@
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+
+const PNG_SIGNATURE = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+const MARKER_COLORS = Object.freeze({
+  renderPrimary: Object.freeze([0, 255, 76]),
+  renderCorner: Object.freeze([255, 255, 255]),
+  hitPrimary: Object.freeze([255, 0, 212]),
+  hitCorner: Object.freeze([0, 234, 255]),
+});
+
+const CRC32_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let index = 0; index < table.length; index += 1) {
+    let value = index;
+    for (let bit = 0; bit < 8; bit += 1) {
+      value = (value & 1) ? (0xEDB88320 ^ (value >>> 1)) : (value >>> 1);
+    }
+    table[index] = value >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buffer) {
+  let crc = 0xFFFFFFFF;
+  for (const byte of buffer) crc = CRC32_TABLE[(crc ^ byte) & 0xFF] ^ (crc >>> 8);
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+function isFiniteRect(rect) {
+  return !!rect
+    && Number.isFinite(rect.x)
+    && Number.isFinite(rect.y)
+    && Number.isFinite(rect.width)
+    && Number.isFinite(rect.height)
+    && rect.width > 0
+    && rect.height > 0;
+}
+
+function rectsOverlap(a, b) {
+  return a.x < b.x + b.width
+    && a.x + a.width > b.x
+    && a.y < b.y + b.height
+    && a.y + a.height > b.y;
+}
+
+function findRenderMarkerRect(renderBounds, hitBounds, options = {}) {
+  if (!isFiniteRect(renderBounds) || !isFiniteRect(hitBounds)) return null;
+  const markerSize = Number.isFinite(options.markerSize) ? Math.max(8, Math.round(options.markerSize)) : 14;
+  const margin = Number.isFinite(options.margin) ? Math.max(0, Math.round(options.margin)) : 3;
+  if (renderBounds.width < markerSize + margin * 2 || renderBounds.height < markerSize + margin * 2) return null;
+
+  const hitLocal = {
+    x: hitBounds.x - renderBounds.x,
+    y: hitBounds.y - renderBounds.y,
+    width: hitBounds.width,
+    height: hitBounds.height,
+  };
+  const maxX = Math.floor(renderBounds.width - margin - markerSize);
+  const maxY = Math.floor(renderBounds.height - margin - markerSize);
+  const candidates = [
+    { corner: "top-left", x: margin, y: margin, width: markerSize, height: markerSize },
+    { corner: "top-right", x: maxX, y: margin, width: markerSize, height: markerSize },
+    { corner: "bottom-left", x: margin, y: maxY, width: markerSize, height: markerSize },
+    { corner: "bottom-right", x: maxX, y: maxY, width: markerSize, height: markerSize },
+  ];
+  return candidates.find((candidate) => !rectsOverlap(candidate, hitLocal)) || null;
+}
+
+function isCompletePng(buffer) {
+  if (!Buffer.isBuffer(buffer) || buffer.length < PNG_SIGNATURE.length + 12) return false;
+  if (!buffer.subarray(0, PNG_SIGNATURE.length).equals(PNG_SIGNATURE)) return false;
+  let offset = PNG_SIGNATURE.length;
+  let chunkIndex = 0;
+  while (offset + 12 <= buffer.length) {
+    const length = buffer.readUInt32BE(offset);
+    const typeStart = offset + 4;
+    const dataEnd = typeStart + 4 + length;
+    const chunkEnd = dataEnd + 4;
+    if (chunkEnd > buffer.length) return false;
+    const type = buffer.subarray(typeStart, typeStart + 4).toString("ascii");
+    if (chunkIndex === 0 && (type !== "IHDR" || length !== 13)) return false;
+    const storedCrc = buffer.readUInt32BE(dataEnd);
+    if (crc32(buffer.subarray(typeStart, dataEnd)) !== storedCrc) return false;
+    if (type === "IEND") return length === 0 && chunkEnd === buffer.length;
+    offset = chunkEnd;
+    chunkIndex += 1;
+  }
+  return false;
+}
+
+function createCaptureTarget(options = {}) {
+  const fsImpl = options.fs || fs;
+  const tempRoot = options.tempRoot || os.tmpdir();
+  const dir = fsImpl.mkdtempSync(path.join(tempRoot, "clawd-niri-inspect-"));
+  try { fsImpl.chmodSync(dir, 0o700); } catch {}
+  const token = typeof options.token === "string" && options.token
+    ? options.token
+    : crypto.randomUUID();
+  const filePath = path.join(dir, `capture-${token}.png`);
+  assertPathAbsent(filePath, fsImpl);
+  return { dir, filePath };
+}
+
+function assertPathAbsent(filePath, fsImpl = fs) {
+  try {
+    fsImpl.accessSync(filePath, fs.constants.F_OK);
+  } catch (err) {
+    if (err && err.code === "ENOENT") return true;
+    throw err;
+  }
+  const error = new Error("niri screenshot target already exists");
+  error.code = "capture-path-exists";
+  throw error;
+}
+
+async function waitForCompletePng(filePath, options = {}) {
+  const fsImpl = options.fs || fs;
+  const timeoutMs = Number.isFinite(options.timeoutMs) ? Math.max(1, options.timeoutMs) : 4000;
+  const pollMs = Number.isFinite(options.pollMs) ? Math.max(1, options.pollMs) : 25;
+  const stableNeeded = Number.isFinite(options.stableCount) ? Math.max(1, options.stableCount) : 2;
+  const delay = options.delay || ((ms) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const deadline = Date.now() + timeoutMs;
+  let lastSize = -1;
+  let stable = 0;
+
+  while (Date.now() <= deadline) {
+    let data = null;
+    try {
+      data = fsImpl.readFileSync(filePath);
+    } catch (err) {
+      if (!err || err.code !== "ENOENT") throw err;
+    }
+    if (data && data.length > 0 && isCompletePng(data)) {
+      if (data.length === lastSize) stable += 1;
+      else stable = 1;
+      lastSize = data.length;
+      if (stable >= stableNeeded) return data;
+    } else {
+      stable = 0;
+      lastSize = data ? data.length : -1;
+    }
+    await delay(pollMs);
+  }
+  const error = new Error("niri screenshot file did not become a complete stable PNG");
+  error.code = "capture-timeout";
+  throw error;
+}
+
+function cleanupCaptureTarget(target, fsImpl = fs) {
+  if (!target || typeof target !== "object") return;
+  if (typeof target.filePath === "string") {
+    try { fsImpl.unlinkSync(target.filePath); } catch (err) { if (!err || err.code !== "ENOENT") throw err; }
+  }
+  if (typeof target.dir === "string") {
+    try { fsImpl.rmdirSync(target.dir); } catch (err) { if (!err || err.code !== "ENOENT") throw err; }
+  }
+}
+
+function colorMatches(actual, expected, tolerance) {
+  return Math.abs(actual[0] - expected[0]) <= tolerance
+    && Math.abs(actual[1] - expected[1]) <= tolerance
+    && Math.abs(actual[2] - expected[2]) <= tolerance;
+}
+
+function findColorComponents(labels, width, height, targetLabel) {
+  const visited = new Uint8Array(labels.length);
+  const components = [];
+  const queue = new Int32Array(labels.length);
+  for (let start = 0; start < labels.length; start += 1) {
+    if (labels[start] !== targetLabel || visited[start]) continue;
+    let read = 0;
+    let write = 0;
+    queue[write++] = start;
+    visited[start] = 1;
+    let count = 0;
+    let minX = width;
+    let minY = height;
+    let maxX = -1;
+    let maxY = -1;
+    while (read < write) {
+      const index = queue[read++];
+      const x = index % width;
+      const y = Math.floor(index / width);
+      count += 1;
+      minX = Math.min(minX, x);
+      minY = Math.min(minY, y);
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+      const neighbours = [index - 1, index + 1, index - width, index + width];
+      for (const neighbour of neighbours) {
+        if (neighbour < 0 || neighbour >= labels.length || visited[neighbour]) continue;
+        const nx = neighbour % width;
+        if (Math.abs(nx - x) > 1) continue;
+        if (labels[neighbour] !== targetLabel) continue;
+        visited[neighbour] = 1;
+        queue[write++] = neighbour;
+      }
+    }
+    components.push({ count, minX, minY, maxX, maxY });
+  }
+  return components;
+}
+
+function hasCornerPair(primaryComponents, cornerComponents, direction, thresholds) {
+  return primaryComponents.some((primary) => {
+    if (primary.count < thresholds.primary) return false;
+    const primaryWidth = primary.maxX - primary.minX + 1;
+    const primaryHeight = primary.maxY - primary.minY + 1;
+    if (primaryWidth < 6 || primaryHeight < 6) return false;
+    const tolerance = Math.max(2, Math.ceil(Math.max(primaryWidth, primaryHeight) * 0.2));
+    return cornerComponents.some((corner) => {
+      if (corner.count < thresholds.corner) return false;
+      const alignedX = direction === "bottom-right"
+        ? Math.abs(corner.maxX - primary.maxX) <= tolerance
+        : Math.abs(corner.minX - primary.minX) <= tolerance;
+      const alignedY = direction === "bottom-right"
+        ? Math.abs(corner.maxY - primary.maxY) <= tolerance
+        : Math.abs(corner.minY - primary.minY) <= tolerance;
+      const onExpectedHalf = direction === "bottom-right"
+        ? corner.minX >= primary.minX + primaryWidth / 2 - tolerance
+          && corner.minY >= primary.minY + primaryHeight / 2 - tolerance
+        : corner.maxX <= primary.minX + primaryWidth / 2 + tolerance
+          && corner.maxY <= primary.minY + primaryHeight / 2 + tolerance;
+      return alignedX && alignedY && onExpectedHalf;
+    });
+  });
+}
+
+function scanNativeImage(nativeImageValue, options = {}) {
+  if (!nativeImageValue || typeof nativeImageValue.isEmpty !== "function" || nativeImageValue.isEmpty()) {
+    return { valid: false, render: false, hit: false, counts: {} };
+  }
+  const size = nativeImageValue.getSize();
+  const bitmap = nativeImageValue.toBitmap();
+  if (!size || !Number.isFinite(size.width) || !Number.isFinite(size.height) || bitmap.length !== size.width * size.height * 4) {
+    return { valid: false, render: false, hit: false, counts: {} };
+  }
+  const tolerance = Number.isFinite(options.tolerance) ? Math.max(0, options.tolerance) : 28;
+  const alphaFloor = Number.isFinite(options.alphaFloor) ? Math.max(0, Math.min(255, options.alphaFloor)) : 128;
+  const counts = {
+    renderPrimary: 0,
+    renderCorner: 0,
+    hitPrimary: 0,
+    hitCorner: 0,
+  };
+  const labels = new Uint8Array(size.width * size.height);
+  const colorEntries = Object.entries(MARKER_COLORS);
+  for (let offset = 0; offset + 3 < bitmap.length; offset += 4) {
+    const alpha = bitmap[offset + 3];
+    if (alpha < alphaFloor) continue;
+    const scale = 255 / alpha;
+    const rgb = [
+      Math.min(255, Math.round(bitmap[offset + 2] * scale)),
+      Math.min(255, Math.round(bitmap[offset + 1] * scale)),
+      Math.min(255, Math.round(bitmap[offset] * scale)),
+    ];
+    for (let colorIndex = 0; colorIndex < colorEntries.length; colorIndex += 1) {
+      const [name, expected] = colorEntries[colorIndex];
+      if (colorMatches(rgb, expected, tolerance)) {
+        counts[name] += 1;
+        labels[offset / 4] = colorIndex + 1;
+        break;
+      }
+    }
+  }
+  const components = Object.fromEntries(colorEntries.map(([name], colorIndex) => [
+    name,
+    findColorComponents(labels, size.width, size.height, colorIndex + 1),
+  ]));
+  const render = hasCornerPair(
+    components.renderPrimary,
+    components.renderCorner,
+    "bottom-right",
+    { primary: 24, corner: 4 },
+  );
+  const hit = hasCornerPair(
+    components.hitPrimary,
+    components.hitCorner,
+    "top-left",
+    { primary: 20, corner: 4 },
+  );
+  return { valid: true, render, hit, counts, size };
+}
+
+module.exports = {
+  MARKER_COLORS,
+  assertPathAbsent,
+  cleanupCaptureTarget,
+  createCaptureTarget,
+  findRenderMarkerRect,
+  isCompletePng,
+  rectsOverlap,
+  scanNativeImage,
+  waitForCompletePng,
+};

--- a/src/niri-inspect-marker.css
+++ b/src/niri-inspect-marker.css
@@ -1,0 +1,42 @@
+.niri-inspect-marker {
+  position: fixed;
+  z-index: 2147483647;
+  width: 14px;
+  height: 14px;
+  box-sizing: border-box;
+  pointer-events: none;
+}
+
+.niri-inspect-marker--top-left { left: 3px; top: 3px; }
+.niri-inspect-marker--top-right { right: 3px; top: 3px; }
+.niri-inspect-marker--bottom-left { left: 3px; bottom: 3px; }
+.niri-inspect-marker--bottom-right { right: 3px; bottom: 3px; }
+
+.niri-inspect-marker--render {
+  background: rgb(0, 255, 76);
+  border: 2px solid rgb(7, 7, 7);
+}
+
+.niri-inspect-marker--render::after {
+  content: "";
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  right: 0;
+  bottom: 0;
+  background: rgb(255, 255, 255);
+}
+
+.niri-inspect-marker--hit {
+  border: 3px solid rgb(255, 0, 212);
+}
+
+.niri-inspect-marker--hit::after {
+  content: "";
+  position: absolute;
+  width: 4px;
+  height: 4px;
+  left: -3px;
+  top: -3px;
+  background: rgb(0, 234, 255);
+}

--- a/src/niri-inspect-preload.js
+++ b/src/niri-inspect-preload.js
@@ -1,0 +1,79 @@
+"use strict";
+
+const VALID_CORNERS = new Set(["top-left", "top-right", "bottom-left", "bottom-right"]);
+
+function readArg(argv, prefix) {
+  for (let index = argv.length - 1; index >= 0; index -= 1) {
+    const value = argv[index];
+    if (typeof value === "string" && value.startsWith(prefix)) return value.slice(prefix.length);
+  }
+  return null;
+}
+
+function exposeNiriInspectBridge(_contextBridge, ipcRenderer, argv = process.argv, globals = {}) {
+  const role = readArg(argv, "--niri-inspect-role=");
+  if (role !== "render" && role !== "hit") return false;
+  const requestedCorner = readArg(argv, "--niri-inspect-corner=");
+  const corner = VALID_CORNERS.has(requestedCorner)
+    ? requestedCorner
+    : "top-left";
+  const windowValue = globals.window || window;
+  const documentValue = globals.document || document;
+
+  const installMarker = () => {
+    const marker = documentValue.createElement("div");
+    marker.id = `niri-inspect-${role}-marker`;
+    marker.className = [
+      "niri-inspect-marker",
+      `niri-inspect-marker--${role}`,
+      `niri-inspect-marker--${role === "hit" ? "top-left" : corner}`,
+    ].join(" ");
+    marker.setAttribute("aria-hidden", "true");
+    documentValue.body.appendChild(marker);
+
+    if (role === "render") {
+      const pointerRoot = documentValue.documentElement;
+      if (!pointerRoot || typeof pointerRoot.addEventListener !== "function") return;
+      pointerRoot.addEventListener("pointerenter", (event) => {
+        if (event.relatedTarget !== null) return;
+        ipcRenderer.send("niri-inspect-render-pointer", {
+          role,
+          inside: true,
+          screenX: Number.isFinite(event.screenX) ? event.screenX : null,
+          screenY: Number.isFinite(event.screenY) ? event.screenY : null,
+        });
+      }, true);
+      pointerRoot.addEventListener("pointerleave", (event) => {
+        if (event.relatedTarget !== null) return;
+        ipcRenderer.send("niri-inspect-render-pointer", {
+          role,
+          inside: false,
+          screenX: Number.isFinite(event.screenX) ? event.screenX : null,
+          screenY: Number.isFinite(event.screenY) ? event.screenY : null,
+        });
+      }, true);
+    }
+
+    windowValue.requestAnimationFrame(() => {
+      windowValue.requestAnimationFrame(() => {
+        ipcRenderer.send("niri-inspect-renderer-ready", { role });
+      });
+    });
+  };
+
+  const install = () => {
+    const stylesheet = documentValue.createElement("link");
+    stylesheet.rel = "stylesheet";
+    stylesheet.href = "niri-inspect-marker.css";
+    stylesheet.addEventListener("load", installMarker, { once: true });
+    documentValue.head.appendChild(stylesheet);
+  };
+  if (documentValue.readyState === "loading") {
+    documentValue.addEventListener("DOMContentLoaded", install, { once: true });
+  } else {
+    install();
+  }
+  return true;
+}
+
+module.exports = { exposeNiriInspectBridge };

--- a/src/niri-ipc-client.js
+++ b/src/niri-ipc-client.js
@@ -1,0 +1,306 @@
+"use strict";
+
+const net = require("net");
+
+const DEFAULT_TIMEOUT_MS = 3000;
+const DEFAULT_LINE_LIMIT = 1024 * 1024;
+
+class NiriIpcError extends Error {
+  constructor(code, message, options = {}) {
+    super(message);
+    this.name = "NiriIpcError";
+    this.code = code;
+    this.poisoned = options.poisoned === true;
+  }
+}
+
+function decodeReply(line) {
+  let parsed;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    throw new NiriIpcError("invalid-json", "niri returned invalid JSON", { poisoned: true });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new NiriIpcError("invalid-reply", "niri returned an invalid reply envelope", { poisoned: true });
+  }
+  if (Object.prototype.hasOwnProperty.call(parsed, "Err")) {
+    const message = typeof parsed.Err === "string" ? parsed.Err : "niri returned an error";
+    throw new NiriIpcError("niri-error", message);
+  }
+  if (!Object.prototype.hasOwnProperty.call(parsed, "Ok")) {
+    throw new NiriIpcError("invalid-reply", "niri reply omitted Ok/Err", { poisoned: true });
+  }
+  return parsed.Ok;
+}
+
+function decodeTaggedResponse(response, tag) {
+  if (!response || typeof response !== "object" || Array.isArray(response)) {
+    throw new NiriIpcError("unexpected-response", `niri response was not ${tag}`);
+  }
+  if (!Object.prototype.hasOwnProperty.call(response, tag)) {
+    throw new NiriIpcError("unexpected-response", `niri response omitted ${tag}`);
+  }
+  return response[tag];
+}
+
+class NiriIpcClient {
+  constructor(options = {}) {
+    this.socketPath = options.socketPath;
+    this.timeoutMs = Number.isFinite(options.timeoutMs)
+      ? Math.max(1, options.timeoutMs)
+      : DEFAULT_TIMEOUT_MS;
+    this.lineLimit = Number.isFinite(options.lineLimit)
+      ? Math.max(256, options.lineLimit)
+      : DEFAULT_LINE_LIMIT;
+    this.createConnection = options.createConnection || ((socketPath) => net.createConnection(socketPath));
+
+    this.socket = null;
+    this.connected = false;
+    this.buffer = Buffer.alloc(0);
+    this.queue = [];
+    this.pending = null;
+    this.connectPromise = null;
+    this.closed = false;
+    this.poisoned = false;
+  }
+
+  request(payload) {
+    if (this.closed) {
+      return Promise.reject(new NiriIpcError("closed", "niri IPC client is closed"));
+    }
+    if (this.poisoned) {
+      return Promise.reject(new NiriIpcError("poisoned", "niri IPC client is poisoned", { poisoned: true }));
+    }
+    return new Promise((resolve, reject) => {
+      this.queue.push({ payload, resolve, reject });
+      this._pump();
+    });
+  }
+
+  version() {
+    return this.request("Version").then((response) => {
+      const value = decodeTaggedResponse(response, "Version");
+      if (typeof value !== "string") {
+        throw new NiriIpcError("unexpected-response", "niri Version response was not a string");
+      }
+      return value;
+    });
+  }
+
+  windows() {
+    return this.request("Windows").then((response) => {
+      const value = decodeTaggedResponse(response, "Windows");
+      if (!Array.isArray(value)) {
+        throw new NiriIpcError("unexpected-response", "niri Windows response was not an array");
+      }
+      return value;
+    });
+  }
+
+  screenshotWindow(options = {}) {
+    const id = options.id;
+    const filePath = options.path;
+    if (!Number.isSafeInteger(id) || id < 0) {
+      return Promise.reject(new NiriIpcError("invalid-request", "ScreenshotWindow requires a safe window id"));
+    }
+    if (typeof filePath !== "string" || !filePath.startsWith("/")) {
+      return Promise.reject(new NiriIpcError("invalid-request", "ScreenshotWindow requires an absolute path"));
+    }
+    return this.request({
+      Action: {
+        ScreenshotWindow: {
+          id,
+          write_to_disk: true,
+          show_pointer: false,
+          path: filePath,
+        },
+      },
+    }).then((response) => {
+      if (response !== "Handled") {
+        throw new NiriIpcError("unexpected-response", "niri ScreenshotWindow was not Handled");
+      }
+      return true;
+    });
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    const error = new NiriIpcError("closed", "niri IPC client closed");
+    this._rejectAll(error);
+    if (this.socket) {
+      try { this.socket.destroy(); } catch {}
+    }
+    this.socket = null;
+    this.connected = false;
+  }
+
+  _connect() {
+    if (this.connectPromise) return this.connectPromise;
+    if (this.socket && this.connected) return Promise.resolve();
+    this.connectPromise = new Promise((resolve, reject) => {
+      let socket;
+      try {
+        socket = this.createConnection(this.socketPath);
+      } catch (err) {
+        reject(new NiriIpcError("connect", `could not connect to niri: ${err && err.message ? err.message : err}`));
+        return;
+      }
+      this.socket = socket;
+      let settled = false;
+      const onConnect = () => {
+        if (settled) return;
+        settled = true;
+        cleanupConnectListeners();
+        this.connected = true;
+        this._wireSocket(socket);
+        resolve();
+      };
+      const onError = (err) => {
+        if (settled) return;
+        settled = true;
+        cleanupConnectListeners();
+        this.socket = null;
+        this.connected = false;
+        reject(new NiriIpcError("connect", `could not connect to niri: ${err && err.message ? err.message : err}`));
+      };
+      const cleanupConnectListeners = () => {
+        socket.removeListener("connect", onConnect);
+        socket.removeListener("error", onError);
+      };
+      socket.once("connect", onConnect);
+      socket.once("error", onError);
+    }).finally(() => {
+      this.connectPromise = null;
+    });
+    return this.connectPromise;
+  }
+
+  _wireSocket(socket) {
+    socket.on("data", (chunk) => this._onData(chunk));
+    socket.on("error", (err) => this._poison("socket-error", err && err.message ? err.message : "niri socket error"));
+    socket.on("end", () => this._poison("eof", "niri socket closed"));
+    socket.on("close", () => {
+      if (!this.closed && !this.poisoned) this._poison("eof", "niri socket closed");
+    });
+  }
+
+  _pump() {
+    if (this.pending || this.closed || this.poisoned || this.queue.length === 0) return;
+    this._connect().then(() => {
+      if (this.pending || this.closed || this.poisoned || this.queue.length === 0) return;
+      const item = this.queue.shift();
+      let encoded;
+      try {
+        encoded = `${JSON.stringify(item.payload)}\n`;
+      } catch (err) {
+        item.reject(new NiriIpcError("invalid-request", err && err.message ? err.message : "request is not serializable"));
+        this._pump();
+        return;
+      }
+      const timer = setTimeout(() => {
+        this._poison("timeout", "niri IPC request timed out");
+      }, this.timeoutMs);
+      this.pending = { ...item, timer };
+      try {
+        this.socket.write(encoded, (err) => {
+          if (err) this._poison("write", err.message || "niri IPC write failed");
+        });
+      } catch (err) {
+        this._poison("write", err && err.message ? err.message : "niri IPC write failed");
+      }
+    }).catch((err) => {
+      const item = this.queue.shift();
+      if (item) item.reject(err);
+      this._pump();
+    });
+  }
+
+  _onData(chunk) {
+    if (this.poisoned || this.closed) return;
+    const incoming = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    this.buffer = Buffer.concat([this.buffer, incoming]);
+    if (this.buffer.length > this.lineLimit && this.buffer.indexOf(0x0A) < 0) {
+      this._poison("oversize", "niri IPC reply exceeded the line limit");
+      return;
+    }
+    while (!this.poisoned) {
+      const newline = this.buffer.indexOf(0x0A);
+      if (newline < 0) break;
+      if (newline > this.lineLimit) {
+        this._poison("oversize", "niri IPC reply exceeded the line limit");
+        return;
+      }
+      const line = this.buffer.subarray(0, newline).toString("utf8");
+      this.buffer = this.buffer.subarray(newline + 1);
+      if (!line.trim()) {
+        this._poison("invalid-reply", "niri IPC returned an empty line");
+        return;
+      }
+      if (!this.pending) {
+        this._poison("desync", "niri IPC returned an unsolicited reply");
+        return;
+      }
+      const pending = this.pending;
+      this.pending = null;
+      clearTimeout(pending.timer);
+      try {
+        pending.resolve(decodeReply(line));
+      } catch (err) {
+        pending.reject(err);
+        if (err && err.poisoned) {
+          this._poison(err.code || "invalid-reply", err.message, { rejectPending: false });
+          return;
+        }
+      }
+      this._pump();
+    }
+    if (
+      !this.poisoned
+      && this.buffer.length > this.lineLimit
+      && this.buffer.indexOf(0x0A) < 0
+    ) {
+      this._poison("oversize", "niri IPC reply exceeded the line limit");
+    }
+  }
+
+  _poison(code, message, options = {}) {
+    if (this.poisoned || this.closed) return;
+    this.poisoned = true;
+    const error = new NiriIpcError(code, message, { poisoned: true });
+    if (options.rejectPending !== false && this.pending) {
+      const pending = this.pending;
+      this.pending = null;
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    while (this.queue.length) this.queue.shift().reject(error);
+    if (this.socket) {
+      try { this.socket.destroy(); } catch {}
+    }
+    this.socket = null;
+    this.connected = false;
+  }
+
+  _rejectAll(error) {
+    if (this.pending) {
+      const pending = this.pending;
+      this.pending = null;
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    while (this.queue.length) this.queue.shift().reject(error);
+  }
+}
+
+function createNiriIpcClient(options) {
+  return new NiriIpcClient(options);
+}
+
+module.exports = {
+  NiriIpcClient,
+  NiriIpcError,
+  createNiriIpcClient,
+  decodeReply,
+};

--- a/src/niri-placement-inspect.js
+++ b/src/niri-placement-inspect.js
@@ -1,0 +1,656 @@
+"use strict";
+
+const { execFile } = require("child_process");
+const { promisify } = require("util");
+const {
+  cleanupCaptureTarget,
+  createCaptureTarget,
+  scanNativeImage,
+  waitForCompletePng,
+} = require("./niri-inspect-artifact");
+const { createNiriIpcClient } = require("./niri-ipc-client");
+
+const execFileAsync = promisify(execFile);
+const POINTER_DWELL_MS = 80;
+const POINTER_TIMEOUT_MS = 20000;
+const READY_TIMEOUT_MS = 5000;
+const WINDOWS_TIMEOUT_MS = 3000;
+const EDGE_MARGIN = 100;
+
+const TRANSITIONS = Object.freeze({
+  off: new Set(["inspecting"]),
+  inspecting: new Set(["parent-coupled-candidate", "unavailable", "faulted"]),
+  "parent-coupled-candidate": new Set(["faulted"]),
+  unavailable: new Set(),
+  faulted: new Set(),
+});
+
+function resolveNiriInspectRequest(options = {}) {
+  const env = options.env || process.env;
+  const argv = options.argv || process.argv;
+  const platform = options.platform || process.platform;
+  if (env.CLAWD_WINDOW_PLACEMENT !== "niri-ipc") {
+    return { requested: false, enabled: false, reason: "default-off", stage: null };
+  }
+  const stage = env.CLAWD_NIRI_STAGE || "inspect";
+  if (stage !== "inspect") {
+    return { requested: true, enabled: false, reason: `stage-${stage}-not-implemented`, stage };
+  }
+  if (platform !== "linux") return { requested: true, enabled: false, reason: "not-linux", stage };
+  if (!argv.includes("--ozone-platform=x11")) {
+    return { requested: true, enabled: false, reason: "not-canonical-x11", stage };
+  }
+  if (typeof env.NIRI_SOCKET !== "string" || !env.NIRI_SOCKET.trim()) {
+    return { requested: true, enabled: false, reason: "missing-niri-socket", stage };
+  }
+  if (env.CLAWD_DISABLE_EDGE_VIRTUALIZATION !== "1") {
+    return { requested: true, enabled: false, reason: "edge-virtualization-enabled", stage };
+  }
+  return {
+    requested: true,
+    enabled: true,
+    reason: null,
+    stage,
+    socketPath: env.NIRI_SOCKET.trim(),
+  };
+}
+
+function matchesNiri2604Release(raw) {
+  if (typeof raw !== "string") return false;
+  return /^26\.04(?:\.\d+)?(?: \([^\r\n()]+\))?$/.test(raw.trim());
+}
+
+function rectsNear(a, b, tolerance = 2) {
+  if (!a || !b) return false;
+  return ["x", "y", "width", "height"].every((key) => (
+    Number.isFinite(a[key])
+    && Number.isFinite(b[key])
+    && Math.abs(a[key] - b[key]) <= tolerance
+  ));
+}
+
+function isWindowInterior(windowInfo, display, margin = EDGE_MARGIN) {
+  const layout = windowInfo && windowInfo.layout;
+  const pos = layout && layout.tile_pos_in_workspace_view;
+  const size = layout && layout.tile_size;
+  const workArea = display && display.workArea;
+  if (!Array.isArray(pos) || pos.length !== 2 || !Array.isArray(size) || size.length !== 2) return false;
+  if (!workArea || !Number.isFinite(workArea.width) || !Number.isFinite(workArea.height)) return false;
+  const [x, y] = pos;
+  const [width, height] = size;
+  if (![x, y, width, height].every(Number.isFinite)) return false;
+  return x >= margin
+    && y >= margin
+    && x + width <= workArea.width - margin
+    && y + height <= workArea.height - margin;
+}
+
+async function queryX11TitleCounts(titles, options = {}) {
+  const exec = options.execFile || execFileAsync;
+  const result = await exec("xwininfo", ["-root", "-tree"], {
+    timeout: 2500,
+    maxBuffer: 1024 * 1024,
+    encoding: "utf8",
+  });
+  const stdout = typeof result === "string" ? result : result.stdout;
+  const lines = String(stdout || "").split(/\r?\n/);
+  const counts = {};
+  for (const title of titles) {
+    const quoted = `"${title}"`;
+    const matches = lines.filter((line) => line.includes(quoted));
+    counts[title] = {
+      count: matches.length,
+      sizes: matches.map((line) => {
+        const geometry = line.match(/\b(\d+)x(\d+)[+-]\d+[+-]\d+/);
+        return geometry
+          ? { width: Number(geometry[1]), height: Number(geometry[2]) }
+          : null;
+      }),
+    };
+  }
+  return counts;
+}
+
+function windowTitle(role, pid, generation, loadEpoch) {
+  return `Clawd niri ${role} ${pid}-${generation}-${loadEpoch}`;
+}
+
+function tombstoneTitle(role, pid, generation, loadEpoch) {
+  return `Clawd niri ${role} loading ${pid}-${generation}-${loadEpoch}`;
+}
+
+function safeWindow(win) {
+  return !!win && (typeof win.isDestroyed !== "function" || !win.isDestroyed());
+}
+
+function safeContents(win) {
+  return safeWindow(win)
+    && win.webContents
+    && (typeof win.webContents.isDestroyed !== "function" || !win.webContents.isDestroyed());
+}
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+class NiriPlacementInspect {
+  constructor(options = {}) {
+    this.config = options.config || resolveNiriInspectRequest(options);
+    this.ipcMain = options.ipcMain;
+    this.screen = options.screen;
+    this.nativeImage = options.nativeImage;
+    this.pid = Number.isSafeInteger(options.pid) ? options.pid : process.pid;
+    this.appId = options.appId || "clawd-on-desk";
+    this.isTrustedEvent = options.isTrustedEvent || (() => false);
+    this.getRenderWindow = options.getRenderWindow || (() => null);
+    this.getHitWindow = options.getHitWindow || (() => null);
+    this.getExpectedHitBounds = options.getExpectedHitBounds || (() => null);
+    this.getLogicalRenderBounds = options.getLogicalRenderBounds || (() => null);
+    this.getPhysicalRenderBounds = options.getPhysicalRenderBounds || (() => null);
+    this.getViewportOffsets = options.getViewportOffsets || (() => ({ x: 0, y: 0 }));
+    this.checkDynamicPrerequisites = options.checkDynamicPrerequisites || (() => ({ ok: true }));
+    this.ensureHitWindow = options.ensureHitWindow || (() => null);
+    this.showDeferredHit = options.showDeferredHit || (() => {});
+    this.startMainTick = options.startMainTick || (() => {});
+    this.setVisualLease = options.setVisualLease || (() => {});
+    this.logger = options.logger || ((line) => console.log(line));
+    this.clientFactory = options.clientFactory || ((clientOptions) => createNiriIpcClient(clientOptions));
+    this.queryX11Titles = options.queryX11Titles || queryX11TitleCounts;
+    this.createCaptureTarget = options.createCaptureTarget || createCaptureTarget;
+    this.waitForCompletePng = options.waitForCompletePng || waitForCompletePng;
+    this.cleanupCaptureTarget = options.cleanupCaptureTarget || cleanupCaptureTarget;
+    this.delay = options.delay || delay;
+    this.pointerDwellMs = options.pointerDwellMs || POINTER_DWELL_MS;
+    this.pointerTimeoutMs = options.pointerTimeoutMs || POINTER_TIMEOUT_MS;
+    this.readyTimeoutMs = options.readyTimeoutMs || READY_TIMEOUT_MS;
+    this.windowsTimeoutMs = options.windowsTimeoutMs || WINDOWS_TIMEOUT_MS;
+
+    this.state = "off";
+    this.generation = Number.isSafeInteger(options.generation) && options.generation > 0
+      ? options.generation
+      : 1;
+    this.renderLoadEpoch = 0;
+    this.hitLoadEpoch = 0;
+    this.renderReady = false;
+    this.hitReady = false;
+    this.pointerInside = false;
+    this.pointerSample = null;
+    this.acceptPointer = false;
+    this.pointerWaiter = null;
+    this.legacyReleased = false;
+    this.legacyReleaseBlocked = false;
+    this.renderInputSafetyReleased = false;
+    this.visualLease = false;
+    this.started = false;
+    this.disposed = false;
+    this.client = null;
+    this.disposers = [];
+    this.result = null;
+    this.invalidReason = null;
+    this.hitInitialShowPending = false;
+  }
+
+  shouldDeferHitMapping() {
+    return this.config.enabled === true;
+  }
+
+  registerIpc() {
+    if (!this.config.enabled || !this.ipcMain || typeof this.ipcMain.on !== "function") return;
+    const onReady = (event, payload) => this._onRendererReady(event, payload);
+    const onPointer = (event, payload) => this._onRenderPointer(event, payload);
+    this.ipcMain.on("niri-inspect-renderer-ready", onReady);
+    this.ipcMain.on("niri-inspect-render-pointer", onPointer);
+    this.disposers.push(() => this.ipcMain.removeListener("niri-inspect-renderer-ready", onReady));
+    this.disposers.push(() => this.ipcMain.removeListener("niri-inspect-render-pointer", onPointer));
+    if (this.screen && typeof this.screen.on === "function") {
+      const invalidateTopology = () => this._invalidate("display-topology-changed");
+      this.screen.on("display-added", invalidateTopology);
+      this.screen.on("display-removed", invalidateTopology);
+      this.screen.on("display-metrics-changed", invalidateTopology);
+      this.disposers.push(() => this.screen.removeListener("display-added", invalidateTopology));
+      this.disposers.push(() => this.screen.removeListener("display-removed", invalidateTopology));
+      this.disposers.push(() => this.screen.removeListener("display-metrics-changed", invalidateTopology));
+    }
+  }
+
+  attachRenderWindow(win) {
+    if (!this.config.enabled || !safeContents(win)) return;
+    this._attachIdentityLifecycle(win, "render");
+  }
+
+  attachHitWindow(win) {
+    if (!this.config.enabled || !safeContents(win)) return;
+    this.hitInitialShowPending = typeof win.isVisible === "function" && !win.isVisible();
+    this._attachIdentityLifecycle(win, "hit");
+  }
+
+  async start() {
+    if (!this.config.enabled || this.started || this.disposed) return null;
+    this.started = true;
+    this._transition("inspecting");
+    try {
+      await this._waitUntil(() => this.renderReady, this.readyTimeoutMs, "render-marker-ready-timeout");
+      this._checkPrerequisites();
+      this.client = this.clientFactory({ socketPath: this.config.socketPath });
+      const version = await this.client.version();
+      this._checkPrerequisites();
+      if (!matchesNiri2604Release(version)) throw this._unavailable("unsupported-niri-version");
+      this._checkPrerequisites();
+      this._setVisualLease(true);
+      this.acceptPointer = true;
+      this.pointerInside = false;
+      this.pointerSample = null;
+      this.logger("Clawd niri inspect: this run will request one compositor screenshot; save clipboard contents first and allow the notification to clear naturally.");
+      this.logger("Clawd niri inspect: move the pointer onto the visible pet and keep it still until the hit window maps.");
+      const pointer = await this._waitForPointerDwell();
+      this._checkPrerequisites();
+      const createdHit = this.ensureHitWindow();
+      if (!safeContents(createdHit)) throw this._unavailable("hit-window-create-failed");
+      await this._waitUntil(() => this.hitReady, this.readyTimeoutMs, "hit-marker-ready-timeout");
+      this._checkPrerequisites();
+      this.acceptPointer = false;
+      this._releaseToLegacy();
+      if (!this.legacyReleased) throw this._unavailable("hit-geometry-mismatch");
+      const topology = await this._inspectTopology();
+      this._checkPrerequisites();
+      const marker = await this._inspectMarkers(topology.render.id);
+      this._checkPrerequisites();
+      if (!marker.render || !marker.hit) throw this._unavailable("marker-oracle-ambiguous");
+      this._transition("parent-coupled-candidate");
+      this.result = Object.freeze({
+        stage: "inspect",
+        verdict: "parent-coupled-candidate",
+        version,
+        handshake: { screenX: pointer.screenX, screenY: pointer.screenY },
+        render: {
+          id: topology.render.id,
+          workspaceId: topology.render.workspace_id,
+          isFloating: topology.render.is_floating === true,
+          layout: topology.render.layout,
+        },
+        hit: {
+          managed: false,
+          expectedBounds: topology.expectedHitBounds,
+          electronBounds: topology.actualHitBounds,
+        },
+        logicalRenderBounds: topology.logicalRenderBounds,
+        physicalRenderBounds: topology.physicalRenderBounds,
+        workArea: topology.workArea,
+        viewportOffsets: topology.viewportOffsets,
+        scaleFactor: topology.scaleFactor,
+        markers: marker,
+      });
+      this.logger(`Clawd niri inspect artifact: ${JSON.stringify(this.result)}`);
+      return this.result;
+    } catch (err) {
+      const reason = err && err.code ? err.code : "inspect-failed";
+      if (this.state === "inspecting") this._transition(err && err.faulted ? "faulted" : "unavailable");
+      this.result = Object.freeze({ stage: "inspect", verdict: this.state, reason });
+      this.logger(`Clawd niri inspect unavailable: ${reason}`);
+      return this.result;
+    } finally {
+      this.acceptPointer = false;
+      this._clearPointerWaiter();
+      this._releaseToLegacy();
+      this._setVisualLease(false);
+    }
+  }
+
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.invalidReason = this.invalidReason || "disposed";
+    this._rejectPointerWaiter(this._unavailable(this.invalidReason));
+    while (this.disposers.length) {
+      try { this.disposers.pop()(); } catch {}
+    }
+    if (this.client) this.client.close();
+    this.client = null;
+    this._setVisualLease(false);
+  }
+
+  _attachIdentityLifecycle(win, role) {
+    const onStart = () => {
+      if (role === "render") {
+        this.renderLoadEpoch += 1;
+        this.renderReady = false;
+      } else {
+        this.hitLoadEpoch += 1;
+        this.hitReady = false;
+      }
+      const epoch = role === "render" ? this.renderLoadEpoch : this.hitLoadEpoch;
+      try { win.setTitle(tombstoneTitle(role, this.pid, this.generation, epoch)); } catch {}
+      if (this.started && this.state === "inspecting") {
+        this._invalidate(`${role}-reload`);
+      }
+    };
+    const onFinish = () => {
+      const epoch = role === "render" ? this.renderLoadEpoch : this.hitLoadEpoch;
+      try { win.setTitle(windowTitle(role, this.pid, this.generation, epoch)); } catch {}
+    };
+    const onPageTitle = (event) => {
+      if (event && typeof event.preventDefault === "function") event.preventDefault();
+    };
+    win.webContents.on("did-start-loading", onStart);
+    win.webContents.on("did-finish-load", onFinish);
+    if (typeof win.on === "function") win.on("page-title-updated", onPageTitle);
+    const onGone = () => this._invalidate(`${role}-renderer-gone`);
+    const onClosed = () => this._invalidate(`${role}-closed`);
+    const onHide = () => this._invalidate(`${role}-hidden`);
+    const onShow = () => {
+      if (role === "hit" && this.hitInitialShowPending) {
+        this.hitInitialShowPending = false;
+        return;
+      }
+      this._invalidate(`${role}-shown`);
+    };
+    win.webContents.on("render-process-gone", onGone);
+    if (typeof win.on === "function") {
+      win.on("closed", onClosed);
+      win.on("hide", onHide);
+      win.on("show", onShow);
+    }
+    this.disposers.push(() => win.webContents.removeListener("did-start-loading", onStart));
+    this.disposers.push(() => win.webContents.removeListener("did-finish-load", onFinish));
+    this.disposers.push(() => win.webContents.removeListener("render-process-gone", onGone));
+    if (typeof win.removeListener === "function") {
+      this.disposers.push(() => win.removeListener("page-title-updated", onPageTitle));
+      this.disposers.push(() => win.removeListener("closed", onClosed));
+      this.disposers.push(() => win.removeListener("hide", onHide));
+      this.disposers.push(() => win.removeListener("show", onShow));
+    }
+  }
+
+  _onRendererReady(event, payload) {
+    if (!payload || (payload.role !== "render" && payload.role !== "hit")) return;
+    const win = payload.role === "render" ? this.getRenderWindow() : this.getHitWindow();
+    if (!safeContents(win) || !this.isTrustedEvent(event, win.webContents)) return;
+    if (payload.role === "render") this.renderReady = true;
+    else this.hitReady = true;
+  }
+
+  _onRenderPointer(event, payload) {
+    const win = this.getRenderWindow();
+    if (!safeContents(win) || !this.isTrustedEvent(event, win.webContents)) return;
+    if (!payload || payload.role !== "render" || !this.acceptPointer) return;
+    if (payload.inside !== true) {
+      const establishedLease = this.pointerInside && !this.pointerWaiter;
+      this.pointerInside = false;
+      this.pointerSample = null;
+      this._cancelPointerDwell();
+      if (establishedLease) this._invalidate("pointer-left-before-hit-map");
+      return;
+    }
+    if (!Number.isFinite(payload.screenX) || !Number.isFinite(payload.screenY)) return;
+    this.pointerInside = true;
+    this.pointerSample = { screenX: payload.screenX, screenY: payload.screenY };
+    this._beginPointerDwell();
+  }
+
+  _beginPointerDwell() {
+    if (!this.pointerWaiter || this.pointerWaiter.dwellTimer) return;
+    this.pointerWaiter.dwellTimer = setTimeout(() => {
+      if (!this.pointerWaiter || !this.pointerInside || !this.pointerSample) return;
+      const waiter = this.pointerWaiter;
+      this.pointerWaiter = null;
+      clearTimeout(waiter.timeoutTimer);
+      if (waiter.prerequisiteTimer) clearInterval(waiter.prerequisiteTimer);
+      waiter.resolve({ ...this.pointerSample });
+    }, this.pointerDwellMs);
+  }
+
+  _cancelPointerDwell() {
+    if (!this.pointerWaiter || !this.pointerWaiter.dwellTimer) return;
+    clearTimeout(this.pointerWaiter.dwellTimer);
+    this.pointerWaiter.dwellTimer = null;
+  }
+
+  _waitForPointerDwell() {
+    return new Promise((resolve, reject) => {
+      const timeoutTimer = setTimeout(() => {
+        if (this.pointerWaiter && this.pointerWaiter.prerequisiteTimer) {
+          clearInterval(this.pointerWaiter.prerequisiteTimer);
+        }
+        this.pointerWaiter = null;
+        reject(this._unavailable("pointer-handshake-timeout"));
+      }, this.pointerTimeoutMs);
+      const prerequisiteTimer = setInterval(() => {
+        try {
+          this._checkPrerequisites();
+        } catch (err) {
+          this._rejectPointerWaiter(err);
+        }
+      }, 50);
+      this.pointerWaiter = { resolve, reject, timeoutTimer, dwellTimer: null, prerequisiteTimer };
+    });
+  }
+
+  _clearPointerWaiter() {
+    if (!this.pointerWaiter) return;
+    clearTimeout(this.pointerWaiter.timeoutTimer);
+    if (this.pointerWaiter.dwellTimer) clearTimeout(this.pointerWaiter.dwellTimer);
+    if (this.pointerWaiter.prerequisiteTimer) clearInterval(this.pointerWaiter.prerequisiteTimer);
+    this.pointerWaiter = null;
+  }
+
+  _rejectPointerWaiter(error) {
+    if (!this.pointerWaiter) return;
+    const waiter = this.pointerWaiter;
+    this._clearPointerWaiter();
+    waiter.reject(error);
+  }
+
+  _checkPrerequisites() {
+    if (this.invalidReason) throw this._unavailable(this.invalidReason);
+    const displays = this.screen && typeof this.screen.getAllDisplays === "function"
+      ? this.screen.getAllDisplays()
+      : [];
+    if (!Array.isArray(displays) || displays.length !== 1) throw this._unavailable("requires-single-output");
+    const result = this.checkDynamicPrerequisites();
+    if (!result || result.ok !== true) {
+      throw this._unavailable(result && result.reason ? result.reason : "dynamic-prerequisite-failed");
+    }
+  }
+
+  async _inspectTopology() {
+    const renderTitle = windowTitle("render", this.pid, this.generation, this.renderLoadEpoch);
+    const hitTitle = windowTitle("hit", this.pid, this.generation, this.hitLoadEpoch);
+    const deadline = Date.now() + this.windowsTimeoutMs;
+    let windows = [];
+    while (Date.now() <= deadline) {
+      this._checkPrerequisites();
+      windows = await this.client.windows();
+      this._checkPrerequisites();
+      const renderMatches = windows.filter((entry) => entry && entry.title === renderTitle);
+      const hitMatches = windows.filter((entry) => entry && entry.title === hitTitle);
+      if (hitMatches.length > 0) throw this._unavailable("hit-is-managed-toplevel");
+      if (renderMatches.length === 1) break;
+      if (renderMatches.length > 1) throw this._unavailable("render-title-not-unique");
+      await this.delay(50);
+    }
+    this._checkPrerequisites();
+    const renderMatches = windows.filter((entry) => entry && entry.title === renderTitle);
+    if (renderMatches.length !== 1) throw this._unavailable("render-window-not-found");
+    const render = renderMatches[0];
+    if (render.app_id !== this.appId) throw this._unavailable("render-app-id-mismatch");
+    if (render.is_floating !== true) throw this._unavailable("render-not-floating");
+
+    const displays = this.screen.getAllDisplays();
+    if (!isWindowInterior(render, displays[0])) throw this._unavailable("render-near-output-edge");
+
+    const titleCounts = await this.queryX11Titles([renderTitle, hitTitle]);
+    this._checkPrerequisites();
+    const renderX11 = titleCounts[renderTitle];
+    const hitX11 = titleCounts[hitTitle];
+    if (
+      !renderX11
+      || !hitX11
+      || renderX11.count !== 1
+      || hitX11.count !== 1
+      || !renderX11.sizes[0]
+      || !hitX11.sizes[0]
+      || renderX11.sizes[0].width <= 0
+      || renderX11.sizes[0].height <= 0
+      || hitX11.sizes[0].width <= 0
+      || hitX11.sizes[0].height <= 0
+    ) {
+      throw this._unavailable("x11-title-identity-mismatch");
+    }
+
+    const hitWin = this.getHitWindow();
+    const expectedHitBounds = this.getExpectedHitBounds();
+    const actualHitBounds = this._getActualHitBounds(hitWin);
+    if (!rectsNear(expectedHitBounds, actualHitBounds)) throw this._unavailable("hit-geometry-mismatch");
+
+    const scaleFactor = displays[0] && Number.isFinite(displays[0].scaleFactor)
+      ? displays[0].scaleFactor
+      : null;
+    return {
+      render,
+      expectedHitBounds,
+      actualHitBounds,
+      logicalRenderBounds: this.getLogicalRenderBounds(),
+      physicalRenderBounds: this.getPhysicalRenderBounds(),
+      workArea: displays[0] && displays[0].workArea ? { ...displays[0].workArea } : null,
+      viewportOffsets: this.getViewportOffsets(),
+      scaleFactor,
+    };
+  }
+
+  async _inspectMarkers(renderId) {
+    this._checkPrerequisites();
+    const renderWin = this.getRenderWindow();
+    const hitWin = this.getHitWindow();
+    if (!safeContents(renderWin) || !safeContents(hitWin)) throw this._unavailable("window-destroyed");
+    const [renderSelfImage, hitSelfImage] = await Promise.all([
+      renderWin.webContents.capturePage(),
+      hitWin.webContents.capturePage(),
+    ]);
+    this._checkPrerequisites();
+    const renderSelf = scanNativeImage(renderSelfImage);
+    const hitSelf = scanNativeImage(hitSelfImage);
+    if (!renderSelf.render) throw this._unavailable("render-marker-not-painted");
+    if (renderSelf.hit) throw this._unavailable("render-marker-not-isolated");
+    if (!hitSelf.hit) throw this._unavailable("hit-marker-not-painted");
+    if (hitSelf.render) throw this._unavailable("hit-marker-not-isolated");
+
+    const target = this.createCaptureTarget();
+    try {
+      this._checkPrerequisites();
+      await this.client.screenshotWindow({ id: renderId, path: target.filePath });
+      this._checkPrerequisites();
+      const png = await this.waitForCompletePng(target.filePath);
+      this._checkPrerequisites();
+      const image = this.nativeImage.createFromBuffer(png);
+      const combined = scanNativeImage(image);
+      return Object.freeze({
+        renderSelf: renderSelf.render,
+        hitSelf: hitSelf.hit,
+        render: combined.render,
+        hit: combined.hit,
+      });
+    } finally {
+      try { this.cleanupCaptureTarget(target); } catch {}
+    }
+  }
+
+  _setVisualLease(active) {
+    const next = active === true;
+    if (this.visualLease === next) return;
+    this.visualLease = next;
+    try { this.setVisualLease(next); } catch {}
+  }
+
+  _releaseToLegacy() {
+    if (this.legacyReleased || this.disposed) return;
+    if (!this.renderInputSafetyReleased) {
+      try {
+        this.startMainTick();
+        this.renderInputSafetyReleased = true;
+      } catch {
+        this.legacyReleaseBlocked = true;
+        this.logger("Clawd niri inspect: could not restore render click-through safety; quit and restart without the experiment variables.");
+        return;
+      }
+    }
+    if (this.legacyReleaseBlocked) return;
+    let hitWin = null;
+    try { hitWin = this.ensureHitWindow(); } catch {}
+    if (!safeContents(hitWin)) {
+      this.legacyReleaseBlocked = true;
+      this.logger("Clawd niri inspect: could not restore the input window; quit and restart without the experiment variables.");
+      return;
+    }
+    if (!rectsNear(this.getExpectedHitBounds(), this._getActualHitBounds(hitWin))) {
+      this.legacyReleaseBlocked = true;
+      this.logger("Clawd niri inspect: the input window geometry is not trustworthy; it will remain hidden. Quit and restart without the experiment variables.");
+      return;
+    }
+    try { this.showDeferredHit(); } catch {}
+    this.legacyReleased = true;
+  }
+
+  _waitUntil(predicate, timeoutMs, code) {
+    const deadline = Date.now() + timeoutMs;
+    return new Promise((resolve, reject) => {
+      const poll = () => {
+        if (this.invalidReason) {
+          reject(this._unavailable(this.invalidReason));
+          return;
+        }
+        if (predicate()) {
+          resolve();
+          return;
+        }
+        if (Date.now() > deadline) {
+          reject(this._unavailable(code));
+          return;
+        }
+        setTimeout(poll, 20);
+      };
+      poll();
+    });
+  }
+
+  _transition(next) {
+    const allowed = TRANSITIONS[this.state];
+    if (!allowed || !allowed.has(next)) throw new Error(`invalid niri inspect transition ${this.state} -> ${next}`);
+    this.state = next;
+  }
+
+  _unavailable(code) {
+    const error = new Error(code);
+    error.code = code;
+    error.faulted = false;
+    return error;
+  }
+
+  _getActualHitBounds(hitWin = this.getHitWindow()) {
+    return safeWindow(hitWin) && typeof hitWin.getBounds === "function"
+      ? hitWin.getBounds()
+      : null;
+  }
+
+  _invalidate(reason) {
+    if (this.disposed || this.invalidReason) return;
+    this.invalidReason = reason;
+    this._rejectPointerWaiter(this._unavailable(reason));
+  }
+}
+
+function createNiriPlacementInspect(options) {
+  return new NiriPlacementInspect(options);
+}
+
+module.exports = {
+  EDGE_MARGIN,
+  NiriPlacementInspect,
+  TRANSITIONS,
+  createNiriPlacementInspect,
+  isWindowInterior,
+  matchesNiri2604Release,
+  queryX11TitleCounts,
+  rectsNear,
+  resolveNiriInspectRequest,
+  windowTitle,
+};

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -201,6 +201,7 @@ function createPetWindowRuntime(options = {}) {
     options.notifyMiniTopologyChangedDuringTransition || noop;
   const exitMiniMode = options.exitMiniMode || noop;
   const shouldReloadAfterRenderProcessGone = createRenderProcessGoneReloadGuard(options);
+  const shownHitWindows = new WeakSet();
 
   function reloadRuntimeWindowWebContents(win, reloadOptions = {}) {
     if (
@@ -2193,8 +2194,16 @@ function createPetWindowRuntime(options = {}) {
       webPreferences: {
         preload: optionsArg.preloadPath,
         backgroundThrottling: false,
+        // Sandboxed Electron preloads cannot require the experiment's local
+        // helper module. Relax the sandbox only for the exact, opt-in render
+        // role; every normal window keeps Electron's default sandbox.
+        ...(Array.isArray(optionsArg.additionalArguments)
+          && optionsArg.additionalArguments.includes("--niri-inspect-role=render")
+          ? { sandbox: false }
+          : {}),
         additionalArguments: [
           "--theme-config=" + JSON.stringify(optionsArg.themeConfig),
+          ...(Array.isArray(optionsArg.additionalArguments) ? optionsArg.additionalArguments : []),
         ],
       },
     });
@@ -2288,6 +2297,7 @@ function createPetWindowRuntime(options = {}) {
       hasShadow: false,
       fullscreenable: false,
       enableLargerThanScreen: true,
+      ...(optionsArg.deferShow === true ? { show: false } : {}),
       ...(isLinux ? { type: linuxWindowType } : {}),
       ...(isMac ? { type: "panel", roundedCorners: false } : {}),
       // KEY EXPERIMENT: allow activation to avoid WS_EX_NOACTIVATE input
@@ -2296,9 +2306,16 @@ function createPetWindowRuntime(options = {}) {
       webPreferences: {
         preload: optionsArg.preloadPath,
         backgroundThrottling: false,
+        // See createRenderWindow(): keep the exception role-specific so an
+        // unrelated additional argument can never disable the sandbox.
+        ...(Array.isArray(optionsArg.additionalArguments)
+          && optionsArg.additionalArguments.includes("--niri-inspect-role=hit")
+          ? { sandbox: false }
+          : {}),
         additionalArguments: [
           "--hit-theme-config=" + JSON.stringify(optionsArg.hitThemeConfig),
           "--hit-platform=" + process.platform,
+          ...(Array.isArray(optionsArg.additionalArguments) ? optionsArg.additionalArguments : []),
         ],
       },
     });
@@ -2311,10 +2328,7 @@ function createPetWindowRuntime(options = {}) {
     // window until createHitWindow() returns and the caller assigns it.
     applyHitInputState(hitWin);
     if (isMac) hitWin.setFocusable(false);
-    hitWin.showInactive();
-    keepOutOfTaskbar(hitWin);
-    if (isWin) hitWin.setAlwaysOnTop(true, topmostLevel);
-    reapplyMacVisibility();
+    if (optionsArg.deferShow !== true) showHitWindow(hitWin);
     hitWin.loadFile(optionsArg.loadFilePath);
     if (isWin && typeof optionsArg.guardAlwaysOnTop === "function") {
       optionsArg.guardAlwaysOnTop(hitWin);
@@ -2330,6 +2344,17 @@ function createPetWindowRuntime(options = {}) {
       reloadRuntimeWindowWebContents(hitWin, { crashKey: "hitWin", details });
     });
     return hitWin;
+  }
+
+  function showHitWindow(hitWinOverride = getHitWindow()) {
+    if (!isLiveWindow(hitWinOverride)) return false;
+    if (shownHitWindows.has(hitWinOverride)) return true;
+    hitWinOverride.showInactive();
+    keepOutOfTaskbar(hitWinOverride);
+    if (isWin) hitWinOverride.setAlwaysOnTop(true, topmostLevel);
+    reapplyMacVisibility();
+    shownHitWindows.add(hitWinOverride);
+    return true;
   }
 
   // §4.3.10's drag protection-period release point. The plan names two call
@@ -2664,6 +2689,7 @@ function createPetWindowRuntime(options = {}) {
     getInitialHitWindowBounds,
     createRenderWindow,
     createHitWindow,
+    showHitWindow,
     reloadWindowWebContents: reloadRuntimeWindowWebContents,
     setDragLocked,
     isDragLocked,

--- a/src/preload-hit.js
+++ b/src/preload-hit.js
@@ -1,4 +1,11 @@
 const { contextBridge, ipcRenderer, webUtils } = require("electron");
+const niriInspectRoleArg = process.argv.find(
+  (arg) => arg === "--niri-inspect-role=render" || arg === "--niri-inspect-role=hit"
+);
+if (niriInspectRoleArg) {
+  const { exposeNiriInspectBridge } = require("./niri-inspect-preload");
+  exposeNiriInspectBridge(contextBridge, ipcRenderer, process.argv);
+}
 
 // Parse hit-renderer theme config from additionalArguments (synchronous, available on first load)
 const hitThemeArg = process.argv.find(a => a.startsWith("--hit-theme-config="));

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,11 @@
 const { contextBridge, ipcRenderer } = require("electron");
+const niriInspectRoleArg = process.argv.find(
+  (arg) => arg === "--niri-inspect-role=render" || arg === "--niri-inspect-role=hit"
+);
+if (niriInspectRoleArg) {
+  const { exposeNiriInspectBridge } = require("./niri-inspect-preload");
+  exposeNiriInspectBridge(contextBridge, ipcRenderer, process.argv);
+}
 
 // Parse theme config from additionalArguments (synchronous, available on first load)
 const themeArg = process.argv.find(a => a.startsWith("--theme-config="));

--- a/test/niri-inspect-artifact.test.js
+++ b/test/niri-inspect-artifact.test.js
@@ -1,0 +1,372 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { describe, it } = require("node:test");
+
+const {
+  MARKER_COLORS,
+  assertPathAbsent,
+  cleanupCaptureTarget,
+  createCaptureTarget,
+  findRenderMarkerRect,
+  isCompletePng,
+  scanNativeImage,
+  waitForCompletePng,
+} = require("../src/niri-inspect-artifact");
+
+function crc32(buffer) {
+  let crc = 0xFFFFFFFF;
+  for (const byte of buffer) {
+    crc ^= byte;
+    for (let bit = 0; bit < 8; bit += 1) {
+      crc = (crc >>> 1) ^ ((crc & 1) ? 0xEDB88320 : 0);
+    }
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0;
+}
+
+function pngChunk(type, data = Buffer.alloc(0)) {
+  const name = Buffer.from(type, "ascii");
+  const length = Buffer.alloc(4);
+  length.writeUInt32BE(data.length);
+  const checksum = Buffer.alloc(4);
+  checksum.writeUInt32BE(crc32(Buffer.concat([name, data])));
+  return Buffer.concat([length, name, data, checksum]);
+}
+
+function minimalPng() {
+  const signature = Buffer.from([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]);
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(1, 0);
+  ihdr.writeUInt32BE(1, 4);
+  ihdr[8] = 8;
+  ihdr[9] = 6;
+  return Buffer.concat([signature, pngChunk("IHDR", ihdr), pngChunk("IEND")]);
+}
+
+function makeNativeImage(regions, options = {}) {
+  const width = options.width || 32;
+  const height = options.height || 32;
+  const alpha = options.alpha || 255;
+  const bitmap = Buffer.alloc(width * height * 4);
+  for (const region of regions) {
+    const color = region.rgb || MARKER_COLORS[region.color];
+    for (let y = region.y; y < region.y + region.height; y += 1) {
+      for (let x = region.x; x < region.x + region.width; x += 1) {
+        const offset = (y * width + x) * 4;
+        bitmap[offset] = Math.round(color[2] * alpha / 255);
+        bitmap[offset + 1] = Math.round(color[1] * alpha / 255);
+        bitmap[offset + 2] = Math.round(color[0] * alpha / 255);
+        bitmap[offset + 3] = alpha;
+      }
+    }
+  }
+  return {
+    isEmpty: () => false,
+    getSize: () => ({ width, height }),
+    toBitmap: () => bitmap,
+  };
+}
+
+function cssRule(css, selector) {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const match = css.match(new RegExp(`${escaped}\\s*\\{([^}]*)\\}`, "s"));
+  assert.ok(match, `missing CSS rule: ${selector}`);
+  return match[1];
+}
+
+function cssPx(block, property) {
+  const match = block.match(new RegExp(`(?:^|;)\\s*${property}:\\s*(-?\\d+(?:\\.\\d+)?)(px)?\\s*;`, "s"));
+  assert.ok(match, `missing CSS pixel property: ${property}`);
+  const value = Number(match[1]);
+  assert.ok(value === 0 || match[2] === "px", `non-zero CSS length must use px: ${property}`);
+  return value;
+}
+
+function cssValue(block, property) {
+  const match = block.match(new RegExp(`(?:^|;)\\s*${property}:\\s*([^;]+?)\\s*;`, "s"));
+  assert.ok(match, `missing CSS property: ${property}`);
+  return match[1].trim();
+}
+
+function cssRgb(block, property) {
+  const match = block.match(new RegExp(
+    `(?:^|;)\\s*${property}:\\s*rgb\\(\\s*(\\d+)\\s*,\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\)\\s*;`,
+    "s",
+  ));
+  assert.ok(match, `missing CSS RGB property: ${property}`);
+  return match.slice(1).map(Number);
+}
+
+function cssBorder(block) {
+  const match = block.match(/(?:^|;)\s*border:\s*(-?\d+(?:\.\d+)?)px\s+solid\s+rgb\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*\)\s*;/s);
+  assert.ok(match, "missing CSS solid RGB border");
+  return { width: Number(match[1]), color: match.slice(2).map(Number) };
+}
+
+function parseProductionMarkerStyle(css) {
+  const base = cssRule(css, ".niri-inspect-marker");
+  const render = cssRule(css, ".niri-inspect-marker--render");
+  const renderAfter = cssRule(css, ".niri-inspect-marker--render::after");
+  const hit = cssRule(css, ".niri-inspect-marker--hit");
+  const hitAfter = cssRule(css, ".niri-inspect-marker--hit::after");
+  const renderBorder = cssBorder(render);
+  const hitBorder = cssBorder(hit);
+  const width = cssPx(base, "width");
+  const height = cssPx(base, "height");
+  const renderCornerWidth = cssPx(renderAfter, "width");
+  const renderCornerHeight = cssPx(renderAfter, "height");
+  const hitCornerWidth = cssPx(hitAfter, "width");
+  const hitCornerHeight = cssPx(hitAfter, "height");
+
+  assert.equal(cssValue(base, "position"), "fixed");
+  assert.equal(cssValue(base, "box-sizing"), "border-box");
+  assert.equal(cssValue(renderAfter, "content"), '""');
+  assert.equal(cssValue(renderAfter, "position"), "absolute");
+  assert.equal(cssValue(hitAfter, "content"), '""');
+  assert.equal(cssValue(hitAfter, "position"), "absolute");
+  assert.ok(width > 0 && height > 0, "marker dimensions must be positive");
+  assert.ok(renderCornerWidth > 0 && renderCornerHeight > 0, "render corner dimensions must be positive");
+  assert.ok(hitCornerWidth > 0 && hitCornerHeight > 0, "hit corner dimensions must be positive");
+  assert.ok(
+    renderBorder.width > 0
+      && renderBorder.width * 2 < width
+      && renderBorder.width * 2 < height,
+    "render border must be positive and leave a visible interior",
+  );
+  assert.ok(
+    hitBorder.width > 0
+      && hitBorder.width * 2 < width
+      && hitBorder.width * 2 < height,
+    "hit border must be positive and leave a visible interior",
+  );
+  return {
+    width,
+    height,
+    render: {
+      border: renderBorder.width,
+      primary: cssRgb(render, "background"),
+      corner: cssRgb(renderAfter, "background"),
+      cornerWidth: renderCornerWidth,
+      cornerHeight: renderCornerHeight,
+      right: cssPx(renderAfter, "right"),
+      bottom: cssPx(renderAfter, "bottom"),
+    },
+    hit: {
+      border: hitBorder.width,
+      primary: hitBorder.color,
+      corner: cssRgb(hitAfter, "background"),
+      cornerWidth: hitCornerWidth,
+      cornerHeight: hitCornerHeight,
+      left: cssPx(hitAfter, "left"),
+      top: cssPx(hitAfter, "top"),
+    },
+  };
+}
+
+const MARKER_CSS = fs.readFileSync(path.join(__dirname, "../src/niri-inspect-marker.css"), "utf8");
+const PRODUCTION_MARKER_STYLE = parseProductionMarkerStyle(MARKER_CSS);
+
+function makeProductionMarkerImage(role, scale, cornerShift = 0, style = PRODUCTION_MARKER_STYLE) {
+  const px = (value) => Math.max(1, Math.round(value * scale));
+  const offsetPx = (value) => Math.round(value * scale);
+  const origin = 6;
+  const outerWidth = px(style.width);
+  const outerHeight = px(style.height);
+  const regions = [];
+  if (role === "render") {
+    const border = px(style.render.border);
+    const innerWidth = outerWidth - border * 2;
+    const innerHeight = outerHeight - border * 2;
+    const cornerWidth = px(style.render.cornerWidth);
+    const cornerHeight = px(style.render.cornerHeight);
+    regions.push({
+      rgb: style.render.primary,
+      x: origin + border,
+      y: origin + border,
+      width: innerWidth,
+      height: innerHeight,
+    });
+    regions.push({
+      rgb: style.render.corner,
+      x: origin + outerWidth - border - cornerWidth - offsetPx(style.render.right) + cornerShift,
+      y: origin + outerHeight - border - cornerHeight - offsetPx(style.render.bottom) + cornerShift,
+      width: cornerWidth,
+      height: cornerHeight,
+    });
+  } else {
+    const border = px(style.hit.border);
+    const cornerWidth = px(style.hit.cornerWidth);
+    const cornerHeight = px(style.hit.cornerHeight);
+    regions.push(
+      { rgb: style.hit.primary, x: origin, y: origin, width: outerWidth, height: border },
+      { rgb: style.hit.primary, x: origin, y: origin + outerHeight - border, width: outerWidth, height: border },
+      { rgb: style.hit.primary, x: origin, y: origin, width: border, height: outerHeight },
+      { rgb: style.hit.primary, x: origin + outerWidth - border, y: origin, width: border, height: outerHeight },
+      {
+        rgb: style.hit.corner,
+        x: origin + border + offsetPx(style.hit.left) + cornerShift,
+        y: origin + border + offsetPx(style.hit.top) + cornerShift,
+        width: cornerWidth,
+        height: cornerHeight,
+      },
+    );
+  }
+  return makeNativeImage(regions, { width: 48, height: 48 });
+}
+
+describe("niri inspect artifacts", () => {
+  it("requires a structurally complete PNG with valid CRCs and terminal IEND", () => {
+    const png = minimalPng();
+    assert.equal(isCompletePng(png), true);
+    assert.equal(isCompletePng(png.subarray(0, png.length - 1)), false);
+    assert.equal(isCompletePng(Buffer.concat([png, Buffer.from([0])])), false);
+    const corrupt = Buffer.from(png);
+    corrupt[corrupt.length - 1] ^= 0xFF;
+    assert.equal(isCompletePng(corrupt), false);
+  });
+
+  it("creates a private absent capture path, waits for stable PNG, and cleans it up", async () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-niri-artifact-test-"));
+    let target = null;
+    try {
+      target = createCaptureTarget({ tempRoot: root, token: "unit" });
+      assert.equal(fs.statSync(target.dir).mode & 0o777, 0o700);
+      assert.equal(assertPathAbsent(target.filePath), true);
+      fs.writeFileSync(target.filePath, minimalPng());
+      assert.throws(
+        () => assertPathAbsent(target.filePath),
+        (err) => err && err.code === "capture-path-exists",
+      );
+
+      let reads = 0;
+      const stable = await waitForCompletePng(target.filePath, {
+        fs: {
+          readFileSync: () => {
+            reads += 1;
+            return reads === 1
+              ? minimalPng().subarray(0, minimalPng().length - 1)
+              : minimalPng();
+          },
+        },
+        timeoutMs: 100,
+        pollMs: 1,
+        stableCount: 2,
+        delay: async () => {},
+      });
+      assert.equal(isCompletePng(stable), true);
+      assert.equal(reads, 3);
+
+      cleanupCaptureTarget(target);
+      assert.equal(fs.existsSync(target.filePath), false);
+      assert.equal(fs.existsSync(target.dir), false);
+      target = null;
+    } finally {
+      if (target) cleanupCaptureTarget(target);
+      fs.rmdirSync(root);
+    }
+  });
+
+  it("selects a render marker corner outside the hit rectangle", () => {
+    const render = { x: 100, y: 100, width: 120, height: 120 };
+    const hit = { x: 100, y: 100, width: 60, height: 60 };
+    const marker = findRenderMarkerRect(render, hit);
+    assert.equal(marker.corner, "top-right");
+    assert.ok(marker.x >= 100 - 20);
+  });
+
+  it("returns null when every marker corner intersects the hit rectangle", () => {
+    assert.equal(findRenderMarkerRect(
+      { x: 0, y: 0, width: 40, height: 40 },
+      { x: 0, y: 0, width: 40, height: 40 },
+    ), null);
+  });
+
+  it("recognizes both asymmetric markers after alpha un-premultiplication", () => {
+    const image = makeNativeImage([
+      { color: "renderPrimary", x: 0, y: 0, width: 8, height: 8 },
+      { color: "renderCorner", x: 4, y: 4, width: 4, height: 4 },
+      { color: "hitPrimary", x: 12, y: 0, width: 10, height: 3 },
+      { color: "hitPrimary", x: 19, y: 0, width: 3, height: 10 },
+      { color: "hitPrimary", x: 12, y: 7, width: 10, height: 3 },
+      { color: "hitPrimary", x: 12, y: 0, width: 3, height: 10 },
+      { color: "hitCorner", x: 12, y: 0, width: 4, height: 4 },
+    ], { alpha: 160 });
+    const result = scanNativeImage(image);
+    assert.equal(result.render, true);
+    assert.equal(result.hit, true);
+  });
+
+  it("matches the shipped marker geometry with two physical pixels of snap margin", () => {
+    assert.deepStrictEqual(PRODUCTION_MARKER_STYLE.render.primary, MARKER_COLORS.renderPrimary);
+    assert.deepStrictEqual(PRODUCTION_MARKER_STYLE.render.corner, MARKER_COLORS.renderCorner);
+    assert.deepStrictEqual(PRODUCTION_MARKER_STYLE.hit.primary, MARKER_COLORS.hitPrimary);
+    assert.deepStrictEqual(PRODUCTION_MARKER_STYLE.hit.corner, MARKER_COLORS.hitCorner);
+
+    for (const scale of [1, 1.25, 1.5, 2]) {
+      for (const shift of [-2, -1, 0, 1, 2]) {
+        const render = scanNativeImage(makeProductionMarkerImage("render", scale, shift));
+        const hit = scanNativeImage(makeProductionMarkerImage("hit", scale, shift));
+        assert.equal(render.render, true, `render marker failed at scale=${scale}, shift=${shift}`);
+        assert.equal(render.hit, false);
+        assert.equal(hit.hit, true, `hit marker failed at scale=${scale}, shift=${shift}`);
+        assert.equal(hit.render, false);
+      }
+    }
+  });
+
+  it("fails closed when bitmap storage is not exactly tightly packed", () => {
+    const image = makeProductionMarkerImage("render", 1);
+    const bitmap = image.toBitmap();
+    const padded = {
+      isEmpty: () => false,
+      getSize: image.getSize,
+      toBitmap: () => Buffer.concat([bitmap, Buffer.alloc(16)]),
+    };
+    assert.deepStrictEqual(scanNativeImage(padded), {
+      valid: false,
+      render: false,
+      hit: false,
+      counts: {},
+    });
+  });
+
+  it("does not accept marker colors below the alpha floor", () => {
+    const image = makeNativeImage([
+      { color: "renderPrimary", x: 0, y: 0, width: 8, height: 8 },
+      { color: "renderCorner", x: 4, y: 4, width: 4, height: 4 },
+    ], { alpha: 80 });
+    assert.equal(scanNativeImage(image).render, false);
+  });
+
+  it("rejects theme-like color totals that do not form the asymmetric fiducials", () => {
+    const image = makeNativeImage([
+      { color: "renderPrimary", x: 0, y: 0, width: 6, height: 6 },
+      { color: "renderCorner", x: 20, y: 20, width: 3, height: 3 },
+      { color: "hitPrimary", x: 0, y: 20, width: 5, height: 5 },
+      { color: "hitCorner", x: 20, y: 0, width: 3, height: 3 },
+    ]);
+    const result = scanNativeImage(image);
+    assert.equal(result.render, false);
+    assert.equal(result.hit, false);
+  });
+
+  it("rejects an aligned corner component that occupies the wrong half", () => {
+    const image = makeNativeImage([
+      { color: "renderPrimary", x: 0, y: 0, width: 10, height: 10 },
+      { color: "renderCorner", x: 9, y: 0, width: 1, height: 10 },
+    ]);
+    assert.equal(scanNativeImage(image).render, false);
+  });
+
+  it("does not let broadly similar colors satisfy the fiducial", () => {
+    const image = makeNativeImage([
+      { rgb: [60, 195, 136], x: 0, y: 0, width: 8, height: 8 },
+      { rgb: [195, 195, 195], x: 4, y: 4, width: 4, height: 4 },
+    ]);
+    assert.equal(scanNativeImage(image).render, false);
+  });
+});

--- a/test/niri-inspect-preload.test.js
+++ b/test/niri-inspect-preload.test.js
@@ -1,0 +1,104 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { describe, it } = require("node:test");
+
+const { exposeNiriInspectBridge } = require("../src/niri-inspect-preload");
+
+function createDomHarness() {
+  const windowListeners = new Map();
+  const rootListeners = new Map();
+  const sent = [];
+  const created = [];
+  const documentValue = {
+    readyState: "complete",
+    documentElement: {
+      addEventListener: (event, callback) => rootListeners.set(event, callback),
+    },
+    createElement(tag) {
+      const listeners = new Map();
+      const element = {
+        tag,
+        addEventListener: (event, callback) => listeners.set(event, callback),
+        setAttribute: () => {},
+        emit: (event) => listeners.get(event)?.(),
+      };
+      created.push(element);
+      return element;
+    },
+    head: {
+      appendChild(element) {
+        if (element.tag === "link") element.emit("load");
+      },
+    },
+    body: { appendChild: () => {} },
+  };
+  const windowValue = {
+    addEventListener: (event, callback) => windowListeners.set(event, callback),
+    requestAnimationFrame: (callback) => callback(),
+  };
+  const ipcRenderer = { send: (...args) => sent.push(args) };
+  return {
+    created,
+    documentValue,
+    ipcRenderer,
+    rootListeners,
+    sent,
+    windowListeners,
+    windowValue,
+  };
+}
+
+describe("niri inspect preload", () => {
+  it("does absolutely nothing without an injected role argument", () => {
+    assert.equal(exposeNiriInspectBridge(null, null, ["electron", "app.js"], {
+      get window() { throw new Error("window must not be read"); },
+      get document() { throw new Error("document must not be read"); },
+    }), false);
+  });
+
+  it("installs the marker only for the last injected role and reports trusted pointer samples", () => {
+    const harness = createDomHarness();
+    assert.equal(exposeNiriInspectBridge(null, harness.ipcRenderer, [
+      "--niri-inspect-role=hit",
+      "--niri-inspect-role=render",
+      "--niri-inspect-corner=bottom-right",
+    ], {
+      window: harness.windowValue,
+      document: harness.documentValue,
+    }), true);
+
+    const marker = harness.created.find((entry) => entry.tag === "div");
+    assert.match(marker.className, /niri-inspect-marker--render/);
+    assert.match(marker.className, /niri-inspect-marker--bottom-right/);
+    assert.deepStrictEqual(harness.sent[0], ["niri-inspect-renderer-ready", { role: "render" }]);
+
+    assert.equal(harness.windowListeners.has("pointerenter"), false);
+    harness.rootListeners.get("pointerenter")({ relatedTarget: null, screenX: 12, screenY: 34 });
+    assert.deepStrictEqual(harness.sent[1], ["niri-inspect-render-pointer", {
+      role: "render",
+      inside: true,
+      screenX: 12,
+      screenY: 34,
+    }]);
+
+    harness.rootListeners.get("pointerleave")({
+      relatedTarget: {},
+      screenX: 56,
+      screenY: 78,
+    });
+    assert.equal(harness.sent.length, 2, "descendant boundary changes must stay internal");
+
+    harness.rootListeners.get("pointerleave")({
+      relatedTarget: null,
+      screenX: 56,
+      screenY: 78,
+    });
+    assert.deepStrictEqual(harness.sent[2], ["niri-inspect-render-pointer", {
+      role: "render",
+      inside: false,
+      screenX: 56,
+      screenY: 78,
+    }]);
+  });
+});

--- a/test/niri-ipc-client.test.js
+++ b/test/niri-ipc-client.test.js
@@ -1,0 +1,117 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const { describe, it } = require("node:test");
+
+const {
+  NiriIpcClient,
+  decodeReply,
+} = require("../src/niri-ipc-client");
+
+class FakeSocket extends EventEmitter {
+  constructor(onWrite = () => {}) {
+    super();
+    this.onWrite = onWrite;
+    this.writes = [];
+    this.destroyed = false;
+  }
+
+  write(value, callback) {
+    this.writes.push(String(value));
+    this.onWrite(String(value), this);
+    if (callback) callback();
+    return true;
+  }
+
+  destroy() {
+    this.destroyed = true;
+  }
+}
+
+function createConnectedClient(onWrite, options = {}) {
+  const socket = new FakeSocket(onWrite);
+  const client = new NiriIpcClient({
+    socketPath: "/run/user/1000/niri.sock",
+    timeoutMs: options.timeoutMs || 100,
+    lineLimit: options.lineLimit || 1024,
+    createConnection: () => {
+      queueMicrotask(() => socket.emit("connect"));
+      return socket;
+    },
+  });
+  return { client, socket };
+}
+
+describe("niri IPC client", () => {
+  it("decodes Ok and typed Err envelopes", () => {
+    assert.deepStrictEqual(decodeReply('{"Ok":{"Windows":[]}}'), { Windows: [] });
+    assert.throws(
+      () => decodeReply('{"Err":"not allowed"}'),
+      (err) => err.code === "niri-error" && err.poisoned === false,
+    );
+    assert.throws(
+      () => decodeReply("{"),
+      (err) => err.code === "invalid-json" && err.poisoned === true,
+    );
+  });
+
+  it("serializes requests and handles fragmented plus coalesced replies", async () => {
+    let writeCount = 0;
+    const { client, socket } = createConnectedClient((_value, ownedSocket) => {
+      writeCount += 1;
+      if (writeCount === 1) {
+        queueMicrotask(() => ownedSocket.emit("data", Buffer.from('{"Ok":{"Version":"26.')));
+        queueMicrotask(() => ownedSocket.emit("data", Buffer.from('04"}}\n')));
+      } else {
+        queueMicrotask(() => ownedSocket.emit("data", Buffer.from('{"Ok":{"Windows":[]}}\n')));
+      }
+    });
+
+    const [version, windows] = await Promise.all([client.version(), client.windows()]);
+    assert.equal(version, "26.04");
+    assert.deepStrictEqual(windows, []);
+    assert.deepStrictEqual(socket.writes.map((line) => JSON.parse(line)), ["Version", "Windows"]);
+    client.close();
+  });
+
+  it("keeps the aligned socket reusable after an in-band Err", async () => {
+    let count = 0;
+    const { client } = createConnectedClient((_value, socket) => {
+      count += 1;
+      const reply = count === 1
+        ? '{"Err":"unsupported"}\n'
+        : '{"Ok":{"Version":"26.04.1"}}\n';
+      queueMicrotask(() => socket.emit("data", Buffer.from(reply)));
+    });
+
+    await assert.rejects(client.windows(), (err) => err.code === "niri-error" && !err.poisoned);
+    assert.equal(await client.version(), "26.04.1");
+    client.close();
+  });
+
+  it("poisons the stream after a timeout", async () => {
+    const { client, socket } = createConnectedClient(() => {}, { timeoutMs: 5 });
+    await assert.rejects(client.version(), (err) => err.code === "timeout" && err.poisoned);
+    await assert.rejects(client.windows(), (err) => err.code === "poisoned" && err.poisoned);
+    assert.equal(socket.destroyed, true);
+  });
+
+  it("emits the exact ScreenshotWindow schema", async () => {
+    const { client, socket } = createConnectedClient((_value, ownedSocket) => {
+      queueMicrotask(() => ownedSocket.emit("data", Buffer.from('{"Ok":"Handled"}\n')));
+    });
+    await client.screenshotWindow({ id: 42, path: "/tmp/capture.png" });
+    assert.deepStrictEqual(JSON.parse(socket.writes[0]), {
+      Action: {
+        ScreenshotWindow: {
+          id: 42,
+          write_to_disk: true,
+          show_pointer: false,
+          path: "/tmp/capture.png",
+        },
+      },
+    });
+    client.close();
+  });
+});

--- a/test/niri-placement-inspect.test.js
+++ b/test/niri-placement-inspect.test.js
@@ -1,0 +1,587 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const { EventEmitter } = require("node:events");
+const { describe, it } = require("node:test");
+
+const { MARKER_COLORS } = require("../src/niri-inspect-artifact");
+const {
+  createNiriPlacementInspect,
+  matchesNiri2604Release,
+  queryX11TitleCounts,
+  resolveNiriInspectRequest,
+} = require("../src/niri-placement-inspect");
+
+function markerImage({ render = false, hit = false } = {}) {
+  const width = 32;
+  const height = 32;
+  const bitmap = Buffer.alloc(width * height * 4);
+  const paint = (colorName, x, y, regionWidth, regionHeight) => {
+    const color = MARKER_COLORS[colorName];
+    for (let py = y; py < y + regionHeight; py += 1) {
+      for (let px = x; px < x + regionWidth; px += 1) {
+        const offset = (py * width + px) * 4;
+        bitmap[offset] = color[2];
+        bitmap[offset + 1] = color[1];
+        bitmap[offset + 2] = color[0];
+        bitmap[offset + 3] = 255;
+      }
+    }
+  };
+  if (render) {
+    paint("renderPrimary", 0, 0, 8, 8);
+    paint("renderCorner", 4, 4, 4, 4);
+  }
+  if (hit) {
+    paint("hitPrimary", 12, 0, 10, 3);
+    paint("hitPrimary", 19, 0, 3, 10);
+    paint("hitPrimary", 12, 7, 10, 3);
+    paint("hitPrimary", 12, 0, 3, 10);
+    paint("hitCorner", 12, 0, 4, 4);
+  }
+  return {
+    isEmpty: () => false,
+    getSize: () => ({ width, height }),
+    toBitmap: () => bitmap,
+  };
+}
+
+function makeWindow(bounds, image, options = {}) {
+  const win = new EventEmitter();
+  const contents = new EventEmitter();
+  contents.isDestroyed = () => false;
+  contents.capturePage = async () => image;
+  win.webContents = contents;
+  win.bounds = { ...bounds };
+  win.visible = options.visible !== false;
+  win.title = "";
+  win.isDestroyed = () => false;
+  win.isVisible = () => win.visible;
+  win.getBounds = () => ({ ...win.bounds });
+  win.setTitle = (title) => { win.title = title; };
+  win.showInactive = () => {
+    win.visible = true;
+    win.emit("show");
+  };
+  return win;
+}
+
+function makeScreen() {
+  const screen = new EventEmitter();
+  screen.getAllDisplays = () => [{
+    id: 1,
+    scaleFactor: 1.25,
+    workArea: { x: 0, y: 0, width: 1000, height: 800 },
+  }];
+  return screen;
+}
+
+describe("niri placement inspect", () => {
+  it("is exact, default-off, and inspect-only at the static gate", () => {
+    assert.deepStrictEqual(resolveNiriInspectRequest({ env: {}, argv: [], platform: "linux" }), {
+      requested: false,
+      enabled: false,
+      reason: "default-off",
+      stage: null,
+    });
+    assert.equal(resolveNiriInspectRequest({
+      env: {
+        CLAWD_WINDOW_PLACEMENT: "niri-ipc",
+        CLAWD_NIRI_STAGE: "drag",
+        CLAWD_DISABLE_EDGE_VIRTUALIZATION: "1",
+        NIRI_SOCKET: "/run/niri.sock",
+      },
+      argv: ["--ozone-platform=x11"],
+      platform: "linux",
+    }).reason, "stage-drag-not-implemented");
+    assert.equal(resolveNiriInspectRequest({
+      env: {
+        CLAWD_WINDOW_PLACEMENT: "niri-ipc",
+        CLAWD_DISABLE_EDGE_VIRTUALIZATION: "1",
+        NIRI_SOCKET: "/run/niri.sock",
+      },
+      argv: ["--ozone-platform=x11"],
+      platform: "linux",
+    }).enabled, true);
+  });
+
+  it("keeps the disabled runtime inert at every class-level entry point", async () => {
+    const ipcMain = new EventEmitter();
+    const screen = new EventEmitter();
+    let clientFactories = 0;
+    const logs = [];
+    const visualLeases = [];
+    const render = makeWindow(
+      { x: 200, y: 200, width: 120, height: 120 },
+      markerImage({ render: true }),
+    );
+    const hit = makeWindow(
+      { x: 210, y: 220, width: 50, height: 60 },
+      markerImage({ hit: true }),
+    );
+    const runtime = createNiriPlacementInspect({
+      config: { enabled: false, requested: false, reason: "default-off", stage: null },
+      ipcMain,
+      screen,
+      readyTimeoutMs: 1,
+      clientFactory: () => { clientFactories += 1; return null; },
+      logger: (line) => logs.push(line),
+      setVisualLease: (active) => visualLeases.push(active),
+    });
+
+    runtime.registerIpc();
+    runtime.attachRenderWindow(render);
+    runtime.attachHitWindow(hit);
+    const result = await runtime.start();
+
+    assert.equal(runtime.shouldDeferHitMapping(), false);
+    assert.equal(result, null);
+    assert.equal(runtime.state, "off");
+    assert.equal(runtime.started, false);
+    assert.equal(clientFactories, 0);
+    assert.deepStrictEqual(logs, []);
+    assert.deepStrictEqual(visualLeases, []);
+    assert.deepStrictEqual(ipcMain.eventNames(), []);
+    assert.deepStrictEqual(screen.eventNames(), []);
+    assert.deepStrictEqual(render.eventNames(), []);
+    assert.deepStrictEqual(render.webContents.eventNames(), []);
+    assert.deepStrictEqual(hit.eventNames(), []);
+    assert.deepStrictEqual(hit.webContents.eventNames(), []);
+    runtime.dispose();
+  });
+
+  it("accepts only the 26.04 release family", () => {
+    assert.equal(matchesNiri2604Release("26.04"), true);
+    assert.equal(matchesNiri2604Release("26.04 (8ed0da4)"), true);
+    assert.equal(matchesNiri2604Release("26.04.2 (unknown commit)"), true);
+    assert.equal(matchesNiri2604Release("26.04.2+git.abc"), false);
+    assert.equal(matchesNiri2604Release("26.04 arbitrary suffix"), false);
+    assert.equal(matchesNiri2604Release("26.05"), false);
+    assert.equal(matchesNiri2604Release("niri 26.04"), false);
+  });
+
+  it("extracts only exact quoted X11 titles and their positive native sizes", async () => {
+    const details = await queryX11TitleCounts(["Clawd niri render 1-1-0", "Clawd niri hit 1-1-0"], {
+      execFile: async () => ({ stdout: [
+        '     0x1 "Clawd niri render 1-1-0": ("clawd" "Clawd")  120x120+200+200  +200+200',
+        '     0x2 "Clawd niri hit 1-1-0": ("clawd" "Clawd")  50x60+210+220  +210+220',
+        '     0x3 "Clawd niri render 1-1-0 suffix": ("clawd" "Clawd")  1x1+0+0  +0+0',
+      ].join("\n") }),
+    });
+    assert.deepStrictEqual(details["Clawd niri render 1-1-0"], {
+      count: 1,
+      sizes: [{ width: 120, height: 120 }],
+    });
+    assert.deepStrictEqual(details["Clawd niri hit 1-1-0"], {
+      count: 1,
+      sizes: [{ width: 50, height: 60 }],
+    });
+  });
+
+  it("keeps reload identity tombstoned until did-finish-load", () => {
+    const render = makeWindow(
+      { x: 200, y: 200, width: 120, height: 120 },
+      markerImage({ render: true }),
+    );
+    const runtime = createNiriPlacementInspect({
+      config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+      pid: 123,
+      getRenderWindow: () => render,
+    });
+    runtime.attachRenderWindow(render);
+
+    render.webContents.emit("did-start-loading");
+    assert.equal(render.title, "Clawd niri render loading 123-1-1");
+    let prevented = false;
+    render.emit("page-title-updated", {
+      preventDefault: () => { prevented = true; },
+    }, "Clawd");
+    assert.equal(prevented, true);
+    assert.equal(render.title, "Clawd niri render loading 123-1-1");
+
+    render.webContents.emit("did-finish-load");
+    assert.equal(render.title, "Clawd niri render 123-1-1");
+    runtime.dispose();
+  });
+
+  it("creates hit only after trusted render dwell and proves the positive marker oracle", async () => {
+    const ipcMain = new EventEmitter();
+    const screen = makeScreen();
+    const render = makeWindow(
+      { x: 200, y: 200, width: 120, height: 120 },
+      markerImage({ render: true }),
+    );
+    let hit = null;
+    let runtime = null;
+    let hitCreates = 0;
+    let tickStarts = 0;
+    const leases = [];
+    const logs = [];
+    let cleanupCalls = 0;
+    const fakeClient = {
+      version: async () => "26.04 (8ed0da4)",
+      windows: async () => [{
+        id: 77,
+        title: render.title,
+        app_id: "clawd-on-desk",
+        workspace_id: 3,
+        is_floating: true,
+        layout: {
+          tile_pos_in_workspace_view: [200, 200],
+          tile_size: [120, 120],
+        },
+      }],
+      screenshotWindow: async () => true,
+      close: () => {},
+    };
+
+    runtime = createNiriPlacementInspect({
+      config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+      ipcMain,
+      screen,
+      nativeImage: { createFromBuffer: () => markerImage({ render: true, hit: true }) },
+      pid: 1234,
+      pointerDwellMs: 1,
+      pointerTimeoutMs: 100,
+      readyTimeoutMs: 100,
+      clientFactory: () => fakeClient,
+      isTrustedEvent: (event, contents) => event.sender === contents,
+      getRenderWindow: () => render,
+      getHitWindow: () => hit,
+      getExpectedHitBounds: () => ({ x: 210, y: 220, width: 50, height: 60 }),
+      checkDynamicPrerequisites: () => ({ ok: true }),
+      ensureHitWindow: () => {
+        if (hit) return hit;
+        hitCreates += 1;
+        hit = makeWindow(
+          { x: 210, y: 220, width: 50, height: 60 },
+          markerImage({ hit: true }),
+          { visible: false },
+        );
+        runtime.attachHitWindow(hit);
+        queueMicrotask(() => {
+          hit.webContents.emit("did-finish-load");
+          ipcMain.emit("niri-inspect-renderer-ready", { sender: hit.webContents }, { role: "hit" });
+        });
+        return hit;
+      },
+      showDeferredHit: () => hit.showInactive(),
+      startMainTick: () => { tickStarts += 1; },
+      setVisualLease: (active) => leases.push(active),
+      queryX11Titles: async (titles) => Object.fromEntries(titles.map((title) => [title, {
+        count: 1,
+        sizes: [{ width: 100, height: 100 }],
+      }])),
+      createCaptureTarget: () => ({ dir: "/tmp/hidden", filePath: "/tmp/hidden/capture.png" }),
+      waitForCompletePng: async () => Buffer.from("complete"),
+      cleanupCaptureTarget: () => { cleanupCalls += 1; },
+      logger: (line) => {
+        logs.push(line);
+        if (line.includes("move the pointer")) {
+          queueMicrotask(() => ipcMain.emit(
+            "niri-inspect-render-pointer",
+            { sender: render.webContents },
+            { role: "render", inside: true, screenX: 240, screenY: 250 },
+          ));
+        }
+      },
+    });
+    runtime.registerIpc();
+    runtime.attachRenderWindow(render);
+    render.webContents.emit("did-finish-load");
+    ipcMain.emit("niri-inspect-renderer-ready", { sender: render.webContents }, { role: "render" });
+
+    assert.equal(hit, null, "hit must not exist before the trusted hover");
+    const result = await runtime.start();
+    assert.equal(result.verdict, "parent-coupled-candidate");
+    assert.equal(hitCreates, 1);
+    assert.equal(hit.visible, true);
+    assert.equal(tickStarts, 1);
+    assert.deepStrictEqual(leases, [true, false]);
+    assert.equal(result.markers.render, true);
+    assert.equal(result.markers.hit, true);
+    assert.equal(cleanupCalls, 1);
+    assert.ok(logs.some((line) => line.includes("inspect artifact")));
+    runtime.dispose();
+  });
+
+  it("does not promote a compositor capture that contains only the render marker", async () => {
+    const ipcMain = new EventEmitter();
+    const screen = makeScreen();
+    const render = makeWindow(
+      { x: 200, y: 200, width: 120, height: 120 },
+      markerImage({ render: true }),
+    );
+    const hit = makeWindow(
+      { x: 210, y: 220, width: 50, height: 60 },
+      markerImage({ hit: true }),
+      { visible: false },
+    );
+    let runtime = null;
+    runtime = createNiriPlacementInspect({
+      config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+      ipcMain,
+      screen,
+      nativeImage: { createFromBuffer: () => markerImage({ render: true }) },
+      pid: 1234,
+      pointerDwellMs: 1,
+      pointerTimeoutMs: 100,
+      readyTimeoutMs: 100,
+      clientFactory: () => ({
+        version: async () => "26.04 (8ed0da4)",
+        windows: async () => [{
+          id: 77,
+          title: render.title,
+          app_id: "clawd-on-desk",
+          workspace_id: 3,
+          is_floating: true,
+          layout: {
+            tile_pos_in_workspace_view: [200, 200],
+            tile_size: [120, 120],
+          },
+        }],
+        screenshotWindow: async () => true,
+        close: () => {},
+      }),
+      isTrustedEvent: (event, contents) => event.sender === contents,
+      getRenderWindow: () => render,
+      getHitWindow: () => hit,
+      getExpectedHitBounds: () => ({ x: 210, y: 220, width: 50, height: 60 }),
+      checkDynamicPrerequisites: () => ({ ok: true }),
+      ensureHitWindow: () => hit,
+      showDeferredHit: () => hit.showInactive(),
+      startMainTick: () => {},
+      queryX11Titles: async (titles) => Object.fromEntries(titles.map((title) => [title, {
+        count: 1,
+        sizes: [{ width: 100, height: 100 }],
+      }])),
+      createCaptureTarget: () => ({ dir: "/tmp/hidden", filePath: "/tmp/hidden/capture.png" }),
+      waitForCompletePng: async () => Buffer.from("complete"),
+      cleanupCaptureTarget: () => {},
+      logger: (line) => {
+        if (line.includes("move the pointer")) {
+          queueMicrotask(() => ipcMain.emit(
+            "niri-inspect-render-pointer",
+            { sender: render.webContents },
+            { role: "render", inside: true, screenX: 240, screenY: 250 },
+          ));
+        }
+      },
+    });
+    runtime.registerIpc();
+    runtime.attachRenderWindow(render);
+    runtime.attachHitWindow(hit);
+    render.webContents.emit("did-finish-load");
+    hit.webContents.emit("did-finish-load");
+    ipcMain.emit("niri-inspect-renderer-ready", { sender: render.webContents }, { role: "render" });
+    ipcMain.emit("niri-inspect-renderer-ready", { sender: hit.webContents }, { role: "hit" });
+
+    const result = await runtime.start();
+    assert.equal(result.verdict, "unavailable");
+    assert.equal(result.reason, "marker-oracle-ambiguous");
+    runtime.dispose();
+  });
+
+  it("restores the legacy hit and tick after a zero-write pointer timeout", async () => {
+    const ipcMain = new EventEmitter();
+    const screen = makeScreen();
+    const render = makeWindow(
+      { x: 200, y: 200, width: 120, height: 120 },
+      markerImage({ render: true }),
+    );
+    const hit = makeWindow(
+      { x: 210, y: 220, width: 50, height: 60 },
+      markerImage({ hit: true }),
+      { visible: false },
+    );
+    let ensures = 0;
+    let shows = 0;
+    let ticks = 0;
+    const runtime = createNiriPlacementInspect({
+      config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+      ipcMain,
+      screen,
+      pointerTimeoutMs: 5,
+      readyTimeoutMs: 50,
+      clientFactory: () => ({ version: async () => "26.04 (8ed0da4)", close: () => {} }),
+      isTrustedEvent: (event, contents) => event.sender === contents,
+      getRenderWindow: () => render,
+      getHitWindow: () => hit,
+      getExpectedHitBounds: () => ({ x: 210, y: 220, width: 50, height: 60 }),
+      checkDynamicPrerequisites: () => ({ ok: true }),
+      ensureHitWindow: () => { ensures += 1; return hit; },
+      showDeferredHit: () => { shows += 1; hit.visible = true; },
+      startMainTick: () => { ticks += 1; },
+      logger: () => {},
+    });
+    runtime.registerIpc();
+    runtime.attachRenderWindow(render);
+    render.webContents.emit("did-finish-load");
+    ipcMain.emit("niri-inspect-renderer-ready", { sender: render.webContents }, { role: "render" });
+
+    const result = await runtime.start();
+    assert.equal(result.verdict, "unavailable");
+    assert.equal(result.reason, "pointer-handshake-timeout");
+    assert.equal(ensures, 1);
+    assert.equal(shows, 1);
+    assert.equal(ticks, 1);
+    runtime.dispose();
+  });
+
+  it("restores render click-through once even when legacy hit recovery is unsafe", () => {
+    let missingTicks = 0;
+    const missingRuntime = createNiriPlacementInspect({
+      config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+      ensureHitWindow: () => null,
+      startMainTick: () => { missingTicks += 1; },
+      logger: () => {},
+    });
+    missingRuntime._releaseToLegacy();
+    missingRuntime._releaseToLegacy();
+    assert.equal(missingTicks, 1);
+    assert.equal(missingRuntime.legacyReleased, false);
+    assert.equal(missingRuntime.legacyReleaseBlocked, true);
+
+    const hit = makeWindow(
+      { x: 0, y: 0, width: 10, height: 10 },
+      markerImage({ hit: true }),
+      { visible: false },
+    );
+    let geometryTicks = 0;
+    let shows = 0;
+    const geometryRuntime = createNiriPlacementInspect({
+      config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+      ensureHitWindow: () => hit,
+      getExpectedHitBounds: () => ({ x: 100, y: 100, width: 10, height: 10 }),
+      startMainTick: () => { geometryTicks += 1; },
+      showDeferredHit: () => { shows += 1; },
+      logger: () => {},
+    });
+    geometryRuntime._releaseToLegacy();
+    geometryRuntime._releaseToLegacy();
+    assert.equal(geometryTicks, 1);
+    assert.equal(shows, 0);
+    assert.equal(geometryRuntime.legacyReleaseBlocked, true);
+  });
+
+  it("does not issue a screenshot after the inspected generation is invalidated", async () => {
+    const screen = makeScreen();
+    const render = makeWindow(
+      { x: 200, y: 200, width: 120, height: 120 },
+      markerImage({ render: true }),
+    );
+    const hit = makeWindow(
+      { x: 210, y: 220, width: 50, height: 60 },
+      markerImage({ hit: true }),
+    );
+    let screenshots = 0;
+    let targets = 0;
+    let runtime = null;
+    render.webContents.capturePage = async () => {
+      runtime._invalidate("render-reload");
+      return markerImage({ render: true });
+    };
+    runtime = createNiriPlacementInspect({
+      config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+      screen,
+      getRenderWindow: () => render,
+      getHitWindow: () => hit,
+      checkDynamicPrerequisites: () => ({ ok: true }),
+      clientFactory: () => null,
+      createCaptureTarget: () => { targets += 1; return { dir: "/tmp/x", filePath: "/tmp/x/a.png" }; },
+    });
+    runtime.client = {
+      screenshotWindow: async () => { screenshots += 1; },
+    };
+
+    await assert.rejects(
+      runtime._inspectMarkers(77),
+      (err) => err && err.code === "render-reload",
+    );
+    assert.equal(targets, 0);
+    assert.equal(screenshots, 0);
+  });
+
+  it("stops topology polling as soon as its generation is invalidated", async () => {
+    const screen = makeScreen();
+    let titleQueries = 0;
+    let runtime = null;
+    runtime = createNiriPlacementInspect({
+      config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+      screen,
+      checkDynamicPrerequisites: () => ({ ok: true }),
+      queryX11Titles: async () => { titleQueries += 1; return {}; },
+    });
+    runtime.client = {
+      windows: async () => {
+        runtime._invalidate("render-reload");
+        return [];
+      },
+    };
+
+    await assert.rejects(
+      runtime._inspectTopology(),
+      (err) => err && err.code === "render-reload",
+    );
+    assert.equal(titleQueries, 0);
+  });
+
+  it("rejects every invalid self-capture before requesting a compositor screenshot", async () => {
+    const cases = [
+      {
+        name: "missing render marker",
+        renderImage: markerImage(),
+        hitImage: markerImage({ hit: true }),
+        code: "render-marker-not-painted",
+      },
+      {
+        name: "hit marker leaked into render self-capture",
+        renderImage: markerImage({ render: true, hit: true }),
+        hitImage: markerImage({ hit: true }),
+        code: "render-marker-not-isolated",
+      },
+      {
+        name: "missing hit marker",
+        renderImage: markerImage({ render: true }),
+        hitImage: markerImage(),
+        code: "hit-marker-not-painted",
+      },
+      {
+        name: "render marker leaked into hit self-capture",
+        renderImage: markerImage({ render: true }),
+        hitImage: markerImage({ render: true, hit: true }),
+        code: "hit-marker-not-isolated",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const screen = makeScreen();
+      const render = makeWindow(
+        { x: 200, y: 200, width: 120, height: 120 },
+        testCase.renderImage,
+      );
+      const hit = makeWindow(
+        { x: 210, y: 220, width: 50, height: 60 },
+        testCase.hitImage,
+      );
+      let screenshots = 0;
+      const runtime = createNiriPlacementInspect({
+        config: { enabled: true, requested: true, socketPath: "/run/niri.sock", stage: "inspect" },
+        screen,
+        getRenderWindow: () => render,
+        getHitWindow: () => hit,
+        checkDynamicPrerequisites: () => ({ ok: true }),
+      });
+      runtime.client = {
+        screenshotWindow: async () => { screenshots += 1; },
+      };
+
+      await assert.rejects(
+        runtime._inspectMarkers(77),
+        (err) => err && err.code === testCase.code,
+        testCase.name,
+      );
+      assert.equal(screenshots, 0, testCase.name);
+    }
+  });
+});

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -2931,6 +2931,7 @@ describe("pet-window-runtime", () => {
       "setBounds",
       { x: 40, y: 0, width: 120, height: 120 },
     ]);
+    assert.equal(Object.hasOwn(instances[0].options.webPreferences, "sandbox"), false);
     assert.equal(harness.runtime.getViewportOffsetY(), 25);
   });
 
@@ -2993,6 +2994,85 @@ describe("pet-window-runtime", () => {
 
     assert.equal(instances[0].options.focusable, false);
     assert.equal(instances[0].options.type, "toolbar");
+    assert.equal(Object.hasOwn(instances[0].options, "show"), false);
+    assert.equal(Object.hasOwn(instances[0].options.webPreferences, "sandbox"), false);
+  });
+
+  it("disables the preload sandbox only for the exact experimental window role", () => {
+    const renderInstances = [];
+    const renderHarness = createRuntime({ isWin: false, isLinux: true });
+    const renderOptions = {
+      BrowserWindow: makeBrowserWindow(renderInstances),
+      size: { width: 120, height: 120 },
+      initialWindowBounds: { x: 40, y: 0, width: 120, height: 120 },
+      initialVirtualBounds: { x: 40, y: 0, width: 120, height: 120 },
+      preloadPath: "preload.js",
+      loadFilePath: "index.html",
+      themeConfig: {},
+      setRenderWindow: renderHarness.setRenderWin,
+    };
+    renderHarness.runtime.createRenderWindow({
+      ...renderOptions,
+      additionalArguments: ["--niri-inspect-role=render"],
+    });
+    renderHarness.runtime.createRenderWindow({
+      ...renderOptions,
+      additionalArguments: ["--unrelated-argument=1"],
+    });
+    renderHarness.runtime.createRenderWindow({
+      ...renderOptions,
+      additionalArguments: ["--niri-inspect-role=hit"],
+    });
+    renderHarness.runtime.createRenderWindow({
+      ...renderOptions,
+      additionalArguments: ["--niri-inspect-role=render-extra"],
+    });
+
+    assert.equal(renderInstances[0].options.webPreferences.sandbox, false);
+    assert.ok(renderInstances[0].options.webPreferences.additionalArguments.includes("--niri-inspect-role=render"));
+    assert.equal(Object.hasOwn(renderInstances[1].options.webPreferences, "sandbox"), false);
+    assert.equal(Object.hasOwn(renderInstances[2].options.webPreferences, "sandbox"), false);
+    assert.equal(Object.hasOwn(renderInstances[3].options.webPreferences, "sandbox"), false);
+
+    const instances = [];
+    const harness = createRuntime({ isWin: false, isLinux: true });
+
+    const hit = harness.runtime.createHitWindow({
+      BrowserWindow: makeBrowserWindow(instances),
+      preloadPath: "preload-hit.js",
+      loadFilePath: "hit.html",
+      hitThemeConfig: {},
+      additionalArguments: ["--niri-inspect-role=hit"],
+      deferShow: true,
+    });
+
+    assert.deepStrictEqual(hit.calls.filter((call) => call[0] === "showInactive"), []);
+    assert.equal(hit.options.show, false);
+    assert.equal(hit.options.webPreferences.sandbox, false);
+    assert.ok(hit.options.webPreferences.additionalArguments.includes("--niri-inspect-role=hit"));
+    assert.equal(harness.runtime.showHitWindow(hit), true);
+    assert.equal(harness.runtime.showHitWindow(hit), true);
+    assert.deepStrictEqual(hit.calls.filter((call) => call[0] === "showInactive"), [["showInactive"]]);
+
+    const wrongRoleInstances = [];
+    harness.runtime.createHitWindow({
+      BrowserWindow: makeBrowserWindow(wrongRoleInstances),
+      preloadPath: "preload-hit.js",
+      loadFilePath: "hit.html",
+      hitThemeConfig: {},
+      additionalArguments: ["--niri-inspect-role=render"],
+    });
+    assert.equal(Object.hasOwn(wrongRoleInstances[0].options.webPreferences, "sandbox"), false);
+
+    const nearMatchInstances = [];
+    harness.runtime.createHitWindow({
+      BrowserWindow: makeBrowserWindow(nearMatchInstances),
+      preloadPath: "preload-hit.js",
+      loadFilePath: "hit.html",
+      hitThemeConfig: {},
+      additionalArguments: ["--niri-inspect-role=hit-extra"],
+    });
+    assert.equal(Object.hasOwn(nearMatchInstances[0].options.webPreferences, "sandbox"), false);
   });
 
   it("materializes virtual bounds into viewport offset and syncs the hit shape once per size", () => {


### PR DESCRIPTION
## Summary

- add an explicit, default-off `niri-ipc` inspect stage for Linux/XWayland
- identify the managed render toplevel and the unmanaged hit-window candidate without moving either window
- use asymmetric render/hit markers plus one compositor screenshot to test whether niri/XWayland composes the hit surface with the render toplevel
- fail closed on unsupported versions, topology changes, ambiguous identity, unsafe geometry, invalid captures, or renderer lifecycle changes

This is a narrow diagnostic experiment based on the evidence @Alxkcx provided in #752. It does **not** implement window movement, single-window mode, workspace following, or a production placement backend.

## Why this is Draft

The implementation and automated evidence are useful enough to review remotely, but it is **not ready for reporter testing or merge** yet.

Two lifecycle hardening items remain:

1. The render `BrowserWindow` can emit one delayed initial `show` after the inspect lifecycle attaches, currently invalidating the generation as `render-shown`. The experimental render path needs deterministic `show: false` → attach → explicit initial show sequencing, while preserving invalidation for later genuine shows.
2. `preload.js` and `preload-hit.js` should make their inspect-role triggers window-specific, matching the exact role-specific sandbox exception by construction.

These will be repaired in follow-up commits before asking the reporter to run a build.

## Activation contract

The experiment remains off unless all of the following are true:

```bash
CLAWD_WINDOW_PLACEMENT=niri-ipc
CLAWD_NIRI_STAGE=inspect
CLAWD_DISABLE_EDGE_VIRTUALIZATION=1
NIRI_SOCKET=/path/to/niri/socket
```

The app must also be running on Linux under the canonical X11/XWayland launch path. The current inspect gate accepts only the niri 26.04 release family and requires a single output with the render window away from output edges.

## Safety boundary

- no `MoveFloatingWindow`, `AdjustFixed`, `MoveWindow`, or other placement action
- no prefs or Settings writes
- no automatic activation
- at most one `ScreenshotWindow` request after the identity, topology, pointer, geometry, and marker prerequisites pass
- private temporary capture path with structural PNG validation and cleanup
- default Windows, macOS, Xorg, Wayland, and normal Linux startup paths remain unchanged

## Verification

- focused: **171 tests, 171 pass, 0 fail, 0 skip**
- full suite: **9331 total, 9289 pass, 0 fail, 42 skip**
- `node --check` for all changed JavaScript files
- `git diff --check`
- real Electron 41.10.4 preload smoke:
  - default render exposes `electronAPI`
  - experimental render exposes `electronAPI`
  - experimental hit exposes `hitAPI`
  - renderer pages do not expose `window.process` or `window.require`

## Reporter boundary

After the two Draft blockers are repaired, the remaining questions require the original niri/XWayland environment: popup parentage, `screenshot_window` popup composition, Linux bitmap behavior at DPR 1.25, and the literal niri `app_id`/window topology.

Related to #752.
