### PR TITLE
test: make macOS signing workflow assertion CRLF-safe

### DIFF
--- a/test/macos-signing-keychain.test.js
+++ b/test/macos-signing-keychain.test.js
@@ -107,7 +107,8 @@ test("only the recognized macOS build module is changed; version/platform mismat
 
 test("the workaround runs only in the Developer ID macOS job before signing", () => {
   const root = path.join(__dirname, "..");
-  const workflow = fs.readFileSync(path.join(root, ".github", "workflows", "build.yml"), "utf8");
+  const workflow = fs.readFileSync(path.join(root, ".github", "workflows", "build.yml"), "utf8")
+    .replace(/\r\n?/g, "\n");
   const macStart = workflow.indexOf("\n  build-mac:");
   const nextJob = workflow.indexOf("\n  build-linux:", macStart);
   const macJob = workflow.slice(macStart, nextJob);


### PR DESCRIPTION
Release candidate run 33831728261 exposed this on windows-latest: the macOS signing workflow assertion hard-coded LF separators, while the Windows checkout was CRLF. Normalize the loaded YAML to LF before slicing and matching. Runtime/build behavior is unchanged. Validation: focused test 4/4 passes on Windows; full local suite reaches 9,406 passes with only the five pre-existing Windows symlink EPERM environment failures.