### PR TITLE
fix(dashboard): hide unavailable remote session actions

### DIFF
--- a/src/dashboard-renderer.js
+++ b/src/dashboard-renderer.js
@@ -862,28 +862,32 @@ function createCard(session, now) {
 
   const actions = document.createElement("div");
   actions.className = "actions";
-  const button = document.createElement("button");
-  button.type = "button";
-  const focusTargetType = session.focusTarget && session.focusTarget.type;
-  button.textContent = focusTargetType === "codex-thread"
-    ? t("dashboardOpenCodexSession")
-    : t("dashboardJumpTerminal");
-  button.disabled = session.canFocus !== true;
-  if (button.disabled) {
-    button.title = focusUnavailableText(session);
-  }
-  button.addEventListener("click", async () => {
-    window.dashboardAPI.focusSession(session.id);
-    // Best-effort ack alongside focus. Most remote-Codex sessions have
-    // canFocus=false (no terminal-jump target) and reach ack through the
-    // Mark-read button instead, but local Codex Stop sessions can land
-    // here so we ack on focus too.
-    if (window.dashboardAPI && typeof window.dashboardAPI.ackCompletion === "function") {
-      try { await window.dashboardAPI.ackCompletion(session.id); }
-      catch (err) { console.warn("ack completion threw:", err); }
+  const hideRemoteFocusButton = session.canFocus !== true
+    && focusUnavailableReasonKey(session) === "sessionFocusUnavailableRemote";
+  if (!hideRemoteFocusButton) {
+    const button = document.createElement("button");
+    button.type = "button";
+    const focusTargetType = session.focusTarget && session.focusTarget.type;
+    button.textContent = focusTargetType === "codex-thread"
+      ? t("dashboardOpenCodexSession")
+      : t("dashboardJumpTerminal");
+    button.disabled = session.canFocus !== true;
+    if (button.disabled) {
+      button.title = focusUnavailableText(session);
     }
-  });
-  actions.appendChild(button);
+    button.addEventListener("click", async () => {
+      window.dashboardAPI.focusSession(session.id);
+      // Best-effort ack alongside focus. Most remote-Codex sessions have
+      // canFocus=false (no terminal-jump target) and reach ack through the
+      // Mark-read button instead, but local Codex Stop sessions can land
+      // here so we ack on focus too.
+      if (window.dashboardAPI && typeof window.dashboardAPI.ackCompletion === "function") {
+        try { await window.dashboardAPI.ackCompletion(session.id); }
+        catch (err) { console.warn("ack completion threw:", err); }
+      }
+    });
+    actions.appendChild(button);
+  }
 
   if (session.canFocus !== true) {
     const reason = focusUnavailableText(session);
@@ -953,6 +957,7 @@ function automationActionState(key) {
 
 function appendSessionAutomation(container, session) {
   if (!container || !session) return;
+  if (session.canConfigureSessionAutomation !== true && !session.sessionAutomationGrantId) return;
   const row = document.createElement("div");
   row.className = "session-automation-row";
   const label = createText("span", "session-automation-label", t("sessionAutomationLabel"));

--- a/test/session-renderer-behavior.test.js
+++ b/test/session-renderer-behavior.test.js
@@ -266,6 +266,13 @@ test("Dashboard renders local/remote/webui reasons and only local folder action"
     "Remote sessions cannot focus a terminal on this computer.",
     "WebUI sessions do not have a local terminal window.",
   ]);
+
+  const cards = byClass(root, "card");
+  const jumpButtons = (card) => descendants(card)
+    .filter((el) => el.tagName === "BUTTON" && el.textContent === "Jump");
+  assert.deepStrictEqual(jumpButtons(cards[0]).map((button) => button.disabled), [true]);
+  assert.deepStrictEqual(jumpButtons(cards[1]), []);
+  assert.deepStrictEqual(jumpButtons(cards[2]).map((button) => button.disabled), [true]);
   assert.strictEqual(byClass(root, "open-folder-button").length, 1);
 });
 
@@ -415,8 +422,13 @@ test("Dashboard session automation sends only sessionId/mode and exact grantId",
     sessionAutomationMode: "auto-tools",
     sessionAutomationGrantId: "grant-current",
   });
-  const { root, automationCalls } = await loadDashboard([configurable, activeButIneligible]);
+  const inactiveIneligible = session("inactive", {
+    canConfigureSessionAutomation: false,
+    sessionAutomationMode: "inherit",
+  });
+  const { root, automationCalls } = await loadDashboard([configurable, activeButIneligible, inactiveIneligible]);
   const selects = byClass(root, "session-automation-select");
+  assert.strictEqual(selects.length, 2);
 
   selects[0].value = "off";
   await selects[0].dispatch("change");


### PR DESCRIPTION
## Summary
- Hide the disabled Jump to Terminal button for remote sessions that cannot be focused locally
- Hide the session automation dropdown when a session cannot configure automation and has no existing override
- Keep local/WebUI unavailable states and existing override revocation visible

## Tests
- node --test test/session-renderer-behavior.test.js test/session-focus-unavailable.test.js
- git diff --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)