### PR TITLE
fix(hermes): restore opted-in tool permission bubbles

### DIFF
--- a/hooks/hermes-plugin/__init__.py
+++ b/hooks/hermes-plugin/__init__.py
@@ -1301,7 +1301,7 @@ def _make_callback(event_name: str):
             if tool_name == "clarify":
                 return _handle_clarify_tool(**kwargs)
             if _PERMISSION_TOOLS and tool_name in _PERMISSION_TOOLS:
-                return _handle_permission_request(tool_name, **kwargs)
+                return _handle_permission_request(**kwargs)
             _handle_hook(event_name, **kwargs)
             return None
         callback.__name__ = "clawd_pre_tool_call"
@@ -1395,6 +1395,8 @@ def _handle_clarify_tool(**kwargs: Any):
 
 def _handle_permission_request(tool_name: str, **kwargs: Any):
     """Show permission bubble for tools that require user approval."""
+    # Python binds tool_name separately; retain it in the state hook payload too.
+    kwargs["tool_name"] = tool_name
     args = kwargs.get("args", {})
     tool_input = _safe_value(args) if args else {}
     session_id = _session_id("pre_tool_call", kwargs)

--- a/scripts/manual/README.md
+++ b/scripts/manual/README.md
@@ -179,3 +179,30 @@ composition smoke, not a Settings GUI smoke.
 The live API smoke covered the account-default root home. Named-profile
 filesystem behavior and isolated-layout cleanup exclusion were covered by the
 native Pi regressions. This adds no live gateway-reload or Codespaces claim.
+
+### Hermes opt-in permission callback follow-up (2026-09-09)
+
+Real API sessions exposed a pre-existing callback error: an opted-in tool name
+was passed both positionally and in the upstream keyword payload, so Python
+raised before the permission request and Hermes continued the tool. The fix
+passes the callback keywords once and preserves the tool name in subsequent
+state events. A regression invokes the registered callback for Allow, Deny and
+no-decision; it fails with the original TypeError before the fix.
+
+Validation used the running Windows desktop app and its Settings Deploy/Repair,
+with the same Raspberry Pi 5 / Hermes 0.20.5 account-default root home. Each
+fresh test CLI temporarily set `CLAWD_HERMES_PERMISSION_TOOLS=terminal`; no
+gateway was restarted and the opt-in was not persisted.
+
+- The user clicked Approve on the real desktop bubble. The remote tool record
+  contained the expected `printf` output and exit code 0.
+- The user clicked Deny on a second real bubble. Its remote tool record contained
+  `User denied this tool execution` and no execution output. The agent did not
+  retry the blocked tool.
+- Dashboard snapshots carried the correct remote profile/host with no local
+  terminal PID. The SSH connection remained healthy after both sessions.
+- Windows plugin, installer and permission-route regressions: 172 passed,
+  zero failures, one privileged-symlink skip.
+
+This verifies the explicit tool opt-in path. It does not claim that Hermes'
+native once/session/always approval UI is fully intercepted.

--- a/test/hermes-plugin.test.js
+++ b/test/hermes-plugin.test.js
@@ -660,6 +660,52 @@ print(json.dumps({
     ]);
   });
 
+  it("routes registered permission callbacks without duplicating the tool name", () => {
+    const output = runPluginPython(String.raw`
+import importlib.util
+import json
+import sys
+
+sys.dont_write_bytecode = True
+spec = importlib.util.spec_from_file_location("hermes_plugin", r"hooks/hermes-plugin/__init__.py")
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+mod._PERMISSION_TOOLS = {"terminal"}
+mod._ensure_process_meta_resolver_started = lambda: None
+mod._append_log = lambda *args, **kwargs: None
+registered = {}
+class Context:
+    def register_hook(self, name, callback):
+        registered[name] = callback
+mod.register(Context())
+events = []
+calls = []
+mod._handle_hook = lambda event, **kwargs: events.append({"event": event, "kwargs": kwargs})
+responses = [{"decision": "allow"}, {"decision": "deny", "message": "Denied in Clawd"}, None]
+def permission(tool_name, tool_input, session_id, platform):
+    calls.append({"tool_name": tool_name, "tool_input": tool_input, "session_id": session_id})
+    return responses.pop(0)
+mod._post_permission = permission
+kwargs = {"tool_name": "terminal", "args": {"command": "printf test"}, "session_id": "callback-session", "task_id": "callback-task"}
+results = [registered["pre_tool_call"](**kwargs) for _ in range(3)]
+print(json.dumps({"results": results, "calls": calls, "events": events}))
+`);
+    const result = JSON.parse(output);
+    assert.strictEqual(result.results[0], null);
+    assert.deepStrictEqual(result.results[1], { action: "block", message: "Denied in Clawd" });
+    assert.strictEqual(result.results[2].action, "block");
+    assert.match(result.results[2].message, /did not return a permission decision/i);
+    assert.deepStrictEqual(result.calls, Array(3).fill({
+      tool_name: "terminal", tool_input: { command: "printf test" }, session_id: "callback-session",
+    }));
+    assert.strictEqual(result.events.length, 2);
+    for (const event of result.events) {
+      assert.strictEqual(event.event, "pre_tool_call");
+      assert.strictEqual(event.kwargs.tool_name, "terminal");
+      assert.strictEqual(event.kwargs.session_id, "callback-session");
+    }
+  });
+
   it("probes existing /state health route before the long blocking permission POST", () => {
     const output = runPluginPython(String.raw`
 import importlib.util


### PR DESCRIPTION
With `CLAWD_HERMES_PERMISSION_TOOLS=terminal`, the registered pre-tool callback passed `tool_name` both positionally and as a keyword. Python raised before the permission POST, and Hermes continued the tool without showing a Clawd bubble. This was reproduced in real Raspberry Pi sessions after #975.

Pass the upstream callback keywords once and retain the tool name in subsequent state events. Add a regression through the registered callback covering Allow, Deny and no-decision; it reproduces the original TypeError before the fix.

Validation completed before push:

- Windows plugin, installer and permission-route tests: 172 passed, 0 failed, 1 privileged-symlink skip.
- Real Raspberry Pi 5 / Hermes 0.20.5 API sessions, using the running Windows desktop app and Settings Deploy/Repair: the user clicked Approve and the tool returned the expected printf output with exit code 0; the user clicked Deny on a second bubble and its tool record returned `User denied this tool execution` with no execution output or retry.
- Dashboard snapshots retained the remote profile/host and no local terminal PID; SSH remained connected. The tool opt-in was scoped to the test processes, and no gateway was restarted.

Detailed validation is recorded in `scripts/manual/README.md`. This covers the explicit tool opt-in path, not full interception of Hermes' native once/session/always approval UI.
