### PR TITLE
fix(state): probe working source pid only after the working window

### DIFF
--- a/src/state-stale-cleanup.js
+++ b/src/state-stale-cleanup.js
@@ -167,11 +167,18 @@ function getStaleSessionDecision(session, options = {}) {
   // and stamp that transition. Otherwise a 20-minute-old Codex turn can be
   // changed to idle with its old timestamp, then deleted immediately by the
   // ordinary 10-minute idle cutoff on the next sweep.
+  //
+  // Source liveness only carries information once that window has elapsed. A
+  // source_pid frequently belongs to a per-event launcher rather than to the
+  // session host — Windows Claude Code runs every hook through a throwaway
+  // pwsh wrapper, so the pid shipped with an event is already gone when the
+  // next sweep reads it. Probing it while the turn is still reporting deletes
+  // the live session between events, and the following event recreates it.
   if (isWorkingLikeState(session.state)) {
-    if (session.pidReachable && session.sourcePid && !isProcessAlive(session.sourcePid)) {
-      return { action: "delete", reason: "working-source-exit" };
-    }
     if (workingStaleMs > 0 && age > workingStaleMs) {
+      if (session.pidReachable && session.sourcePid && !isProcessAlive(session.sourcePid)) {
+        return { action: "delete", reason: "working-source-exit" };
+      }
       return { action: "idle", reason: "working-timeout", updateTimestamp: true };
     }
     return { action: null };

--- a/src/state-stale-cleanup.js
+++ b/src/state-stale-cleanup.js
@@ -168,17 +168,24 @@ function getStaleSessionDecision(session, options = {}) {
   // changed to idle with its old timestamp, then deleted immediately by the
   // ordinary 10-minute idle cutoff on the next sweep.
   //
-  // Source liveness only carries information once that window has elapsed. A
+  // With an age window enabled, only check source liveness after it elapses. A
   // source_pid frequently belongs to a per-event launcher rather than to the
   // session host — Windows Claude Code runs every hook through a throwaway
   // pwsh wrapper, so the pid shipped with an event is already gone when the
   // next sweep reads it. Probing it while the turn is still reporting deletes
   // the live session between events, and the following event recreates it.
   if (isWorkingLikeState(session.state)) {
-    if (workingStaleMs > 0 && age > workingStaleMs) {
-      if (session.pidReachable && session.sourcePid && !isProcessAlive(session.sourcePid)) {
-        return { action: "delete", reason: "working-source-exit" };
-      }
+    const workingWindowElapsed = workingStaleMs > 0 && age > workingStaleMs;
+    // Zero disables age-based expiry, not process-death cleanup. In particular,
+    // a local Codex session may have only a source PID when agent PID discovery
+    // failed, so the earlier agent-exit check cannot retire it on its own.
+    if (
+      (workingStaleMs === 0 || workingWindowElapsed)
+      && session.pidReachable && session.sourcePid && !isProcessAlive(session.sourcePid)
+    ) {
+      return { action: "delete", reason: "working-source-exit" };
+    }
+    if (workingWindowElapsed) {
       return { action: "idle", reason: "working-timeout", updateTimestamp: true };
     }
     return { action: null };

--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -176,6 +176,22 @@ describe("state stale cleanup decisions", () => {
     }).result, { action: null });
   });
 
+  it("does not probe the source before or at a positive working-window boundary", () => {
+    const now = 2_000_000;
+    for (const state of ["working", "thinking", "juggling"]) {
+      for (const age of [1_000, WORKING_STALE_MS]) {
+        for (const agentPid of [null, 10]) {
+          const { result, calls } = decision(session({
+            state, agentId: "claude-code", agentPid, sourcePid: 20,
+            updatedAt: now - age,
+          }), { now, alivePids: new Set([10]) });
+          assert.deepStrictEqual(result, { action: null });
+          assert.deepStrictEqual(calls, agentPid ? [10] : []);
+        }
+      }
+    }
+  });
+
   it("keeps working-like state set explicit", () => {
     assert.strictEqual(isWorkingLikeState("working"), true);
     assert.strictEqual(isWorkingLikeState("thinking"), true);
@@ -452,6 +468,51 @@ describe("state stale cleanup decisions", () => {
       alivePids: new Set(),
       staleConfig,
     }).result, { action: "delete", reason: "agent-exit" });
+  });
+
+  it("keeps source-exit cleanup with Codex age expiry disabled and no agent pid", () => {
+    const now = 100 * 60 * 60 * 1000;
+    for (const state of ["working", "thinking", "juggling"]) {
+      for (const updatedAt of [now - 1_000, 1]) {
+        for (const codexOriginator of [null, "codex_work_desktop"]) {
+          const { result, calls } = decision(session({
+            state, agentId: "codex", codexOriginator,
+            agentPid: null, sourcePid: 20, updatedAt,
+          }), { now, staleConfig: { codexWorkingStaleMs: 0 } });
+          assert.deepStrictEqual(result, { action: "delete", reason: "working-source-exit" });
+          assert.deepStrictEqual(calls, [20]);
+        }
+      }
+    }
+  });
+
+  it("does not age out live or unprobeable sources when Codex age expiry is disabled", () => {
+    const now = 100 * 60 * 60 * 1000;
+    const target = session({
+      state: "working", agentId: "codex", agentPid: null, sourcePid: 20, updatedAt: 1,
+    });
+    const options = { now, staleConfig: { codexWorkingStaleMs: 0 } };
+    const live = decision(target, { ...options, alivePids: new Set([20]) });
+    assert.deepStrictEqual(live.result, { action: null });
+    assert.deepStrictEqual(live.calls, [20]);
+    for (const overrides of [{ sourcePid: null }, { pidReachable: false }]) {
+      const unprobeable = decision({ ...target, ...overrides }, options);
+      assert.deepStrictEqual(unprobeable.result, { action: null });
+      assert.deepStrictEqual(unprobeable.calls, []);
+    }
+  });
+
+  it("preserves distinct source and agent death checks with Codex age expiry disabled", () => {
+    const target = session({
+      state: "working", agentId: "codex", agentPid: 10, sourcePid: 20,
+    });
+    const staleConfig = { codexWorkingStaleMs: 0 };
+    const sourceDead = decision(target, { staleConfig, alivePids: new Set([10]) });
+    assert.deepStrictEqual(sourceDead.result, { action: "delete", reason: "working-source-exit" });
+    assert.deepStrictEqual(sourceDead.calls, [10, 20]);
+    const agentDead = decision(target, { staleConfig, alivePids: new Set([20]) });
+    assert.deepStrictEqual(agentDead.result, { action: "delete", reason: "agent-exit" });
+    assert.deepStrictEqual(agentDead.calls, [10]);
   });
 
   it("starts Codex Desktop idle retention from the stamped timeout transition", () => {

--- a/test/state-stale-cleanup.test.js
+++ b/test/state-stale-cleanup.test.js
@@ -158,6 +158,24 @@ describe("state stale cleanup decisions", () => {
     })).result, { action: null });
   });
 
+  it("keeps an actively reporting working session whose source process already exited", () => {
+    // Several agents launch each hook through a throwaway shell (on Windows
+    // Claude Code uses a per-event pwsh wrapper), so the source_pid that ships
+    // with an event is dead again within the second. Source liveness only means
+    // something once the turn has actually gone quiet for the working window.
+    const now = 2_000_000;
+    assert.deepStrictEqual(decision(session({
+      state: "working",
+      agentId: "claude-code",
+      agentPid: 10,
+      sourcePid: 20,
+      updatedAt: now - 1_000,
+    }), {
+      now,
+      alivePids: new Set([10]),
+    }).result, { action: null });
+  });
+
   it("keeps working-like state set explicit", () => {
     assert.strictEqual(isWorkingLikeState("working"), true);
     assert.strictEqual(isWorkingLikeState("thinking"), true);


### PR DESCRIPTION
Fixes #992.

## Problem

`getStaleSessionDecision` probes `sourcePid` liveness for every working-like session on **every** sweep, with no age condition. A session that reports a hook event every second is therefore deleted about a second after each event and recreated by the next one, so the pet flips between the working and idle animations for the whole run.

The probe used to be gated behind the working window (`else if (age > workingStaleMs)`); `05372be6` (#960) moved it into the new working-like branch and dropped the gate.

That combines badly with how `source_pid` is produced on Windows. Claude Code launches each hook through a throwaway wrapper:

```
node.exe (hook) <- pwsh.exe <- claude.exe <- claude.exe <- explorer.exe
```

`pwsh.exe` is in `BASE_TERMINAL_NAMES_WIN`, so the walk in `hooks/shared-process.js` selects that per-event wrapper as `terminalPid` and ships it as `source_pid`. It is dead before the next sweep reads it, while `agentPid` stays alive the whole session. From one ~9-minute window of `session-debug.log` on v1.0.0, three live sessions, 317 deletions:

```
23:56:39.324 event sid=…YjNiM2Uw… state=working … agentPid=36076 sourcePid=32956 -> incoming=working/PreToolUse
23:56:43.984 stale-delete working-source-exit sid=…YjNiM2Uw… state=working … agentPid=36076 sourcePid=29688
23:56:51.283 event sid=…YjNiM2Uw… <deleted> -> incoming=working/PreToolUse
```

## Change

Move the source-liveness probe back inside the working-window check. A working-like session is only judged on its source PID once it has actually been silent for its effective `workingStaleMs`; before that it is left alone.

Behaviour preserved:

- `agent-exit` is unchanged and still deletes immediately when the agent process dies — that is the branch that retires a session whose terminal was really closed, since the agent dies with it.
- Orphaned/lingering working sessions are still deleted with `working-source-exit` after `workingStaleMs`, as they were before v1.0.0.
- `05372be6`'s separation of the active-turn timeout from the idle-card cutoff is kept: a working-like session still settles through the working timeout first and stamps that transition.

One deliberate consequence worth a maintainer's eye: with `workingStaleMs === 0` (the local-Codex "never idle a silent turn by age" choice) the source probe no longer runs for those sessions either. `agent-exit` still covers a dead Codex process, and `codex-hook.js` sends `source_pid = agentPid` on the `preferAgentPid` path, so I do not think anything is lost — say the word if you would rather keep a floor there.

## Verification

- New regression test in `test/state-stale-cleanup.test.js`: an actively reporting working session whose `sourcePid` is dead and whose `agentPid` is alive yields `{ action: null }`. It fails on `main` with `{ action: 'delete', reason: 'working-source-exit' }`.
- `node --test test/state-stale-cleanup.test.js` — 46/46 pass. The two existing `working-source-exit` assertions (the generic one and the OpenCode stale-floor one) both already use aged sessions and still pass unchanged.
- Full `node test/run-tests.js` on Windows 11: 9410 pass / 2 fail. Both failures reproduce on unmodified `main` in the same worktree and are environmental — `cigarette-accessory-electron` (Electron render harness) and one Reasonix 5s-timeout timing test that passes on re-run.
