### PR TITLE
feat(dsh): permission lifecycle replies dismiss stale approval bubbles 

### DIFF
--- a/hooks/dsh-clawd-bridge/lib/clawd-client.js
+++ b/hooks/dsh-clawd-bridge/lib/clawd-client.js
@@ -221,6 +221,24 @@ export function parsePermissionResult(result) {
   }
 }
 
+export async function notifyPermissionReplied(payload = {}, options = {}) {
+  // Fire-and-forget lifecycle notification: the Clawd server may still hold
+  // this ApprovalRequest while we leave without a decision (request
+  // cancelled, plugin reload). permission_event: "replied" makes it dismiss
+  // the matching bubble instead of parking it until the approval timeout.
+  return post('/permission', {
+    agent_id: 'deepseek-harness',
+    hook_source: 'dsh-plugin',
+    hook_event_name: 'PermissionRequest',
+    ...payload,
+    permission_event: 'replied',
+  }, {
+    ...options,
+    timeoutMs: Number.isFinite(options.timeoutMs) ? options.timeoutMs : STATE_TIMEOUT_MS,
+    maxResponseBytes: 4096,
+  })
+}
+
 export async function requestPermission(body, options = {}) {
   const result = await post('/permission', body, {
     ...options,

--- a/hooks/dsh-clawd-bridge/lib/index.js
+++ b/hooks/dsh-clawd-bridge/lib/index.js
@@ -8,7 +8,7 @@
 // native provider remains the sole owner of ask_user_question.
 
 import { randomUUID } from 'node:crypto'
-import { postState, requestPermission } from './clawd-client.js'
+import { postState, requestPermission, notifyPermissionReplied } from './clawd-client.js'
 
 export const name = 'dsh-clawd-bridge'
 
@@ -218,9 +218,21 @@ export function createApprovalHandler(
   requestPermissionImpl = requestPermission,
   permissionTimeoutMs = DEFAULT_PERMISSION_TIMEOUT_MS,
   lifetimeSignal = null,
+  notifyRepliedImpl = notifyPermissionReplied,
 ) {
   return async (req, next) => {
-    if (req?.signal?.aborted) return 'cancelled'
+    const payload = buildApprovalPayload(req)
+    const notifyReplied = () => {
+      // Best-effort lifecycle notification: if the Clawd server still holds
+      // this request while we leave without a decision (request cancelled or
+      // plugin reload), dismiss its bubble instead of parking it until the
+      // 10-minute approval timeout. Fire-and-forget; a late/foreign post is a
+      // harmless no-op server-side (matched=0).
+      try {
+        void notifyRepliedImpl(payload)
+      } catch {}
+    }
+    if (req?.signal?.aborted) { notifyReplied(); return 'cancelled' }
     // A plugin reload/dispose only removes this answerer. It must not claim
     // that the DSH asker cancelled the approval; continue to the next
     // waterfall listener so the native/web answerer can take over.
@@ -237,8 +249,8 @@ export function createApprovalHandler(
     } finally {
       linked.cleanup()
     }
-    if (req?.signal?.aborted) return 'cancelled'
-    if (lifetimeSignal?.aborted) return next()
+    if (req?.signal?.aborted) { notifyReplied(); return 'cancelled' }
+    if (lifetimeSignal?.aborted) { notifyReplied(); return next() }
     if (answer?.kind === 'cancelled') return 'cancelled'
     if (answer?.kind === 'decision') {
       return answer.decision === 'allow' ? 'allowed-once' : 'rejected'
@@ -297,7 +309,7 @@ export function apply(ctx, config = {}) {
     if (!approvalCtx || typeof approvalCtx.on !== 'function') return
     approvalCtx.on(
       'approval/request',
-      createApprovalHandler(requestPermission, permissionTimeoutMs, generation.signal),
+      createApprovalHandler(requestPermission, permissionTimeoutMs, generation.signal, notifyPermissionReplied),
       { prepend: true },
     )
   })

--- a/src/main.js
+++ b/src/main.js
@@ -2011,7 +2011,7 @@ const _permCtx = {
 };
 const _perm = initPermission(_permCtx);
 permissionPresentationRuntime = _perm;
-const { showPermissionBubble, resolvePermissionEntry, sendPermissionResponse, repositionBubbles, permLog, PASSTHROUGH_TOOLS, addPendingPermission, removePendingPermission, isPermissionEntryLive, canAutoResolvePendingPermission, beginSessionTrustConfirmation, endSessionTrustConfirmation, syncPermissionBubbleContent, maybeStartRemoteApproval, clearCodexNotifyBubbles, showCodexUserInputBubble, clearCodexUserInputBubbles, showKimiNotifyBubble, clearKimiNotifyBubbles, syncPermissionShortcuts, replyOpencodeFamilyPermission, dismissOpencodeFamilyPermissionResolvedExternally } = _perm;
+const { showPermissionBubble, resolvePermissionEntry, sendPermissionResponse, repositionBubbles, permLog, PASSTHROUGH_TOOLS, addPendingPermission, removePendingPermission, isPermissionEntryLive, canAutoResolvePendingPermission, beginSessionTrustConfirmation, endSessionTrustConfirmation, syncPermissionBubbleContent, maybeStartRemoteApproval, clearCodexNotifyBubbles, showCodexUserInputBubble, clearCodexUserInputBubbles, showKimiNotifyBubble, clearKimiNotifyBubbles, syncPermissionShortcuts, replyOpencodeFamilyPermission, dismissOpencodeFamilyPermissionResolvedExternally, dismissDshPermissionResolvedExternally } = _perm;
 const pendingPermissions = _perm.pendingPermissions;
 let permDebugLog = null; // set after app.whenReady()
 let updateDebugLog = null; // set after app.whenReady()
@@ -2806,6 +2806,7 @@ const _serverCtx = {
   maybeStartRemoteApproval,
   replyOpencodeFamilyPermission,
   dismissOpencodeFamilyPermissionResolvedExternally,
+  dismissDshPermissionResolvedExternally,
   syncPermissionShortcuts,
   permLog,
 };

--- a/src/permission.js
+++ b/src/permission.js
@@ -5029,6 +5029,66 @@ function dismissOpencodeFamilyPermissionResolvedExternally(identity) {
   return matches.length;
 }
 
+// DSH lifecycle reply (permission_event="replied" from the dsh-clawd-bridge
+// plugin): the plugin left an ApprovalRequest without a Clawd decision
+// (request cancelled, plugin reload). Remove the matching pending entry and
+// tear down its bubble immediately instead of parking it until the approval
+// timeout. Mirrors dismissOpencodeFamilyPermissionResolvedExternally above;
+// DSH entries are matched by entry.toolUseId (the plugin's request_id ==
+// ApprovalRequest.callId) plus the canonical session id.
+function dismissDshPermissionResolvedExternally(identity) {
+  const requestId = typeof identity?.requestId === "string" && identity.requestId
+    ? identity.requestId
+    : null;
+  const sessionId = identity?.sessionId || null;
+  if (!requestId || !sessionId) {
+    permLog("dsh external resolve no-op: invalid identity");
+    return 0;
+  }
+
+  const matches = pendingPermissions.filter((entry) => (
+    entry
+    && entry.agentId === "deepseek-harness"
+    && entry.isDsh === true
+    && entry.toolUseId === requestId
+    && entry.sessionId === sessionId
+  ));
+
+  if (matches.length === 0) {
+    permLog(`dsh external resolve no-op: request=${boundedPermissionIdentityForLog(requestId)}`);
+    return 0;
+  }
+
+  for (const entry of matches) {
+    const index = pendingPermissions.indexOf(entry);
+    if (index !== -1) pendingPermissions.splice(index, 1);
+  }
+  notifyPermissionsChanged("resolved-externally");
+
+  for (const entry of matches) {
+    cancelRemoteApproval(entry, { reason: "dsh-resolved-externally" });
+    if (entry._delayTimer) { clearTimeout(entry._delayTimer); entry._delayTimer = null; }
+    if (entry.autoCloseTimer) { clearTimeout(entry.autoCloseTimer); entry.autoCloseTimer = null; }
+    if (entry.autoExpireTimer) { clearTimeout(entry.autoExpireTimer); entry.autoExpireTimer = null; }
+    if (entry.abortHandler && entry.res) {
+      try { entry.res.removeListener("close", entry.abortHandler); } catch {}
+    }
+    hidePermissionBubbleSafely(entry);
+    notifyPermissionResolved(entry, "resolved-externally");
+    // Best-effort 204 so a still-open plugin long-poll cannot hang until the
+    // approval timeout; an already-destroyed socket is a no-op (writableFinished).
+    if (entry.res && !entry.res.writableFinished && typeof entry.res.writeHead === "function") {
+      try { sendNoDecisionResponse(entry.res, "resolved-externally", "dsh"); } catch {}
+    }
+  }
+
+  repositionBubbles();
+  repositionDependentBubbles();
+  syncPermissionShortcuts();
+  permLog(`dsh external resolve matched: request=${boundedPermissionIdentityForLog(requestId)} count=${matches.length}`);
+  return matches.length;
+}
+
 // Mirrors the DND dispatcher: CC res.destroy() so it falls back to chat,
 // opencode skips the bridge reply so TUI takes over, codex just closes.
 // options.subagentOnly (#451) restricts the sweep to entries that came from a
@@ -5174,6 +5234,7 @@ return {
   dismissPermissionsByAgent, dismissInteractivePermissionBubbles,
   dismissPermissionsForDnd,
   dismissOpencodeFamilyPermissionResolvedExternally,
+  dismissDshPermissionResolvedExternally,
   syncPermissionShortcuts,
   replyOpencodeFamilyPermission,
   // Exposed for the payload↔renderer contract test (plan §3.5/§9): the

--- a/src/server-route-permission.js
+++ b/src/server-route-permission.js
@@ -645,7 +645,7 @@ function handlePermissionPost(req, res, options) {
       return;
     }
     const { agentId } = hookIdentity;
-    if (hasPermissionEventDiscriminator && !isOpencodeFamily(agentId)) {
+    if (hasPermissionEventDiscriminator && !isOpencodeFamily(agentId) && agentId !== "deepseek-harness") {
       res.writeHead(200, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
       res.end("ok");
       ctx.permLog(`permission lifecycle no-op: unsupported agent=${agentId || "unknown"}`);
@@ -1577,6 +1577,39 @@ function handlePermissionPost(req, res, options) {
       // Blocking HTTP. The in-process DSH plugin awaits this response inside
       // approval/request. A 204 means no Clawd decision; the plugin calls
       // next() so DSH's downstream web answerer remains authoritative.
+      // ── DeepSeek Harness permission lifecycle (permission_event=replied) ──
+      // The DSH bridge plugin posts fire-and-forget when it leaves an
+      // ApprovalRequest without a Clawd decision (request cancelled or plugin
+      // reload). Dismiss the matching bubble immediately instead of parking
+      // it until the 10-minute approval timeout — mirrors the opencode-family
+      // lifecycle channel above.
+      if (hasPermissionEventDiscriminator && agentId === "deepseek-harness") {
+        res.writeHead(200, { [CLAWD_SERVER_HEADER]: CLAWD_SERVER_ID });
+        res.end("ok");
+        if (data.permission_event !== "replied") {
+          ctx.permLog("dsh permission lifecycle no-op: unsupported event");
+          return;
+        }
+        const rawSessionId = normalizeString(data.session_id);
+        const requestId = typeof data.request_id === "string" && data.request_id
+          ? data.request_id
+          : null;
+        if (!rawSessionId || !requestId) {
+          ctx.permLog(`dsh permission lifecycle no-op: ${!rawSessionId ? "missing session_id" : "missing request_id"}`);
+          return;
+        }
+        const sessionIdentity = resolvePermissionSession(rawSessionId, rawSessionId);
+        const dismissed = typeof ctx.dismissDshPermissionResolvedExternally === "function"
+          ? ctx.dismissDshPermissionResolvedExternally({
+            agentId,
+            requestId,
+            sessionId: sessionIdentity.sessionId,
+          })
+          : 0;
+        ctx.permLog(`dsh permission lifecycle replied: request=${boundedPermissionLogValue(requestId)} matched=${dismissed}`);
+        return;
+      }
+
       if (agentId === "deepseek-harness") {
         const toolName = typeof data.tool_name === "string" && data.tool_name.trim()
           ? data.tool_name.trim()

--- a/test/dsh-bridge-plugin.test.js
+++ b/test/dsh-bridge-plugin.test.js
@@ -212,3 +212,50 @@ test("DSH plugin registers public seams only and contains session/created except
   assert.strictEqual(typeof disposer, "function");
   disposer();
 });
+
+test("DSH approval handler notifies Clawd lifecycle when the asker cancels", async () => {
+  const { createApprovalHandler } = await bridge();
+  const notified = [];
+  const controller = new AbortController();
+  const handler = createApprovalHandler(
+    async () => { throw new Error("must not contact Clawd"); },
+    1000,
+    null,
+    (payload) => { notified.push(payload); return Promise.resolve({ ok: true }); },
+  );
+  const req = {
+    agent: { session: { id: "s3", header: { cwd: "C:/repo" } } },
+    toolName: "bash",
+    callId: "call-lifecycle-1",
+    reason: "test",
+    signal: controller.signal,
+  };
+  controller.abort();
+  assert.strictEqual(await handler(req, async () => "native"), "cancelled");
+  assert.strictEqual(notified.length, 1);
+  assert.strictEqual(notified[0].agent_id, "deepseek-harness");
+  assert.strictEqual(notified[0].tool_use_id, "call-lifecycle-1");
+  assert.strictEqual(notified[0].session_id, "deepseek-harness:s3");
+});
+
+test("DSH approval handler notifies Clawd lifecycle on plugin disposal before delegating", async () => {
+  const { createApprovalHandler } = await bridge();
+  const notified = [];
+  const lifetime = new AbortController();
+  const handler = createApprovalHandler(
+    (_payload, { signal }) => new Promise((resolve) => {
+      signal.addEventListener("abort", () => resolve({ kind: "cancelled" }), { once: true });
+    }),
+    1000,
+    lifetime.signal,
+    (payload) => { notified.push(payload); return Promise.resolve({ ok: true }); },
+  );
+  const pending = handler(
+    { agent: { session: { id: "s4", header: { cwd: "C:/repo" } } }, toolName: "bash", callId: "call-lifecycle-2" },
+    async () => "native",
+  );
+  lifetime.abort();
+  assert.strictEqual(await pending, "native");
+  assert.strictEqual(notified.length, 1);
+  assert.strictEqual(notified[0].tool_use_id, "call-lifecycle-2");
+});

--- a/test/permission-dsh-response.test.js
+++ b/test/permission-dsh-response.test.js
@@ -154,4 +154,31 @@ describe("DSH permission response contract", () => {
     assert.strictEqual(entry.res.captured.statusCode, 204);
     assert.strictEqual(entry.res.captured.destroyed, false);
   });
+
+  it("dismisses a pending DSH entry on an external resolved lifecycle reply", () => {
+    const perm = initPermission(makeCtx());
+    const entry = makeEntry({ toolUseId: "call-lifecycle-9" });
+    perm.pendingPermissions.push(entry);
+    const dismissed = perm.dismissDshPermissionResolvedExternally({
+      agentId: "deepseek-harness",
+      requestId: "call-lifecycle-9",
+      sessionId: "deepseek-harness:session-1",
+    });
+    assert.strictEqual(dismissed, 1);
+    assert.strictEqual(perm.pendingPermissions.includes(entry), false);
+    assert.strictEqual(entry.res.captured.statusCode, 204);
+    assert.strictEqual(entry.res.captured.ended, true);
+  });
+
+  it("no-ops when the resolved request is not pending", () => {
+    const perm = initPermission(makeCtx());
+    assert.strictEqual(
+      perm.dismissDshPermissionResolvedExternally({
+        agentId: "deepseek-harness",
+        requestId: "call-lifecycle-x",
+        sessionId: "deepseek-harness:session-1",
+      }),
+      0,
+    );
+  });
 });

--- a/test/server-route-permission.test.js
+++ b/test/server-route-permission.test.js
@@ -2225,6 +2225,60 @@ describe("server-route-permission POST", () => {
     assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, [entry]);
   });
 
+  it("routes a DSH replied lifecycle before every create/decision gate and never records a request", async () => {
+    const lifecycleCalls = [];
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "deepseek-harness",
+      hook_source: "dsh-plugin",
+      permission_event: "replied",
+      session_id: "deepseek-harness:ses-life",
+      request_id: "call-life",
+    }), {
+      ctx: {
+        doNotDisturb: true,
+        hideBubbles: true,
+        isAgentEnabled: () => false,
+        isAgentPermissionsEnabled: () => false,
+        dismissDshPermissionResolvedExternally: (identity) => {
+          lifecycleCalls.push(identity);
+          return 1;
+        },
+      },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.headers[CLAWD_SERVER_HEADER], CLAWD_SERVER_ID);
+    assert.strictEqual(res.body, "ok");
+    assert.deepStrictEqual(lifecycleCalls, [{
+      agentId: "deepseek-harness",
+      requestId: "call-life",
+      sessionId: localSessionKey("deepseek-harness:ses-life"),
+    }]);
+    assert.deepStrictEqual(res.recorder, [], "lifecycle must not create a PermissionRequest recorder");
+    assert.deepStrictEqual(res.ctx.calls.updateSession, []);
+    assert.deepStrictEqual(res.ctx.calls.showPermissionBubble, []);
+    assert.deepStrictEqual(res.ctx.calls.addPendingPermission, []);
+    assert.deepStrictEqual(res.ctx.calls.maybeStartRemoteApproval, []);
+  });
+
+  it("200-no-ops a malformed DSH replied lifecycle identity", async () => {
+    const res = await callPermissionPost(JSON.stringify({
+      agent_id: "deepseek-harness",
+      hook_source: "dsh-plugin",
+      permission_event: "replied",
+      session_id: null,
+      request_id: "call-life",
+    }), {
+      ctx: {
+        dismissDshPermissionResolvedExternally: () => { throw new Error("must not be called"); },
+      },
+    });
+
+    assert.strictEqual(res.statusCode, 200);
+    assert.strictEqual(res.body, "ok");
+    assert.deepStrictEqual(res.ctx.calls.addPendingPermission, []);
+  });
+
   it("leaves DSH ask_user_question with the native provider", async () => {
     const res = await callPermissionPost(JSON.stringify({
       agent_id: "deepseek-harness",


### PR DESCRIPTION
## 问题

DSH 权限请求被取消（asker `AbortSignal`/会话终止）或插件被卸载/重载时，`dsh-clawd-bridge` 的 approval handler 直接返回 `cancelled` / 调用 `next()`，**Clawd 侧没有任何"已解决"信号**：pending entry 和气泡滞留到 10 分钟 approval timeout，配合会话状态通知看起来就是"弹窗一直弹出、不感知变化"。详见 [clawd-on-desk#988](https://github.com/rullerzhou-afk/clawd-on-desk/issues/988)。

现状：只有 `opencode-family` 有 `permission_event: "replied"` 生命周期通道；`deepseek-harness` 在 `server-route-permission.js`（约 648 行）被当作 `unsupported agent` no-op。

## 改动（镜像 opencode-family 生命周期通道）

**插件侧 `hooks/dsh-clawd-bridge`**
- `clawd-client.js`：新增 `notifyPermissionReplied(payload)` —— fire-and-forget `POST /permission`，带 `agent_id: deepseek-harness`、`hook_source: dsh-plugin`、`permission_event: "replied"`、`session_id`、`request_id`
- `index.js`：`createApprovalHandler` 增加可注入的 `notifyRepliedImpl`（默认 `notifyPermissionReplied`），在**没有拿到 Clawd 决定就退出**的路径（asker 取消、插件释放后 delegating）发一次 lifecycle 通知

**服务端 `src/server-route-permission.js`**
- 生命周期门放行 `deepseek-harness`（其他 agent 仍 no-op）
- 新增 DSH `replied` 分支：任意 create/decision gate 之前处理（200 `ok`，不建 request recorder），缺失/畸形字段 200 并日志 no-op

**`src/permission.js`**
- 新增 `dismissDshPermissionResolvedExternally(identity)`：按 `toolUseId + canonical sessionId` 匹配 pending DSH 条目 → 摘除、销毁气泡、清 auto-close/expire 定时器与远程审批、移除 close listener、`notifyPermissionResolved`、尽力回 204（`writableFinished` 守卫）给仍挂着的长连接；无匹配 no-op（matched=0）

**`src/main.js`**：把新 dismisser 接线到路由 context。

## 测试

- `test/dsh-bridge-plugin.test.js` → 10/10（+2：asker 取消、插件释放时各发一次 replied）
- `test/permission-dsh-response.test.js` → 9/9（+2：外部 resolve 摘除 entry 且回 204；无匹配 no-op）
- `test/server-route-permission.test.js` → 105/105（+2：DSH replied 路由先于所有 gate、不记录 request；畸形身份 200-no-op）

## 说明

- DSH 仍不进入 `KNOWN_PERMISSION_AGENTS`（Clawd 侧 permission automation 对 DSH 继续 DEFER，不改变审批策略）；本改动只保证"请求已由外部解决"时气泡生命周期**同步结束**
- 长连接 204 是尽力而为（client 已断开时 `writableFinished` 跳过）
- 其他 agent 的 lifecycle no-op 行为不变

Closes #988