### PR TITLE
fix(build): use the temporary keychain password for macOS signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,6 +179,12 @@ jobs:
           fi
           echo "mode=developer-id" >> "$GITHUB_OUTPUT"
 
+      - name: Correct macOS signing keychain password
+        if: steps.mac-signing.outputs.mode == 'developer-id'
+        run: |
+          node --test test/macos-signing-keychain.test.js
+          node scripts/prepare-macos-signing.js
+
       - name: Build macOS (Developer ID signed and notarized)
         if: steps.mac-signing.outputs.mode == 'developer-id'
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ scripts/manual/*
 !scripts/assert-no-retired-telegram-sidecar.js
 !scripts/verify-release-version.js
 !scripts/verify-release-contributors.js
+!scripts/prepare-macos-signing.js
 !scripts/after-pack-koffi.js
 !scripts/audit-packaged-native.js
 !scripts/native-package-policy.json

--- a/docs/guides/release-signing.md
+++ b/docs/guides/release-signing.md
@@ -144,6 +144,15 @@ base64 -i "/绝对路径/AuthKey_<KEY_ID>.p8" | pbcopy
 - 只配置一部分：立即失败并列出缺少的 Secret 名称，不打印 Secret 内容。
 - 推送 `v*` tag：五项缺任何一项都失败，绝不生成 ad-hoc 官方版本。
 
+当前锁定的 `app-builder-lib@26.15.7` 把证书导出密码误传给
+`security set-key-partition-list -k`，该参数实际需要临时钥匙串密码，
+会导致 `SecKeychainUnlock`。Developer ID 构建前会运行
+`node scripts/prepare-macos-signing.js`，仅修正 CI 安装的 macOS 签名模块，
+不更改共享依赖版本、Windows 构建或应用运行时代码。脚本核对版本及修改前后
+完整文件 SHA256；遇到未知版本/内容会停止，升级该依赖时必须重新审查并移除
+或更新此临时兼容处理。这个错误不要求改动现有 Secrets；修复仍须通过后续
+真实签名、公证和分发包验证。
+
 ## 5. 首次发布验证
 
 1. 在 Actions 手动运行 `Build & Release`，不要先推正式 tag。

--- a/scripts/prepare-macos-signing.js
+++ b/scripts/prepare-macos-signing.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+// app-builder-lib 26.15.7 passes the certificate password to the keychain's
+// set-key-partition-list. Keep this workaround in the macOS signing job only;
+// remove it after a reviewed upstream fix. Neither shared dependencies nor
+// packaged application files need to change.
+const VERSION = "26.15.7";
+const ORIGINAL_SHA256 = "9f7d789b326147b6da29e1218d6e3f76b0314c68cf5d0f1efa59338a3c86e71a";
+const PATCHED_SHA256 = "5b6551607c61c75cd1eadb2165b05513ff6d6b2965d129b5db9192b7e99e6fd1";
+
+function sha256(source) {
+  return crypto.createHash("sha256").update(source).digest("hex");
+}
+
+function patchSigningSource(source) {
+  if (sha256(source) === PATCHED_SHA256) return source;
+  if (sha256(source) !== ORIGINAL_SHA256) {
+    throw new Error("Unrecognized app-builder-lib macOS signing source; review the keychain workaround before building.");
+  }
+  const patched = source
+    .replace("importCerts(keychainFile, certPaths, cscPasswords)",
+      "importCerts(keychainFile, certPaths, cscPasswords, keychainPassword)")
+    .replace("async function importCerts(keychainFile, paths, keyPasswords)",
+      "async function importCerts(keychainFile, paths, keyPasswords, keychainPassword)")
+    .replace('["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", password, keychainFile]',
+      '["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]');
+  if (sha256(patched) !== PATCHED_SHA256) {
+    throw new Error("macOS signing workaround did not produce the reviewed source.");
+  }
+  return patched;
+}
+
+function prepareMacSigning({
+  platform = process.platform,
+  builderRoot = path.join(__dirname, "..", "node_modules", "app-builder-lib"),
+} = {}) {
+  if (platform !== "darwin") throw new Error("The signing workaround is macOS-only.");
+  const pkg = JSON.parse(fs.readFileSync(path.join(builderRoot, "package.json"), "utf8"));
+  if (pkg.version !== VERSION) {
+    throw new Error("Unexpected app-builder-lib version; review the macOS signing workaround before building.");
+  }
+  const filename = path.join(builderRoot, "out", "codeSign", "macCodeSign.js");
+  const source = fs.readFileSync(filename, "utf8");
+  const patched = patchSigningSource(source);
+  if (patched === source) return false;
+  fs.writeFileSync(filename, patched);
+  return true;
+}
+
+if (require.main === module) {
+  try {
+    console.log(prepareMacSigning()
+      ? "Applied app-builder-lib 26.15.7 macOS keychain password workaround."
+      : "app-builder-lib 26.15.7 macOS keychain password workaround already applied.");
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { patchSigningSource, prepareMacSigning };

--- a/test/macos-signing-keychain.test.js
+++ b/test/macos-signing-keychain.test.js
@@ -1,0 +1,117 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const vm = require("node:vm");
+const { test } = require("node:test");
+const { patchSigningSource, prepareMacSigning } = require("../scripts/prepare-macos-signing");
+
+const installedSource = fs.readFileSync(require.resolve("app-builder-lib/out/codeSign/macCodeSign"), "utf8");
+
+// Execute the actual locked upstream function, but never invoke security or
+// read credentials. Distinct synthetic certificate/keychain passwords catch
+// the regression that caused run 33767194750 to fail.
+async function captureSigningCalls(source) {
+  const calls = [];
+  const exported = {};
+  const stubs = {
+    "builder-util": {
+      exec: async (file, args) => { calls.push({ file, args }); return ""; },
+      copyFile: async () => {},
+      unlinkIfExists: async () => {},
+      isEmptyOrSpaces: (value) => !value,
+      log: { warn() {} },
+    },
+    "../util/dynamicImport": {},
+    crypto: { ...crypto, randomBytes: (length) => Buffer.alloc(length, 1) },
+    "fs/promises": { rename: async () => {} },
+    "lazy-val": { Lazy: class {
+      constructor(fn) { this.fn = fn; }
+      get value() { return this.fn(); }
+    } },
+    os: { homedir: () => "/synthetic-home", tmpdir: () => "/synthetic-tmp" },
+    path,
+    "temp-file": { getTempName: () => "synthetic-root-certs" },
+    "../util/flags": {},
+    "./codesign": { importCertificate: async (link) => `/synthetic/${link}.p12` },
+  };
+  vm.runInNewContext(source, {
+    exports: exported,
+    require(name) {
+      assert.ok(Object.hasOwn(stubs, name), `Unstubbed dependency: ${name}`);
+      return stubs[name];
+    },
+    process: { env: {}, platform: "darwin" },
+    __dirname: "/synthetic-builder/codeSign",
+  });
+  await exported.createKeychain({
+    tmpDir: {},
+    currentDir: "/synthetic-project",
+    cscLink: "application",
+    cscKeyPassword: "synthetic-application-password",
+    cscILink: "installer",
+    cscIKeyPassword: "synthetic-installer-password",
+  });
+  return calls.map(({ args }) => Array.from(args));
+}
+
+test("both certificates use their import passwords and the shared keychain password for partition access", async () => {
+  const calls = await captureSigningCalls(patchSigningSource(installedSource));
+  const option = (args, flag) => args[args.indexOf(flag) + 1];
+  const created = option(calls.find((args) => args[0] === "create-keychain"), "-p");
+  const unlocked = option(calls.find((args) => args[0] === "unlock-keychain"), "-p");
+  assert.equal(created, unlocked);
+  const imports = calls.filter((args) => args[0] === "import");
+  assert.deepEqual(imports.map((args) => option(args, "-P")), [
+    "synthetic-application-password", "synthetic-installer-password",
+  ]);
+  const partitions = calls.filter((args) => args[0] === "set-key-partition-list");
+  assert.equal(partitions.length, 2);
+  for (const args of partitions) {
+    assert.equal(option(args, "-k"), created);
+    assert.equal(option(args, "-S"), "apple-tool:,apple:");
+  }
+});
+
+test("the reviewed signing patch is idempotent and rejects changed upstream content", () => {
+  const patched = patchSigningSource(installedSource);
+  assert.equal(patchSigningSource(patched), patched);
+  assert.throws(() => patchSigningSource(`${installedSource}\n// changed`), /Unrecognized/);
+});
+
+test("only the recognized macOS build module is changed; version/platform mismatches preserve it", (t) => {
+  const builderRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-mac-signing-"));
+  t.after(() => fs.rmSync(builderRoot, { recursive: true, force: true }));
+  const filename = path.join(builderRoot, "out", "codeSign", "macCodeSign.js");
+  fs.mkdirSync(path.dirname(filename), { recursive: true });
+  const pkgPath = path.join(builderRoot, "package.json");
+  const pkg = JSON.stringify({ version: "26.15.7" });
+  fs.writeFileSync(pkgPath, pkg);
+  fs.writeFileSync(filename, installedSource);
+  for (const platform of ["win32", "linux"]) {
+    assert.throws(() => prepareMacSigning({ builderRoot, platform }), /macOS-only/);
+    assert.equal(fs.readFileSync(filename, "utf8"), installedSource);
+  }
+  fs.writeFileSync(pkgPath, JSON.stringify({ version: "26.15.8" }));
+  assert.throws(() => prepareMacSigning({ builderRoot, platform: "darwin" }), /Unexpected/);
+  assert.equal(fs.readFileSync(filename, "utf8"), installedSource);
+  fs.writeFileSync(pkgPath, pkg);
+  prepareMacSigning({ builderRoot, platform: "darwin" });
+  assert.equal(fs.readFileSync(filename, "utf8"), patchSigningSource(installedSource));
+  assert.equal(prepareMacSigning({ builderRoot, platform: "darwin" }), false);
+  assert.equal(fs.readFileSync(pkgPath, "utf8"), pkg);
+});
+
+test("the workaround runs only in the Developer ID macOS job before signing", () => {
+  const root = path.join(__dirname, "..");
+  const workflow = fs.readFileSync(path.join(root, ".github", "workflows", "build.yml"), "utf8");
+  const macStart = workflow.indexOf("\n  build-mac:");
+  const nextJob = workflow.indexOf("\n  build-linux:", macStart);
+  const macJob = workflow.slice(macStart, nextJob);
+  assert.match(macJob, /name: Correct macOS signing keychain password\n\s+if: steps\.mac-signing\.outputs\.mode == 'developer-id'\n\s+run: \|\n\s+node --test test\/macos-signing-keychain\.test\.js\n\s+node scripts\/prepare-macos-signing\.js/);
+  assert.ok(macJob.indexOf("node scripts/prepare-macos-signing.js") < macJob.indexOf("name: Build macOS (Developer ID signed and notarized)"));
+  assert.doesNotMatch(workflow.slice(0, macStart) + workflow.slice(nextJob), /prepare-macos-signing/);
+});


### PR DESCRIPTION
The locked `app-builder-lib@26.15.7` passes the certificate export password to `security set-key-partition-list -k`, which requires the generated temporary keychain password. This caused the macOS signing failure in Build & Release run 33767194750.

Pass the generated keychain password through to partition-list setup while retaining each certificate's own password for import. Apply the workaround only before Developer ID signing in the macOS build job, with exact version and before/after SHA256 guards. Unknown upstream content stops the build; a reviewed upstream fix should replace this workaround.

Shared dependency versions, application runtime code, and Windows/Linux build jobs are unchanged. No signing credentials need to be changed for this argument mismatch.

Validation: 50 focused signing, package configuration, release-version, and contributor tests passed. Removing the fix makes the password regression test fail. The real helper entry point was also checked against an isolated dependency copy, including a second idempotent invocation. Signing-function tests stub all native and credential operations; these results do not establish successful signing or notarization.

The manual, non-publishing [Build & Release run 33820913990](https://github.com/rullerzhou-afk/clawd-on-desk/actions/runs/33820913990) passed at `3982d70e079da52df2f2e56527cd15d3b8f06ca5`, including Developer ID signing and notarization for both macOS architectures, signed DMG/ZIP verification, packaged native audits and updater metadata checks. Windows, Linux, and the five-target package audit also passed; the release job was skipped. The signed `mac-installer` artifact is `9918517580`.

All seven PR checks passed. Keep this draft for review: CI verification does not replace isolated macOS installation, upgrade, GUI, or real A→B updater acceptance.
