### PR TITLE
fix(opencode): hydrate context usage for resumed sessions

### DIFF
--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -70,6 +70,13 @@ const CONTEXT_LIMIT_CACHE_MS = 60 * 1000;
 // tracked, so long-lived hosts (days of sessions) stay bounded even though
 // _lastStatePerSession itself is intentionally unbounded.
 const MAX_CONTEXT_USAGE_ENTRIES = 1024;
+// Resume hydration reads one recent page. Bootstrap examines at most 20
+// directory-owned root sessions; it never creates Clawd lifecycle activity.
+const CONTEXT_HISTORY_LIMIT = 20;
+const CONTEXT_BOOTSTRAP_LIMIT = 20;
+const CONTEXT_HISTORY_TIMEOUT_MS = 2000;
+const CONTEXT_HISTORY_RETRY_MS = 30 * 1000;
+const CONTEXT_HISTORY_MAX_CONCURRENT = 4;
 // Fire-and-forget: the IIFE never blocks the event hook's return value, so a
 // generous timeout is safe. 200ms was too tight when Clawd's IPC roundtrip
 // (main → renderer → main) ran under load and silently timed out.
@@ -726,7 +733,7 @@ export function createOpencodeFamilyPlugin(config) {
     return sessions || null;
   }
 
-  function getContextState(instanceToken, sessionId, create = false) {
+  function getContextState(instanceToken, sessionId, create = false, activityObserved = true) {
     const normalized = normalizeSessionId(sessionId);
     if (!normalized) return null;
     const sessions = getContextSessionMap(instanceToken, create);
@@ -739,9 +746,18 @@ export function createOpencodeFamilyPlugin(config) {
         latestSequence: 0,
         inFlight: new Map(),
         delivered: null,
+        liveRevision: 0,
+        hydration: null,
+        nextHydrationAt: 0,
+        activityObserved,
       };
       sessions.set(normalized, state);
+      if (sessions.size > MAX_CONTEXT_USAGE_ENTRIES) {
+        const oldest = sessions.keys().next().value;
+        if (oldest !== normalized) sessions.delete(oldest);
+      }
     }
+    if (state && create && activityObserved) state.activityObserved = true;
     return state || null;
   }
 
@@ -760,7 +776,9 @@ export function createOpencodeFamilyPlugin(config) {
       ? _contextStateByInstance.values()
       : [getContextSessionMap(instanceToken)].filter(Boolean);
     for (const sessions of maps) {
-      for (const sessionId of sessions.keys()) ids.add(sessionId);
+      for (const [sessionId, state] of sessions) {
+        if (state.activityObserved) ids.add(sessionId);
+      }
     }
     return ids;
   }
@@ -795,7 +813,12 @@ export function createOpencodeFamilyPlugin(config) {
       ..._lastStatePerSession.keys(),
       ..._sessionParentById.keys(),
       ..._sessionParentById.values(),
-      ..._statePostTailBySession.keys(),
+      // A bootstrap-only metadata queue cannot create a session and must not
+      // manufacture SessionEnd ownership during a global disposal.
+      ...[..._statePostQueueBySession].filter(([, queue]) => (
+        (queue.active && queue.active.body.metadata_only !== true)
+        || queue.pending.some((entry) => entry.body.metadata_only !== true)
+      )).map(([sessionId]) => sessionId),
     ]);
     for (const sessionId of collectContextSessionIds()) ids.add(sessionId);
     const root = normalizeSessionId(_rootSessionId);
@@ -925,7 +948,7 @@ export function createOpencodeFamilyPlugin(config) {
   // Snapshot mutable request data synchronously. session.deleted cleanup runs
   // immediately after enqueue, so cwd/title/process fields must already be
   // frozen before a queued delivery waits behind an older request.
-  function snapshotPost(body, logTag) {
+  function snapshotPost(body, logTag, contextDirectory) {
     const outbound = { ...(body || {}) };
     // Enrich every outbound body with process-tree fields. Cached after first
     // call so this is just a few object assignments per POST.
@@ -941,7 +964,9 @@ export function createOpencodeFamilyPlugin(config) {
     // walk finds no terminal to report.
     const orcaPaneKey = orcaPaneKeyFromEnv();
     if (orcaPaneKey) outbound.orca_pane_key = orcaPaneKey;
-    const cwd = resolveSessionDirectory(outbound.session_id);
+    const cwd = contextDirectory === undefined
+      ? resolveSessionDirectory(outbound.session_id)
+      : { directory: contextDirectory, source: "context-instance" };
     if (cwd.directory) outbound.cwd = cwd.directory;
     else delete outbound.cwd;
     outbound.agent_pid = process.pid;
@@ -1026,8 +1051,8 @@ export function createOpencodeFamilyPlugin(config) {
     return snapshot;
   }
 
-  function createStatePostSnapshot(body) {
-    const snapshot = snapshotPost(body, `STATE state=${body && body.state}`);
+  function createStatePostSnapshot(body, contextDirectory) {
+    const snapshot = snapshotPost(body, `STATE state=${body && body.state}`, contextDirectory);
     let resolve;
     snapshot.completion = new Promise((done) => { resolve = done; });
     snapshot.waiters = [{ resolve, kinds: metadataFieldKinds(snapshot) }];
@@ -1126,9 +1151,9 @@ export function createOpencodeFamilyPlugin(config) {
     debugLog(`POST[${incoming.reqId}] ${incoming.logTag} overflow=dropped-old req=${dropped.reqId}`);
   }
 
-  function postStateToClawd(body) {
+  function postStateToClawd(body, contextDirectory) {
     const sessionId = normalizeSessionId(body && body.session_id) || DEFAULT_SESSION_ID;
-    const snapshot = createStatePostSnapshot(body);
+    const snapshot = createStatePostSnapshot(body, contextDirectory);
     const replaceable = isReplaceableStateSnapshot(snapshot);
     const metadata = isMetadataStateSnapshot(snapshot);
     const terminal = !!body && body.event === "SessionEnd";
@@ -1555,7 +1580,7 @@ export function createOpencodeFamilyPlugin(config) {
   // message.updated handler: the session message rides on properties.info
   // (assistant role, tokens populated after the step finishes). The event hook
   // never awaits this path; its returned promise is intentionally detached.
-  function handleContextUsageEvent(event, instance) {
+  function handleContextUsageEvent(event, instance, hydration = null) {
     try {
       // MiMo uses this shared core but its SDK/event contract is not proven to
       // match OpenCode's message.updated/provider.list contract. Keep #830
@@ -1581,17 +1606,18 @@ export function createOpencodeFamilyPlugin(config) {
         debugLog("CTX skip reason=no-session-id");
         return;
       }
+      const previousState = getContextState(instanceToken, clawdSessionId);
+      // Even an unfinished assistant update supersedes a historical read.
+      // Keep the existing valid-sample sequence independent: zero-token live
+      // updates must not change the real-time pipeline's calculation/dedup.
+      if (!hydration && previousState) previousState.liveRevision += 1;
       const used = extractContextUsageUsed(info.tokens);
       if (!Number.isFinite(used) || used <= 0) {
         debugLog(`CTX skip reason=${Number.isFinite(used) ? "zero-tokens" : "no-tokens"}`);
         return;
       }
-      const state = getContextState(instanceToken, clawdSessionId, true);
-      const sessions = getContextSessionMap(instanceToken);
-      if (sessions && sessions.size > MAX_CONTEXT_USAGE_ENTRIES) {
-        const oldest = sessions.keys().next().value;
-        if (oldest !== undefined && oldest !== clawdSessionId) sessions.delete(oldest);
-      }
+      const state = getContextState(instanceToken, clawdSessionId, true, hydration?.activityObserved !== false);
+      if (!hydration && !previousState) state.liveRevision += 1;
 
       const sequence = ++state.sequence;
       state.latestSequence = sequence;
@@ -1601,7 +1627,8 @@ export function createOpencodeFamilyPlugin(config) {
       const modelID = info.modelID || null;
       return resolveContextLimit(providerID, modelID, instance && instance.client)
         .then((limit) => {
-          if (!isCurrentContextSample(instanceToken, clawdSessionId, state, generation, sequence)) {
+          if (!isCurrentContextSample(instanceToken, clawdSessionId, state, generation, sequence)
+            || (hydration && state.liveRevision !== hydration.liveRevision)) {
             debugLog(`CTX discard session=${clawdSessionId} seq=${sequence} reason=stale`);
             return null;
           }
@@ -1624,8 +1651,9 @@ export function createOpencodeFamilyPlugin(config) {
           const body = buildContextUsageBody(clawdSessionId, used, sample.limit);
           body.state = "idle";
           body.event = "SessionUpdate";
-          return postStateToClawd(body).then((delivered) => {
-            if (delivered && isCurrentContextSample(instanceToken, clawdSessionId, state, generation, sequence)) {
+          return postStateToClawd(body, hydration ? instance.directory : undefined).then((delivered) => {
+            if (delivered && isCurrentContextSample(instanceToken, clawdSessionId, state, generation, sequence)
+              && (!hydration || state.liveRevision === hydration.liveRevision)) {
               state.delivered = sample;
             }
           });
@@ -1638,6 +1666,132 @@ export function createOpencodeFamilyPlugin(config) {
         });
     } catch (err) {
       debugLog(`CTX handler THROW msg=${err && err.message}`);
+    }
+  }
+
+  function hydrateContextUsage(event, instance) {
+    if (AGENT_ID !== "opencode" || !instance.directory
+      || !["session.created", "session.updated", "session.status", "session.idle", "tui.session.select"].includes(event.type)
+      || typeof instance.client?.session?.messages !== "function") return;
+
+    const rawId = getEventSessionId(event);
+    const sessionId = normalizeSessionId(rawId);
+    if (!sessionId) return;
+    if (event.type === "session.created" || event.type === "session.updated") {
+      const info = getEventSessionInfo(event);
+      if ((info.infoSessionId && normalizeSessionId(info.infoSessionId) !== sessionId)
+        || (info.directory && normalizeDirectoryOwnershipKey(info.directory)
+          !== normalizeDirectoryOwnershipKey(instance.directory))) return;
+    }
+    return hydrateContextSession(rawId, instance);
+  }
+
+  // Both list and message reads are cancellable and bounded even if an SDK
+  // ignores AbortSignal. Register before yielding so a burst of events cannot
+  // exceed the per-Instance request limit.
+  async function readContextHistory(instance, read) {
+    const controller = new AbortController();
+    instance.historyRequests.add(controller);
+    let onAbort;
+    const aborted = new Promise((_, reject) => {
+      onAbort = () => reject(new Error("context history cancelled"));
+      controller.signal.addEventListener("abort", onAbort, { once: true });
+    });
+    const timer = setTimeout(() => controller.abort(), CONTEXT_HISTORY_TIMEOUT_MS);
+    try {
+      return await Promise.race([Promise.resolve().then(() => read(controller.signal)), aborted]);
+    } finally {
+      clearTimeout(timer);
+      controller.signal.removeEventListener("abort", onAbort);
+      instance.historyRequests.delete(controller);
+    }
+  }
+
+  function hydrateContextSession(rawId, instance, activityObserved = true) {
+    const sessionId = normalizeSessionId(rawId);
+    const state = getContextState(instance.instanceToken, sessionId, true, activityObserved);
+    if (state.hydration || state.inFlight.size > 0
+      || (state.delivered && Number.isFinite(state.delivered.limit) && state.delivered.limit > 0)
+      || Date.now() < state.nextHydrationAt
+      || instance.historyRequests.size >= CONTEXT_HISTORY_MAX_CONCURRENT) return;
+
+    const liveRevision = state.liveRevision;
+    const current = () => !instance.disposed && getContextState(instance.instanceToken, sessionId) === state
+      && state.liveRevision === liveRevision;
+    const id = rawId.startsWith(sessionIdPrefix) ? rawId.slice(sessionIdPrefix.length) : rawId;
+    state.nextHydrationAt = Date.now() + CONTEXT_HISTORY_RETRY_MS;
+    // Defer SDK entry until after the current event enqueues its lifecycle
+    // POST. Hydrated metadata must never race ahead of that session creation.
+    state.hydration = readContextHistory(instance, (signal) => current()
+      ? instance.client.session.messages({
+        path: { id },
+        query: { directory: instance.directory, limit: CONTEXT_HISTORY_LIMIT },
+        signal,
+      })
+      : null).then(async (result) => {
+      if (!current()) return;
+      const messages = Array.isArray(result) ? result : result?.data;
+      if (!Array.isArray(messages)) return;
+      // The SDK returns a chronological page. Use the message timestamp/id
+      // to select the newest usable assistant, never the largest token sum
+      // (compaction can reduce usage). Reject foreign/malformed identities.
+      let latest = null;
+      for (const message of messages.slice(-CONTEXT_HISTORY_LIMIT)) {
+        const info = message?.info;
+        if (info?.role !== "assistant" || info.sessionID !== id
+          || typeof info.id !== "string" || !info.id
+          || !Number.isFinite(info.time?.created)
+          || !(extractContextUsageUsed(info.tokens) > 0)) continue;
+        if (!latest || info.time.created > latest.time.created
+          || (info.time.created === latest.time.created && info.id > latest.id)) latest = info;
+      }
+      if (latest) {
+        await handleContextUsageEvent({ type: "message.updated", properties: { info: latest } }, instance,
+          { liveRevision, activityObserved });
+      }
+    }).catch(() => {
+      // A missing/unsupported SDK route or a timeout leaves usage unknown.
+      // A later resume signal may retry; errors never become lifecycle events.
+      debugLog(`CTX history unavailable session=${sessionId}`);
+    }).finally(() => {
+      state.hydration = null;
+    });
+    return state.hydration;
+  }
+
+  async function bootstrapContextUsage(instance) {
+    if (AGENT_ID !== "opencode" || !instance.directory
+      || typeof instance.client?.session?.list !== "function"
+      || typeof instance.client?.session?.messages !== "function") return;
+    const revision = instance.lifecycleRevision;
+    const current = () => !instance.disposed && instance.lifecycleRevision === revision;
+    try {
+      const result = await readContextHistory(instance, (signal) => instance.client.session.list({
+        query: { directory: instance.directory, limit: CONTEXT_BOOTSTRAP_LIMIT, roots: true }, signal,
+      }));
+      if (!current()) return;
+      const sessions = Array.isArray(result) ? result : result?.data;
+      if (!Array.isArray(sessions)) return;
+      const candidates = sessions.filter((info) => (
+        typeof info?.id === "string" && info.id.trim() && info.id.trim() === info.id
+        && !info.parentID && !info.time?.archived
+        && normalizeDirectoryOwnershipKey(info.directory) === normalizeDirectoryOwnershipKey(instance.directory)
+      )).sort((a, b) => (b.time?.updated || 0) - (a.time?.updated || 0)).slice(0, CONTEXT_BOOTSTRAP_LIMIT);
+      let cursor = 0;
+      await Promise.all(Array.from({ length: CONTEXT_HISTORY_MAX_CONCURRENT }, async () => {
+        while (current() && cursor < candidates.length) {
+          const info = candidates[cursor++];
+          // Live observation wins, including pending SDK work and zero-token
+          // updates. A list response is never evidence of a new generation.
+          const id = normalizeSessionId(info.id);
+          if (getContextState(instance.instanceToken, id)
+            || _sessionDirectoryById.has(id) || _sessionInstanceDirectoryById.has(id)) continue;
+          await hydrateContextSession(info.id, instance, false);
+        }
+      }));
+    } catch {
+      // Hosts without this query contract retain event-driven hydration.
+      debugLog("CTX bootstrap unavailable");
     }
   }
 
@@ -2000,13 +2154,33 @@ export function createOpencodeFamilyPlugin(config) {
       ? ctx.directory
       : "";
     const instanceToken = registerInstanceDirectory(instanceDirectory);
+    const contextInstance = {
+      client: instanceClient, instanceToken, directory: instanceDirectory,
+      historyRequests: new Set(), lifecycleRevision: 0, disposed: false,
+    };
     let instanceDisposed = false;
     debugLog(`INIT directory=${instanceDirectory} serverUrl=${instanceServerUrl} pid=${process.pid} hasClient=${!!instanceClient}`);
     // Sync init blocks the TUI boot path; later POSTs hit the cached result.
     getStablePid();
     await startBridge();
+    // Never await SDK requests during plugin initialization: the host router
+    // may itself be waiting for this initializer to return.
+    queueMicrotask(() => { void bootstrapContextUsage(contextInstance); });
+
+    function disposeInstance(event) {
+      if (instanceDisposed) return;
+      instanceDisposed = true;
+      contextInstance.disposed = true;
+      for (const controller of contextInstance.historyRequests) controller.abort();
+      cleanupSessionDirectory(event, "before-send", instanceDirectory, instanceToken);
+      unregisterInstanceDirectory(instanceToken);
+    }
 
     return {
+      // Newer hosts invoke dispose() instead of delivering the legacy event.
+      dispose: async () => disposeInstance({
+        type: "server.instance.disposed", properties: { directory: instanceDirectory },
+      }),
       event: async ({ event }) => {
         try {
           if (!event || typeof event.type !== "string") return;
@@ -2031,15 +2205,14 @@ export function createOpencodeFamilyPlugin(config) {
           // source. Capture before translate/drop because session.updated does
           // not map to a Clawd state and info-only deleted events need its id.
           if (event.type === "server.instance.disposed") {
-            cleanupSessionDirectory(event, "before-send", instanceDirectory, instanceToken);
-            if (!instanceDisposed) {
-              instanceDisposed = true;
-              unregisterInstanceDirectory(instanceToken);
-            }
+            disposeInstance(event);
             // Instance disposal is cleanup-only. Some host versions may attach
             // a session id, but it must never revive fallback pointers or
             // synthesize a SessionEnd for that (possibly unrelated) session.
             return;
+          }
+          if (event.type === "session.created" || event.type === "session.deleted") {
+            contextInstance.lifecycleRevision += 1;
           }
           captureSessionDirectory(event);
           captureSessionInstanceDirectory(event, instanceDirectory);
@@ -2097,6 +2270,7 @@ export function createOpencodeFamilyPlugin(config) {
           }
 
           const mapped = translateEvent(event);
+          if (mapped?.event !== "SessionEnd") hydrateContextUsage(event, contextInstance);
           if (!mapped) {
             // Log ignored session.* events only — they are low-frequency and
             // occasionally useful for diagnosis. message.part.updated ignores

--- a/hooks/opencode-family-plugin/core.mjs
+++ b/hooks/opencode-family-plugin/core.mjs
@@ -749,16 +749,34 @@ export function createOpencodeFamilyPlugin(config) {
         liveRevision: 0,
         hydration: null,
         nextHydrationAt: 0,
+        pendingHydration: null,
+        undeliveredContext: null,
+        historyController: null,
+        wakeHydration: null,
         activityObserved,
       };
       sessions.set(normalized, state);
       if (sessions.size > MAX_CONTEXT_USAGE_ENTRIES) {
-        const oldest = sessions.keys().next().value;
-        if (oldest !== normalized) sessions.delete(oldest);
+        // Prefer an unserved bootstrap candidate over an explicit selection.
+        const oldest = [...sessions].find(([id, entry]) => (
+          id !== normalized && !entry.activityObserved && entry.pendingHydration
+        ))?.[0] || sessions.keys().next().value;
+        if (oldest !== normalized) {
+          invalidateContextHydration(sessions.get(oldest));
+          sessions.delete(oldest);
+        }
       }
     }
     if (state && create && activityObserved) state.activityObserved = true;
     return state || null;
+  }
+
+  function invalidateContextHydration(state) {
+    if (!state) return;
+    state.pendingHydration = null;
+    state.undeliveredContext = null;
+    state.historyController?.abort();
+    state.wakeHydration?.();
   }
 
   function resetContextSession(sessionId, instanceToken) {
@@ -766,6 +784,7 @@ export function createOpencodeFamilyPlugin(config) {
     if (!normalized) return;
     const sessions = getContextSessionMap(instanceToken);
     if (!sessions) return;
+    invalidateContextHydration(sessions.get(normalized));
     sessions.delete(normalized);
     if (sessions.size === 0) _contextStateByInstance.delete(contextInstanceToken(instanceToken));
   }
@@ -785,10 +804,16 @@ export function createOpencodeFamilyPlugin(config) {
 
   function cleanupContextState(sessionIds, options = {}) {
     if (options.clearAll === true) {
+      for (const sessions of _contextStateByInstance.values()) {
+        for (const state of sessions.values()) invalidateContextHydration(state);
+      }
       _contextStateByInstance.clear();
       return;
     }
     if (options.clearInstance === true && options.instanceToken != null) {
+      for (const state of getContextSessionMap(options.instanceToken)?.values() || []) {
+        invalidateContextHydration(state);
+      }
       _contextStateByInstance.delete(contextInstanceToken(options.instanceToken));
       return;
     }
@@ -798,7 +823,10 @@ export function createOpencodeFamilyPlugin(config) {
       ? _contextStateByInstance.values()
       : [getContextSessionMap(options.instanceToken)].filter(Boolean);
     for (const sessions of maps) {
-      for (const sessionId of ids) sessions.delete(sessionId);
+      for (const sessionId of ids) {
+        invalidateContextHydration(sessions.get(sessionId));
+        sessions.delete(sessionId);
+      }
     }
     for (const [token, sessions] of _contextStateByInstance) {
       if (sessions.size === 0) _contextStateByInstance.delete(token);
@@ -990,6 +1018,9 @@ export function createOpencodeFamilyPlugin(config) {
     debugLog(`POST[${snapshot.reqId}] ${snapshot.logTag} cwdSource=${snapshot.cwdSource} start candidates=[${candidates.join(",")}]`);
 
     for (const port of candidates) {
+      if (urlPath === STATE_PATH && !pruneStaleContextSnapshot(snapshot)) {
+        return { recognized: false, metadataAccepted: false };
+      }
       const controller = new AbortController();
       const timer = setTimeout(() => controller.abort(), POST_TIMEOUT_MS);
       const t0 = Date.now();
@@ -1051,6 +1082,21 @@ export function createOpencodeFamilyPlugin(config) {
     return snapshot;
   }
 
+  function pruneStaleContextSnapshot(snapshot) {
+    if (!snapshot.contextIsCurrent || snapshot.contextIsCurrent()) return true;
+    delete snapshot.body.context_usage;
+    snapshot.contextIsCurrent = null;
+    snapshot.waiters = (snapshot.waiters || []).filter((waiter) => {
+      if (!waiter.kinds.has("context")) return true;
+      waiter.resolve(false);
+      return false;
+    });
+    refreshSnapshotPayload(snapshot);
+    // A title may share this queued POST. Drop only the stale context field
+    // and its acknowledgement waiter, not the independent title update.
+    return metadataFieldKinds(snapshot).size > 0;
+  }
+
   function createStatePostSnapshot(body, contextDirectory) {
     const snapshot = snapshotPost(body, `STATE state=${body && body.state}`, contextDirectory);
     let resolve;
@@ -1068,6 +1114,7 @@ export function createOpencodeFamilyPlugin(config) {
 
   function mergeQueuedMetadataSnapshot(existing, incoming) {
     const incomingKinds = metadataFieldKinds(incoming);
+    if (!incomingKinds.has("context")) incoming.contextIsCurrent = existing.contextIsCurrent;
     const mergedBody = { ...existing.body, ...incoming.body };
     incoming.body = mergedBody;
     refreshSnapshotPayload(incoming);
@@ -1151,9 +1198,10 @@ export function createOpencodeFamilyPlugin(config) {
     debugLog(`POST[${incoming.reqId}] ${incoming.logTag} overflow=dropped-old req=${dropped.reqId}`);
   }
 
-  function postStateToClawd(body, contextDirectory) {
+  function postStateToClawd(body, contextDirectory, contextIsCurrent = null) {
     const sessionId = normalizeSessionId(body && body.session_id) || DEFAULT_SESSION_ID;
     const snapshot = createStatePostSnapshot(body, contextDirectory);
+    snapshot.contextIsCurrent = contextIsCurrent;
     const replaceable = isReplaceableStateSnapshot(snapshot);
     const metadata = isMetadataStateSnapshot(snapshot);
     const terminal = !!body && body.event === "SessionEnd";
@@ -1610,7 +1658,10 @@ export function createOpencodeFamilyPlugin(config) {
       // Even an unfinished assistant update supersedes a historical read.
       // Keep the existing valid-sample sequence independent: zero-token live
       // updates must not change the real-time pipeline's calculation/dedup.
-      if (!hydration && previousState) previousState.liveRevision += 1;
+      if (!hydration && previousState) {
+        previousState.liveRevision += 1;
+        invalidateContextHydration(previousState);
+      }
       const used = extractContextUsageUsed(info.tokens);
       if (!Number.isFinite(used) || used <= 0) {
         debugLog(`CTX skip reason=${Number.isFinite(used) ? "zero-tokens" : "no-tokens"}`);
@@ -1648,25 +1699,37 @@ export function createOpencodeFamilyPlugin(config) {
           // Same serialized metadata delivery as the session-title push
           // (#841): state/event scaffolding is inert on the route side because
           // metadata_only short-circuits lifecycle handling.
-          const body = buildContextUsageBody(clawdSessionId, used, sample.limit);
-          body.state = "idle";
-          body.event = "SessionUpdate";
-          return postStateToClawd(body, hydration ? instance.directory : undefined).then((delivered) => {
-            if (delivered && isCurrentContextSample(instanceToken, clawdSessionId, state, generation, sequence)
-              && (!hydration || state.liveRevision === hydration.liveRevision)) {
-              state.delivered = sample;
-            }
-          });
+          const packet = { sample, generation, sequence, liveRevision: hydration?.liveRevision };
+          if (hydration) state.undeliveredContext = packet;
+          return deliverContextSample(instanceToken, clawdSessionId, state, packet,
+            hydration ? instance.directory : undefined);
         })
         .catch((err) => {
           debugLog(`CTX handler ASYNC THROW msg=${err && err.message}`);
         })
         .finally(() => {
           state.inFlight.delete(sequence);
+          state.wakeHydration?.();
         });
     } catch (err) {
       debugLog(`CTX handler THROW msg=${err && err.message}`);
     }
+  }
+
+  function deliverContextSample(instanceToken, sessionId, state, packet, directory) {
+    const current = () => isCurrentContextSample(instanceToken, sessionId, state,
+      packet.generation, packet.sequence)
+      && (packet.liveRevision === undefined || state.liveRevision === packet.liveRevision);
+    if (!current()) return Promise.resolve();
+    const body = buildContextUsageBody(sessionId, packet.sample.used, packet.sample.limit);
+    body.state = "idle";
+    body.event = "SessionUpdate";
+    return postStateToClawd(body, directory, packet.liveRevision === undefined ? null : current).then((delivered) => {
+      if (delivered && current()) {
+        state.delivered = packet.sample;
+        if (state.undeliveredContext === packet) state.undeliveredContext = null;
+      }
+    });
   }
 
   function hydrateContextUsage(event, instance) {
@@ -1689,8 +1752,9 @@ export function createOpencodeFamilyPlugin(config) {
   // Both list and message reads are cancellable and bounded even if an SDK
   // ignores AbortSignal. Register before yielding so a burst of events cannot
   // exceed the per-Instance request limit.
-  async function readContextHistory(instance, read) {
+  async function readContextHistory(instance, read, state = null) {
     const controller = new AbortController();
+    if (state) state.historyController = controller;
     instance.historyRequests.add(controller);
     let onAbort;
     const aborted = new Promise((_, reject) => {
@@ -1704,17 +1768,78 @@ export function createOpencodeFamilyPlugin(config) {
       clearTimeout(timer);
       controller.signal.removeEventListener("abort", onAbort);
       instance.historyRequests.delete(controller);
+      if (state?.historyController === controller) state.historyController = null;
+      scheduleContextHydration(instance);
     }
   }
 
   function hydrateContextSession(rawId, instance, activityObserved = true) {
+    if (instance.disposed) return;
     const sessionId = normalizeSessionId(rawId);
     const state = getContextState(instance.instanceToken, sessionId, true, activityObserved);
-    if (state.hydration || state.inFlight.size > 0
-      || (state.delivered && Number.isFinite(state.delivered.limit) && state.delivered.limit > 0)
-      || Date.now() < state.nextHydrationAt
-      || instance.historyRequests.size >= CONTEXT_HISTORY_MAX_CONCURRENT) return;
+    if (!state) return;
+    state.wakeHydration = () => scheduleContextHydration(instance);
+    // A signal is an intent, not a best-effort attempt to acquire a slot. Keep
+    // one per state so deletion/eviction also bounds all retained work.
+    state.pendingHydration = {
+      rawId, liveRevision: state.liveRevision,
+      activityObserved: activityObserved || state.pendingHydration?.activityObserved === true,
+    };
+    scheduleContextHydration(instance);
+  }
 
+  function scheduleContextHydration(instance) {
+    if (instance.disposed || instance.hydrationDrainQueued) return;
+    instance.hydrationDrainQueued = true;
+    // The originating event must enqueue its lifecycle POST first.
+    queueMicrotask(() => {
+      instance.hydrationDrainQueued = false;
+      if (!instance.disposed) drainContextHydration(instance);
+    });
+  }
+
+  function drainContextHydration(instance) {
+    clearTimeout(instance.hydrationTimer);
+    instance.hydrationTimer = null;
+    const sessions = getContextSessionMap(instance.instanceToken);
+    if (!sessions) return;
+    let nextWake = Infinity;
+    const now = Date.now();
+    const pending = [...sessions].filter(([, state]) => state.pendingHydration)
+      .sort(([, a], [, b]) => Number(b.pendingHydration.activityObserved) - Number(a.pendingHydration.activityObserved));
+    for (const [sessionId, state] of pending) {
+      const intent = state.pendingHydration;
+      if (state.liveRevision !== intent.liveRevision
+        || (state.delivered && Number.isFinite(state.delivered.limit) && state.delivered.limit > 0)) {
+        state.pendingHydration = null;
+        continue;
+      }
+      if (state.hydration || state.inFlight.size > 0) continue;
+      if (state.undeliveredContext) {
+        state.pendingHydration = null;
+        state.hydration = deliverContextSample(instance.instanceToken, sessionId, state,
+          state.undeliveredContext, instance.directory).finally(() => {
+          state.hydration = null;
+          scheduleContextHydration(instance);
+        });
+        continue;
+      }
+      if (now < state.nextHydrationAt) {
+        nextWake = Math.min(nextWake, state.nextHydrationAt);
+        continue;
+      }
+      if (instance.historyRequests.size >= CONTEXT_HISTORY_MAX_CONCURRENT) continue;
+      state.pendingHydration = null;
+      startContextHydration(intent.rawId, instance, state, intent.activityObserved);
+    }
+    if (Number.isFinite(nextWake)) {
+      instance.hydrationTimer = setTimeout(() => scheduleContextHydration(instance), Math.max(1, nextWake - Date.now()));
+      instance.hydrationTimer.unref?.();
+    }
+  }
+
+  function startContextHydration(rawId, instance, state, activityObserved) {
+    const sessionId = normalizeSessionId(rawId);
     const liveRevision = state.liveRevision;
     const current = () => !instance.disposed && getContextState(instance.instanceToken, sessionId) === state
       && state.liveRevision === liveRevision;
@@ -1728,7 +1853,7 @@ export function createOpencodeFamilyPlugin(config) {
         query: { directory: instance.directory, limit: CONTEXT_HISTORY_LIMIT },
         signal,
       })
-      : null).then(async (result) => {
+      : null, state).then(async (result) => {
       if (!current()) return;
       const messages = Array.isArray(result) ? result : result?.data;
       if (!Array.isArray(messages)) return;
@@ -1755,6 +1880,7 @@ export function createOpencodeFamilyPlugin(config) {
       debugLog(`CTX history unavailable session=${sessionId}`);
     }).finally(() => {
       state.hydration = null;
+      scheduleContextHydration(instance);
     });
     return state.hydration;
   }
@@ -1777,18 +1903,15 @@ export function createOpencodeFamilyPlugin(config) {
         && !info.parentID && !info.time?.archived
         && normalizeDirectoryOwnershipKey(info.directory) === normalizeDirectoryOwnershipKey(instance.directory)
       )).sort((a, b) => (b.time?.updated || 0) - (a.time?.updated || 0)).slice(0, CONTEXT_BOOTSTRAP_LIMIT);
-      let cursor = 0;
-      await Promise.all(Array.from({ length: CONTEXT_HISTORY_MAX_CONCURRENT }, async () => {
-        while (current() && cursor < candidates.length) {
-          const info = candidates[cursor++];
-          // Live observation wins, including pending SDK work and zero-token
-          // updates. A list response is never evidence of a new generation.
-          const id = normalizeSessionId(info.id);
-          if (getContextState(instance.instanceToken, id)
-            || _sessionDirectoryById.has(id) || _sessionInstanceDirectoryById.has(id)) continue;
-          await hydrateContextSession(info.id, instance, false);
-        }
-      }));
+      for (const info of candidates) {
+        if (!current()) break;
+        // Existing state may own a pending selection, an active query or a
+        // live sample. All pending work now belongs to the same scheduler.
+        const id = normalizeSessionId(info.id);
+        if (getContextState(instance.instanceToken, id)
+          || _sessionDirectoryById.has(id) || _sessionInstanceDirectoryById.has(id)) continue;
+        hydrateContextSession(info.id, instance, false);
+      }
     } catch {
       // Hosts without this query contract retain event-driven hydration.
       debugLog("CTX bootstrap unavailable");
@@ -2157,6 +2280,7 @@ export function createOpencodeFamilyPlugin(config) {
     const contextInstance = {
       client: instanceClient, instanceToken, directory: instanceDirectory,
       historyRequests: new Set(), lifecycleRevision: 0, disposed: false,
+      hydrationTimer: null, hydrationDrainQueued: false,
     };
     let instanceDisposed = false;
     debugLog(`INIT directory=${instanceDirectory} serverUrl=${instanceServerUrl} pid=${process.pid} hasClient=${!!instanceClient}`);
@@ -2171,6 +2295,8 @@ export function createOpencodeFamilyPlugin(config) {
       if (instanceDisposed) return;
       instanceDisposed = true;
       contextInstance.disposed = true;
+      clearTimeout(contextInstance.hydrationTimer);
+      contextInstance.hydrationTimer = null;
       for (const controller of contextInstance.historyRequests) controller.abort();
       cleanupSessionDirectory(event, "before-send", instanceDirectory, instanceToken);
       unregisterInstanceDirectory(instanceToken);

--- a/test/opencode-family-hydration-scheduling.test.js
+++ b/test/opencode-family-hydration-scheduling.test.js
@@ -1,0 +1,505 @@
+"use strict";
+
+// #1006: exercise the Node plugin and the real route/state acceptance contract.
+// Only the OpenCode SDK history and the in-process HTTP transport are fixtures.
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { EventEmitter } = require("node:events");
+const { syncBuiltinESMExports } = require("node:module");
+const { pathToFileURL } = require("node:url");
+const { before, after, it, mock } = require("node:test");
+const { handleStatePost } = require("../src/server-route-state");
+const { makeSessionKey } = require("../src/session-key");
+const initState = require("../src/state");
+const themeLoader = require("../src/theme-loader");
+
+const TEMP_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "clawd-hydration-scheduling-"));
+const directory = path.join(TEMP_DIR, "project");
+const originalFetch = globalThis.fetch;
+const originalBun = globalThis.Bun;
+let createOpencodeFamilyPlugin;
+themeLoader.init(path.join(__dirname, "..", "src"));
+const theme = themeLoader.loadTheme("clawd");
+
+before(async () => {
+  mock.method(os, "homedir", () => TEMP_DIR);
+  syncBuiltinESMExports();
+  delete globalThis.Bun;
+  const runtimeDir = path.join(TEMP_DIR, ".clawd");
+  fs.mkdirSync(runtimeDir, { mode: 0o700 });
+  fs.writeFileSync(path.join(runtimeDir, "runtime.json"), JSON.stringify({
+    app: "clawd-on-desk", port: 23333, ownerPid: process.pid,
+  }), { mode: 0o600 });
+  ({ createOpencodeFamilyPlugin } = await import(pathToFileURL(
+    path.join(__dirname, "..", "hooks", "opencode-family-plugin", "core.mjs")
+  ).href));
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  if (originalBun === undefined) delete globalThis.Bun;
+  else globalThis.Bun = originalBun;
+  mock.restoreAll();
+  syncBuiltinESMExports();
+  fs.rmSync(TEMP_DIR, { recursive: true, force: true });
+});
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function history(id, used = 320) {
+  return { info: {
+    id: `msg_${id}`, sessionID: id, role: "assistant",
+    time: { created: 1, completed: 2 }, providerID: "fixture", modelID: "model",
+    tokens: { input: used },
+  }, parts: [] };
+}
+
+const key = (id) => makeSessionKey({ profileId: "local", rawSessionId: `opencode:${id}` });
+const status = (id) => ({ type: "session.status", properties: { sessionID: id, status: { type: "busy" } } });
+const select = (id) => ({ type: "tui.session.select", properties: { sessionID: id } });
+
+async function settle(plugin) {
+  // All fixtures resolve without wall-clock I/O. Flush microtasks, route events
+  // and the serialized POST queues, without emitting a second resume signal.
+  await flushTurns();
+  await Promise.all([...plugin.__test._statePostTailBySession.values()]);
+}
+
+async function flushTurns() {
+  for (let i = 0; i < 40; i++) await new Promise((resolve) => setImmediate(resolve));
+}
+
+async function setup(t, { list, messages = async ({ path: p }) => ({ data: [history(p.id)] }) } = {}) {
+  const noop = () => {};
+  const ctx = {
+    lang: "en", theme, doNotDisturb: false, miniTransitioning: false, miniMode: false,
+    mouseOverPet: false, idlePaused: false, forceEyeResend: false, eyePauseUntil: 0,
+    mouseStillSince: Date.now(), playSound: noop, sendToRenderer: noop, syncHitWin: noop,
+    sendToHitWin: noop, buildContextMenu: noop, buildTrayMenu: noop, pendingPermissions: [],
+    getCursorScreenPoint: () => ({ x: 0, y: 0 }), isAgentEnabled: () => true,
+    permLog: noop, resolvePermissionEntry: noop,
+  };
+  const api = initState(ctx);
+  Object.assign(ctx, api);
+  const posts = [];
+  const queries = [];
+  let active = 0;
+  let peak = 0;
+  const responseGates = [];
+  globalThis.fetch = async (_url, options) => {
+    const body = JSON.parse(options.body);
+    const req = new EventEmitter();
+    req.headers = {};
+    const record = { body };
+    posts.push(record);
+    const response = await new Promise((resolve) => {
+      let code;
+      let headers;
+      const res = {
+        writeHead(statusCode, values) { code = statusCode; headers = values; },
+        end() {
+          record.status = code;
+          record.accepted = headers["X-Clawd-Metadata-Accepted"] === "1"
+            || headers["x-clawd-metadata-accepted"] === "1";
+          resolve({ status: code, headers: new Headers(headers), text: async () => "" });
+        },
+      };
+      handleStatePost(req, res, {
+        ctx, createRequestHookRecorder: () => ({
+          acceptedUnlessDnd: noop, droppedByDisabled: noop, droppedByDnd: noop,
+          droppedInvalidAgent: noop, droppedUnsupported: noop,
+        }), shouldDropForDnd: () => false, codexOfficialTurns: new Map(), isWinHost: false,
+      });
+      setImmediate(() => { req.emit("data", Buffer.from(options.body)); req.emit("end"); });
+    });
+    const gate = responseGates.find((candidate) => candidate.match(record));
+    if (gate) { gate.match = () => false; await gate.promise; }
+    return response;
+  };
+  const client = {
+    _client: { post: async () => ({ data: {} }) },
+    session: {
+      messages: async (options) => {
+        queries.push(options);
+        active++;
+        peak = Math.max(peak, active);
+        try { return await messages(options); } finally { active--; }
+      },
+      ...(list ? { list: async () => typeof list === "function" ? list() : ({ data: list }) } : {}),
+    },
+    provider: { list: async () => ({ data: { all: [
+      { id: "fixture", models: { model: { limit: { context: 1000 } } } },
+    ] } }) },
+  };
+  const plugin = createOpencodeFamilyPlugin({
+    agentId: "opencode", hookSource: "opencode-plugin", sessionIdPrefix: "opencode:",
+    logFileName: "opencode-plugin.log",
+  });
+  const hooks = await plugin({ directory, client });
+  const instances = [hooks];
+  t.after(async () => {
+    for (const gate of responseGates) gate.resolve();
+    for (const instance of instances) await instance.dispose();
+    await settle(plugin);
+    await plugin.__test.closeBridgeForTest();
+    await plugin.__test.flushDebugLog();
+    api.cleanup();
+  });
+  assert.equal(plugin.__test._bridgeRuntime, "node");
+  return {
+    plugin, hooks, api, client, posts, queries, responseGates, instances,
+    peak: () => peak,
+    usage: (id) => api.sessions.get(key(id))?.contextUsage ?? undefined,
+    emit: (event) => hooks.event({ event }),
+    seed: (id) => api.updateSession(key(id), "working", "PreToolUse", {
+      cwd: directory, agentId: "opencode", profileId: "local", rawSessionId: `opencode:${id}`,
+    }),
+  };
+}
+
+it("counts an in-flight bootstrap list against the same four-request capacity", async (t) => {
+  const listGate = deferred();
+  const messagesGate = deferred();
+  const h = await setup(t, {
+    list: () => listGate.promise,
+    messages: async ({ path: p }) => { await messagesGate.promise; return { data: [history(p.id)] }; },
+  });
+  t.after(() => { listGate.resolve({ data: [] }); messagesGate.resolve(); });
+  for (let i = 0; i < 4; i++) await h.emit(status(`s${i}`));
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 3, "the list still owns one slot");
+  listGate.resolve({ data: [] });
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 4);
+  messagesGate.resolve();
+  await settle(h.plugin);
+  assert.equal(h.usage("s3")?.used, 320);
+});
+
+it("an explicit selection precedes unserved bootstrap candidates", async (t) => {
+  const gate = deferred();
+  const h = await setup(t, {
+    list: Array.from({ length: 10 }, (_, i) => ({ id: `s${i}`, directory, time: { updated: 10 - i } })),
+    messages: async ({ path: p }) => {
+      if (Number(p.id.slice(1)) < 4) await gate.promise;
+      return { data: [history(p.id)] };
+    },
+  });
+  t.after(() => gate.resolve());
+  await settle(h.plugin);
+  h.seed("s9");
+  await h.emit(select("s9"));
+  gate.resolve();
+  await settle(h.plugin);
+  assert.equal(h.queries[4].path.id, "s9");
+  assert.equal(h.queries.length, 10);
+  assert.equal(h.usage("s9")?.used, 320);
+});
+
+it("a timed-out read releases capacity and cannot publish its late result", async (t) => {
+  const gate = deferred();
+  const h = await setup(t, { messages: async ({ path: p }) => {
+    if (p.id !== "waiting") await gate.promise; // Deliberately ignores AbortSignal.
+    return { data: [history(p.id)] };
+  } });
+  t.after(() => gate.resolve());
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: Date.now() });
+  for (let i = 0; i < 4; i++) await h.emit(status(`busy${i}`));
+  await h.emit(status("waiting"));
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 4);
+  t.mock.timers.tick(2001);
+  await settle(h.plugin);
+  assert.equal(h.usage("waiting")?.used, 320);
+  assert.ok(h.queries.slice(0, 4).every((q) => q.signal.aborted));
+  gate.resolve();
+  await settle(h.plugin);
+  for (let i = 0; i < 4; i++) assert.equal(h.usage(`busy${i}`), undefined);
+});
+
+it("a new generation discards the cached predecessor and hydrates fresh history", async (t) => {
+  let used = 900;
+  const h = await setup(t, {
+    list: [{ id: "reused", directory }],
+    messages: async ({ path: p }) => ({ data: [history(p.id, used)] }),
+  });
+  await settle(h.plugin);
+  assert.equal(h.api.sessions.size, 0);
+  used = 50;
+  await h.emit({ type: "session.created", properties: { info: { id: "reused", directory } } });
+  await settle(h.plugin);
+  assert.equal(h.usage("reused")?.used, 50);
+  assert.equal(h.queries.length, 2);
+  assert.ok(!h.posts.some((p) => p.accepted && p.body.context_usage?.used === 900));
+});
+
+it("disposal clears one instance's pending work without affecting another client/directory", async (t) => {
+  const gate = deferred();
+  const h = await setup(t, { messages: async ({ path: p }) => {
+    await gate.promise; return { data: [history(p.id)] };
+  } });
+  t.after(() => gate.resolve());
+  for (let i = 0; i < 5; i++) await h.emit(select(`first${i}`));
+  const otherQueries = [];
+  const otherDirectory = path.join(TEMP_DIR, "other-project");
+  const second = await h.plugin({ directory: otherDirectory, client: {
+    ...h.client,
+    session: { messages: async (options) => {
+      otherQueries.push(options);
+      await gate.promise;
+      return { data: [history(options.path.id, 50)] };
+    } },
+  } });
+  h.instances.push(second);
+  for (let i = 0; i < 5; i++) {
+    await second.event({ event: status(`second${i}`) });
+  }
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 4);
+  assert.equal(otherQueries.length, 4);
+  await h.hooks.dispose();
+  gate.resolve();
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 4);
+  assert.equal(otherQueries.length, 5);
+  assert.ok(otherQueries.every((q) => q.query.directory === otherDirectory));
+  assert.equal(h.usage("second4")?.used, 50);
+  assert.equal(h.plugin.__test._contextStateByInstance.size, 1);
+});
+
+it("bounds retained intents and evicts unserved bootstrap work before recent selections", async (t) => {
+  const gate = deferred();
+  const h = await setup(t, {
+    list: Array.from({ length: 20 }, (_, i) => ({ id: `bootstrap${i}`, directory, time: { updated: 20 - i } })),
+    messages: async ({ path: p }) => { await gate.promise; return { data: [history(p.id)] }; },
+  });
+  t.after(() => gate.resolve());
+  await settle(h.plugin);
+  // Synchronous burst: capacity stays occupied while intents reach their cap.
+  for (let i = 0; i < 1010; i++) void h.emit(select(`selected${i}`));
+  const states = [...h.plugin.__test._contextStateByInstance.values()][0];
+  assert.equal(states.size, 1024);
+  assert.equal([...states.values()].filter((state) => state.pendingHydration).length, 1020);
+  assert.ok(states.has("opencode:selected0"));
+  assert.ok(states.has("opencode:selected1009"));
+  assert.equal(states.has("opencode:bootstrap4"), false);
+  assert.equal(h.queries.length, 4);
+  // Cancel instead of actually querying a thousand fixture sessions.
+  await h.hooks.dispose();
+  gate.resolve();
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 4);
+  assert.equal(h.plugin.__test._contextStateByInstance.size, 0);
+});
+
+it("control: hydrates after the first normal lifecycle event through the real route", async (t) => {
+  const h = await setup(t);
+  await h.emit(status("control"));
+  await settle(h.plugin);
+  assert.equal(h.usage("control")?.used, 320);
+  assert.deepEqual(h.posts.map((p) => p.body.metadata_only === true), [false, true]);
+  assert.equal(h.posts.at(-1).accepted, true);
+});
+
+it("replays unaccepted bootstrap context after one lifecycle event inside the cooldown", async (t) => {
+  const h = await setup(t, { list: [{ id: "late", directory }] });
+  await settle(h.plugin);
+  assert.equal(h.posts.length, 1);
+  assert.equal(h.posts[0].status, 204);
+  assert.equal(h.posts[0].accepted, false);
+  assert.equal(h.api.sessions.size, 0, "bootstrap must not create a session");
+  await h.emit(status("late"));
+  await settle(h.plugin);
+  assert.equal(h.api.sessions.size, 1);
+  assert.equal(h.usage("late")?.used, 320, "one lifecycle signal must recover the undelivered sample");
+  assert.equal(h.queries.length, 1, "replay does not need another history read");
+});
+
+it("serves the selected fifth bootstrap session when a history slot is freed", async (t) => {
+  const gate = deferred();
+  const ids = ["one", "two", "three", "four", "five"];
+  const h = await setup(t, {
+    list: ids.map((id, i) => ({ id, directory, time: { updated: 10 - i } })),
+    messages: async ({ path: p }) => {
+      if (p.id !== "five") await gate.promise;
+      return { data: [history(p.id)] };
+    },
+  });
+  t.after(() => gate.resolve());
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 4);
+  h.seed("five");
+  await h.emit(select("five"));
+  assert.equal(h.queries.length, 4);
+  gate.resolve();
+  await settle(h.plugin);
+  assert.equal(h.usage("five")?.used, 320, "the original selection must survive full capacity");
+  assert.deepEqual(h.queries.map((q) => q.path.id), ids);
+  assert.equal(h.peak(), 4);
+});
+
+it("retains a lifecycle signal while the unaccepted bootstrap POST is still pending", async (t) => {
+  const h = await setup(t, { list: [{ id: "late", directory }] });
+  const gate = { ...deferred(), match: (p) => p.body.metadata_only };
+  h.responseGates.push(gate);
+  await flushTurns();
+  assert.equal(h.posts[0].accepted, false);
+  await h.emit(status("late"));
+  gate.resolve();
+  await settle(h.plugin);
+  assert.equal(h.usage("late")?.used, 320);
+  assert.equal(h.queries.length, 1);
+});
+
+it("drains capacity-blocked event requests without bootstrap or another event", async (t) => {
+  const gate = deferred();
+  const h = await setup(t, { messages: async ({ path: p }) => {
+    if (Number(p.id.slice(1)) < 4) await gate.promise;
+    return { data: [history(p.id)] };
+  } });
+  t.after(() => gate.resolve());
+  for (let i = 0; i < 10; i++) {
+    h.seed(`s${i}`);
+    await h.emit(select(`s${i}`));
+    await h.emit(select(`s${i}`));
+  }
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 4);
+  gate.resolve();
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 10);
+  assert.equal(new Set(h.queries.map((q) => q.path.id)).size, 10);
+  assert.equal(h.usage("s9")?.used, 320);
+  assert.equal(h.peak(), 4);
+});
+
+it("services one signal retained during SDK failure cooldown without polling forever", async (t) => {
+  let fail = true;
+  const h = await setup(t, { messages: async ({ path: p }) => {
+    if (fail) throw new Error("offline");
+    return { data: [history(p.id)] };
+  } });
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: Date.now() });
+  await h.emit(status("retry"));
+  await settle(h.plugin);
+  await h.emit(select("retry"));
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 1);
+  t.mock.timers.tick(30_001);
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 2, "the retained signal must wake once at cooldown expiry");
+  t.mock.timers.tick(90_000);
+  await settle(h.plugin);
+  assert.equal(h.queries.length, 2, "a failed retry must not create a recurring poll");
+  fail = false;
+  await h.emit(select("retry"));
+  await settle(h.plugin);
+  assert.equal(h.usage("retry")?.used, 320);
+});
+
+const terminal = (kind, id) => kind === "session.deleted"
+  ? { type: kind, properties: { info: { id, directory } } }
+  : { type: kind, properties: { directory } };
+
+for (const kind of ["session.deleted", "server.instance.disposed", "dispose"]) {
+  it(`cancels a capacity-blocked selection on ${kind}`, async (t) => {
+    const gate = deferred();
+    const h = await setup(t, { messages: async ({ path: p }) => {
+      if (p.id !== "waiting") await gate.promise;
+      return { data: [history(p.id)] };
+    } });
+    t.after(() => gate.resolve());
+    for (let i = 0; i < 4; i++) await h.emit(select(`busy${i}`));
+    await h.emit(select("waiting"));
+    if (kind === "dispose") await h.hooks.dispose();
+    else await h.emit(terminal(kind, "waiting"));
+    gate.resolve();
+    await settle(h.plugin);
+    assert.ok(!h.queries.some((q) => q.path.id === "waiting"));
+    assert.equal(h.usage("waiting"), undefined);
+  });
+
+  it(`clears an unaccepted sample and a cooldown wakeup on ${kind}`, async (t) => {
+    const h = await setup(t, { list: [{ id: "cached", directory }], messages: async ({ path: p }) => {
+      if (p.id === "retry") throw new Error("offline");
+      return { data: [history(p.id)] };
+    } });
+    await settle(h.plugin);
+    t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: Date.now() });
+    await h.emit(select("retry"));
+    await settle(h.plugin);
+    await h.emit(select("retry"));
+    if (kind === "dispose") await h.hooks.dispose();
+    else {
+      await h.emit(terminal(kind, "cached"));
+      if (kind === "session.deleted") await h.emit(terminal(kind, "retry"));
+    }
+    await settle(h.plugin);
+    const count = h.queries.length;
+    t.mock.timers.tick(31_000);
+    await settle(h.plugin);
+    assert.equal(h.queries.length, count);
+    assert.equal(h.plugin.__test._contextStateByInstance.size, 0);
+    assert.ok(h.posts.filter((p) => p.body.metadata_only).every((p) => !p.accepted));
+  });
+}
+
+for (const used of [50, 0]) {
+  it(`new live context (${used} tokens) invalidates a selection waiting for capacity`, async (t) => {
+    const gate = deferred();
+    const h = await setup(t, { messages: async ({ path: p }) => {
+      if (p.id !== "waiting") await gate.promise;
+      return { data: [history(p.id, 900)] };
+    } });
+    t.after(() => gate.resolve());
+    for (let i = 0; i < 4; i++) await h.emit(select(`busy${i}`));
+    h.seed("waiting");
+    await h.emit(select("waiting"));
+    await h.emit({ type: "message.updated", properties: { info: history("waiting", used).info } });
+    gate.resolve();
+    await settle(h.plugin);
+    assert.ok(!h.queries.some((q) => q.path.id === "waiting"));
+    assert.equal(h.usage("waiting")?.used, used || undefined);
+  });
+
+  it(`new live context (${used} tokens) invalidates cached replay behind a slow lifecycle POST`, async (t) => {
+    const h = await setup(t, { list: [{ id: "late", directory }] });
+    await settle(h.plugin);
+    const gate = { ...deferred(), match: (p) => !p.body.metadata_only };
+    h.responseGates.push(gate);
+    await h.emit(status("late"));
+    await flushTurns();
+    await h.emit({ type: "message.updated", properties: { info: history("late", used).info } });
+    gate.resolve();
+    await settle(h.plugin);
+    assert.equal(h.usage("late")?.used, used || undefined);
+    assert.ok(!h.posts.some((p) => p.accepted && p.body.context_usage?.used === 320));
+  });
+}
+
+for (const titleFirst of [false, true]) {
+  it(`preserves a title merged ${titleFirst ? "before" : "after"} a stale cached context replay`, async (t) => {
+    const h = await setup(t, { list: [{ id: "late", directory }] });
+    await settle(h.plugin);
+    const gate = { ...deferred(), match: (p) => !p.body.metadata_only };
+    h.responseGates.push(gate);
+    const lifecycle = h.emit(status("late"));
+    if (!titleFirst) await flushTurns();
+    await h.emit({ type: "session.updated", properties: { info: { id: "late", directory, title: "Renamed session" } } });
+    await lifecycle;
+    await flushTurns();
+    await h.emit({ type: "message.updated", properties: { info: history("late", 0).info } });
+    gate.resolve();
+    await settle(h.plugin);
+    assert.equal(h.usage("late"), undefined);
+    assert.equal(h.api.sessions.get(key("late")).sessionTitle, "Renamed session");
+    assert.ok(h.posts.some((p) => p.accepted && p.body.session_title === "Renamed session" && !p.body.context_usage));
+  });
+}

--- a/test/opencode-family-state-ordering-disposal.test.js
+++ b/test/opencode-family-state-ordering-disposal.test.js
@@ -1437,7 +1437,7 @@ describe("opencode resume context hydration", () => {
     assert.strictEqual(h.queries.length, 0);
   });
 
-  it("retries rejected/unaccepted hydration on a later signal with a bounded cooldown", async () => {
+  it("cools down failed reads but replays an unaccepted sample without rereading history", async () => {
     const originalNow = Date.now;
     let now = originalNow();
     Date.now = () => now;
@@ -1456,11 +1456,10 @@ describe("opencode resume context hydration", () => {
       await settle(h.plugin);
       assert.strictEqual(h.queries.length, 2);
       assert.strictEqual([...h.plugin.__test._contextStateByInstance.values()][0].get("opencode:ses_resume").delivered, null);
-      now += 31_000;
       fetchImpl = async (url, opts) => { const call = parseFetchCall(url, opts); h.calls.push(call); return clawdResponse(call.body); };
       await emit(h.hooks, resumed());
       await settle(h.plugin);
-      assert.strictEqual(h.queries.length, 3);
+      assert.strictEqual(h.queries.length, 2);
       assert.strictEqual(h.metadata().length, 1);
     } finally { Date.now = originalNow; }
   });
@@ -1473,9 +1472,8 @@ describe("opencode resume context hydration", () => {
     assert.strictEqual(h.queries.length, 4);
     gate.resolve({ data: [] });
     await settle(h.plugin);
-    await emit(h.hooks, resumed("ses_9"));
-    await settle(h.plugin);
-    assert.strictEqual(h.queries.length, 5, "a skipped session can be retried after capacity is freed");
+    assert.strictEqual(h.queries.length, 10, "all original signals are served after capacity is freed");
+    assert.strictEqual(new Set(h.queries.map((query) => query.path.id)).size, 10);
   });
 
   it("keeps client/directory lookups isolated across initialized instances", async () => {

--- a/test/opencode-family-state-ordering-disposal.test.js
+++ b/test/opencode-family-state-ordering-disposal.test.js
@@ -1269,3 +1269,356 @@ describe("opencode-family context usage event wiring", () => {
     assert.strictEqual(plugin.__test._contextStateByInstance.has(instanceToken), false);
   });
 });
+
+// #883: resume signals must hydrate metadata without synthesizing activity.
+describe("opencode resume context hydration", () => {
+  const directory = path.join(TMP_HOME, "resume-context");
+  const sessionID = "ses_resume";
+  const history = (used = 321, id = "msg_latest", created = 2, sid = sessionID) => ({
+    info: { id, sessionID: sid, role: "assistant", time: { created, completed: created + 1 },
+      providerID: "openai", modelID: "test-model", tokens: { input: used } },
+    parts: [],
+  });
+  const resumed = (sid = sessionID) => lifecycle("session.updated", sid, directory);
+  async function setup(messages, params = CONFIG, list = null) {
+    const calls = [];
+    const queries = [];
+    fetchImpl = async (url, opts) => {
+      const call = parseFetchCall(url, opts);
+      calls.push(call);
+      return clawdResponse(call.body);
+    };
+    const client = {
+      session: { messages: async (options) => { queries.push(options); return messages(options); } },
+      provider: { list: async () => ({ data: { all: [
+        { id: "openai", models: { "test-model": { limit: { context: 1000 } } } },
+      ] } }) },
+    };
+    if (list) client.session.list = list;
+    const plugin = createOpencodeFamilyPlugin(params);
+    const hooks = await plugin({ ...createContext(directory), client });
+    return { plugin, hooks, client, calls, queries,
+      metadata: () => calls.filter((call) => call.body.context_usage).map((call) => call.body) };
+  }
+  async function settle(plugin) {
+    for (let i = 0; i < 20; i++) await new Promise((resolve) => setImmediate(resolve));
+    await waitForQueueEmpty(plugin);
+  }
+
+  it("hydrates an existing session on session.updated without another assistant event or lifecycle POST", async () => {
+    const h = await setup(async () => ({ data: [history()] }));
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.strictEqual(h.metadata().length, 1);
+    assert.deepStrictEqual(h.metadata()[0].context_usage, { used: 321, limit: 1000, source: "opencode" });
+    assert.strictEqual(h.metadata()[0].metadata_only, true);
+    assert.strictEqual(h.metadata()[0].session_id, "opencode:ses_resume");
+    assert.strictEqual(h.calls.filter((call) => !call.body.metadata_only).length, 0);
+    assert.strictEqual(h.plugin.__test._lastStatePerSession.size, 0);
+    assert.strictEqual(h.queries[0].path.id, sessionID, "SDK receives the raw session id");
+    assert.strictEqual(h.queries[0].query.directory, directory);
+    assert.ok(h.queries[0].query.limit > 0 && h.queries[0].query.limit <= 100);
+  });
+
+  it("hydrates explicit TUI selection without treating it as session activity", async () => {
+    const h = await setup(async () => [history()]);
+    await emit(h.hooks, { type: "tui.session.select", properties: { sessionID } });
+    await settle(h.plugin);
+    assert.strictEqual(h.metadata().length, 1);
+    assert.ok(h.calls.every((call) => call.body.metadata_only));
+  });
+
+  it("queues hydration behind the lifecycle that first makes a resumed session visible", async () => {
+    const h = await setup(async () => ({ data: [history()] }));
+    await emit(h.hooks, { type: "session.status", properties: { sessionID, status: { type: "busy" } } });
+    await settle(h.plugin);
+    assert.deepStrictEqual(h.calls.map((call) => call.body.metadata_only === true), [false, true]);
+    assert.strictEqual(h.calls[0].body.event, "UserPromptSubmit");
+    assert.strictEqual(h.plugin.__test._lastStatePerSession.get("opencode:ses_resume"), "thinking");
+  });
+
+  it("chooses the latest valid assistant by message order, including decreased usage after compaction", async () => {
+    const h = await setup(async () => ({ data: [history(900, "msg_old", 1), history(100),
+      { info: { id: "msg_user", sessionID, role: "user", time: { created: 3 } }, parts: [] },
+      history(0, "msg_incomplete", 4), history(800, "msg_foreign", 5, "ses_other")] }));
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.deepStrictEqual(h.metadata().map((body) => body.context_usage.used), [100]);
+  });
+
+  it("coalesces repeated resume signals and stops querying after accepted hydration", async () => {
+    const gate = deferred();
+    const h = await setup(() => gate.promise);
+    for (let i = 0; i < 10; i++) await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 1);
+    gate.resolve({ data: [history()] });
+    await settle(h.plugin);
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 1);
+    assert.strictEqual(h.metadata().length, 1);
+  });
+
+  it("discards a delayed history result after a newer real-time sample, even when usage decreases", async () => {
+    const gate = deferred();
+    const h = await setup(() => gate.promise);
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 1);
+    await emit(h.hooks, { type: "message.updated", properties: { info: history(50).info } });
+    await settle(h.plugin);
+    gate.resolve({ data: [history(900)] });
+    await settle(h.plugin);
+    assert.deepStrictEqual(h.metadata().map((body) => body.context_usage.used), [50]);
+  });
+
+  it("invalidates pending history even when the incoming assistant update has no usable tokens yet", async () => {
+    const gate = deferred();
+    const h = await setup(() => gate.promise);
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    await emit(h.hooks, { type: "message.updated", properties: { info: history(0).info } });
+    gate.resolve({ data: [history(900)] });
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 1);
+    assert.strictEqual(h.metadata().length, 0);
+  });
+
+  for (const terminal of ["session.deleted", "server.instance.disposed"]) {
+    it(`drops a history result after ${terminal}`, async () => {
+      const gate = deferred();
+      const h = await setup(() => gate.promise);
+      await emit(h.hooks, resumed());
+      await settle(h.plugin);
+      assert.strictEqual(h.queries.length, 1);
+      await emit(h.hooks, terminal === "session.deleted" ? lifecycle(terminal, sessionID, directory)
+        : { type: terminal, properties: { directory } });
+      gate.resolve({ data: [history()] });
+      await settle(h.plugin);
+      assert.strictEqual(h.metadata().length, 0);
+      assert.strictEqual(h.plugin.__test._contextStateByInstance.size, 0);
+    });
+  }
+
+  it("does not publish unknown usage or invent a zero percentage", async () => {
+    for (const result of [{ data: [] }, { error: { message: "unavailable" } }, { data: [history(0)] },
+      { data: [history(100, "msg_foreign", 1, "ses_other")] }]) {
+      const h = await setup(async () => result);
+      await emit(h.hooks, resumed());
+      await settle(h.plugin);
+      assert.strictEqual(h.queries.length, 1);
+      assert.strictEqual(h.metadata().length, 0);
+    }
+  });
+
+  it("preserves unknown model limit as null", async () => {
+    const h = await setup(async () => ({ data: [history()] }));
+    h.client.provider.list = async () => ({ data: { all: [] } });
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.deepStrictEqual(h.metadata().map((body) => body.context_usage), [
+      { used: 321, limit: null, source: "opencode" },
+    ]);
+  });
+
+  it("does not query MiMo, missing identities, conflicting identities, or another directory", async () => {
+    const mimo = await setup(async () => ({ data: [history()] }), {
+      ...CONFIG, agentId: "mimocode", hookSource: "mimocode-plugin", sessionIdPrefix: "mimocode:",
+    });
+    await emit(mimo.hooks, resumed());
+    await settle(mimo.plugin);
+    assert.strictEqual(mimo.queries.length, 0);
+    const h = await setup(async () => ({ data: [history()] }));
+    await emit(h.hooks, { type: "session.updated", properties: {} });
+    await emit(h.hooks, lifecycle("session.updated", sessionID, directory, null, { id: "ses_other" }));
+    await emit(h.hooks, lifecycle("session.updated", sessionID, directory + "-other"));
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 0);
+  });
+
+  it("retries rejected/unaccepted hydration on a later signal with a bounded cooldown", async () => {
+    const originalNow = Date.now;
+    let now = originalNow();
+    Date.now = () => now;
+    try {
+      let fail = true;
+      const h = await setup(async () => { if (fail) throw new Error("offline"); return { data: [history()] }; });
+      await emit(h.hooks, resumed());
+      await settle(h.plugin);
+      await emit(h.hooks, resumed());
+      await settle(h.plugin);
+      assert.strictEqual(h.queries.length, 1);
+      fail = false;
+      now += 31_000;
+      fetchImpl = async () => clawdResponse(null, { metadataAccepted: false });
+      await emit(h.hooks, resumed());
+      await settle(h.plugin);
+      assert.strictEqual(h.queries.length, 2);
+      assert.strictEqual([...h.plugin.__test._contextStateByInstance.values()][0].get("opencode:ses_resume").delivered, null);
+      now += 31_000;
+      fetchImpl = async (url, opts) => { const call = parseFetchCall(url, opts); h.calls.push(call); return clawdResponse(call.body); };
+      await emit(h.hooks, resumed());
+      await settle(h.plugin);
+      assert.strictEqual(h.queries.length, 3);
+      assert.strictEqual(h.metadata().length, 1);
+    } finally { Date.now = originalNow; }
+  });
+
+  it("bounds concurrent history requests per instance", async () => {
+    const gate = deferred();
+    const h = await setup(() => gate.promise);
+    for (let i = 0; i < 10; i++) await emit(h.hooks, resumed(`ses_${i}`));
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 4);
+    gate.resolve({ data: [] });
+    await settle(h.plugin);
+    await emit(h.hooks, resumed("ses_9"));
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 5, "a skipped session can be retried after capacity is freed");
+  });
+
+  it("keeps client/directory lookups isolated across initialized instances", async () => {
+    const h = await setup(async () => ({ data: [history(100)] }));
+    const otherDirectory = directory + "-second";
+    const otherQueries = [];
+    const second = await h.plugin({ directory: otherDirectory, client: {
+      ...h.client,
+      session: { messages: async (options) => { otherQueries.push(options); return { data: [history(200, "msg_2", 2, "ses_second")] }; } },
+    } });
+    await emit(h.hooks, resumed());
+    await emit(second, lifecycle("session.updated", "ses_second", otherDirectory));
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 1);
+    assert.strictEqual(otherQueries.length, 1);
+    assert.strictEqual(otherQueries[0].query.directory, otherDirectory);
+    assert.deepStrictEqual(h.metadata().map((body) => [body.session_id, body.context_usage.used]), [
+      ["opencode:ses_resume", 100], ["opencode:ses_second", 200],
+    ]);
+  });
+
+  it("does not let old history overwrite a recreated generation", async () => {
+    const old = deferred();
+    let first = true;
+    const h = await setup(() => { if (first) { first = false; return old.promise; } return { data: [history(50)] }; });
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    await emit(h.hooks, lifecycle("session.deleted", sessionID, directory));
+    await settle(h.plugin);
+    await emit(h.hooks, lifecycle("session.created", sessionID, directory));
+    await settle(h.plugin);
+    old.resolve({ data: [history(900)] });
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 2);
+    assert.deepStrictEqual(h.metadata().map((body) => body.context_usage.used), [50]);
+  });
+
+  it("keeps the history fence through a delayed model-limit lookup", async () => {
+    const gate = deferred();
+    let providerCalls = 0;
+    const h = await setup(async () => ({ data: [history(900)] }));
+    h.client.provider.list = () => { providerCalls++; return gate.promise; };
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.strictEqual(providerCalls, 1);
+    await emit(h.hooks, { type: "message.updated", properties: { info: history(0).info } });
+    gate.resolve({ data: { all: [] } });
+    await settle(h.plugin);
+    assert.strictEqual(h.metadata().length, 0);
+  });
+
+  it("times out a hung SDK without blocking the event hook or publishing metadata", async () => {
+    const h = await setup(() => new Promise(() => {}));
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 1);
+    await waitFor(() => h.queries[0].signal.aborted, "history request did not time out", 3000);
+    await settle(h.plugin);
+    assert.strictEqual(h.metadata().length, 0);
+    assert.strictEqual([...h.plugin.__test._contextStateByInstance.values()][0].get("opencode:ses_resume").hydration, null);
+  });
+
+  it("hydrates recent directory-owned sessions at startup without lifecycle or fallback ownership", async () => {
+    const listQueries = [];
+    const h = await setup(async () => ({ data: [history()] }), CONFIG, async (options) => {
+      listQueries.push(options);
+      return { data: [
+        { id: sessionID, directory, time: { updated: 10 } },
+        { id: "ses_foreign", directory: directory + "-other", time: { updated: 20 } },
+        { id: "ses_child", directory, parentID: sessionID, time: { updated: 30 } },
+        { id: "ses_archived", directory, time: { updated: 40, archived: 50 } },
+      ] };
+    });
+    await settle(h.plugin);
+    assert.strictEqual(listQueries.length, 1);
+    assert.strictEqual(listQueries[0].query.directory, directory);
+    assert.ok(listQueries[0].query.limit > 0 && listQueries[0].query.limit <= 20);
+    assert.strictEqual(h.queries.length, 1);
+    assert.strictEqual(h.metadata().length, 1);
+    assert.strictEqual(h.metadata()[0].cwd, directory);
+    assert.ok(h.calls.every((call) => call.body.metadata_only));
+    assert.strictEqual(h.plugin.__test._rootSessionId, null);
+    assert.strictEqual(h.plugin.__test._lastSeenSessionId, null);
+    assert.strictEqual(h.plugin.__test._sessionInstanceDirectoryById.size, 0);
+    await emit(h.hooks, { type: "server.instance.disposed", properties: { directory } });
+    await settle(h.plugin);
+    assert.ok(h.calls.every((call) => call.body.metadata_only), "bootstrap-only sessions must not get SessionEnd");
+    assert.strictEqual(h.plugin.__test._contextStateByInstance.size, 0);
+  });
+
+  it("discards an obsolete bootstrap list when a session is deleted while listing", async () => {
+    const gate = deferred();
+    let listed = false;
+    const h = await setup(async () => ({ data: [history()] }), CONFIG, () => { listed = true; return gate.promise; });
+    await settle(h.plugin);
+    assert.strictEqual(listed, true);
+    await emit(h.hooks, lifecycle("session.deleted", sessionID, directory));
+    gate.resolve({ data: [{ id: sessionID, directory, time: { updated: 10 } }] });
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 0);
+    assert.strictEqual(h.metadata().length, 0);
+  });
+
+  it("does not replace a session already observed live while bootstrap was listing", async () => {
+    const gate = deferred();
+    let listed = false;
+    const h = await setup(async () => ({ data: [history(900)] }), CONFIG, () => { listed = true; return gate.promise; });
+    await settle(h.plugin);
+    assert.strictEqual(listed, true);
+    await emit(h.hooks, { type: "message.updated", properties: { info: history(50).info } });
+    await settle(h.plugin);
+    gate.resolve({ data: [{ id: sessionID, directory, time: { updated: 10 } }] });
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 0);
+    assert.deepStrictEqual(h.metadata().map((body) => body.context_usage.used), [50]);
+  });
+
+  it("caps bootstrap to the twenty most recent sessions without following history pages", async () => {
+    const h = await setup(async () => ({ data: [] }), CONFIG, async () => ({ data:
+      Array.from({ length: 30 }, (_, i) => ({ id: `ses_${i}`, directory, time: { updated: i } })),
+    }));
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 20);
+    assert.deepStrictEqual(h.queries.map((q) => q.path.id).sort(),
+      Array.from({ length: 20 }, (_, i) => `ses_${i + 10}`).sort());
+    assert.strictEqual(h.calls.length, 0);
+  });
+
+  it("honors the modern host dispose hook and cancels pending bootstrap without SessionEnd", async () => {
+    const gate = deferred();
+    let signal;
+    const h = await setup(async () => ({ data: [history()] }), CONFIG,
+      (options) => { signal = options.signal; return gate.promise; });
+    await settle(h.plugin);
+    assert.strictEqual(typeof h.hooks.dispose, "function");
+    await h.hooks.dispose();
+    assert.strictEqual(signal.aborted, true);
+    gate.resolve({ data: [{ id: sessionID, directory }] });
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 0);
+    assert.strictEqual(h.calls.length, 0);
+    await emit(h.hooks, resumed());
+    await settle(h.plugin);
+    assert.strictEqual(h.queries.length, 0);
+  });
+});


### PR DESCRIPTION
Resumed OpenCode sessions can lack context usage until another assistant update. This adds bounded startup/resume hydration and preserves a single resume signal when history capacity is occupied or bootstrap metadata arrives before the Clawd session exists. Refs #883.

## Changes

- Inspect up to 20 recent, non-archived root sessions in the initialized directory; read one page of 20 messages per session and select the latest usable assistant, including decreased usage after compaction.
- Share four history-request slots between bootstrap and event-driven hydration, with a two-second timeout. Retain one deduplicated pending intent per session and drain automatically when capacity becomes available; explicit selections precede unserved bootstrap candidates.
- Retain a compact unaccepted sample and replay it behind the normal lifecycle POST, including when that signal arrives while the original POST is pending. Update delivered state only after metadata acceptance.
- Preserve signals received during the 30-second history-query cooldown using one instance timer; a failed retry does not create a recurring poll. Pending intents and cached samples share the existing 1024-session bound.
- Cancel stale work on deletion, recreation, disposal, eviction or newer live context, including zero-token updates. Recheck queued historical metadata before sending while preserving independently merged title updates.
- Keep metadata-only delivery, token calculation, HUD semantics and MiMo capability unchanged. Bootstrap never creates missing Clawd sessions or claims lifecycle ownership.

## Validation

- Added 24 scheduling regressions using the plugin's Node runtime and real `handleStatePost` / `state.js` modules. Both reported sequences failed on `e269ce4d`, while the normal control passed. Cancellation, live precedence, cooldown, capacity, isolation and title/context merging are covered.
- `node --test test/opencode*.test.js test/server-route-state.test.js`: **369 passed, 0 failed**.
- `npm run verify:electron`: Electron 41.10.4 verified.
- `npm test`: **9760 passed, 10 failed, 41 skipped** (9811 total). The failures exactly match the previously reproduced `test/session-renderer-behavior.test.js` baseline failures; unrelated renderer files remain unchanged.
- Real OpenCode CLI **1.18.30** on macOS, imported synthetic history and real Clawd HTTP/state modules: both scheduling sequences leave context absent on `e269ce4d` and produce **320 / 1000 (32%)** after the revision. The early-bootstrap case injects one controlled `session.status`; the capacity case uses one real host `tui.session.select`, with the first four SDK reads held and then released. No new assistant event or model call; peak history concurrency is four.
- Actual Dashboard HTML/preload/renderer in hidden Electron displays **Context: 320 / 1,000 (32%)**, with no renderer errors. Only context metadata fields changed in the existing session.

## Remaining acceptance / limits

The original **Windows 11 ARM64 / OpenCode Desktop 1.18.18 packaged-app** recovery scenario and its actual event sequence remain a separate acceptance item. Node/module tests and imported-fixture process checks do not validate that Desktop host. Older sessions outside the startup window need a supported event; this does not add lifecycle discovery for hosts that emit no session activity.
