### PR TITLE
fix(win): keep non-activating hit-window clicks deliverable

### DIFF
--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -11,7 +11,7 @@ This document holds the state machine, theme system, UI runtime, and platform ca
 
 输入事件流：`hitWin renderer → IPC → main → renderWin renderer`
 
-Windows 的 hit window 在原生 activation controller 可用时按前台全屏状态切换 `WS_EX_NOACTIVATE`：非全屏时清除该扩展样式，全屏时重新设置以避免点击和拖拽把前台切到 Clawd。Electron 内部保持 non-focusable；首次显示前安装的 `WM_MOUSEACTIVATE` hook 通过一次性 `Chrome.IgnoreMouseActivate` 属性让 Chromium 返回不激活窗口但仍投递 pointer 的 `MA_NOACTIVATE`，而不是吞点击的 `MA_NOACTIVATEANDEAT`。输入窗口仍和渲染窗口分离，并永久接收 mouse events。
+Windows 的 hit window 在原生 activation controller 可用时按前台全屏状态切换 `WS_EX_NOACTIVATE`：非全屏时清除该扩展样式，全屏时重新设置以避免点击和拖拽把前台切到 Clawd。Electron 内部保持 non-focusable；首次显示前安装的 `WM_MOUSEACTIVATE` hook 通过一次性 `Chrome.IgnoreMouseActivate` 属性让 Chromium 对该消息返回 `MA_NOACTIVATE`（不因这条消息激活窗口，也不丢弃鼠标输入），避免 `MA_NOACTIVATEANDEAT` 吞掉点击。该消息的返回值不保证普通桌面点击始终保持 OS 前台归属，相关限制见 Known Limits。输入窗口仍和渲染窗口分离，并永久接收 mouse events。
 
 ## State Machine
 
@@ -250,6 +250,7 @@ Mini 状态映射：
 ## Known Limits
 
 - Windows 原生 activation controller 依赖打包目标内的 Koffi；不可用时不调用会扰动前台的 Electron `setFocusable(false)`，而以旧的 focusable 输入窗降级，桌面交互仍可用但全屏点击可能短暂抢前台
+- Windows 非全屏态会清除输入窗的 `WS_EX_NOACTIVATE`；点击桌宠可能短暂把 OS 前台归属切到 Clawd，即使 Electron `win.isFocused()` 仍为 false。mouse-activation hook 不消除这项既有的普通桌面限制
 - 当前开发环境没有 macOS 手测机；所有 macOS 特定路径都只能做 code review + best-effort 推断，真正行为变化需要额外人工验证
 - 启动恢复依赖 `detectRunningClaudeProcesses()` 与后续 hook 事件
 - Windows 前台窗口锁通过 ALT trick + `koffi` FFI 绕过，仍有边缘失败可能

--- a/docs/project/theme-state-ui.md
+++ b/docs/project/theme-state-ui.md
@@ -11,7 +11,7 @@ This document holds the state machine, theme system, UI runtime, and platform ca
 
 输入事件流：`hitWin renderer → IPC → main → renderWin renderer`
 
-Windows 的 hit window 在原生 activation controller 可用时按前台全屏状态切换 `WS_EX_NOACTIVATE`：非全屏时清除样式以恢复普通 activation 语义，全屏时设置样式以避免点击和拖拽把前台切到 Clawd。Electron 内部保持 non-focusable，避免 Chromium 在 pointerdown 时绕过原生样式主动激活窗口。真实合成点击已确认样式置位和清除时 pointer 都能到达 renderer，因此不能把 pointer 路由归因于清除样式。输入窗口仍和渲染窗口分离，并永久接收 mouse events，避免旧单窗口 alpha hit-test 路径的拖拽失效。
+Windows 的 hit window 在原生 activation controller 可用时按前台全屏状态切换 `WS_EX_NOACTIVATE`：非全屏时清除该扩展样式，全屏时重新设置以避免点击和拖拽把前台切到 Clawd。Electron 内部保持 non-focusable；首次显示前安装的 `WM_MOUSEACTIVATE` hook 通过一次性 `Chrome.IgnoreMouseActivate` 属性让 Chromium 返回不激活窗口但仍投递 pointer 的 `MA_NOACTIVATE`，而不是吞点击的 `MA_NOACTIVATEANDEAT`。输入窗口仍和渲染窗口分离，并永久接收 mouse events。
 
 ## State Machine
 
@@ -238,7 +238,7 @@ Mini 状态映射：
 ## Electron And Platform Notes
 
 - `win.setFocusable(false)`：渲染窗口永不抢焦点
-- Windows `hitWin`：原生 activation controller 可用时 Electron 始终 non-focusable；仅在非全屏前台时清除 `WS_EX_NOACTIVATE`，全屏时重新设置。controller / Koffi 不可用时回退到旧的 Electron focusable 构造，优先保住桌面点击与拖拽，但不承诺全屏防抢焦点
+- Windows `hitWin`：原生 activation controller 可用时 Electron 始终 non-focusable；仅在非全屏前台时清除 `WS_EX_NOACTIVATE`，全屏时重新设置。生命周期内的 mouse-activation hook 防止 Chromium 返回 `MA_NOACTIVATEANDEAT`。controller / Koffi 或首次 hook 准备不可用时回退到旧的 Electron focusable 路径，优先保住桌面点击与拖拽，但不承诺全屏防抢焦点
 - `win.showInactive()`：显示时不打断用户输入
 - 渲染 / 输入窗口都依赖 `backgroundThrottling: false`；unfocused 节流会放大眼球追踪和输入恢复的时序问题
 - 路径统一用 `path.join(__dirname, ...)`
@@ -250,7 +250,6 @@ Mini 状态映射：
 ## Known Limits
 
 - Windows 原生 activation controller 依赖打包目标内的 Koffi；不可用时不调用会扰动前台的 Electron `setFocusable(false)`，而以旧的 focusable 输入窗降级，桌面交互仍可用但全屏点击可能短暂抢前台
-- Windows 非全屏态为恢复普通 activation 语义会清除输入窗的 `WS_EX_NOACTIVATE`；点击桌宠可能短暂把 OS 前台归属切到 Clawd，即使 Electron `win.isFocused()` 仍为 false
 - 当前开发环境没有 macOS 手测机；所有 macOS 特定路径都只能做 code review + best-effort 推断，真正行为变化需要额外人工验证
 - 启动恢复依赖 `detectRunningClaudeProcesses()` 与后续 hook 事件
 - Windows 前台窗口锁通过 ALT trick + `koffi` FFI 绕过，仍有边缘失败可能

--- a/src/main.js
+++ b/src/main.js
@@ -1826,11 +1826,8 @@ function moveWindowForDrag() { return petWindowRuntime.moveWindowForDrag(); }
 // with the inverse of the fullscreen state. The native controller toggles
 // WS_EX_NOACTIVATE without calling BrowserWindow.setFocusable(false), whose
 // Focus(false) side effect deactivates the user's fullscreen foreground app.
-// Leaving fullscreen removes the native style. When the native controller is
-// available, Electron itself remains non-focusable for the hit window's
-// lifetime so Chromium cannot explicitly activate Clawd on pointerdown. If
-// Koffi/user32 initialization failed, construction deliberately falls back to
-// the legacy focusable window so desktop click/drag remains available.
+// A WM_MOUSEACTIVATE hook keeps clicks deliverable while Electron remains
+// non-focusable. If setup fails, the window falls back before first show.
 const setHitWinFocusable = _hitWindowActivationRuntime.setHitWinFocusable;
 
 // ── Mini Mode — delegated to src/mini.js ──
@@ -4867,6 +4864,9 @@ function createWindow() {
     loadFilePath: path.join(__dirname, "hit.html"),
     hitThemeConfig: themeRuntime.getHitRendererConfig(),
     guardAlwaysOnTop,
+    prepareActivation: (createdHitWin) => (
+      _hitWindowActivationRuntime.controller.prepare(createdHitWin)
+    ),
     onDidFinishLoad: () => {
       sendToHitWin("theme-config", themeRuntime.getHitRendererConfig());
       if (themeRuntime.isReloadInProgress()) return;
@@ -5684,6 +5684,7 @@ if (!gotTheLock) {
     if (!_remoteSshRuntime || typeof _remoteSshRuntime.shutdown !== "function") {
       try { _remoteSshRuntime.cleanup(); } catch {}
     }
+    _hitWindowActivationRuntime.controller.dispose();
     if (hitWin && !hitWin.isDestroyed()) hitWin.destroy();
   });
 

--- a/src/package-koffi-smoke.js
+++ b/src/package-koffi-smoke.js
@@ -3,10 +3,26 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const { getReleaseTarget, resolveRuntimeTarget } = require("./native-package-target");
+const {
+  WM_MOUSEACTIVATE,
+  MA_NOACTIVATE,
+  MOUSE_ACTIVATE_PROP,
+} = require("./win-hit-window-activation");
 
 const SMOKE_FLAG = "--clawd-package-smoke";
 const TARGET_PREFIX = "--clawd-package-smoke-target=";
 const OUTPUT_PREFIX = "--clawd-package-smoke-output=";
+const HIT_TEST_CLIENT_MOUSE_DOWN = 0x02010001;
+const WINDOWS_MOUSE_ACTIVATE_PROBE_SOURCE = `
+const koffi = require(process.argv[1]);
+const hwnd = BigInt(process.argv[2]);
+const property = process.argv[3];
+const user32 = koffi.load("user32.dll");
+const SendMessageW = user32.func("intptr_t __stdcall SendMessageW(void* hWnd, uint32 Msg, void* wParam, intptr_t lParam)");
+const GetPropW = user32.func("void* __stdcall GetPropW(void* hWnd, str16 lpString)");
+const result = Number(SendMessageW(hwnd, ${WM_MOUSEACTIVATE}, hwnd, ${HIT_TEST_CLIENT_MOUSE_DOWN}));
+process.stdout.write(JSON.stringify({ result, ignorePropertyConsumed: !GetPropW(hwnd, property) }));
+`;
 
 function comparablePath(value) {
   let resolved = path.resolve(String(value || ""));
@@ -242,8 +258,7 @@ async function runWindowsFullscreenAutoHideRuntimeProbe({
   timeoutMs = 8_000,
 } = {}) {
   const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-  const createPetWindow = (x, backgroundColor) => {
-    const win = new BrowserWindow({
+  const createPetWindow = (x, backgroundColor, focusable) => new BrowserWindow({
       show: false,
       x,
       y: 40,
@@ -253,18 +268,23 @@ async function runWindowsFullscreenAutoHideRuntimeProbe({
       alwaysOnTop: true,
       skipTaskbar: true,
       backgroundColor,
-      focusable: false,
+      focusable,
     });
+  const showPetWindow = (win) => {
     win.showInactive();
     win.setAlwaysOnTop(true, "pop-up-menu");
-    return win;
   };
 
-  const renderWin = createPetWindow(40, "#245c3a");
-  const hitWin = createPetWindow(240, "#5c2424");
+  const renderWin = createPetWindow(40, "#245c3a", false);
+  const hitWin = createPetWindow(240, "#5c2424", false);
   const fullscreenWindows = [];
   let topmostRuntime = null;
   try {
+    if (!hitActivation.prepare(hitWin)) {
+      throw new Error("Packaged fullscreen runtime hit-window preparation failed");
+    }
+    showPetWindow(renderWin);
+    showPetWindow(hitWin);
     const createPetWindowRuntime = require("./pet-window-runtime");
     const createTopmostRuntime = require("./topmost-runtime");
     const petWindowRuntime = createPetWindowRuntime({
@@ -395,35 +415,110 @@ async function runWindowsFullscreenAutoHideRuntimeProbe({
       if (!win.isDestroyed()) win.destroy();
     }
     if (!renderWin.isDestroyed()) renderWin.destroy();
+    hitActivation.dispose();
     if (!hitWin.isDestroyed()) hitWin.destroy();
   }
 }
 
-function runHitWindowNoActivateRoundTrip(hitActivation, win, errors = []) {
+function createWindowsMouseActivateProbe(options = {}) {
+  const execFile = options.execFile || require("node:child_process").execFile;
+  const executable = options.executable || process.execPath;
+  const koffiPath = options.koffiPath || require.resolve("koffi");
+  return (win) => new Promise((resolve, reject) => {
+    const hwnd = nativeWindowHandleId(win);
+    execFile(
+      executable,
+      ["-e", WINDOWS_MOUSE_ACTIVATE_PROBE_SOURCE, koffiPath, hwnd, MOUSE_ACTIVATE_PROP],
+      {
+        encoding: "utf8",
+        env: { ...process.env, ELECTRON_RUN_AS_NODE: "1" },
+        timeout: 5_000,
+        windowsHide: true,
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          reject(new Error(`Packaged external WM_MOUSEACTIVATE probe failed: ${stderr || error.message}`));
+          return;
+        }
+        try {
+          resolve(JSON.parse(stdout));
+        } catch (parseError) {
+          reject(new Error(`Packaged external WM_MOUSEACTIVATE probe returned invalid JSON: ${parseError.message}`));
+        }
+      },
+    );
+  });
+}
+
+async function runHitWindowNoActivateRoundTrip(hitActivation, win, errors = [], probeMouseActivate) {
   const describeErrors = () => errors.join(" | ");
   const initialNonActivating = hitActivation.isNonActivating(win);
-  if (initialNonActivating !== true) {
-    throw new Error(`Packaged WS_EX_NOACTIVATE initial state missing: ${describeErrors()}`);
+  if (initialNonActivating !== true || win.isFocusable() !== false) {
+    throw new Error(`Packaged hit window did not start fully non-activating: ${describeErrors()}`);
+  }
+  if (!win.isWindowMessageHooked(WM_MOUSEACTIVATE)) {
+    throw new Error("Packaged desktop WM_MOUSEACTIVATE guard was not installed");
   }
   if (!hitActivation.setFocusable(win, true) || hitActivation.isNonActivating(win) !== false) {
     throw new Error(`Packaged WS_EX_NOACTIVATE initial clear failed: ${describeErrors()}`);
   }
+  const desktopMouseActivate = await probeMouseActivate();
+  if (desktopMouseActivate.result !== MA_NOACTIVATE || !desktopMouseActivate.ignorePropertyConsumed) {
+    throw new Error(
+      `Packaged desktop WM_MOUSEACTIVATE returned ${desktopMouseActivate.result}, ` +
+      `propertyConsumed=${desktopMouseActivate.ignorePropertyConsumed}`,
+    );
+  }
   if (!hitActivation.setFocusable(win, false) || hitActivation.isNonActivating(win) !== true) {
     throw new Error(`Packaged WS_EX_NOACTIVATE enable failed: ${describeErrors()}`);
+  }
+  if (!win.isWindowMessageHooked(WM_MOUSEACTIVATE)) {
+    throw new Error("Packaged WM_MOUSEACTIVATE guard was not installed");
+  }
+  const fullscreenMouseActivate = await probeMouseActivate();
+  if (fullscreenMouseActivate.result !== MA_NOACTIVATE || !fullscreenMouseActivate.ignorePropertyConsumed) {
+    throw new Error(
+      `Packaged fullscreen-request WM_MOUSEACTIVATE returned ${fullscreenMouseActivate.result}, ` +
+      `propertyConsumed=${fullscreenMouseActivate.ignorePropertyConsumed}`,
+    );
   }
   if (!hitActivation.setFocusable(win, true) || hitActivation.isNonActivating(win) !== false) {
     throw new Error(`Packaged WS_EX_NOACTIVATE final restore failed: ${describeErrors()}`);
   }
+  if (!win.isWindowMessageHooked(WM_MOUSEACTIVATE)) {
+    throw new Error("Packaged restored WM_MOUSEACTIVATE guard was removed");
+  }
+  const restoredMouseActivate = await probeMouseActivate();
+  if (restoredMouseActivate.result !== MA_NOACTIVATE || !restoredMouseActivate.ignorePropertyConsumed) {
+    throw new Error(
+      `Packaged restored WM_MOUSEACTIVATE returned ${restoredMouseActivate.result}, ` +
+      `propertyConsumed=${restoredMouseActivate.ignorePropertyConsumed}`,
+    );
+  }
   return {
+    electronFocusable: false,
     initialNonActivating: true,
     afterInitialClear: false,
-    afterFullscreenEnable: true,
+    desktopMouseActivate: MA_NOACTIVATE,
+    afterFullscreenRequest: true,
+    fullscreenMouseActivate: MA_NOACTIVATE,
     afterFinalRestore: false,
+    restoredMouseActivate: MA_NOACTIVATE,
   };
 }
 
 async function runPlatformProbe({ BrowserWindow, target, koffi }) {
   if (target.runtimePlatform === "win32") {
+    const { createHitWindowActivationController } = require("./win-hit-window-activation");
+    const hitActivationErrors = [];
+    const hitActivation = createHitWindowActivationController({
+      isWin: true,
+      koffi,
+      onError: (err) => hitActivationErrors.push(err && err.message ? err.message : String(err)),
+    });
+    if (!hitActivation.available) {
+      throw new Error(`Hit-window activation controller unavailable: ${hitActivationErrors.join(" | ")}`);
+    }
     const win = new BrowserWindow({
       show: false,
       width: 80,
@@ -432,12 +527,14 @@ async function runPlatformProbe({ BrowserWindow, target, koffi }) {
       focusable: false,
     });
     try {
+      if (!hitActivation.prepare(win)) {
+        throw new Error(`Hit-window activation preparation failed: ${hitActivationErrors.join(" | ")}`);
+      }
       win.showInactive();
       await new Promise((resolve) => setTimeout(resolve, 100));
       const { createCloakInspector } = require("./win-cloak-recovery");
       const { createForegroundFullscreenProbe } = require("./win-fullscreen-detect");
       const { createForegroundWindowsTerminalProbe } = require("./win-foreground-terminal");
-      const { createHitWindowActivationController } = require("./win-hit-window-activation");
       const logs = [];
       const cloak = createCloakInspector({ isWin: true, log: (line) => logs.push(line) });
       try {
@@ -458,19 +555,11 @@ async function runPlatformProbe({ BrowserWindow, target, koffi }) {
           fullscreenProbe,
           koffi,
         });
-        const hitActivationErrors = [];
-        const hitActivation = createHitWindowActivationController({
-          isWin: true,
-          koffi,
-          onError: (err) => hitActivationErrors.push(err && err.message ? err.message : String(err)),
-        });
-        if (!hitActivation.available) {
-          throw new Error(`Hit-window activation controller unavailable: ${hitActivationErrors.join(" | ")}`);
-        }
-        const hitWindowNoActivateRoundTrip = runHitWindowNoActivateRoundTrip(
+        const hitWindowNoActivateRoundTrip = await runHitWindowNoActivateRoundTrip(
           hitActivation,
           win,
           hitActivationErrors,
+          createWindowsMouseActivateProbe().bind(null, win),
         );
         const fullscreenAutoHideRuntime = fullscreenIdentity.foregroundControllable
           ? await runWindowsFullscreenAutoHideRuntimeProbe({
@@ -520,6 +609,7 @@ async function runPlatformProbe({ BrowserWindow, target, koffi }) {
         cloak.dispose();
       }
     } finally {
+      hitActivation.dispose();
       win.destroy();
     }
   }
@@ -651,6 +741,7 @@ module.exports = {
   runWindowsFullscreenIdentityProbe,
   waitForSmokeCondition,
   runWindowsFullscreenAutoHideRuntimeProbe,
+  createWindowsMouseActivateProbe,
   runHitWindowNoActivateRoundTrip,
   runPlatformProbe,
   runPackageKoffiSmoke,

--- a/src/pet-window-runtime.js
+++ b/src/pet-window-runtime.js
@@ -2277,6 +2277,7 @@ function createPetWindowRuntime(options = {}) {
     }
     const initialHitWindowBounds = getInitialHitWindowBounds();
     const hitWin = new BrowserWindow({
+      ...(isWin ? { show: false } : {}),
       width: initialHitWindowBounds.width,
       height: initialHitWindowBounds.height,
       x: initialHitWindowBounds.x,
@@ -2291,14 +2292,10 @@ function createPetWindowRuntime(options = {}) {
       enableLargerThanScreen: true,
       ...(isLinux ? { type: linuxWindowType } : {}),
       ...(isMac ? { type: "panel", roundedCorners: false } : {}),
-      // Windows normally starts with Electron's activation path disabled. The
-      // native controller removes WS_EX_NOACTIVATE outside fullscreen, while
-      // Electron remains non-focusable so Chromium does not explicitly
-      // activate Clawd on a fullscreen click/drag. If that controller could
-      // not initialize, main opts into the legacy focusable construction so
-      // desktop pointer interaction is not stranded behind an FFI failure.
-      // Linux keeps its existing non-focusable behavior; macOS is normalized
-      // immediately after construction below.
+      // Windows normally starts with Electron activation disabled. The native
+      // controller installs the click-delivery guard and toggles only
+      // WS_EX_NOACTIVATE. If setup is unavailable, retain the legacy focusable
+      // path so desktop click/drag still works.
       focusable: isWin ? windowsHitWindowFocusable : !isLinux,
       webPreferences: {
         preload: optionsArg.preloadPath,
@@ -2318,6 +2315,10 @@ function createPetWindowRuntime(options = {}) {
     // window until createHitWindow() returns and the caller assigns it.
     applyHitInputState(hitWin);
     if (isMac) hitWin.setFocusable(false);
+    if (isWin && typeof optionsArg.prepareActivation === "function") {
+      const prepared = optionsArg.prepareActivation(hitWin);
+      if (prepared === false && !windowsHitWindowFocusable) hitWin.setFocusable(true);
+    }
     hitWin.showInactive();
     keepOutOfTaskbar(hitWin);
     if (isWin) hitWin.setAlwaysOnTop(true, topmostLevel);

--- a/src/win-hit-window-activation.js
+++ b/src/win-hit-window-activation.js
@@ -3,14 +3,15 @@
 // Electron's BrowserWindow.setFocusable(false) calls Focus(false) on Windows.
 // That deactivates whichever application currently owns the foreground, so
 // using it when a fullscreen game/video is detected makes Clawd itself take
-// foreground. When available, this controller lets the hit BrowserWindow stay
-// Electron-non-focusable for its lifetime and toggles only WS_EX_NOACTIVATE.
-// Desktop pointer delivery is validated independently; clearing the native
-// style restores ordinary activation semantics but is not claimed as the
-// cause of input routing.
+// foreground. Keep Electron non-focusability fixed for the window's lifetime,
+// toggle only WS_EX_NOACTIVATE, and intercept WM_MOUSEACTIVATE so Chromium uses
+// MA_NOACTIVATE instead of eating the click with MA_NOACTIVATEANDEAT.
 
 const GWL_EXSTYLE = -20;
 const WS_EX_NOACTIVATE = 0x08000000n;
+const WM_MOUSEACTIVATE = 0x0021;
+const MA_NOACTIVATE = 3;
+const MOUSE_ACTIVATE_PROP = "Chrome.IgnoreMouseActivate";
 const SWP_NOSIZE = 0x0001;
 const SWP_NOMOVE = 0x0002;
 const SWP_NOZORDER = 0x0004;
@@ -39,6 +40,9 @@ function createHitWindowActivationController(options = {}) {
   let pointerBits = Number(options.pointerBits) || 0;
   let styleRefreshPending = false;
   let refreshFailureReported = false;
+  let hookedWindow = null;
+  let hookArmFailureWindow = null;
+  let legacyFallbackWindow = null;
 
   if (isWin && !bindings) {
     try {
@@ -55,10 +59,18 @@ function createHitWindowActivationController(options = {}) {
       const SetWindowPos = user32.func(
         "bool __stdcall SetWindowPos(void* hWnd, void* hWndInsertAfter, int X, int Y, int cx, int cy, uint32 uFlags)",
       );
+      const SetPropW = user32.func(
+        "bool __stdcall SetPropW(void* hWnd, str16 lpString, void* hData)",
+      );
+      const RemovePropW = user32.func(
+        "void* __stdcall RemovePropW(void* hWnd, str16 lpString)",
+      );
       bindings = {
         getStyle: (hwnd) => GetWindowLongPtrW(hwnd, GWL_EXSTYLE),
         setStyle: (hwnd, value) => SetWindowLongPtrW(hwnd, GWL_EXSTYLE, value),
         refreshStyle: (hwnd) => SetWindowPos(hwnd, null, 0, 0, 0, 0, STYLE_REFRESH_FLAGS),
+        armMouseActivate: (hwnd) => SetPropW(hwnd, MOUSE_ACTIVATE_PROP, hwnd),
+        clearMouseActivate: (hwnd) => RemovePropW(hwnd, MOUSE_ACTIVATE_PROP),
       };
       hwndOf = (win) => {
         if (!win || typeof win.getNativeWindowHandle !== "function") return null;
@@ -80,6 +92,8 @@ function createHitWindowActivationController(options = {}) {
     && typeof bindings.getStyle === "function"
     && typeof bindings.setStyle === "function"
     && typeof bindings.refreshStyle === "function"
+    && typeof bindings.armMouseActivate === "function"
+    && typeof bindings.clearMouseActivate === "function"
     && typeof hwndOf === "function"
   );
 
@@ -143,31 +157,103 @@ function createHitWindowActivationController(options = {}) {
     }
   }
 
+  function removeMouseActivateHook(win = hookedWindow) {
+    if (!hookedWindow) return true;
+    if (win && hookedWindow !== win) return false;
+    const current = hookedWindow;
+    if (typeof current.isDestroyed === "function" && current.isDestroyed()) {
+      hookedWindow = null;
+      return true;
+    }
+    if (typeof current.unhookWindowMessage !== "function") return false;
+    try {
+      const hwnd = liveHwnd(current);
+      current.unhookWindowMessage(WM_MOUSEACTIVATE);
+      hookedWindow = null;
+      if (hwnd) bindings.clearMouseActivate(hwnd);
+      return true;
+    } catch (error) {
+      reportError(error);
+      return false;
+    }
+  }
+
+  function armMouseActivate(hwnd, win) {
+    try {
+      if (bindings.armMouseActivate(hwnd)) {
+        hookArmFailureWindow = null;
+        return true;
+      }
+      if (hookArmFailureWindow !== win) {
+        hookArmFailureWindow = win;
+        reportError(new Error("Windows hit-window mouse activation guard failed"));
+      }
+    } catch (error) {
+      if (hookArmFailureWindow !== win) {
+        hookArmFailureWindow = win;
+        reportError(error);
+      }
+    }
+    return false;
+  }
+
+  function ensureMouseActivateHook(win) {
+    if (hookedWindow === win) return true;
+    if (hookedWindow && !removeMouseActivateHook()) return false;
+    const hwnd = liveHwnd(win);
+    if (!hwnd || typeof win.hookWindowMessage !== "function") return false;
+    try {
+      win.hookWindowMessage(WM_MOUSEACTIVATE, () => { armMouseActivate(hwnd, win); });
+      hookedWindow = win;
+      if (!armMouseActivate(hwnd, win)) {
+        removeMouseActivateHook(win);
+        return false;
+      }
+      return true;
+    } catch (error) {
+      reportError(error);
+      return false;
+    }
+  }
+
+  function prepare(win) {
+    if (!isWin || !win) return false;
+    if (typeof win.isDestroyed === "function" && win.isDestroyed()) return false;
+    if (legacyFallbackWindow === win) return false;
+    const prepared = ensureMouseActivateHook(win);
+    legacyFallbackWindow = prepared ? null : win;
+    return prepared;
+  }
+
   function setFocusable(win, focusable) {
     if (!isWin || !win) return false;
     if (typeof win.isDestroyed === "function" && win.isDestroyed()) return false;
+    // A failed pre-show guard falls back to Electron focusability and must not
+    // later drift into a mixed Electron-focusable/native-controlled state.
+    if (legacyFallbackWindow === win) return false;
+
+    const hookReady = ensureMouseActivateHook(win);
+    // Do not short-circuit: fullscreen style safety still matters if the
+    // delivery guard cannot be re-armed on an already visible window.
     const next = !!focusable;
+    const styleReady = next
+      ? available && setNoActivate(win, false)
+      : setNoActivate(win, true);
+    return hookReady && styleReady;
+  }
 
-    if (!next) {
-      // Do not fall back to BrowserWindow.setFocusable(false): that exact call
-      // deactivates the user's fullscreen foreground window. If native style
-      // control is unavailable, main uses the legacy focusable construction
-      // instead. This method stays a no-op rather than mixing Electron and
-      // native activation paths after the window has been created.
-      return setNoActivate(win, true);
-    }
-
-    // Never call BrowserWindow.setFocusable(true). Electron must continue to
-    // consider the hit layer non-focusable, otherwise Chromium explicitly
-    // activates it on pointerdown even while WS_EX_NOACTIVATE is present.
-    // Clearing the native style restores ordinary desktop activation behavior;
-    // the Electron-level non-focusable contract remains intact.
-    return available && setNoActivate(win, false);
+  function dispose() {
+    const removed = removeMouseActivateHook();
+    hookArmFailureWindow = null;
+    legacyFallbackWindow = null;
+    return removed;
   }
 
   return {
     available,
+    dispose,
     isNonActivating: readNoActivate,
+    prepare,
     setFocusable,
   };
 }
@@ -205,5 +291,8 @@ module.exports = {
   createHitWindowFocusableSetter,
   GWL_EXSTYLE,
   WS_EX_NOACTIVATE,
+  WM_MOUSEACTIVATE,
+  MA_NOACTIVATE,
+  MOUSE_ACTIVATE_PROP,
   STYLE_REFRESH_FLAGS,
 };

--- a/test/package-koffi-smoke.test.js
+++ b/test/package-koffi-smoke.test.js
@@ -221,23 +221,36 @@ test("packaged native HWND proof survives a runner that cannot foreground Browse
   assert.equal(result.fullscreenObserved, false);
 });
 
-test("packaged hit-window smoke proves initial, clear, enable, and final restore states", () => {
+test("packaged hit-window smoke preserves the style round trip and delivers both mouse-activation modes", async () => {
   let nonActivating = true;
   const calls = [];
-  const result = runHitWindowNoActivateRoundTrip({
+  let mouseActivateCalls = 0;
+  const win = {
+    isFocusable: () => false,
+    isWindowMessageHooked: () => true,
+  };
+  const result = await runHitWindowNoActivateRoundTrip({
     isNonActivating: () => nonActivating,
     setFocusable: (_win, focusable) => {
       calls.push(focusable);
       nonActivating = !focusable;
       return true;
     },
-  }, {});
+  }, win, [], () => {
+    mouseActivateCalls += 1;
+    return { result: 3, ignorePropertyConsumed: true };
+  });
 
   assert.deepEqual(calls, [true, false, true]);
+  assert.equal(mouseActivateCalls, 3);
   assert.deepEqual(result, {
+    electronFocusable: false,
     initialNonActivating: true,
     afterInitialClear: false,
-    afterFullscreenEnable: true,
+    desktopMouseActivate: 3,
+    afterFullscreenRequest: true,
+    fullscreenMouseActivate: 3,
     afterFinalRestore: false,
+    restoredMouseActivate: 3,
   });
 });

--- a/test/pet-window-runtime.test.js
+++ b/test/pet-window-runtime.test.js
@@ -2806,18 +2806,29 @@ describe("pet-window-runtime", () => {
     assert.doesNotMatch(petRuntimeOptions, /[,{]\s*isNearWorkAreaEdge\s*,/);
   });
 
-  it("creates the Windows hit window with Electron activation disabled", () => {
+  it("prepares the Windows non-focusable hit window before its first show", () => {
     const instances = [];
     const harness = createRuntime();
+    let preparedWindow = null;
     harness.runtime.createHitWindow({
       BrowserWindow: makeBrowserWindow(instances),
       preloadPath: "preload-hit.js",
       loadFilePath: "hit.html",
       hitThemeConfig: { ok: true },
       guardAlwaysOnTop: (win) => harness.calls.push(["guard", win]),
+      prepareActivation: (win) => {
+        preparedWindow = win;
+        win.calls.push(["prepareActivation"]);
+      },
     });
 
+    assert.equal(instances[0].options.show, false);
     assert.equal(instances[0].options.focusable, false);
+    assert.strictEqual(preparedWindow, instances[0]);
+    assert.ok(
+      instances[0].calls.findIndex((call) => call[0] === "prepareActivation")
+        < instances[0].calls.findIndex((call) => call[0] === "showInactive"),
+    );
     assert.deepStrictEqual(instances[0].calls.filter((call) => call[0] === "setIgnoreMouseEvents"), [
       ["setIgnoreMouseEvents", false],
     ]);
@@ -2839,6 +2850,24 @@ describe("pet-window-runtime", () => {
     });
 
     assert.equal(instances[0].options.focusable, true);
+  });
+
+  it("falls back before show when per-window activation preparation fails", () => {
+    const instances = [];
+    const harness = createRuntime();
+    harness.runtime.createHitWindow({
+      BrowserWindow: makeBrowserWindow(instances),
+      preloadPath: "preload-hit.js",
+      loadFilePath: "hit.html",
+      hitThemeConfig: { ok: true },
+      prepareActivation: () => false,
+    });
+
+    const focusableIndex = instances[0].calls.findIndex(
+      (call) => call[0] === "setFocusable" && call[1] === true,
+    );
+    const showIndex = instances[0].calls.findIndex((call) => call[0] === "showInactive");
+    assert.ok(focusableIndex >= 0 && focusableIndex < showIndex);
   });
 
   it("reloadWindowWebContents ignores destroyed windows and webContents", () => {

--- a/test/topmost-runtime.test.js
+++ b/test/topmost-runtime.test.js
@@ -60,6 +60,14 @@ class FakeWindow extends EventEmitter {
   setIgnoreMouseEvents(...args) {
     this.calls.push(["setIgnoreMouseEvents", ...args]);
   }
+
+  hookWindowMessage(...args) {
+    this.calls.push(["hookWindowMessage", ...args]);
+  }
+
+  unhookWindowMessage(...args) {
+    this.calls.push(["unhookWindowMessage", ...args]);
+  }
 }
 
 function makeTimers() {
@@ -663,6 +671,8 @@ describe("topmost runtime Windows recovery", () => {
           return 0n;
         },
         refreshStyle: () => true,
+        armMouseActivate: () => true,
+        clearMouseActivate: () => null,
       },
     });
     const setHitWinFocusable = createHitWindowFocusableSetter({
@@ -687,6 +697,8 @@ describe("topmost runtime Windows recovery", () => {
     assert.equal((style & WS_EX_NOACTIVATE) !== 0n, false);
     assert.equal(nativeWrites.length, 2);
     assert.equal(hitWin.calls.some((call) => call[0] === "setFocusable"), false);
+    assert.equal(hitWin.calls.filter((call) => call[0] === "hookWindowMessage").length, 1);
+    assert.equal(hitWin.calls.some((call) => call[0] === "unhookWindowMessage"), false);
   });
 
   it("uses one fullscreen native observation for both focusability and auto-hide per poll tick", () => {

--- a/test/win-hit-window-activation.test.js
+++ b/test/win-hit-window-activation.test.js
@@ -10,6 +10,8 @@ const {
   createHitWindowActivationRuntime,
   createHitWindowFocusableSetter,
   WS_EX_NOACTIVATE,
+  WM_MOUSEACTIVATE,
+  MA_NOACTIVATE,
   STYLE_REFRESH_FLAGS,
 } = require("../src/win-hit-window-activation");
 
@@ -17,11 +19,14 @@ function makeHarness({
   initialStyle = 0n,
   electronFocusable = false,
   refreshResult = true,
+  armResult = true,
   onError,
 } = {}) {
   let style = initialStyle;
   const nativeCalls = [];
   const electronCalls = [];
+  const windowMessageCalls = [];
+  const windowMessageHooks = new Map();
   const hwnd = { id: 42 };
   const win = {
     isDestroyed: () => false,
@@ -29,6 +34,14 @@ function makeHarness({
     setFocusable(value) {
       electronFocusable = !!value;
       electronCalls.push(value);
+    },
+    hookWindowMessage(message, callback) {
+      windowMessageCalls.push(["hookWindowMessage", message]);
+      windowMessageHooks.set(message, callback);
+    },
+    unhookWindowMessage(message) {
+      windowMessageCalls.push(["unhookWindowMessage", message]);
+      windowMessageHooks.delete(message);
     },
   };
   const controller = createHitWindowActivationController({
@@ -52,6 +65,16 @@ function makeHarness({
         nativeCalls.push(["refreshStyle", STYLE_REFRESH_FLAGS]);
         return typeof refreshResult === "function" ? refreshResult() : refreshResult;
       },
+      armMouseActivate(candidate) {
+        assert.strictEqual(candidate, hwnd);
+        nativeCalls.push(["armMouseActivate"]);
+        return typeof armResult === "function" ? armResult() : armResult;
+      },
+      clearMouseActivate(candidate) {
+        assert.strictEqual(candidate, hwnd);
+        nativeCalls.push(["clearMouseActivate"]);
+        return null;
+      },
     },
     onError,
   });
@@ -60,24 +83,34 @@ function makeHarness({
     win,
     nativeCalls,
     electronCalls,
+    windowMessageCalls,
+    dispatchWindowMessage(message) {
+      return windowMessageHooks.get(message)?.(Buffer.alloc(8), Buffer.alloc(8));
+    },
     getStyle: () => style,
   };
 }
 
 describe("Windows hit-window activation controller", () => {
-  it("adds WS_EX_NOACTIVATE without calling Electron setFocusable(false)", () => {
+  it("guards fullscreen mouse activation without calling Electron setFocusable(false)", () => {
     const h = makeHarness({ initialStyle: 0x00080088n });
+    assert.equal(MA_NOACTIVATE, 3);
 
     assert.equal(h.controller.setFocusable(h.win, false), true);
 
     assert.equal((h.getStyle() & WS_EX_NOACTIVATE) !== 0n, true);
     assert.deepStrictEqual(h.electronCalls, []);
+    assert.deepStrictEqual(h.windowMessageCalls, [["hookWindowMessage", WM_MOUSEACTIVATE]]);
     assert.deepStrictEqual(h.nativeCalls, [
+      ["armMouseActivate"],
       ["getStyle"],
       ["setStyle", 0x08080088n],
       ["refreshStyle", STYLE_REFRESH_FLAGS],
       ["getStyle"],
     ]);
+
+    assert.equal(h.dispatchWindowMessage(WM_MOUSEACTIVATE), undefined);
+    assert.deepStrictEqual(h.nativeCalls.at(-1), ["armMouseActivate"]);
   });
 
   it("is idempotent while the hit window is already non-activating", () => {
@@ -85,20 +118,34 @@ describe("Windows hit-window activation controller", () => {
 
     assert.equal(h.controller.setFocusable(h.win, false), true);
 
-    assert.deepStrictEqual(h.nativeCalls, [["getStyle"]]);
+    assert.deepStrictEqual(h.nativeCalls, [["armMouseActivate"], ["getStyle"]]);
     assert.deepStrictEqual(h.electronCalls, []);
+    assert.deepStrictEqual(h.windowMessageCalls, [["hookWindowMessage", WM_MOUSEACTIVATE]]);
   });
 
-  it("removes only WS_EX_NOACTIVATE when fullscreen ends", () => {
-    const h = makeHarness({ initialStyle: WS_EX_NOACTIVATE | 0x00080088n });
+  it("keeps the hook while restoring desktop activation semantics", () => {
+    const h = makeHarness({ initialStyle: 0x00080088n });
+
+    assert.equal(h.controller.setFocusable(h.win, false), true);
 
     assert.equal(h.controller.setFocusable(h.win, true), true);
 
     assert.equal(h.getStyle(), 0x00080088n);
     assert.deepStrictEqual(h.electronCalls, []);
+    assert.deepStrictEqual(h.windowMessageCalls, [["hookWindowMessage", WM_MOUSEACTIVATE]]);
+    assert.equal(h.dispatchWindowMessage(WM_MOUSEACTIVATE), undefined);
+    assert.deepStrictEqual(h.nativeCalls.at(-1), ["armMouseActivate"]);
+
+    assert.equal(h.controller.dispose(), true);
+    assert.equal(h.controller.dispose(), true);
+    assert.deepStrictEqual(h.windowMessageCalls, [
+      ["hookWindowMessage", WM_MOUSEACTIVATE],
+      ["unhookWindowMessage", WM_MOUSEACTIVATE],
+    ]);
+    assert.deepStrictEqual(h.nativeCalls.at(-1), ["clearMouseActivate"]);
   });
 
-  it("keeps Electron focusability disabled when native activation is restored", () => {
+  it("clears native non-activation on desktop while retaining the delivery hook", () => {
     const h = makeHarness({
       initialStyle: WS_EX_NOACTIVATE | 0x88n,
       electronFocusable: false,
@@ -108,6 +155,37 @@ describe("Windows hit-window activation controller", () => {
 
     assert.deepStrictEqual(h.electronCalls, []);
     assert.equal((h.getStyle() & WS_EX_NOACTIVATE) !== 0n, false);
+    assert.deepStrictEqual(h.windowMessageCalls, [["hookWindowMessage", WM_MOUSEACTIVATE]]);
+    assert.equal(h.dispatchWindowMessage(WM_MOUSEACTIVATE), undefined);
+    assert.deepStrictEqual(h.nativeCalls.at(-1), ["armMouseActivate"]);
+  });
+
+  it("prepares only the delivery hook before first show", () => {
+    const h = makeHarness({ initialStyle: WS_EX_NOACTIVATE | 0x88n });
+
+    assert.equal(h.controller.prepare(h.win), true);
+
+    assert.equal(h.getStyle(), WS_EX_NOACTIVATE | 0x88n);
+    assert.deepStrictEqual(h.nativeCalls, [["armMouseActivate"]]);
+    assert.deepStrictEqual(h.windowMessageCalls, [["hookWindowMessage", WM_MOUSEACTIVATE]]);
+  });
+
+  it("latches a failed pre-show guard into the legacy fallback", () => {
+    let armAllowed = false;
+    const h = makeHarness({ armResult: () => armAllowed });
+
+    assert.equal(h.controller.prepare(h.win), false);
+    armAllowed = true;
+    assert.equal(h.controller.setFocusable(h.win, false), false);
+
+    assert.deepStrictEqual(h.nativeCalls, [
+      ["armMouseActivate"],
+      ["clearMouseActivate"],
+    ]);
+    assert.deepStrictEqual(h.windowMessageCalls, [
+      ["hookWindowMessage", WM_MOUSEACTIVATE],
+      ["unhookWindowMessage", WM_MOUSEACTIVATE],
+    ]);
   });
 
   it("never falls back to the focus-stealing Electron false call when native refresh fails", () => {
@@ -115,6 +193,38 @@ describe("Windows hit-window activation controller", () => {
 
     assert.equal(h.controller.setFocusable(h.win, false), false);
     assert.deepStrictEqual(h.electronCalls, []);
+  });
+
+  it("deduplicates repeated arm failures until the same window recovers", () => {
+    const errors = [];
+    let armAllowed = false;
+    const h = makeHarness({
+      armResult: () => armAllowed,
+      onError: (error) => errors.push(error.message),
+    });
+
+    assert.equal(h.controller.setFocusable(h.win, true), false);
+    assert.equal(h.controller.setFocusable(h.win, true), false);
+    assert.deepStrictEqual(h.windowMessageCalls, [
+      ["hookWindowMessage", WM_MOUSEACTIVATE],
+      ["unhookWindowMessage", WM_MOUSEACTIVATE],
+      ["hookWindowMessage", WM_MOUSEACTIVATE],
+      ["unhookWindowMessage", WM_MOUSEACTIVATE],
+    ]);
+    assert.deepStrictEqual(
+      h.nativeCalls.filter((call) => call[0] === "armMouseActivate"),
+      [["armMouseActivate"], ["armMouseActivate"]],
+    );
+    assert.deepStrictEqual(errors, ["Windows hit-window mouse activation guard failed"]);
+
+    armAllowed = true;
+    assert.equal(h.controller.setFocusable(h.win, true), true);
+    armAllowed = false;
+    h.dispatchWindowMessage(WM_MOUSEACTIVATE);
+    assert.deepStrictEqual(errors, [
+      "Windows hit-window mouse activation guard failed",
+      "Windows hit-window mouse activation guard failed",
+    ]);
   });
 
   it("retries an owed native style refresh even when the style bit already matches", () => {
@@ -170,13 +280,25 @@ describe("Windows hit-window activation controller", () => {
       mainSource,
       /const setHitWinFocusable = _hitWindowActivationRuntime\.setHitWinFocusable/,
     );
+    assert.match(
+      mainSource,
+      /prepareActivation:\s*\(createdHitWin\)\s*=>[\s\S]*?_hitWindowActivationRuntime\.controller\.prepare\(createdHitWin\)/,
+    );
     assert.doesNotMatch(mainSource, /hitWin\.setFocusable\(/);
     assert.match(mainSource, /setHitWinFocusable,\s*\n/);
+
+    const disposeIndex = mainSource.indexOf("_hitWindowActivationRuntime.controller.dispose()");
+    const destroyIndex = mainSource.indexOf("hitWin.destroy()", disposeIndex);
+    assert.ok(disposeIndex >= 0 && destroyIndex > disposeIndex);
   });
 
   it("composes controller availability, fallback construction, and the live setter", () => {
     let style = WS_EX_NOACTIVATE;
-    const hitWin = { isDestroyed: () => false };
+    const hitWin = {
+      isDestroyed: () => false,
+      hookWindowMessage: () => {},
+      unhookWindowMessage: () => {},
+    };
     const runtime = createHitWindowActivationRuntime({
       isWin: true,
       pointerBits: 64,
@@ -186,6 +308,8 @@ describe("Windows hit-window activation controller", () => {
         getStyle: () => style,
         setStyle: (_hwnd, next) => { style = BigInt.asUintN(64, BigInt(next)); },
         refreshStyle: () => true,
+        armMouseActivate: () => true,
+        clearMouseActivate: () => null,
       },
     });
 


### PR DESCRIPTION
Addresses #997. Keep the issue open for longer-running confirmation because this intermittent failure still cannot be induced on demand.

## Summary

- install a Windows `WM_MOUSEACTIVATE` delivery guard before the hit window is first shown
- use Chromium's one-shot `Chrome.IgnoreMouseActivate` property so native mouse activation resolves to `MA_NOACTIVATE` instead of `MA_NOACTIVATEANDEAT`
- preserve the existing fullscreen focus-safety contract: Electron stays non-focusable, while `WS_EX_NOACTIVATE` is cleared on the desktop and restored for fullscreen foreground apps
- fall back to the legacy `focusable: true` construction before first show if the native controller or per-window guard cannot be prepared
- extend packaged Koffi smoke coverage to verify the real window-message result and property consumption

## Captured root cause and reproduction boundary

The failure was captured once on an already-stuck local Clawd v1.0.0 instance. It could not be induced reliably from a healthy instance.

In that bad state, the Windows hit window returned `MA_NOACTIVATEANDEAT (4)` for `WM_MOUSEACTIVATE`. No DOM `pointerdown` followed, no drag-lock IPC was sent, and the main-process drag lock remained clear. The hit renderer was alive. This matches a visible pet whose input is discarded before the renderer and explains why activating Clawd through the tray or restarting could temporarily restore input.

The v1 activation change in `bd6f354d` deliberately made the hit `BrowserWindow` Electron-non-focusable to avoid stealing foreground from fullscreen applications. That safety requirement is valid. The missing piece was keeping Chromium's mouse-activation path deliverable while the window remains non-focusable.

This change pre-arms and re-arms `Chrome.IgnoreMouseActivate` around `WM_MOUSEACTIVATE`, making Chromium return deliverable `MA_NOACTIVATE (3)`. Windows hit windows are created hidden so the guard is ready before `showInactive()`, and the hook/property are disposed before the HWND is destroyed.

## Relationship to #998

This is complementary to #998, not a replacement for it.

#998 handles failures after pointer delivery has begun: a `pointerdown` has created a drag lock, the closing event is lost, or the hit renderer becomes unresponsive. Its watchdog and recovery paths need a drag lock or renderer failure to observe.

The locally captured state stopped earlier, at native mouse activation: `WM_MOUSEACTIVATE=4`, no DOM `pointerdown`, no drag lock, and a responsive renderer. A drag-lock watchdog therefore has nothing to age out, and the unresponsive-renderer path does not fire. Both fixes close different failure stages.

## Fullscreen safety

This PR intentionally keeps the repository's high-risk Windows rule intact and does not modify `AGENTS.md` or `src/topmost-runtime.js`:

- with the native controller available, the hit window is created with Electron `focusable: false`
- the existing fullscreen poll still clears `WS_EX_NOACTIVATE` on the desktop and sets it while a fullscreen app owns foreground
- runtime code never calls `BrowserWindow.setFocusable(false)`, whose Windows `Focus(false)` side effect can disrupt the foreground fullscreen app
- if controller setup or first-window preparation fails, fallback happens before visibility through the legacy `focusable: true` path; that preserves desktop interaction but does not claim fullscreen focus protection

## Validation

- Focused Node tests: 245 passed, 0 failed, 0 skipped (`package-koffi-smoke`, `pet-window-runtime`, `topmost-runtime`, and `win-hit-window-activation`).
- `node --check`, `git diff --check`, Electron 41.10.4 verification, repository asset audit (0 errors; one existing size warning), and Windows x64 unpacked native inventory audit passed.
- Exact installed Windows x64 candidate on Windows 10 build 19045: `SendInput` clicks reached the DOM 20/20 times; drag delivery passed and the hit/render windows moved together by `(-57, -29)`. A real fullscreen foreground HWND stayed unchanged throughout. The hit window had `WS_EX_NOACTIVATE=true` and `WM_MOUSEACTIVATE=3` while fullscreen.
- Installed `app.asar` SHA-256: `05ABC6D5F191654EEBE1AABF1FD2DF88B3F7DDBD21DDEEA3AF46DAAAE0818120`. The four changed runtime sources extracted from that archive matched the current worktree byte-for-byte.
- The exact installed packaged smoke reached the downstream fullscreen-auto-hide probe, so its preceding external `WM_MOUSEACTIVATE` round trip completed. The overall smoke later timed out waiting for pet windows to auto-hide over the first fullscreen HWND; this PR does not claim a complete packaged-smoke pass.
- Full `npm test` is not green, but introduced no new failure against clean `upstream/main` (`043b2da1`): current branch 9,750 total / 9,695 passed / 12 failed / 43 skipped; clean baseline 9,746 total / 9,688 passed / 15 failed / 43 skipped. All current failures also reproduce on baseline (10 Dashboard renderer failures, one Windows temporary-directory rename `EPERM`, and one local PowerShell execution-policy failure).

## Verification boundary

The original bad state was captured, but there is no stable trigger or long-duration A/B reproduction. The 20/20 result validates repeated native input delivery on the exact installed candidate; it does not prove that every long-running occurrence of #997 shares this cause. Windows ARM64 and the wider fullscreen game/video matrix were not tested; macOS and Linux runtime paths are unchanged.