### PR TITLE
Harden local /permission ingress against browser requests

### DIFF
--- a/docs/project/agent-runtime-architecture.md
+++ b/docs/project/agent-runtime-architecture.md
@@ -248,6 +248,40 @@ DeepSeek Harness 权限气泡（approval waterfall，阻塞）：
     → DND / disabled / bubble hidden / Clawd unavailable 时 stdout "{}"，Codex 回到原生审批提示
 ```
 
+## Local Permission HTTP Boundary
+
+The local `POST /permission` endpoint is a native hook/plugin interface. Before
+reading the body or recording a hook event, `src/server.js` rejects any `Origin`
+header (including empty or `null`), an HTTP Host other than explicit
+`127.0.0.1`, `localhost`, or `[::1]` with an optional valid port, and a media type
+other than `application/json` (parameters such as `charset=utf-8` are allowed).
+Duplicate Host or Content-Type fields are rejected. Forwarded headers do not
+grant access, and OPTIONS does not enable cross-origin preflight.
+
+These are browser-request guards: loopback binding and CORS response restrictions
+alone do not prevent a simple cross-origin POST from creating approval UI.
+Rejected requests receive an empty 400/403/415 response and a closed connection,
+without a Clawd success marker or an agent approval/denial. Native hooks retain
+their own no-decision fallback. Custom proxies targeting the local endpoint must
+preserve this native request contract; a browser frontend is not supported here.
+
+This does not authenticate unrestricted same-user processes, which can construct
+the permitted headers. A token stored in a same-user-readable runtime file would
+not provide that isolation either. Receiving an `allow` on a caller's own HTTP
+request does not establish authority over another pending request. Pi's legacy
+state-only response and Task passthrough semantics remain unchanged.
+
+Authenticated Remote SSH traffic retains its separate profile-bound nonce
+ingress and trusted profile stamping; these local checks do not replace that
+contract. `/state` is outside this permission-specific guard.
+
+Regression evidence uses the real HTTP router and permission ownership module
+in `test/server-permission-ingress.test.js`. The Electron fixture additionally
+checks a cross-origin loopback webpage and real approval windows with isolated
+user data, no installed hooks, no remote clients, and no executed agent tools.
+It does not establish public-Internet reachability across browser-specific local
+network access controls or replace real agent/OS compatibility checks.
+
 ## Local Recap Projection
 
 The recap is a local projection of accepted runtime activity, not a second observer at the HTTP or `updateSession()` entry. After agent gates, Codex source/replay arbitration, permission provenance handling, subagent filtering, and completion arbitration settle, `src/state.js` maps the accepted boundary through `src/recap-metrics.js` and sends an allowlisted canonical event to `src/recap-runtime.js`.

--- a/src/server.js
+++ b/src/server.js
@@ -715,6 +715,43 @@ function stopClaudeSettingsWatcher() {
   return claudeSettingsWatcher.stop();
 }
 
+function rejectUnsafeLocalPermissionRequest(req, res) {
+    // This endpoint is for native hooks, not browser UI. Loopback binding and
+    // absent CORS headers alone do not stop simple cross-origin POSTs. These
+    // checks do not authenticate unrestricted processes under the same OS user.
+    const headers = req.headers || {};
+    const host = typeof headers.host === "string"
+      ? /^(?:127\.0\.0\.1|localhost|\[::1\])(?::([0-9]{1,5}))?$/i.exec(headers.host)
+      : null;
+    let status = 0;
+    if (Object.prototype.hasOwnProperty.call(headers, "origin")
+      || !host
+      || (host[1] !== undefined && (Number(host[1]) < 1 || Number(host[1]) > 65535))) {
+      status = 403;
+    } else {
+      // Node discards duplicate Host / Content-Type fields by default. Reject
+      // ambiguous requests rather than validating only the retained first value.
+      const seen = new Set();
+      const raw = req.rawHeaders || [];
+      for (let i = 0; i < raw.length; i += 2) {
+        const name = raw[i].toLowerCase();
+        if (name !== "host" && name !== "content-type") continue;
+        if (seen.has(name)) { status = 400; break; }
+        seen.add(name);
+      }
+      const type = typeof headers["content-type"] === "string"
+        ? headers["content-type"].split(";", 1)[0].trim().toLowerCase()
+        : "";
+      if (!status && type !== "application/json") status = 415;
+    }
+    if (!status) return false;
+    // No agent decision or success marker on a transport rejection. Close
+    // without waiting for body bytes; native clients retain their own fallback.
+    res.writeHead(status, { "Connection": "close" });
+    res.end();
+    return true;
+}
+
 function routeHttpRequest(req, res, remoteProfile = null) {
     // Secure Remote SSH traffic must terminate at its profile-bound ingress,
     // never at the compatibility-oriented local main server. Rejecting the
@@ -746,6 +783,7 @@ function routeHttpRequest(req, res, remoteProfile = null) {
         isClaudeStatuslineMetadataAllowed,
       });
     } else if (req.method === "POST" && req.url === "/permission") {
+      if (!remoteProfile && rejectUnsafeLocalPermissionRequest(req, res)) return;
       handlePermissionPost(req, res, {
         ctx,
         createRequestHookRecorder,

--- a/test/fixtures/permission-ingress-electron.js
+++ b/test/fixtures/permission-ingress-electron.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const { app, BrowserWindow, ipcMain } = require("electron");
+const http = require("node:http");
+const fs = require("node:fs");
+const path = require("node:path");
+const assert = require("node:assert/strict");
+const { once } = require("node:events");
+const { registerPermissionIpc } = require("../../src/permission");
+const { createPermissionIngressHarness, postPermission, dummyPermission, waitUntil } = require("../helpers/permission-ingress-harness");
+
+// Run with Electron, never with the application main: no real profile, hooks,
+// integrations, agent tools, or remote approvals are loaded by this fixture.
+const evidenceDir = process.env.CLAWD_INGRESS_EVIDENCE_DIR;
+const expectBlocked = process.env.CLAWD_INGRESS_EXPECT_BLOCKED !== "0";
+app.on("window-all-closed", () => {});
+const deadline = setTimeout(() => app.exit(1), 25000);
+
+app.whenReady().then(async () => {
+  const harness = await createPermissionIngressHarness({ render: true });
+  const registration = registerPermissionIpc({ ipcMain, permission: harness.permission });
+  const pageServer = http.createServer((_req, res) => {
+    res.writeHead(200, { "Content-Type": "text/html" });
+    res.end("<!doctype html><title>Issue 976 isolated cross-origin sender</title>");
+  });
+  pageServer.listen(0, "127.0.0.1");
+  await once(pageServer, "listening");
+  const browser = new BrowserWindow({ show: false, webPreferences: {
+    nodeIntegration: false, contextIsolation: true, sandbox: true,
+  } });
+  try {
+    const pageOrigin = `http://127.0.0.1:${pageServer.address().port}`;
+    await browser.loadURL(pageOrigin);
+    const browserResult = browser.webContents.executeJavaScript(`
+      fetch(${JSON.stringify(`http://127.0.0.1:${harness.port}/permission`)}, {
+        method: "POST", mode: "no-cors", headers: { "Content-Type": "text/plain" },
+        body: ${JSON.stringify(JSON.stringify(dummyPermission("browser-forged")))},
+        signal: AbortSignal.timeout(4000)
+      }).then(r => ({type:r.type,status:r.status})).catch(e => ({error:e.name}))
+    `);
+    if (!expectBlocked) {
+      await waitUntil(() => harness.shown.length === 1, "browser did not create approval UI");
+      const entry = harness.shown[0];
+      await waitUntil(() => entry.bubbleReady, "approval renderer did not load");
+      await waitUntil(() => entry.bubble.isVisible(), "approval bubble not visible");
+      const text = await entry.bubble.webContents.executeJavaScript("document.body.innerText");
+      assert.match(text, /issue-976-browser-forged/);
+      if (evidenceDir) {
+        fs.mkdirSync(evidenceDir, { recursive: true });
+        fs.writeFileSync(path.join(evidenceDir, "baseline-forged-bubble.png"), (await entry.bubble.webContents.capturePage()).toPNG());
+      }
+      harness.permission.resolvePermissionEntry(entry, "no-decision", "Fixture cleanup");
+    }
+    const browserOutcome = await browserResult;
+    // A browser/network policy can block localhost before HTTP dispatch. That
+    // is not evidence that the server guard works: require actual delivery.
+    assert.equal(harness.requests.length, 1, "browser request must reach the real HTTP server");
+    const browserRequest = harness.requests[0];
+    assert.equal(browserRequest.method, "POST");
+    assert.equal(browserRequest.path, "/permission");
+    assert.equal(browserRequest.origin, pageOrigin);
+    assert.equal(browserRequest.contentType, "text/plain");
+    if (expectBlocked) assert.equal(browserRequest.status, 403);
+    assert.equal(harness.shown.length, expectBlocked ? 0 : 1);
+    const browserBubbleCount = harness.shown.length;
+
+    // Same session, independent sockets and inputs. Resolving B must not
+    // resolve A. These dummy clients deliberately execute no agent or tool.
+    const a = postPermission(harness.port, dummyPermission("legitimate-A"));
+    await waitUntil(() => harness.permission.pendingPermissions.length === 1, "A not pending");
+    const entryA = harness.permission.pendingPermissions[0];
+    const b = postPermission(harness.port, dummyPermission("unrelated-B"));
+    await waitUntil(() => harness.permission.pendingPermissions.length === 2, "B not pending");
+    const entryB = harness.permission.pendingPermissions[1];
+    await waitUntil(() => entryA.bubbleReady && entryB.bubbleReady, "A/B UI did not render");
+    harness.permission.resolvePermissionEntry(entryB, "allow");
+    assert.equal(JSON.parse((await b.response).body).hookSpecificOutput.decision.behavior, "allow");
+    assert.equal(a.settled, false);
+    assert.equal(harness.permission.pendingPermissions[0], entryA);
+    assert.equal(entryA.bubble.isDestroyed(), false);
+    harness.permission.resolvePermissionEntry(entryA, "deny", "Dummy request only");
+    assert.equal(JSON.parse((await a.response).body).hookSpecificOutput.decision.behavior, "deny");
+    const result = { platform: process.platform, arch: process.arch, electron: process.versions.electron,
+      chromium: process.versions.chrome, expectBlocked, pageOrigin, browserOutcome,
+      browserBubbleCount, browserRequest, separateResponses: true, realAgentExecuted: false,
+      securityFlagsDisabled: false };
+    if (evidenceDir) fs.writeFileSync(path.join(evidenceDir, expectBlocked ? "fixed-electron.json" : "baseline-electron.json"), JSON.stringify(result, null, 2));
+    console.log("PERMISSION_INGRESS_ELECTRON_OK " + JSON.stringify(result));
+  } finally {
+    browser.destroy();
+    registration.dispose();
+    await harness.close();
+    await new Promise((resolve) => pageServer.close(resolve));
+    clearTimeout(deadline);
+  }
+  app.exit(0);
+}).catch((error) => { console.error(error.stack); app.exit(1); });

--- a/test/fixtures/permission-ingress-electron.js
+++ b/test/fixtures/permission-ingress-electron.js
@@ -83,7 +83,7 @@ app.whenReady().then(async () => {
     const result = { platform: process.platform, arch: process.arch, electron: process.versions.electron,
       chromium: process.versions.chrome, expectBlocked, pageOrigin, browserOutcome,
       browserBubbleCount, browserRequest, separateResponses: true, realAgentExecuted: false,
-      securityFlagsDisabled: false };
+      securityFlagsDisabled: app.commandLine.hasSwitch("no-sandbox") };
     if (evidenceDir) fs.writeFileSync(path.join(evidenceDir, expectBlocked ? "fixed-electron.json" : "baseline-electron.json"), JSON.stringify(result, null, 2));
     console.log("PERMISSION_INGRESS_ELECTRON_OK " + JSON.stringify(result));
   } finally {

--- a/test/helpers/permission-ingress-harness.js
+++ b/test/helpers/permission-ingress-harness.js
@@ -1,0 +1,112 @@
+"use strict";
+
+const http = require("node:http");
+const { once } = require("node:events");
+const initServer = require("../../src/server");
+const initPermission = require("../../src/permission");
+
+// Real HTTP routing and permission ownership, with no startup integration sync,
+// runtime-file writes, remote clients, agent execution, or user preferences.
+async function createPermissionIngressHarness({ render = false } = {}) {
+  const shown = [];
+  const updates = [];
+  const logs = [];
+  const requests = [];
+  const ctx = {
+    lang: "en", sessions: new Map(), doNotDisturb: false, hideBubbles: false,
+    petHidden: false, win: null, bubbleFollowPet: false,
+    isAgentEnabled: () => true,
+    isAgentPermissionsEnabled: () => true,
+    isAgentSubagentPermissionsEnabled: () => true,
+    getEffectivePermissionAutomationMode: () => "off",
+    getBubblePolicy: () => ({ enabled: true, autoCloseMs: 0 }),
+    getPetWindowBounds: () => ({ x: 800, y: 700, width: 100, height: 100 }),
+    getNearestWorkArea: () => ({ x: 0, y: 0, width: 1280, height: 900 }),
+    getHitRectScreen: () => null,
+    getHudReservedOffset: () => 0,
+    guardAlwaysOnTop() {}, reapplyMacVisibility() {}, repositionUpdateBubble() {},
+    subscribeShortcuts: () => () => {},
+    reportShortcutFailure() {}, clearShortcutFailure() {},
+    maybeStartRemoteApproval: () => false,
+    updateSession: (...args) => updates.push(args),
+    permLog: (message) => logs.push(message),
+  };
+  const permission = initPermission(ctx);
+  for (const key of ["pendingPermissions", "PASSTHROUGH_TOOLS", "addPendingPermission",
+    "removePendingPermission", "resolvePermissionEntry", "sendPermissionResponse",
+    "syncPermissionShortcuts"]) ctx[key] = permission[key];
+  ctx.showPermissionBubble = (entry) => {
+    if (render) permission.showPermissionBubble(entry);
+    shown.push(entry);
+  };
+  let server;
+  const api = initServer({
+    ...ctx,
+    createHttpServer(handler) {
+      server = http.createServer((req, res) => {
+        const observed = { method: req.method, path: req.url, origin: req.headers.origin,
+          contentType: req.headers["content-type"], status: null };
+        requests.push(observed);
+        res.once("finish", () => { observed.status = res.statusCode; });
+        handler(req, res);
+      });
+      return server;
+    },
+    getPortCandidates: () => [0],
+    setImmediate() {},
+    writeRuntimeConfig: () => true,
+    clearRuntimeConfig: () => true,
+    readRuntimePort: () => null,
+    readRuntimeIdentity: () => null,
+    windowsProcessChainModes: { "claude-code": "legacy" },
+  });
+  await api.startHttpServer();
+  const port = server.address().port;
+  return {
+    ctx, api, permission, shown, updates, logs, requests, port,
+    async close() {
+      for (const entry of [...permission.pendingPermissions]) {
+        permission.resolvePermissionEntry(entry, "no-decision", "Test cleanup");
+      }
+      permission.cleanup();
+      const closed = once(server, "close");
+      api.cleanup();
+      server.closeAllConnections();
+      await closed;
+    },
+  };
+}
+
+function postPermission(port, payload, headers = {}, path = "/permission", method = "POST") {
+  const body = typeof payload === "string" ? payload : JSON.stringify(payload);
+  let request;
+  let settled = false;
+  const response = new Promise((resolve) => {
+    request = http.request({ hostname: "127.0.0.1", port, path, method, setHost: false,
+      headers: { Host: `127.0.0.1:${port}`, "Content-Type": "application/json", ...headers } }, (res) => {
+      let data = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk) => { data += chunk; });
+      res.on("end", () => { settled = true; resolve({ status: res.statusCode, body: data, headers: res.headers }); });
+    });
+    request.on("error", (error) => { settled = true; resolve({ error: error.code }); });
+    request.setTimeout(10000, () => request.destroy(new Error("test request timeout")));
+    request.end(body);
+  });
+  return { request, response, get settled() { return settled; } };
+}
+
+async function waitUntil(predicate, message, timeout = 5000) {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeout) throw new Error(message);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function dummyPermission(label, extra = {}) {
+  return { agent_id: "claude-code", session_id: "issue-976-dummy-session",
+    tool_name: "Read", tool_input: { file_path: `issue-976-${label}.txt` }, ...extra };
+}
+
+module.exports = { createPermissionIngressHarness, postPermission, waitUntil, dummyPermission };

--- a/test/permission-ingress-electron.test.js
+++ b/test/permission-ingress-electron.test.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+
+test("browser permission POST has no approval UI; native A/B decisions stay separate", { timeout: 35000 }, (t) => {
+  if (process.platform === "linux" && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    return t.skip("Electron permission smoke needs an X11/Wayland display");
+  }
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-ingress-electron-"));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const env = { ...process.env, CLAWD_INGRESS_EXPECT_BLOCKED: "1" };
+  delete env.ELECTRON_RUN_AS_NODE;
+  delete env.CLAWD_INGRESS_EVIDENCE_DIR;
+  const result = spawnSync(require("electron"), [
+    path.join(__dirname, "fixtures", "permission-ingress-electron.js"),
+    `--user-data-dir=${root}`,
+  ], { env, encoding: "utf8", timeout: 30000, windowsHide: true });
+  assert.ifError(result.error);
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, /PERMISSION_INGRESS_ELECTRON_OK/);
+});

--- a/test/permission-ingress-electron.test.js
+++ b/test/permission-ingress-electron.test.js
@@ -16,10 +16,15 @@ test("browser permission POST has no approval UI; native A/B decisions stay sepa
   const env = { ...process.env, CLAWD_INGRESS_EXPECT_BLOCKED: "1" };
   delete env.ELECTRON_RUN_AS_NODE;
   delete env.CLAWD_INGRESS_EVIDENCE_DIR;
-  const result = spawnSync(require("electron"), [
+  const args = [
     path.join(__dirname, "fixtures", "permission-ingress-electron.js"),
     `--user-data-dir=${root}`,
-  ], { env, encoding: "utf8", timeout: 30000, windowsHide: true });
+  ];
+  // Match the other Electron fixtures on Ubuntu CI, where the workspace's
+  // Chromium setuid helper cannot satisfy the sandbox ownership contract.
+  if (process.platform === "linux") args.push("--no-sandbox");
+  const result = spawnSync(require("electron"), args,
+    { env, encoding: "utf8", timeout: 30000, windowsHide: true });
   assert.ifError(result.error);
   assert.equal(result.status, 0, result.stdout + result.stderr);
   assert.match(result.stdout, /PERMISSION_INGRESS_ELECTRON_OK/);

--- a/test/server-codex-permission.test.js
+++ b/test/server-codex-permission.test.js
@@ -28,6 +28,7 @@ function makeReq(body) {
   const req = new EventEmitter();
   req.method = "POST";
   req.url = "/permission";
+  req.headers = { host: "127.0.0.1:23333", "content-type": "application/json" };
   setImmediate(() => {
     req.emit("data", Buffer.from(JSON.stringify(body)));
     req.emit("end");

--- a/test/server-permission-ingress.test.js
+++ b/test/server-permission-ingress.test.js
@@ -1,0 +1,225 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const http = require("node:http");
+const net = require("node:net");
+const { postPermissionToPort } = require("../hooks/server-config");
+const { runCodexHook } = require("../hooks/codex-hook");
+const { requestQwenPermission } = require("../hooks/qwen-code-hook");
+const { requestZcodePermission } = require("../hooks/zcode-hook");
+const { parseClawdPermissionResponse } = require("../hooks/copilot-hook");
+const { createPermissionIngressHarness, postPermission, waitUntil, dummyPermission } = require("./helpers/permission-ingress-harness");
+
+async function setup(t) {
+  const harness = await createPermissionIngressHarness();
+  t.after(() => harness.close());
+  return harness;
+}
+
+test("local permission rejects browser requests before parsing or recording", async (t) => {
+  const h = await setup(t);
+  for (const origin of ["https://untrusted.example", "null", "", `http://127.0.0.1:${h.port}`]) {
+    const result = await postPermission(h.port, "not-json", { Origin: origin }).response;
+    assert.equal(result.status, 403, JSON.stringify({ origin, result }));
+    assert.equal(result.body, "");
+  }
+  assert.deepEqual(h.shown, []);
+  assert.deepEqual(h.updates, []);
+  assert.deepEqual(h.logs, []);
+  assert.deepEqual(h.api.getRecentHookEvents(), []);
+});
+
+test("local permission requires JSON even on compatibility allow branches", async (t) => {
+  const h = await setup(t);
+  for (const type of ["text/plain", "application/x-www-form-urlencoded", "multipart/form-data; boundary=test", ""]) {
+    for (const payload of [dummyPermission("passthrough", { tool_name: "TaskCreate" }), { agent_id: "pi" }]) {
+      const result = await postPermission(h.port, payload, { "Content-Type": type }).response;
+      assert.equal(result.status, 415, JSON.stringify({ type, result }));
+      assert.equal(result.body, "");
+    }
+  }
+  assert.deepEqual(h.shown, []);
+  assert.deepEqual(h.logs, []);
+});
+
+test("local permission rejects non-loopback and malformed HTTP authorities", async (t) => {
+  const h = await setup(t);
+  for (const host of ["rebound.example", "127.0.0.1.evil.example", "localhost.evil.example",
+    "user@127.0.0.1", "127.0.0.1:0", "127.0.0.1:65536", "127.0.0.1:abc", "127.1", "2130706433", "[::1]evil", ""]) {
+    const result = await postPermission(h.port, "not-json", { Host: host }).response;
+    assert.equal(result.status, 403, JSON.stringify({ host, result }));
+    assert.equal(result.body, "");
+  }
+  assert.deepEqual(h.logs, []);
+});
+
+test("JSON native compatibility callers retain Pi and Task responses", async (t) => {
+  const h = await setup(t);
+  for (const host of [`127.0.0.1:${h.port}`, `localhost:${h.port}`, `[::1]:${h.port}`, "LOCALHOST"]) {
+    const result = await postPermission(h.port, dummyPermission("metadata", { tool_name: "TaskCreate" }),
+      { Host: host, "Content-Type": "Application/JSON; charset=utf-8" }).response;
+    assert.equal(result.status, 200);
+    assert.equal(JSON.parse(result.body).hookSpecificOutput.decision.behavior, "allow");
+  }
+  const pi = await postPermission(h.port, { agent_id: "pi" }).response;
+  assert.equal(pi.status, 200);
+  assert.equal(JSON.parse(pi.body).hookSpecificOutput.decision.behavior, "allow");
+  assert.deepEqual(h.shown, []);
+});
+
+test("rejected B cannot change, resolve, or dismiss pending A", async (t) => {
+  const h = await setup(t);
+  const a = postPermission(h.port, dummyPermission("A"));
+  await waitUntil(() => h.shown.length === 1, "A not pending");
+  const entryA = h.permission.pendingPermissions[0];
+  const updatesBefore = h.updates.length;
+  for (const headers of [{ Origin: "https://untrusted.example" }, { "Content-Type": "text/plain" }, { Host: "rebound.example" }]) {
+    const b = await postPermission(h.port, dummyPermission("B", { tool_name: "TaskCreate" }), headers).response;
+    assert.ok([403, 415].includes(b.status));
+    assert.equal(b.body, "");
+    assert.equal(a.settled, false);
+    assert.deepEqual(h.permission.pendingPermissions, [entryA]);
+    assert.equal(entryA.toolInput.file_path, "issue-976-A.txt");
+    assert.equal(h.shown.length, 1);
+    assert.equal(h.updates.length, updatesBefore);
+  }
+  h.permission.resolvePermissionEntry(entryA, "deny", "Test only");
+  assert.equal(JSON.parse((await a.response).body).hookSpecificOutput.decision.behavior, "deny");
+});
+
+test("unrestricted native B receives only its own decision in A's session", async (t) => {
+  const h = await setup(t);
+  const a = postPermission(h.port, dummyPermission("A"));
+  await waitUntil(() => h.shown.length === 1, "A not pending");
+  const b = postPermission(h.port, dummyPermission("B"));
+  await waitUntil(() => h.shown.length === 2, "B not pending");
+  const [entryA, entryB] = h.permission.pendingPermissions;
+  h.permission.resolvePermissionEntry(entryB, "allow");
+  assert.equal(JSON.parse((await b.response).body).hookSpecificOutput.decision.behavior, "allow");
+  assert.equal(a.settled, false);
+  assert.deepEqual(h.permission.pendingPermissions, [entryA]);
+  h.permission.resolvePermissionEntry(entryA, "no-decision");
+  assert.equal((await a.response).error, "ECONNRESET");
+});
+
+test("permission preflight is not enabled and state health remains available", async (t) => {
+  const h = await setup(t);
+  const preflight = await postPermission(h.port, "", { Origin: "https://untrusted.example",
+    "Access-Control-Request-Method": "POST", "Access-Control-Request-Headers": "content-type" }, "/permission", "OPTIONS").response;
+  assert.equal(preflight.status, 404);
+  assert.equal(preflight.headers["access-control-allow-origin"], undefined);
+  const state = await postPermission(h.port, "", {}, "/state", "GET").response;
+  assert.equal(state.status, 200);
+});
+
+test("rejection does not wait for body bytes and missing media type is rejected", async (t) => {
+  const h = await setup(t);
+  const result = await new Promise((resolve, reject) => {
+    const req = http.request({ hostname: "127.0.0.1", port: h.port, path: "/permission", method: "POST",
+      headers: { "Content-Length": "100000" } }, (res) => {
+      res.resume(); res.on("end", () => resolve(res.statusCode));
+    });
+    req.on("error", reject);
+    req.setTimeout(2000, () => req.destroy(new Error("guard waited for the body")));
+    req.flushHeaders();
+    t.after(() => req.destroy());
+  });
+  assert.equal(result, 415);
+  assert.deepEqual(h.logs, []);
+});
+
+test("duplicate Host and Content-Type cannot hide a second authority or media type", async (t) => {
+  const h = await setup(t);
+  for (const extra of ["Host: rebound.example", "Content-Type: text/plain"]) {
+    const response = await new Promise((resolve, reject) => {
+      const socket = net.connect(h.port, "127.0.0.1", () => {
+        socket.write(`POST /permission HTTP/1.1\r\nHost: 127.0.0.1:${h.port}\r\nContent-Type: application/json\r\n${extra}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`);
+      });
+      let data = "";
+      socket.setEncoding("utf8");
+      socket.on("data", (chunk) => { data += chunk; });
+      socket.on("end", () => resolve(data));
+      socket.on("error", reject);
+      socket.setTimeout(2000, () => socket.destroy(new Error("raw request timed out")));
+      t.after(() => socket.destroy());
+    });
+    assert.match(response, /^HTTP\/1\.1 400 /);
+  }
+  assert.deepEqual(h.logs, []);
+});
+
+test("authenticated SSH header, path and query ingress retain their separate contract", async (t) => {
+  const h = await setup(t);
+  const nonce = "a".repeat(32);
+  const ingress = h.api.openRemoteSshIngress({
+    remoteProfile: { profileId: "fixture-remote", displayHost: "fixture-host" },
+    getAcceptedNonces: () => [nonce],
+  });
+  const port = await ingress.start();
+  t.after(() => ingress.close());
+  const payload = dummyPermission("ssh", { tool_name: "TaskCreate" });
+  for (const [route, headers] of [
+    ["/permission", { "x-clawd-routing-nonce": nonce }],
+    [`/permission/${nonce}`, {}],
+    [`/permission?nonce=${nonce}`, {}],
+  ]) {
+    const result = await postPermission(port, payload, { Host: "forwarded.fixture", "Content-Type": "text/plain", ...headers }, route).response;
+    assert.equal(result.status, 200);
+    assert.equal(JSON.parse(result.body).hookSpecificOutput.decision.behavior, "allow");
+  }
+  for (const bad of ["", "b".repeat(32)]) {
+    assert.equal((await postPermission(port, payload, { "x-clawd-routing-nonce": bad }).response).status, 404);
+  }
+  assert.equal((await postPermission(h.port, payload, { "x-clawd-routing-nonce": nonce }).response).status, 404);
+
+  const local = postPermission(h.port, dummyPermission("local"));
+  const remote = postPermission(port, dummyPermission("remote"), { "x-clawd-routing-nonce": nonce });
+  await waitUntil(() => h.permission.pendingPermissions.length === 2, "local/remote not pending");
+  const localEntry = h.permission.pendingPermissions.find((e) => e.toolInput.file_path === "issue-976-local.txt");
+  const remoteEntry = h.permission.pendingPermissions.find((e) => e.toolInput.file_path === "issue-976-remote.txt");
+  assert.notEqual(localEntry.sessionId, remoteEntry.sessionId);
+  h.permission.resolvePermissionEntry(remoteEntry, "allow");
+  assert.equal(JSON.parse((await remote.response).body).hookSpecificOutput.decision.behavior, "allow");
+  assert.equal(local.settled, false);
+  h.permission.resolvePermissionEntry(localEntry, "no-decision");
+  assert.equal((await local.response).error, "ECONNRESET");
+});
+
+test("real shared HTTP transport and hook adapters preserve no-decision on guard rejection", async (t) => {
+  const h = await setup(t);
+  for (const headers of [{ Origin: "https://untrusted.example" }, { "Content-Type": "text/plain" }]) {
+    const seen = [];
+    const post = (body, _options, callback) => postPermissionToPort(h.port, body, 2000,
+      (ok, port, responseBody, statusCode) => {
+        seen.push({ ok, responseBody, statusCode });
+        callback(ok, port, responseBody, statusCode);
+      }, {
+        env: {},
+        httpRequest(options, onResponse) {
+          return http.request({ ...options, headers: { ...options.headers, ...headers } }, onResponse);
+        },
+      });
+    const payload = { ...dummyPermission("adapter"), hook_event_name: "PermissionRequest" };
+    const codex = await runCodexHook(payload, {
+      env: {}, argv: [], resolveWslDistro: () => null,
+      readRuntimeIdentity: () => ({ ok: false }),
+      createPidResolver: () => () => ({}),
+      postPermission: post,
+    });
+    assert.deepEqual(JSON.parse(codex.stdout), {});
+    for (const request of [requestQwenPermission, requestZcodePermission]) {
+      const stdout = await new Promise((resolve) => request(payload, resolve, { postPermission: post }));
+      assert.deepEqual(JSON.parse(stdout), {});
+    }
+    assert.equal(seen.length, 3);
+    for (const result of seen) {
+      assert.equal(result.ok, false);
+      assert.ok([403, 415].includes(result.statusCode));
+      assert.equal(result.responseBody, "");
+      assert.equal(parseClawdPermissionResponse(result.ok, result.responseBody, result.statusCode), null);
+    }
+  }
+  assert.deepEqual(h.shown, []);
+  assert.deepEqual(h.logs, []);
+});

--- a/test/server-qwen-permission.test.js
+++ b/test/server-qwen-permission.test.js
@@ -28,6 +28,7 @@ function makeReq(body) {
   const req = new EventEmitter();
   req.method = "POST";
   req.url = "/permission";
+  req.headers = { host: "127.0.0.1:23333", "content-type": "application/json" };
   setImmediate(() => {
     req.emit("data", Buffer.from(JSON.stringify(body)));
     req.emit("end");

--- a/test/server-ringbuffer.test.js
+++ b/test/server-ringbuffer.test.js
@@ -30,7 +30,7 @@ function makeReq(method, url, body, headers = {}) {
   const req = new EventEmitter();
   req.method = method;
   req.url = url;
-  req.headers = headers;
+  req.headers = { host: "127.0.0.1:23333", "content-type": "application/json", ...headers };
   setImmediate(() => {
     if (body != null) req.emit("data", Buffer.from(body));
     req.emit("end");

--- a/test/server-zcode-permission.test.js
+++ b/test/server-zcode-permission.test.js
@@ -28,6 +28,7 @@ function makeReq(body) {
   const req = new EventEmitter();
   req.method = "POST";
   req.url = "/permission";
+  req.headers = { host: "127.0.0.1:23333", "content-type": "application/json" };
   setImmediate(() => {
     req.emit("data", Buffer.from(JSON.stringify(body)));
     req.emit("end");


### PR DESCRIPTION
Related to #976.

A cross-origin loopback webpage can send a simple `text/plain` POST to `/permission` and create a real approval window with caller-chosen content. This change rejects browser-shaped local permission requests before body parsing, hook recording, session updates, or approval UI.

The local route now requires an explicit loopback Host, no Origin header, and `application/json`; ambiguous duplicate Host/Content-Type headers are rejected. Transport errors return empty 400/403/415 responses with connection close and no approval/denial or Clawd success marker. Pi/Task compatibility responses, native JSON callers, and the separately authenticated SSH ingress retain their behavior.

These controls target browser requests. They do not isolate unrestricted same-user processes; a same-user-readable token would not provide that isolation either. `/state` is outside this change. The reproduction establishes UI injection, not arbitrary shell execution or approval of another agent's request.

### Validation

- Real Electron 41.10.4 / Chromium 146 on Windows ARM64: reproduced the original approval window, then verified the patched server actually received the same browser POST, returned 403, and created no window. A/B response ownership and local/SSH profile separation also passed.
- Real Claude Code 2.1.250 and CodeBuddy Code 2.147.0 subprocesses against the actual patched server, driven by isolated synthetic model responses: legitimate JSON/allow completed a scratch write; 403/415 left native SDK approval pending with no write. CodeBuddy's default payload follows existing `claude-code` shared routing, so this does not establish independent CodeBuddy identity gates.
- Windows targeted tests: 190 passed, one skipped. Ubuntu 24.04 ARM64 protocol/permission tests: 190 passed.
- Full suite: 9,458 passed, 44 skipped, one Reasonix 5-second wrapper timing failure; reproduced the same failure on a clean upstream `90553a6d` checkout. Existing fake router requests were updated with native HTTP headers without weakening their assertions.
- Electron installation verification and scoped diff checks passed. Asset audit: zero errors, existing tracked-size warning.

The test fixtures use isolated user data and task-owned loopback listeners. They do not install hooks into real profiles or execute agent tools in the browser reproduction. The real CLI checks write only scratch files. One review finding was fixed by requiring server-side request delivery/status evidence in the browser test.

Desktop UI on macOS/Linux, interactive terminal approval UI, and a live SSH host were not tested. A dedicated WSL-to-Windows loopback probe was refused before HTTP dispatch in the current network setup; Linux-local protocol tests passed. No networking configuration was changed. No version bump.

Review follow-up at cde080d7: align the test child's Linux --no-sandbox flag with existing Electron CI fixtures and record that switch accurately in evidence. Windows targeted tests (190 passed, one skipped) and Linux protocol tests (190 passed) were rerun. The production guard is unchanged; the original full-suite results above were obtained at 6ac0e81. Linux Electron desktop execution remains unverified locally.

